### PR TITLE
fix(clerk-expo): Use base-64 package instead of isomorphic from @clerk/shared

### DIFF
--- a/.changeset/curly-parrots-camp.md
+++ b/.changeset/curly-parrots-camp.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-expo': minor
 ---
 
-Use `base-64` package for Expo instead of the isomorphic from `@clerk/shared` due to errors about `Maximum call stack size exceeded`
+Use `base-64` package for Expo instead of the isomorphic from `@clerk/shared` due to errors about `Maximum call stack size exceeded` on `global.Buffer`

--- a/.changeset/curly-parrots-camp.md
+++ b/.changeset/curly-parrots-camp.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': minor
+---
+
+Use `base-64` package for Expo instead of the isomorphic from `@clerk/shared` due to errors about `Maximum call stack size exceeded`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5919,6 +5919,134 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "license": "MIT",
@@ -8010,6 +8138,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/base-64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
+      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
+      "dev": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.4",
@@ -10591,6 +10725,11 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -33141,7 +33280,7 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "1.0.0-alpha-v5.3",
+      "version": "1.0.0-alpha-v5.4",
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.0.0-alpha-v5.3",
@@ -33150,7 +33289,7 @@
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@cloudflare/workers-types": "^3.18.0",
         "@types/chai": "^4.3.3",
         "@types/cookie": "^0.5.1",
@@ -33180,11 +33319,11 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "1.0.0-alpha-v5.4",
+      "version": "1.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.4",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.4"
+        "@clerk/clerk-js": "5.0.0-alpha-v5.6",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.6"
       },
       "devDependencies": {
         "@types/chrome": "*",
@@ -33205,12 +33344,12 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "5.0.0-alpha-v5.4",
+      "version": "5.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/localizations": "2.0.0-alpha-v5.4",
+        "@clerk/localizations": "2.0.0-alpha-v5.5",
         "@clerk/shared": "2.0.0-alpha-v5.3",
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
         "@floating-ui/react": "0.25.4",
@@ -33545,16 +33684,18 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "1.0.0-alpha-v5.4",
+      "version": "1.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.4",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.4",
+        "@clerk/clerk-js": "5.0.0-alpha-v5.6",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.6",
         "@clerk/shared": "2.0.0-alpha-v5.3",
+        "base-64": "^1.0.0",
         "react-native-url-polyfill": "2.0.0"
       },
       "devDependencies": {
-        "@clerk/types": "^4.0.0-alpha-v5.4",
+        "@clerk/types": "^4.0.0-alpha-v5.6",
+        "@types/base-64": "^1.0.2",
         "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
@@ -33576,12 +33717,12 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "1.0.0-alpha-v5.4",
+      "version": "1.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.3",
+        "@clerk/backend": "1.0.0-alpha-v5.4",
         "@clerk/shared": "2.0.0-alpha-v5.3",
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "cookies": "0.8.0"
       },
       "devDependencies": {
@@ -33599,17 +33740,17 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "5.0.0-alpha-v5.4",
+      "version": "5.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.3",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.4",
-        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.3",
+        "@clerk/backend": "1.0.0-alpha-v5.4",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.6",
+        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.4",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/cookie": "^0.5.0",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
@@ -33629,10 +33770,10 @@
     },
     "packages/localizations": {
       "name": "@clerk/localizations",
-      "version": "2.0.0-alpha-v5.4",
+      "version": "2.0.0-alpha-v5.5",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
@@ -33648,16 +33789,16 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "5.0.0-alpha-v5.4",
+      "version": "5.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.3",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.4",
+        "@clerk/backend": "1.0.0-alpha-v5.4",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.6",
         "@clerk/shared": "2.0.0-alpha-v5.3",
         "path-to-regexp": "6.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
@@ -33682,11 +33823,11 @@
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
-      "version": "5.0.0-alpha-v5.4",
+      "version": "5.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.0.0-alpha-v5.3",
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "eslint-config-custom": "*",
         "semver": "^7.5.4",
         "tslib": "2.4.1"
@@ -33714,17 +33855,17 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "4.0.0-alpha-v5.4",
+      "version": "4.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.3",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.4",
+        "@clerk/backend": "1.0.0-alpha-v5.4",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.6",
         "@clerk/shared": "2.0.0-alpha-v5.3",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@remix-run/react": "^2.0.0",
         "@remix-run/server-runtime": "^2.0.0",
         "@types/cookie": "^0.5.0",
@@ -33750,16 +33891,16 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "5.0.0-alpha-v5.3",
+      "version": "5.0.0-alpha-v5.4",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.3",
+        "@clerk/backend": "1.0.0-alpha-v5.4",
         "@clerk/shared": "2.0.0-alpha-v5.3",
         "camelcase-keys": "6.2.2",
         "snakecase-keys": "3.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/express": "4.17.14",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
@@ -33801,7 +33942,7 @@
         "swr": "2.2.0"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
         "@types/node": "^18.17.0",
@@ -33837,7 +33978,7 @@
       "version": "2.0.0-alpha-v5.2",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.4",
+        "@clerk/types": "4.0.0-alpha-v5.6",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "typescript": "*"
@@ -33852,7 +33993,7 @@
     },
     "packages/types": {
       "name": "@clerk/types",
-      "version": "4.0.0-alpha-v5.4",
+      "version": "4.0.0-alpha-v5.6",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.1"
@@ -33870,126 +34011,6 @@
     "packages/types/node_modules/csstype": {
       "version": "3.1.1",
       "license": "MIT"
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
-      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
-      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
-      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
-      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
-      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
-      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
-      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
-      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -42,10 +42,12 @@
     "@clerk/clerk-js": "5.0.0-alpha-v5.6",
     "@clerk/clerk-react": "5.0.0-alpha-v5.6",
     "@clerk/shared": "2.0.0-alpha-v5.3",
+    "base-64": "^1.0.0",
     "react-native-url-polyfill": "2.0.0"
   },
   "devDependencies": {
     "@clerk/types": "^4.0.0-alpha-v5.6",
+    "@types/base-64": "^1.0.2",
     "@types/node": "^18.17.0",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/packages/expo/src/polyfills/base64Polyfill.ts
+++ b/packages/expo/src/polyfills/base64Polyfill.ts
@@ -1,10 +1,9 @@
-import { isomorphicAtob } from '@clerk/shared/isomorphicAtob';
-import { isomorphicBtoa } from '@clerk/shared/isomorphicBtoa';
+import { decode, encode } from 'base-64';
 
 if (!global.btoa) {
-  global.btoa = isomorphicBtoa;
+  global.btoa = encode;
 }
 
 if (!global.atob) {
-  global.atob = isomorphicAtob;
+  global.atob = decode;
 }


### PR DESCRIPTION
## Description

This PR revert's the change about using the isomorphic `encode` and `decode` helpers from `@clerk/shared` to use the [base-64](https://www.npmjs.com/package/base-64) package.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [X] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
