### PR TITLE
feat(clerk-js): Throw error if routing options are used incorrectly

### DIFF
--- a/.changeset/brave-suits-drive.md
+++ b/.changeset/brave-suits-drive.md
@@ -1,0 +1,10 @@
+---
+'@clerk/clerk-js': major
+---
+
+All the components that using routing will throw a runtime error if the a path property is provided with a routing strategy other than path.
+
+Example that will throw an error:
+```tsx
+<SignIn routing='hash' path='/sign-in' />
+```

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -115,3 +115,7 @@ export function clerkRedirectUrlIsMissingScheme(): never {
 export function clerkFailedToLoadThirdPartyScript(name?: string): never {
   throw new Error(`${errorPrefix} Unable to retrieve a third party script${name ? ` ${name}` : ''}.`);
 }
+
+export function clerkInvalidRoutingStrategy(strategy?: string): never {
+  throw new Error(`${errorPrefix} Invalid routing strategy, path cannot be used in tandem with ${strategy}.`);
+}

--- a/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
+++ b/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
@@ -6,10 +6,13 @@ describe('auth prop helpers', () => {
       expect(normalizeRoutingOptions({ path: 'test' })).toEqual({ routing: 'path', path: 'test' });
     });
 
-    it('returns the same options if routing was provided (any routing) and path was provided (avoid breaking integrations)', () => {
-      expect(normalizeRoutingOptions({ routing: 'path', path: 'test' })).toEqual({ routing: 'path', path: 'test' });
-      expect(normalizeRoutingOptions({ routing: 'hash', path: 'test' })).toEqual({ routing: 'hash', path: 'test' });
-      expect(normalizeRoutingOptions({ routing: 'virtual' })).toEqual({ routing: 'virtual' });
+    it('it throws an error when path is provided and routing strategy is not path', () => {
+      expect(() => {
+        normalizeRoutingOptions({ path: 'test', routing: 'hash' });
+      }).toThrow('ClerkJS: Invalid routing strategy, path cannot be used in tandem with hash.');
+      expect(() => {
+        normalizeRoutingOptions({ path: 'test', routing: 'virtual' });
+      }).toThrow('ClerkJS: Invalid routing strategy, path cannot be used in tandem with virtual.');
     });
   });
 });

--- a/packages/clerk-js/src/utils/authPropHelpers.ts
+++ b/packages/clerk-js/src/utils/authPropHelpers.ts
@@ -3,6 +3,7 @@ import type { ClerkOptions, DisplayConfigResource, RoutingOptions, RoutingStrate
 import type { ParsedQs } from 'qs';
 import qs from 'qs';
 
+import { clerkInvalidRoutingStrategy } from '../core/errors';
 import { hasBannedProtocol, isAllowedRedirectOrigin, isValidUrl } from './url';
 
 type PickRedirectionUrlKey = 'afterSignUpUrl' | 'afterSignInUrl' | 'signInUrl' | 'signUpUrl';
@@ -122,6 +123,10 @@ export const normalizeRoutingOptions = ({
 }): RoutingOptions => {
   if (!!path && !routing) {
     return { routing: 'path', path };
+  }
+
+  if (routing !== 'path' && !!path) {
+    clerkInvalidRoutingStrategy(routing);
   }
 
   return { routing, path } as RoutingOptions;

--- a/packages/clerk-js/src/utils/authPropHelpers.ts
+++ b/packages/clerk-js/src/utils/authPropHelpers.ts
@@ -126,7 +126,7 @@ export const normalizeRoutingOptions = ({
   }
 
   if (routing !== 'path' && !!path) {
-    clerkInvalidRoutingStrategy(routing);
+    return clerkInvalidRoutingStrategy(routing);
   }
 
   return { routing, path } as RoutingOptions;


### PR DESCRIPTION
## Description

This PR introduces a breaking change for all the components using routing, if the a `path` property is provided with a routing strategy other than `path` a runtime error will be thrown.

Example that will throw an error:
```tsx
<SignIn routing='hash' path='/sign-in' />
```

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
