### PR TITLE
chore(repo): v5 extra cleanups

### DIFF
--- a/.changeset/red-worms-fetch.md
+++ b/.changeset/red-worms-fetch.md
@@ -1,0 +1,26 @@
+---
+'@clerk/clerk-js': major
+'@clerk/shared': major
+'@clerk/clerk-sdk-node': minor
+'@clerk/backend': minor
+'@clerk/nextjs': minor
+'@clerk/clerk-react': minor
+'@clerk/clerk-expo': minor
+---
+
+Breaking Changes:
+
+- Drop `isLegacyFrontendApiKey` from `@clerk/shared`
+- Drop default exports from `@clerk/clerk-js`
+    - on headless Clerk type
+    - on ui and ui.retheme `Portal`
+- Use `isProductionFromSecretKey` instead of `isProductionFromApiKey`
+- Use `isDevelopmentFromSecretKey` instead of `isDevelopmentFromApiKey`
+
+Changes:
+
+- Rename `HeadlessBrowserClerkConstrutor` / `HeadlessBrowserClerkConstructor` (typo)
+- Use `isomorphicAtob` / `isomorhpicBtoa` to replace `base-64` in `@clerk/expo`
+- Refactor merging build-time and runtime props in `@clerk/backend` clerk client
+- Drop `node-fetch` dependency from `@clerk/backend`
+- Drop duplicate test in `@clerk/backend`

--- a/package-lock.json
+++ b/package-lock.json
@@ -33347,7 +33347,6 @@
         "babel-plugin-module-resolver": "^5.0.0",
         "bundlewatch": "^0.3.3",
         "eslint-config-custom": "*",
-        "node-fetch": "^2.6.0",
         "react-refresh": "^0.14.0",
         "react-refresh-typescript": "^2.0.5",
         "semver": "^7.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8026,11 +8026,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/base-64": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.4",
       "dev": true,
@@ -10621,10 +10616,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
       "license": "MIT"
     },
     "node_modules/base-x": {
@@ -33666,12 +33657,10 @@
         "@clerk/clerk-js": "5.0.0-alpha-v5.2",
         "@clerk/clerk-react": "5.0.0-alpha-v5.2",
         "@clerk/shared": "2.0.0-alpha-v5.2",
-        "base-64": "1.0.0",
         "react-native-url-polyfill": "2.0.0"
       },
       "devDependencies": {
         "@clerk/types": "^4.0.0-alpha-v5.2",
-        "@types/base-64": "^1.0.0",
         "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -81,7 +81,7 @@ export type AuthReason = AuthErrorReason | TokenVerificationErrorReason;
 
 export type RequestState = SignedInState | SignedOutState | InterstitialState | UnknownState;
 
-export type LoadResourcesOptions = {
+type LoadResourcesOptions = {
   loadSession?: boolean;
   loadUser?: boolean;
   loadOrganization?: boolean;

--- a/packages/backend/src/tokens/factory.test.ts
+++ b/packages/backend/src/tokens/factory.test.ts
@@ -1,0 +1,96 @@
+import type QUnit from 'qunit';
+
+import type { ApiClient } from '../api';
+import { createAuthenticateRequest } from './factory';
+
+export default (QUnit: QUnit) => {
+  const { module, test } = QUnit;
+
+  module('createAuthenticateRequest({ options, apiClient })', hooks => {
+    let fakeAuthenticateRequest;
+    hooks.afterEach(() => {
+      fakeAuthenticateRequest?.restore();
+    });
+
+    test('fallbacks to build-time options', async assert => {
+      const buildTimeOptions = {
+        secretKey: 'sk',
+        jwtKey: 'jwtKey',
+        apiUrl: 'apiUrl',
+        apiVersion: 'apiVersion',
+        proxyUrl: 'proxyUrl',
+        publishableKey: 'pk',
+        isSatellite: false,
+        domain: 'domain',
+        audience: 'domain',
+      };
+
+      const { authenticateRequest } = createAuthenticateRequest({
+        options: buildTimeOptions,
+        apiClient: {} as ApiClient,
+      });
+
+      const requestState = await authenticateRequest({ request: new Request('http://example.com/') });
+      assert.propContains(requestState.toAuth()?.debug(), buildTimeOptions);
+    });
+
+    test('overrides build-time options with runtime options', async assert => {
+      const buildTimeOptions = {
+        secretKey: 'sk',
+        jwtKey: 'jwtKey',
+        apiUrl: 'apiUrl',
+        apiVersion: 'apiVersion',
+        proxyUrl: 'proxyUrl',
+        publishableKey: 'pk',
+        isSatellite: false,
+        domain: 'domain',
+        audience: 'domain',
+      };
+
+      const { authenticateRequest } = createAuthenticateRequest({
+        options: buildTimeOptions,
+        apiClient: {} as ApiClient,
+      });
+
+      const overrides = {
+        secretKey: 'r-sk',
+        publishableKey: 'r-pk',
+      };
+      const requestState = await authenticateRequest({
+        request: new Request('http://example.com/'),
+        ...overrides,
+      });
+      assert.propContains(requestState.toAuth()?.debug(), {
+        ...buildTimeOptions,
+        ...overrides,
+      });
+    });
+
+    test('ignore runtime apiUrl and apiVersion options', async assert => {
+      const buildTimeOptions = {
+        secretKey: 'sk',
+        jwtKey: 'jwtKey',
+        apiUrl: 'apiUrl',
+        apiVersion: 'apiVersion',
+        proxyUrl: 'proxyUrl',
+        publishableKey: 'pk',
+        isSatellite: false,
+        domain: 'domain',
+        audience: 'domain',
+      };
+
+      const { authenticateRequest } = createAuthenticateRequest({
+        options: buildTimeOptions,
+        apiClient: {} as ApiClient,
+      });
+
+      const requestState = await authenticateRequest({
+        request: new Request('http://example.com/'),
+        // @ts-expect-error is used to check runtime code
+        apiUrl: 'r-apiUrl',
+        apiVersion: 'r-apiVersion',
+      });
+      assert.propContains(requestState.toAuth()?.debug(), buildTimeOptions);
+    });
+  });
+};

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -1,5 +1,5 @@
 import { checkCrossOrigin } from '../util/request';
-import { isDevelopmentFromSecretKey, isProductionFromApiKey } from '../util/shared';
+import { isDevelopmentFromSecretKey, isProductionFromSecretKey } from '../util/shared';
 import type { AuthStatusOptionsType, RequestState } from './authStatus';
 import { AuthErrorReason, interstitial, signedIn, signedOut } from './authStatus';
 import { verifyToken } from './verify';
@@ -105,7 +105,7 @@ export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: Interstitia
 export const potentialFirstRequestOnProductionEnvironment: InterstitialRule = options => {
   const { secretKey = '', clientUat, cookieToken } = options;
 
-  if (isProductionFromApiKey(secretKey) && !clientUat && !cookieToken) {
+  if (isProductionFromSecretKey(secretKey) && !clientUat && !cookieToken) {
     return signedOut(options, AuthErrorReason.CookieAndUATMissing);
   }
   return undefined;

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -1,5 +1,5 @@
 import { checkCrossOrigin } from '../util/request';
-import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/shared';
+import { isDevelopmentFromSecretKey, isProductionFromApiKey } from '../util/shared';
 import type { AuthStatusOptionsType, RequestState } from './authStatus';
 import { AuthErrorReason, interstitial, signedIn, signedOut } from './authStatus';
 import { verifyToken } from './verify';
@@ -45,7 +45,7 @@ const isBrowser = (userAgent: string | undefined) => VALID_USER_AGENTS.test(user
 // automatically treated as signed out. This exception is needed for development, because the any // missing uat throws an interstitial in development.
 export const nonBrowserRequestInDevRule: InterstitialRule = options => {
   const { secretKey, userAgent } = options;
-  if (isDevelopmentFromApiKey(secretKey || '') && !isBrowser(userAgent)) {
+  if (isDevelopmentFromSecretKey(secretKey || '') && !isBrowser(userAgent)) {
     return signedOut(options, AuthErrorReason.HeaderMissingNonBrowser);
   }
   return undefined;
@@ -70,7 +70,7 @@ export const crossOriginRequestWithoutHeader: InterstitialRule = options => {
 
 export const isPrimaryInDevAndRedirectsToSatellite: InterstitialRule = options => {
   const { secretKey = '', isSatellite, searchParams } = options;
-  const isDev = isDevelopmentFromApiKey(secretKey);
+  const isDev = isDevelopmentFromSecretKey(secretKey);
 
   if (isDev && !isSatellite && shouldRedirectToSatelliteUrl(searchParams)) {
     return interstitial(options, AuthErrorReason.PrimaryRespondsToSyncing);
@@ -80,7 +80,7 @@ export const isPrimaryInDevAndRedirectsToSatellite: InterstitialRule = options =
 
 export const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = options => {
   const { secretKey = '', clientUat } = options;
-  const res = isDevelopmentFromApiKey(secretKey);
+  const res = isDevelopmentFromSecretKey(secretKey);
   if (res && !clientUat) {
     return interstitial(options, AuthErrorReason.CookieUATMissing);
   }
@@ -96,7 +96,7 @@ export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: Interstitia
   const crossOriginReferrer =
     referrer && checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedProto });
 
-  if (isDevelopmentFromApiKey(secretKey) && crossOriginReferrer) {
+  if (isDevelopmentFromSecretKey(secretKey) && crossOriginReferrer) {
     return interstitial(options, AuthErrorReason.CrossOriginReferrer);
   }
   return undefined;

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,7 +1,7 @@
 import { constants } from '../constants';
 import { assertValidSecretKey } from '../util/assertValidSecretKey';
 import { buildRequest, stripAuthorizationHeader } from '../util/IsomorphicRequest';
-import { isDevelopmentFromApiKey } from '../util/shared';
+import { isDevelopmentFromSecretKey } from '../util/shared';
 import type { AuthStatusOptionsType, RequestState } from './authStatus';
 import { AuthErrorReason, interstitial, signedOut, unknownState } from './authStatus';
 import type { TokenCarrier } from './errors';
@@ -32,7 +32,7 @@ export type OptionalVerifyTokenOptions = Partial<
 export type AuthenticateRequestOptions = AuthStatusOptionsType & OptionalVerifyTokenOptions & { request: Request };
 
 function assertSignInUrlExists(signInUrl: string | undefined, key: string): asserts signInUrl is string {
-  if (!signInUrl && isDevelopmentFromApiKey(key)) {
+  if (!signInUrl && isDevelopmentFromSecretKey(key)) {
     throw new Error(`Missing signInUrl. Pass a signInUrl for dev instances if an app is satellite`);
   }
 }

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -2,7 +2,7 @@ import { constants } from '../constants';
 import { assertValidSecretKey } from '../util/assertValidSecretKey';
 import { buildRequest, stripAuthorizationHeader } from '../util/IsomorphicRequest';
 import { isDevelopmentFromApiKey } from '../util/shared';
-import type { AuthStatusOptionsType, LoadResourcesOptions, RequestState } from './authStatus';
+import type { AuthStatusOptionsType, RequestState } from './authStatus';
 import { AuthErrorReason, interstitial, signedOut, unknownState } from './authStatus';
 import type { TokenCarrier } from './errors';
 import { TokenVerificationError, TokenVerificationErrorReason } from './errors';

--- a/packages/backend/src/util/mergePreDefinedOptions.ts
+++ b/packages/backend/src/util/mergePreDefinedOptions.ts
@@ -1,0 +1,8 @@
+export function mergePreDefinedOptions<T extends Record<string, any>>(preDefinedOptions: T, options: Partial<T>): T {
+  return Object.keys(preDefinedOptions).reduce(
+    (obj: T, key: string) => {
+      return { ...obj, [key]: options[key] || obj[key] };
+    },
+    { ...preDefinedOptions },
+  );
+}

--- a/packages/backend/src/util/shared.ts
+++ b/packages/backend/src/util/shared.ts
@@ -1,6 +1,6 @@
 export { addClerkPrefix, getScriptUrl, getClerkJsMajorVersionOrTag } from '@clerk/shared/url';
 export { callWithRetry } from '@clerk/shared/callWithRetry';
-export { isDevelopmentFromSecretKey, isProductionFromApiKey, parsePublishableKey } from '@clerk/shared/keys';
+export { isDevelopmentFromSecretKey, isProductionFromSecretKey, parsePublishableKey } from '@clerk/shared/keys';
 export { deprecated, deprecatedProperty } from '@clerk/shared/deprecated';
 
 import { buildErrorThrower } from '@clerk/shared/error';

--- a/packages/backend/src/util/shared.ts
+++ b/packages/backend/src/util/shared.ts
@@ -1,6 +1,6 @@
 export { addClerkPrefix, getScriptUrl, getClerkJsMajorVersionOrTag } from '@clerk/shared/url';
 export { callWithRetry } from '@clerk/shared/callWithRetry';
-export { isDevelopmentFromApiKey, isProductionFromApiKey, parsePublishableKey } from '@clerk/shared/keys';
+export { isDevelopmentFromSecretKey, isProductionFromApiKey, parsePublishableKey } from '@clerk/shared/keys';
 export { deprecated, deprecatedProperty } from '@clerk/shared/deprecated';
 
 import { buildErrorThrower } from '@clerk/shared/error';

--- a/packages/backend/tests/suites.ts
+++ b/packages/backend/tests/suites.ts
@@ -1,6 +1,5 @@
 // Import all suites
 // TODO: Automate this step using dynamic imports
-import apiTest from './dist/api/factory.test.js';
 import factoryTest from './dist/api/factory.test.js';
 import exportsTest from './dist/exports.test.js';
 import redirectTest from './dist/redirections.test.js';
@@ -19,7 +18,6 @@ import utilsTest from './dist/utils.test.js';
 
 // Add them to the suite array
 const suites = [
-  apiTest,
   authObjectsTest,
   exportsTest,
   jwtAssertionsTest,

--- a/packages/backend/tests/suites.ts
+++ b/packages/backend/tests/suites.ts
@@ -5,6 +5,7 @@ import factoryTest from './dist/api/factory.test.js';
 import exportsTest from './dist/exports.test.js';
 import redirectTest from './dist/redirections.test.js';
 import authObjectsTest from './dist/tokens/authObjects.test.js';
+import tokenFactoryTest from './dist/tokens/factory.test.js';
 import jwtAssertionsTest from './dist/tokens/jwt/assertions.test.js';
 import cryptoKeysTest from './dist/tokens/jwt/cryptoKeys.test.js';
 import signJwtTest from './dist/tokens/jwt/signJwt.test.js';
@@ -33,6 +34,7 @@ const suites = [
   factoryTest,
   redirectTest,
   utilsTest,
+  tokenFactoryTest,
 ];
 
 export default suites;

--- a/packages/clerk-js/headless/index.d.ts
+++ b/packages/clerk-js/headless/index.d.ts
@@ -1,4 +1,3 @@
-import { Clerk } from '../dist/types/index.headless';
+export { Clerk } from '../dist/types/index.headless';
 
-export default Clerk;
 export * from '../dist/types/index.headless';

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -84,7 +84,6 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "bundlewatch": "^0.3.3",
     "eslint-config-custom": "*",
-    "node-fetch": "^2.6.0",
     "react-refresh": "^0.14.0",
     "react-refresh-typescript": "^2.0.5",
     "semver": "^7.5.2",

--- a/packages/clerk-js/src/ui.retheme/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui.retheme/lazyModules/providers.tsx
@@ -12,7 +12,7 @@ const OptionsProvider = lazy(() => import('../contexts').then(m => ({ default: m
 const AppearanceProvider = lazy(() => import('../customizables').then(m => ({ default: m.AppearanceProvider })));
 const VirtualRouter = lazy(() => import('../router').then(m => ({ default: m.VirtualRouter })));
 const InternalThemeProvider = lazy(() => import('../styledSystem').then(m => ({ default: m.InternalThemeProvider })));
-const Portal = lazy(() => import('./../portal'));
+const Portal = lazy(() => import('./../portal').then(m => ({ default: m.Portal })));
 const FlowMetadataProvider = lazy(() => import('./../elements').then(m => ({ default: m.FlowMetadataProvider })));
 const Modal = lazy(() => import('./../elements').then(m => ({ default: m.Modal })));
 

--- a/packages/clerk-js/src/ui.retheme/portal/index.tsx
+++ b/packages/clerk-js/src/ui.retheme/portal/index.tsx
@@ -14,7 +14,7 @@ type PortalProps<CtxType extends AvailableComponentCtx, PropsType = Omit<CtxType
   props?: PropsType & { path?: string; routing?: string };
 } & Pick<CtxType, 'componentName'>;
 
-export default class Portal<CtxType extends AvailableComponentCtx> extends React.PureComponent<PortalProps<CtxType>> {
+export class Portal<CtxType extends AvailableComponentCtx> extends React.PureComponent<PortalProps<CtxType>> {
   render(): React.ReactPortal {
     const { props, component, componentName, node } = this.props;
 

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -12,7 +12,7 @@ const OptionsProvider = lazy(() => import('../contexts').then(m => ({ default: m
 const AppearanceProvider = lazy(() => import('../customizables').then(m => ({ default: m.AppearanceProvider })));
 const VirtualRouter = lazy(() => import('../router').then(m => ({ default: m.VirtualRouter })));
 const InternalThemeProvider = lazy(() => import('../styledSystem').then(m => ({ default: m.InternalThemeProvider })));
-const Portal = lazy(() => import('./../portal'));
+const Portal = lazy(() => import('./../portal').then(m => ({ default: m.Portal })));
 const FlowMetadataProvider = lazy(() => import('./../elements').then(m => ({ default: m.FlowMetadataProvider })));
 const Modal = lazy(() => import('./../elements').then(m => ({ default: m.Modal })));
 

--- a/packages/clerk-js/src/ui/portal/index.tsx
+++ b/packages/clerk-js/src/ui/portal/index.tsx
@@ -14,7 +14,7 @@ type PortalProps<CtxType extends AvailableComponentCtx, PropsType = Omit<CtxType
   props?: PropsType & { path?: string; routing?: string };
 } & Pick<CtxType, 'componentName'>;
 
-export default class Portal<CtxType extends AvailableComponentCtx> extends React.PureComponent<PortalProps<CtxType>> {
+export class Portal<CtxType extends AvailableComponentCtx> extends React.PureComponent<PortalProps<CtxType>> {
   render(): React.ReactPortal {
     const { props, component, componentName, node } = this.props;
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -42,12 +42,10 @@
     "@clerk/clerk-js": "5.0.0-alpha-v5.2",
     "@clerk/clerk-react": "5.0.0-alpha-v5.2",
     "@clerk/shared": "2.0.0-alpha-v5.2",
-    "base-64": "1.0.0",
     "react-native-url-polyfill": "2.0.0"
   },
   "devDependencies": {
     "@clerk/types": "^4.0.0-alpha-v5.2",
-    "@types/base-64": "^1.0.0",
     "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/packages/expo/src/polyfills/base64Polyfill.ts
+++ b/packages/expo/src/polyfills/base64Polyfill.ts
@@ -1,9 +1,10 @@
-import { decode, encode } from 'base-64';
+import { isomorphicAtob } from '@clerk/shared/isomorphicAtob';
+import { isomorphicBtoa } from '@clerk/shared/isomorphicBtoa';
 
 if (!global.btoa) {
-  global.btoa = encode;
+  global.btoa = isomorphicBtoa;
 }
 
 if (!global.atob) {
-  global.atob = decode;
+  global.atob = isomorphicAtob;
 }

--- a/packages/nextjs/src/pages/ClerkProvider.tsx
+++ b/packages/nextjs/src/pages/ClerkProvider.tsx
@@ -32,7 +32,7 @@ export function ClerkProvider({ children, ...props }: NextClerkProviderProps): J
 
   const navigate = (to: string) => push(to);
   const mergedProps = mergeNextClerkPropsWithEnv({ ...props, navigate });
-  // withServerSideAuth automatically injects __clerk_ssr_state
+  // ClerkProvider automatically injects __clerk_ssr_state
   // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state
   // @ts-expect-error initialState is hidden from the types as it's a private prop
   const initialState = props.authServerSideProps?.__clerk_ssr_state || props.__clerk_ssr_state;

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -1,7 +1,7 @@
 import type { AuthObject, RequestState } from '@clerk/backend';
 import { buildRequestUrl, constants, TokenVerificationErrorReason } from '@clerk/backend';
 import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from '@clerk/shared/devBrowser';
-import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import type { Autocomplete } from '@clerk/types';
 import type Link from 'next/link';
 import type { NextFetchEvent, NextMiddleware, NextRequest } from 'next/server';
@@ -162,7 +162,7 @@ const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
 
     if (isIgnoredRoute(req)) {
       logger.debug({ isIgnoredRoute: true });
-      if (isDevelopmentFromApiKey(options.secretKey || SECRET_KEY) && !params.ignoredRoutes) {
+      if (isDevelopmentFromSecretKey(options.secretKey || SECRET_KEY) && !params.ignoredRoutes) {
         console.warn(
           receivedRequestForIgnoredRoute(req.experimental_clerkUrl.href, JSON.stringify(DEFAULT_CONFIG_MATCHER)),
         );
@@ -296,7 +296,7 @@ const appendDevBrowserOnCrossOrigin = (req: WithClerkUrl<NextRequest>, res: Resp
   if (
     shouldAppendDevBrowser &&
     !!location &&
-    isDevelopmentFromApiKey(opts.secretKey || SECRET_KEY) &&
+    isDevelopmentFromSecretKey(opts.secretKey || SECRET_KEY) &&
     isCrossOrigin(req.experimental_clerkUrl, location)
   ) {
     const dbJwt = req.cookies.get(DEV_BROWSER_JWT_MARKER)?.value || '';
@@ -345,7 +345,7 @@ const isRequestMethodIndicatingApiRoute = (req: NextRequest): boolean => {
  * In development, attempt to detect clock skew based on the requestState. This check should run when requestState.isInterstitial is true. If detected, we throw an error.
  */
 const assertClockSkew = (requestState: RequestState, opts: AuthMiddlewareParams): void => {
-  if (!isDevelopmentFromApiKey(opts.secretKey || SECRET_KEY)) {
+  if (!isDevelopmentFromSecretKey(opts.secretKey || SECRET_KEY)) {
     return;
   }
 
@@ -363,7 +363,7 @@ const assertInfiniteRedirectionLoop = (
   opts: AuthMiddlewareParams,
   requestState: RequestState,
 ): NextResponse => {
-  if (!isDevelopmentFromApiKey(opts.secretKey || SECRET_KEY)) {
+  if (!isDevelopmentFromSecretKey(opts.secretKey || SECRET_KEY)) {
     return res;
   }
 
@@ -403,7 +403,7 @@ const withNormalizedClerkUrl = (req: NextRequest): WithClerkUrl<NextRequest> => 
 };
 
 const informAboutProtectedRoute = (path: string, params: AuthMiddlewareParams, isApiRoute: boolean) => {
-  if (params.debug || isDevelopmentFromApiKey(params.secretKey || SECRET_KEY)) {
+  if (params.debug || isDevelopmentFromSecretKey(params.secretKey || SECRET_KEY)) {
     console.warn(
       informAboutProtectedRouteInfo(
         path,

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -1,7 +1,7 @@
 import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, constants } from '@clerk/backend';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
-import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -239,7 +239,7 @@ export const handleMultiDomainAndProxy = (req: NextRequest, opts: WithAuthOption
     throw new Error(missingDomainAndProxy);
   }
 
-  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(SECRET_KEY)) {
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromSecretKey(SECRET_KEY)) {
     throw new Error(missingSignInUrlInDev);
   }
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -94,8 +94,8 @@ type UseAuth = () => UseAuthReturn;
  * Once Clerk loads, `isLoaded` will be set to `true`, and you can
  * safely access the `userId` and `sessionId` variables.
  *
- * For projects using NextJs or Remix, you can have immediate access to this data  during SSR
- * simply by using the `withServerSideAuth` helper.
+ * For projects using NextJs or Remix, you can have immediate access to this data during SSR
+ * simply by using the `ClerkProvider`.
  *
  * @example
  * A simple example:
@@ -115,9 +115,6 @@ type UseAuth = () => UseAuthReturn;
  * Basic example in a NextJs app. This page will be fully rendered during SSR:
  *
  * import { useAuth } from '@clerk/nextjs'
- * import { withServerSideAuth } from '@clerk/nextjs/api'
- *
- * export getServerSideProps = withServerSideAuth();
  *
  * export HelloPage = () => {
  *   const { isSignedIn, sessionId, userId } = useAuth();

--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -16,9 +16,6 @@ type UseSession = () => UseSessionReturn;
  * Once Clerk loads, `isLoaded` will be set to `true`, and you can
  * safely access `isSignedIn` state and `session`.
  *
- * For projects using NextJs or Remix, you can make this state available during SSR
- * simply by using the `withServerSideAuth` helper and setting the `loadSession` flag to `true`.
- *
  * @example
  * A simple example:
  *
@@ -30,22 +27,6 @@ type UseSession = () => UseSessionReturn;
  *     return null;
  *   }
  *   return <div>{session.updatedAt}</div>
- * }
- *
- * @example
- * Basic example in a NextJs app. This page will be fully rendered during SSR:
- *
- * import { useSession } from '@clerk/nextjs'
- * import { withServerSideAuth } from '@clerk/nextjs/api'
- *
- * export getServerSideProps = withServerSideAuth({ loadSession: true});
- *
- * export HelloPage = () => {
- *   const { isSignedIn, session } = useSession();
- *   if(!isSignedIn) {
- *     return null;
- *   }
- *  return <div>{session.updatedAt}</div>
  * }
  */
 export const useSession: UseSession = () => {

--- a/packages/react/src/hooks/useUser.ts
+++ b/packages/react/src/hooks/useUser.ts
@@ -14,10 +14,6 @@ type UseUserReturn =
  * Once Clerk loads, `isLoaded` will be set to `true`, and you can
  * safely access `isSignedIn` state and `user`.
  *
- * For projects using NextJs or Remix, you can make this state available during SSR
- * simply by using the `withServerSideAuth` helper and setting the `loadUser` flag to `true`.
- *
- *
  * @example
  * A simple example:
  *
@@ -30,23 +26,6 @@ type UseUserReturn =
  *   }
  *   return <div>Hello, {user.firstName}</div>
  * }
- *
- * @example
- * Basic example in a NextJs app. This page will be fully rendered during SSR:
- *
- * import { useUser } from '@clerk/nextjs'
- * import { withServerSideAuth } from '@clerk/nextjs/api'
- *
- * export getServerSideProps = withServerSideAuth({ loadUser: true});
- *
- * export HelloPage = () => {
- *   const { isSignedIn, user } = useUser();
- *   if(!isSignedIn) {
- *     return null;
- *   }
- *   return <div>Hello, {user.firstName}</div>
- * }
- *
  */
 export function useUser(): UseUserReturn {
   const user = useUserContext();

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -12,7 +12,6 @@ import type {
   HandleOAuthCallbackParams,
   ListenerCallback,
   OrganizationListProps,
-  OrganizationMembershipResource,
   OrganizationProfileProps,
   OrganizationResource,
   OrganizationSwitcherProps,

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -36,7 +36,7 @@ import type {
   BrowserClerkConstructor,
   ClerkProp,
   HeadlessBrowserClerk,
-  HeadlessBrowserClerkConstrutor,
+  HeadlessBrowserClerkConstructor,
   IsomorphicClerkOptions,
 } from './types';
 import { errorThrower, isConstructor, loadClerkJsScript } from './utils';
@@ -163,7 +163,7 @@ export class IsomorphicClerk {
         // Set a fixed Clerk version
         let c: ClerkProp;
 
-        if (isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstrutor>(this.Clerk)) {
+        if (isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstructor>(this.Clerk)) {
           // Construct a new Clerk object if a constructor is passed
           c = new this.Clerk(this.#publishableKey, {
             proxyUrl: this.proxyUrl,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -55,7 +55,7 @@ export interface BrowserClerkConstructor {
   new (publishableKey: string, options?: DomainOrProxyUrl): BrowserClerk;
 }
 
-export interface HeadlessBrowserClerkConstrutor {
+export interface HeadlessBrowserClerkConstructor {
   new (publishableKey: string, options?: DomainOrProxyUrl): HeadlessBrowserClerk;
 }
 
@@ -88,7 +88,7 @@ export type ClerkProp =
   | BrowserClerkConstructor
   | BrowserClerk
   | HeadlessBrowserClerk
-  | HeadlessBrowserClerkConstrutor
+  | HeadlessBrowserClerkConstructor
   | undefined
   | null;
 

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -69,7 +69,7 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 })
 `);
 
-export const noSecretKeyOrApiKeyError = createErrorMessage(`
+export const noSecretKeyError = createErrorMessage(`
 A secretKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
 If your runtime supports environment variables, you can add a CLERK_SECRET_KEY variable to your config.
 Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -2,7 +2,7 @@ import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, Clerk } from '@clerk/backend';
 import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
-import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
 import { isTruthy } from '@clerk/shared/underscore';
 
@@ -69,7 +69,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
 
-  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey)) {
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromSecretKey(secretKey)) {
     throw new Error(satelliteAndMissingSignInUrl);
   }
 

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -6,11 +6,7 @@ import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
 import { isTruthy } from '@clerk/shared/underscore';
 
-import {
-  noSecretKeyOrApiKeyError,
-  satelliteAndMissingProxyUrlAndDomain,
-  satelliteAndMissingSignInUrl,
-} from '../errors';
+import { noSecretKeyError, satelliteAndMissingProxyUrlAndDomain, satelliteAndMissingSignInUrl } from '../errors';
 import { getEnvVariable } from '../utils';
 import type { LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 
@@ -30,7 +26,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
   const secretKey = opts.secretKey || getEnvVariable('CLERK_SECRET_KEY', context) || '';
 
   if (!secretKey) {
-    throw new Error(noSecretKeyOrApiKeyError);
+    throw new Error(noSecretKeyError);
   }
 
   const publishableKey = opts.publishableKey || getEnvVariable('CLERK_PUBLISHABLE_KEY', context) || '';

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -1,6 +1,7 @@
 import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, constants, createIsomorphicRequest } from '@clerk/backend';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
+import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from '@clerk/shared/proxy';
 import type { ServerResponse } from 'http';
 
@@ -108,8 +109,6 @@ export const decorateResponseWithObservabilityHeaders = (res: ServerResponse, re
   requestState.reason && res.setHeader(constants.Headers.AuthReason, encodeURIComponent(requestState.reason));
   requestState.status && res.setHeader(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };
-
-const isDevelopmentFromApiKey = (secretKey: string): boolean => secretKey.startsWith('sk_test_');
 
 const absoluteProxyUrl = (relativeOrAbsoluteUrl: string, baseUrl: string): string => {
   if (!relativeOrAbsoluteUrl || !isValidProxyUrl(relativeOrAbsoluteUrl) || !isProxyUrlRelative(relativeOrAbsoluteUrl)) {

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -1,7 +1,7 @@
 import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, constants, createIsomorphicRequest } from '@clerk/backend';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
-import { isDevelopmentFromApiKey } from '@clerk/shared/keys';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from '@clerk/shared/proxy';
 import type { ServerResponse } from 'http';
 
@@ -73,7 +73,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
 
-  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey || '')) {
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromSecretKey(secretKey || '')) {
     throw new Error(satelliteAndMissingSignInUrl);
   }
 

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -39,7 +39,9 @@ export const createClerkExpressRequireAuth = (createOpts: CreateClerkExpressMidd
           requestState,
         });
         if (interstitial.errors) {
-          // TODO(@dimkl): return interstitial errors ?
+          // Temporarily return Unauthenticated instead of the interstitial errors since we don't
+          // want to expose any internal error (possible errors are http 401, 500 response from BAPI)
+          // It will be dropped with the removal of fetching remotePrivateInterstitial
           next(new Error('Unauthenticated'));
           return;
         }

--- a/packages/sdk-node/src/clerkExpressWithAuth.ts
+++ b/packages/sdk-node/src/clerkExpressWithAuth.ts
@@ -29,7 +29,9 @@ export const createClerkExpressWithAuth = (createOpts: CreateClerkExpressMiddlew
           requestState,
         });
         if (interstitial.errors) {
-          // TODO(@dimkl): return interstitial errors ?
+          // Temporarily return Unauthenticated instead of the interstitial errors since we don't
+          // want to expose any internal error (possible errors are http 401, 500 response from BAPI)
+          // It will be dropped with the removal of fetching remotePrivateInterstitial
           next(new Error('Unauthenticated'));
           return;
         }

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -1,7 +1,7 @@
 import {
   buildPublishableKey,
   createDevOrStagingUrlCache,
-  isDevelopmentFromApiKey,
+  isDevelopmentFromSecretKey,
   isProductionFromApiKey,
   isPublishableKey,
   parsePublishableKey,
@@ -83,7 +83,7 @@ describe('isDevOrStagingUrl(url)', () => {
   });
 });
 
-describe('isDevelopmentFromApiKey(key)', () => {
+describe('isDevelopmentFromSecretKey(key)', () => {
   const cases: Array<[string, boolean]> = [
     ['sk_live_Y2xlcmsuY2xlcmsuZGV2JA==', false],
     ['sk_test_Y2xlcmsuY2xlcmsuZGV2JA==', true],
@@ -92,7 +92,7 @@ describe('isDevelopmentFromApiKey(key)', () => {
   ];
 
   test.each(cases)('given %p as a publishable key string, returns %p', (publishableKeyStr, expected) => {
-    const result = isDevelopmentFromApiKey(publishableKeyStr);
+    const result = isDevelopmentFromSecretKey(publishableKeyStr);
     expect(result).toEqual(expected);
   });
 });

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -2,7 +2,6 @@ import {
   buildPublishableKey,
   createDevOrStagingUrlCache,
   isDevelopmentFromApiKey,
-  isLegacyFrontendApiKey,
   isProductionFromApiKey,
   isPublishableKey,
   parsePublishableKey,
@@ -54,15 +53,6 @@ describe('isPublishableKey(key)', () => {
 
   it('returns false if the key is not a valid publishable key', () => {
     expect(isPublishableKey('clerk.clerk.com')).toBe(false);
-  });
-});
-
-describe('isLegacyFrontendApiKey(key)', () => {
-  it('returns true if the key is a valid legacy frontend Api key', () => {
-    expect(isLegacyFrontendApiKey('clerk.clerk.com')).toBe(true);
-  });
-  it('returns true if the key is not a valid legacy frontend Api key', () => {
-    expect(isLegacyFrontendApiKey('pk_live_Y2xlcmsuY2xlcmsuZGV2JA==')).toBe(false);
   });
 });
 

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -2,7 +2,7 @@ import {
   buildPublishableKey,
   createDevOrStagingUrlCache,
   isDevelopmentFromSecretKey,
-  isProductionFromApiKey,
+  isProductionFromSecretKey,
   isPublishableKey,
   parsePublishableKey,
 } from '../keys';
@@ -97,7 +97,7 @@ describe('isDevelopmentFromSecretKey(key)', () => {
   });
 });
 
-describe('isProductionFromApiKey(key)', () => {
+describe('isProductionFromSecretKey(key)', () => {
   const cases: Array<[string, boolean]> = [
     ['sk_live_Y2xlcmsuY2xlcmsuZGV2JA==', true],
     ['sk_test_Y2xlcmsuY2xlcmsuZGV2JA==', false],
@@ -106,7 +106,7 @@ describe('isProductionFromApiKey(key)', () => {
   ];
 
   test.each(cases)('given %p as a publishable key string, returns %p', (publishableKeyStr, expected) => {
-    const result = isProductionFromApiKey(publishableKeyStr);
+    const result = isProductionFromSecretKey(publishableKeyStr);
     expect(result).toEqual(expected);
   });
 });

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -70,7 +70,7 @@ export function createDevOrStagingUrlCache() {
   };
 }
 
-export function isDevelopmentFromApiKey(apiKey: string): boolean {
+export function isDevelopmentFromSecretKey(apiKey: string): boolean {
   return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
 }
 

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -50,12 +50,6 @@ export function isPublishableKey(key: string) {
   return hasValidPrefix && hasValidFrontendApiPostfix;
 }
 
-export function isLegacyFrontendApiKey(key: string) {
-  key = key || '';
-
-  return key.startsWith('clerk.');
-}
-
 export function createDevOrStagingUrlCache() {
   const devOrStagingUrlCache = new Map<string, boolean>();
 

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -74,6 +74,6 @@ export function isDevelopmentFromSecretKey(apiKey: string): boolean {
   return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
 }
 
-export function isProductionFromApiKey(apiKey: string): boolean {
+export function isProductionFromSecretKey(apiKey: string): boolean {
   return apiKey.startsWith('live_') || apiKey.startsWith('sk_live_');
 }


### PR DESCRIPTION
## Description

Breaking Changes:

- Drop `isLegacyFrontendApiKey` from `@clerk/shared`
- Drop default exports from `@clerk/clerk-js`
    - on headless Clerk type
    - on ui and ui.retheme `Portal`
- Use `isProductionFromSecretKey` instead of `isProductionFromApiKey`
- Use `isDevelopmentFromSecretKey` instead of `isDevelopmentFromApiKey`

Changes:

- Rename `HeadlessBrowserClerkConstrutor` / `HeadlessBrowserClerkConstructor` (typo)
- Use `isomorphicAtob` / `isomorhpicBtoa` to replace `base-64` in `@clerk/expo`
- Refactor merging build-time and runtime props in `@clerk/backend` clerk client
- Drop `node-fetch` dependency from `@clerk/backend`
- Drop duplicate test in `@clerk/backend`

**Review it per commit!**

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
