### PR TITLE
chore(shared): Drop deprecations

### DIFF
--- a/.changeset/cuddly-cougars-check.md
+++ b/.changeset/cuddly-cougars-check.md
@@ -1,0 +1,13 @@
+---
+'@clerk/shared': major
+'@clerk/clerk-react': major
+---
+
+Drop deprecations. Migration steps:
+- use `EmailLinkError` instead of `MagicLinkError`
+- use `isEmailLinkError` instead of `isMagicLinkError`
+- use `EmailLinkErrorCode` instead of `MagicLinkErrorCode`
+- use `useEmailLink` instead of `useMagicLink`
+- use `buildRequestUrl` from `@clerk/backend` instead of `getRequestUrl` from `@clerk/shared`
+- use `OrganizationProvider` instead of `OrganizationContext`
+- use `userMemberships` instead of `organizationList` from `useOrganizationList`

--- a/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganizationList.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganizationList.test.tsx
@@ -38,15 +38,6 @@ describe('useOrganizationList', () => {
     expect(result.current.isLoaded).toBe(true);
     expect(result.current.setActive).toBeDefined();
     expect(result.current.createOrganization).toBeDefined();
-    expect(result.current.organizationList).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          membership: expect.objectContaining({
-            role: 'basic_member',
-          }),
-        }),
-      ]),
-    );
 
     expect(result.current.userInvitations).toEqual(
       expect.objectContaining({

--- a/packages/react/src/contexts/OrganizationContext.tsx
+++ b/packages/react/src/contexts/OrganizationContext.tsx
@@ -1,1 +1,1 @@
-export { OrganizationProvider, OrganizationContext, useOrganizationContext } from '@clerk/shared/react';
+export { OrganizationProvider, useOrganizationContext } from '@clerk/shared/react';

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -1,7 +1,5 @@
 import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 
-import { deprecated } from './deprecated';
-
 export function isUnauthorizedError(e: any): boolean {
   const status = e?.status;
   const code = e?.errors?.[0]?.code;
@@ -169,20 +167,6 @@ export class ClerkRuntimeError extends Error {
   };
 }
 
-/**
- * @deprecated Use `EmailLinkError` instead.
- */
-export class MagicLinkError extends Error {
-  code: string;
-
-  constructor(code: string) {
-    super(code);
-    this.code = code;
-    Object.setPrototypeOf(this, MagicLinkError.prototype);
-    deprecated('MagicLinkError', 'Use `EmailLinkError` instead.');
-  }
-}
-
 export class EmailLinkError extends Error {
   code: string;
 
@@ -193,33 +177,9 @@ export class EmailLinkError extends Error {
   }
 }
 
-/**
- * Check if the error is a MagicLinkError.
- * @deprecated Use `isEmailLinkError` instead.
- */
-export function isMagicLinkError(err: Error): err is MagicLinkError {
-  deprecated('isMagicLinkError', 'Use `isEmailLinkError` instead.');
-  return err instanceof MagicLinkError;
-}
-
 export function isEmailLinkError(err: Error): err is EmailLinkError {
   return err instanceof EmailLinkError;
 }
-
-const _MagicLinkErrorCode = {
-  Expired: 'expired',
-  Failed: 'failed',
-};
-
-/**
- * @deprecated Use `EmailLinkErrorCode` instead.
- */
-export const MagicLinkErrorCode = new Proxy(_MagicLinkErrorCode, {
-  get(target, prop, receiver) {
-    deprecated('MagicLinkErrorCode', 'Use `EmailLinkErrorCode` instead.');
-    return Reflect.get(target, prop, receiver);
-  },
-});
 
 export const EmailLinkErrorCode = {
   Expired: 'expired',

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -1,5 +1,3 @@
-import { deprecated } from './deprecated';
-
 export function isValidProxyUrl(key: string | undefined) {
   if (!key) {
     return true;
@@ -21,21 +19,4 @@ export function proxyUrlToAbsoluteURL(url: string | undefined): string {
     return '';
   }
   return isProxyUrlRelative(url) ? new URL(url, window.location.origin).toString() : url;
-}
-
-/**
- * @deprecated Use `buildRequestUrl` from @clerk/backend
- */
-export function getRequestUrl({ request, relativePath }: { request: Request; relativePath?: string }): URL {
-  deprecated('getRequestUrl', 'Use `buildRequestUrl` from @clerk/backend instead.');
-  const { headers, url: initialUrl } = request;
-  const url = new URL(initialUrl);
-  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? (headers as any)['host'] ?? url.host;
-
-  // X-Forwarded-Proto could be 'https, http'
-  let protocol =
-    (headers.get('X-Forwarded-Proto') ?? (headers as any)['X-Forwarded-Proto'])?.split(',')[0] ?? url.protocol;
-  protocol = protocol.replace(/[:/]/, '');
-
-  return new URL(relativePath || url.pathname, `${protocol}://${host}`);
 }

--- a/packages/shared/src/react/contexts.tsx
+++ b/packages/shared/src/react/contexts.tsx
@@ -4,15 +4,12 @@ import type {
   ActiveSessionResource,
   ClientResource,
   LoadedClerk,
-  OrganizationInvitationResource,
-  OrganizationMembershipResource,
   OrganizationResource,
   UserResource,
 } from '@clerk/types';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
-import { deprecated } from '../deprecated';
 import { SWRConfig } from './clerk-swr';
 import { createContextAndHook } from './hooks/createContextAndHook';
 
@@ -51,14 +48,6 @@ const OrganizationProvider = ({
       </OrganizationContextInternal.Provider>
     </SWRConfig>
   );
-};
-
-/**
- * @deprecated use OrganizationProvider instead
- */
-export const OrganizationContext = (...args: Parameters<typeof OrganizationProvider>) => {
-  deprecated('OrganizationContext', 'Use `OrganizationProvider` instead');
-  return OrganizationProvider(...args);
 };
 
 export {

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -11,7 +11,6 @@ import type {
   UserOrganizationInvitationResource,
 } from '@clerk/types';
 
-import { deprecatedObjectProperty } from '../../deprecated';
 import { useClerkInstanceContext, useUserContext } from '../contexts';
 import type { PaginatedResources, PaginatedResourcesWithDefault } from '../types';
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
@@ -37,7 +36,6 @@ type UseOrganizationListParams = {
       });
 };
 
-type OrganizationList = ReturnType<typeof createOrganizationList>;
 const undefinedPaginatedResource = {
   data: undefined,
   count: undefined,
@@ -60,10 +58,6 @@ type UseOrganizationList = <T extends UseOrganizationListParams>(
 ) =>
   | {
       isLoaded: false;
-      /**
-       * @deprecated Use userMemberships instead
-       */
-      organizationList: undefined;
       createOrganization: undefined;
       setActive: undefined;
       userMemberships: PaginatedResourcesWithDefault<OrganizationMembershipResource>;
@@ -72,10 +66,6 @@ type UseOrganizationList = <T extends UseOrganizationListParams>(
     }
   | {
       isLoaded: boolean;
-      /**
-       * @deprecated Use userMemberships instead
-       */
-      organizationList: OrganizationList;
       createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource>;
       setActive: SetActive;
       userMemberships: PaginatedResources<
@@ -208,7 +198,6 @@ export const useOrganizationList: UseOrganizationList = params => {
   if (!isClerkLoaded) {
     return {
       isLoaded: false,
-      organizationList: undefined,
       createOrganization: undefined,
       setActive: undefined,
       userMemberships: undefinedPaginatedResource,
@@ -217,23 +206,12 @@ export const useOrganizationList: UseOrganizationList = params => {
     };
   }
 
-  const result = {
+  return {
     isLoaded: isClerkLoaded,
-    organizationList: createOrganizationList(user.organizationMemberships),
     setActive: clerk.setActive,
     createOrganization: clerk.createOrganization,
     userMemberships: memberships,
     userInvitations: invitations,
     userSuggestions: suggestions,
   };
-  deprecatedObjectProperty(result, 'organizationList', 'Use `userMemberships` instead.');
-
-  return result;
 };
-
-function createOrganizationList(organizationMemberships: OrganizationMembershipResource[]) {
-  return organizationMemberships.map(organizationMembership => ({
-    membership: organizationMembership,
-    organization: organizationMembership.organization,
-  }));
-}

--- a/packages/shared/src/react/index.ts
+++ b/packages/shared/src/react/index.ts
@@ -3,7 +3,6 @@ export * from './hooks';
 export {
   ClerkInstanceContext,
   ClientContext,
-  OrganizationContext,
   OrganizationProvider,
   SessionContext,
   useClerkInstanceContext,


### PR DESCRIPTION
## Description

Drop deprecations. Migration steps:
- use `EmailLinkError` instead of `MagicLinkError`
- use `isEmailLinkError` instead of `isMagicLinkError`
- use `EmailLinkErrorCode` instead of `MagicLinkErrorCode`
- use `useEmailLink` instead of `useMagicLink`
- use `buildRequestUrl` from `@clerk/backend` instead of `getRequestUrl` from `@clerk/shared`
- use `OrganizationProvider` instead of `OrganizationContext`
- use `userMemberships` instead of `organizationList` from `useOrganizationList`

Depends on:
- clerk-js : https://github.com/clerk/javascript/pull/2082

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
