### PR TITLE
fix(clerk-js): Emit session when permissions or role of the active memberships change

### DIFF
--- a/.changeset/dry-students-reflect.md
+++ b/.changeset/dry-students-reflect.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Emit session when permissions or role of the active memberships change.

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -8,6 +8,7 @@ import type {
   GetInvitationsParams,
   GetMembershipRequestParams,
   GetMemberships,
+  GetMembershipsParams,
   GetPendingInvitationsParams,
   GetRolesParams,
   InviteMemberParams,
@@ -26,7 +27,6 @@ import type {
   UpdateMembershipParams,
   UpdateOrganizationParams,
 } from '@clerk/types';
-import type { GetMembershipsParams } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
 import { convertPageToOffset } from '../../utils/pagesToOffset';
@@ -109,11 +109,16 @@ export class Organization extends BaseResource implements OrganizationResource {
   };
 
   getRoles = async (getRolesParams?: GetRolesParams) => {
-    return await BaseResource._fetch({
-      path: `/organizations/${this.id}/roles`,
-      method: 'GET',
-      search: convertPageToOffset(getRolesParams) as any,
-    }).then(res => {
+    return await BaseResource._fetch(
+      {
+        path: `/organizations/${this.id}/roles`,
+        method: 'GET',
+        search: convertPageToOffset(getRolesParams) as any,
+      },
+      {
+        forceUpdateClient: true,
+      },
+    ).then(res => {
       const { data: roles, total_count } = res?.response as unknown as ClerkPaginatedResponse<RoleJSON>;
 
       return {
@@ -126,11 +131,16 @@ export class Organization extends BaseResource implements OrganizationResource {
   getDomains = async (
     getDomainParams?: GetDomainsParams,
   ): Promise<ClerkPaginatedResponse<OrganizationDomainResource>> => {
-    return await BaseResource._fetch({
-      path: `/organizations/${this.id}/domains`,
-      method: 'GET',
-      search: convertPageToOffset(getDomainParams) as any,
-    })
+    return await BaseResource._fetch(
+      {
+        path: `/organizations/${this.id}/domains`,
+        method: 'GET',
+        search: convertPageToOffset(getDomainParams) as any,
+      },
+      {
+        forceUpdateClient: true,
+      },
+    )
       .then(res => {
         const { data: invites, total_count } =
           res?.response as unknown as ClerkPaginatedResponse<OrganizationDomainJSON>;
@@ -197,13 +207,18 @@ export class Organization extends BaseResource implements OrganizationResource {
       deprecated('offset', 'Use `initialPage` instead in Organization.limit.', 'organization:getMemberships:offset');
     }
 
-    return await BaseResource._fetch({
-      path: `/organizations/${this.id}/memberships`,
-      method: 'GET',
-      search: isDeprecatedParams
-        ? getMembershipsParams
-        : (convertPageToOffset(getMembershipsParams as unknown as any) as any),
-    })
+    return await BaseResource._fetch(
+      {
+        path: `/organizations/${this.id}/memberships`,
+        method: 'GET',
+        search: isDeprecatedParams
+          ? getMembershipsParams
+          : (convertPageToOffset(getMembershipsParams as unknown as any) as any),
+      },
+      {
+        forceUpdateClient: true,
+      },
+    )
       .then(res => {
         if (isDeprecatedParams) {
           const organizationMembershipsJSON = res?.response as unknown as OrganizationMembershipJSON[];
@@ -248,11 +263,16 @@ export class Organization extends BaseResource implements OrganizationResource {
   getInvitations = async (
     getInvitationsParams?: GetInvitationsParams,
   ): Promise<ClerkPaginatedResponse<OrganizationInvitationResource>> => {
-    return await BaseResource._fetch({
-      path: `/organizations/${this.id}/invitations`,
-      method: 'GET',
-      search: convertPageToOffset(getInvitationsParams) as any,
-    })
+    return await BaseResource._fetch(
+      {
+        path: `/organizations/${this.id}/invitations`,
+        method: 'GET',
+        search: convertPageToOffset(getInvitationsParams) as any,
+      },
+      {
+        forceUpdateClient: true,
+      },
+    )
       .then(res => {
         const { data: requests, total_count } =
           res?.response as unknown as ClerkPaginatedResponse<OrganizationInvitationJSON>;

--- a/packages/clerk-js/src/utils/memoizeStateListenerCallback.ts
+++ b/packages/clerk-js/src/utils/memoizeStateListenerCallback.ts
@@ -28,7 +28,11 @@ function clientChanged(prev: ClientResource, next: ClientResource): boolean {
 }
 
 function sessionChanged(prev: SessionResource, next: SessionResource): boolean {
-  return prev.id !== next.id || prev.updatedAt.getTime() < next.updatedAt.getTime();
+  return (
+    prev.id !== next.id ||
+    prev.updatedAt.getTime() < next.updatedAt.getTime() ||
+    sessionUserMembershipPermissionsChanged(next, prev)
+  );
 }
 
 function userChanged(prev: UserResource, next: UserResource): boolean {
@@ -42,6 +46,25 @@ function userMembershipsChanged(prev: UserResource, next: UserResource): boolean
   return (
     prev.organizationMemberships.length !== next.organizationMemberships.length ||
     prev.organizationMemberships[0]?.updatedAt !== next.organizationMemberships[0]?.updatedAt
+  );
+}
+
+function sessionUserMembershipPermissionsChanged(prev: SessionResource, next: SessionResource): boolean {
+  if (prev.lastActiveOrganizationId !== next.lastActiveOrganizationId) {
+    return true;
+  }
+
+  const prevActiveMembership = prev.user?.organizationMemberships?.find(
+    mem => mem.organization.id === prev.lastActiveOrganizationId,
+  );
+
+  const nextActiveMembership = next.user?.organizationMemberships?.find(
+    mem => mem.organization.id === prev.lastActiveOrganizationId,
+  );
+
+  return (
+    prevActiveMembership?.role !== nextActiveMembership?.role ||
+    prevActiveMembership?.permissions?.length !== nextActiveMembership?.permissions?.length
   );
 }
 


### PR DESCRIPTION
## Description

This PR allows for clerk-js to detect when the role or permissions of the active organization memberships of the user has changed and emit them for subscribers (in this case clerk-react is what we are interested in).

### Before

https://github.com/clerk/javascript/assets/19269911/5a391888-d798-45f0-a1ed-6aa21e3ed9db


### After

https://github.com/clerk/javascript/assets/19269911/492f0e4b-27e0-46b0-b1d2-2803b02bab81



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
