### PR TITLE
chore(*): Replace children react nodes with React.PropsWithChildren

### DIFF
--- a/.changeset/wicked-shoes-boil.md
+++ b/.changeset/wicked-shoes-boil.md
@@ -1,0 +1,9 @@
+---
+'gatsby-plugin-clerk': patch
+'@clerk/clerk-js': patch
+'@clerk/nextjs': patch
+'@clerk/clerk-react': patch
+'@clerk/remix': patch
+---
+
+Use `React.PropsWithChildren` instead of manually using `children: React.ReactNode

--- a/packages/clerk-js/src/ui.retheme/contexts/CoreClerkContextWrapper.tsx
+++ b/packages/clerk-js/src/ui.retheme/contexts/CoreClerkContextWrapper.tsx
@@ -8,11 +8,10 @@ import { CoreSessionContext } from './CoreSessionContext';
 import { CoreUserContext } from './CoreUserContext';
 import { assertClerkSingletonExists } from './utils';
 
-type CoreClerkContextWrapperProps = {
+type CoreClerkContextWrapperProps = React.PropsWithChildren<{
   clerk: Clerk;
-  children: React.ReactNode;
   swrConfig?: any;
-};
+}>;
 
 type CoreClerkContextProviderState = Resources;
 

--- a/packages/clerk-js/src/ui.retheme/contexts/EnvironmentContext.tsx
+++ b/packages/clerk-js/src/ui.retheme/contexts/EnvironmentContext.tsx
@@ -5,8 +5,7 @@ import { assertContextExists } from './utils';
 
 const EnvironmentContext = React.createContext<EnvironmentResource | null>(null);
 
-interface EnvironmentProviderProps {
-  children: React.ReactNode;
+interface EnvironmentProviderProps extends React.PropsWithChildren {
   value: EnvironmentResource;
 }
 

--- a/packages/clerk-js/src/ui.retheme/contexts/OptionsContext.tsx
+++ b/packages/clerk-js/src/ui.retheme/contexts/OptionsContext.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 
 export const OptionsContext = React.createContext<ClerkOptions>({});
 
-interface OptionsProviderProps {
-  children: React.ReactNode;
+interface OptionsProviderProps extends React.PropsWithChildren {
   value: ClerkOptions;
 }
 

--- a/packages/clerk-js/src/ui.retheme/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui.retheme/lazyModules/providers.tsx
@@ -16,7 +16,7 @@ const Portal = lazy(() => import('./../portal'));
 const FlowMetadataProvider = lazy(() => import('./../elements').then(m => ({ default: m.FlowMetadataProvider })));
 const Modal = lazy(() => import('./../elements').then(m => ({ default: m.Modal })));
 
-type LazyProvidersProps = React.PropsWithChildren<{ clerk: any; environment: any; options: any; children: any }>;
+type LazyProvidersProps = React.PropsWithChildren<{ clerk: any; environment: any; options: any }>;
 
 export const LazyProviders = (props: LazyProvidersProps) => {
   return (

--- a/packages/clerk-js/src/ui.retheme/router/BaseRouter.tsx
+++ b/packages/clerk-js/src/ui.retheme/router/BaseRouter.tsx
@@ -9,7 +9,7 @@ import { match } from './pathToRegexp';
 import { Route } from './Route';
 import { RouteContext } from './RouteContext';
 
-interface BaseRouterProps {
+interface BaseRouterProps extends React.PropsWithChildren {
   basePath: string;
   startPath: string;
   getPath: () => string;
@@ -25,7 +25,6 @@ interface BaseRouterProps {
     clearUrlStateParam: () => void;
     socialProvider: string;
   };
-  children: React.ReactNode;
 }
 
 export const BaseRouter = ({

--- a/packages/clerk-js/src/ui.retheme/router/HashRouter.tsx
+++ b/packages/clerk-js/src/ui.retheme/router/HashRouter.tsx
@@ -5,9 +5,8 @@ import { BaseRouter } from './BaseRouter';
 
 export const hashRouterBase = 'CLERK-ROUTER/HASH';
 
-interface HashRouterProps {
+interface HashRouterProps extends React.PropsWithChildren {
   preservedParams?: string[];
-  children: React.ReactNode;
 }
 
 export const HashRouter = ({ preservedParams, children }: HashRouterProps): JSX.Element => {

--- a/packages/clerk-js/src/ui.retheme/router/PathRouter.tsx
+++ b/packages/clerk-js/src/ui.retheme/router/PathRouter.tsx
@@ -4,10 +4,9 @@ import { hasUrlInFragment, mergeFragmentIntoUrl, stripOrigin } from '../../utils
 import { useCoreClerk } from '../contexts';
 import { BaseRouter } from './BaseRouter';
 
-interface PathRouterProps {
+interface PathRouterProps extends React.PropsWithChildren {
   basePath: string;
   preservedParams?: string[];
-  children: React.ReactNode;
 }
 
 export const PathRouter = ({ basePath, preservedParams, children }: PathRouterProps): JSX.Element | null => {

--- a/packages/clerk-js/src/ui.retheme/router/Switch.tsx
+++ b/packages/clerk-js/src/ui.retheme/router/Switch.tsx
@@ -8,7 +8,7 @@ function assertRoute(v: any): v is React.ReactElement<RouteProps> {
   return !!v && React.isValidElement(v) && typeof v === 'object' && (v as React.ReactElement).type === Route;
 }
 
-export function Switch({ children }: { children: React.ReactNode }): JSX.Element {
+export function Switch({ children }: React.PropsWithChildren): JSX.Element {
   const router = useRouter();
 
   let node: React.ReactNode = null;

--- a/packages/clerk-js/src/ui.retheme/router/VirtualRouter.tsx
+++ b/packages/clerk-js/src/ui.retheme/router/VirtualRouter.tsx
@@ -4,11 +4,10 @@ import { useClerkModalStateParams } from '../hooks';
 import { BaseRouter } from './BaseRouter';
 export const VIRTUAL_ROUTER_BASE_PATH = 'CLERK-ROUTER/VIRTUAL';
 
-interface VirtualRouterProps {
+interface VirtualRouterProps extends React.PropsWithChildren {
   startPath: string;
   preservedParams?: string[];
   onExternalNavigate?: () => any;
-  children: React.ReactNode;
 }
 
 export const VirtualRouter = ({

--- a/packages/clerk-js/src/ui/contexts/CoreClerkContextWrapper.tsx
+++ b/packages/clerk-js/src/ui/contexts/CoreClerkContextWrapper.tsx
@@ -8,11 +8,10 @@ import { CoreSessionContext } from './CoreSessionContext';
 import { CoreUserContext } from './CoreUserContext';
 import { assertClerkSingletonExists } from './utils';
 
-type CoreClerkContextWrapperProps = {
+type CoreClerkContextWrapperProps = React.PropsWithChildren<{
   clerk: Clerk;
-  children: React.ReactNode;
   swrConfig?: any;
-};
+}>;
 
 type CoreClerkContextProviderState = Resources;
 

--- a/packages/clerk-js/src/ui/contexts/EnvironmentContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/EnvironmentContext.tsx
@@ -5,8 +5,7 @@ import { assertContextExists } from './utils';
 
 const EnvironmentContext = React.createContext<EnvironmentResource | null>(null);
 
-interface EnvironmentProviderProps {
-  children: React.ReactNode;
+interface EnvironmentProviderProps extends React.PropsWithChildren {
   value: EnvironmentResource;
 }
 

--- a/packages/clerk-js/src/ui/contexts/OptionsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/OptionsContext.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 
 export const OptionsContext = React.createContext<ClerkOptions>({});
 
-interface OptionsProviderProps {
-  children: React.ReactNode;
+interface OptionsProviderProps extends React.PropsWithChildren {
   value: ClerkOptions;
 }
 

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -16,7 +16,7 @@ const Portal = lazy(() => import('./../portal'));
 const FlowMetadataProvider = lazy(() => import('./../elements').then(m => ({ default: m.FlowMetadataProvider })));
 const Modal = lazy(() => import('./../elements').then(m => ({ default: m.Modal })));
 
-type LazyProvidersProps = React.PropsWithChildren<{ clerk: any; environment: any; options: any; children: any }>;
+type LazyProvidersProps = React.PropsWithChildren<{ clerk: any; environment: any; options: any }>;
 
 export const LazyProviders = (props: LazyProvidersProps) => {
   return (

--- a/packages/clerk-js/src/ui/router/BaseRouter.tsx
+++ b/packages/clerk-js/src/ui/router/BaseRouter.tsx
@@ -9,7 +9,7 @@ import { match } from './pathToRegexp';
 import { Route } from './Route';
 import { RouteContext } from './RouteContext';
 
-interface BaseRouterProps {
+interface BaseRouterProps extends React.PropsWithChildren {
   basePath: string;
   startPath: string;
   getPath: () => string;
@@ -25,7 +25,6 @@ interface BaseRouterProps {
     clearUrlStateParam: () => void;
     socialProvider: string;
   };
-  children: React.ReactNode;
 }
 
 export const BaseRouter = ({

--- a/packages/clerk-js/src/ui/router/HashRouter.tsx
+++ b/packages/clerk-js/src/ui/router/HashRouter.tsx
@@ -5,9 +5,8 @@ import { BaseRouter } from './BaseRouter';
 
 export const hashRouterBase = 'CLERK-ROUTER/HASH';
 
-interface HashRouterProps {
+interface HashRouterProps extends React.PropsWithChildren {
   preservedParams?: string[];
-  children: React.ReactNode;
 }
 
 export const HashRouter = ({ preservedParams, children }: HashRouterProps): JSX.Element => {

--- a/packages/clerk-js/src/ui/router/PathRouter.tsx
+++ b/packages/clerk-js/src/ui/router/PathRouter.tsx
@@ -4,10 +4,9 @@ import { hasUrlInFragment, mergeFragmentIntoUrl, stripOrigin } from '../../utils
 import { useCoreClerk } from '../contexts';
 import { BaseRouter } from './BaseRouter';
 
-interface PathRouterProps {
+interface PathRouterProps extends React.PropsWithChildren {
   basePath: string;
   preservedParams?: string[];
-  children: React.ReactNode;
 }
 
 export const PathRouter = ({ basePath, preservedParams, children }: PathRouterProps): JSX.Element | null => {

--- a/packages/clerk-js/src/ui/router/Switch.tsx
+++ b/packages/clerk-js/src/ui/router/Switch.tsx
@@ -8,7 +8,7 @@ function assertRoute(v: any): v is React.ReactElement<RouteProps> {
   return !!v && React.isValidElement(v) && typeof v === 'object' && (v as React.ReactElement).type === Route;
 }
 
-export function Switch({ children }: { children: React.ReactNode }): JSX.Element {
+export function Switch({ children }: React.PropsWithChildren): JSX.Element {
   const router = useRouter();
 
   let node: React.ReactNode = null;

--- a/packages/clerk-js/src/ui/router/VirtualRouter.tsx
+++ b/packages/clerk-js/src/ui/router/VirtualRouter.tsx
@@ -4,11 +4,10 @@ import { useClerkModalStateParams } from '../hooks';
 import { BaseRouter } from './BaseRouter';
 export const VIRTUAL_ROUTER_BASE_PATH = 'CLERK-ROUTER/VIRTUAL';
 
-interface VirtualRouterProps {
+interface VirtualRouterProps extends React.PropsWithChildren {
   startPath: string;
   preservedParams?: string[];
   onExternalNavigate?: () => any;
-  children: React.ReactNode;
 }
 
 export const VirtualRouter = ({

--- a/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
+++ b/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
@@ -14,10 +14,10 @@ const SDK_METADATA = {
 
 __internal__setErrorThrowerOptions({ packageName: 'gatsby-plugin-clerk' });
 
-export type GatsbyClerkProviderProps = {
-  children: React.ReactNode;
+export type GatsbyClerkProviderProps = React.PropsWithChildren<{
   clerkState: any;
-} & IsomorphicClerkOptions;
+}> &
+  IsomorphicClerkOptions;
 
 export function ClerkProvider({ children, ...rest }: GatsbyClerkProviderProps) {
   const { clerkState, ...restProps } = rest;

--- a/packages/nextjs/src/pages/__tests__/index.test.tsx
+++ b/packages/nextjs/src/pages/__tests__/index.test.tsx
@@ -64,10 +64,4 @@ describe('ClerkProvider', () => {
       expectTypeOf({ ...defaultProps, clerkJSVariant: 'test' }).not.toMatchTypeOf<ClerkProviderProps>();
     });
   });
-
-  describe('children', () => {
-    it('errors if no children', () => {
-      expectTypeOf({}).not.toMatchTypeOf<ClerkProviderProps>();
-    });
-  });
 });

--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -2,8 +2,7 @@ import type { IsomorphicClerkOptions } from '@clerk/clerk-react';
 import type { MultiDomainAndOrProxy, PublishableKeyOrFrontendApi } from '@clerk/types';
 import type React from 'react';
 
-export type NextClerkProviderProps = {
-  children: React.ReactNode;
+export type NextClerkProviderProps = React.PropsWithChildren<{
   /**
    * If set to true, the NextJS middleware will be invoked
    * every time the client-side auth state changes (sign-out, sign-in, organization switch etc.).
@@ -13,7 +12,8 @@ export type NextClerkProviderProps = {
    * @default true
    */
   __unstable_invokeMiddlewareOnAuthStateChange?: boolean;
-} & Omit<IsomorphicClerkOptions, keyof PublishableKeyOrFrontendApi> &
+}> &
+  Omit<IsomorphicClerkOptions, keyof PublishableKeyOrFrontendApi> &
   Partial<PublishableKeyOrFrontendApi> &
   Omit<IsomorphicClerkOptions, keyof MultiDomainAndOrProxy> &
   MultiDomainAndOrProxy;

--- a/packages/react/src/components/SignOutButton.tsx
+++ b/packages/react/src/components/SignOutButton.tsx
@@ -5,11 +5,10 @@ import type { WithClerkProp } from '../types';
 import { assertSingleChild, normalizeWithDefaultValue, safeExecute } from '../utils';
 import { withClerk } from './withClerk';
 
-export type SignOutButtonProps = {
+export type SignOutButtonProps = React.PropsWithChildren<{
   signOutCallback?: SignOutCallback;
   signOutOptions?: SignOutOptions;
-  children?: React.ReactNode;
-};
+}>;
 
 export const SignOutButton = withClerk(
   ({ clerk, children, ...props }: React.PropsWithChildren<WithClerkProp<SignOutButtonProps>>) => {

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -11,11 +11,10 @@ import { OrganizationProvider } from './OrganizationContext';
 import { SessionContext } from './SessionContext';
 import { UserContext } from './UserContext';
 
-type ClerkContextProvider = {
+type ClerkContextProvider = React.PropsWithChildren<{
   isomorphicClerkOptions: IsomorphicClerkOptions;
   initialState: InitialState | undefined;
-  children: React.ReactNode;
-};
+}>;
 
 export type ClerkContextProviderState = Resources;
 

--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -12,10 +12,10 @@ __internal__setErrorThrowerOptions({
   packageName: '@clerk/clerk-react',
 });
 
-export type ClerkProviderProps = IsomorphicClerkOptions & {
-  children: React.ReactNode;
-  initialState?: InitialState;
-};
+export type ClerkProviderProps = IsomorphicClerkOptions &
+  React.PropsWithChildren<{
+    initialState?: InitialState;
+  }>;
 
 function ClerkProviderBase(props: ClerkProviderProps): JSX.Element {
   const { initialState, children, ...restIsomorphicClerkOptions } = props;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -74,13 +74,12 @@ export type ClerkProp =
   | undefined
   | null;
 
-type ButtonProps = {
+type ButtonProps = React.PropsWithChildren<{
   afterSignInUrl?: string;
   afterSignUpUrl?: string;
   redirectUrl?: string;
   mode?: 'redirect' | 'modal';
-  children?: React.ReactNode;
-};
+}>;
 
 export type SignInButtonProps = ButtonProps;
 export interface SignUpButtonProps extends ButtonProps {

--- a/packages/react/src/utils/childrenUtils.tsx
+++ b/packages/react/src/utils/childrenUtils.tsx
@@ -18,7 +18,7 @@ export const normalizeWithDefaultValue = (children: React.ReactNode | undefined,
     children = defaultText;
   }
   if (typeof children === 'string') {
-    children = <button>{children}</button>;
+    children = <button type='button'>{children}</button>;
   }
   return children;
 };

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -40,15 +40,14 @@ export const useOrganizationProfileCustomPages = (children: React.ReactNode | Re
   });
 };
 
-type UseCustomPagesParams = {
-  children: React.ReactNode | React.ReactNode[];
+type UseCustomPagesParams = React.PropsWithChildren<{
   LinkComponent: any;
   PageComponent: any;
   reorderItemsLabels: string[];
   componentName: string;
-};
+}>;
 
-type CustomPageWithIdType = UserProfilePageProps & { children?: React.ReactNode };
+type CustomPageWithIdType = React.PropsWithChildren<UserProfilePageProps>;
 
 const useCustomPages = ({
   children,

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -14,10 +14,10 @@ const SDK_METADATA = {
   version: PACKAGE_VERSION,
 };
 
-export type RemixClerkProviderProps = {
-  children: React.ReactNode;
+export type RemixClerkProviderProps = React.PropsWithChildren<{
   clerkState: ClerkState;
-} & IsomorphicClerkOptions;
+}> &
+  IsomorphicClerkOptions;
 
 /**
  * Remix hydration errors should not stop Clerk navigation from working, as the components mount only after


### PR DESCRIPTION
## Description

Replace `children` react nodes with `React.PropsWithChildren` to make our codebase consistent.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [x] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
