### PR TITLE
feat(backend): Deprecate createSMSMessage

### DIFF
--- a/.changeset/slimy-windows-grab.md
+++ b/.changeset/slimy-windows-grab.md
@@ -1,0 +1,12 @@
+---
+'@clerk/backend': patch
+---
+
+Deprecate `createSMSMessage` and `SMSMessageApi` from `clerkClient`.
+
+The `/sms_messages` Backend API endpoint will also be dropped in the future since this feature will no longer be available for new Clerk instances.
+
+For a brief period it will still be accessible for instances that have used it in the past 7
+days (13-11-2023 to 20-11-2023).
+
+New instances will get a 403 forbidden response if they try to access it.

--- a/packages/backend/src/api/endpoints/SMSMessageApi.ts
+++ b/packages/backend/src/api/endpoints/SMSMessageApi.ts
@@ -1,3 +1,5 @@
+import { deprecated } from '@clerk/shared/deprecated';
+
 import type { SMSMessage } from '../resources/SMSMessage';
 import { AbstractAPI } from './AbstractApi';
 
@@ -8,8 +10,18 @@ type SMSParams = {
   message: string;
 };
 
+/**
+ * @deprecated This endpoint is no longer available and the function will be removed in the next major version.
+ */
 export class SMSMessageAPI extends AbstractAPI {
+  /**
+   * @deprecated This endpoint is no longer available and the function will be removed in the next major version.
+   */
   public async createSMSMessage(params: SMSParams) {
+    deprecated(
+      'SMSMessageAPI.createSMSMessage',
+      'This endpoint is no longer available and the function will be removed in the next major version.',
+    );
     return this.request<SMSMessage>({
       method: 'POST',
       path: basePath,


### PR DESCRIPTION
## Description

The deprecation commit of https://github.com/clerk/javascript/pull/2165 for release in v4

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Deprecation

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
