### PR TITLE
chore(clerk-sdk-node): Warn about `{esm|cjs}/instance` subpath import deprecation warning

### DIFF
--- a/.changeset/ten-scissors-applaud.md
+++ b/.changeset/ten-scissors-applaud.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': patch
+---
+
+Warn about `@clerk/clerk-sdk-node/{esm|cjs}/instance` deprecation warning

--- a/packages/sdk-node/src/instance.ts
+++ b/packages/sdk-node/src/instance.ts
@@ -1,8 +1,10 @@
+import { deprecated } from '@clerk/shared';
+
 import { Clerk } from './clerkClient';
 
 export default Clerk;
 
-export type { WithAuthProp, RequireAuthProp } from './types';
+export type { RequireAuthProp, WithAuthProp } from './types';
 
 export {
   AllowlistIdentifier,
@@ -17,8 +19,10 @@ export {
   OrganizationMembership,
   OrganizationMembershipPublicUserData,
   PhoneNumber,
-  Session,
   SMSMessage,
+  Session,
   User,
   Verification,
 } from '@clerk/backend';
+
+deprecated('@clerk/clerk-sdk-node/instance', 'Use `@clerk/clerk-sdk-node` instead.');


### PR DESCRIPTION
## Description

Warn about `@clerk/clerk-sdk-node/{esm|cjs}/instance` deprecation warning

Will be dropped in the next major version with : https://github.com/clerk/javascript/pull/2021
<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
