### PR TITLE
feat(nextjs): Introduce `apiUnauthorizedResponseTransformer` function in `authMiddleware`

### DIFF
--- a/.changeset/fuzzy-snakes-poke.md
+++ b/.changeset/fuzzy-snakes-poke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': minor
+---
+
+Introduce `apiUnauthorizedResponseTransformer` function to manipulate API 401 Unauthorized NextResponse returned by authMiddleware

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -28,8 +28,11 @@ const decorateResponseWithObservabilityHeaders = (res: NextResponse, requestStat
   requestState.status && res.headers.set(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };
 
-export const handleUnknownState = (requestState: RequestState) => {
-  const response = apiEndpointUnauthorizedNextResponse();
+export const handleUnknownState = (
+  requestState: RequestState,
+  unknownStateTransformer: (res: NextResponse) => NextResponse,
+) => {
+  const response = unknownStateTransformer(apiEndpointUnauthorizedNextResponse());
   decorateResponseWithObservabilityHeaders(response, requestState);
   return response;
 };


### PR DESCRIPTION
## Description

This pull request proposes a potential solution for users who have created a Nextjs + tRPC project and encounter errors on the tRPC client when Clerk's `authMiddleware` returns a NextResponse with a `null` body. This occurs when the client expects to receive a tRPC structured error object.

To address the issue, we are introducing the `apiUnauthorizedResponseTransformer` property on `authMiddleware`. This property is a function that users can pass to transform the `NextResponse` generated by Clerk when an API endpoint call results in the Unknown state (401 Unauthorized).

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
