### PR TITLE
fix(nextjs): Removes the dot that breaks the link to the docs

### DIFF
--- a/.changeset/honest-onions-work.md
+++ b/.changeset/honest-onions-work.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Fixes the docs link pointing to clerk.com/docs in the `authAuthHeaderMissing` error by removing the trailing `.`

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -36,7 +36,7 @@ export const authAuthHeaderMissing = (helperName = 'auth') =>
 - Your Middleware matcher is configured to match this route or page.
 - If you are using the src directory, make sure the Middleware file is inside of it.
 
-For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs.
+For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs
 `;
 
 export const clockSkewDetected = (verifyMessage: string) =>


### PR DESCRIPTION
## Description
Removes the typo that breaks the link on a nextjs-clerk  authAuthHeaderMissing  Error, which added the annoying dot to the link and was breaking it.

## Checklist

- [x ] `npm test` runs as expected.
- [x ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
