### PR TITLE
fix(shared): Add missing `files` entry in `package.json`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -67,7 +67,8 @@
     "react",
     "constants",
     "apiUrlFromPublishableKey",
-    "scripts"
+    "scripts",
+    "telemetry"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Description

While reading https://github.com/clerk/javascript/pull/2154 I noticed that `telemetry` was missing from the `files` array in `package.json`. This is needed for the "Expo folder workaround" with the subpaths.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
