### PR TITLE
fix(clerk-js): Hide Add domain button when user is missing `org:sys_domains:manage` (#2240)

### DIFF
--- a/.changeset/strong-cows-sit.md
+++ b/.changeset/strong-cows-sit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide "Add domain" button inside `<OrganizationProfile/>` when user is missing the `org:sys_domains:manage` permission.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
@@ -87,11 +87,13 @@ const OrganizationDomainsSection = () => {
     >
       <DomainList redirectSubPath={'domain'} />
 
-      <AddBlockButton
-        textLocalizationKey={localizationKeys('organizationProfile.profilePage.domainSection.primaryButton')}
-        id='addOrganizationDomain'
-        onClick={() => navigate('domain')}
-      />
+      <Gate permission='org:sys_domains:manage'>
+        <AddBlockButton
+          textLocalizationKey={localizationKeys('organizationProfile.profilePage.domainSection.primaryButton')}
+          id='addOrganizationDomain'
+          onClick={() => navigate('domain')}
+        />
+      </Gate>
     </ProfileSection>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationSettings.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationSettings.test.tsx
@@ -1,4 +1,4 @@
-import type { OrganizationDomainResource, OrganizationMembershipResource } from '@clerk/types';
+import type { ClerkPaginatedResponse, OrganizationDomainResource, OrganizationMembershipResource } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 
@@ -30,6 +30,7 @@ describe('OrganizationSettings', () => {
     );
 
     const { getByText } = render(<OrganizationSettings />, { wrapper });
+
     await waitFor(() => {
       expect(fixtures.clerk.organization?.getMemberships).toHaveBeenCalled();
       expect(getByText('Settings')).toBeDefined();
@@ -63,7 +64,10 @@ describe('OrganizationSettings', () => {
   });
 
   it.skip('disables organization profile button and enables leave when user is not admin', async () => {
-    const adminsList: OrganizationMembershipResource[] = [createFakeMember({ id: '1', orgId: '1', role: 'admin' })];
+    const adminsList: ClerkPaginatedResponse<OrganizationMembershipResource> = {
+      data: [createFakeMember({ id: '1', orgId: '1', role: 'admin' })],
+      total_count: 1,
+    };
 
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
@@ -98,7 +102,7 @@ describe('OrganizationSettings', () => {
     expect(fixtures.clerk.organization?.getDomains).not.toBeCalled();
   });
 
-  it('shows domains when `read` permission exists', async () => {
+  it('shows domains when `read` permission exists but hides the Add domain button', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withOrganizationDomains();
@@ -117,6 +121,30 @@ describe('OrganizationSettings', () => {
 
     await new Promise(r => setTimeout(r, 100));
     expect(queryByText('Verified domains')).toBeInTheDocument();
+    expect(queryByText('Add domain')).not.toBeInTheDocument();
+    expect(fixtures.clerk.organization?.getDomains).toBeCalled();
+  });
+
+  it('shows domains and shows the Add domain button when `org:sys_domains:manage` exists', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withOrganizations();
+      f.withOrganizationDomains();
+      f.withUser({
+        email_addresses: ['test@clerk.dev'],
+        organization_memberships: [{ name: 'Org1', permissions: ['org:sys_domains:read', 'org:sys_domains:manage'] }],
+      });
+    });
+    fixtures.clerk.organization?.getDomains.mockReturnValue(
+      Promise.resolve({
+        data: [],
+        total_count: 0,
+      }),
+    );
+    const { queryByText } = await act(() => render(<OrganizationSettings />, { wrapper }));
+
+    await new Promise(r => setTimeout(r, 100));
+    expect(queryByText('Verified domains')).toBeInTheDocument();
+    expect(queryByText('Add domain')).toBeInTheDocument();
     expect(fixtures.clerk.organization?.getDomains).toBeCalled();
   });
 
@@ -156,18 +184,21 @@ describe('OrganizationSettings', () => {
     });
 
     it.skip('disabled leave organization button with delete organization button', async () => {
-      const adminsList: OrganizationMembershipResource[] = [
-        createFakeMember({
-          id: '1',
-          orgId: '1',
-          role: 'admin',
-        }),
-        createFakeMember({
-          id: '2',
-          orgId: '1',
-          role: 'admin',
-        }),
-      ];
+      const adminsList: ClerkPaginatedResponse<OrganizationMembershipResource> = {
+        data: [
+          createFakeMember({
+            id: '1',
+            orgId: '1',
+            role: 'admin',
+          }),
+          createFakeMember({
+            id: '2',
+            orgId: '1',
+            role: 'admin',
+          }),
+        ],
+        total_count: 2,
+      };
 
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
@@ -212,21 +243,18 @@ describe('OrganizationSettings', () => {
       expect(fixtures.router.navigate).toHaveBeenCalledWith('profile');
     });
 
-    it('navigates to Leave Organization page when clicking on the respective button and user is not admin', async () => {
-      const adminsList: OrganizationMembershipResource[] = [createFakeMember({ id: '1', orgId: '1', role: 'admin' })];
-
+    // TODO(@panteliselef): Update this test to allow user to leave an org, only if there will be at least one person left with the minimum set of permissions
+    it('navigates to Leave Organization page when clicking on the respective button', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
           email_addresses: ['test@clerk.dev'],
-          organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
+          organization_memberships: [{ name: 'Org1', permissions: [] }],
         });
       });
 
-      fixtures.clerk.organization?.getMemberships.mockReturnValue(Promise.resolve(adminsList));
       const { findByText } = render(<OrganizationSettings />, { wrapper });
       await waitFor(async () => {
-        // expect(fixtures.clerk.organization?.getMemberships).toHaveBeenCalled();
         await userEvent.click(await findByText(/leave organization/i, { exact: false }));
       });
       expect(fixtures.router.navigate).toHaveBeenCalledWith('leave');


### PR DESCRIPTION


## Description

Backport of #2240
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
