### PR TITLE
fix(repo): Build ahead of release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,22 +45,20 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           playwright-enabled: true # Must be present to enable caching on branched workflows
 
+      - name: Build
+        run: npx turbo build $TURBO_ARGS
+
       - name: Create Release PR
         id: changesets
         uses: changesets/action@v1
         with:
           commit: "chore(repo): Version packages"
-          publish: npx turbo build $TURBO_ARGS && changeset publish && git push --follow-tags
+          publish: changeset publish && git push --follow-tags
         env:
           GITHUB_TOKEN: ${{ secrets.CLERK_COOKIE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          TURBO_ARGS: ${{ env.TURBO_ARGS}}
-          TURBO_TEAM: ${{ env.TURBO_TEAM }}
-          TURBO_TOKEN: ${{ env.TURBO_TOKEN }}
-          TURBO_REMOTE_ONLY: ${{ env.TURBO_REMOTE_ONLY }}
-          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ env.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
       - name: Trigger workflows on related repos
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Description

Environment variable access between these actions isn't playing out well. This PR simply moves the build process out of the changelog publish cmd.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
