### PR TITLE
fix(repo): Disable preparating clerk-js-proxy production release PR on pre-mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,22 @@ jobs:
           retry-exempt-status-codes: 400,401
           github-token: ${{ secrets.CLERK_COOKIE_PAT }}
           script: |
-            const clerkjsVersion = require('./packages/clerk-js/package.json').version;
-            github.rest.actions.createWorkflowDispatch({
-              owner: 'clerk',
-              repo: 'cloudflare-workers',
-              workflow_id: 'prepare-prod-clerkjs-proxy-pr.yml',
-              ref: 'main',
-              inputs: { version: clerkjsVersion }
-            })
+            const preMode = require("fs").existsSync("./.changeset/pre.json");
+            if (!preMode) {
+              const clerkjsVersion = require('./packages/clerk-js/package.json').version;
+
+              github.rest.actions.createWorkflowDispatch({
+                owner: 'clerk',
+                repo: 'cloudflare-workers',
+                workflow_id: 'prepare-prod-clerkjs-proxy-pr.yml',
+                ref: 'main',
+                inputs: { version: clerkjsVersion }
+              })
+            } else{
+              core.warning("Changeset in pre-mode should not prepare a ClerkJS production release")
+            }
+
+
 
       - name: Generate notification payload
         id: notification


### PR DESCRIPTION
## Description

When entering a pre-release mode (using changeset pre-mode) we should not prepare versions for production release in `clerkjs-proxy` worker from the `main` branch since they are ONLY meant to be released upon being stable. Also by leaving the action to be triggered with pre-release tags the clerk-js-proxy release production with the latest stable version is being overwritten and this may cause an accidental release of an alpha-v5 tag as stable.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
