### PR TITLE
chore(remix): Drop deprecations

### DIFF
--- a/.changeset/many-weeks-march.md
+++ b/.changeset/many-weeks-march.md
@@ -1,0 +1,10 @@
+---
+'@clerk/remix': major
+---
+
+Drop deprecations. Migration steps:
+
+- use `CLERK_SECRET_KEY` instead of `CLERK_API_KEY` env variable
+- use `secretKey` instead of `apiKey`
+- use `CLERK_PUBLISHABLE_KEY` instead of `CLERK_FRONTEND_API` env variable
+- use `publishableKey` instead of `frontendApi`

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -45,7 +45,6 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
   assertValidClerkState(clerkState);
   const {
     __clerk_ssr_state,
-    __frontendApi,
     __publishableKey,
     __proxyUrl,
     __domain,
@@ -68,7 +67,6 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
   }, []);
 
   const mergedProps = {
-    frontendApi: __frontendApi as any,
     publishableKey: __publishableKey as any,
     proxyUrl: __proxyUrl as any,
     domain: __domain as any,

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -7,7 +7,6 @@ export type ClerkState = {
   __internal_clerk_state: {
     __clerk_ssr_interstitial: string;
     __clerk_ssr_state: InitialState;
-    __frontendApi: string | undefined;
     __publishableKey: string | undefined;
     __proxyUrl: string | undefined;
     __domain: string | undefined;

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -70,8 +70,8 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 `);
 
 export const noSecretKeyOrApiKeyError = createErrorMessage(`
-A secretKey or apiKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
-If your runtime supports environment variables, you can add a CLERK_SECRET_KEY or CLERK_API_KEY variable to your config.
+A secretKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
+If your runtime supports environment variables, you can add a CLERK_SECRET_KEY variable to your config.
 Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.
 `);
 

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,6 +1,5 @@
 import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, Clerk } from '@clerk/backend';
-import { deprecated } from '@clerk/shared/deprecated';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
 import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
@@ -31,15 +30,6 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
 
   if (!secretKey) {
     throw new Error(noSecretKeyOrApiKeyError);
-  }
-
-  const frontendApi = opts.frontendApi || getEnvVariable('CLERK_FRONTEND_API', context) || '';
-  if (frontendApi) {
-    if (getEnvVariable('CLERK_FRONTEND_API', context)) {
-      deprecated('CLERK_FRONTEND_API', 'Use `CLERK_PUBLISHABLE_KEY` instead.');
-    } else {
-      deprecated('frontendApi', 'Use `publishableKey` instead.');
-    }
   }
 
   const publishableKey = opts.publishableKey || getEnvVariable('CLERK_PUBLISHABLE_KEY', context) || '';
@@ -90,7 +80,6 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     audience,
     secretKey,
     jwtKey,
-    frontendApi,
     publishableKey,
     loadUser,
     loadSession,

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -5,7 +5,7 @@ import { authenticateRequest } from './authenticateRequest';
 import type { GetAuthReturn, LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 import { interstitialJsonResponse, unknownResponse } from './utils';
 
-type GetAuthOptions = Pick<RootAuthLoaderOptions, 'apiKey' | 'secretKey'>;
+type GetAuthOptions = Pick<RootAuthLoaderOptions, 'secretKey'>;
 
 export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): GetAuthReturn {
   if (!args || (args && (!args.request || !args.context))) {

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -11,10 +11,6 @@ export type RootAuthLoaderOptions = {
   frontendApi?: string;
   publishableKey?: string;
   jwtKey?: string;
-  /**
-   * @deprecated Use `secretKey` instead.
-   */
-  apiKey?: string;
   secretKey?: string;
   loadUser?: boolean;
   loadSession?: boolean;

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -5,10 +5,6 @@ import type { DataFunctionArgs, LoaderFunction } from '@remix-run/server-runtime
 export type GetAuthReturn = Promise<AuthObject>;
 
 export type RootAuthLoaderOptions = {
-  /**
-   * @deprecated Use `publishableKey` instead.
-   */
-  frontendApi?: string;
   publishableKey?: string;
   jwtKey?: string;
   secretKey?: string;

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -86,7 +86,8 @@ export const interstitialJsonResponse = (
       __loader: opts.loader,
       __clerk_ssr_interstitial_html: loadInterstitialFromLocal({
         debugData: debugRequestState(requestState),
-        frontendApi: requestState.frontendApi,
+        // TODO(@dimkl): use empty string for frontendApi until type is fixed in @clerk/backend to drop it
+        frontendApi: '',
         publishableKey: requestState.publishableKey,
         // TODO: This needs to be the version of clerk/remix not clerk/react
         // pkgVersion: LIB_VERSION,
@@ -107,7 +108,6 @@ export const injectRequestStateIntoResponse = async (
   requestState: RequestState,
   context: AppLoadContext,
 ) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const clone = response.clone();
   const data = await clone.json();
 
@@ -151,11 +151,9 @@ export function injectRequestStateIntoDeferredData(
  * @internal
  */
 export function getResponseClerkState(requestState: RequestState, context: AppLoadContext) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { reason, message, isSignedIn, isInterstitial, ...rest } = requestState;
   const clerkState = wrapWithClerkState({
     __clerk_ssr_state: rest.toAuth(),
-    __frontendApi: requestState.frontendApi,
     __publishableKey: requestState.publishableKey,
     __proxyUrl: requestState.proxyUrl,
     __domain: requestState.domain,


### PR DESCRIPTION
## Description

Drop deprecations. Migration steps:

- use `CLERK_SECRET_KEY` instead of `CLERK_API_KEY` env variable
- use `secretKey` instead of `apiKey`
- use `CLERK_PUBLISHABLE_KEY` instead of `CLERK_FRONTEND_API` env variable
- use `publishableKey` instead of `frontendApi`

Extra:
- refactor to use `isDevelopmentFromApiKey` from `@clerk/shared`

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
