### PR TITLE
fix(clerk-js): Require role to be selected before sending organization invite

### DIFF
--- a/.changeset/khaki-spoons-teach.md
+++ b/.changeset/khaki-spoons-teach.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Require role to be selected before sending organization invite, affects `<OrganizationProfile/>` and <CreateOrganization/>`.

--- a/packages/clerk-js/src/ui.retheme/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/OrganizationProfile/InviteMembersForm.tsx
@@ -30,16 +30,20 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   const { t, locale } = useLocalizations();
   const [isValidUnsubmittedEmail, setIsValidUnsubmittedEmail] = useState(false);
 
-  if (!organization) {
-    return null;
-  }
-
   const validateUnsubmittedEmail = (value: string) => setIsValidUnsubmittedEmail(isEmail(value));
 
   const emailAddressField = useFormControl('emailAddress', '', {
     type: 'text',
     label: localizationKeys('formFieldLabel__emailAddresses'),
   });
+
+  const roleField = useFormControl('role', '', {
+    label: localizationKeys('formFieldLabel__role'),
+  });
+
+  if (!organization) {
+    return null;
+  }
 
   const {
     props: {
@@ -58,7 +62,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     },
   } = emailAddressField;
 
-  const canSubmit = !!emailAddressField.value.length || isValidUnsubmittedEmail;
+  const canSubmit = (!!emailAddressField.value.length || isValidUnsubmittedEmail) && !!roleField.value;
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -122,7 +126,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
           />
         </Flex>
       </Form.ControlRow>
-      <AsyncRoleSelect />
+      <AsyncRoleSelect {...roleField} />
       <FormButtonContainer>
         <Form.SubmitButton
           block={false}
@@ -139,24 +143,21 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   );
 };
 
-const AsyncRoleSelect = () => {
+const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
   const { options, isLoading } = useFetchRoles();
-  const roleField = useFormControl('role', '', {
-    label: localizationKeys('formFieldLabel__role'),
-  });
 
   return (
-    <Form.ControlRow elementId={roleField.id}>
+    <Form.ControlRow elementId={field.id}>
       <Flex
         direction='col'
         gap={2}
       >
-        <Text localizationKey={roleField.label} />
+        <Text localizationKey={field.label} />
         <RoleSelect
-          {...roleField.props}
+          {...field.props}
           roles={options}
           isDisabled={isLoading}
-          onChange={value => roleField.setValue(value)}
+          onChange={value => field.setValue(value)}
           triggerSx={t => ({ width: t.sizes.$48, justifyContent: 'space-between', display: 'flex' })}
           optionListSx={t => ({ minWidth: t.sizes.$48 })}
         />

--- a/packages/clerk-js/src/ui.retheme/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -24,7 +24,7 @@ describe('InviteMembersPage', () => {
   });
 
   describe('Submitting', () => {
-    it('enables the Send button when one or more email has been entered', async () => {
+    it('keeps the Send button disabled until a role is selected and one or more email has been entered', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
@@ -34,10 +34,14 @@ describe('InviteMembersPage', () => {
       });
 
       fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByText, getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
 
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
+
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       expect(getByRole('button', { name: 'Send invitations' })).not.toBeDisabled();
     });
 
@@ -172,6 +176,9 @@ describe('InviteMembersPage', () => {
       );
       const { getByRole, userEvent, getByText, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       await waitFor(() =>
         expect(
@@ -206,8 +213,11 @@ describe('InviteMembersPage', () => {
           status: 400,
         }),
       );
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, userEvent, getByTestId, getByText } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'invalid@clerk.dev');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
 
       expect(getByTestId('tag-input')).not.toHaveValue();
@@ -236,8 +246,11 @@ describe('InviteMembersPage', () => {
           status: 403,
         }),
       );
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, getByText, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'blocked@clerk.dev');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
 
       expect(getByTestId('tag-input')).not.toHaveValue();

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -30,16 +30,20 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   const { t, locale } = useLocalizations();
   const [isValidUnsubmittedEmail, setIsValidUnsubmittedEmail] = useState(false);
 
-  if (!organization) {
-    return null;
-  }
-
   const validateUnsubmittedEmail = (value: string) => setIsValidUnsubmittedEmail(isEmail(value));
 
   const emailAddressField = useFormControl('emailAddress', '', {
     type: 'text',
     label: localizationKeys('formFieldLabel__emailAddresses'),
   });
+
+  const roleField = useFormControl('role', '', {
+    label: localizationKeys('formFieldLabel__role'),
+  });
+
+  if (!organization) {
+    return null;
+  }
 
   const {
     props: {
@@ -58,7 +62,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     },
   } = emailAddressField;
 
-  const canSubmit = !!emailAddressField.value.length || isValidUnsubmittedEmail;
+  const canSubmit = (!!emailAddressField.value.length || isValidUnsubmittedEmail) && !!roleField.value;
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -122,7 +126,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
           />
         </Flex>
       </Form.ControlRow>
-      <AsyncRoleSelect />
+      <AsyncRoleSelect {...roleField} />
       <FormButtonContainer>
         <Form.SubmitButton
           block={false}
@@ -139,24 +143,21 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   );
 };
 
-const AsyncRoleSelect = () => {
+const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
   const { options, isLoading } = useFetchRoles();
-  const roleField = useFormControl('role', '', {
-    label: localizationKeys('formFieldLabel__role'),
-  });
 
   return (
-    <Form.ControlRow elementId={roleField.id}>
+    <Form.ControlRow elementId={field.id}>
       <Flex
         direction='col'
         gap={2}
       >
-        <Text localizationKey={roleField.label} />
+        <Text localizationKey={field.label} />
         <RoleSelect
-          {...roleField.props}
+          {...field.props}
           roles={options}
           isDisabled={isLoading}
-          onChange={value => roleField.setValue(value)}
+          onChange={value => field.setValue(value)}
           triggerSx={t => ({ width: t.sizes.$48, justifyContent: 'space-between', display: 'flex' })}
           optionListSx={t => ({ minWidth: t.sizes.$48 })}
         />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -24,7 +24,7 @@ describe('InviteMembersPage', () => {
   });
 
   describe('Submitting', () => {
-    it('enables the Send button when one or more email has been entered', async () => {
+    it('keeps the Send button disabled until a role is selected and one or more email has been entered', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
@@ -34,10 +34,14 @@ describe('InviteMembersPage', () => {
       });
 
       fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByText, getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
 
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
+
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       expect(getByRole('button', { name: 'Send invitations' })).not.toBeDisabled();
     });
 
@@ -172,6 +176,9 @@ describe('InviteMembersPage', () => {
       );
       const { getByRole, userEvent, getByText, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       await waitFor(() =>
         expect(
@@ -206,8 +213,11 @@ describe('InviteMembersPage', () => {
           status: 400,
         }),
       );
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, userEvent, getByTestId, getByText } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'invalid@clerk.dev');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
 
       expect(getByTestId('tag-input')).not.toHaveValue();
@@ -236,8 +246,11 @@ describe('InviteMembersPage', () => {
           status: 403,
         }),
       );
-      const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
+      const { getByRole, getByText, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(getByTestId('tag-input'), 'blocked@clerk.dev');
+      await waitFor(() => expect(getByRole('button', { name: /select an option/i })).not.toBeDisabled());
+      await userEvent.click(getByRole('button', { name: /select an option/i }));
+      await userEvent.click(getByText(/^member$/i));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
 
       expect(getByTestId('tag-input')).not.toHaveValue();


### PR DESCRIPTION
## Description
This PR disabled the submit button until the role is selected otherwise a FAPI request would fire and fail.
Unfortunately field errors are not supported for the internal Select component, and it would be too much work for a v4 hot fix.

*The changes are introduced for both `ui` and `ui.retheme` as this is a bug fix and needs to be backported to v4.*

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
