### PR TITLE
feat(clerk-js,types): New `updatePassword` method for UserResource

### DIFF
--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -17,6 +17,7 @@ import type {
   TOTPJSON,
   TOTPResource,
   UpdateUserParams,
+  UpdateUserPasswordParams,
   UserJSON,
   UserResource,
   VerifyTOTPParams,
@@ -196,6 +197,13 @@ export class User extends BaseResource implements UserResource {
   update = (params: UpdateUserParams): Promise<UserResource> => {
     return this._basePatch({
       body: normalizeUnsafeMetadata(params),
+    });
+  };
+
+  updatePassword = (params: UpdateUserPasswordParams): Promise<UserResource> => {
+    return this._basePatch({
+      body: params,
+      path: `${this.path()}/password`,
     });
   };
 

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -179,6 +179,9 @@ export interface UserJSON extends ClerkResourceJSON {
   external_accounts: ExternalAccountJSON[];
   organization_memberships: OrganizationMembershipJSON[];
   password_enabled: boolean;
+  /**
+   * @deprecated This will be removed in the next major version
+   */
   password: string;
   profile_image_id: string;
   first_name: string;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -64,6 +64,7 @@ export interface UserResource extends ClerkResource {
   createdAt: Date | null;
 
   update: (params: UpdateUserParams) => Promise<UserResource>;
+  updatePassword: (params: UpdateUserPasswordParams) => Promise<UserResource>;
   createEmailAddress: (params: CreateEmailAddressParams) => Promise<EmailAddressResource>;
   createPhoneNumber: (params: CreatePhoneNumberParams) => Promise<PhoneNumberResource>;
   createWeb3Wallet: (params: CreateWeb3WalletParams) => Promise<Web3WalletResource>;
@@ -75,9 +76,13 @@ export interface UserResource extends ClerkResource {
   verifyTOTP: (params: VerifyTOTPParams) => Promise<TOTPResource>;
   disableTOTP: () => Promise<DeletedObjectResource>;
   createBackupCode: () => Promise<BackupCodeResource>;
+
   get verifiedExternalAccounts(): ExternalAccountResource[];
+
   get unverifiedExternalAccounts(): ExternalAccountResource[];
+
   get hasVerifiedEmailAddress(): boolean;
+
   get hasVerifiedPhoneNumber(): boolean;
 }
 
@@ -108,4 +113,17 @@ type UpdateUserJSON = Pick<
   | 'unsafe_metadata'
 >;
 
-export type UpdateUserParams = Partial<SnakeToCamel<UpdateUserJSON>>;
+export type UpdateUserParams = Partial<
+  SnakeToCamel<UpdateUserJSON> & {
+    /**
+     * @deprecated This will be removed in the next major version. Please use `updatePassword(params)` instead
+     */
+    password: string;
+  }
+>;
+
+export type UpdateUserPasswordParams = {
+  newPassword: string;
+  currentPassword?: string;
+  signOutOfOtherSessions?: boolean;
+};


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

We recently introduced a new FAPI endpoint for updating a user's password
PATCH /v1/me/password

### Body

- `current_password` (optional) The user must supply their current password if there is one. If not, this property should not be included in the request.
- `new_passsword` The new password

### Responses
200 OK - Password Changed successfully
422 Invalid Password 

## Changes of this PR
This PR 
- adds a new method at the `User` class that performs a PATCH request to `/v1/me/password` FAPI endpoint.
- markes the `password` property of `UpdateUserParams` as deprecated
<!-- Fixes # (issue number) -->
