### PR TITLE
feat: Introduce user latest session activity date and allow ordering & filtering when listing users 

### DIFF
--- a/.changeset/funny-lamps-work.md
+++ b/.changeset/funny-lamps-work.md
@@ -1,0 +1,7 @@
+---
+'@clerk/backend': minor
+---
+
+- Added the `User.last_active_at` timestamp field which stores the latest date of session activity, with day precision. For further details, please consult the [Backend API documentation](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUser).
+- Added the `last_active_at_since` filtering parameter for the Users listing request. The new parameter can be used to retrieve users that have displayed session activity since the given date. For further details, please consult the [Backend API documentation](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList).
+- Added the `last_active_at` available options for the `orderBy` parameter of the Users listing request. For further details, please consult the [Backend API documentation](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList).

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -15,11 +15,22 @@ type UserCountParams = {
   query?: string;
   userId?: string[];
   externalId?: string[];
+  last_active_at_since?: number;
 };
 
 type UserListParams = ClerkPaginationRequest<
   UserCountParams & {
-    orderBy?: 'created_at' | 'updated_at' | '+created_at' | '+updated_at' | '-created_at' | '-updated_at';
+    orderBy?:
+      | 'created_at'
+      | 'updated_at'
+      | '+created_at'
+      | '+updated_at'
+      | '-created_at'
+      | '-updated_at'
+      | '+last_sign_in_at'
+      | '+last_active_at'
+      | '-last_sign_in_at'
+      | '-last_active_at';
   }
 >;
 

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -271,6 +271,7 @@ export interface UserJSON extends ClerkResourceJSON {
   unsafe_metadata: UserUnsafeMetadata;
   created_at: number;
   updated_at: number;
+  last_active_at: number | null;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/User.ts
+++ b/packages/backend/src/api/resources/User.ts
@@ -33,6 +33,7 @@ export class User {
     readonly phoneNumbers: PhoneNumber[] = [],
     readonly web3Wallets: Web3Wallet[] = [],
     readonly externalAccounts: ExternalAccount[] = [],
+    readonly lastActiveAt: number | null,
   ) {}
 
   static fromJSON(data: UserJSON): User {
@@ -64,6 +65,7 @@ export class User {
       (data.phone_numbers || []).map(x => PhoneNumber.fromJSON(x)),
       (data.web3_wallets || []).map(x => Web3Wallet.fromJSON(x)),
       (data.external_accounts || []).map((x: ExternalAccountJSON) => ExternalAccount.fromJSON(x)),
+      data.last_active_at,
     );
   }
 }


### PR DESCRIPTION
## Description

- **[backend]**: Adds the `User.last_active_at` timestamp field in the user model, see [Backend API docs](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUser).
- **[backend]**: Adds the `last_active_at_since` filtering parameter when requesting the list of users, see [Backend API docs](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList).
- **[backend]**: Adds the `last_active_at` as a valid option for the `orderBy` parameter for the UserList request, see [Backend API docs](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList). 

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
