### PR TITLE
chore: Update link to Replay docs in Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -38,7 +38,7 @@ body:
 
         Instructions:
         - [How to create a minimal reproduction](https://clerkdev.notion.site/Creating-a-Minimal-Reproduction-0436afc4203f41aa9aa8700968aaef48?pvs=4)
-        - [How to record a Replay](https://docs.replay.io/bug-reports/recording-a-replay)
+        - [How to record a Replay](https://docs.replay.io/getting-started/recording-your-first-replay)
         - [How to record a Jam](https://jam.dev/docs/get-started)
     validations:
       required: true


### PR DESCRIPTION
## Description

Replay changed their link and current link is 404

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
