### PR TITLE
fix(backend): Added missing types to create invitation

### DIFF
--- a/.changeset/fast-swans-smile.md
+++ b/.changeset/fast-swans-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Added missing types for clerkClient.invitations.createInvitation

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -8,6 +8,8 @@ type CreateParams = {
   emailAddress: string;
   redirectUrl?: string;
   publicMetadata?: UserPublicMetadata;
+  delay?: boolean;
+  ignoreExisting?: boolean;
 };
 
 type GetInvitationListParams = {


### PR DESCRIPTION
## Description

The https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/CreateInvitation endpoint accepts delay and ignored_existing params, but the SDK does not (https://github.com/clerk/javascript/blob/6a33709ccf48586f1a8b62216688ea300b7b5dfb/packages/backend/src/api/endpoints/InvitationApi.ts#L7).

Fixes SDK-1051

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
