### PR TITLE
fix(clerk-js): Render phone number input if applicable during sign up invitation flow

### DIFF
--- a/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
+++ b/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
@@ -462,5 +462,65 @@ describe('determineActiveFields()', () => {
         }),
       ).toEqual(result);
     });
+
+    it('phone is shown if enabled in the token case', () => {
+      const [___, attributes, result] = [
+        'email only option',
+        {
+          email_address: {
+            enabled: true,
+            required: true,
+          },
+          phone_number: {
+            enabled: true,
+            required: true,
+          },
+          first_name: {
+            enabled: true,
+            required: true,
+          },
+          last_name: {
+            enabled: true,
+            required: true,
+          },
+          password: {
+            enabled: false,
+            required: false,
+          },
+          username: {
+            enabled: false,
+            required: false,
+          },
+        },
+        {
+          emailAddress: {
+            required: true,
+            disabled: true,
+          },
+          phoneNumber: {
+            required: true,
+          },
+          ticket: {
+            required: true,
+          },
+          firstName: {
+            required: true,
+          },
+          lastName: {
+            required: true,
+          },
+        },
+      ] as Scenario;
+
+      const res = determineActiveFields({
+        attributes: attributes,
+        hasTicket: true,
+        hasEmail: true,
+        activeCommIdentifierType: getInitialActiveIdentifier(attributes, isProgressiveSignUp),
+        isProgressiveSignUp,
+      });
+
+      expect(res).toEqual(result);
+    });
   });
 });

--- a/packages/clerk-js/src/ui/signUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/signUp/signUpFormHelpers.ts
@@ -194,7 +194,7 @@ function getPhoneNumberField({
 }: FieldDeterminationProps): Field | undefined {
   if (isProgressiveSignUp) {
     // If there is no ticket and phone number is enabled, we have to show it in the SignUp form
-    const show = !hasTicket && attributes.phone_number.enabled;
+    const show = attributes.phone_number.enabled;
 
     if (!show) {
       return;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

This fixes a bug which came up after we released the required/optional options for email & phones. During an invitation flow and the instance has configured required phone numbers, the user landed in the sign-up form. The phone number input wasn't rendered, as we didn't consider it at all during an invitation flow before the new options, and the user wasn't able to complete the sign-up

<!-- Fixes # (issue number) -->
