### PR TITLE
fix(repo): Fix error when evaluating 'timeout-minutes'

### DIFF
--- a/.github/workflows/base-build.yml
+++ b/.github/workflows/base-build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     # if: ${{ github.repository == 'clerk/javascript' }}
     runs-on: ${{ vars.RUNNER_NORMAL }}
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL }}
+    timeout-minutes: ${{  fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   action:
-    timeout-minutes: ${{ vars.TIMEOUT_MINUTES_SHORT }}
+    timeout-minutes: ${{  fromJSON(vars.TIMEOUT_MINUTES_SHORT) }}
     runs-on: ${{ vars.RUNNER_NORMAL }}
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
## Description

Fix `error when evaluating 'timeout-minutes'` for :
- lock-threads ( i will restart the latest failed job this PR is merged)
- base-build

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
