### PR TITLE
chore(integration): Improve Playwright logging

### DIFF
--- a/integration/models/applicationConfig.ts
+++ b/integration/models/applicationConfig.ts
@@ -16,7 +16,7 @@ export const applicationConfig = () => {
   const files = new Map<string, string>();
   const scripts: Scripts = { dev: 'npm run dev', serve: 'npm run serve', build: 'npm run build', setup: 'npm i' };
   const envFormatters = { public: (key: string) => key, private: (key: string) => key };
-  const logger = createLogger({ prefix: 'appConfig', color: 'bgYellow' });
+  const logger = createLogger({ prefix: 'appConfig', color: 'yellow' });
   const dependencies = new Map<string, string>();
 
   const self = {

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -19,7 +19,7 @@ export const common: PlaywrightTestConfig = {
   timeout: process.env.CI ? 90000 : 30000,
   maxFailures: process.env.CI ? 1 : undefined,
   workers: process.env.CI ? numAvailableWorkers : '70%',
-  reporter: [[process.env.CI ? 'html' : 'line', { open: 'never' }]] as any,
+  reporter: process.env.CI ? 'line' : 'list',
   use: {
     trace: 'on-first-retry',
     bypassCSP: true, // We probably need to limit this to specific tests

--- a/integration/scripts/logger.ts
+++ b/integration/scripts/logger.ts
@@ -2,7 +2,20 @@
 import { default as chalk } from 'chalk';
 
 const getRandomChalkColor = () => {
-  const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+  const colors = [
+    'red',
+    'green',
+    'yellow',
+    'blue',
+    'magenta',
+    'cyan',
+    'redBright',
+    'greenBright',
+    'yellowBright',
+    'blueBright',
+    'magentaBright',
+    'cyanBright',
+  ];
   return colors[Math.floor(Math.random() * colors.length)];
 };
 

--- a/integration/scripts/logger.ts
+++ b/integration/scripts/logger.ts
@@ -2,7 +2,7 @@
 import { default as chalk } from 'chalk';
 
 const getRandomChalkColor = () => {
-  const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
+  const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
   return colors[Math.floor(Math.random() * colors.length)];
 };
 

--- a/integration/scripts/logger.ts
+++ b/integration/scripts/logger.ts
@@ -1,23 +1,23 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { default as chalk } from 'chalk';
 
-const getRandomChalkBgColor = () => {
-  const colors = ['bgRed', 'bgGreen', 'bgYellow', 'bgBlue', 'bgMagenta', 'bgCyan', 'bgWhite'];
+const getRandomChalkColor = () => {
+  const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
   return colors[Math.floor(Math.random() * colors.length)];
 };
 
 type CreateLoggerOptions = { prefix: string; color?: string };
 export const createLogger = (opts: CreateLoggerOptions) => {
   const { color, prefix } = opts;
-  const prefixBgColor = color || getRandomChalkBgColor();
+  const prefixColor = color || getRandomChalkColor();
   return {
     info: (msg: string) => {
       if (process.env.DEBUG) {
-        console.info(`${chalk[prefixBgColor](`[${prefix}]`)} ${msg}`);
+        console.info(`${chalk[prefixColor](`[${prefix}]`)} ${msg}`);
       }
     },
     child: (childOpts: CreateLoggerOptions) => {
-      return createLogger({ prefix: `${prefix} :: ${childOpts.prefix}`, color: prefixBgColor });
+      return createLogger({ prefix: `${prefix} :: ${childOpts.prefix}`, color: prefixColor });
     },
   };
 };


### PR DESCRIPTION
## Description

Improvements to the output you see when running our integration tests / Playwright:

- Color the text, not the text background. This improves readability
- Change the [`reporter`](https://playwright.dev/docs/test-reporters) to `line` in CI and `list` locally. Before we used `html` in CI but we didn't do anything with the output

Example of new output: https://github.com/clerk/javascript/actions/runs/7058789001/job/19215097030?pr=2243

Before:

![image](https://github.com/clerk/javascript/assets/16143594/b4999a7d-b298-4e9b-b5cd-b2ad403a766e)

After:

![image](https://github.com/clerk/javascript/assets/16143594/9f4499a5-3ca4-48f7-8e96-4e849cb3e348)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
