### PR TITLE
chore(repo): Cache extraneous node_module versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          show-progress: false
 
       - name: Setup
         id: config
@@ -84,8 +87,6 @@ jobs:
               core.warning("Changeset in pre-mode should not prepare a ClerkJS production release")
             }
 
-
-
       - name: Generate notification payload
         id: notification
         if: steps.changesets.outputs.published == 'true'
@@ -101,4 +102,29 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANGELOG_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
+  # We're running the CI workflow (where node v20 modules are cached) in
+  # merge_group and not on main, we need to explicitly cache node_modules here so
+  # that follow-on branches can use the cached version of node_modules rather
+  # than recreating them every time.
+  cache-for-alternate-node-versions:
+    name: Cache for Alternate Node Versions
+    runs-on: ${{ vars.RUNNER_NORMAL }}
+    timeout-minutes: ${{ fromJSON(vars.TIMEOUT_MINUTES_NORMAL) }}
+    continue-on-error: true
 
+    strategy:
+      matrix:
+        version: [ 20 ] # NOTE: 18 is cached in the main release workflow
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Cache node_modules (Node v${{ matrix.version }})
+        uses: ./.github/actions/init
+        with:
+          node-version: ${{ matrix.version }}
+          turbo-team: ''
+          turbo-token: ''


### PR DESCRIPTION
## Description

In our CI unit tests, we run against Node 18 and Node 20 and we cache the `node_modules` output.

Node 20, however, continuously creates a new cache and the reason for this is that we run CI on the `merge_group` event and not on `main`.

Branches and PRs only have access to caches created within the scope of their branch, their base branch, and the default branch, which does not include merge groups.

This adds a simple job which ensures that `node_modules` for specific node versions (in this case, just v20) are cached in a way that follow-on branches are able to access it.

The job itself will add a very minimal amount of time to `main` and `release/v4` while having significant benefits downstream.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
