### PR TITLE
chore(backend,nextjs,clerk-sdk-node): Drop legacy return response in BAPI responses

### DIFF
--- a/.changeset/mighty-pugs-knock.md
+++ b/.changeset/mighty-pugs-knock.md
@@ -1,0 +1,17 @@
+---
+'@clerk/clerk-sdk-node': major
+'@clerk/backend': major
+'@clerk/nextjs': major
+---
+
+Change the response payload of Backend API requests to return `{ data, errors }` instead of return the data and throwing on error response.
+Code example to keep the same behavior:
+```typescript
+import { users } from '@clerk/backend';
+import { ClerkAPIResponseError } from '@clerk/shared/error';
+
+const { data, errors, clerkTraceId, status, statusText } = await users.getUser('user_deadbeef');
+if(errors){
+    throw new ClerkAPIResponseError(statusText, { data: errors, status, clerkTraceId });
+}
+```

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -149,12 +149,9 @@ export async function signedIn<T extends AuthStatusOptionsType>(
     loadOrganization && orgId ? organizations.getOrganization({ organizationId: orgId }) : Promise.resolve(undefined),
   ]);
 
-  const session = sessionResp;
-  const user = userResp;
-  const organization = organizationResp;
-  // const session = sessionResp && !sessionResp.errors ? sessionResp.data : undefined;
-  // const user = userResp && !userResp.errors ? userResp.data : undefined;
-  // const organization = organizationResp && !organizationResp.errors ? organizationResp.data : undefined;
+  const session = sessionResp && !sessionResp.errors ? sessionResp.data : undefined;
+  const user = userResp && !userResp.errors ? userResp.data : undefined;
+  const organization = organizationResp && !organizationResp.errors ? organizationResp.data : undefined;
 
   const authObject = signedInAuthObject(
     sessionClaims,

--- a/packages/backend/src/util/assertResponse.ts
+++ b/packages/backend/src/util/assertResponse.ts
@@ -1,0 +1,9 @@
+type ApiResponse<T> = { data: T | null; errors: null | any[] };
+type SuccessApiResponse<T> = { data: T; errors: null };
+type ErrorApiResponse = { data: null; errors: any[]; clerkTraceId: string; status: number; statusText: string };
+export function assertResponse<T>(assert: Assert, resp: ApiResponse<T>): asserts resp is SuccessApiResponse<T> {
+  assert.equal(resp.errors, null);
+}
+export function assertErrorResponse<T>(assert: Assert, resp: ApiResponse<T>): asserts resp is ErrorApiResponse {
+  assert.notEqual(resp.errors, null);
+}

--- a/packages/backend/src/util/mockFetch.ts
+++ b/packages/backend/src/util/mockFetch.ts
@@ -5,6 +5,7 @@ export function jsonOk(body: unknown, status = 200) {
   const mockResponse = {
     ok: true,
     status,
+    statusText: status.toString(),
     headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);
@@ -19,6 +20,7 @@ export function jsonNotOk(body: unknown) {
   const mockResponse = {
     ok: false,
     status: 422,
+    statusText: 422,
     headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);
@@ -32,7 +34,8 @@ export function jsonError(body: unknown, status = 500) {
   // Mock response object that satisfies the window.Response interface
   const mockResponse = {
     ok: false,
-    status: status,
+    status,
+    statusText: status.toString(),
     headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -5,5 +5,10 @@ import { auth } from './auth';
 
 export async function currentUser(): Promise<User | null> {
   const { userId } = auth();
-  return userId ? clerkClient.users.getUser(userId) : null;
+  if (!userId) return null;
+
+  const { data, errors } = await clerkClient.users.getUser(userId);
+  if (errors) return null;
+
+  return data;
 }

--- a/packages/sdk-node/examples/express/src/runtime-keys-middleware.ts
+++ b/packages/sdk-node/examples/express/src/runtime-keys-middleware.ts
@@ -21,8 +21,12 @@ app.use(clerk.expressWithAuth());
 app.get('/', async (req: WithAuthProp<Request>, res: Response) => {
   const { userId, debug } = req.auth;
   console.log(debug());
-  const user = userId ? await clerk.users.getUser(userId) : null;
-  res.json({ auth: req.auth, user });
+  if (!userId) return res.json({ auth: req.auth, user: null });
+
+  const { data, errors } = await clerk.users.getUser(userId);
+  if (errors) return res.json({ auth: req.auth, user: null });
+
+  return res.json({ auth: req.auth, user: data });;
 });
 
 // @ts-ignore

--- a/packages/sdk-node/examples/node/src/organizations.ts
+++ b/packages/sdk-node/examples/node/src/organizations.ts
@@ -1,18 +1,29 @@
 import { organizations, users } from '@clerk/clerk-sdk-node';
 
 console.log('Get user to create organization');
-const [creator] = await users.getUserList();
+const { data, errors } = await users.getUserList();
+if (errors) {
+  throw new Error(errors);
+}
+
+const creator = data[0];
 
 console.log('Create organization');
-const organization = await organizations.createOrganization({
+const { data: organization } = await organizations.createOrganization({
   name: 'test-organization',
   createdBy: creator.id,
 });
 console.log(organization);
 
 console.log('Update organization metadata');
-const updatedOrganizationMetadata =
-  await organizations.updateOrganizationMetadata(organization.id, {
+const { data: updatedOrganizationMetadata, errors: uomErrors } = await organizations.updateOrganizationMetadata(
+  organization.id,
+  {
     publicMetadata: { test: 1 },
-  });
+  },
+);
+if (uomErrors) {
+  throw new Error(uomErrors);
+}
+
 console.log(updatedOrganizationMetadata);

--- a/packages/sdk-node/examples/node/src/sessions.ts
+++ b/packages/sdk-node/examples/node/src/sessions.ts
@@ -9,33 +9,25 @@ const sessionIdtoRevoke = process.env.SESSION_ID_TO_REVOKE || '';
 const sessionToken = process.env.SESSION_TOKEN || '';
 
 console.log('Get session list');
-const sessionList = await sessions.getSessionList();
+const { data: sessionList } = await sessions.getSessionList();
 console.log(sessionList);
 
 console.log('Get session list filtered by userId');
-const filteredSessions1 = await sessions.getSessionList({ userId });
+const { data: filteredSessions1 } = await sessions.getSessionList({ userId });
 console.log(filteredSessions1);
 
 console.log('Get session list filtered by clientId');
-const filteredSessions2 = await sessions.getSessionList({ clientId });
+const { data: filteredSessions2 } = await sessions.getSessionList({ clientId });
 console.log(filteredSessions2);
 
 console.log('Get single session');
-const session = await sessions.getSession(sessionId);
+const { data: session } = await sessions.getSession(sessionId);
 console.log(session);
 
-try {
-  console.log('Revoke session');
-  const revokedSession = await sessions.revokeSession(sessionIdtoRevoke);
-  console.log(revokedSession);
-} catch (error) {
-  console.log(error);
-}
+console.log('Revoke session');
+const { data: revokedSession } = await sessions.revokeSession(sessionIdtoRevoke);
+console.log(revokedSession);
 
-try {
-  console.log('Verify session');
-  const verifiedSession = await sessions.verifySession(sessionId, sessionToken);
-  console.log(verifiedSession);
-} catch (error) {
-  console.log(error);
-}
+console.log('Verify session');
+const { data: verifiedSession } = await sessions.verifySession(sessionId, sessionToken);
+console.log(verifiedSession);

--- a/packages/sdk-node/examples/node/src/users.ts
+++ b/packages/sdk-node/examples/node/src/users.ts
@@ -3,7 +3,7 @@
 import { users } from '@clerk/clerk-sdk-node';
 
 console.log('Create user');
-const createdUser = await users.createUser({
+const { data: createdUser, errors: createUserErrors } = await users.createUser({
   emailAddress: ['test@example.com'],
   phoneNumber: ['+15555555555'],
   externalId: 'a-unique-id',
@@ -21,36 +21,46 @@ const createdUser = await users.createUser({
   },
   password: '123456+ABCd',
 });
+if (createUserErrors) {
+  throw new Error(createUserErrors);
+}
 console.log(createdUser);
 const createdUserId = createdUser.id as string;
 
 console.log('Get single user');
-const user = await users.getUser(createdUserId);
+const { data: user, errors: userErrors } = await users.getUser(createdUserId);
+if (userErrors) {
+  throw new Error(userErrors);
+}
 console.log(user);
 
 await users.deleteUser(createdUserId);
 
 console.log('Get user list');
-const userList = await users.getUserList();
+const { data: userList, errors: userListErrors } = await users.getUserList();
+if (userListErrors) {
+  throw new Error(userListErrors);
+}
 console.log(userList);
 
-try {
-  console.log('Update user');
+console.log('Update user');
 
-  const updatedUser = await users.updateUser(createdUserId, {
-    firstName: 'Kyle',
-    lastName: 'Reese',
-    publicMetadata: {
-      zodiac_sign: 'leo',
-      ascendant: 'scorpio',
-    },
-  });
-
-  console.log(updatedUser);
-} catch (error) {
-  console.log(error);
+const { user: updatedUser, errors: updateUserErrors } = await users.updateUser(createdUserId, {
+  firstName: 'Kyle',
+  lastName: 'Reese',
+  publicMetadata: {
+    zodiac_sign: 'leo',
+    ascendant: 'scorpio',
+  },
+});
+if (updateUserErrors) {
+  throw new Error(updateUserErrors);
 }
+console.log(updatedUser);
 
 console.log('Get total count of users');
-const count = await users.getCount();
+const { data: count, errors: countErrors } = await users.getCount();
+if (countErrors) {
+  throw new Error(countErrors);
+}
 console.log(count);

--- a/packages/sdk-node/src/__tests__/middleware.test.ts
+++ b/packages/sdk-node/src/__tests__/middleware.test.ts
@@ -87,7 +87,7 @@ describe('ClerkExpressWithAuth', () => {
       isUnknown: false,
       toAuth: () => ({ sessionId: '1' }),
     } as unknown as RequestState);
-    clerkClient.remotePrivateInterstitial.mockReturnValue('<html>interstitial</html>');
+    clerkClient.remotePrivateInterstitial.mockReturnValue({ data: '<html>interstitial</html>', errors: null });
 
     await createClerkExpressWithAuth({ clerkClient })()(req, res, mockNext as NextFunction);
 
@@ -189,7 +189,7 @@ describe('ClerkExpressRequireAuth', () => {
       isUnknown: false,
       toAuth: () => ({ sessionId: '1' }),
     } as unknown as RequestState);
-    clerkClient.remotePrivateInterstitial.mockReturnValue('<html>interstitial</html>');
+    clerkClient.remotePrivateInterstitial.mockReturnValue({ data: '<html>interstitial</html>', errors: null });
 
     await createClerkExpressRequireAuth({ clerkClient })()(req, res, mockNext as NextFunction);
 

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -20,7 +20,7 @@ export async function loadInterstitial({
    * and avoid the extra network call
    */
   if (requestState.publishableKey) {
-    return clerkClient.localInterstitial({
+    const data = clerkClient.localInterstitial({
       publishableKey: requestState.publishableKey,
       proxyUrl: requestState.proxyUrl,
       signInUrl: requestState.signInUrl,
@@ -29,8 +29,14 @@ export async function loadInterstitial({
       clerkJSVersion,
       clerkJSUrl,
     });
+
+    return {
+      data,
+      errors: null,
+    };
   }
-  return await clerkClient.remotePrivateInterstitial();
+
+  return clerkClient.remotePrivateInterstitial();
 }
 
 export const authenticateRequest = (opts: AuthenticateRequestParams) => {

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -38,7 +38,12 @@ export const createClerkExpressRequireAuth = (createOpts: CreateClerkExpressMidd
           clerkClient,
           requestState,
         });
-        return handleInterstitialCase(res, requestState, interstitial);
+        if (interstitial.errors) {
+          // TODO(@dimkl): return interstitial errors ?
+          next(new Error('Unauthenticated'));
+          return;
+        }
+        return handleInterstitialCase(res, requestState, interstitial.data);
       }
 
       if (requestState.isSignedIn) {

--- a/packages/sdk-node/src/clerkExpressWithAuth.ts
+++ b/packages/sdk-node/src/clerkExpressWithAuth.ts
@@ -28,7 +28,12 @@ export const createClerkExpressWithAuth = (createOpts: CreateClerkExpressMiddlew
           clerkClient,
           requestState,
         });
-        return handleInterstitialCase(res, requestState, interstitial);
+        if (interstitial.errors) {
+          // TODO(@dimkl): return interstitial errors ?
+          next(new Error('Unauthenticated'));
+          return;
+        }
+        return handleInterstitialCase(res, requestState, interstitial.data);
       }
 
       (req as WithAuthProp<any>).auth = {


### PR DESCRIPTION
## Description

Currently the BAPI responses are in `{ data: unknown | null, errors: [] | null }` format but to avoid introducing a breaking change we convert those responses and return only the `data` part or `throw` an error if there are `errors`.
With this PR we will drop the transformation and return the actual response. This is a breaking change since from now on
- no error will be thrown from the BAPI requests client
- the caller will have to check for the `errors` prop in the return value to verify if the request succeeded
- the caller will have to retrieve the response data from the `data` prop in the return value

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [] `@clerk/fastify`
- [] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
