### PR TITLE
fix(clerk-js): Add setter for sdkMetadata to address error (#2237)

### DIFF
--- a/.changeset/young-experts-attack.md
+++ b/.changeset/young-experts-attack.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add setter for sdkMetadata on Clerk to address issues arising from older versions of the SDK.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -191,6 +191,10 @@ export default class Clerk implements ClerkInterface {
     return Clerk.version;
   }
 
+  set sdkMetadata(metadata: SDKMetadata) {
+    Clerk.sdkMetadata = metadata;
+  }
+
   get sdkMetadata(): SDKMetadata {
     return Clerk.sdkMetadata;
   }


### PR DESCRIPTION
Backporting #2237 to the release/v4 branch

(cherry picked from commit 0551488fb67fc6ec117e8d19796094c4601013d2)