### PR TITLE
fix(localizations): Added missing key and en-US localization

### DIFF
--- a/.changeset/curvy-timers-play.md
+++ b/.changeset/curvy-timers-play.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add missing localization key for invalid phone_number (unstable error) in the en-US localization

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -715,6 +715,7 @@ export const enUS: LocalizationResource = {
     form_username_invalid_length: '',
     form_username_invalid_character: '',
     form_param_format_invalid: '',
+    form_param_format_invalid__phone_number: 'Phone number must be in a valid international format',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',
     form_password_length_too_short: '',
     form_param_nil: '',


### PR DESCRIPTION
## Description

Added missing parameter for localizations

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [x] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
