### PR TITLE
feat(types): Add `permissions` to `meta` field of fapi error

### DIFF
--- a/.changeset/bright-knives-jump.md
+++ b/.changeset/bright-knives-jump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': patch
+---
+
+Add `permissions` to `meta` field of fapi error.

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -16,6 +16,7 @@ export interface ClerkAPIError {
         message: string;
       }[];
     };
+    permissions?: string[];
   };
 }
 


### PR DESCRIPTION
## Description
![image](https://github.com/clerk/javascript/assets/19269911/aa8fa24e-101b-49e6-89ed-f5df40e4b1ea)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
