### PR TITLE
fix(repo): GHA optimizations

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Enable Playwright?'
     required: false
     default: 'false'
+  turbo-summarize:
+    description: 'The token to use for Turbo task summaries'
+    required: false
+    default: 'false'
   turbo-enabled:
     description: 'Enable Turbo?'
     required: false
@@ -44,6 +48,7 @@ runs:
         CACHE_DIR: ${{ inputs.turbo-cache-dir }}
         REMOTE_ONLY: ${{ inputs.turbo-remote-only }}
         SIGNATURE: ${{ inputs.turbo-signature }}
+        SUMMARIZE: ${{ inputs.turbo-summarize }}
         TEAM: ${{ inputs.turbo-team }}
         TOKEN: ${{ inputs.turbo-token }}
       with:
@@ -54,13 +59,14 @@ runs:
               ? os.availableParallelism()
               : os.cpus().length;
 
-          const { ENABLED, CACHE_DIR, SIGNATURE, REMOTE_ONLY, TEAM, TOKEN } = process.env
+          const { ENABLED, CACHE_DIR, SIGNATURE, REMOTE_ONLY, SUMMARIZE, TEAM, TOKEN } = process.env
 
           core.exportVariable('TURBO_ARGS',
             [
               '--output-logs=new-only',
               `--cache-dir=${CACHE_DIR}`,
-              `--concurrency=${cpus}`
+              `--concurrency=${cpus}`,
+              `--summarize=${SUMMARIZE}`,
             ].join(' ')
           )
 

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -90,7 +90,7 @@ runs:
       id: npm-cache
       with:
         path: ./node_modules
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-node-modules-${{ hashFiles('package-lock.json') }}
 
     - name: Install NPM Dependencies
       if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           name: turbo-summary-report-lint-${{ github.run_id }}-${{ github.run_attempt }}
           path: .turbo/runs
-          retention-days: 3
+          retention-days: 5
 
   unit-tests:
     name: Unit Tests
@@ -122,17 +122,17 @@ jobs:
         with:
           name: turbo-summary-report-unit-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node-version }}
           path: .turbo/runs
-          retention-days: 3
+          retention-days: 5
 
   integration-tests:
     name: Integration Tests
     needs: formatting-linting
-    runs-on: ${{ vars.RUNNER_LARGE }}
+    runs-on: ${{ vars.RUNNER_MEDIUM }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
     strategy:
       matrix:
-        test-name: [ 'generic', 'nextjs', 'remix' ]
+        test-name: [ 'generic', 'nextjs' ] # TODO: Add 'remix' when ready
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,6 @@ jobs:
   #     #   uses: actions/upload-artifact@v3
   #     #   if: always()
   #     #   with:
-  #     #     name: integration-report-${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
+  #     #     name: integration-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
   #     #     path: playwright-report/
   #     #     retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           show-progress: false
 
       - name: Setup
-        timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+        timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         id: config
         uses: ./.github/actions/init
         with:
@@ -79,89 +79,89 @@ jobs:
           path: .turbo/runs
           retention-days: 1
 
-  # unit-tests:
-  #   name: Unit Tests
-  #   needs: formatting-linting
-  #   runs-on: ${{ vars.RUNNER_LARGE }}
-  #   timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+  unit-tests:
+    name: Unit Tests
+    needs: formatting-linting
+    runs-on: ${{ vars.RUNNER_LARGE }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
-  #   strategy:
-  #     matrix:
-  #       node-version: [ 18, 20 ]
+    strategy:
+      matrix:
+        node-version: [ 18, 20 ]
 
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         show-progress: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          show-progress: false
 
-  #     - name: Setup
-  #       id: config
-  #       uses: ./.github/actions/init
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-  #         turbo-team: ${{ vars.TURBO_TEAM }}
-  #         turbo-token: ${{ secrets.TURBO_TOKEN }}
+      - name: Setup
+        id: config
+        uses: ./.github/actions/init
+        with:
+          node-version: ${{ matrix.node-version }}
+          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
-  #     - name: Run tests
-  #       run: npx turbo test $TURBO_ARGS
-  #       env:
-  #         NODE_VERSION: ${{ matrix.node-version }}
+      - name: Run tests
+        run: npx turbo test $TURBO_ARGS
+        env:
+          NODE_VERSION: ${{ matrix.node-version }}
 
-  # integration-tests:
-  #   name: Integration Tests
-  #   needs: formatting-linting
-  #   runs-on: ${{ vars.RUNNER_LARGE }}
-  #   timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+  integration-tests:
+    name: Integration Tests
+    needs: formatting-linting
+    runs-on: ${{ vars.RUNNER_LARGE }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
-  #   strategy:
-  #     matrix:
-  #       test-name: [ 'generic', 'nextjs', 'remix' ]
+    strategy:
+      matrix:
+        test-name: [ 'generic', 'nextjs', 'remix' ]
 
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         show-progress: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          show-progress: false
 
-  #     - name: Setup
-  #       id: config
-  #       uses: ./.github/actions/init
-  #       with:
-  #         turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-  #         turbo-team: ${{ vars.TURBO_TEAM }}
-  #         turbo-token: ${{ secrets.TURBO_TOKEN }}
-  #         playwright-enabled: true
+      - name: Setup
+        id: config
+        uses: ./.github/actions/init
+        with:
+          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          playwright-enabled: true
 
-  #     - name: Verdaccio
-  #       uses: ./.github/actions/verdaccio
-  #       with:
-  #         publish-cmd: |
-  #           if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS && npx changeset publish --no-git-tag; fi
+      - name: Verdaccio
+        uses: ./.github/actions/verdaccio
+        with:
+          publish-cmd: |
+            if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS && npx changeset publish --no-git-tag; fi
 
-  #     - name: Install @clerk/backend in /integration
-  #       working-directory: ./integration
-  #       run: npm init -y && npm install @clerk/backend
+      - name: Install @clerk/backend in /integration
+        working-directory: ./integration
+        run: npm init -y && npm install @clerk/backend
 
-  #     - name: Install @clerk/clerk-js in os temp
-  #       working-directory: ${{runner.temp}}
-  #       run: mkdir clerk-js && cd clerk-js && npm init -y && npm install @clerk/clerk-js
+      - name: Install @clerk/clerk-js in os temp
+        working-directory: ${{runner.temp}}
+        run: mkdir clerk-js && cd clerk-js && npm init -y && npm install @clerk/clerk-js
 
-  #     - name: Run Integration Tests
-  #       run: npm run test:integration:${{ matrix.test-name }}
-  #       env:
-  #         E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
-  #         E2E_CLERK_VERSION: 'latest'
-  #         INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
-  #         MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
+      - name: Run Integration Tests
+        run: npm run test:integration:${{ matrix.test-name }}
+        env:
+          E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
+          E2E_CLERK_VERSION: 'latest'
+          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+          MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
 
-  #     # - name: Upload Integration Report for ${{ matrix.test-name }}
-  #     #   uses: actions/upload-artifact@v3
-  #     #   if: always()
-  #     #   with:
-  #     #     name: integration-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
-  #     #     path: playwright-report/
-  #     #     retention-days: 1
+      # - name: Upload Integration Report for ${{ matrix.test-name }}
+      #   uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: integration-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
+      #     path: playwright-report/
+      #     retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   formatting-linting:
     name: Formatting, linting & changeset checks
-    runs-on: ${{ vars.RUNNER_NORMAL }}
+    runs-on: ${{ vars.RUNNER_MEDIUM }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,19 @@ jobs:
 
     strategy:
       matrix:
-        test-name: [ 'generic', 'nextjs' ] # TODO: Add 'remix' when ready
+        # TODO: Remove `matrix.test-name != 'remix'` when ready, or from matrix when required check is disabled
+        test-name: [ 'generic', 'nextjs', 'remix' ]
 
     steps:
       - name: Checkout Repo
+        if: ${{ matrix.test-name != 'remix' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           show-progress: false
 
       - name: Setup
+        if: ${{ matrix.test-name != 'remix' }}
         id: config
         uses: ./.github/actions/init
         with:
@@ -151,20 +154,24 @@ jobs:
           playwright-enabled: true
 
       - name: Verdaccio
+        if: ${{ matrix.test-name != 'remix' }}
         uses: ./.github/actions/verdaccio
         with:
           publish-cmd: |
             if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS && npx changeset publish --no-git-tag; fi
 
       - name: Install @clerk/backend in /integration
+        if: ${{ matrix.test-name != 'remix' }}
         working-directory: ./integration
         run: npm init -y && npm install @clerk/backend
 
       - name: Install @clerk/clerk-js in os temp
+        if: ${{ matrix.test-name != 'remix' }}
         working-directory: ${{runner.temp}}
         run: mkdir clerk-js && cd clerk-js && npm init -y && npm install @clerk/clerk-js
 
       - name: Run Integration Tests
+        if: ${{ matrix.test-name != 'remix' }}
         run: npm run test:integration:${{ matrix.test-name }}
         env:
           E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
@@ -173,6 +180,7 @@ jobs:
           MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
 
       # - name: Upload Integration Report for ${{ matrix.test-name }}
+      #   if: ${{ matrix.test-name != 'remix' }}
       #   uses: actions/upload-artifact@v3
       #   if: always()
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ concurrency:
 jobs:
   formatting-linting:
     name: Formatting, linting & changeset checks
-    runs-on: ${{ vars.RUNNER_MEDIUM }}
+    runs-on: ${{ vars.RUNNER_LARGE }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+    env:
+      TURBO_SUMMARIZE: true
 
     steps:
       - name: Checkout Repo
@@ -34,6 +36,7 @@ jobs:
         with:
           turbo-remote-only: false
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          turbo-summarize: ${{ env.TURBO_SUMMARIZE }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
@@ -67,89 +70,98 @@ jobs:
         timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
         run: npm run lint -- $TURBO_ARGS -- --quiet
 
-  unit-tests:
-    name: Unit Tests
-    needs: formatting-linting
-    runs-on: ${{ vars.RUNNER_LARGE }}
-    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
-
-    strategy:
-      matrix:
-        node-version: [ 18, 20 ]
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
+      - name: Upload Turbo Summary
+        uses: actions/upload-artifact@v3
+        if: ${{ env.TURBO_SUMMARIZE == 'true' }}
+        continue-on-error: true
         with:
-          fetch-depth: 0
-          show-progress: false
+          name: turbo-summary-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .turbo/runs
+          retention-days: 1
 
-      - name: Setup
-        id: config
-        uses: ./.github/actions/init
-        with:
-          node-version: ${{ matrix.node-version }}
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-          turbo-team: ${{ vars.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
+  # unit-tests:
+  #   name: Unit Tests
+  #   needs: formatting-linting
+  #   runs-on: ${{ vars.RUNNER_LARGE }}
+  #   timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
-      - name: Run tests
-        run: npx turbo test $TURBO_ARGS
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
+  #   strategy:
+  #     matrix:
+  #       node-version: [ 18, 20 ]
 
-  integration-tests:
-    name: Integration Tests
-    needs: formatting-linting
-    runs-on: ${{ vars.RUNNER_LARGE }}
-    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         show-progress: false
 
-    strategy:
-      matrix:
-        test-name: [ 'generic', 'nextjs', 'remix' ]
+  #     - name: Setup
+  #       id: config
+  #       uses: ./.github/actions/init
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+  #         turbo-team: ${{ vars.TURBO_TEAM }}
+  #         turbo-token: ${{ secrets.TURBO_TOKEN }}
 
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          show-progress: false
+  #     - name: Run tests
+  #       run: npx turbo test $TURBO_ARGS
+  #       env:
+  #         NODE_VERSION: ${{ matrix.node-version }}
 
-      - name: Setup
-        id: config
-        uses: ./.github/actions/init
-        with:
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-          turbo-team: ${{ vars.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          playwright-enabled: true
+  # integration-tests:
+  #   name: Integration Tests
+  #   needs: formatting-linting
+  #   runs-on: ${{ vars.RUNNER_LARGE }}
+  #   timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
 
-      - name: Verdaccio
-        uses: ./.github/actions/verdaccio
-        with:
-          publish-cmd: |
-            if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS && npx changeset publish --no-git-tag; fi
+  #   strategy:
+  #     matrix:
+  #       test-name: [ 'generic', 'nextjs', 'remix' ]
 
-      - name: Install @clerk/backend in /integration
-        working-directory: ./integration
-        run: npm init -y && npm install @clerk/backend
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         show-progress: false
 
-      - name: Install @clerk/clerk-js in os temp
-        working-directory: ${{runner.temp}}
-        run: mkdir clerk-js && cd clerk-js && npm init -y && npm install @clerk/clerk-js
+  #     - name: Setup
+  #       id: config
+  #       uses: ./.github/actions/init
+  #       with:
+  #         turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+  #         turbo-team: ${{ vars.TURBO_TEAM }}
+  #         turbo-token: ${{ secrets.TURBO_TOKEN }}
+  #         playwright-enabled: true
 
-      - name: Run Integration Tests
-        run: npm run test:integration:${{ matrix.test-name }}
-        env:
-          E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
-          E2E_CLERK_VERSION: 'latest'
-          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
-          MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
+  #     - name: Verdaccio
+  #       uses: ./.github/actions/verdaccio
+  #       with:
+  #         publish-cmd: |
+  #           if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS && npx changeset publish --no-git-tag; fi
 
-      # - name: Upload Integration Report for ${{ matrix.test-name }}
-      #   uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: integration-report-${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
-      #     path: playwright-report/
-      #     retention-days: 1
+  #     - name: Install @clerk/backend in /integration
+  #       working-directory: ./integration
+  #       run: npm init -y && npm install @clerk/backend
+
+  #     - name: Install @clerk/clerk-js in os temp
+  #       working-directory: ${{runner.temp}}
+  #       run: mkdir clerk-js && cd clerk-js && npm init -y && npm install @clerk/clerk-js
+
+  #     - name: Run Integration Tests
+  #       run: npm run test:integration:${{ matrix.test-name }}
+  #       env:
+  #         E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
+  #         E2E_CLERK_VERSION: 'latest'
+  #         INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+  #         MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
+
+  #     # - name: Upload Integration Report for ${{ matrix.test-name }}
+  #     #   uses: actions/upload-artifact@v3
+  #     #   if: always()
+  #     #   with:
+  #     #     name: integration-report-${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-name }}
+  #     #     path: playwright-report/
+  #     #     retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     name: Formatting, linting & changeset checks
     runs-on: ${{ vars.RUNNER_LARGE }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+
     env:
       TURBO_SUMMARIZE: true
 
@@ -75,15 +76,18 @@ jobs:
         if: ${{ env.TURBO_SUMMARIZE == 'true' }}
         continue-on-error: true
         with:
-          name: turbo-summary-report-${{ github.run_id }}-${{ github.run_attempt }}
+          name: turbo-summary-report-lint-${{ github.run_id }}-${{ github.run_attempt }}
           path: .turbo/runs
-          retention-days: 1
+          retention-days: 3
 
   unit-tests:
     name: Unit Tests
     needs: formatting-linting
     runs-on: ${{ vars.RUNNER_LARGE }}
     timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+
+    env:
+      TURBO_SUMMARIZE: true
 
     strategy:
       matrix:
@@ -102,6 +106,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          turbo-summarize: ${{ env.TURBO_SUMMARIZE }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
@@ -109,6 +114,15 @@ jobs:
         run: npx turbo test $TURBO_ARGS
         env:
           NODE_VERSION: ${{ matrix.node-version }}
+
+      - name: Upload Turbo Summary
+        uses: actions/upload-artifact@v3
+        if: ${{ env.TURBO_SUMMARIZE == 'true' }}
+        continue-on-error: true
+        with:
+          name: turbo-summary-report-unit-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node-version }}
+          path: .turbo/runs
+          retention-days: 3
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
+    timeout-minutes: 3
     permissions:
       contents: read
       pull-requests: write

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -1,4 +1,6 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
+import os from 'node:os';
+
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { defineConfig, devices } from '@playwright/test';
 import { config } from 'dotenv';
@@ -6,14 +8,17 @@ import * as path from 'path';
 
 config({ path: path.resolve(__dirname, '.env.local') });
 
+const numAvailableWorkers = os.cpus().length - 1;
+
 export const common: PlaywrightTestConfig = {
   testDir: './tests',
   snapshotDir: './tests/snapshots',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  timeout: process.env.CI ? 90000 : 30000,
-  workers: process.env.CI ? '50%' : '70%',
+  timeout: 30000,
+  maxFailures: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? numAvailableWorkers : '70%',
   reporter: [[process.env.CI ? 'html' : 'line', { open: 'never' }]] as any,
   use: {
     trace: 'on-first-retry',

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -16,7 +16,7 @@ export const common: PlaywrightTestConfig = {
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  timeout: 30000,
+  timeout: process.env.CI ? 90000 : 30000,
   maxFailures: process.env.CI ? 1 : undefined,
   workers: process.env.CI ? numAvailableWorkers : '70%',
   reporter: [[process.env.CI ? 'html' : 'line', { open: 'never' }]] as any,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "release": "TURBO_FORCE=true FORCE_COLOR=1 npm run build -- --force && changeset publish && git push --follow-tags",
     "release:snapshot": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag snapshot --no-git-tag",
     "release:staging": "TURBO_FORCE=true FORCE_COLOR=1 npm run build && changeset publish --tag staging --no-git-tag",
+    "release:verdaccio": "if [ \"$(npm config get registry)\" = \"https://registry.npmjs.org/\" ]; then echo 'Error: Using default registry' && exit 1; else TURBO_CONCURRENCY=1 npm run build && changeset publish --no-git-tag; fi",
     "test": "FORCE_COLOR=1 turbo test --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:cache:clear": "FORCE_COLOR=1 turbo test:cache:clear --continue --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:integration:base": "DEBUG=1 npx playwright test --config integration/playwright.config.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -26,8 +26,7 @@
     "NODE_VERSION",
     "NPM_VERSION",
     "TZ",
-    "VERCEL",
-    "GITHUB_ACCESS_TOKEN"
+    "VERCEL"
   ],
   "pipeline": {
     "build": {

--- a/turbo.json
+++ b/turbo.json
@@ -3,20 +3,7 @@
   "remoteCache": {
     "signature": true
   },
-  "globalDependencies": [
-    ".changeset/changelog.js",
-    ".changeset/config.json",
-    ".github/**",
-    ".jit",
-    ".nvmrc",
-    ".prettier*",
-    "jest.*.ts",
-    "package.json",
-    "package-lock.json",
-    "tsconfig.json",
-    "tsconfig.*.json",
-    "verdaccio.yaml"
-  ],
+  "globalDependencies": ["jest.*.ts", "package.json", "package-lock.json", "tsconfig.json", "tsconfig.*.json"],
   "globalEnv": [
     "CLERK_*",
     "GATSBY_CLERK_*",


### PR DESCRIPTION
## Description

**NPM:**
  - Cache `node_modules` based off of `package-lock.json` not `**/package-lock.json`. This was likely the culprit of the missing caches due to the integration tests updating their own package-lock.json files.

**Turborepo:**
  - Remove `GITHUB_ACCESS_TOKEN` from `globalEnv` as it rotates regularly.
  - Remove, ultimately, unnecessary files from `globalDependencies`.
  - Summarize the task runs, for future analysis.

**Playwright:**
  - Fail fast.
  - Use all available resources.
    - When we were on the smaller GHA boxes, this was limited to 50% (1 vCPU), so when we upgraded to 8 vCPU, it was only using 4. This ensures that we're using one less than all available vCPUs for workers.
    - _**Outcome:**_ Reduced the box to medium as Playwright requires (and only utilizes) less resources. Regardless of how many workers you allow, with 4 tests, it only spins up 1 worker. With 5 tests, 2 workers. Will increase as-needed.

**Other:**
  - Skipping Remix Integration tests until they're good to go.
    - If we remove from `required`, I can remove it from the matrix altogether.
  - Fix type coercion of string var to int for `timeout-minutes`.
  - Temp re-add of `release:verdaccio` NPM script. (Only used in nightly.)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
