### PR TITLE
chore(repo): Add workbench color customizations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,4 +25,17 @@
     "nextjs",
     "publint"
   ],
+
+  // https://code.visualstudio.com/api/references/theme-color
+  "workbench.colorCustomizations": {
+    "list.activeSelectionBackground":"#3b63f133",
+    "list.inactiveSelectionBackground":"#3b63f112",
+    "sideBarSectionHeader.background":"#3b63f112",
+    "sideBarSectionHeader.foreground": "#103FEF",
+    "titleBar.activeBackground": "#103fef",
+    "titleBar.activeForeground": "#ffffff",
+    "titleBar.border": "#ffffff",
+    "titleBar.inactiveBackground": "#103fef",
+    "titleBar.inactiveForeground": "#ffffff",
+  },
 }


### PR DESCRIPTION
## Description

When dealing with multiple VSCode concurrent instances, and actively moving between them, it's hard to keep track of which window is which. This aims to cut down on that overhead.

![Screenshot 2023-11-16 at 10 50 55 PM](https://github.com/clerk/javascript/assets/26691/085ad2f1-e8ac-4f9e-8422-de3a1f058f81)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: editor config

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
