### PR TITLE
fix(nextjs): Improve type inference for the return type of auth helper (#2047)

### DIFF
--- a/.changeset/new-eels-mix.md
+++ b/.changeset/new-eels-mix.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+---
+
+Fix type inferance for auth helper.

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -166,7 +166,7 @@ export function sanitizeAuthObject<T extends Record<any, any>>(authObject: T): T
  */
 export const makeAuthObjectSerializable = <T extends Record<string, unknown>>(obj: T): T => {
   // remove any non-serializable props from the returned object
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   const { debug, getToken, ...rest } = obj as unknown as AuthObject;
   return rest as unknown as T;
 };

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -45,7 +45,9 @@ export const createGetAuth = ({
     return (
       req: RequestLike,
       opts?: GetAuthOpts,
-    ): AuthObjectWithDeprecatedResources<SignedInAuthObject | SignedOutAuthObject> => {
+    ):
+      | AuthObjectWithDeprecatedResources<SignedInAuthObject>
+      | AuthObjectWithDeprecatedResources<SignedOutAuthObject> => {
       const debug = getHeader(req, constants.Headers.EnableDebug) === 'true';
       if (debug) {
         logger.enable();


### PR DESCRIPTION
## Description

Backport of #2047
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
