### PR TITLE
fix(clerk-js): Use setActive instead of navigating when deleting a user

### DIFF
--- a/.changeset/quiet-cougars-care.md
+++ b/.changeset/quiet-cougars-care.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use `Clerk.setActive` after deleting a user to reuse the same logic as signing out.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
-    "source.organizeImports": true
   },
   "eslint.workingDirectories": [{ "mode": "auto" }],
 }

--- a/packages/clerk-js/src/ui/components/UserProfile/DeletePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/DeletePage.tsx
@@ -1,25 +1,18 @@
-import { useCoreClerk, useCoreUser, useEnvironment } from '../../contexts';
+import { useCoreClerk, useCoreUser } from '../../contexts';
 import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, useCardState, withCardStateProvider } from '../../elements';
-import { useRouter } from '../../router';
 import { handleError, useFormControl } from '../../utils';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
 
 export const DeletePage = withCardStateProvider(() => {
   const card = useCardState();
-  const environment = useEnvironment();
-  const router = useRouter();
   const user = useCoreUser();
   const clerk = useCoreClerk();
 
   const deleteUser = async () => {
     try {
       await user.delete();
-      if (clerk.client.activeSessions.length > 0) {
-        await router.navigate(environment.displayConfig.afterSignOutOneUrl);
-      } else {
-        await router.navigate(environment.displayConfig.afterSignOutAllUrl);
-      }
+      await clerk.setActive({ session: null });
     } catch (e) {
       handleError(e, [], card.setError);
     }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Using `setActive` here is better as it correctly broadcasts the event and navigates to the correct path (we had the `displayConfig` path hardcoded here).

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
