### PR TITLE
fix(clerk-js,shared): Refresh invited members upon revocation (#2058)

### DIFF
--- a/.changeset/thirty-doors-peel.md
+++ b/.changeset/thirty-doors-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Refresh invited members upon revocation

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -33,7 +33,7 @@ export const ActiveMembersList = () => {
       .catch(err => handleError(err, [], card.setError));
   };
 
-  const handleRemove = (membership: OrganizationMembershipResource) => () => {
+  const handleRemove = (membership: OrganizationMembershipResource) => async () => {
     return card
       .runAsync(async () => {
         const destroyedMembership = await membership.destroy();

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -22,11 +22,12 @@ export const InvitedMembersList = () => {
     return null;
   }
 
-  const revoke = (invitation: OrganizationInvitationResource) => () => {
+  const revoke = (invitation: OrganizationInvitationResource) => async () => {
     return card
       .runAsync(async () => {
         await invitation.revoke();
-        await (invitations as any).unstable__mutate?.();
+        await invitations?.revalidate?.();
+        return invitation;
       })
       .catch(err => handleError(err, [], card.setError));
   };


### PR DESCRIPTION
Backporting #2058 to the release/v4 branch

(cherry picked from commit 59336d3d468edd205c0e5501b7d5046611ee217d)