### PR TITLE
fix(remix): Avoid always showing `frontendApi` deprecation

### DIFF
--- a/.changeset/plenty-bottles-grow.md
+++ b/.changeset/plenty-bottles-grow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Avoid always showing deprecation warnings for `frontendApi` in `@clerk/remix`

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -86,7 +86,9 @@ export const interstitialJsonResponse = (
       __loader: opts.loader,
       __clerk_ssr_interstitial_html: loadInterstitialFromLocal({
         debugData: debugRequestState(requestState),
-        frontendApi: requestState.frontendApi,
+        // Use frontendApi only when legacy frontendApi is used to avoid showing deprecation warning
+        // since the requestState always contains the frontendApi constructed by publishableKey.
+        frontendApi: requestState.publishableKey ? '' : requestState.frontendApi,
         publishableKey: requestState.publishableKey,
         // TODO: This needs to be the version of clerk/remix not clerk/react
         // pkgVersion: LIB_VERSION,
@@ -155,7 +157,9 @@ export function getResponseClerkState(requestState: RequestState, context: AppLo
   const { reason, message, isSignedIn, isInterstitial, ...rest } = requestState;
   const clerkState = wrapWithClerkState({
     __clerk_ssr_state: rest.toAuth(),
-    __frontendApi: requestState.frontendApi,
+    // Use frontendApi only when legacy frontendApi is used to avoid showing deprecation warning
+    // since the requestState always contains the frontendApi constructed by publishableKey.
+    __frontendApi: requestState.publishableKey ? '' : requestState.frontendApi,
     __publishableKey: requestState.publishableKey,
     __proxyUrl: requestState.proxyUrl,
     __domain: requestState.domain,


### PR DESCRIPTION
## Description

Avoid always showing `frontendApi` on `@clerk/remix`!

Similar to: https://github.com/clerk/javascript/pull/1856
Resolves comment: https://github.com/clerk/javascript/pull/1823#issuecomment-1801389095

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
