### PR TITLE
chore(repo): Introduce integration test for vite with sdk-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
     strategy:
       matrix:
-        test-name: [ 'generic', 'nextjs' ]
+        test-name: [ 'generic', 'nextjs', 'express' ]
 
     steps:
       - name: Checkout Repo

--- a/integration/constants.ts
+++ b/integration/constants.ts
@@ -1,9 +1,10 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 export const constants = {
-  TMP_DIR: path.join(process.cwd(), '.temp_integration'),
-  APPS_STATE_FILE: path.join(process.cwd(), '.temp_integration', 'state.json'),
+  TMP_DIR: path.join(os.tmpdir(), '.temp_integration'),
+  APPS_STATE_FILE: path.join(os.tmpdir(), '.temp_integration', 'state.json'),
   /**
    * A URL to a running app that will be used to run the tests against.
    * This is usually used when running the app has been started manually,

--- a/integration/models/applicationConfig.ts
+++ b/integration/models/applicationConfig.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { constants } from '../constants';
 import { createLogger, fs } from '../scripts';
 import { application } from './application.js';
 import type { EnvironmentConfig } from './environment';
@@ -62,10 +63,9 @@ export const applicationConfig = () => {
     commit: async (opts?: { stableHash?: string }) => {
       const { stableHash } = opts || {};
       logger.info(`Creating project "${name}"`);
-      const TMP_DIR = path.join(process.cwd(), '.temp_integration');
 
       const appDirName = stableHash || `${name}__${Date.now()}__${hash()}`;
-      const appDirPath = path.resolve(TMP_DIR, appDirName);
+      const appDirPath = path.resolve(constants.TMP_DIR, appDirName);
 
       // Copy template files
       for (const template of templates) {

--- a/integration/presets/express.ts
+++ b/integration/presets/express.ts
@@ -2,6 +2,7 @@ import { constants } from '../constants';
 import { applicationConfig } from '../models/applicationConfig';
 import { templates } from '../templates';
 
+const clerkNodeLocal = `file:${process.cwd()}/packages/sdk-node`;
 const vite = applicationConfig()
   .setName('express-vite')
   .useTemplate(templates['express-vite'])
@@ -10,7 +11,7 @@ const vite = applicationConfig()
   .addScript('dev', 'npm run dev')
   .addScript('build', 'npm run build')
   .addScript('serve', 'npm run start')
-  .addDependency('@clerk/clerk-sdk-node', constants.E2E_CLERK_VERSION);
+  .addDependency('@clerk/clerk-sdk-node', constants.E2E_CLERK_VERSION || clerkNodeLocal);
 
 export const express = {
   vite,

--- a/integration/presets/express.ts
+++ b/integration/presets/express.ts
@@ -1,0 +1,17 @@
+import { constants } from '../constants';
+import { applicationConfig } from '../models/applicationConfig';
+import { templates } from '../templates';
+
+const vite = applicationConfig()
+  .setName('express-vite')
+  .useTemplate(templates['express-vite'])
+  .setEnvFormatter('public', key => `VITE_${key}`)
+  .addScript('setup', 'npm i --prefer-offline')
+  .addScript('dev', 'npm run dev')
+  .addScript('build', 'npm run build')
+  .addScript('serve', 'npm run start')
+  .addDependency('@clerk/clerk-sdk-node', constants.E2E_CLERK_VERSION);
+
+export const express = {
+  vite,
+} as const;

--- a/integration/presets/index.ts
+++ b/integration/presets/index.ts
@@ -1,4 +1,5 @@
 import { envs } from './envs';
+import { express } from './express';
 import { createLongRunningApps } from './longRunningApps';
 import { next } from './next';
 import { react } from './react';
@@ -6,6 +7,7 @@ import { remix } from './remix';
 
 export const appConfigs = {
   envs,
+  express,
   longRunningApps: createLongRunningApps(),
   next,
   react,

--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -1,6 +1,7 @@
 import type { LongRunningApplication } from '../models/longRunningApplication';
 import { longRunningApplication } from '../models/longRunningApplication';
 import { envs } from './envs';
+import { express } from './express';
 import { next } from './next';
 import { react } from './react';
 import { remix } from './remix';
@@ -12,6 +13,7 @@ import { remix } from './remix';
  */
 export const createLongRunningApps = () => {
   const configs = [
+    { id: 'express.vite.withEmailCodes', config: express.vite, env: envs.withEmailCodes },
     { id: 'react.vite.withEmailCodes', config: react.vite, env: envs.withEmailCodes },
     { id: 'react.vite.withEmailLinks', config: react.vite, env: envs.withEmailLinks },
     { id: 'remix.node.withEmailCodes', config: remix.remixNode, env: envs.withEmailCodes },

--- a/integration/presets/next.ts
+++ b/integration/presets/next.ts
@@ -2,6 +2,7 @@ import { constants } from '../constants';
 import { applicationConfig } from '../models/applicationConfig.js';
 import { templates } from '../templates/index.js';
 
+const clerkNextjsLocal = `file:${process.cwd()}/packages/nextjs`;
 const appRouter = applicationConfig()
   .setName('next-app-router')
   .useTemplate(templates['next-app-router'])
@@ -11,7 +12,7 @@ const appRouter = applicationConfig()
   .addScript('build', 'npm run build')
   .addScript('serve', 'npm run start')
   .addDependency('next', constants.E2E_NEXTJS_VERSION)
-  .addDependency('@clerk/nextjs', constants.E2E_CLERK_VERSION);
+  .addDependency('@clerk/nextjs', constants.E2E_CLERK_VERSION || clerkNextjsLocal);
 
 const appRouterTurbo = appRouter
   .clone()

--- a/integration/presets/react.ts
+++ b/integration/presets/react.ts
@@ -2,6 +2,9 @@ import { constants } from '../constants';
 import { applicationConfig } from '../models/applicationConfig';
 import { templates } from '../templates';
 
+const clerkReactLocal = `file:${process.cwd()}/packages/react`;
+const clerkThemesLocal = `file:${process.cwd()}/packages/themes`;
+
 const cra = applicationConfig()
   .setName('react-cra')
   .useTemplate(templates['react-cra'])
@@ -10,8 +13,8 @@ const cra = applicationConfig()
   .addScript('dev', 'npm run start')
   .addScript('build', 'npm run build')
   .addScript('serve', 'npm run start')
-  .addDependency('@clerk/clerk-react', constants.E2E_CLERK_VERSION)
-  .addDependency('@clerk/themes', constants.E2E_CLERK_VERSION);
+  .addDependency('@clerk/clerk-react', constants.E2E_CLERK_VERSION || clerkReactLocal)
+  .addDependency('@clerk/themes', constants.E2E_CLERK_VERSION || clerkThemesLocal);
 
 const vite = cra
   .clone()

--- a/integration/presets/remix.ts
+++ b/integration/presets/remix.ts
@@ -1,14 +1,17 @@
+import { constants } from '../constants';
 import { applicationConfig } from '../models/applicationConfig.js';
 import { templates } from '../templates/index.js';
 
+const clerkRemixLocal = `file:${process.cwd()}/packages/remix`;
 const remixNode = applicationConfig()
   .setName('remix-node')
   .useTemplate(templates['remix-node'])
   .setEnvFormatter('public', key => `${key}`)
   .addScript('setup', 'npm i --prefer-offline')
   .addScript('dev', 'npm run dev')
-  .addScript('build', 'npm run build');
-// .addScript('serve', 'npm run start');
+  .addScript('build', 'npm run build')
+  .addScript('serve', 'npm run start')
+  .addDependency('@clerk/remix', constants.E2E_CLERK_VERSION || clerkRemixLocal);
 
 export const remix = {
   remixNode,

--- a/integration/scripts/clerkJsServer.ts
+++ b/integration/scripts/clerkJsServer.ts
@@ -3,6 +3,7 @@
 import os from 'node:os';
 import path from 'node:path';
 
+import { constants } from '../constants';
 import { stateFile } from '../models/stateFile';
 import { awaitableTreekill, fs, waitForServer } from './index';
 import { run } from './run';
@@ -40,9 +41,8 @@ const serveFromTempDir = async () => {
   const port = 18211;
   const serverUrl = `http://localhost:${port}`;
   const now = Date.now();
-  const TMP_DIR = path.join(process.cwd(), '.temp_integration');
-  const stdoutFilePath = path.resolve(TMP_DIR, `clerkJsHttpServer.${now}.log`);
-  const stderrFilePath = path.resolve(TMP_DIR, `clerkJsHttpServer.${now}.err.log`);
+  const stdoutFilePath = path.resolve(constants.TMP_DIR, `clerkJsHttpServer.${now}.log`);
+  const stderrFilePath = path.resolve(constants.TMP_DIR, `clerkJsHttpServer.${now}.err.log`);
   const clerkJsTempDir = getClerkJsTempDir();
   const proc = run(`node_modules/.bin/http-server ${clerkJsTempDir} -d --gzip --cors -a localhost`, {
     cwd: process.cwd(),

--- a/integration/scripts/waitForServer.ts
+++ b/integration/scripts/waitForServer.ts
@@ -1,8 +1,19 @@
+type WaitForServerArgsType = {
+  log;
+  delayInMs?: number;
+  maxAttempts?: number;
+  shouldExit?: () => boolean;
+};
+
 // Poll a url until it returns a 200 status code
-export const waitForServer = async (url: string, opts: { delayInMs?: number; maxAttempts?: number; log }) => {
-  const { delayInMs = 1000, maxAttempts = 20, log } = opts || {};
+export const waitForServer = async (url: string, opts: WaitForServerArgsType) => {
+  const { log, delayInMs = 1000, maxAttempts = 20, shouldExit = () => false } = opts;
   let attempts = 0;
   while (attempts < maxAttempts) {
+    if (shouldExit()) {
+      throw new Error(`Polling ${url} failed after ${maxAttempts} attempts (due to forced exit)`);
+    }
+
     try {
       log(`Polling ${url}...`);
       const res = await fetch(url);
@@ -15,5 +26,6 @@ export const waitForServer = async (url: string, opts: { delayInMs?: number; max
     attempts++;
     await new Promise(resolve => setTimeout(resolve, delayInMs));
   }
+
   throw new Error(`Polling ${url} failed after ${maxAttempts} attempts`);
 };

--- a/integration/templates/express-vite/.gitignore
+++ b/integration/templates/express-vite/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/integration/templates/express-vite/package.json
+++ b/integration/templates/express-vite/package.json
@@ -1,20 +1,21 @@
 {
   "name": "express-vite",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "scripts": {
-    "dev": "PORT=$PORT ts-node src/server/main.ts",
-    "start": "PORT=$PORT ts-node src/server/main.ts",
     "build": "vite build",
+    "dev": "PORT=$PORT ts-node src/server/main.ts",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview --port $PORT --no-open"
+    "preview": "vite preview --port $PORT --no-open",
+    "start": "PORT=$PORT ts-node src/server/main.ts"
   },
   "dependencies": {
+    "dotenv": "^16.3.1",
     "ejs": "^3.1.6",
     "express": "^4.18.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3",
-    "vite-express": "*"
+    "vite-express": "^0.11.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",

--- a/integration/templates/express-vite/package.json
+++ b/integration/templates/express-vite/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "express-vite",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "PORT=$PORT ts-node src/server/main.ts",
+    "start": "PORT=$PORT ts-node src/server/main.ts",
+    "build": "vite build",
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview --port $PORT --no-open"
+  },
+  "dependencies": {
+    "ejs": "^3.1.6",
+    "express": "^4.18.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.3",
+    "vite-express": "*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.15",
+    "@types/node": "^18.11.18",
+    "nodemon": "^2.0.20",
+    "vite": "^4.0.4"
+  }
+}

--- a/integration/templates/express-vite/src/server/main.ts
+++ b/integration/templates/express-vite/src/server/main.ts
@@ -1,0 +1,60 @@
+// Should be at the top of the file - used to load clerk secret key
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import { clerkClient } from '@clerk/clerk-sdk-node';
+import express from 'express';
+import ViteExpress from 'vite-express';
+
+const app = express();
+
+app.set('view engine', 'ejs');
+app.set('views', 'src/views');
+
+app.get('/api/protected', [clerkClient.expressRequireAuth() as any], (_req: any, res: any) => {
+  res.send('Protected API response').end();
+});
+
+app.get('/sign-in', (_req: any, res: any) => {
+  return res.render('sign-in.ejs', {
+    publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY,
+    signInUrl: process.env.CLERK_SIGN_IN_URL,
+  });
+});
+
+app.get('/', (_req: any, res: any) => {
+  return res.render('index.ejs', {
+    publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY,
+    signInUrl: process.env.CLERK_SIGN_IN_URL,
+  });
+});
+
+app.get('/sign-up', (_req: any, res: any) => {
+  return res.render('sign-up.ejs', {
+    publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY,
+    signUpUrl: process.env.CLERK_SIGN_UP_URL,
+  });
+});
+
+app.get('/protected', (_req: any, res: any) => {
+  return res.render('protected.ejs', {
+    publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY,
+    signInUrl: process.env.CLERK_SIGN_IN_URL,
+    signUpUrl: process.env.CLERK_SIGN_UP_URL,
+  });
+});
+
+// Handle authentication error, otherwise application will crash
+// @ts-ignore
+app.use((err, req, res, next) => {
+  if (err) {
+    console.error(err);
+    res.status(401).end();
+    return;
+  }
+
+  return next();
+});
+
+const port = parseInt(process.env.PORT as string) || 3002;
+ViteExpress.listen(app, port, () => console.log(`Server is listening on port ${port}...`));

--- a/integration/templates/express-vite/src/views/index.ejs
+++ b/integration/templates/express-vite/src/views/index.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script
+      data-clerk-publishable-key="<%= publishableKey %>"
+      onLoad="startClerk()"
+      crossorigin="anonymous"
+      async=""
+      src="https://clerk.clerk.com/npm/@clerk/clerk-js@4/dist/clerk.browser.js"
+    ></script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="user-state"></div>
+
+    <script>
+      window.startClerk = async () => {
+        await Clerk.load({ signInUrl: '<%= signInUrl %>' });
+        const appEl = document.querySelector('#app');
+        const controlStateEl = document.querySelector('#user-state');
+
+        if (Clerk.user) {
+          Clerk.mountUserButton(appEl);
+          controlStateEl.innerHTML = 'SignedIn';
+        } else {
+          controlStateEl.innerHTML = 'SignedOut';
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/integration/templates/express-vite/src/views/protected.ejs
+++ b/integration/templates/express-vite/src/views/protected.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script
+      data-clerk-publishable-key="<%= publishableKey %>"
+      onLoad="startClerk()"
+      crossorigin="anonymous"
+      async=""
+      src="https://clerk.clerk.com/npm/@clerk/clerk-js@4/dist/clerk.browser.js"
+    ></script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="user-state"></div>
+
+    <script>
+      window.startClerk = async () => {
+        await Clerk.load({ signInUrl: '<%= signInUrl %>' });
+
+        if (Clerk.user) {
+          const apiResponse = await fetch('/api/protected').then(res => res.text());
+
+          const div = document.createElement('div');
+          div.setAttribute('data-test-id', 'protected-api-response');
+          div.innerText = apiResponse;
+          document.body.appendChild(div);
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/integration/templates/express-vite/src/views/sign-in.ejs
+++ b/integration/templates/express-vite/src/views/sign-in.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script
+      data-clerk-publishable-key="<%= publishableKey %>"
+      onLoad="startClerk()"
+      crossorigin="anonymous"
+      async=""
+      src="https://clerk.clerk.com/npm/@clerk/clerk-js@4/dist/clerk.browser.js"
+    ></script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="user-state"></div>
+
+    <script>
+      window.startClerk = async () => {
+        await Clerk.load({ signInUrl: '<%= signInUrl %>' });
+        Clerk.mountSignIn(document.querySelector('#app'));
+      };
+    </script>
+  </body>
+</html>

--- a/integration/templates/express-vite/src/views/sign-up.ejs
+++ b/integration/templates/express-vite/src/views/sign-up.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script
+      data-clerk-publishable-key="<%= publishableKey %>"
+      onLoad="startClerk()"
+      crossorigin="anonymous"
+      async=""
+      src="https://clerk.clerk.com/npm/@clerk/clerk-js@4/dist/clerk.browser.js"
+    ></script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="user-state"></div>
+
+    <script>
+      window.startClerk = async () => {
+        await Clerk.load({ signInUrl: '<%= signInUrl %>' });
+        Clerk.mountSignUp(document.querySelector('#app'));
+      };
+    </script>
+  </body>
+</html>

--- a/integration/templates/express-vite/tsconfig.json
+++ b/integration/templates/express-vite/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/integration/templates/express-vite/vite.config.ts
+++ b/integration/templates/express-vite/vite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({});

--- a/integration/templates/index.ts
+++ b/integration/templates/index.ts
@@ -7,6 +7,7 @@ export const templates = {
   'next-app-router': resolve(__dirname, './next-app-router'),
   'react-cra': resolve(__dirname, './react-cra'),
   'react-vite': resolve(__dirname, './react-vite'),
+  'express-vite': resolve(__dirname, './express-vite'),
   'remix-node': resolve(__dirname, './remix-node'),
 } as const;
 

--- a/integration/tests/sign-in-smoke.test.ts
+++ b/integration/tests/sign-in-smoke.test.ts
@@ -38,7 +38,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('sign in s
     await u.page.pause();
   });
 
-  test('access protected page', async ({ page, context }) => {
+  test('access protected page @express', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
     await u.po.signIn.goTo();
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });

--- a/integration/tests/sign-in-smoke.test.ts
+++ b/integration/tests/sign-in-smoke.test.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { appConfigs } from '../presets';
 import type { FakeUser } from '../testUtils';
@@ -35,6 +35,18 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('sign in s
     await u.po.signIn.goTo();
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
     await u.po.expect.toBeSignedIn();
+    await u.page.pause();
+  });
+
+  test('access protected page', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+    await u.po.signIn.goTo();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+    await u.po.expect.toBeSignedIn();
+
+    expect(await u.page.locator("data-test-id='protected-api-response'").count()).toEqual(0);
+    await u.page.goToRelative('/protected');
+    await u.page.isVisible("data-test-id='protected-api-response'");
     await u.page.pause();
   });
 });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:cache:clear": "FORCE_COLOR=1 turbo test:cache:clear --continue --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:integration:base": "DEBUG=1 npx playwright test --config integration/playwright.config.ts",
     "test:integration:deployment:nextjs": "DEBUG=1 npx playwright test --config integration/playwright.deployments.config.ts",
+    "test:integration:express": "E2E_APP_ID=express.* npm run test:integration:base -- --grep \"@generic|@express\"",
     "test:integration:generic": "E2E_APP_ID=react.vite.* npm run test:integration:base -- --grep @generic",
     "test:integration:nextjs": "E2E_APP_ID=next.appRouter.withEmailCodes npm run test:integration:base -- --grep \"@generic|@nextjs\"",
     "test:integration:remix": "echo 'placeholder'",

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -9,5 +9,5 @@ done
 for d in playground/*
 do
     echo $d
-    yalc remove --all
+    npx yalc remove --all
 done

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,8 @@
     "NODE_VERSION",
     "NPM_VERSION",
     "TZ",
-    "VERCEL"
+    "VERCEL",
+    "VITE_CLERK_*"
   ],
   "pipeline": {
     "build": {
@@ -27,7 +28,6 @@
         "tsconfig.build.json",
         "tsconfig.declarations.json",
         "tsup.config.ts",
-
         "!**/**/*.test.*",
         "!**/test/**",
         "!**/tests/**",
@@ -67,7 +67,6 @@
         "tsconfig.json",
         "tsconfig.*.json",
         "tsup.config.ts",
-
         "!**/__snapshots__/**",
         "!CHANGELOG.md",
         "!coverage/**",


### PR DESCRIPTION
## Description

Add integration test to verify that `@clerk/shared` tree-shaking works in backend application that do not use `react` as dependency.
We have introduced an Express + Vite template application that uses `@clerk/clerk-sdk-node` with the following endpoints
- `/api/protected` endpoint that uses `expressRequireAuth()` from `@clerk/clerk-sdk-node` to verify authentication
- `/sign-in` renders HTML that mounts `<SignIn/>` client-side component using ClerkJS
- `/sign-up` renders HTML that mounts `<SignUp/>` client-side component using ClerkJS
- `/protected` renders HTML `SignedIn` or `SignedOut` context and makes a request to the `/api/protected` to fetch the response that will be appended in body and asserted via playwright.

https://github.com/clerkinc/javascript/issues/1883

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [x] `build/tooling/chore`
