### PR TITLE
feat(clerk-js,types): Fetch custom roles and localize them

### DIFF
--- a/.changeset/famous-forks-buy.md
+++ b/.changeset/famous-forks-buy.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add support for custom roles in `<OrganizationProfile/>`.
+
+The previous roles (`admin` and `basic_member`), are still kept as a fallback.

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -9,6 +9,7 @@ import type {
   GetMembershipRequestParams,
   GetMemberships,
   GetPendingInvitationsParams,
+  GetRolesParams,
   InviteMemberParams,
   InviteMembersParams,
   OrganizationDomainJSON,
@@ -20,6 +21,7 @@ import type {
   OrganizationMembershipRequestJSON,
   OrganizationMembershipRequestResource,
   OrganizationResource,
+  RoleJSON,
   SetOrganizationLogoParams,
   UpdateMembershipParams,
   UpdateOrganizationParams,
@@ -31,6 +33,7 @@ import { convertPageToOffset } from '../../utils/pagesToOffset';
 import { BaseResource, OrganizationInvitation, OrganizationMembership } from './internal';
 import { OrganizationDomain } from './OrganizationDomain';
 import { OrganizationMembershipRequest } from './OrganizationMembershipRequest';
+import { Role } from './Role';
 
 export class Organization extends BaseResource implements OrganizationResource {
   pathRoot = '/organizations';
@@ -102,6 +105,21 @@ export class Organization extends BaseResource implements OrganizationResource {
   update = async (params: UpdateOrganizationParams): Promise<OrganizationResource> => {
     return this._basePatch({
       body: params,
+    });
+  };
+
+  getRoles = async (getRolesParams?: GetRolesParams) => {
+    return await BaseResource._fetch({
+      path: `/organizations/${this.id}/roles`,
+      method: 'GET',
+      search: convertPageToOffset(getRolesParams) as any,
+    }).then(res => {
+      const { data: roles, total_count } = res?.response as unknown as ClerkPaginatedResponse<RoleJSON>;
+
+      return {
+        total_count,
+        data: roles.map(role => new Role(role)),
+      };
     });
   };
 

--- a/packages/clerk-js/src/core/resources/Permission.ts
+++ b/packages/clerk-js/src/core/resources/Permission.ts
@@ -1,24 +1,23 @@
-import type { RoleJSON, RoleResource } from '@clerk/types';
+import type { PermissionJSON, PermissionResource } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
-import { Permission } from './Permission';
 
-export class Role extends BaseResource implements RoleResource {
+export class Permission extends BaseResource implements PermissionResource {
   id!: string;
   key!: string;
   name!: string;
   description!: string;
-  permissions: Permission[] = [];
+  type!: 'system';
   createdAt!: Date;
   updatedAt!: Date;
 
-  constructor(data: RoleJSON) {
+  constructor(data: PermissionJSON) {
     super();
     this.fromJSON(data);
   }
 
-  protected fromJSON(data: RoleJSON | null): this {
+  protected fromJSON(data: PermissionJSON | null): this {
     if (!data) {
       return this;
     }
@@ -27,7 +26,7 @@ export class Role extends BaseResource implements RoleResource {
     this.key = data.key;
     this.name = data.name;
     this.description = data.description;
-    this.permissions = data.permissions.map(perm => new Permission(perm));
+    this.type = data.type;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;

--- a/packages/clerk-js/src/core/resources/Permission.ts
+++ b/packages/clerk-js/src/core/resources/Permission.ts
@@ -11,7 +11,7 @@ export class Permission extends BaseResource implements PermissionResource {
   key!: string;
   name!: string;
   description!: string;
-  type!: 'system';
+  type!: 'system' | 'user';
   createdAt!: Date;
   updatedAt!: Date;
 

--- a/packages/clerk-js/src/core/resources/Permission.ts
+++ b/packages/clerk-js/src/core/resources/Permission.ts
@@ -3,6 +3,9 @@ import type { PermissionJSON, PermissionResource } from '@clerk/types';
 import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
 
+/**
+ * @experimental
+ */
 export class Permission extends BaseResource implements PermissionResource {
   id!: string;
   key!: string;

--- a/packages/clerk-js/src/core/resources/Role.ts
+++ b/packages/clerk-js/src/core/resources/Role.ts
@@ -4,6 +4,9 @@ import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
 import { Permission } from './Permission';
 
+/**
+ * @experimental
+ */
 export class Role extends BaseResource implements RoleResource {
   id!: string;
   key!: string;

--- a/packages/clerk-js/src/core/resources/Role.ts
+++ b/packages/clerk-js/src/core/resources/Role.ts
@@ -1,0 +1,34 @@
+import type { RoleJSON, RoleResource } from '@clerk/types';
+
+import { unixEpochToDate } from '../../utils/date';
+import { BaseResource } from './internal';
+
+export class Role extends BaseResource implements RoleResource {
+  id!: string;
+  key!: string;
+  name!: string;
+  description!: string;
+  permissions: string[] = [];
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  constructor(data: RoleJSON) {
+    super();
+    this.fromJSON(data);
+  }
+
+  protected fromJSON(data: RoleJSON | null): this {
+    if (!data) {
+      return this;
+    }
+
+    this.id = data.id;
+    this.key = data.key;
+    this.name = data.name;
+    this.description = data.description;
+    this.permissions = data.permissions;
+    this.createdAt = unixEpochToDate(data.created_at);
+    this.updatedAt = unixEpochToDate(data.updated_at);
+    return this;
+  }
+}

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -13,6 +13,7 @@ Organization {
   "getMembershipRequests": [Function],
   "getMemberships": [Function],
   "getPendingInvitations": [Function],
+  "getRoles": [Function],
   "hasImage": true,
   "id": "test_id",
   "imageUrl": "https://clerk.com",

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -17,6 +17,7 @@ OrganizationMembership {
     "getMembershipRequests": [Function],
     "getMemberships": [Function],
     "getPendingInvitations": [Function],
+    "getRoles": [Function],
     "hasImage": true,
     "id": "test_org_id",
     "imageUrl": "https://clerk.com",

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -165,7 +165,6 @@ export const CreateOrganizationForm = (props: CreateOrganizationFormProps) => {
       >
         {organization && (
           <InviteMembersForm
-            organization={organization}
             resetButtonLabel={localizationKeys('createOrganization.invitePage.formButtonReset')}
             onSuccess={wizard.nextStep}
             onReset={completeFlow}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -69,7 +69,7 @@ export const ActiveMembersList = () => {
 const MemberRow = (props: {
   membership: OrganizationMembershipResource;
   onRemove: () => unknown;
-  options: any;
+  options: Parameters<typeof RoleSelect>[0]['roles'];
   onRoleChange: (role: string) => unknown;
 }) => {
   const { membership, onRemove, onRoleChange, options } = props;

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -1,10 +1,11 @@
-import type { MembershipRole, OrganizationMembershipResource } from '@clerk/types';
+import type { OrganizationMembershipResource } from '@clerk/types';
 
 import { Gate } from '../../common/Gate';
 import { useCoreOrganization, useCoreUser } from '../../contexts';
 import { Badge, localizationKeys, Td, Text } from '../../customizables';
 import { ThreeDotsMenu, useCardState, UserPreview } from '../../elements';
-import { handleError, roleLocalizationKey } from '../../utils';
+import { useFetchRoles, useLocalizeCustomRoles } from '../../hooks/useFetchRoles';
+import { handleError } from '../../utils';
 import { DataTable, RoleSelect, RowContainer } from './MemberListTable';
 
 export const ActiveMembersList = () => {
@@ -13,11 +14,13 @@ export const ActiveMembersList = () => {
     memberships: true,
   });
 
+  const { options, isLoading: loadingRoles } = useFetchRoles();
+
   if (!organization) {
     return null;
   }
 
-  const handleRoleChange = (membership: OrganizationMembershipResource) => (newRole: MembershipRole) => {
+  const handleRoleChange = (membership: OrganizationMembershipResource) => (newRole: string) => {
     return card
       .runAsync(async () => {
         return await membership.update({ role: newRole });
@@ -41,7 +44,7 @@ export const ActiveMembersList = () => {
       onPageChange={n => memberships?.fetchPage?.(n)}
       itemCount={memberships?.count || 0}
       pageCount={memberships?.pageCount || 0}
-      isLoading={memberships?.isLoading}
+      isLoading={memberships?.isLoading || loadingRoles}
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),
@@ -53,6 +56,7 @@ export const ActiveMembersList = () => {
         <MemberRow
           key={m.id}
           membership={m}
+          options={options}
           onRoleChange={handleRoleChange(m)}
           onRemove={handleRemove(m)}
         />
@@ -65,9 +69,11 @@ export const ActiveMembersList = () => {
 const MemberRow = (props: {
   membership: OrganizationMembershipResource;
   onRemove: () => unknown;
-  onRoleChange?: (role: MembershipRole) => unknown;
+  options: any;
+  onRoleChange: (role: string) => unknown;
 }) => {
-  const { membership, onRemove, onRoleChange } = props;
+  const { membership, onRemove, onRoleChange, options } = props;
+  const { localizeCustomRole } = useLocalizeCustomRoles();
   const card = useCardState();
   const user = useCoreUser();
 
@@ -94,17 +100,13 @@ const MemberRow = (props: {
       <Td>
         <Gate
           permission={'org:sys_memberships:manage'}
-          fallback={
-            <Text
-              sx={t => ({ opacity: t.opacity.$inactive })}
-              localizationKey={roleLocalizationKey(membership.role)}
-            />
-          }
+          fallback={<Text sx={t => ({ opacity: t.opacity.$inactive })}>{localizeCustomRole(membership.role)}</Text>}
         >
           <RoleSelect
             isDisabled={card.isLoading || !onRoleChange}
             value={membership.role}
             onChange={onRoleChange}
+            roles={options}
           />
         </Gate>
       </Td>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -1,26 +1,21 @@
 import { isClerkAPIResponseError } from '@clerk/shared/error';
-import type { ClerkAPIError, MembershipRole, OrganizationResource } from '@clerk/types';
-import React from 'react';
+import type { ClerkAPIError, MembershipRole } from '@clerk/types';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 
+import { useCoreOrganization } from '../../contexts';
 import { Flex, Text } from '../../customizables';
-import {
-  Form,
-  FormButtonContainer,
-  Select,
-  SelectButton,
-  SelectOptionList,
-  TagInput,
-  useCardState,
-} from '../../elements';
+import { Form, FormButtonContainer, TagInput, useCardState } from '../../elements';
+import { useFetchRoles } from '../../hooks/useFetchRoles';
 import type { LocalizationKey } from '../../localization';
 import { localizationKeys, useLocalizations } from '../../localization';
 import { useRouter } from '../../router';
-import { createListFormat, handleError, roleLocalizationKey, useFormControl } from '../../utils';
+import { createListFormat, handleError, useFormControl } from '../../utils';
+import { RoleSelect } from './MemberListTable';
 
 const isEmail = (str: string) => /^\S+@\S+\.\S+$/.test(str);
 
 type InviteMembersFormProps = {
-  organization: OrganizationResource;
   onSuccess: () => void;
   onReset?: () => void;
   primaryButtonLabel?: LocalizationKey;
@@ -29,21 +24,17 @@ type InviteMembersFormProps = {
 
 export const InviteMembersForm = (props: InviteMembersFormProps) => {
   const { navigate } = useRouter();
-  const { onSuccess, onReset = () => navigate('..'), resetButtonLabel, organization } = props;
+  const { onSuccess, onReset = () => navigate('..'), resetButtonLabel } = props;
+  const { organization } = useCoreOrganization();
   const card = useCardState();
   const { t, locale } = useLocalizations();
-  const [isValidUnsubmittedEmail, setIsValidUnsubmittedEmail] = React.useState(false);
+  const [isValidUnsubmittedEmail, setIsValidUnsubmittedEmail] = useState(false);
 
   if (!organization) {
     return null;
   }
 
   const validateUnsubmittedEmail = (value: string) => setIsValidUnsubmittedEmail(isEmail(value));
-
-  const roles: Array<{ label: string; value: MembershipRole }> = [
-    { label: t(roleLocalizationKey('admin')), value: 'admin' },
-    { label: t(roleLocalizationKey('basic_member')), value: 'basic_member' },
-  ];
 
   const emailAddressField = useFormControl('emailAddress', '', {
     type: 'text',
@@ -67,18 +58,17 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     },
   } = emailAddressField;
 
-  const roleField = useFormControl('role', 'basic_member', {
-    options: roles,
-    label: localizationKeys('formFieldLabel__role'),
-    placeholder: '',
-  });
-
   const canSubmit = !!emailAddressField.value.length || isValidUnsubmittedEmail;
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    const submittedData = new FormData(e.currentTarget);
     return organization
-      .inviteMembers({ emailAddresses: emailAddressField.value.split(','), role: roleField.value as MembershipRole })
+      .inviteMembers({
+        emailAddresses: emailAddressField.value.split(','),
+        role: submittedData.get('role') as MembershipRole,
+      })
       .then(onSuccess)
       .catch(err => {
         if (isClerkAPIResponseError(err)) {
@@ -132,25 +122,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
           />
         </Flex>
       </Form.ControlRow>
-      <Form.ControlRow elementId={roleField.id}>
-        <Flex
-          direction='col'
-          gap={2}
-        >
-          <Text localizationKey={roleField.label} />
-          {/*@ts-expect-error  Select expects options to be an array but useFormControl returns an optional field. */}
-          <Select
-            elementId='role'
-            {...roleField.props}
-            onChange={option => roleField.setValue(option.value)}
-          >
-            <SelectButton sx={t => ({ width: t.sizes.$48, justifyContent: 'space-between', display: 'flex' })}>
-              {roleField.props.options?.find(o => o.value === roleField.value)?.label}
-            </SelectButton>
-            <SelectOptionList sx={t => ({ minWidth: t.sizes.$48 })} />
-          </Select>
-        </Flex>
-      </Form.ControlRow>
+      <AsyncRoleSelect />
       <FormButtonContainer>
         <Form.SubmitButton
           block={false}
@@ -164,5 +136,31 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
         />
       </FormButtonContainer>
     </Form.Root>
+  );
+};
+
+const AsyncRoleSelect = () => {
+  const { options, isLoading } = useFetchRoles();
+  const roleField = useFormControl('role', '', {
+    label: localizationKeys('formFieldLabel__role'),
+  });
+
+  return (
+    <Form.ControlRow elementId={roleField.id}>
+      <Flex
+        direction='col'
+        gap={2}
+      >
+        <Text localizationKey={roleField.label} />
+        <RoleSelect
+          {...roleField.props}
+          roles={options}
+          isDisabled={isLoading}
+          onChange={value => roleField.setValue(value)}
+          triggerSx={t => ({ width: t.sizes.$48, justifyContent: 'space-between', display: 'flex' })}
+          optionListSx={t => ({ minWidth: t.sizes.$48 })}
+        />
+      </Flex>
+    </Form.ControlRow>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersPage.tsx
@@ -40,10 +40,7 @@ export const InviteMembersPage = withCardStateProvider(() => {
             __unstable_manageBillingMembersLimit={__unstable_manageBillingMembersLimit}
           />
         )}
-        <InviteMembersForm
-          organization={organization}
-          onSuccess={wizard.nextStep}
-        />
+        <InviteMembersForm onSuccess={wizard.nextStep} />
       </ContentPage>
       <SuccessPage
         title={title}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -3,7 +3,8 @@ import type { OrganizationInvitationResource } from '@clerk/types';
 import { useCoreOrganization } from '../../contexts';
 import { localizationKeys, Td, Text } from '../../customizables';
 import { ThreeDotsMenu, useCardState, UserPreview } from '../../elements';
-import { handleError, roleLocalizationKey } from '../../utils';
+import { useLocalizeCustomRoles } from '../../hooks/useFetchRoles';
+import { handleError } from '../../utils';
 import { DataTable, RowContainer } from './MemberListTable';
 
 export const InvitedMembersList = () => {
@@ -52,6 +53,7 @@ export const InvitedMembersList = () => {
 
 const InvitationRow = (props: { invitation: OrganizationInvitationResource; onRevoke: () => unknown }) => {
   const { invitation, onRevoke } = props;
+  const { localizeCustomRole } = useLocalizeCustomRoles();
   return (
     <RowContainer>
       <Td>
@@ -64,7 +66,7 @@ const InvitationRow = (props: { invitation: OrganizationInvitationResource; onRe
       <Td>
         <Text
           colorScheme={'neutral'}
-          localizationKey={roleLocalizationKey(invitation.role)}
+          localizationKey={localizeCustomRole(invitation.role)}
         />
       </Td>
       <Td>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -138,19 +138,19 @@ export const RoleSelect = (props: {
 
   const shouldDisplayLegacyRoles = !roles;
 
-  const legacy_roles: Array<{ label: string; value: MembershipRole }> = [
+  const legacyRoles: Array<{ label: string; value: MembershipRole }> = [
     { label: 'admin', value: 'admin' },
     { label: 'basic_member', value: 'basic_member' },
   ];
 
-  const legacy_excludedRoles: Array<{ label: string; value: MembershipRole }> = [
+  const legacyExcludedRoles: Array<{ label: string; value: MembershipRole }> = [
     { label: 'guest_member', value: 'guest_member' },
   ];
   const { localizeCustomRole } = useLocalizeCustomRoles();
 
-  const selectedRole = [...(roles || []), ...legacy_roles, ...legacy_excludedRoles].find(r => r.value === value);
+  const selectedRole = [...(roles || []), ...legacyRoles, ...legacyExcludedRoles].find(r => r.value === value);
 
-  const localizedOptions = (!shouldDisplayLegacyRoles ? roles : legacy_roles).map(role => ({
+  const localizedOptions = (!shouldDisplayLegacyRoles ? roles : legacyRoles).map(role => ({
     value: role.value,
     label: localizeCustomRole(role.value) || role.label,
   }));

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -2,23 +2,10 @@ import type { MembershipRole } from '@clerk/types';
 import React from 'react';
 
 import type { LocalizationKey } from '../../customizables';
-import {
-  Col,
-  descriptors,
-  Flex,
-  Spinner,
-  Table,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-  useLocalizations,
-} from '../../customizables';
+import { Col, descriptors, Flex, Spinner, Table, Tbody, Td, Text, Th, Thead, Tr } from '../../customizables';
 import { Pagination, Select, SelectButton, SelectOptionList } from '../../elements';
-import type { PropsOfComponent } from '../../styledSystem';
-import { roleLocalizationKey } from '../../utils';
+import { useLocalizeCustomRoles } from '../../hooks/useFetchRoles';
+import type { PropsOfComponent, ThemableCssProp } from '../../styledSystem';
 
 type MembersListTableProps = {
   headers: LocalizationKey[];
@@ -139,38 +126,61 @@ export const RowContainer = (props: PropsOfComponent<typeof Tr>) => {
   );
 };
 
-export const RoleSelect = (props: { value: MembershipRole; onChange: any; isDisabled?: boolean }) => {
-  const { value, onChange, isDisabled } = props;
-  const { t } = useLocalizations();
+export const RoleSelect = (props: {
+  roles: { label: string; value: string }[] | undefined;
+  value: MembershipRole;
+  onChange: (params: string) => unknown;
+  isDisabled?: boolean;
+  triggerSx?: ThemableCssProp;
+  optionListSx?: ThemableCssProp;
+}) => {
+  const { value, roles, onChange, isDisabled, triggerSx, optionListSx } = props;
 
-  const roles: Array<{ label: string; value: MembershipRole }> = [
-    { label: t(roleLocalizationKey('admin')), value: 'admin' },
-    { label: t(roleLocalizationKey('basic_member')), value: 'basic_member' },
+  const shouldDisplayLegacyRoles = !roles;
+
+  const legacy_roles: Array<{ label: string; value: MembershipRole }> = [
+    { label: 'admin', value: 'admin' },
+    { label: 'basic_member', value: 'basic_member' },
   ];
 
-  const excludedRoles: Array<{ label: string; value: MembershipRole }> = [
-    { label: t(roleLocalizationKey('guest_member')), value: 'guest_member' },
+  const legacy_excludedRoles: Array<{ label: string; value: MembershipRole }> = [
+    { label: 'guest_member', value: 'guest_member' },
   ];
+  const { localizeCustomRole } = useLocalizeCustomRoles();
 
-  const selectedRole = [...roles, ...excludedRoles].find(r => r.value === value);
+  const selectedRole = [...(roles || []), ...legacy_roles, ...legacy_excludedRoles].find(r => r.value === value);
+
+  const localizedOptions = (!shouldDisplayLegacyRoles ? roles : legacy_roles).map(role => ({
+    value: role.value,
+    label: localizeCustomRole(role.value) || role.label,
+  }));
 
   return (
     <Select
       elementId='role'
-      options={roles}
+      options={localizedOptions}
       value={value}
       onChange={role => onChange(role.value)}
     >
+      {/*Store value inside an input in order to be accessible as form data*/}
+      <input
+        name='role'
+        type='hidden'
+        value={value}
+      />
       <SelectButton
-        sx={t => ({
-          color: t.colors.$colorTextSecondary,
-          backgroundColor: 'transparent',
-        })}
+        sx={
+          triggerSx ||
+          (t => ({
+            color: t.colors.$colorTextSecondary,
+            backgroundColor: 'transparent',
+          }))
+        }
         isDisabled={isDisabled}
       >
-        {selectedRole?.label}
+        {localizeCustomRole(selectedRole?.value) || selectedRole?.label}
       </SelectButton>
-      <SelectOptionList />
+      <SelectOptionList sx={optionListSx} />
     </Select>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -1,6 +1,7 @@
 import type { MembershipRole, OrganizationInvitationResource } from '@clerk/types';
 import { describe } from '@jest/globals';
 import { waitFor } from '@testing-library/dom';
+import { act } from '@testing-library/react';
 import React from 'react';
 
 import { ClerkAPIResponseError } from '../../../../core/resources';
@@ -18,7 +19,7 @@ describe('InviteMembersPage', () => {
     });
 
     fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
-    const { getByText } = render(<InviteMembersPage />, { wrapper });
+    const { getByText } = await act(() => render(<InviteMembersPage />, { wrapper }));
     expect(getByText('Invite new members to this organization')).toBeDefined();
   });
 
@@ -59,6 +60,43 @@ describe('InviteMembersPage', () => {
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
         emailAddresses: ['test+1@clerk.com'],
         role: 'basic_member' as MembershipRole,
+      });
+    });
+
+    it('fetches custom role and sends invite to email entered and teacher role when clicking Send', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getRoles.mockResolvedValueOnce({
+        data: [
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: '1',
+            description: '',
+            updatedAt: new Date(),
+            createdAt: new Date(),
+            permissions: [],
+            name: 'Teacher',
+            key: 'org:teacher',
+          },
+        ],
+        total_count: 1,
+      });
+      fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
+      const { getByRole, userEvent, getByTestId, getByText } = render(<InviteMembersPage />, { wrapper });
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await userEvent.click(getByRole('button', { name: 'Select an option' }));
+      await userEvent.click(getByText('Teacher'));
+      await userEvent.click(getByRole('button', { name: 'Send invitations' }));
+      expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
+        emailAddresses: ['test+1@clerk.com'],
+        role: 'org:teacher' as MembershipRole,
       });
     });
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -12,18 +12,19 @@ const { createFixtures } = bindCreateFixtures('OrganizationProfile');
 
 describe('InviteMembersPage', () => {
   it('renders the component', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     const { getByText } = render(<InviteMembersPage />, { wrapper });
     expect(getByText('Invite new members to this organization')).toBeDefined();
   });
 
   describe('Submitting', () => {
     it('enables the Send button when one or more email has been entered', async () => {
-      const { wrapper } = await createFixtures(f => {
+      const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
           email_addresses: ['test@clerk.com'],
@@ -31,6 +32,7 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
 
@@ -47,9 +49,12 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, userEvent, getByTestId, getByText } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await userEvent.click(getByRole('button', { name: 'Select an option' }));
+      await userEvent.click(getByText('Member'));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
         emailAddresses: ['test+1@clerk.com'],
@@ -66,12 +71,15 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, userEvent, getByTestId, getByText } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(
         getByTestId('tag-input'),
         'test+1@clerk.com,test+2@clerk.com,test+3@clerk.com,test+4@clerk.com,',
       );
+      await userEvent.click(getByRole('button', { name: 'Select an option' }));
+      await userEvent.click(getByText('Member'));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
         emailAddresses: ['test+1@clerk.com', 'test+2@clerk.com', 'test+3@clerk.com', 'test+4@clerk.com'],
@@ -88,10 +96,11 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
       const { getByRole, userEvent, getByText, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
-      await userEvent.click(getByRole('button', { name: 'Member' }));
+      await userEvent.click(getByRole('button', { name: 'Select an option' }));
       await userEvent.click(getByText('Admin'));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
@@ -109,6 +118,7 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockRejectedValueOnce(
         new ClerkAPIResponseError('Error', {
           data: [
@@ -143,6 +153,7 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockRejectedValueOnce(
         new ClerkAPIResponseError('Error', {
           data: [
@@ -173,6 +184,7 @@ describe('InviteMembersPage', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.organization?.inviteMembers.mockRejectedValueOnce(
         new ClerkAPIResponseError('Error', {
           data: [
@@ -203,6 +215,7 @@ describe('InviteMembersPage', () => {
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
       const { getByRole, userEvent } = render(<InviteMembersPage />, { wrapper });
       await userEvent.click(getByRole('button', { name: 'Cancel' }));

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -13,11 +13,11 @@ const { createFixtures } = bindCreateFixtures('OrganizationProfile');
 
 describe('OrganizationMembers', () => {
   it('renders the Organization Members page', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1'] });
     });
-
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     const { getByText, getByRole } = render(<OrganizationMembers />, { wrapper });
 
     await waitFor(() => {
@@ -33,11 +33,13 @@ describe('OrganizationMembers', () => {
   });
 
   it('shows requests if domains is turned on', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withOrganizationDomains();
       f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1'] });
     });
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     const { getByRole } = render(<OrganizationMembers />, { wrapper });
 
@@ -47,10 +49,12 @@ describe('OrganizationMembers', () => {
   });
 
   it('shows an invite button inside invitations tab if the current user is an admin', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     const { getByRole, getByText } = render(<OrganizationMembers />, { wrapper });
 
@@ -62,13 +66,15 @@ describe('OrganizationMembers', () => {
   });
 
   it('does not show invitations and requests if user is not an admin', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
         email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', permissions: [] }],
       });
     });
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     const { queryByRole } = render(<OrganizationMembers />, { wrapper });
 
@@ -84,6 +90,8 @@ describe('OrganizationMembers', () => {
       f.withOrganizations();
       f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     const { getByRole } = render(<OrganizationMembers />, { wrapper });
 
@@ -145,6 +153,8 @@ describe('OrganizationMembers', () => {
         total_count: 2,
       }),
     );
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     const { queryByText, queryAllByRole } = render(<OrganizationMembers />, { wrapper });
 
@@ -220,6 +230,7 @@ describe('OrganizationMembers', () => {
       });
     });
 
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     fixtures.clerk.organization?.getMembershipRequests.mockReturnValue(
       Promise.resolve({
         data: [],
@@ -261,6 +272,8 @@ describe('OrganizationMembers', () => {
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
+
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
 
     fixtures.clerk.organization?.getInvitations.mockReturnValue(
       Promise.resolve({
@@ -310,6 +323,8 @@ describe('OrganizationMembers', () => {
       });
     });
 
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
+
     fixtures.clerk.organization?.getDomains.mockReturnValue(
       Promise.resolve({
         data: [],
@@ -347,6 +362,7 @@ describe('OrganizationMembers', () => {
       });
     });
 
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     fixtures.clerk.organization?.getMemberships.mockReturnValue(
       Promise.resolve({
         data: membersList,

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useLoadingStatus } from './useLoadingStatus';
 import { useSafeState } from './useSafeState';
@@ -17,7 +17,7 @@ export const useFetch = <T>(
 
   const fetcherRef = useRef(fetcher);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!fetcherRef.current) {
       return;
     }

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import { useLoadingStatus } from './useLoadingStatus';
 import { useSafeState } from './useSafeState';
@@ -17,7 +17,7 @@ export const useFetch = <T>(
 
   const fetcherRef = useRef(fetcher);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!fetcherRef.current) {
       return;
     }

--- a/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
@@ -1,0 +1,25 @@
+import { useCoreOrganization } from '../contexts';
+import { useLocalizations } from '../localization';
+import { customRoleLocalizationKey, roleLocalizationKey } from '../utils';
+import { useFetch } from './useFetch';
+
+const getRolesParams = {
+  pageSize: 20,
+};
+export const useFetchRoles = () => {
+  const { organization } = useCoreOrganization();
+  const { data, status } = useFetch(organization?.getRoles, getRolesParams);
+
+  return {
+    isLoading: status.isLoading,
+    options: data?.data?.map(role => ({ value: role.key, label: role.name })),
+  };
+};
+
+export const useLocalizeCustomRoles = () => {
+  const { t } = useLocalizations();
+  return {
+    localizeCustomRole: (param: string | undefined) =>
+      t(customRoleLocalizationKey(param)) || t(roleLocalizationKey(param)),
+  };
+};

--- a/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
@@ -4,6 +4,10 @@ import { customRoleLocalizationKey, roleLocalizationKey } from '../utils';
 import { useFetch } from './useFetch';
 
 const getRolesParams = {
+  /**
+   * Fetch at most 20 roles, it is not expected for an app to have more.
+   * We also prevent the creation of more than 20 roles in dashboard.
+   */
   pageSize: 20,
 };
 export const useFetchRoles = () => {

--- a/packages/clerk-js/src/ui/utils/roleLocalizationKey.ts
+++ b/packages/clerk-js/src/ui/utils/roleLocalizationKey.ts
@@ -9,6 +9,16 @@ const roleToLocalizationKey: Record<MembershipRole, LocalizationKey> = {
   admin: localizationKeys('membershipRole__admin'),
 };
 
-export const roleLocalizationKey = (role: MembershipRole): LocalizationKey => {
+export const roleLocalizationKey = (role: MembershipRole | undefined): LocalizationKey | undefined => {
+  if (!role) {
+    return undefined;
+  }
   return roleToLocalizationKey[role];
+};
+
+export const customRoleLocalizationKey = (role: MembershipRole | undefined): LocalizationKey | undefined => {
+  if (!role) {
+    return undefined;
+  }
+  return localizationKeys(`roles.${role}`);
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,7 @@ export * from './organizationMembershipRequest';
 export * from './organizationSettings';
 export * from './organizationSuggestion';
 export * from './passwords';
+export * from './permission';
 export * from './phoneNumber';
 export * from './redirects';
 export * from './resource';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,7 @@ export * from './passwords';
 export * from './phoneNumber';
 export * from './redirects';
 export * from './resource';
+export * from './role';
 export * from './saml';
 export * from './samlAccount';
 export * from './session';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -363,6 +363,9 @@ export interface OrganizationDomainJSON extends ClerkResourceJSON {
   total_pending_suggestions: number;
 }
 
+/**
+ * @experimental
+ */
 export interface RoleJSON extends ClerkResourceJSON {
   object: 'role';
   id: string;
@@ -374,6 +377,9 @@ export interface RoleJSON extends ClerkResourceJSON {
   updated_at: number;
 }
 
+/**
+ * @experimental
+ */
 export interface PermissionJSON extends ClerkResourceJSON {
   object: 'permission';
   id: string;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -363,6 +363,17 @@ export interface OrganizationDomainJSON extends ClerkResourceJSON {
   total_pending_suggestions: number;
 }
 
+export interface RoleJSON extends ClerkResourceJSON {
+  object: 'role';
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  permissions: string[];
+  created_at: number;
+  updated_at: number;
+}
+
 export interface PublicOrganizationDataJSON {
   id: string;
   name: string;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -369,7 +369,18 @@ export interface RoleJSON extends ClerkResourceJSON {
   key: string;
   name: string;
   description: string;
-  permissions: string[];
+  permissions: PermissionJSON[];
+  created_at: number;
+  updated_at: number;
+}
+
+export interface PermissionJSON extends ClerkResourceJSON {
+  object: 'permission';
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  type: 'system';
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -386,7 +386,7 @@ export interface PermissionJSON extends ClerkResourceJSON {
   key: string;
   name: string;
   description: string;
-  type: 'system';
+  type: 'system' | 'user';
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -15,6 +15,9 @@ export type LocalizationResource = DeepPartial<_LocalizationResource>;
 
 type _LocalizationResource = {
   locale: string;
+  roles: {
+    [r: string]: LocalizationValue;
+  };
   socialButtonsBlockButton: LocalizationValue;
   dividerText: LocalizationValue;
   formFieldLabel__emailAddress: LocalizationValue;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -15,6 +15,11 @@ export type LocalizationResource = DeepPartial<_LocalizationResource>;
 
 type _LocalizationResource = {
   locale: string;
+  /**
+   * @experimental
+   * Add role keys and their localized value
+   * e.g. roles:{ 'org:teacher': 'Teacher'}
+   */
   roles: {
     [r: string]: LocalizationValue;
   };

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -4,6 +4,7 @@ import type { OrganizationInvitationResource, OrganizationInvitationStatus } fro
 import type { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
 import type { OrganizationMembershipRequestResource } from './organizationMembershipRequest';
 import type { ClerkResource } from './resource';
+import type { RoleResource } from './role';
 
 declare global {
   /**
@@ -49,6 +50,7 @@ export interface OrganizationResource extends ClerkResource {
    */
   getPendingInvitations: (params?: GetPendingInvitationsParams) => Promise<OrganizationInvitationResource[]>;
   getInvitations: (params?: GetInvitationsParams) => Promise<ClerkPaginatedResponse<OrganizationInvitationResource>>;
+  getRoles: (params?: GetRolesParams) => Promise<ClerkPaginatedResponse<RoleResource>>;
   getDomains: (params?: GetDomainsParams) => Promise<ClerkPaginatedResponse<OrganizationDomainResource>>;
   getMembershipRequests: (
     params?: GetMembershipRequestParams,
@@ -70,6 +72,17 @@ export interface OrganizationResource extends ClerkResource {
 export type GetMembershipsParams = {
   role?: MembershipRole[];
 } & ClerkPaginationParams;
+
+export type GetRolesParams = {
+  /**
+   * This is the starting point for your fetched results. The initial value persists between re-renders
+   */
+  initialPage?: number;
+  /**
+   * Maximum number of items returned per request. The initial value persists between re-renders
+   */
+  pageSize?: number;
+};
 
 export type GetMembersParams = {
   /**

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -50,6 +50,9 @@ export interface OrganizationResource extends ClerkResource {
    */
   getPendingInvitations: (params?: GetPendingInvitationsParams) => Promise<OrganizationInvitationResource[]>;
   getInvitations: (params?: GetInvitationsParams) => Promise<ClerkPaginatedResponse<OrganizationInvitationResource>>;
+  /**
+   * @experimental
+   */
   getRoles: (params?: GetRolesParams) => Promise<ClerkPaginatedResponse<RoleResource>>;
   getDomains: (params?: GetDomainsParams) => Promise<ClerkPaginatedResponse<OrganizationDomainResource>>;
   getMembershipRequests: (
@@ -73,6 +76,9 @@ export type GetMembershipsParams = {
   role?: MembershipRole[];
 } & ClerkPaginationParams;
 
+/**
+ * @experimental
+ */
 export type GetRolesParams = {
   /**
    * This is the starting point for your fetched results. The initial value persists between re-renders

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -40,7 +40,9 @@ export interface OrganizationMembershipResource extends ClerkResource {
   update: (updateParams: UpdateOrganizationMembershipParams) => Promise<OrganizationMembershipResource>;
 }
 
-export type MembershipRole = 'admin' | 'basic_member' | 'guest_member';
+// Adding (string & {}) allows for getting eslint autocomplete but also accepts any string
+// eslint-disable-next-line
+export type MembershipRole = 'admin' | 'basic_member' | 'guest_member' | (string & {});
 
 export type OrganizationPermission =
   | 'org:sys_domains:manage'

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -1,12 +1,11 @@
-import type { PermissionResource } from './permission';
 import type { ClerkResource } from './resource';
 
-export interface RoleResource extends ClerkResource {
+export interface PermissionResource extends ClerkResource {
   id: string;
   key: string;
   name: string;
+  type: 'system';
   description: string;
-  permissions: PermissionResource[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -1,5 +1,8 @@
 import type { ClerkResource } from './resource';
 
+/**
+ * @experimental
+ */
 export interface PermissionResource extends ClerkResource {
   id: string;
   key: string;

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -7,7 +7,7 @@ export interface PermissionResource extends ClerkResource {
   id: string;
   key: string;
   name: string;
-  type: 'system';
+  type: 'system' | 'user';
   description: string;
   createdAt: Date;
   updatedAt: Date;

--- a/packages/types/src/role.ts
+++ b/packages/types/src/role.ts
@@ -1,6 +1,9 @@
 import type { PermissionResource } from './permission';
 import type { ClerkResource } from './resource';
 
+/**
+ * @experimental
+ */
 export interface RoleResource extends ClerkResource {
   id: string;
   key: string;

--- a/packages/types/src/role.ts
+++ b/packages/types/src/role.ts
@@ -1,0 +1,11 @@
+import type { ClerkResource } from './resource';
+
+export interface RoleResource extends ClerkResource {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  permissions: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Description

This PR
- Introduces RoleResource and PermissionResource.
- Updates RoleSelect to accept roles as a prop.
- Fetch custom roles from FAPI inside `InviteMembersPage` & `ActiveMembers`.
- Accept custom localizations based on role key when this is passed in the localization object via ClerkProvider.

**This PR will need to backported to v4 as it is complementary to "custom roles & permissions"**
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
