### PR TITLE
chore(clerk-js): Remove unused import of useLocalStorage

### DIFF
--- a/packages/clerk-js/src/ui/elements/PhoneInput/useFormattedPhoneNumber.ts
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/useFormattedPhoneNumber.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useLocalStorage } from '../../hooks';
 import { extractDigits, formatPhoneNumber, parsePhoneString } from '../../utils';
 import type { CountryIso } from './countryCodeData';
 import { IsoToCountryMap } from './countryCodeData';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
