### PR TITLE
fix(clerk-js): Avoid wrapping NotificationCountBadge of OrgSwitcher with Gate

### DIFF
--- a/.changeset/brown-clouds-divide.md
+++ b/.changeset/brown-clouds-divide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+A bug fix for prefetching data for OrganizationSwitcher and correctly displaying a notification count in the switcher as well.

--- a/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 
-import { NotificationCountBadge, withGate } from '../../common';
+import { NotificationCountBadge, useGate } from '../../common';
 import {
   useCoreOrganization,
   useCoreOrganizationList,
@@ -72,32 +72,30 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
     );
   }),
 );
-const NotificationCountBadgeSwitcherTrigger = withGate(
-  () => {
-    /**
-     * Prefetch user invitations and suggestions
-     */
-    const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
-    const { organizationSettings } = useEnvironment();
-    const isDomainsEnabled = organizationSettings?.domains?.enabled;
-    const { membershipRequests } = useCoreOrganization({
-      membershipRequests: isDomainsEnabled || undefined,
-    });
 
-    const notificationCount =
-      (userInvitations.count || 0) + (userSuggestions.count || 0) + (membershipRequests?.count || 0);
-
-    return (
-      <NotificationCountBadge
-        containerSx={t => ({
-          marginLeft: `${t.space.$2}`,
-        })}
-        notificationCount={notificationCount}
-      />
-    );
-  },
-  {
-    // if the user is not able to accept a request we should not notify them
+const NotificationCountBadgeSwitcherTrigger = () => {
+  /**
+   * Prefetch user invitations and suggestions
+   */
+  const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
+  const { organizationSettings } = useEnvironment();
+  const { isAuthorizedUser: canAcceptRequests } = useGate({
     permission: 'org:sys_memberships:manage',
-  },
-);
+  });
+  const isDomainsEnabled = organizationSettings?.domains?.enabled;
+  const { membershipRequests } = useCoreOrganization({
+    membershipRequests: (isDomainsEnabled && canAcceptRequests) || undefined,
+  });
+
+  const notificationCount =
+    (userInvitations.count || 0) + (userSuggestions.count || 0) + (membershipRequests?.count || 0);
+
+  return (
+    <NotificationCountBadge
+      containerSx={t => ({
+        marginLeft: `${t.space.$2}`,
+      })}
+      notificationCount={notificationCount}
+    />
+  );
+};

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 
-import { NotificationCountBadge, withGate } from '../../common';
+import { NotificationCountBadge, useGate } from '../../common';
 import {
   useCoreOrganization,
   useCoreOrganizationList,
@@ -72,32 +72,30 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
     );
   }),
 );
-const NotificationCountBadgeSwitcherTrigger = withGate(
-  () => {
-    /**
-     * Prefetch user invitations and suggestions
-     */
-    const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
-    const { organizationSettings } = useEnvironment();
-    const isDomainsEnabled = organizationSettings?.domains?.enabled;
-    const { membershipRequests } = useCoreOrganization({
-      membershipRequests: isDomainsEnabled || undefined,
-    });
 
-    const notificationCount =
-      (userInvitations.count || 0) + (userSuggestions.count || 0) + (membershipRequests?.count || 0);
-
-    return (
-      <NotificationCountBadge
-        containerSx={t => ({
-          marginLeft: `${t.space.$2}`,
-        })}
-        notificationCount={notificationCount}
-      />
-    );
-  },
-  {
-    // if the user is not able to accept a request we should not notify them
+const NotificationCountBadgeSwitcherTrigger = () => {
+  /**
+   * Prefetch user invitations and suggestions
+   */
+  const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
+  const { organizationSettings } = useEnvironment();
+  const { isAuthorizedUser: canAcceptRequests } = useGate({
     permission: 'org:sys_memberships:manage',
-  },
-);
+  });
+  const isDomainsEnabled = organizationSettings?.domains?.enabled;
+  const { membershipRequests } = useCoreOrganization({
+    membershipRequests: (isDomainsEnabled && canAcceptRequests) || undefined,
+  });
+
+  const notificationCount =
+    (userInvitations.count || 0) + (userSuggestions.count || 0) + (membershipRequests?.count || 0);
+
+  return (
+    <NotificationCountBadge
+      containerSx={t => ({
+        marginLeft: `${t.space.$2}`,
+      })}
+      notificationCount={notificationCount}
+    />
+  );
+};


### PR DESCRIPTION
## Description
In order to see notifications for suggestions and invitations you don't have to have a permission or have an active organization. Previously we incorrectly wrapped this component with `Gate`. Instead we only want to check if you have have the `org:sys_memberships:mananage` permission in order to fetch and include in the counter the requests of an active organization.
### Before

https://github.com/clerk/javascript/assets/19269911/2fc086ce-223e-45d0-92a7-7b9b02482ace


### After

https://github.com/clerk/javascript/assets/19269911/a6c3215f-6462-4605-a457-3307b8e65913


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
