### PR TITLE
feat(clerk-js,types): Pass unsafe metadata to signin component for oauth

### DIFF
--- a/.changeset/little-apes-yawn.md
+++ b/.changeset/little-apes-yawn.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add unsafe metadata to signin component and method

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -170,8 +170,12 @@ export class SignIn extends BaseResource implements SignInResource {
     });
   };
 
-  public authenticateWithRedirect = async (params: AuthenticateWithRedirectParams): Promise<void> => {
-    const { strategy, redirectUrl, redirectUrlComplete, identifier } = params || {};
+  public authenticateWithRedirect = async (
+    params: AuthenticateWithRedirectParams & {
+      unsafeMetadata?: SignUpUnsafeMetadata;
+    },
+  ): Promise<void> => {
+    const { strategy, redirectUrl, redirectUrlComplete, identifier, unsafeMetadata } = params || {};
 
     const { firstFactorVerification } =
       strategy === 'saml' && this.id
@@ -184,6 +188,7 @@ export class SignIn extends BaseResource implements SignInResource {
             strategy,
             identifier,
             redirectUrl: SignIn.clerk.buildUrlWithAuth(redirectUrl),
+            unsafeMetadata,
             actionCompleteRedirectUrl: redirectUrlComplete,
           });
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
@@ -24,7 +24,7 @@ export const SignInSocialButtons = React.memo((props: SocialButtonsProps) => {
       {...props}
       oauthCallback={strategy => {
         return signIn
-          .authenticateWithRedirect({ strategy, redirectUrl, redirectUrlComplete })
+          .authenticateWithRedirect({ strategy, redirectUrl, redirectUrlComplete, unsafeMetadata: ctx.unsafeMetadata })
           .catch(err => handleError(err, [], card.setError));
       }}
       web3Callback={() => {

--- a/packages/types/src/clerk.retheme.ts
+++ b/packages/types/src/clerk.retheme.ts
@@ -629,6 +629,10 @@ export type SignInProps = {
    */
   appearance?: SignInTheme;
   /**
+   * Additional arbitrary metadata to be stored alongside the User object
+   */
+  unsafeMetadata?: SignUpUnsafeMetadata;
+  /**
    * Initial values that are used to prefill the sign in form.
    */
   initialValues?: SignInInitialValues;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -629,6 +629,10 @@ export type SignInProps = {
    */
   appearance?: SignInTheme;
   /**
+   * Additional arbitrary metadata to be stored alongside the User object
+   */
+  unsafeMetadata?: SignUpUnsafeMetadata;
+  /**
    * Initial values that are used to prefill the sign in form.
    */
   initialValues?: SignInInitialValues;

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -84,7 +84,9 @@ export interface SignInResource extends ClerkResource {
 
   attemptSecondFactor: (params: AttemptSecondFactorParams) => Promise<SignInResource>;
 
-  authenticateWithRedirect: (params: AuthenticateWithRedirectParams) => Promise<void>;
+  authenticateWithRedirect: (
+    params: AuthenticateWithRedirectParams & { unsafeMetadata?: SignUpUnsafeMetadata },
+  ) => Promise<void>;
 
   authenticateWithWeb3: (params: AuthenticateWithWeb3Params) => Promise<SignInResource>;
 
@@ -158,6 +160,7 @@ export type SignInCreateParams = (
       redirectUrl: string;
       actionCompleteRedirectUrl?: string;
       identifier?: string;
+      unsafeMetadata?: SignUpUnsafeMetadata;
     }
   | {
       strategy: TicketStrategy;


### PR DESCRIPTION
## Description

While I was using the SignIn component from `@clerk/nextjs`, I notice that the user is created if the user uses a social button, what I think is ok, but since I rely on the unsafe metadata this is a bad news for me because only the SignUp components supports it. This PR is to solve that issue, adding the unsafe metadata to the SignIn component too.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
