### PR TITLE
chore(repo): Drop private package eslint-config-custom changeset

### DIFF
--- a/.changeset/metal-olives-press.md
+++ b/.changeset/metal-olives-press.md
@@ -1,5 +1,4 @@
 ---
-'eslint-config-custom': minor
 ---
 
 Extends ESLint capabilities for individual packages


### PR DESCRIPTION
## Description

Adding private packages changesets causes the changeset version to change the package.json of all packages depending on it to use the specific version even though the version may be defined as `*`. This change is causing issues in our integration tests because on setup the npm tries to retrieve the specific version from npm and fails (cannot find a private package).

We have tried using `ignore` in changeset/config.json but multiple Validation errors are thrown from the packages depending on it.

<img width="1529" alt="Screenshot 2023-11-01 at 15 07 39" src="https://github.com/clerkinc/javascript/assets/3936408/2497309b-2fa8-4d66-a551-97308d2881b2">

This fixes the issue with integrations tests in `Version Packages` PR https://github.com/clerkinc/javascript/pull/2000/files

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
