### PR TITLE
chore(repo): Rename `@staging` tag to `@canary`

### DIFF
--- a/.changeset/curvy-mails-rhyme.md
+++ b/.changeset/curvy-mails-rhyme.md
@@ -3,4 +3,4 @@
 '@clerk/shared': patch
 ---
 
-Rename the @staging tag to @canary
+Rename the @staging tag to @canary. Drop support for @next tag.

--- a/.changeset/curvy-mails-rhyme.md
+++ b/.changeset/curvy-mails-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Rename the @staging tag to @canary

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,5 +1,5 @@
-name: Staging release
-run-name: Staging release from ${{ github.ref_name }}
+name: Canary release
+run-name: Canary release from ${{ github.ref_name }}
 
 on:
   push:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  staging-release:
+  canary-release:
     if: ${{ github.repository == 'clerk/javascript' }}
     runs-on: ${{ vars.RUNNER_NORMAL }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
@@ -29,13 +29,13 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Version packages for staging
+      - name: Version packages for canary
         id: version-packages
-        run: npm run version:staging | tail -1 >> "$GITHUB_OUTPUT"
+        run: npm run version:canary | tail -1 >> "$GITHUB_OUTPUT"
 
-      - name: Staging release
+      - name: Canary release
         if: steps.version-packages.outputs.success == '1'
-        run: npm run release:staging
+        run: npm run release:canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -51,23 +51,23 @@ jobs:
             const clerkjsVersion = require('./packages/clerk-js/package.json').version;
             const nextjsVersion = require('./packages/nextjs/package.json').version;
 
-            if (clerkjsVersion.includes('staging')) {
+            if (clerkjsVersion.includes('canary')) {
               console.log('clerk-js changed, will notify clerk/cloudflare-workers');
               github.rest.actions.createWorkflowDispatch({
                 owner: 'clerk',
                 repo: 'cloudflare-workers',
-                workflow_id: 'release-staging-clerkjs-proxy.yml',
+                workflow_id: 'release-canary-clerkjs-proxy.yml',
                 ref: 'main',
                 inputs: { version: clerkjsVersion }
               })
             }
 
-            if (nextjsVersion.includes('staging')) {
+            if (nextjsVersion.includes('canary')) {
               console.log('clerk/nextjs changed, will notify clerk/accounts');
               github.rest.actions.createWorkflowDispatch({
                 owner: 'clerk',
                 repo: 'accounts',
-                workflow_id: 'release-staging.yml',
+                workflow_id: 'release-canary.yml',
                 ref: 'main',
                 inputs: { version: nextjsVersion }
               })

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -67,7 +67,7 @@ jobs:
               github.rest.actions.createWorkflowDispatch({
                 owner: 'clerk',
                 repo: 'accounts',
-                workflow_id: 'release-canary.yml',
+                workflow_id: 'release-staging.yml',
                 ref: 'main',
                 inputs: { version: nextjsVersion }
               })

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -2,10 +2,10 @@
 
 ## TLDR (day-to-day dev flow)
 
-Every time a PR is merged into `main`, an automated staging release will happen. Once the packages are pushed to `npm`, the following actions will take place:
+Every time a PR is merged into `main`, an automated canary release will happen. Once the packages are pushed to `npm`, the following actions will take place:
 
-- The staging `clerkjs-proxy` worker will start serving the most recent `@staging` version of `@clerk/clerk-js`, completely bypassing any Cloudflare and JSDeliver edge caches.
-- The staging Accounts project will be deployed using the most recent `@staging` version of `@clerk/nextjs`.
+- The canary `clerkjs-proxy` worker will start serving the most recent `@canary` version of `@clerk/clerk-js`, completely bypassing any Cloudflare and JSDeliver edge caches.
+- The canary Accounts project will be deployed using the most recent `@canary` version of `@clerk/nextjs`.
 
 ## Stable releases
 
@@ -17,16 +17,16 @@ Actions that will be triggered:
 
 For more details, refer to [PUBLISH.md](https://github.com/clerk/javascript/blob/main/docs/PUBLISH.md).
 
-## Automated staging releases
+## Automated canary releases
 
-A staging release will be triggered every time PR is merged into `main`. Once versioning and publishing is done, the `clerk/javascript` repo will dispatch a workflow event, notifying other related Clerk repos of the new releases.
+A canary release will be triggered every time PR is merged into `main`. Once versioning and publishing is done, the `clerk/javascript` repo will dispatch a workflow event, notifying other related Clerk repos of the new releases.
 
 Actions that will be triggered:
 
-- `clerk/cloudflare-workers`: The latest clerk-js versions in `clerkjs-proxy/wrangler.toml` will be updated and directly committed to `main`. A second workflow will perform a staging release of the `clerkjs-proxy` worker.
-- `clerk/accounts`: A new Accounts deployment will take place, using the most recent staging `@clerk/nextjs` version. This change will not be committed to `main`.
+- `clerk/cloudflare-workers`: The latest clerk-js versions in `clerkjs-proxy/wrangler.toml` will be updated and directly committed to `main`. A second workflow will perform a canary release of the `clerkjs-proxy` worker.
+- `clerk/accounts`: A new Accounts deployment will take place, using the most recent canary `@clerk/nextjs` version. This change will not be committed to `main`.
 
-For more details about staging releases, refer to [PUBLISH.md](https://github.com/clerk/javascript/blob/main/docs/PUBLISH.md).
+For more details about canary releases, refer to [PUBLISH.md](https://github.com/clerk/javascript/blob/main/docs/PUBLISH.md).
 
 ## Quality checks
 

--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -10,13 +10,13 @@ Every time a PR is merged into `main`, the changesets action parses all changese
 
 To release a new stable version of all Clerk packages, find the "Version Packages" PR, verify the changes, and merge it.
 
-## Publishing staging package versions (`@staging`)
+## Publishing canary package versions (`@canary`)
 
-An automated staging release will be take place every time a PR gets merged into `main`.
+An automated canary release will be take place every time a PR gets merged into `main`.
 
-- Staging versions use the following format: `@clerk/package@x.y.z-staging.commit`, where `package` is the package name, `x`,`y`,`z` are the major, minor and patch versions respectively, `staging` is a stable prerelease mame and `commit` is the id of the last commit in the branch.
-- Currently, staging version changes are _not_ committed to the repo and no git tags will be generated. Using this strategy, we avoid merge conflicts, allowing us to constantly deploy staging versions without switching the repo to a "prerelease" mode.
-- During a staging release, `@clerk/clerk-js` will also be released. If needed, use the `clerkJSVersion` prop to use a specific version, eg: `<ClerkProvider clerkJSVersion='4.1.1-staging.90012' />`
+- Staging versions use the following format: `@clerk/package@x.y.z-canary.commit`, where `package` is the package name, `x`,`y`,`z` are the major, minor and patch versions respectively, `canary` is a stable prerelease mame and `commit` is the id of the last commit in the branch.
+- Currently, canary version changes are _not_ committed to the repo and no git tags will be generated. Using this strategy, we avoid merge conflicts, allowing us to constantly deploy canary versions without switching the repo to a "prerelease" mode.
+- During a canary release, `@clerk/clerk-js` will also be released. If needed, use the `clerkJSVersion` prop to use a specific version, eg: `<ClerkProvider clerkJSVersion='4.1.1-canary.90012' />`
 - A package will not be published if it's not affected by a changeset.
 
 ## Publishing snapshot package versions (`@snapshot`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8268,7 +8268,7 @@
       "version": "18.18.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
       "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -10476,9 +10476,8 @@
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -10488,9 +10487,8 @@
     },
     "node_modules/basic-auth/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -12254,9 +12252,8 @@
     },
     "node_modules/corser": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -18585,9 +18582,8 @@
     },
     "node_modules/http-server": {
       "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
-      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "^2.0.1",
         "chalk": "^4.1.2",
@@ -18612,9 +18608,8 @@
     },
     "node_modules/http-server/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -18627,9 +18622,8 @@
     },
     "node_modules/http-server/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -18643,9 +18637,8 @@
     },
     "node_modules/http-server/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -18655,24 +18648,21 @@
     },
     "node_modules/http-server/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-server/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/http-server/node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -18682,9 +18672,8 @@
     },
     "node_modules/http-server/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -25230,9 +25219,8 @@
     },
     "node_modules/portfinder": {
       "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
-      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^2.6.4",
         "debug": "^3.2.7",
@@ -25244,18 +25232,16 @@
     },
     "node_modules/portfinder/node_modules/async": {
       "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
     },
     "node_modules/portfinder/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -27540,9 +27526,8 @@
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -30486,9 +30471,6 @@
     },
     "node_modules/typescript": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -30564,7 +30546,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -30604,8 +30586,6 @@
     },
     "node_modules/union": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "dev": true,
       "dependencies": {
         "qs": "^6.4.0"
@@ -30742,9 +30722,8 @@
     },
     "node_modules/url-join": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/url-loader": {
       "version": "4.1.1",
@@ -32530,7 +32509,6 @@
         "@babel/preset-typescript": "^7.12.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@svgr/webpack": "^6.2.1",
-        "@types/node": "^18.18.0",
         "@types/qs": "^6.9.3",
         "@types/react": "*",
         "@types/react-dom": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -687,7 +686,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -969,7 +968,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -980,7 +979,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -991,7 +990,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1080,7 +1079,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1091,7 +1090,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1102,7 +1101,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.21.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -1116,7 +1115,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1127,7 +1126,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1138,7 +1137,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1149,7 +1148,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1160,7 +1159,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1171,7 +1170,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1196,7 +1195,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1210,7 +1209,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.21.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -2308,7 +2307,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@builder.io/partytown": {
@@ -3491,7 +3490,6 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -3513,12 +3511,10 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.21.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3532,7 +3528,6 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3543,7 +3538,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.49.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3799,7 +3793,6 @@
     },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -3809,7 +3802,6 @@
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
       "version": "8.12.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3824,22 +3816,18 @@
     },
     "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/deepmerge": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-json-stringify": "^5.7.0"
@@ -4438,7 +4426,6 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -4451,7 +4438,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -4463,7 +4449,6 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@iarna/toml": {
@@ -4557,7 +4542,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -4572,7 +4557,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4580,7 +4565,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -4592,7 +4577,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -4603,7 +4588,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -4614,7 +4599,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4622,7 +4607,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4638,7 +4623,7 @@
     },
     "node_modules/@jest/console/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4652,7 +4637,7 @@
     },
     "node_modules/@jest/console/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4667,7 +4652,7 @@
     },
     "node_modules/@jest/console/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4678,12 +4663,12 @@
     },
     "node_modules/@jest/console/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/console/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4691,7 +4676,7 @@
     },
     "node_modules/@jest/console/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4702,7 +4687,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -4748,7 +4733,7 @@
     },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4762,7 +4747,7 @@
     },
     "node_modules/@jest/core/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4777,7 +4762,7 @@
     },
     "node_modules/@jest/core/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4788,12 +4773,12 @@
     },
     "node_modules/@jest/core/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4801,7 +4786,7 @@
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -4814,7 +4799,7 @@
     },
     "node_modules/@jest/core/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4825,12 +4810,12 @@
     },
     "node_modules/@jest/core/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4841,7 +4826,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.5.0",
@@ -4855,7 +4840,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.5.0",
@@ -4867,7 +4852,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.4.3"
@@ -4878,7 +4863,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4894,7 +4879,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -4908,7 +4893,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -4950,7 +4935,7 @@
     },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4964,7 +4949,7 @@
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4979,7 +4964,7 @@
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4990,12 +4975,12 @@
     },
     "node_modules/@jest/reporters/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5014,7 +4999,7 @@
     },
     "node_modules/@jest/reporters/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5022,7 +5007,7 @@
     },
     "node_modules/@jest/reporters/node_modules/jest-worker": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5036,7 +5021,7 @@
     },
     "node_modules/@jest/reporters/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5050,7 +5035,7 @@
     },
     "node_modules/@jest/reporters/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5061,7 +5046,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -5072,7 +5057,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -5085,7 +5070,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -5099,7 +5084,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.5.0",
@@ -5113,7 +5098,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -5138,7 +5123,7 @@
     },
     "node_modules/@jest/transform/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5152,7 +5137,7 @@
     },
     "node_modules/@jest/transform/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5167,7 +5152,7 @@
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5178,17 +5163,17 @@
     },
     "node_modules/@jest/transform/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/transform/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/transform/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5196,12 +5181,12 @@
     },
     "node_modules/@jest/transform/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@jest/transform/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5212,7 +5197,7 @@
     },
     "node_modules/@jest/transform/node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -5224,7 +5209,7 @@
     },
     "node_modules/@jest/types": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -5240,7 +5225,7 @@
     },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5254,7 +5239,7 @@
     },
     "node_modules/@jest/types/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5269,7 +5254,7 @@
     },
     "node_modules/@jest/types/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5280,12 +5265,12 @@
     },
     "node_modules/@jest/types/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/types/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5293,7 +5278,7 @@
     },
     "node_modules/@jest/types/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7274,7 +7259,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -7328,7 +7313,7 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -7336,7 +7321,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -7890,7 +7875,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -7902,7 +7887,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -7910,7 +7895,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -7919,7 +7904,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -8121,7 +8106,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8155,12 +8140,12 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -8168,7 +8153,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -8307,7 +8292,7 @@
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -8446,7 +8431,7 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/testing-library__jest-dom": {
@@ -8495,7 +8480,7 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -8503,7 +8488,7 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/yoga-layout": {
@@ -9388,7 +9373,6 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -9404,7 +9388,6 @@
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -9421,7 +9404,6 @@
     },
     "node_modules/acorn": {
       "version": "8.10.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -9449,7 +9431,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9509,7 +9490,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -9525,7 +9505,6 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.12.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9540,7 +9519,6 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv-keywords": {
@@ -9574,7 +9552,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -9588,7 +9566,7 @@
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -9610,7 +9588,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9638,7 +9615,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -9693,7 +9670,6 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/are-we-there-yet": {
@@ -9713,7 +9689,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -9934,7 +9910,6 @@
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -9999,7 +9974,6 @@
     },
     "node_modules/avvio": {
       "version": "8.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archy": "^1.0.0",
@@ -10049,7 +10023,7 @@
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.5.0",
@@ -10069,7 +10043,7 @@
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10083,7 +10057,7 @@
     },
     "node_modules/babel-jest/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10098,7 +10072,7 @@
     },
     "node_modules/babel-jest/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -10109,12 +10083,12 @@
     },
     "node_modules/babel-jest/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/babel-jest/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10122,7 +10096,7 @@
     },
     "node_modules/babel-jest/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10186,7 +10160,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -10201,7 +10175,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -10357,7 +10331,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -10445,7 +10419,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.5.0",
@@ -10872,7 +10846,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -10907,7 +10881,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -11165,7 +11139,7 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11326,7 +11300,7 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11423,7 +11397,7 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/clean-regexp": {
@@ -11690,7 +11664,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -11735,7 +11709,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -11753,7 +11727,7 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -12815,7 +12789,7 @@
     },
     "node_modules/dedent": {
       "version": "0.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -12866,7 +12840,6 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -13114,7 +13087,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13289,7 +13262,6 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -13500,7 +13472,7 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14038,7 +14010,6 @@
     },
     "node_modules/eslint": {
       "version": "8.49.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -14683,7 +14654,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -14789,7 +14759,6 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14803,12 +14772,10 @@
     },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14823,7 +14790,6 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14834,12 +14800,10 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.20.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -14853,7 +14817,6 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14861,7 +14824,6 @@
     },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14872,7 +14834,6 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14883,7 +14844,6 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -14899,7 +14859,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -14992,7 +14952,6 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15005,7 +14964,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -15055,7 +15013,7 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -15070,7 +15028,7 @@
     },
     "node_modules/expect": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.5.0",
@@ -15093,7 +15051,7 @@
     },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15107,7 +15065,7 @@
     },
     "node_modules/expect/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15122,7 +15080,7 @@
     },
     "node_modules/expect/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15133,12 +15091,12 @@
     },
     "node_modules/expect/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/expect/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -15146,7 +15104,7 @@
     },
     "node_modules/expect/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15154,7 +15112,7 @@
     },
     "node_modules/expect/node_modules/jest-diff": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -15168,7 +15126,7 @@
     },
     "node_modules/expect/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -15182,7 +15140,7 @@
     },
     "node_modules/expect/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -15195,7 +15153,7 @@
     },
     "node_modules/expect/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15206,12 +15164,12 @@
     },
     "node_modules/expect/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/expect/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15444,12 +15402,10 @@
     },
     "node_modules/fast-content-type-parse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -15491,7 +15447,6 @@
     },
     "node_modules/fast-json-stringify": {
       "version": "5.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/deepmerge": "^1.0.0",
@@ -15504,7 +15459,6 @@
     },
     "node_modules/fast-json-stringify/node_modules/ajv": {
       "version": "8.12.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15519,17 +15473,14 @@
     },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
@@ -15537,7 +15488,6 @@
     },
     "node_modules/fast-redact": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15550,7 +15500,6 @@
     },
     "node_modules/fast-uri": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastest-levenshtein": {
@@ -15562,7 +15511,6 @@
     },
     "node_modules/fastify": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.3.1",
@@ -15584,7 +15532,6 @@
     },
     "node_modules/fastify-plugin": {
       "version": "4.5.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -15607,7 +15554,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -15729,7 +15676,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -15829,7 +15775,6 @@
     },
     "node_modules/find-my-way": {
       "version": "7.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -15846,7 +15791,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -15870,7 +15814,6 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -15882,7 +15825,6 @@
     },
     "node_modules/flat-cache/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15901,7 +15843,6 @@
     },
     "node_modules/flat-cache/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -15915,7 +15856,6 @@
     },
     "node_modules/flatted": {
       "version": "3.2.7",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -16195,7 +16135,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17733,7 +17672,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -17762,7 +17701,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -17982,7 +17921,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -18513,7 +18451,7 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/html-rewriter-wasm": {
@@ -18962,7 +18900,7 @@
     },
     "node_modules/import-local": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -18980,7 +18918,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -19148,7 +19085,6 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -19352,7 +19288,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19495,7 +19431,6 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19786,7 +19721,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -19794,7 +19729,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -19809,7 +19744,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -19817,7 +19752,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -19830,7 +19765,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19838,7 +19773,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -19849,7 +19784,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -19862,7 +19797,7 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19870,7 +19805,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.1.5",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -19915,7 +19850,7 @@
     },
     "node_modules/jest": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.5.0",
@@ -19940,7 +19875,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -19952,7 +19887,7 @@
     },
     "node_modules/jest-changed-files/node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -19966,7 +19901,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -19996,7 +19931,7 @@
     },
     "node_modules/jest-circus/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20010,7 +19945,7 @@
     },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20025,7 +19960,7 @@
     },
     "node_modules/jest-circus/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20036,12 +19971,12 @@
     },
     "node_modules/jest-circus/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20049,7 +19984,7 @@
     },
     "node_modules/jest-circus/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20057,7 +19992,7 @@
     },
     "node_modules/jest-circus/node_modules/jest-diff": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20071,7 +20006,7 @@
     },
     "node_modules/jest-circus/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20085,7 +20020,7 @@
     },
     "node_modules/jest-circus/node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -20099,7 +20034,7 @@
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20112,7 +20047,7 @@
     },
     "node_modules/jest-circus/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20123,12 +20058,12 @@
     },
     "node_modules/jest-circus/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20139,7 +20074,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.5.0",
@@ -20172,7 +20107,7 @@
     },
     "node_modules/jest-cli/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20186,7 +20121,7 @@
     },
     "node_modules/jest-cli/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20201,7 +20136,7 @@
     },
     "node_modules/jest-cli/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20212,12 +20147,12 @@
     },
     "node_modules/jest-cli/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-cli/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20225,7 +20160,7 @@
     },
     "node_modules/jest-cli/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20236,7 +20171,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -20280,7 +20215,7 @@
     },
     "node_modules/jest-config/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20294,7 +20229,7 @@
     },
     "node_modules/jest-config/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20309,7 +20244,7 @@
     },
     "node_modules/jest-config/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20320,12 +20255,12 @@
     },
     "node_modules/jest-config/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -20344,7 +20279,7 @@
     },
     "node_modules/jest-config/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20352,7 +20287,7 @@
     },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20365,7 +20300,7 @@
     },
     "node_modules/jest-config/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20376,12 +20311,12 @@
     },
     "node_modules/jest-config/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20392,7 +20327,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -20403,7 +20338,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20418,7 +20353,7 @@
     },
     "node_modules/jest-each/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20432,7 +20367,7 @@
     },
     "node_modules/jest-each/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20447,7 +20382,7 @@
     },
     "node_modules/jest-each/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20458,12 +20393,12 @@
     },
     "node_modules/jest-each/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-each/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20471,7 +20406,7 @@
     },
     "node_modules/jest-each/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20484,7 +20419,7 @@
     },
     "node_modules/jest-each/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20495,12 +20430,12 @@
     },
     "node_modules/jest-each/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-each/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20537,7 +20472,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -20553,7 +20488,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20561,7 +20496,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20585,7 +20520,7 @@
     },
     "node_modules/jest-haste-map/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20593,7 +20528,7 @@
     },
     "node_modules/jest-haste-map/node_modules/jest-worker": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -20607,7 +20542,7 @@
     },
     "node_modules/jest-haste-map/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20621,7 +20556,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.4.3",
@@ -20633,7 +20568,7 @@
     },
     "node_modules/jest-leak-detector/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20644,7 +20579,7 @@
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20657,12 +20592,12 @@
     },
     "node_modules/jest-leak-detector/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -20681,7 +20616,7 @@
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20695,7 +20630,7 @@
     },
     "node_modules/jest-message-util/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20710,7 +20645,7 @@
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20721,12 +20656,12 @@
     },
     "node_modules/jest-message-util/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20734,7 +20669,7 @@
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20747,7 +20682,7 @@
     },
     "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20758,12 +20693,12 @@
     },
     "node_modules/jest-message-util/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20774,7 +20709,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20787,7 +20722,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20803,7 +20738,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20811,7 +20746,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20830,7 +20765,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.4.3",
@@ -20842,7 +20777,7 @@
     },
     "node_modules/jest-resolve/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20856,7 +20791,7 @@
     },
     "node_modules/jest-resolve/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20871,7 +20806,7 @@
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20882,12 +20817,12 @@
     },
     "node_modules/jest-resolve/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-resolve/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20895,7 +20830,7 @@
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20906,7 +20841,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -20937,7 +20872,7 @@
     },
     "node_modules/jest-runner/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20951,7 +20886,7 @@
     },
     "node_modules/jest-runner/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20966,7 +20901,7 @@
     },
     "node_modules/jest-runner/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20977,12 +20912,12 @@
     },
     "node_modules/jest-runner/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-runner/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20990,7 +20925,7 @@
     },
     "node_modules/jest-runner/node_modules/jest-worker": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -21004,7 +20939,7 @@
     },
     "node_modules/jest-runner/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21018,7 +20953,7 @@
     },
     "node_modules/jest-runner/node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -21032,7 +20967,7 @@
     },
     "node_modules/jest-runner/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21043,7 +20978,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -21075,7 +21010,7 @@
     },
     "node_modules/jest-runtime/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21089,7 +21024,7 @@
     },
     "node_modules/jest-runtime/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21104,7 +21039,7 @@
     },
     "node_modules/jest-runtime/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21115,12 +21050,12 @@
     },
     "node_modules/jest-runtime/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -21139,7 +21074,7 @@
     },
     "node_modules/jest-runtime/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21147,7 +21082,7 @@
     },
     "node_modules/jest-runtime/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21158,7 +21093,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -21191,7 +21126,7 @@
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21205,7 +21140,7 @@
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21220,7 +21155,7 @@
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21231,12 +21166,12 @@
     },
     "node_modules/jest-snapshot/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -21244,7 +21179,7 @@
     },
     "node_modules/jest-snapshot/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21252,7 +21187,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-diff": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21266,7 +21201,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21280,7 +21215,7 @@
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -21293,7 +21228,7 @@
     },
     "node_modules/jest-snapshot/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21304,12 +21239,12 @@
     },
     "node_modules/jest-snapshot/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21320,7 +21255,7 @@
     },
     "node_modules/jest-util": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -21336,7 +21271,7 @@
     },
     "node_modules/jest-util/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21350,7 +21285,7 @@
     },
     "node_modules/jest-util/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21365,7 +21300,7 @@
     },
     "node_modules/jest-util/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21376,12 +21311,12 @@
     },
     "node_modules/jest-util/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-util/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21389,7 +21324,7 @@
     },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21400,7 +21335,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -21416,7 +21351,7 @@
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21430,7 +21365,7 @@
     },
     "node_modules/jest-validate/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21445,7 +21380,7 @@
     },
     "node_modules/jest-validate/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21456,12 +21391,12 @@
     },
     "node_modules/jest-validate/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21469,7 +21404,7 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -21482,7 +21417,7 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21493,12 +21428,12 @@
     },
     "node_modules/jest-validate/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21509,7 +21444,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.5.0",
@@ -21527,7 +21462,7 @@
     },
     "node_modules/jest-watcher/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21541,7 +21476,7 @@
     },
     "node_modules/jest-watcher/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21556,7 +21491,7 @@
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21567,12 +21502,12 @@
     },
     "node_modules/jest-watcher/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-watcher/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21580,7 +21515,7 @@
     },
     "node_modules/jest-watcher/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21658,7 +21593,7 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -21770,7 +21705,6 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -21980,7 +21914,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21988,7 +21922,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -22000,7 +21933,6 @@
     },
     "node_modules/light-my-request": {
       "version": "5.9.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "cookie": "^0.5.0",
@@ -22366,7 +22298,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -22502,7 +22433,6 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
@@ -22776,7 +22706,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -22790,7 +22720,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22803,7 +22733,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -23757,7 +23687,7 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-object-hash": {
@@ -23803,7 +23733,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24368,7 +24298,6 @@
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -24444,7 +24373,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
@@ -24543,7 +24471,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -24557,7 +24484,6 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -25047,7 +24973,6 @@
     },
     "node_modules/pino": {
       "version": "8.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -25068,7 +24993,6 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.0.0",
@@ -25077,7 +25001,6 @@
     },
     "node_modules/pino-abstract-transport/node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25100,7 +25023,6 @@
     },
     "node_modules/pino-abstract-transport/node_modules/readable-stream": {
       "version": "4.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -25114,7 +25036,6 @@
     },
     "node_modules/pino-abstract-transport/node_modules/split2": {
       "version": "4.2.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -25122,12 +25043,11 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -25135,7 +25055,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -25146,7 +25066,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -25158,7 +25078,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -25169,7 +25089,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -25970,7 +25890,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -25986,7 +25905,7 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -26079,7 +25998,6 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -26092,7 +26010,6 @@
     },
     "node_modules/process-warning": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -26113,7 +26030,7 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -26125,7 +26042,7 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -26180,7 +26097,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -26251,7 +26167,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.0.2",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -26340,7 +26256,6 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/quick-lru": {
@@ -26447,7 +26362,6 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -26583,7 +26497,6 @@
     },
     "node_modules/react-dom": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -26890,7 +26803,6 @@
     },
     "node_modules/real-require": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -27211,7 +27123,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27219,7 +27131,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27274,7 +27185,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -27285,7 +27196,7 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -27311,7 +27222,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27347,7 +27258,6 @@
     },
     "node_modules/ret": {
       "version": "0.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -27371,7 +27281,6 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -27572,7 +27481,6 @@
     },
     "node_modules/safe-regex2": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ret": "~0.2.0"
@@ -27580,7 +27488,6 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27609,7 +27516,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27640,7 +27546,6 @@
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/select-hose": {
@@ -27860,7 +27765,6 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-function-name": {
@@ -28130,7 +28034,7 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -28443,7 +28347,6 @@
     },
     "node_modules/sonic-boom": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -28529,7 +28432,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -28538,7 +28441,7 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -28724,7 +28627,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
@@ -28774,7 +28677,7 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -28785,7 +28688,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -28898,7 +28801,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -28927,7 +28830,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -28967,12 +28870,12 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29052,7 +28955,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -29075,7 +28977,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29111,7 +29013,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29626,7 +29527,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -29639,7 +29540,7 @@
     },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -29666,7 +29567,6 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -29690,7 +29590,6 @@
     },
     "node_modules/thread-stream": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -29761,7 +29660,6 @@
     },
     "node_modules/tiny-lru": {
       "version": "10.4.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -29798,7 +29696,7 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-fast-properties": {
@@ -30473,7 +30371,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -30484,7 +30381,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -30589,6 +30486,8 @@
     },
     "node_modules/typescript": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -30945,7 +30844,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -31231,7 +31130,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -32022,7 +31921,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -32085,7 +31984,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -32099,7 +31998,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -32110,7 +32009,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -32253,7 +32152,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -32293,7 +32192,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -32330,7 +32229,7 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -32346,7 +32245,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "nuke": "./scripts/nuke.sh",
     "prepare": "husky install",
     "release": "TURBO_FORCE=true FORCE_COLOR=1 npm run build -- --force && changeset publish && git push --follow-tags",
-    "release:snapshot": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag snapshot --no-git-tag",
     "release:canary": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag canary --no-git-tag",
+    "release:snapshot": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag snapshot --no-git-tag",
     "release:verdaccio": "if [ \"$(npm config get registry)\" = \"https://registry.npmjs.org/\" ]; then echo 'Error: Using default registry' && exit 1; else TURBO_CONCURRENCY=1 npm run build && changeset publish --no-git-tag; fi",
     "test": "FORCE_COLOR=1 turbo test --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:cache:clear": "FORCE_COLOR=1 turbo test:cache:clear --continue --concurrency=${TURBO_CONCURRENCY:-80%}",
@@ -38,8 +38,8 @@
     "turbo:clean": "turbo daemon clean",
     "update:lockfile": "npm run nuke && npm install -D --arch=x64 --platform=linux turbo && npm install -D --arch=arm64 --platform=darwin turbo",
     "version": "changeset version && ./scripts/version-info.sh",
-    "version:snapshot": "./scripts/snapshot.mjs",
     "version:canary": "./scripts/canary.mjs",
+    "version:snapshot": "./scripts/snapshot.mjs",
     "yalc:all": "for d in packages/*/; do echo $d; cd $d; yalc push --replace --sig; cd '../../'; done"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky install",
     "release": "TURBO_FORCE=true FORCE_COLOR=1 npm run build -- --force && changeset publish && git push --follow-tags",
     "release:snapshot": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag snapshot --no-git-tag",
-    "release:staging": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag staging --no-git-tag",
+    "release:canary": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag canary --no-git-tag",
     "release:verdaccio": "if [ \"$(npm config get registry)\" = \"https://registry.npmjs.org/\" ]; then echo 'Error: Using default registry' && exit 1; else TURBO_CONCURRENCY=1 npm run build && changeset publish --no-git-tag; fi",
     "test": "FORCE_COLOR=1 turbo test --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:cache:clear": "FORCE_COLOR=1 turbo test:cache:clear --continue --concurrency=${TURBO_CONCURRENCY:-80%}",
@@ -39,7 +39,7 @@
     "update:lockfile": "npm run nuke && npm install -D --arch=x64 --platform=linux turbo && npm install -D --arch=arm64 --platform=darwin turbo",
     "version": "changeset version && ./scripts/version-info.sh",
     "version:snapshot": "./scripts/snapshot.mjs",
-    "version:staging": "./scripts/staging.mjs",
+    "version:canary": "./scripts/canary.mjs",
     "yalc:all": "for d in packages/*/; do echo $d; cd $d; yalc push --replace --sig; cd '../../'; done"
   },
   "devDependencies": {

--- a/packages/clerk-js/scripts/purge-cache.mjs
+++ b/packages/clerk-js/scripts/purge-cache.mjs
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import {createRequire} from 'module';
+import { createRequire } from 'module';
 import fetch from 'node-fetch';
 import semver from 'semver';
 

--- a/packages/clerk-js/scripts/purge-cache.mjs
+++ b/packages/clerk-js/scripts/purge-cache.mjs
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createRequire } from 'module';
+import {createRequire} from 'module';
 import fetch from 'node-fetch';
 import semver from 'semver';
 
@@ -12,10 +12,8 @@ const major = parsedVersion.major;
 try {
   if (!prerelease) {
     await fetch(`https://purge.jsdelivr.net/npm/@clerk/clerk-js@${major}/dist/clerk.browser.js`);
-  } else if (prerelease === 'staging') {
-    await fetch(`https://purge.jsdelivr.net/npm/@clerk/clerk-js@staging/dist/clerk.browser.js`);
   } else {
-    await fetch(`https://purge.jsdelivr.net/npm/@clerk/clerk-js@next/dist/clerk.browser.js`);
+    await fetch(`https://purge.jsdelivr.net/npm/@clerk/clerk-js@canary/dist/clerk.browser.js`);
   }
   console.log(`🎉 JSDelivr cache for @clerk/clerk-js (${version}) was successfully purged!`);
 } catch (err) {

--- a/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
+++ b/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
@@ -21,7 +21,7 @@
  *
  *  Solution:
  *  A given clerk.browser.js file will only load its corresponding chunks using a fixed version. Example:
- *  - clerk.browser.js loads from https://pk.accounts.dev/npm/@clerk/clerk-js@staging/dist/clerk.browser.js
+ *  - clerk.browser.js loads from https://pk.accounts.dev/npm/@clerk/clerk-js@canary/dist/clerk.browser.js
  *  - all other chunks need to be loaded from https://pk.accounts.dev/npm/@clerk/clerk-js@__PKG_VERSION__/dist/
  */
 if (!__DEV__) {

--- a/packages/shared/src/__tests__/url.test.ts
+++ b/packages/shared/src/__tests__/url.test.ts
@@ -60,16 +60,12 @@ describe('addClerkPrefix(str)', () => {
 describe('getClerkJsMajorVersionOrTag', () => {
   const stagingFrontendApi = 'foobar.lclstage.dev';
 
-  it('returns staging if pkgVersion is not provided and frontendApi is staging', () => {
-    expect(getClerkJsMajorVersionOrTag(stagingFrontendApi)).toBe('staging');
+  it('returns canary if pkgVersion is not provided and frontendApi is staging', () => {
+    expect(getClerkJsMajorVersionOrTag(stagingFrontendApi)).toBe('canary');
   });
 
   it('returns latest if pkgVersion is not provided and frontendApi is not staging', () => {
     expect(getClerkJsMajorVersionOrTag('foobar.dev')).toBe('latest');
-  });
-
-  it('returns next if pkgVersion contains next', () => {
-    expect(getClerkJsMajorVersionOrTag('foobar.dev', '1.2.3-next.4')).toBe('next');
   });
 
   it('returns the major version if pkgVersion is provided', () => {
@@ -100,15 +96,9 @@ describe('getScriptUrl', () => {
     );
   });
 
-  it('returns URL using the major version if only pkgVersion contains next', () => {
-    expect(getScriptUrl(frontendApi, { pkgVersion: '1.2.3-next.4' })).toBe(
-      'https://foobar.dev/npm/@clerk/clerk-js@next/dist/clerk.browser.js',
-    );
-  });
-
-  it('returns URL using the staging tag if frontendApi is staging', () => {
+  it('returns URL using the canary tag if frontendApi is staging', () => {
     expect(getScriptUrl('https://foobar.lclstage.dev', {})).toBe(
-      'https://foobar.lclstage.dev/npm/@clerk/clerk-js@staging/dist/clerk.browser.js',
+      'https://foobar.lclstage.dev/npm/@clerk/clerk-js@canary/dist/clerk.browser.js',
     );
   });
 });

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -32,21 +32,16 @@ export function addClerkPrefix(str: string | undefined) {
 /**
  *
  * Retrieve the clerk-js major tag using the major version from the pkgVersion
- * param or use the frontendApi to determine if the staging tag should be used.
- * The default tag is `latest` and a `next` pkgVersion also exists to retrieve
- * the next canary release.
+ * param or use the frontendApi to determine if the canary tag should be used.
+ * The default tag is `latest`.
  */
 export const getClerkJsMajorVersionOrTag = (frontendApi: string, pkgVersion?: string) => {
   if (!pkgVersion && isStaging(frontendApi)) {
-    return 'staging';
+    return 'canary';
   }
 
   if (!pkgVersion) {
     return 'latest';
-  }
-
-  if (pkgVersion.includes('next')) {
-    return 'next';
   }
 
   return pkgVersion.split('.')[0] || 'latest';

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['custom/node', 'custom/typescript'],
+  rules: {
+    'import/no-unresolved': ['error', { ignore: ['^#'] }],
+  },
+};

--- a/scripts/canary.mjs
+++ b/scripts/canary.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env zx
 
-import 'zx/globals';
-import {constants} from './common.mjs';
+import { $, echo } from 'zx';
+
+import { constants } from './common.mjs';
 
 await $`npx json -I -f ${constants.ChangesetConfigFile} -e "this.changelog = false"`;
 

--- a/scripts/canary.mjs
+++ b/scripts/canary.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env zx
 
 import 'zx/globals';
-import { constants } from './common.mjs';
+import {constants} from './common.mjs';
 
 await $`npx json -I -f ${constants.ChangesetConfigFile} -e "this.changelog = false"`;
 
-const res = await $`npx changeset version --snapshot staging`;
+const res = await $`npx changeset version --snapshot canary`;
 const success = !res.stderr.includes('No unreleased changesets found');
 
 await $`git checkout HEAD -- ${constants.ChangesetConfigFile}`;


### PR DESCRIPTION
## Description

This PR renames the `@staging` package tag to `@canary`.

We need to make changes to other parts of the Clerk infrastructure first to support this change.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
