### PR TITLE
fix(backend): strip experimental__has from serializable auth object (#2101)

### DIFF
--- a/.changeset/weak-elephants-grin.md
+++ b/.changeset/weak-elephants-grin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Strip `experimental__has` from the auth object in `makeAuthObjectSerializable()`. This fixes an issue in Next.js where an error is being thrown when this function is passed to a client component as a prop.

--- a/packages/backend/src/tokens/authObjects.test.ts
+++ b/packages/backend/src/tokens/authObjects.test.ts
@@ -1,0 +1,18 @@
+import type QUnit from 'qunit';
+
+import { makeAuthObjectSerializable, signedOutAuthObject } from './authObjects';
+
+export default (QUnit: QUnit) => {
+  const { module, test } = QUnit;
+
+  module('makeAuthObjectSerializable', () => {
+    test('removes non-serializable props', assert => {
+      const authObject = signedOutAuthObject();
+      const serializableAuthObject = makeAuthObjectSerializable(authObject);
+
+      for (const key in serializableAuthObject) {
+        assert.notStrictEqual(typeof serializableAuthObject[key], 'function');
+      }
+    });
+  });
+};

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -192,7 +192,7 @@ export function sanitizeAuthObject<T extends Record<any, any>>(authObject: T): T
 export const makeAuthObjectSerializable = <T extends Record<string, unknown>>(obj: T): T => {
   // remove any non-serializable props from the returned object
 
-  const { debug, getToken, ...rest } = obj as unknown as AuthObject;
+  const { debug, getToken, experimental__has, ...rest } = obj as unknown as AuthObject;
   return rest as unknown as T;
 };
 

--- a/packages/backend/tests/suites.ts
+++ b/packages/backend/tests/suites.ts
@@ -4,6 +4,7 @@ import apiTest from './dist/api/factory.test.js';
 import factoryTest from './dist/api/factory.test.js';
 import exportsTest from './dist/exports.test.js';
 import redirectTest from './dist/redirections.test.js';
+import authObjectsTest from './dist/tokens/authObjects.test.js';
 import interstitialRequestTest from './dist/tokens/interstitial.test.js';
 import jwtAssertionsTest from './dist/tokens/jwt/assertions.test.js';
 import cryptoKeysTest from './dist/tokens/jwt/cryptoKeys.test.js';
@@ -19,6 +20,7 @@ import utilsTest from './dist/utils.test.js';
 // Add them to the suite array
 const suites = [
   apiTest,
+  authObjectsTest,
   exportsTest,
   jwtAssertionsTest,
   requestTest,


### PR DESCRIPTION
Backporting #2101 to the release/v4 branch

(cherry picked from commit a6451aecef0bac578b295b524f1246dede3a7598)