### PR TITLE
feat(backend): Support totalCount on BAPI responses

### DIFF
--- a/.changeset/new-cougars-taste.md
+++ b/.changeset/new-cougars-taste.md
@@ -1,0 +1,23 @@
+---
+'@clerk/backend': minor
+---
+
+Expose `totalCount` from `@clerk/backend` client responses for responses
+containing pagination information or for responses with type `{ data: object[] }`.
+
+
+Example:
+```typescript
+import { Clerk } from '@clerk/backend'
+
+const clerkClient = Clerk({ secretKey: '...'});
+
+// current
+const { data } = await clerkClient.organizations.getOrganizationList();
+console.log('totalCount: ', data.length);
+
+// new
+const { data, totalCount } = await clerkClient.organizations.getOrganizationList();
+console.log('totalCount: ', totalCount);
+
+```

--- a/packages/backend/src/api/factory.test.ts
+++ b/packages/backend/src/api/factory.test.ts
@@ -5,7 +5,7 @@ import emailJson from '../fixtures/responses/email.json';
 import userJson from '../fixtures/responses/user.json';
 import runtime from '../runtime';
 import { assertErrorResponse, assertResponse } from '../util/assertResponse';
-import { jsonError, jsonNotOk, jsonOk } from '../util/mockFetch';
+import { jsonError, jsonNotOk, jsonOk, jsonPaginatedOk } from '../util/mockFetch';
 import { createBackendApiClient } from './factory';
 
 export default (QUnit: QUnit) => {
@@ -30,7 +30,7 @@ export default (QUnit: QUnit) => {
       const response = await apiClient.users.getUser('user_deadbeef');
 
       assertResponse(assert, response);
-      const { data: payload } = response;
+      const { data: payload, totalCount } = response;
 
       assert.equal(payload.firstName, 'John');
       assert.equal(payload.lastName, 'Doe');
@@ -38,6 +38,7 @@ export default (QUnit: QUnit) => {
       assert.equal(payload.phoneNumbers[0].phoneNumber, '+311-555-2368');
       assert.equal(payload.externalAccounts[0].emailAddress, 'john.doe@clerk.test');
       assert.equal(payload.publicMetadata.zodiac_sign, 'leo');
+      assert.equal(totalCount, undefined);
 
       assert.ok(
         fakeFetch.calledOnceWith('https://api.clerk.test/v1/users/user_deadbeef', {
@@ -57,7 +58,7 @@ export default (QUnit: QUnit) => {
 
       const response = await apiClient.users.getUserList({ offset: 2, limit: 5 });
       assertResponse(assert, response);
-      const { data: payload } = response;
+      const { data: payload, totalCount } = response;
 
       assert.equal(payload[0].firstName, 'John');
       assert.equal(payload[0].lastName, 'Doe');
@@ -65,6 +66,7 @@ export default (QUnit: QUnit) => {
       assert.equal(payload[0].phoneNumbers[0].phoneNumber, '+311-555-2368');
       assert.equal(payload[0].externalAccounts[0].emailAddress, 'john.doe@clerk.test');
       assert.equal(payload[0].publicMetadata.zodiac_sign, 'leo');
+      assert.equal(totalCount, 1);
 
       assert.ok(
         fakeFetch.calledOnceWith('https://api.clerk.test/v1/users?offset=2&limit=5', {
@@ -92,15 +94,46 @@ export default (QUnit: QUnit) => {
         '{"from_email_name":"foobar123","email_address_id":"test@test.dev","body":"this is a test","subject":"this is a test"}';
       const response = await apiClient.emails.createEmail(body);
       assertResponse(assert, response);
-      const { data: payload } = response;
+      const { data: payload, totalCount } = response;
 
       assert.equal(JSON.stringify(payload.data), '{}');
       assert.equal(payload.id, 'ema_2PHa2N3bS7D6NPPQ5mpHEg0waZQ');
+      assert.equal(totalCount, undefined);
 
       assert.ok(
         fakeFetch.calledOnceWith('https://api.clerk.test/v1/emails', {
           method: 'POST',
           body: requestBody,
+          headers: {
+            Authorization: 'Bearer deadbeef',
+            'Content-Type': 'application/json',
+            'Clerk-Backend-SDK': '@clerk/backend',
+          },
+        }),
+      );
+    });
+
+    test('executes a successful backend API request for a paginated response', async assert => {
+      fakeFetch = sinon.stub(runtime, 'fetch');
+      fakeFetch.onCall(0).returns(jsonPaginatedOk([userJson], 3));
+
+      const response = await apiClient.users.getUserList({ offset: 2, limit: 5 });
+      assertResponse(assert, response);
+      const { data: payload, totalCount } = response;
+
+      assert.equal(payload[0].firstName, 'John');
+      assert.equal(payload[0].lastName, 'Doe');
+      assert.equal(payload[0].emailAddresses[0].emailAddress, 'john.doe@clerk.test');
+      assert.equal(payload[0].phoneNumbers[0].phoneNumber, '+311-555-2368');
+      assert.equal(payload[0].externalAccounts[0].emailAddress, 'john.doe@clerk.test');
+      assert.equal(payload[0].publicMetadata.zodiac_sign, 'leo');
+      // payload.length is different from response total_count to check that totalCount use the total_count from response
+      assert.equal(payload.length, 1);
+      assert.equal(totalCount, 3);
+
+      assert.ok(
+        fakeFetch.calledOnceWith('https://api.clerk.test/v1/users?offset=2&limit=5', {
+          method: 'GET',
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -320,3 +320,8 @@ export interface DeletedObjectJSON {
   slug?: string;
   deleted: boolean;
 }
+
+export interface PaginatedResponseJSON {
+  data: object[];
+  total_count?: number;
+}

--- a/packages/backend/src/util/mockFetch.ts
+++ b/packages/backend/src/util/mockFetch.ts
@@ -15,6 +15,24 @@ export function jsonOk(body: unknown, status = 200) {
   return Promise.resolve(mockResponse);
 }
 
+export function jsonPaginatedOk(body: unknown[], total_count: number, status = 200) {
+  // Mock response object that satisfies the window.Response interface
+  const mockResponse = {
+    ok: true,
+    status,
+    statusText: status.toString(),
+    headers: { get: mockHeadersGet },
+    json() {
+      return Promise.resolve({
+        data: body,
+        total_count,
+      });
+    },
+  };
+
+  return Promise.resolve(mockResponse);
+}
+
 export function jsonNotOk(body: unknown) {
   // Mock response object that satisfies the window.Response interface
   const mockResponse = {


### PR DESCRIPTION
## Description

The backend clerkClient will return a `totalCount: number` in the responses for BAPI responses:
- with `total_count` prop of response
- with an array of objects as `data` prop of response

The `totalCount` is NOT included in:
- single resource responses
- error responses

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
