### PR TITLE
chore(*): Drop default exports

### DIFF
--- a/.changeset/clever-scissors-reflect.md
+++ b/.changeset/clever-scissors-reflect.md
@@ -1,0 +1,16 @@
+---
+'@clerk/chrome-extension': major
+'@clerk/clerk-js': major
+'@clerk/clerk-sdk-node': major
+'@clerk/backend': major
+'@clerk/clerk-react': major
+'@clerk/clerk-expo': major
+---
+
+Drop default exports from all packages. Migration guide:
+- use `import { Clerk } from '@clerk/backend';`
+- use `import { clerkInstance } from '@clerk/clerk-sdk-node';`
+- use `import { Clerk } from '@clerk/clerk-sdk-node';`
+- use `import { Clerk } from '@clerk/clerk-js';`
+- use `import { Clerk } from '@clerk/clerk-js/headless';`
+- use `import { IsomorphicClerk } from '@clerk/clerk-react'`

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -17,7 +17,7 @@ type GetInvitationListParams = {
    * @example
    * get all revoked invitations
    *
-   * import Clerk from '@clerk/backend';
+   * import { Clerk } from '@clerk/backend';
    * const clerkClient = Clerk(...)
    * await clerkClient.invitations.getInvitationList({ status: 'revoked })
    *

--- a/packages/chrome-extension/src/ClerkProvider.tsx
+++ b/packages/chrome-extension/src/ClerkProvider.tsx
@@ -1,4 +1,4 @@
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 import type { ClerkProp, ClerkProviderProps as ClerkReactProviderProps } from '@clerk/clerk-react';
 import { __internal__setErrorThrowerOptions, ClerkProvider as ClerkReactProvider } from '@clerk/clerk-react';
 import React from 'react';

--- a/packages/chrome-extension/src/singleton.ts
+++ b/packages/chrome-extension/src/singleton.ts
@@ -1,4 +1,4 @@
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 import type { ClerkProp } from '@clerk/clerk-react';
 
 import type { TokenCache } from './cache';

--- a/packages/clerk-js/headless/index.d.ts
+++ b/packages/clerk-js/headless/index.d.ts
@@ -1,4 +1,4 @@
-import Clerk from '../dist/types/index.headless';
+import { Clerk } from '../dist/types/index.headless';
 
 export default Clerk;
 export * from '../dist/types/index.headless';

--- a/packages/clerk-js/src/core/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/clerk.redirects.test.ts
@@ -1,4 +1,4 @@
-import Clerk from './clerk';
+import { Clerk } from './clerk';
 import type { AuthConfig, DisplayConfig } from './resources/internal';
 import { Client, Environment } from './resources/internal';
 
@@ -10,13 +10,15 @@ jest.mock('./resources/Client');
 jest.mock('./resources/Environment');
 
 // Because Jest, don't ask me why...
-jest.mock('./devBrowserHandler', () => () => ({
-  clear: jest.fn(),
-  setup: jest.fn(),
-  getDevBrowserJWT: jest.fn(() => 'deadbeef'),
-  setDevBrowserJWT: jest.fn(),
-  removeDevBrowserJWT: jest.fn(),
-  usesUrlBasedSessionSync: mockUsesUrlBasedSessionSync,
+jest.mock('./devBrowserHandler', () => ({
+  createDevBrowserHandler: () => ({
+    clear: jest.fn(),
+    setup: jest.fn(),
+    getDevBrowserJWT: jest.fn(() => 'deadbeef'),
+    setDevBrowserJWT: jest.fn(),
+    removeDevBrowserJWT: jest.fn(),
+    usesUrlBasedSessionSync: mockUsesUrlBasedSessionSync,
+  }),
 }));
 
 Client.getInstance = jest.fn().mockImplementation(() => {

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -2,7 +2,7 @@ import type { ActiveSessionResource, SignInJSON, SignUpJSON, TokenResource } fro
 import { waitFor } from '@testing-library/dom';
 
 import { mockNativeRuntime } from '../testUtils';
-import Clerk from './clerk';
+import { Clerk } from './clerk';
 import { eventBus, events } from './events';
 import type { AuthConfig, DisplayConfig, Organization } from './resources/internal';
 import { BaseResource, Client, EmailLinkErrorCode, Environment, SignIn, SignUp } from './resources/internal';
@@ -17,13 +17,15 @@ jest.mock('./resources/Client');
 jest.mock('./resources/Environment');
 
 // Because Jest, don't ask me why...
-jest.mock('./devBrowserHandler', () => () => ({
-  clear: jest.fn(),
-  setup: jest.fn(),
-  getDevBrowserJWT: jest.fn(() => 'deadbeef'),
-  setDevBrowserJWT: jest.fn(),
-  removeDevBrowserJWT: jest.fn(),
-  usesUrlBasedSessionSync: mockUsesUrlBasedSessionSync,
+jest.mock('./devBrowserHandler', () => ({
+  createDevBrowserHandler: () => ({
+    clear: jest.fn(),
+    setup: jest.fn(),
+    getDevBrowserJWT: jest.fn(() => 'deadbeef'),
+    setDevBrowserJWT: jest.fn(),
+    removeDevBrowserJWT: jest.fn(),
+    usesUrlBasedSessionSync: mockUsesUrlBasedSessionSync,
+  }),
 }));
 
 Client.getInstance = jest.fn().mockImplementation(() => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -86,7 +86,7 @@ import {
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
 import { CLERK_SATELLITE_URL, CLERK_SYNCED, ERROR_CODES } from './constants';
 import type { DevBrowserHandler } from './devBrowserHandler';
-import createDevBrowserHandler from './devBrowserHandler';
+import { createDevBrowserHandler } from './devBrowserHandler';
 import {
   clerkErrorInitFailed,
   clerkInvalidSignInUrlFormat,
@@ -98,7 +98,7 @@ import {
   clerkRedirectUrlIsMissingScheme,
 } from './errors';
 import type { FapiClient, FapiRequestCallback } from './fapiClient';
-import createFapiClient from './fapiClient';
+import { createFapiClient } from './fapiClient';
 import {
   BaseResource,
   Client,
@@ -134,7 +134,7 @@ const defaultOptions: ClerkOptions = {
   isInterstitial: false,
 };
 
-export default class Clerk implements ClerkInterface {
+export class Clerk implements ClerkInterface {
   public static mountComponentRenderer?: MountComponentRenderer;
 
   public static version: string = __PKG_VERSION__;

--- a/packages/clerk-js/src/core/devBrowserHandler.test.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.test.ts
@@ -1,5 +1,5 @@
 import type { CreateDevBrowserHandlerOptions } from './devBrowserHandler';
-import createDevBrowserHandler from './devBrowserHandler';
+import { createDevBrowserHandler } from './devBrowserHandler';
 
 describe('detBrowserHandler', () => {
   const { getDevBrowserJWT, setDevBrowserJWT, removeDevBrowserJWT } = createDevBrowserHandler(

--- a/packages/clerk-js/src/core/devBrowserHandler.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.ts
@@ -29,7 +29,7 @@ export type CreateDevBrowserHandlerOptions = {
 };
 
 // export type DevBrowserHandler = ReturnType<typeof createDevBrowserHandler>;
-export default function createDevBrowserHandler({
+export function createDevBrowserHandler({
   frontendApi,
   fapiClient,
 }: CreateDevBrowserHandlerOptions): DevBrowserHandler {

--- a/packages/clerk-js/src/core/fapiClient.test.ts
+++ b/packages/clerk-js/src/core/fapiClient.test.ts
@@ -1,6 +1,6 @@
 import type { Clerk } from '@clerk/types';
 
-import createFapiClient from './fapiClient';
+import { createFapiClient } from './fapiClient';
 
 const mockedClerkInstance = {
   frontendApi: 'clerk.example.com',

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -59,7 +59,7 @@ export interface FapiClient {
   request<T>(requestInit: FapiRequestInit): Promise<FapiResponse<T>>;
 }
 
-export default function createFapiClient(clerkInstance: Clerk): FapiClient {
+export function createFapiClient(clerkInstance: Clerk): FapiClient {
   const onBeforeRequestCallbacks: Array<FapiRequestCallback<unknown>> = [];
   const onAfterResponseCallbacks: Array<FapiRequestCallback<unknown>> = [];
 

--- a/packages/clerk-js/src/core/resources/internal.ts
+++ b/packages/clerk-js/src/core/resources/internal.ts
@@ -1,4 +1,4 @@
-export type { default as Clerk } from '../clerk';
+export type { Clerk } from '../clerk';
 export * from './Base';
 export * from './UserSettings';
 export * from './AuthConfig';

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -5,9 +5,8 @@ import './utils/setWebpackChunkPublicPath';
 
 import 'regenerator-runtime/runtime';
 
-import Clerk from './core/clerk';
+import { Clerk } from './core/clerk';
 
-// eslint-disable-next-line import/no-unresolved -- this is a webpack alias
 import { mountComponentRenderer } from '~ui/Components';
 
 Clerk.mountComponentRenderer = mountComponentRenderer;

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -1,6 +1,6 @@
 import 'regenerator-runtime/runtime';
 
-import Clerk from './core/clerk';
+import { Clerk } from './core/clerk';
 
 const publishableKey =
   document.querySelector('script[data-clerk-publishable-key]')?.getAttribute('data-clerk-publishable-key') ||

--- a/packages/clerk-js/src/index.headless.ts
+++ b/packages/clerk-js/src/index.headless.ts
@@ -1,10 +1,10 @@
 import 'regenerator-runtime/runtime';
 
-import Clerk from './core/clerk';
+import { Clerk } from './core/clerk';
 
 export * from './core/resources/Error';
 
-export default Clerk;
+export { Clerk };
 
 if (module.hot) {
   module.hot.accept();

--- a/packages/clerk-js/src/index.ts
+++ b/packages/clerk-js/src/index.ts
@@ -1,14 +1,13 @@
 import 'regenerator-runtime/runtime';
 
-// eslint-disable-next-line import/no-unresolved -- this is a webpack alias
 import { mountComponentRenderer } from '~ui/Components';
 
-import Clerk from './core/clerk';
+import { Clerk } from './core/clerk';
 
 export * from './core/resources/Error';
 
 Clerk.mountComponentRenderer = mountComponentRenderer;
-export default Clerk;
+export { Clerk };
 
 if (module.hot) {
   module.hot.accept();

--- a/packages/clerk-js/src/ui/utils/test/createFixtures.tsx
+++ b/packages/clerk-js/src/ui/utils/test/createFixtures.tsx
@@ -2,7 +2,7 @@ import type { ClerkOptions, ClientJSON, EnvironmentJSON, LoadedClerk } from '@cl
 import { jest } from '@jest/globals';
 import React from 'react';
 
-import { default as ClerkCtor } from '../../../core/clerk';
+import { Clerk as ClerkCtor } from '../../../core/clerk';
 import { Client, Environment } from '../../../core/resources';
 import { ComponentContext, CoreClerkContextWrapper, EnvironmentProvider, OptionsProvider } from '../../contexts';
 import { AppearanceProvider } from '../../customizables';

--- a/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
@@ -1,5 +1,5 @@
-import type Clerk from '../core/clerk';
-import createFapiClient from '../core/fapiClient';
+import type { Clerk } from '../core/clerk';
+import { createFapiClient } from '../core/fapiClient';
 
 export const retrieveCaptchaInfo = (clerk: Clerk) => {
   const _environment = clerk.__unstable__environment;

--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -1,5 +1,5 @@
 import type { FapiRequestInit, FapiResponse } from '@clerk/clerk-js/dist/types/core/fapiClient';
-import Clerk from '@clerk/clerk-js/headless';
+import { Clerk } from '@clerk/clerk-js/headless';
 import type { HeadlessBrowserClerk } from '@clerk/clerk-react';
 
 import type { TokenCache } from './cache';

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -1,7 +1,7 @@
 import type { ClientResource, InitialState, Resources } from '@clerk/types';
 import React from 'react';
 
-import IsomorphicClerk from '../isomorphicClerk';
+import { IsomorphicClerk } from '../isomorphicClerk';
 import type { IsomorphicClerkOptions } from '../types';
 import { deriveState } from '../utils/deriveState';
 import { AuthContext } from './AuthContext';

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@ import { useCallback } from 'react';
 import { useAuthContext } from '../contexts/AuthContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { invalidStateError } from '../errors';
-import type IsomorphicClerk from '../isomorphicClerk';
+import type { IsomorphicClerk } from '../isomorphicClerk';
 import { errorThrower } from '../utils';
 import { createGetToken, createSignOut } from './utils';
 

--- a/packages/react/src/hooks/utils.ts
+++ b/packages/react/src/hooks/utils.ts
@@ -1,4 +1,4 @@
-import type IsomorphicClerk from '../isomorphicClerk';
+import type { IsomorphicClerk } from '../isomorphicClerk';
 
 /**
  * @internal

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -55,7 +55,7 @@ type MethodName<T> = {
 
 type MethodCallback = () => Promise<unknown> | unknown;
 
-export default class IsomorphicClerk {
+export class IsomorphicClerk {
   private readonly mode: 'browser' | 'server';
   private readonly publishableKey?: string;
   private readonly options: IsomorphicClerkOptions;

--- a/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -44,7 +44,6 @@ exports[`module exports should not change unless explicitly set 1`] = `
   "createIsomorphicRequest",
   "debugRequestState",
   "decodeJwt",
-  "default",
   "deserialize",
   "domains",
   "emailAddresses",

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -46,8 +46,6 @@ export {
   users,
 };
 
-export default clerkClient;
-
 export type { ClerkMiddleware, ClerkMiddlewareOptions, LooseAuthProp, RequireAuthProp, StrictAuthProp, WithAuthProp };
 
 export { createClerkExpressRequireAuth, createClerkExpressWithAuth };

--- a/packages/sdk-node/src/instance.ts
+++ b/packages/sdk-node/src/instance.ts
@@ -1,6 +1,6 @@
 import { Clerk } from './clerkClient';
 
-export default Clerk;
+export { Clerk };
 
 export type { WithAuthProp, RequireAuthProp } from './types';
 


### PR DESCRIPTION
## Description

Drop default exports from all packages. Migration guide:
- use `import { Clerk } from '@clerk/backend';`
- use `import { clerkInstance } from '@clerk/clerk-sdk-node';`
- use `import { Clerk } from '@clerk/clerk-sdk-node';`
- use `import { Clerk } from '@clerk/clerk-js';`
- use `import { Clerk } from '@clerk/clerk-js/headless';`
- use `import { IsomorphicClerk } from '@clerk/clerk-react'`

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
