### PR TITLE
chore(clerk-js): Use `userMemberships` instead of `organizationList` inside `OrganizationSwitcher`

### DIFF
--- a/.changeset/friendly-tables-chew.md
+++ b/.changeset/friendly-tables-chew.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use `userMemberships` instead of `organizationList` inside `<OrganizationSwitcher/>`.

--- a/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/UserMembershipList.tsx
@@ -1,6 +1,7 @@
 import type { OrganizationResource } from '@clerk/types';
 import React from 'react';
 
+import { InfiniteListSpinner } from '../../common';
 import {
   useCoreOrganization,
   useCoreOrganizationList,
@@ -9,24 +10,53 @@ import {
 } from '../../contexts';
 import { Box, descriptors, localizationKeys } from '../../customizables';
 import { OrganizationPreview, PersonalWorkspacePreview, PreviewButton } from '../../elements';
+import { useInView } from '../../hooks';
 import { SwitchArrows } from '../../icons';
 import { common } from '../../styledSystem';
+import { organizationListParams } from './utils';
 
 export type UserMembershipListProps = {
   onPersonalWorkspaceClick: React.MouseEventHandler;
   onOrganizationClick: (org: OrganizationResource) => unknown;
+};
+
+const useFetchMemberships = () => {
+  const { userMemberships } = useCoreOrganizationList({
+    userMemberships: organizationListParams.userMemberships,
+  });
+
+  const { ref } = useInView({
+    threshold: 0,
+    onChange: inView => {
+      if (!inView) {
+        return;
+      }
+      if (userMemberships.hasNextPage) {
+        userMemberships.fetchNext?.();
+      }
+    },
+  });
+
+  return {
+    userMemberships,
+    ref,
+  };
 };
 export const UserMembershipList = (props: UserMembershipListProps) => {
   const { onPersonalWorkspaceClick, onOrganizationClick } = props;
 
   const { hidePersonal } = useOrganizationSwitcherContext();
   const { organization: currentOrg } = useCoreOrganization();
-  const { organizationList } = useCoreOrganizationList();
+  const { ref, userMemberships } = useFetchMemberships();
   const user = useCoreUser();
 
-  const otherOrgs = (organizationList || []).map(e => e.organization).filter(o => o.id !== currentOrg?.id);
+  const otherOrgs = ((userMemberships.count || 0) > 0 ? userMemberships.data || [] : [])
+    .map(e => e.organization)
+    .filter(o => o.id !== currentOrg?.id);
 
   const { username, primaryEmailAddress, primaryPhoneNumber, ...userWithoutIdentifiers } = user;
+
+  const { isLoading, hasNextPage } = userMemberships;
 
   return (
     <Box
@@ -71,6 +101,7 @@ export const UserMembershipList = (props: UserMembershipListProps) => {
           />
         </PreviewButton>
       ))}
+      {(hasNextPage || isLoading) && <InfiniteListSpinner ref={ref} />}
     </Box>
   );
 };

--- a/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -4,7 +4,11 @@ import { describe } from '@jest/globals';
 import { act, render, runFakeTimers, waitFor } from '../../../../testUtils';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { OrganizationSwitcher } from '../OrganizationSwitcher';
-import { createFakeUserOrganizationInvitation, createFakeUserOrganizationSuggestion } from './utlis';
+import {
+  createFakeUserOrganizationInvitation,
+  createFakeUserOrganizationMembership,
+  createFakeUserOrganizationSuggestion,
+} from './utlis';
 
 const { createFixtures } = bindCreateFixtures('OrganizationSwitcher');
 
@@ -130,10 +134,42 @@ describe('OrganizationSwitcher', () => {
     });
 
     it('lists all organizations the user belongs to', async () => {
-      const { wrapper, props } = await createFixtures(f => {
+      const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1', 'Org2'] });
       });
+
+      fixtures.clerk.user?.getOrganizationMemberships.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeUserOrganizationMembership({
+              id: '1',
+              organization: {
+                id: '1',
+                name: 'Org1',
+                slug: 'org1',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+            createFakeUserOrganizationMembership({
+              id: '2',
+              organization: {
+                id: '2',
+                name: 'Org2',
+                slug: 'org2',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+          ],
+          total_count: 2,
+        }),
+      );
 
       props.setProps({ hidePersonal: false });
       const { getAllByText, getByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
@@ -313,6 +349,39 @@ describe('OrganizationSwitcher', () => {
           create_organization_enabled: false,
         });
       });
+
+      fixtures.clerk.user?.getOrganizationMemberships.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeUserOrganizationMembership({
+              id: '1',
+              organization: {
+                id: '1',
+                name: 'Org1',
+                slug: 'org1',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+            createFakeUserOrganizationMembership({
+              id: '2',
+              organization: {
+                id: '2',
+                name: 'Org2',
+                slug: 'org2',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+          ],
+          total_count: 2,
+        }),
+      );
+
       fixtures.clerk.setActive.mockReturnValueOnce(Promise.resolve());
 
       props.setProps({ hidePersonal: true });

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -4,7 +4,11 @@ import { describe } from '@jest/globals';
 import { act, render, runFakeTimers, waitFor } from '../../../../testUtils';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { OrganizationSwitcher } from '../OrganizationSwitcher';
-import { createFakeUserOrganizationInvitation, createFakeUserOrganizationSuggestion } from './utlis';
+import {
+  createFakeUserOrganizationInvitation,
+  createFakeUserOrganizationMembership,
+  createFakeUserOrganizationSuggestion,
+} from './utlis';
 
 const { createFixtures } = bindCreateFixtures('OrganizationSwitcher');
 
@@ -130,10 +134,42 @@ describe('OrganizationSwitcher', () => {
     });
 
     it('lists all organizations the user belongs to', async () => {
-      const { wrapper, props } = await createFixtures(f => {
+      const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1', 'Org2'] });
       });
+
+      fixtures.clerk.user?.getOrganizationMemberships.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeUserOrganizationMembership({
+              id: '1',
+              organization: {
+                id: '1',
+                name: 'Org1',
+                slug: 'org1',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+            createFakeUserOrganizationMembership({
+              id: '2',
+              organization: {
+                id: '2',
+                name: 'Org2',
+                slug: 'org2',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+          ],
+          total_count: 2,
+        }),
+      );
 
       props.setProps({ hidePersonal: false });
       const { getAllByText, getByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
@@ -313,6 +349,39 @@ describe('OrganizationSwitcher', () => {
           create_organization_enabled: false,
         });
       });
+
+      fixtures.clerk.user?.getOrganizationMemberships.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeUserOrganizationMembership({
+              id: '1',
+              organization: {
+                id: '1',
+                name: 'Org1',
+                slug: 'org1',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+            createFakeUserOrganizationMembership({
+              id: '2',
+              organization: {
+                id: '2',
+                name: 'Org2',
+                slug: 'org2',
+                membersCount: 1,
+                adminDeleteEnabled: false,
+                maxAllowedMemberships: 1,
+                pendingInvitationsCount: 1,
+              },
+            }),
+          ],
+          total_count: 2,
+        }),
+      );
+
       fixtures.clerk.setActive.mockReturnValueOnce(Promise.resolve());
 
       props.setProps({ hidePersonal: true });


### PR DESCRIPTION
## Description

This PR replaces the deprecated usage of `organizationList` from useOrganizationList with `userMemberships` that is returned from the same hook.

This PR also unblocks #2102

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
