### PR TITLE
fix(clerk-js): Use strict equality operator to check for lockout errors in handleRedirectCallback (#2072)

### DIFF
--- a/.changeset/clever-vans-flash.md
+++ b/.changeset/clever-vans-flash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use strict equality operator to check for lockout errors in handleRedirectCallback

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1036,8 +1036,8 @@ export default class Clerk implements ClerkInterface {
       }
     }
 
-    const userLockedFromSignUp = su.externalAccountErrorCode == 'user_locked';
-    const userLockedFromSignIn = si.firstFactorVerificationErrorCode == 'user_locked';
+    const userLockedFromSignUp = su.externalAccountErrorCode === 'user_locked';
+    const userLockedFromSignIn = si.firstFactorVerificationErrorCode === 'user_locked';
 
     if (userLockedFromSignUp) {
       return navigateToSignUp();


### PR DESCRIPTION
Backporting #2072 to the release/v4 branch

(cherry picked from commit 034abeb762744c4948ef6600b21cd9dd68d165a8)