### PR TITLE
chore(clerk-js): Consolidate ticket based sign up

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -51,53 +51,39 @@ function _SignUpStart(): JSX.Element {
     username: useFieldState('username', ''),
     phoneNumber: useFieldState('phone_number', ''),
     password: useFieldState('password', ''),
-    invitationToken: useFieldState(
-      'invitation_token',
-      getClerkQueryParam('__clerk_invitation_token') || '',
-    ),
-    organizationInvitationToken: useFieldState(
+    ticket: useFieldState(
       'ticket',
-      getClerkQueryParam('__clerk_ticket') || '',
+      getClerkQueryParam('__clerk_ticket') ||
+        getClerkQueryParam('__clerk_invitation_token') ||
+        '',
     ),
   } as const;
   type FormFieldsKey = keyof typeof formFields;
 
   const [error, setError] = React.useState<string | undefined>();
-  const hasInvitationToken = !!formFields.invitationToken.value;
-  const hasOrganizationInvitationToken =
-    !!formFields.organizationInvitationToken.value;
-  const hasToken = hasInvitationToken || hasOrganizationInvitationToken;
+  const hasTicket = !!formFields.ticket.value;
 
-  const fields = determineFirstPartyFields(
-    environment,
-    hasInvitationToken,
-    hasOrganizationInvitationToken,
-  );
+  const fields = determineFirstPartyFields(environment, hasTicket);
   const oauthOptions = userSettings.socialProviderStrategies;
   const web3Options = userSettings.web3FirstFactors;
 
   const handleTokenFlow = () => {
-    const invitationToken = formFields.invitationToken.value;
-    const organizationInvitationToken =
-      formFields.organizationInvitationToken.value;
-    if (!invitationToken && !organizationInvitationToken) {
+    const ticket = formFields.ticket.value;
+    if (!ticket) {
       return;
     }
-    const invitationParams: SignUpParams = invitationToken
-      ? { invitation_token: invitationToken }
-      : { strategy: 'ticket', ticket: organizationInvitationToken };
+    const signUpParams: SignUpParams = { strategy: 'ticket', ticket };
     setIsLoading(true);
 
     signUp
-      .create(invitationParams)
+      .create(signUpParams)
       .then(res => {
         formFields.emailAddress.setValue(res.emailAddress || '');
         void completeSignUpFlow(res);
       })
       .catch(err => {
         /* Clear token values when an error occurs in the initial sign up attempt */
-        formFields.invitationToken.setValue('');
-        formFields.organizationInvitationToken.setValue('');
+        formFields.ticket.setValue('');
         handleError(err, [], setError);
       })
       .finally(() => {
@@ -160,18 +146,15 @@ function _SignUpStart(): JSX.Element {
       reqFields.push(formFields.phoneNumber);
     }
 
-    if (fields.organizationInvitationToken) {
+    if (fields.ticket) {
       // FIXME: Constructing a fake fields object for strategy.
-      reqFields.push(
-        {
-          name: 'strategy',
-          value: 'ticket',
-          setError: noop,
-          setValue: noop,
-          error: undefined,
-        },
-        formFields.emailAddress,
-      );
+      reqFields.push({
+        name: 'strategy',
+        value: 'ticket',
+        setError: noop,
+        setValue: noop,
+        error: undefined,
+      });
     }
 
     try {
@@ -280,11 +263,11 @@ function _SignUpStart(): JSX.Element {
   ) : null;
 
   const shouldShowEmailAddressField =
-    (hasToken && !!formFields.emailAddress.value) ||
+    (hasTicket && !!formFields.emailAddress.value) ||
     fields.emailAddress ||
     (fields.emailOrPhone && emailOrPhoneActive === 'emailAddress');
 
-  const disabledEmailField = hasToken && !!formFields.emailAddress.value;
+  const disabledEmailField = hasTicket && !!formFields.emailAddress.value;
 
   const emailAddressField = shouldShowEmailAddressField && (
     <Control
@@ -336,10 +319,10 @@ function _SignUpStart(): JSX.Element {
     <>
       <Header error={error} className='cl-auth-form-header-compact' />
       <Body>
-        {!hasToken && oauthOptions.length > 0 && (
+        {!hasTicket && oauthOptions.length > 0 && (
           <SignUpOAuth oauthOptions={oauthOptions} setError={setError} />
         )}
-        {!hasToken && web3Options.length > 0 && (
+        {!hasTicket && web3Options.length > 0 && (
           <SignUpWeb3 web3Options={web3Options} setError={setError} />
         )}
         {atLeastOneFormField && (

--- a/packages/clerk-js/src/ui/signUp/utils.test.ts
+++ b/packages/clerk-js/src/ui/signUp/utils.test.ts
@@ -201,18 +201,22 @@ describe('determineFirstPartyFields()', () => {
     ];
 
     it.each(scenaria)('%s', (___, environment, result) => {
-      expect(determineFirstPartyFields(environment as EnvironmentResource)).toEqual(result);
+      expect(
+        determineFirstPartyFields(environment as EnvironmentResource),
+      ).toEqual(result);
     });
 
-    it.each(scenaria)('with invitation, %s', (___, environment, result) => {
-      // Email address or phone number cannot be required when there's an
-      // invitation token present. Instead, we'll require the invitationToken
-      // parameter
-      const expected = { ...result, invitationToken: 'required' };
+    it.each(scenaria)('with ticket, %s', (___, environment, result) => {
+      // Email address or phone number cannot be required when there's a
+      // ticket token present. Instead, we'll require the ticket parameter.
+      const expected = { ...result, ticket: 'required' };
       delete expected.emailAddress;
       delete expected.phoneNumber;
       delete expected.emailOrPhone;
-      const res = determineFirstPartyFields(environment as EnvironmentResource, true);
+      const res = determineFirstPartyFields(
+        environment as EnvironmentResource,
+        true,
+      );
       expect(res).toMatchObject(expected);
     });
   });

--- a/packages/clerk-js/src/ui/signUp/utils.ts
+++ b/packages/clerk-js/src/ui/signUp/utils.ts
@@ -9,8 +9,7 @@ type FieldKeys =
   | 'firstName'
   | 'lastName'
   | 'password'
-  | 'invitationToken'
-  | 'organizationInvitationToken';
+  | 'ticket';
 
 // TODO: Refactor SignUp component and remove
 // this leftover type
@@ -27,8 +26,7 @@ function isEmailOrPhone(attributes: Attributes) {
 
 export function determineFirstPartyFields(
   environment: EnvironmentResource,
-  hasInvitation?: boolean,
-  hasOrganizationInvitation?: boolean,
+  hasTicket?: boolean,
 ): Fields {
   const { attributes } = environment.userSettings;
 
@@ -44,10 +42,8 @@ export function determineFirstPartyFields(
           : 'on'),
     );
 
-  if (hasInvitation) {
-    fields.invitationToken = 'required';
-  } else if (hasOrganizationInvitation) {
-    fields.organizationInvitationToken = 'required';
+  if (hasTicket) {
+    fields.ticket = 'required';
   } else if (isEmailOrPhone(attributes)) {
     fields.emailOrPhone = 'required';
   } else if (attributes.email_address.used_for_first_factor) {

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -117,7 +117,6 @@ export type SignUpAttributes = {
   action_complete_redirect_url: string;
   transfer: boolean;
   unsafe_metadata: Record<string, unknown>;
-  invitation_token: string;
   ticket: string;
 } & Record<
   SignUpAttribute | Exclude<SignUpIdentification, OAuthStrategy>,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

We currently have two sign up flows that boil down to using a token to create an account; instance and organizations invitations.

In our BE, we have consolidated the two to simply send a ticket and specify the "ticket" verification strategy. Our FE code however, still treats the two flows differently and tries to differentiate between an instance invitation token and an organization invitation token.

This commit consolidates the two token-based flows into simply passing a `{ticket: "",strategy:"ticket}` payload when creating the sign up.

The "__clerk_invitation_token" query parameter is still supported to ensure backwards compatibility with any pending invitations that might have been created before the BE consolidation was deployed.

## Test plan

Create an instance with organizations enabled. Send out instance invitations and organization invitations. Try out different instance configurations, like password based and passwordless, optional fields (first and last name).

Looks like the sign up flow still works as expected.

<!-- Fixes # (issue number) -->
