### PR TITLE
fix(repo): GHA timeout-minutes conversion

### DIFF
--- a/.github/workflows/base-e2e.yml
+++ b/.github/workflows/base-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     continue-on-error: true
     runs-on: ${{ vars.RUNNER_NORMAL }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_LONG }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_LONG) }}
     concurrency:
       group: integration-${{ github.ref }}-${{ inputs.script }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
   formatting-linting:
     name: Formatting, linting & changeset checks
     runs-on: ${{ vars.RUNNER_NORMAL }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
     steps:
       - name: Checkout Repo
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -47,31 +47,31 @@ jobs:
           echo "FORCE_COLOR: $FORCE_COLOR"
 
       - name: Require Changeset
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: if [ "${{ github.event.pull_request.user.login }}" = "clerk-cookie" ]; then echo 'Skipping' && exit 0; else npx changeset status --since=origin/main; fi
 
       - name: Check Formatting
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: npm run format:check
 
       - name: Lint packages using publint
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: npm run lint:publint -- $TURBO_ARGS
 
       - name: Lint types using attw
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: npm run lint:attw -- $TURBO_ARGS
         continue-on-error: true  # TODO: Remove this when all related errors are fixed
 
       - name: Run lint
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: npm run lint -- $TURBO_ARGS -- --quiet
 
   unit-tests:
     name: Unit Tests
     needs: formatting-linting
     runs-on: ${{ vars.RUNNER_LARGE }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
     strategy:
       matrix:
@@ -102,7 +102,7 @@ jobs:
     name: Integration Tests
     needs: formatting-linting
     runs-on: ${{ vars.RUNNER_LARGE }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
     strategy:
       matrix:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
   snapshot-release:
     if: ${{ startsWith(github.event.comment.body, '!snapshot') && github.repository == 'clerk/javascript' && github.event.issue.pull_request }}
     runs-on: ${{ vars.RUNNER_LARGE }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -14,7 +14,7 @@ jobs:
   staging-release:
     if: ${{ github.repository == 'clerk/javascript' }}
     runs-on: ${{ vars.RUNNER_NORMAL }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Release
     if: ${{ github.repository == 'clerk/javascript' }}
     runs-on: ${{ vars.RUNNER_NORMAL }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Description

Fixes GHA timeout-minutes integer conversion.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
