### PR TITLE
chore(repo): Use valid deps in playground/nextjs

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -10,12 +10,12 @@
     "yalc:add": "yalc add -- @clerk/shared @clerk/types @clerk/backend @clerk/clerk-react @clerk/clerk-sdk-node @clerk/nextjs"
   },
   "dependencies": {
-    "@clerk/backend": "file:.yalc/@clerk/backend",
-    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
-    "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
-    "@clerk/nextjs": "file:.yalc/@clerk/nextjs",
-    "@clerk/shared": "file:.yalc/@clerk/shared",
-    "@clerk/types": "file:.yalc/@clerk/types",
+    "@clerk/backend": "latest",
+    "@clerk/clerk-react": "latest",
+    "@clerk/clerk-sdk-node": "latest",
+    "@clerk/nextjs": "latest",
+    "@clerk/shared": "latest",
+    "@clerk/types": "latest",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Description

I'm trying to deploy `playground/nextjs` to Vercel so the deps need to be valid versions, not Yalc stuff

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
