### PR TITLE
fix(backend,nextjs,remix,clerk-sdk-node): Allow for a preferred host source.

### DIFF
--- a/.changeset/sour-squids-sip.md
+++ b/.changeset/sour-squids-sip.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+'@clerk/remix': patch
+---
+
+Allow for a preferred source for the host attribute: default(host) | x-forwarded-host

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -17,7 +17,10 @@ export function checkCrossOrigin({
   forwardedHost?: string | null;
   forwardedProto?: string | null;
 }) {
-  const finalURL = buildOrigin({ forwardedProto, forwardedHost, protocol: originURL.protocol, host });
+  const finalURL = buildOrigin(
+    { forwardedProto, forwardedHost, protocol: originURL.protocol, host },
+    { hostPreference: 'forwarded' },
+  );
   return finalURL && new URL(finalURL).origin !== originURL.origin;
 }
 

--- a/packages/backend/src/utils.test.ts
+++ b/packages/backend/src/utils.test.ts
@@ -1,11 +1,13 @@
 import type QUnit from 'qunit';
 
-import { buildOrigin, buildRequestUrl } from './utils';
+import { buildOrigin, type BuildOriginOptions, buildRequestUrl } from './utils';
+
+const fwdOpts: BuildOriginOptions = { hostPreference: 'forwarded' };
 
 export default (QUnit: QUnit) => {
   const { module, test } = QUnit;
 
-  module('buildOrigin({ protocol, forwardedProto, forwardedHost, host })', () => {
+  module('buildOrigin({ protocol, forwardedProto, forwardedHost, host }, { hostPreference: "default" })', () => {
     test('without any param', assert => {
       assert.equal(buildOrigin({}), '');
     });
@@ -24,29 +26,29 @@ export default (QUnit: QUnit) => {
 
     test('with forwarded proto', assert => {
       assert.equal(
-        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedProto: 'https' }),
-        'https://localhost:3000',
+        buildOrigin({ protocol: 'http', host: 'example-host.com', forwardedProto: 'https' }),
+        'https://example-host.com',
       );
     });
 
     test('with forwarded proto - with multiple values', assert => {
       assert.equal(
-        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedProto: 'https,http' }),
-        'https://localhost:3000',
+        buildOrigin({ protocol: 'http', host: 'example-host.com', forwardedProto: 'https,http' }),
+        'https://example-host.com',
       );
     });
 
     test('with forwarded host', assert => {
       assert.equal(
-        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedHost: 'example.com' }),
-        'http://example.com',
+        buildOrigin({ protocol: 'http', host: 'example-host.com', forwardedHost: 'example.com' }),
+        'http://example-host.com',
       );
     });
 
     test('with forwarded host - with multiple values', assert => {
       assert.equal(
-        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedHost: 'example.com,example-2.com' }),
-        'http://example.com',
+        buildOrigin({ protocol: 'http', host: 'example-host.com', forwardedHost: 'example.com,example-2.com' }),
+        'http://example-host.com',
       );
     });
 
@@ -54,18 +56,18 @@ export default (QUnit: QUnit) => {
       assert.equal(
         buildOrigin({
           protocol: 'http',
-          host: 'localhost:3000',
+          host: 'example-host.com',
           forwardedProto: 'https',
           forwardedHost: 'example.com',
         }),
-        'https://example.com',
+        'https://example-host.com',
       );
     });
 
     test('with forwarded proto and host - without protocol', assert => {
       assert.equal(
-        buildOrigin({ host: 'localhost:3000', forwardedProto: 'https', forwardedHost: 'example.com' }),
-        'https://example.com',
+        buildOrigin({ host: 'example-host.com', forwardedProto: 'https', forwardedHost: 'example.com' }),
+        'https://example-host.com',
       );
     });
 
@@ -81,6 +83,88 @@ export default (QUnit: QUnit) => {
     });
   });
 
+  module('buildOrigin({ protocol, forwardedProto, forwardedHost, host }, { hostPreference: "forwarded" })', () => {
+    test('without any param', assert => {
+      assert.equal(buildOrigin({}, fwdOpts), '');
+    });
+
+    test('with protocol', assert => {
+      assert.equal(buildOrigin({ protocol: 'http' }, fwdOpts), '');
+    });
+
+    test('with host', assert => {
+      assert.equal(buildOrigin({ host: 'localhost:3000' }, fwdOpts), '');
+    });
+
+    test('with protocol and host', assert => {
+      assert.equal(buildOrigin({ protocol: 'http', host: 'localhost:3000' }, fwdOpts), 'http://localhost:3000');
+    });
+
+    test('with forwarded proto', assert => {
+      assert.equal(
+        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedProto: 'https' }, fwdOpts),
+        'https://localhost:3000',
+      );
+    });
+
+    test('with forwarded proto - with multiple values', assert => {
+      assert.equal(
+        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedProto: 'https,http' }, fwdOpts),
+        'https://localhost:3000',
+      );
+    });
+
+    test('with forwarded host', assert => {
+      assert.equal(
+        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedHost: 'example.com' }, fwdOpts),
+        'http://example.com',
+      );
+    });
+
+    test('with forwarded host - with multiple values', assert => {
+      assert.equal(
+        buildOrigin({ protocol: 'http', host: 'localhost:3000', forwardedHost: 'example.com,example-2.com' }, fwdOpts),
+        'http://example.com',
+      );
+    });
+
+    test('with forwarded proto and host', assert => {
+      assert.equal(
+        buildOrigin(
+          {
+            protocol: 'http',
+            host: 'localhost:3000',
+            forwardedProto: 'https',
+            forwardedHost: 'example.com',
+          },
+          fwdOpts,
+        ),
+        'https://example.com',
+      );
+    });
+
+    test('with forwarded proto and host - without protocol', assert => {
+      assert.equal(
+        buildOrigin({ host: 'localhost:3000', forwardedProto: 'https', forwardedHost: 'example.com' }, fwdOpts),
+        'https://example.com',
+      );
+    });
+
+    test('with forwarded proto and host - without host', assert => {
+      assert.equal(
+        buildOrigin({ protocol: 'http', forwardedProto: 'https', forwardedHost: 'example.com' }, fwdOpts),
+        'https://example.com',
+      );
+    });
+
+    test('with forwarded proto and host - without host and protocol', assert => {
+      assert.equal(
+        buildOrigin({ forwardedProto: 'https', forwardedHost: 'example.com' }, fwdOpts),
+        'https://example.com',
+      );
+    });
+  });
+
   module('buildRequestUrl({ request, path })', () => {
     test('without headers', assert => {
       const req = new Request('http://localhost:3000/path');
@@ -89,9 +173,9 @@ export default (QUnit: QUnit) => {
 
     test('with forwarded proto / host headers', assert => {
       const req = new Request('http://localhost:3000/path', {
-        headers: { 'x-forwarded-host': 'example.com', 'x-forwarded-proto': 'https,http' },
+        headers: { 'x-forwarded-host': 'example.com', 'x-forwarded-proto': 'https,http', host: 'example-host.com' },
       });
-      assert.equal(buildRequestUrl(req), 'https://example.com/path');
+      assert.equal(buildRequestUrl(req), 'https://example-host.com/path');
     });
 
     test('with forwarded proto / host and host headers', assert => {
@@ -102,7 +186,7 @@ export default (QUnit: QUnit) => {
           host: 'example-host.com',
         },
       });
-      assert.equal(buildRequestUrl(req), 'https://example.com/path');
+      assert.equal(buildRequestUrl(req), 'https://example-host.com/path');
     });
 
     test('with path', assert => {
@@ -113,6 +197,41 @@ export default (QUnit: QUnit) => {
     test('with query params in request', assert => {
       const req = new Request('http://localhost:3000/path');
       assert.equal(buildRequestUrl(req), 'http://localhost:3000/path');
+    });
+  });
+
+  module('buildRequestUrl({ request, path }, { hostPreference: "forwarded" })', () => {
+    test('without headers', assert => {
+      const req = new Request('http://localhost:3000/path');
+      assert.equal(buildRequestUrl(req, fwdOpts), 'http://localhost:3000/path');
+    });
+
+    test('with forwarded proto / host headers', assert => {
+      const req = new Request('http://localhost:3000/path', {
+        headers: { 'x-forwarded-host': 'example.com', 'x-forwarded-proto': 'https,http' },
+      });
+      assert.equal(buildRequestUrl(req, fwdOpts), 'https://example.com/path');
+    });
+
+    test('with forwarded proto / host and host headers', assert => {
+      const req = new Request('http://localhost:3000/path', {
+        headers: {
+          'x-forwarded-host': 'example.com',
+          'x-forwarded-proto': 'https,http',
+          host: 'example-host.com',
+        },
+      });
+      assert.equal(buildRequestUrl(req, fwdOpts), 'https://example.com/path');
+    });
+
+    test('with path', assert => {
+      const req = new Request('http://localhost:3000/path');
+      assert.equal(buildRequestUrl(req, '/other-path', fwdOpts), 'http://localhost:3000/other-path');
+    });
+
+    test('with query params in request', assert => {
+      const req = new Request('http://localhost:3000/path');
+      assert.equal(buildRequestUrl(req, fwdOpts), 'http://localhost:3000/path');
     });
   });
 };

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -3,18 +3,36 @@ import { constants } from './constants';
 const getHeader = (req: Request, key: string) => req.headers.get(key);
 const getFirstValueFromHeader = (value?: string | null) => value?.split(',')[0];
 
-type BuildRequestUrl = (request: Request, path?: string) => URL;
-export const buildRequestUrl: BuildRequestUrl = (request, path) => {
+type BuildRequestUrl =
+  | ((request: Request, path?: string | BuildOriginOptions) => URL)
+  | ((request: Request, opts?: string | BuildOriginOptions) => URL)
+  | ((request: Request, pathOrOpts?: string | BuildOriginOptions, opts?: BuildOriginOptions) => URL);
+
+export const buildRequestUrl: BuildRequestUrl = (request, pathOrOpts, opts) => {
   const initialUrl = new URL(request.url);
+
+  let path: string | undefined;
+  let options: BuildOriginOptions | undefined;
+
+  if (typeof pathOrOpts === 'object' && 'hostPreference' in pathOrOpts) {
+    options = pathOrOpts;
+  } else {
+    path = pathOrOpts;
+    options = opts;
+  }
 
   const forwardedProto = getHeader(request, constants.Headers.ForwardedProto);
   const forwardedHost = getHeader(request, constants.Headers.ForwardedHost);
   const host = getHeader(request, constants.Headers.Host);
   const protocol = initialUrl.protocol;
 
-  const base = buildOrigin({ protocol, forwardedProto, forwardedHost, host: host || initialUrl.host });
+  const base = buildOrigin({ protocol, forwardedProto, forwardedHost, host: host || initialUrl.host }, options);
 
   return new URL(path || initialUrl.pathname, base);
+};
+
+export type BuildOriginOptions = {
+  hostPreference: 'default' | 'forwarded';
 };
 
 type BuildOriginParams = {
@@ -23,9 +41,14 @@ type BuildOriginParams = {
   forwardedHost?: string | null;
   host?: string | null;
 };
-type BuildOrigin = (params: BuildOriginParams) => string;
-export const buildOrigin: BuildOrigin = ({ protocol, forwardedProto, forwardedHost, host }) => {
-  const resolvedHost = getFirstValueFromHeader(forwardedHost) ?? host;
+type BuildOrigin = (params: BuildOriginParams, options?: BuildOriginOptions) => string;
+
+export const buildOrigin: BuildOrigin = ({ protocol, forwardedProto, forwardedHost, host }, opts) => {
+  const { hostPreference = 'default' } = opts || {};
+
+  const fwd = getFirstValueFromHeader(forwardedHost);
+
+  const resolvedHost = hostPreference === 'default' ? host ?? fwd : fwd ?? host;
   const resolvedProtocol = getFirstValueFromHeader(forwardedProto) ?? protocol?.replace(/[:/]/, '');
 
   if (!resolvedHost || !resolvedProtocol) {

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -152,7 +152,6 @@ const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
     const req = withNormalizedClerkUrl(_req);
 
     logger.debug('URL debug', {
-      url: req.nextUrl.href,
       method: req.method,
       headers: stringifyHeaders(req.headers),
       nextUrl: req.nextUrl.href,

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -46,7 +46,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     isTruthy(getEnvVariable('CLERK_IS_SATELLITE', context)) ||
     false;
 
-  const requestURL = buildRequestUrl(request);
+  const requestURL = buildRequestUrl(request, { hostPreference: 'forwarded' });
 
   const relativeOrAbsoluteProxyUrl = handleValueOrFn(
     opts?.proxyUrl,

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -53,7 +53,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     });
   });
 
-  const requestUrl = buildRequestUrl(isomorphicRequest);
+  const requestUrl = buildRequestUrl(isomorphicRequest, { hostPreference: 'forwarded' });
   const isSatellite = handleValueOrFn(options?.isSatellite, requestUrl, env.isSatellite);
   const domain = handleValueOrFn(options?.domain, requestUrl) || env.domain;
   const signInUrl = options?.signInUrl || env.signInUrl;


### PR DESCRIPTION
## Description

An upstream change https://github.com/vercel/next.js/pull/58500 in the handling of `X-Forwarded-Host` caused a number of issues for our URL parsing methods.

The upstream change was that, if empty, Next was setting the `X-Forwarded-Host` header.

The root issue on our end was that we prefer the `X-Forwarded-Host` header, if present, over `Host`.

In an effort to avoid future complications, I've made the following changes:

- Remove `url` from `authMiddleware` debug logging.
  - It was set to the exact same value as `nextUrl` and ultimately causing confusion.
- Extend the root `buildOrigin` and `buildRequestUrl` functions in `@clerk/backend` to support a preferred host source.
  - `{ hostPreference: "default" }`: Use `Host` if available; Otherwise `X-Forwarded-Host`.
  - `{ hostPreference: "forwarded" }`: Use `X-Forwarded-Host` if available; Otherwise `Host`.
- Updated call-sites in other packages so that they operate in the same fashion prior to this PR.





<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
