### PR TITLE
chore(*): Set correct info on required Node & React version

### DIFF
--- a/.changeset/late-flies-switch.md
+++ b/.changeset/late-flies-switch.md
@@ -1,0 +1,13 @@
+---
+'gatsby-plugin-clerk': patch
+'@clerk/chrome-extension': patch
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+'@clerk/fastify': patch
+'@clerk/nextjs': patch
+'@clerk/clerk-react': patch
+'@clerk/remix': patch
+'@clerk/clerk-expo': patch
+---
+
+Set correct information on required Node.js and React versions in README

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -48,7 +48,7 @@ This package provides Clerk Backend API resources and low-level authentication u
 
 ## How to use
 
-Works on Node.js `>=18.18.0` (or later) or on any V8 Isolates runtimes (eg Cloudflare Workers).
+Works on Node.js `>=18.17.0` (or later) or on any V8 Isolates runtimes (eg Cloudflare Workers).
 
 ```sh
 npm install @clerk/backend

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -39,7 +39,7 @@ To use this package you should first create a Clerk application and retrieve a `
 
 ### Prerequisites
 
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 
 ### Installation
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -36,8 +36,8 @@ Clerk is the easiest way to add authentication and user management to your Expo 
 
 ### Prerequisites
 
-- React v16+
-- Node.js `>=18.18.0` or later
+- React v18+
+- Node.js `>=18.17.0` or later
 - An application built using Expo
 
 If an expo app already exists, you can skip this section and go straight to Installation.

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -39,7 +39,7 @@ To use this plugin you should first create a Clerk application and retrieve a `S
 
 ### Prerequisites
 
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 - Fastify v4+
 
 ### Installation

--- a/packages/gatsby-plugin-clerk/README.md
+++ b/packages/gatsby-plugin-clerk/README.md
@@ -37,7 +37,7 @@ Clerk is the easiest way to add authentication and user management to your Gatsb
 ### Prerequisites
 
 - Gatsby v5+
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 
 ### Installation
 

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -38,7 +38,7 @@ and profile management to your application in minutes.
 ### Prerequisites
 
 - Next.js v10+
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 
 ### Installation
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -36,8 +36,8 @@ Clerk is the easiest way to add authentication and user management to your React
 
 ### Prerequisites
 
-- React v16+
-- Node.js `>=18.18.0` or later
+- React v18+
+- Node.js `>=18.17.0` or later
 
 ### Installation
 

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -37,7 +37,7 @@ Clerk is the easiest way to add authentication and user management to your Remix
 ### Prerequisites
 
 - Remix `^2.0.0` or later
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 
 ### Installation
 

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -37,7 +37,7 @@ the <a href="https://clerk.com/docs/reference/node/getting-started?utm_source=gi
 
 ### Prerequisites
 
-- Node.js `>=18.18.0` or later
+- Node.js `>=18.17.0` or later
 
 ## Installation
 


### PR DESCRIPTION
## Description

Set correct information on required Node.js and React versions in READMEs. This was missed in the previous updates when changing the minimum Node.js version to 18.18.0 and then down to 18.17.0

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
