### PR TITLE
fix(clerk-js): Pass dev_browser to AP via query param, fix AP origin …

### DIFF
--- a/.changeset/afraid-countries-smash.md
+++ b/.changeset/afraid-countries-smash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Pass dev_browser to AP via query param, fix AP origin detection util

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -1494,5 +1494,41 @@ describe('Clerk singleton', () => {
       const url = sut.buildUrlWithAuth('foo');
       expect(url).toBe('foo');
     });
+
+    it('uses the hash to propagate the dev_browser JWT by default on dev', async () => {
+      mockUsesUrlBasedSessionSync.mockReturnValue(true);
+      const sut = new Clerk(devFrontendApi);
+      await sut.load();
+
+      const url = sut.buildUrlWithAuth('https://example.com/some-path');
+      expect(url).toBe('https://example.com/some-path#__clerk_db_jwt[deadbeef]');
+    });
+
+    it('uses the query param to propagate the dev_browser JWT if specified by option on dev', async () => {
+      mockUsesUrlBasedSessionSync.mockReturnValue(true);
+      const sut = new Clerk(devFrontendApi);
+      await sut.load();
+
+      const url = sut.buildUrlWithAuth('https://example.com/some-path', { useQueryParam: true });
+      expect(url).toBe('https://example.com/some-path?__dev_session=deadbeef');
+    });
+
+    it('uses the query param to propagate the dev_browser JWT to Account Portal pages on dev - non-kima', async () => {
+      mockUsesUrlBasedSessionSync.mockReturnValue(true);
+      const sut = new Clerk(devFrontendApi);
+      await sut.load();
+
+      const url = sut.buildUrlWithAuth('https://accounts.abcef.12345.dev.lclclerk.com');
+      expect(url).toBe('https://accounts.abcef.12345.dev.lclclerk.com/?__dev_session=deadbeef');
+    });
+
+    it('uses the query param to propagate the dev_browser JWT to Account Portal pages on dev - kima', async () => {
+      mockUsesUrlBasedSessionSync.mockReturnValue(true);
+      const sut = new Clerk(devFrontendApi);
+      await sut.load();
+
+      const url = sut.buildUrlWithAuth('https://rested-anemone-14.accounts.dev');
+      expect(url).toBe('https://rested-anemone-14.accounts.dev/?__dev_session=deadbeef');
+    });
   });
 });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -65,7 +65,7 @@ import {
   ignoreEventValue,
   inActiveBrowserTab,
   inBrowser,
-  isAccountsHostedPages,
+  isDevAccountPortalOrigin,
   isDevOrStagingUrl,
   isError,
   isRedirectForFAPIInitiatedFlow,
@@ -668,9 +668,10 @@ export default class Clerk implements ClerkInterface {
       return clerkMissingDevBrowserJwt();
     }
 
-    const asQueryParam = !!options?.useQueryParam;
+    // Use query param for Account Portal pages so that SSR can access the dev_browser JWT
+    const asQueryParam = !!options?.useQueryParam || isDevAccountPortalOrigin(toURL.hostname);
 
-    return setDevBrowserJWTInURL(toURL.href, devBrowserJwt, asQueryParam);
+    return setDevBrowserJWTInURL(toURL, devBrowserJwt, asQueryParam).href;
   }
 
   public buildSignInUrl(options?: RedirectOptions): string {
@@ -1231,7 +1232,7 @@ export default class Clerk implements ClerkInterface {
     this.#authService = new SessionCookieService(this);
     this.#pageLifecycle = createPageLifecycle();
 
-    const isInAccountsHostedPages = isAccountsHostedPages(window?.location.hostname);
+    const isInAccountsHostedPages = isDevAccountPortalOrigin(window?.location.hostname);
 
     this.#setupListeners();
 

--- a/packages/clerk-js/src/core/devBrowserHandler.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.ts
@@ -103,7 +103,7 @@ export default function createDevBrowserHandler({
 
   async function setUrlBasedSessionSyncBrowser(): Promise<void> {
     // 1. Get the JWT from hash search parameters when the redirection comes from Clerk Hosted Pages
-    const devBrowserToken = getDevBrowserJWTFromURL(window.location.href);
+    const devBrowserToken = getDevBrowserJWTFromURL(new URL(window.location.href));
     if (devBrowserToken) {
       setDevBrowserJWT(devBrowserToken);
       return;

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -8,9 +8,9 @@ import {
   getSearchParameterFromHash,
   hasBannedProtocol,
   hasExternalAccountSignUpError,
-  isAccountsHostedPages,
   isAllowedRedirectOrigin,
   isDataUri,
+  isDevAccountPortalOrigin,
   isRedirectForFAPIInitiatedFlow,
   isValidUrl,
   mergeFragmentIntoUrl,
@@ -18,22 +18,22 @@ import {
   trimTrailingSlash,
 } from '../url';
 
-describe('isAccountsHostedPages(url)', () => {
+describe('isDevAccountPortalOrigin(url)', () => {
   const goodUrls: Array<[string | URL, boolean]> = [
     ['clerk.dev.lclclerk.com', false],
     ['clerk.prod.lclclerk.com', false],
     ['clerk.abc.efg.lclstage.dev', false],
     ['clerk.abc.efg.stgstage.dev', false],
     ['accounts.abc.efg.dev.lclclerk.com', true],
-    ['https://accounts.abc.efg.stg.lclclerk.com', true],
-    [new URL('https://clerk.abc.efg.lcl.dev'), false],
-    [new URL('https://accounts.abc.efg.lcl.dev'), true],
-    [new URL('https://accounts.abc.efg.stg.dev'), true],
+    ['rested-anemone-14.accounts.dev', true],
+    ['rested-anemone-14.accounts.dev.accountsstage.dev', true],
+    ['rested-anemone-14.accounts.dev.accounts.lclclerk.com', true],
+    ['rested-anemone-14.clerk.accounts.dev', false],
   ];
 
-  test.each(goodUrls)('.isAccountsHostedPages(%s)', (a, expected) => {
+  test.each(goodUrls)('.isDevAccountPortalOrigin(%s)', (a, expected) => {
     // @ts-ignore
-    expect(isAccountsHostedPages(a)).toBe(expected);
+    expect(isDevAccountPortalOrigin(a)).toBe(expected);
   });
 });
 

--- a/packages/nextjs/src/server/authMiddleware.test.ts
+++ b/packages/nextjs/src/server/authMiddleware.test.ts
@@ -456,14 +456,14 @@ describe('Dev Browser JWT when redirecting to cross origin', function () {
     expect(authenticateRequest).toBeCalled();
   });
 
-  it('appends the Dev Browser JWT on the URL when cookie __clerk_db_jwt exists', async () => {
+  it('appends the Dev Browser JWT to the search when cookie __clerk_db_jwt exists and location is an Account Portal URL', async () => {
     const resp = await authMiddleware({
       beforeAuth: () => NextResponse.next(),
     })(mockRequest({ url: '/protected', appendDevBrowserCookie: true }), {} as NextFetchEvent);
 
     expect(resp?.status).toEqual(307);
     expect(resp?.headers.get('location')).toEqual(
-      'https://accounts.included.katydid-92.lcl.dev/sign-in?redirect_url=https%3A%2F%2Fwww.clerk.com%2Fprotected#__clerk_db_jwt[test_jwt]',
+      'https://accounts.included.katydid-92.lcl.dev/sign-in?redirect_url=https%3A%2F%2Fwww.clerk.com%2Fprotected&__dev_session=test_jwt',
     );
     expect(resp?.headers.get('x-clerk-auth-reason')).toEqual('redirect');
     expect(authenticateRequest).toBeCalled();

--- a/packages/nextjs/src/server/devBrowser.ts
+++ b/packages/nextjs/src/server/devBrowser.ts
@@ -1,23 +1,45 @@
-// TODO: This is a duplicate of part of packages/clerk-js/src/utils/devBrowser.ts
+// TODO: This is a partial duplicate of part of packages/clerk-js/src/utils/devBrowser.ts
 // TODO: To be removed when we can extract this utility to @clerk/shared
+
+export const DEV_BROWSER_SSO_JWT_PARAMETER = '__dev_session';
+
+//
+// Below this line should be identical to clerk-js version
+//
+
 export const DEV_BROWSER_JWT_MARKER = '__clerk_db_jwt';
 const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
 
-function extractDevBrowserJWT(url: string): string {
-  const matches = url.match(DEV_BROWSER_JWT_MARKER_REGEXP);
-  return matches ? matches[1] : '';
+// Sets the dev_browser JWT in the hash or the search
+export function setDevBrowserJWTInURL(url: URL, jwt: string, asQueryParam: boolean): URL {
+  const resultURL = new URL(url);
+
+  // extract & strip existing jwt from hash
+  const jwtFromHash = extractDevBrowserJWTFromHash(resultURL.hash);
+  resultURL.hash = resultURL.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
+  if (resultURL.href.endsWith('#')) {
+    resultURL.hash = '';
+  }
+
+  // extract & strip existing jwt from search
+  const jwtFromSearch = resultURL.searchParams.get(DEV_BROWSER_SSO_JWT_PARAMETER);
+  resultURL.searchParams.delete(DEV_BROWSER_SSO_JWT_PARAMETER);
+
+  // Existing jwt takes precedence
+  const jwtToSet = jwtFromHash || jwtFromSearch || jwt;
+
+  if (jwtToSet) {
+    if (asQueryParam) {
+      resultURL.searchParams.append(DEV_BROWSER_SSO_JWT_PARAMETER, jwtToSet);
+    } else {
+      resultURL.hash = resultURL.hash + `${DEV_BROWSER_JWT_MARKER}[${jwtToSet}]`;
+    }
+  }
+
+  return resultURL;
 }
 
-export function setDevBrowserJWTInURL(url: string, jwt?: string): string {
-  if (!jwt) {
-    return url;
-  }
-
-  const dbJwt = extractDevBrowserJWT(url);
-  if (dbJwt) {
-    url.replace(`${DEV_BROWSER_JWT_MARKER}[${dbJwt}]`, jwt);
-    return url;
-  }
-  const hasHash = (url || '').includes('#');
-  return `${url}${hasHash ? '' : '#'}${DEV_BROWSER_JWT_MARKER}[${(jwt || '').trim()}]`;
+function extractDevBrowserJWTFromHash(hash: string): string {
+  const matches = hash.match(DEV_BROWSER_JWT_MARKER_REGEXP);
+  return matches ? matches[1] : '';
 }

--- a/packages/nextjs/src/server/url.ts
+++ b/packages/nextjs/src/server/url.ts
@@ -1,0 +1,44 @@
+// TODO: This is a partial duplicate of part of packages/clerk-js/src/utils/url.ts
+// TODO: To be removed when we can extract this utility to @clerk/shared
+
+export const LEGACY_DEV_SUFFIXES = ['.lcl.dev', '.lclstage.dev', '.lclclerk.com'];
+export const CURRENT_DEV_SUFFIXES = ['.accounts.dev', '.accountsstage.dev', '.accounts.lclclerk.com'];
+
+const accountPortalCache = new Map<string, boolean>();
+
+export function isDevAccountPortalOrigin(hostname: string): boolean {
+  if (!hostname) {
+    return false;
+  }
+
+  let res = accountPortalCache.get(hostname);
+
+  if (res === undefined) {
+    res = isLegacyDevAccountPortalOrigin(hostname) || isCurrentDevAccountPortalOrigin(hostname);
+    accountPortalCache.set(hostname, res);
+  }
+
+  return res;
+}
+
+// Returns true for hosts such as:
+// * accounts.foo.bar-13.lcl.dev
+// * accounts.foo.bar-13.lclstage.dev
+// * accounts.foo.bar-13.dev.lclclerk.com
+function isLegacyDevAccountPortalOrigin(host: string): boolean {
+  return LEGACY_DEV_SUFFIXES.some(legacyDevSuffix => {
+    return host.startsWith('accounts.') && host.endsWith(legacyDevSuffix);
+  });
+}
+
+// Returns true for hosts such as:
+// * foo-bar-13.accounts.dev
+// * foo-bar-13.accountsstage.dev
+// * foo-bar-13.accounts.lclclerk.com
+// But false for:
+// * foo-bar-13.clerk.accounts.lclclerk.com
+function isCurrentDevAccountPortalOrigin(host: string): boolean {
+  return CURRENT_DEV_SUFFIXES.some(currentDevSuffix => {
+    return host.endsWith(currentDevSuffix) && !host.endsWith('.clerk' + currentDevSuffix);
+  });
+}


### PR DESCRIPTION
…detection util

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

To make the dev_browser JWT available to the SSR context on Account Portal, we need to pass the JWT via the query, not the hash.

The current PR detects whether the URL we are navigating to is an AP URL & passes the db JWT as a query param.

Also fixed the AP origin detection util, which did not cover kima instances (ported logic from our backend).

Adding @chanioxaris to help verify if the AP origin detection logic is accurate.