### PR TITLE
chore(repo): Fix nextjs canary release & show tests package versions

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -51,7 +51,11 @@ jobs:
           E2E_CLERK_VERSION: 'latest'
           INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
           MAILSAC_API_KEY: ${{ secrets.MAILSAC_API_KEY }}
+          E2E_NEXTJS_VERSION: 'canary'
 
+      - name: Show package versions
+        working-directory: ${{runner.temp}}
+        run: npm list
   notify-slack:
     name: Notify Slack
     needs: integration-tests


### PR DESCRIPTION
## Description

Currently, the `Nightly upstream tests` Github action seems to run with the latest next version instead of the next canary. This PR adds the missing env to make it run with the canary and also adds a step in the action to show the packages (with their version) that the tests run

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
