### PR TITLE
chore(*): Downgrade minimum version to node@18.17

### DIFF
--- a/.changeset/bright-plants-swim.md
+++ b/.changeset/bright-plants-swim.md
@@ -1,0 +1,18 @@
+---
+'gatsby-plugin-clerk': major
+'@clerk/chrome-extension': major
+'@clerk/localizations': major
+'@clerk/clerk-js': major
+'@clerk/clerk-sdk-node': major
+'@clerk/backend': major
+'@clerk/fastify': major
+'@clerk/nextjs': major
+'@clerk/shared': major
+'@clerk/themes': major
+'@clerk/clerk-react': major
+'@clerk/remix': major
+'@clerk/types': major
+'@clerk/clerk-expo': major
+---
+
+Change the minimal Node.js version required by Clerk to `18.17.0`.

--- a/integration/templates/next-app-router/package.json
+++ b/integration/templates/next-app-router/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "next": "13.5.4",
@@ -18,6 +18,6 @@
     "typescript": "5.1.6"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   }
 }

--- a/integration/templates/react-cra/package.json
+++ b/integration/templates/react-cra/package.json
@@ -34,11 +34,11 @@
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   }
 }

--- a/integration/templates/react-vite/package.json
+++ b/integration/templates/react-vite/package.json
@@ -15,7 +15,7 @@
     "react-router-dom": "^6.14.1"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -28,6 +28,6 @@
     "vite": "^4.3.9"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   }
 }

--- a/integration/templates/remix-node/package.json
+++ b/integration/templates/remix-node/package.json
@@ -21,13 +21,13 @@
     "@remix-run/dev": "^1.19.3",
     "@remix-run/eslint-config": "^1.18.1",
     "@remix-run/serve": "^1.18.1",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "zx": "^7.2.3"
       },
       "engines": {
-        "node": ">=18.18.0",
+        "node": ">=18.17.0",
         "npm": ">=8.5.0"
       },
       "workspaces": {
@@ -33255,20 +33255,20 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "1.0.0-alpha-v5.0",
+      "version": "1.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.0.0-alpha-v5.0",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
         "cookie": "0.5.0",
         "snakecase-keys": "5.4.4",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@cloudflare/workers-types": "^3.18.0",
         "@types/chai": "^4.3.3",
         "@types/cookie": "^0.5.1",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "@types/qunit": "^2.19.7",
         "@types/sinon": "^10.0.13",
         "chai": "^4.3.6",
@@ -33285,7 +33285,7 @@
         "workerd": "^1.20230518.0"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       }
     },
     "packages/backend/node_modules/tslib": {
@@ -33294,15 +33294,15 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "1.0.0-alpha-v5.0",
+      "version": "1.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.0",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.0"
+        "@clerk/clerk-js": "5.0.0-alpha-v5.1",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.1"
       },
       "devDependencies": {
         "@types/chrome": "*",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
         "eslint-config-custom": "*",
@@ -33310,7 +33310,7 @@
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -33318,12 +33318,12 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "5.0.0-alpha-v5.0",
+      "version": "5.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/localizations": "1.26.8-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/localizations": "2.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
         "@floating-ui/react": "0.25.4",
@@ -33368,7 +33368,7 @@
         "webpack-merge": "^5.9.0"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -33658,19 +33658,19 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "1.0.0-alpha-v5.0",
+      "version": "1.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.0",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
+        "@clerk/clerk-js": "5.0.0-alpha-v5.1",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
         "base-64": "1.0.0",
         "react-native-url-polyfill": "2.0.0"
       },
       "devDependencies": {
-        "@clerk/types": "^4.0.0-alpha-v5.0",
+        "@clerk/types": "^4.0.0-alpha-v5.1",
         "@types/base-64": "^1.0.0",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
         "eslint-config-custom": "*",
@@ -33680,7 +33680,7 @@
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "expo-auth-session": ">=4",
@@ -33690,22 +33690,22 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "1.0.0-alpha-v5.0",
+      "version": "1.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/backend": "1.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "cookies": "0.8.0"
       },
       "devDependencies": {
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "fastify": ">=4",
@@ -33713,25 +33713,25 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "5.0.0-alpha-v5.0",
+      "version": "5.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.0",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.0",
-        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.0",
+        "@clerk/backend": "1.0.0-alpha-v5.1",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.1",
+        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.1",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@types/cookie": "^0.5.0",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "gatsby": "^5.0.0",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "gatsby": "^4.24.8 || ^5"
@@ -33743,17 +33743,17 @@
     },
     "packages/localizations": {
       "name": "@clerk/localizations",
-      "version": "1.26.8-alpha-v5.0",
+      "version": "2.0.0-alpha-v5.1",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
-        "@types/node": "^18.18.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -33761,17 +33761,17 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "5.0.0-alpha-v5.0",
+      "version": "5.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.0",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
+        "@clerk/backend": "1.0.0-alpha-v5.1",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
         "path-to-regexp": "6.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
-        "@types/node": "^18.18.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
+        "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
         "eslint-config-custom": "*",
@@ -33780,7 +33780,7 @@
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "next": ">=10",
@@ -33795,18 +33795,18 @@
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
-      "version": "5.0.0-alpha-v5.0",
+      "version": "5.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.0.0-alpha-v5.0",
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "eslint-config-custom": "*",
         "semver": "^7.5.4",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/themes": "2.0.0-alpha-v5.0",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
         "@types/semver": "^7.5.4",
@@ -33814,7 +33814,7 @@
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -33826,28 +33826,28 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "4.0.0-alpha-v5.0",
+      "version": "4.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.0",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
+        "@clerk/backend": "1.0.0-alpha-v5.1",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@remix-run/react": "^2.0.0",
         "@remix-run/server-runtime": "^2.0.0",
         "@types/cookie": "^0.5.0",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
         "eslint-config-custom": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "@remix-run/react": "^2.0.0",
@@ -33862,18 +33862,18 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "5.0.0-alpha-v5.0",
+      "version": "5.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.0",
-        "@clerk/shared": "2.0.0-alpha-v5.0",
+        "@clerk/backend": "1.0.0-alpha-v5.1",
+        "@clerk/shared": "2.0.0-alpha-v5.1",
         "camelcase-keys": "6.2.2",
         "snakecase-keys": "3.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@types/express": "4.17.14",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "nock": "^13.0.7",
         "npm-run-all": "^4.1.5",
@@ -33883,7 +33883,7 @@
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       }
     },
     "packages/sdk-node/node_modules/snakecase-keys": {
@@ -33904,7 +33904,7 @@
     },
     "packages/shared": {
       "name": "@clerk/shared",
-      "version": "2.0.0-alpha-v5.0",
+      "version": "2.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "0.4.1",
@@ -33912,16 +33912,16 @@
         "swr": "2.2.0"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
         "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -33937,13 +33937,13 @@
       "version": "2.0.0-alpha-v5.0",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.0",
-        "@types/node": "^18.18.0",
+        "@clerk/types": "4.0.0-alpha-v5.1",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -33951,19 +33951,19 @@
     },
     "packages/types": {
       "name": "@clerk/types",
-      "version": "4.0.0-alpha-v5.0",
+      "version": "4.0.0-alpha-v5.1",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.1"
       },
       "devDependencies": {
-        "@types/node": "^18.18.0",
+        "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
         "typescript": "*"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=18.17.0"
       }
     },
     "packages/types/node_modules/csstype": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "packageManager": "npm@8.5.0",
   "engines": {
-    "node": ">=18.18.0",
+    "node": ">=18.17.0",
     "npm": ">=8.5.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -58,7 +58,7 @@
     "@cloudflare/workers-types": "^3.18.0",
     "@types/chai": "^4.3.3",
     "@types/cookie": "^0.5.1",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/qunit": "^2.19.7",
     "@types/sinon": "^10.0.13",
     "chai": "^4.3.6",
@@ -75,7 +75,7 @@
     "workerd": "^1.20230518.0"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/chrome": "*",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "eslint-config-custom": "*",
@@ -61,7 +61,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -100,7 +100,7 @@
     "react": ">=18"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@clerk/types": "^4.0.0-alpha-v5.1",
     "@types/base-64": "^1.0.0",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "eslint-config-custom": "*",
@@ -63,7 +63,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -46,7 +46,7 @@
     "cookies": "0.8.0"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "tsup": "*",
     "typescript": "*"
@@ -56,7 +56,7 @@
     "fastify-plugin": "^4.5.0"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gatsby-plugin-clerk/package.json
+++ b/packages/gatsby-plugin-clerk/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@clerk/types": "4.0.0-alpha-v5.1",
     "@types/cookie": "^0.5.0",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "gatsby": "^5.0.0",
     "typescript": "*"
@@ -62,7 +62,7 @@
     "gatsby": "^4.24.8 || ^5"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/localizations/package.json
+++ b/packages/localizations/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@clerk/types": "4.0.0-alpha-v5.1",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "tsup": "*",
     "typescript": "*"
@@ -48,7 +48,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nextjs/examples/next/package.json
+++ b/packages/nextjs/examples/next/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
     "eslint": "8.21.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@clerk/types": "4.0.0-alpha-v5.1",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "eslint-config-custom": "*",
@@ -79,7 +79,7 @@
     "react-dom": "^17.0.2 || ^18.0.0-0"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@clerk/themes": "2.0.0-alpha-v5.0",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "@types/semver": "^7.5.4",
@@ -75,7 +75,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -80,7 +80,7 @@
     "@remix-run/react": "^2.0.0",
     "@remix-run/server-runtime": "^2.0.0",
     "@types/cookie": "^0.5.0",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "eslint-config-custom": "*",
@@ -93,7 +93,7 @@
     "react-dom": ">=18.0.0"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk-node/examples/express/package.json
+++ b/packages/sdk-node/examples/express/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-next": "12.2.3",
     "eslint": "8.21.0",
     "nodemon": "^2.0.14",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@clerk/types": "4.0.0-alpha-v5.1",
     "@types/express": "4.17.14",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "nock": "^13.0.7",
     "npm-run-all": "^4.1.5",
@@ -71,7 +71,7 @@
     "typescript": "*"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -92,7 +92,7 @@
     "@clerk/types": "4.0.0-alpha-v5.1",
     "@types/glob-to-regexp": "0.4.1",
     "@types/js-cookie": "3.0.2",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "tsup": "*",
     "typescript": "*"
@@ -106,7 +106,7 @@
     }
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@clerk/types": "4.0.0-alpha-v5.1",
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "typescript": "*"
   },
@@ -46,7 +46,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,13 +39,13 @@
     "csstype": "3.1.1"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
+    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "tsup": "*",
     "typescript": "*"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=18.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
-    "@types/node": "^18.18",
+    "@types/node": "^18.17",
     "eslint": "8.24.0",
     "tslib": "^2.5.0",
     "typescript": "4.8.4"

--- a/playground/gatsby/package.json
+++ b/playground/gatsby/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^18.18",
+    "@types/node": "^18.17",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "typescript": "^4.9.3"


### PR DESCRIPTION
## Description

To support Vercel (using node@18.17) for node@18 runtime we need to downgrade our minimum node version.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [x] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-expo`
- [x] `@clerk/fastify`
- [x] `gatsby-plugin-clerk`
- [x] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [x] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
