### PR TITLE
feat(clerk-js): Add default Allowed redirect origins

### DIFF
--- a/.changeset/fast-ads-mix.md
+++ b/.changeset/fast-ads-mix.md
@@ -6,6 +6,5 @@ Introducing default values for allowed redirect origins, this change will apply 
 
 Let's assume the host of the application is `test.host`, the origins will be
 - `https://test.host/`
-- `https://test.host/*`
+- `https://yourawesomeapp.clerk.accounts.dev/`
 - `https://*.yourawesomeapp.clerk.accounts.dev/`
-- `https://*.yourawesomeapp.clerk.accounts.dev/*`

--- a/.changeset/fast-ads-mix.md
+++ b/.changeset/fast-ads-mix.md
@@ -1,0 +1,11 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Introducing default values for allowed redirect origins, this change will apply default values for the `allowedRedirectOrigins option`, if there is no value provided the defaults will be similar to the example below.
+
+Let's assume the host of the application is `test.host`, the origins will be
+- `https://test.host/`
+- `https://test.host/*`
+- `https://*.yourawesomeapp.clerk.accounts.dev/`
+- `https://*.yourawesomeapp.clerk.accounts.dev/*`

--- a/.changeset/fast-ads-mix.md
+++ b/.changeset/fast-ads-mix.md
@@ -2,7 +2,7 @@
 '@clerk/clerk-js': minor
 ---
 
-Introducing default values for allowed redirect origins, this change will apply default values for the `allowedRedirectOrigins option`, if there is no value provided the defaults will be similar to the example below.
+Introducing default values for `allowedRedirectOrigins`. If no value is provided, default values similar to the example below will apply.
 
 Let's assume the host of the application is `test.host`, the origins will be
 - `https://test.host/`

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -2,7 +2,6 @@ import type { ActiveSessionResource, SignInJSON, SignUpJSON, TokenResource } fro
 import { waitFor } from '@testing-library/dom';
 
 import { mockNativeRuntime } from '../testUtils';
-import { getETLDPlusOneFromFrontendApi } from '../utils';
 import { Clerk } from './clerk';
 import { eventBus, events } from './events';
 import type { AuthConfig, DisplayConfig, Organization } from './resources/internal';

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -1,4 +1,3 @@
-import { parsePublishableKey } from '@clerk/shared';
 import type { ActiveSessionResource, SignInJSON, SignUpJSON, TokenResource } from '@clerk/types';
 import { waitFor } from '@testing-library/dom';
 
@@ -406,10 +405,10 @@ describe('Clerk singleton', () => {
     });
 
     it('contains the default allowed origin values', async () => {
-      const sut = new Clerk(frontendApi);
+      const sut = new Clerk(productionPublishableKey);
       await sut.load();
 
-      const frontendApiStr = parsePublishableKey(sut.publishableKey)?.frontendApi || sut.frontendApi;
+      const frontendApiStr = sut.frontendApi;
 
       expect(sut.allowedRedirectOrigins).toEqual([
         window.location.origin,
@@ -420,7 +419,7 @@ describe('Clerk singleton', () => {
     });
 
     it('contains only the allowedRedirectOrigins options given', async () => {
-      const sut = new Clerk(frontendApi);
+      const sut = new Clerk(productionPublishableKey);
       await sut.load({
         allowedRedirectOrigins: ['https://test.host'],
       });

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -403,29 +403,6 @@ describe('Clerk singleton', () => {
 
       expect(document.cookie).toContain(mockJwt);
     });
-
-    it('contains the default allowed origin values', async () => {
-      const sut = new Clerk(productionPublishableKey);
-      await sut.load();
-
-      const frontendApiStr = sut.frontendApi;
-
-      expect(sut.allowedRedirectOrigins).toEqual([
-        window.location.origin,
-        `${window.location.origin}/*`,
-        `https://*.${getETLDPlusOneFromFrontendApi(frontendApiStr)}`,
-        `https://*.${getETLDPlusOneFromFrontendApi(frontendApiStr)}/*`,
-      ]);
-    });
-
-    it('contains only the allowedRedirectOrigins options given', async () => {
-      const sut = new Clerk(productionPublishableKey);
-      await sut.load({
-        allowedRedirectOrigins: ['https://test.host'],
-      });
-
-      expect(sut.allowedRedirectOrigins).toEqual(['https://test.host']);
-    });
   });
 
   describe('.signOut()', () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -264,7 +264,7 @@ export class Clerk implements ClerkInterface {
         origins.push(window.location.origin + '/*');
       }
 
-      const frontendApi = parsePublishableKey(this.publishableKey)?.frontendApi || this.frontendApi;
+      const frontendApi = this.frontendApi;
 
       origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
       origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}/*`);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -65,6 +65,7 @@ import {
   createPageLifecycle,
   errorThrower,
   getClerkQueryParam,
+  getETLDPlusOneFromFrontendApi,
   hasExternalAccountSignUpError,
   ignoreEventValue,
   inActiveBrowserTab,
@@ -255,6 +256,25 @@ export class Clerk implements ClerkInterface {
 
   public isReady = (): boolean => this.#isReady;
 
+  get allowedRedirectOrigins(): (string | RegExp)[] | undefined {
+    if (!this.#options.allowedRedirectOrigins) {
+      const origins = [];
+      if (inBrowser()) {
+        origins.push(window.location.origin);
+        origins.push(window.location.origin + '/*');
+      }
+
+      const frontendApi = parsePublishableKey(this.publishableKey)?.frontendApi || this.frontendApi;
+
+      origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+      origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}/*`);
+
+      return origins;
+    }
+
+    return this.#options.allowedRedirectOrigins;
+  }
+
   public load = async (options?: ClerkOptions): Promise<void> => {
     if (this.#isReady) {
       return;
@@ -264,6 +284,8 @@ export class Clerk implements ClerkInterface {
       ...defaultOptions,
       ...options,
     };
+
+    this.#options.allowedRedirectOrigins = this.allowedRedirectOrigins;
 
     if (this.#options.standardBrowser) {
       this.#isReady = await this.#loadInStandardBrowser();

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -3,6 +3,7 @@ import type { SignUpResource } from '@clerk/types';
 import {
   appendAsQueryParams,
   buildURL,
+  createAllowedRedirectOrigins,
   getAllETLDs,
   getETLDPlusOneFromFrontendApi,
   getSearchParameterFromHash,
@@ -458,5 +459,35 @@ describe('isAllowedRedirectOrigin', () => {
   test.each(cases)('isAllowedRedirectOrigin("%s","%s") === %s', (url, allowedOrigins, expected) => {
     expect(isAllowedRedirectOrigin(url, allowedOrigins)).toEqual(expected);
     expect(warnMock).toHaveBeenCalledTimes(Number(!expected)); // Number(boolean) evaluates to 0 or 1
+  });
+});
+
+describe('createAllowedRedirectOrigins', () => {
+  it('contains the default allowed origin values if no value is provided', async () => {
+    const frontendApi = 'https://somename.clerk.accounts.dev';
+    const allowedRedirectOriginsValuesUndefined = createAllowedRedirectOrigins(undefined, frontendApi);
+    const allowedRedirectOriginsValuesEmptyArray = createAllowedRedirectOrigins([], frontendApi);
+
+    expect(allowedRedirectOriginsValuesUndefined).toEqual([
+      'http://localhost',
+      `https://${getETLDPlusOneFromFrontendApi(frontendApi)}`,
+      `https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`,
+    ]);
+
+    expect(allowedRedirectOriginsValuesEmptyArray).toEqual([
+      'http://localhost',
+      `https://${getETLDPlusOneFromFrontendApi(frontendApi)}`,
+      `https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`,
+    ]);
+  });
+
+  it('contains only the allowedRedirectOrigins options given', async () => {
+    const frontendApi = 'https://somename.clerk.accounts.dev';
+    const allowedRedirectOriginsValues = createAllowedRedirectOrigins(
+      ['https://test.host', 'https://*.test.host'],
+      frontendApi,
+    );
+
+    expect(allowedRedirectOriginsValues).toEqual(['https://test.host', 'https://*.test.host']);
   });
 });

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -350,3 +350,22 @@ export const isAllowedRedirectOrigin = (_url: string, allowedRedirectOrigins: Ar
   }
   return isAllowed;
 };
+
+export function createAllowedRedirectOrigins(
+  allowedRedirectOrigins: Array<string | RegExp> | undefined,
+  frontendApi: string,
+): (string | RegExp)[] | undefined {
+  if (!allowedRedirectOrigins || allowedRedirectOrigins.length === 0) {
+    const origins = [];
+    if (typeof window !== 'undefined' && !!window.location) {
+      origins.push(window.location.origin);
+    }
+
+    origins.push(`https://${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+    origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+
+    return origins;
+  }
+
+  return allowedRedirectOrigins;
+}

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -355,17 +355,17 @@ export function createAllowedRedirectOrigins(
   allowedRedirectOrigins: Array<string | RegExp> | undefined,
   frontendApi: string,
 ): (string | RegExp)[] | undefined {
-  if (!allowedRedirectOrigins || allowedRedirectOrigins.length === 0) {
-    const origins = [];
-    if (typeof window !== 'undefined' && !!window.location) {
-      origins.push(window.location.origin);
-    }
-
-    origins.push(`https://${getETLDPlusOneFromFrontendApi(frontendApi)}`);
-    origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
-
-    return origins;
+  if (Array.isArray(allowedRedirectOrigins) && !!allowedRedirectOrigins.length) {
+    return allowedRedirectOrigins;
   }
 
-  return allowedRedirectOrigins;
+  const origins = [];
+  if (typeof window !== 'undefined' && !!window.location) {
+    origins.push(window.location.origin);
+  }
+
+  origins.push(`https://${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+  origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+
+  return origins;
 }


### PR DESCRIPTION
## Description

This PR introduces default values for the `allowedRedirectOrigins` option, the current implementation does not provide any defaults, with this change if there is no option provided the default will be similar to the example below.

Let's say the host of the application is `test.host`, the origins will be
- `https://test.host/`
- `https://yourawesomeapp.clerk.accounts.dev/`
- `https://*.yourawesomeapp.clerk.accounts.dev/`

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [X] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
