### PR TITLE
fix(clerk-js): Fallback to FAPI error message for password pwned case

### DIFF
--- a/.changeset/rare-bottles-sell.md
+++ b/.changeset/rare-bottles-sell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fallback to the API error message when the password is pwned and there is no translation available.

--- a/packages/clerk-js/src/ui.retheme/utils/passwordUtils.ts
+++ b/packages/clerk-js/src/ui.retheme/utils/passwordUtils.ts
@@ -38,7 +38,7 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
   const { t, locale, passwordSettings } = localizationConfig;
 
   if (errors?.[0]?.code === 'form_password_size_in_bytes_exceeded' || errors?.[0]?.code === 'form_password_pwned') {
-    return `${t(localizationKeys(`unstable__errors.${errors?.[0]?.code}` as any))}`;
+    return `${t(localizationKeys(`unstable__errors.${errors?.[0]?.code}` as any)) || errors?.[0]?.message}`;
   }
 
   if (errors?.[0]?.code === 'form_password_not_strong_enough') {

--- a/packages/clerk-js/src/ui/utils/passwordUtils.ts
+++ b/packages/clerk-js/src/ui/utils/passwordUtils.ts
@@ -38,7 +38,7 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
   const { t, locale, passwordSettings } = localizationConfig;
 
   if (errors?.[0]?.code === 'form_password_size_in_bytes_exceeded' || errors?.[0]?.code === 'form_password_pwned') {
-    return `${t(localizationKeys(`unstable__errors.${errors?.[0]?.code}` as any))}`;
+    return `${t(localizationKeys(`unstable__errors.${errors?.[0]?.code}` as any)) || errors?.[0]?.message}`;
   }
 
   if (errors?.[0]?.code === 'form_password_not_strong_enough') {


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fallback to fapi error when the password has been found in a data breach. This is a very small fix for support, will follow up with a ticket to fix the larger issue with this utility.
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
