### PR TITLE
chore(types,clerk-react): Make `routerPush` / `routerReplace` both required or both optional

### DIFF
--- a/.changeset/tiny-forks-sit.md
+++ b/.changeset/tiny-forks-sit.md
@@ -3,6 +3,4 @@
 '@clerk/types': minor
 ---
 
-Update `<ClerkProvider/>` `routerPush` and `routerReplace` options to be both required or both missing.
-Also used internally the `Without` generic instead of `Omit` to resolve issues with complex types and
-partially making a type property optional.
+Update the TypeScript types of `<ClerkProvider />`. If you use the `routerPush` prop you're now required to also provide the `routerReplace` prop (or other way around). You can also not provide them at all since both props are optional.

--- a/.changeset/tiny-forks-sit.md
+++ b/.changeset/tiny-forks-sit.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+Update `<ClerkProvider/>` `routerPush` and `routerReplace` options to be both required or both missing.
+Also used internally the `Without` generic instead of `Omit` to resolve issues with complex types and
+partially making a type property optional.

--- a/.github/workflows/ui-retheme-changes-reminder.yml
+++ b/.github/workflows/ui-retheme-changes-reminder.yml
@@ -6,7 +6,13 @@ on:
       - main
     paths:
       - 'packages/clerk-js/src/ui/**'
-
+      # files with matching `*.retheme.ts` retheme variant
+      - 'packages/localizations/src/en-US.ts'
+      - 'packages/localizations/src/index.ts'
+      - 'packages/types/src/appearance.ts'
+      - 'packages/types/src/clerk.ts'
+      - 'packages/types/src/index.ts'
+      - 'packages/types/src/localization.ts'
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,5 @@ examples
 node_modules
 package-lock.json
 playground
+packages/backend/tests/**/*.js
+/**/CHANGELOG.md

--- a/packages/react/src/contexts/__tests__/ClerkProvider.test.tsx
+++ b/packages/react/src/contexts/__tests__/ClerkProvider.test.tsx
@@ -224,4 +224,23 @@ describe('ClerkProvider', () => {
       expectTypeOf({ publishableKey: 'test' }).not.toMatchTypeOf<ClerkProviderProps>();
     });
   });
+
+  describe('navigation options', () => {
+    it('expects both routerPush & routerReplace to pass', () => {
+      expectTypeOf({
+        publishableKey: 'test',
+        children: '',
+        routerPush: () => {},
+        routerReplace: () => {},
+      }).toMatchTypeOf<ClerkProviderProps>();
+    });
+
+    it('errors if one of routerPush / routerReplace is passed', () => {
+      expectTypeOf({
+        publishableKey: 'test',
+        children: '',
+        routerPush: () => {},
+      }).not.toMatchTypeOf<ClerkProviderProps>();
+    });
+  });
 });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,6 +11,7 @@ import type {
   SignInRedirectOptions,
   SignUpRedirectOptions,
   UserResource,
+  Without,
 } from '@clerk/types';
 import type React from 'react';
 
@@ -23,7 +24,7 @@ declare global {
   }
 }
 
-export type IsomorphicClerkOptions = Omit<ClerkOptions, 'isSatellite'> & {
+export type IsomorphicClerkOptions = Without<ClerkOptions, 'isSatellite'> & {
   Clerk?: ClerkProp;
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';
@@ -37,19 +38,10 @@ export type ClerkProviderProps = IsomorphicClerkOptions & {
   initialState?: InitialState;
 };
 
-// TODO(@dimkl): replacing it with the following make nextjs type tests fail
-//   `Exclude<IsomorphicClerkOptions, 'publishableKey'> & { publishableKey?: string }`
-// find another way to reduce the duplication.
-export type ClerkProviderOptionsWrapper = Omit<ClerkOptions, 'isSatellite'> & {
-  Clerk?: ClerkProp;
-  clerkJSUrl?: string;
-  clerkJSVariant?: 'headless' | '';
-  clerkJSVersion?: string;
-  sdkMetadata?: SDKMetadata;
+export type ClerkProviderOptionsWrapper = Without<IsomorphicClerkOptions, 'publishableKey'> & {
   publishableKey?: string;
-} & MultiDomainAndOrProxy & {
-    children: React.ReactNode;
-  };
+  children: React.ReactNode;
+};
 
 export interface BrowserClerkConstructor {
   new (publishableKey: string, options?: DomainOrProxyUrl): BrowserClerk;
@@ -75,7 +67,7 @@ export interface MountProps {
 }
 
 export interface HeadlessBrowserClerk extends Clerk {
-  load: (opts?: Omit<ClerkOptions, 'isSatellite'>) => Promise<void>;
+  load: (opts?: Without<ClerkOptions, 'isSatellite'>) => Promise<void>;
   updateClient: (client: ClientResource) => void;
 }
 

--- a/packages/types/src/clerk.retheme.ts
+++ b/packages/types/src/clerk.retheme.ts
@@ -495,7 +495,25 @@ export type CustomNavigation = (to: string, options?: NavigateOptions) => Promis
 
 export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 
-export interface ClerkOptions {
+/**
+ * Navigation options used to replace or push history changes.
+ * Both `routerPush` & `routerReplace` OR none options should be passed.
+ */
+type ClerkOptionsNavigationFn =
+  | {
+      routerPush?: never;
+      routerReplace?: never;
+    }
+  | {
+      routerPush: (to: string) => Promise<unknown> | unknown;
+      routerReplace: (to: string) => Promise<unknown> | unknown;
+    };
+
+type ClerkOptionsNavigation = ClerkOptionsNavigationFn & {
+  routerDebug?: boolean;
+};
+
+export type ClerkOptions = ClerkOptionsNavigation & {
   appearance?: Appearance;
   localization?: LocalizationResource;
   /**
@@ -535,7 +553,7 @@ export interface ClerkOptions {
       };
 
   sdkMetadata?: SDKMetadata;
-}
+};
 
 export interface NavigateOptions {
   replace?: boolean;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -495,16 +495,27 @@ export type CustomNavigation = (to: string, options?: NavigateOptions) => Promis
 
 export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 
-export interface ClerkOptions {
+/**
+ * Navigation options used to replace or push history changes.
+ * Both `routerPush` & `routerReplace` OR none options should be passed.
+ */
+type ClerkOptionsNavigationFn =
+  | {
+      routerPush?: never;
+      routerReplace?: never;
+    }
+  | {
+      routerPush: (to: string) => Promise<unknown> | unknown;
+      routerReplace: (to: string) => Promise<unknown> | unknown;
+    };
+
+type ClerkOptionsNavigation = ClerkOptionsNavigationFn & {
+  routerDebug?: boolean;
+};
+
+export type ClerkOptions = ClerkOptionsNavigation & {
   appearance?: Appearance;
   localization?: LocalizationResource;
-  /**
-   * Navigation
-   */
-  routerPush?: (to: string) => Promise<unknown> | unknown;
-  routerReplace?: (to: string) => Promise<unknown> | unknown;
-  routerDebug?: boolean;
-
   polling?: boolean;
   selectInitialSession?: (client: ClientResource) => ActiveSessionResource | null;
   /** Controls if ClerkJS will load with the standard browser setup using Clerk cookies */
@@ -536,7 +547,7 @@ export interface ClerkOptions {
       };
 
   sdkMetadata?: SDKMetadata;
-}
+};
 
 export interface NavigateOptions {
   replace?: boolean;


### PR DESCRIPTION
## Description

Changes (review per commit for more info):
- Use `Without` generic to resolve issues with `Omit` and complex types
- Make `routerPush` and `routerReplace` options both required or both optional
- Improve performance of formatting CICD step by ignoring some git ignored or already formatted (since they are auto-generated) files

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
