### PR TITLE
chore(backend): Limit exposed token verification related errors

### DIFF
--- a/.changeset/smooth-baboons-shake.md
+++ b/.changeset/smooth-baboons-shake.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-sdk-node': major
+'@clerk/backend': major
+'@clerk/nextjs': major
+'@clerk/remix': major
+---
+
+Limit TokenVerificationError exports to TokenVerificationError and TokenVerificationErrorReason

--- a/packages/backend/src/exports.test.ts
+++ b/packages/backend/src/exports.test.ts
@@ -33,8 +33,6 @@ export default (QUnit: QUnit) => {
         'SignInToken',
         'Token',
         'TokenVerificationError',
-        'TokenVerificationErrorAction',
-        'TokenVerificationErrorCode',
         'TokenVerificationErrorReason',
         'User',
         'Verification',

--- a/packages/backend/src/tokens/index.ts
+++ b/packages/backend/src/tokens/index.ts
@@ -1,7 +1,7 @@
 export * from './authObjects';
 export { AuthStatus } from './authStatus';
 export type { RequestState } from './authStatus';
-export * from './errors';
+export { TokenVerificationError, TokenVerificationErrorReason } from './errors';
 export * from './factory';
 export { loadInterstitialFromLocal } from './interstitial';
 export { debugRequestState } from './request';

--- a/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
@@ -27,8 +27,6 @@ exports[`/server public exports should not include a breaking change 1`] = `
   "SignInToken",
   "Token",
   "TokenVerificationError",
-  "TokenVerificationErrorAction",
-  "TokenVerificationErrorCode",
   "TokenVerificationErrorReason",
   "User",
   "Verification",

--- a/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -29,8 +29,6 @@ exports[`module exports should not change unless explicitly set 1`] = `
   "SignInToken",
   "Token",
   "TokenVerificationError",
-  "TokenVerificationErrorAction",
-  "TokenVerificationErrorCode",
   "TokenVerificationErrorReason",
   "User",
   "Verification",


### PR DESCRIPTION
## Description

Removes both `TokenVerificationErrorAction` & `TokenVerificationErrorCode` from `@clerk/backend` exports as both are internal.

It also happens to support @flawnn's work/use-case in https://github.com/clerk/javascript/pull/1980, once we backport to `release/v4`.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
