### PR TITLE
feat(types): Unified method to retrieve OAuth and Web3 provider data

### DIFF
--- a/.changeset/giant-grapes-join.md
+++ b/.changeset/giant-grapes-join.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': minor
+---
+
+Introduced a unified method `getProvider` for retrieving provider data for both OAuth and Web3 providers.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,6 +30,7 @@ export * from './organizationSettings';
 export * from './organizationSuggestion';
 export * from './passwords';
 export * from './phoneNumber';
+export * from './providers';
 export * from './redirects';
 export * from './resource';
 export * from './saml';

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -1,8 +1,9 @@
+import { type ProviderData, ProviderType } from './providers';
 import type { OAuthStrategy } from './strategies';
 
 export type OAuthScope = string;
 
-export interface OAuthProviderData {
+export interface OAuthProviderData extends ProviderData {
   provider: OAuthProvider;
   strategy: OAuthStrategy;
   name: string;
@@ -65,150 +66,175 @@ export type OAuthProvider =
 export const OAUTH_PROVIDERS: OAuthProviderData[] = [
   {
     provider: 'google',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_google',
     name: 'Google',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-google',
   },
   {
     provider: 'discord',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_discord',
     name: 'Discord',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-discord',
   },
   {
     provider: 'facebook',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_facebook',
     name: 'Facebook',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-facebook',
   },
   {
     provider: 'twitch',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_twitch',
     name: 'Twitch',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-twitch',
   },
   {
     provider: 'twitter',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_twitter',
     name: 'Twitter',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-twitter',
   },
   {
     provider: 'microsoft',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_microsoft',
     name: 'Microsoft',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-microsoft',
   },
   {
     provider: 'tiktok',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_tiktok',
     name: 'TikTok',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-tiktok',
   },
   {
     provider: 'linkedin',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_linkedin',
     name: 'LinkedIn',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-linkedin',
   },
   {
     provider: 'linkedin_oidc',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_linkedin_oidc',
     name: 'LinkedIn',
     docsUrl: 'https://clerk.com/docs/authentication/social-connections/linkedin-oidc',
   },
   {
     provider: 'github',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_github',
     name: 'GitHub',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-github',
   },
   {
     provider: 'gitlab',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_gitlab',
     name: 'GitLab',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-gitlab',
   },
   {
     provider: 'dropbox',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_dropbox',
     name: 'Dropbox',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-dropbox',
   },
   {
     provider: 'atlassian',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_atlassian',
     name: 'Atlassian',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-atlassian',
   },
   {
     provider: 'bitbucket',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_bitbucket',
     name: 'Bitbucket',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-bitbucket',
   },
   {
     provider: 'hubspot',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_hubspot',
     name: 'HubSpot',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-hubspot',
   },
   {
     provider: 'notion',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_notion',
     name: 'Notion',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-notion',
   },
   {
     provider: 'apple',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_apple',
     name: 'Apple',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-apple',
   },
   {
     provider: 'line',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_line',
     name: 'LINE',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-line',
   },
   {
     provider: 'instagram',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_instagram',
     name: 'Instagram',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-instagram',
   },
   {
     provider: 'coinbase',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_coinbase',
     name: 'Coinbase',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-coinbase',
   },
   {
     provider: 'spotify',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_spotify',
     name: 'Spotify',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-spotify',
   },
   {
     provider: 'xero',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_xero',
     name: 'Xero',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-xero',
   },
   {
     provider: 'box',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_box',
     name: 'Box',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-box',
   },
   {
     provider: 'slack',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_slack',
     name: 'Slack',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-slack',
   },
   {
     provider: 'linear',
+    providerType: ProviderType.OAuth,
     strategy: 'oauth_linear',
     name: 'Linear',
     docsUrl: 'https://clerk.com/docs/authentication/social-connection-with-linear',

--- a/packages/types/src/providers.ts
+++ b/packages/types/src/providers.ts
@@ -1,0 +1,32 @@
+import type { OAuthProvider, OAuthProviderData } from './oauth';
+import { OAUTH_PROVIDERS } from './oauth';
+import type { OAuthStrategy, Web3Strategy } from './strategies';
+import type { Web3Provider, Web3ProviderData } from './web3';
+import { WEB3_PROVIDERS } from './web3';
+
+export interface ProviderData {
+  providerType: ProviderType;
+}
+
+export enum ProviderType {
+  OAuth = 'oauth',
+  Web3 = 'web3',
+}
+
+interface getProviderDataProps {
+  provider?: OAuthProvider | Web3Provider;
+  strategy?: OAuthStrategy | Web3Strategy;
+}
+
+export function getProviderData({
+  provider,
+  strategy,
+}: getProviderDataProps): OAuthProviderData | Web3ProviderData | undefined | null {
+  const providers = [...OAUTH_PROVIDERS, ...WEB3_PROVIDERS];
+
+  if (provider) {
+    return providers.find(oauth_provider => oauth_provider.provider == provider);
+  }
+
+  return providers.find(oauth_provider => oauth_provider.strategy == strategy);
+}

--- a/packages/types/src/web3.ts
+++ b/packages/types/src/web3.ts
@@ -1,6 +1,8 @@
+import type { ProviderData } from './providers';
+import { ProviderType } from './providers';
 import type { Web3Strategy } from './strategies';
 
-export interface Web3ProviderData {
+export interface Web3ProviderData extends ProviderData {
   provider: Web3Provider;
   strategy: Web3Strategy;
   name: string;
@@ -13,6 +15,7 @@ export type Web3Provider = MetamaskWeb3Provider;
 export const WEB3_PROVIDERS: Web3ProviderData[] = [
   {
     provider: 'metamask',
+    providerType: ProviderType.Web3,
     strategy: 'web3_metamask_signature',
     name: 'MetaMask',
   },


### PR DESCRIPTION
## Description

This PR is introducing a unified method `getProvider` for retrieving provider data for both OAuth and Web3 providers.

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [X] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
