### PR TITLE
fix(clerk-js,shared): Refresh invited members upon revocation

### DIFF
--- a/.changeset/thirty-doors-peel.md
+++ b/.changeset/thirty-doors-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Refresh invited members upon revocation

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -28,7 +28,7 @@ export const ActiveMembersList = () => {
       .catch(err => handleError(err, [], card.setError));
   };
 
-  const handleRemove = (membership: OrganizationMembershipResource) => () => {
+  const handleRemove = (membership: OrganizationMembershipResource) => async () => {
     return card
       .runAsync(async () => {
         const destroyedMembership = await membership.destroy();

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -17,11 +17,12 @@ export const InvitedMembersList = () => {
     return null;
   }
 
-  const revoke = (invitation: OrganizationInvitationResource) => () => {
+  const revoke = (invitation: OrganizationInvitationResource) => async () => {
     return card
       .runAsync(async () => {
         await invitation.revoke();
-        await (invitations as any).unstable__mutate?.();
+        await invitations?.revalidate?.();
+        return invitation;
       })
       .catch(err => handleError(err, [], card.setError));
   };

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -1,9 +1,11 @@
 import type {
+  ClerkPaginatedResponse,
   ClerkPaginationParams,
   GetDomainsParams,
   GetInvitationsParams,
   GetMembershipRequestParams,
   GetMembershipsParams,
+  GetMembersParams,
   GetPendingInvitationsParams,
   OrganizationDomainResource,
   OrganizationInvitationResource,
@@ -11,8 +13,6 @@ import type {
   OrganizationMembershipResource,
   OrganizationResource,
 } from '@clerk/types';
-import type { ClerkPaginatedResponse } from '@clerk/types';
-import type { GetMembersParams } from '@clerk/types';
 
 import { deprecated } from '../../deprecated';
 import { useSWR } from '../clerk-swr';


### PR DESCRIPTION
## Description

This ensures that the list of members invited to an organization is revalidated upon the revocation of an invitation.

Fixes SDK-890

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
