### PR TITLE
fix(clerk-js): Use strict equality operator to check for lockout erro…

### DIFF
--- a/.changeset/clever-vans-flash.md
+++ b/.changeset/clever-vans-flash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use strict equality operator to check for lockout errors in handleRedirectCallback

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1039,8 +1039,8 @@ export default class Clerk implements ClerkInterface {
       }
     }
 
-    const userLockedFromSignUp = su.externalAccountErrorCode == 'user_locked';
-    const userLockedFromSignIn = si.firstFactorVerificationErrorCode == 'user_locked';
+    const userLockedFromSignUp = su.externalAccountErrorCode === 'user_locked';
+    const userLockedFromSignIn = si.firstFactorVerificationErrorCode === 'user_locked';
 
     if (userLockedFromSignUp) {
       return navigateToSignUp();


### PR DESCRIPTION
…rs in handleRedirectCallback

## Description

Using strict equality `===` instead of `==`.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
