### PR TITLE
fix(clerk-js): Make the instant password field focusable if autofilled

### DIFF
--- a/.changeset/tall-roses-invent.md
+++ b/.changeset/tall-roses-invent.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Make the instant password field focusable if it is autofilled.

--- a/packages/clerk-js/src/ui.retheme/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui.retheme/components/SignIn/SignInStart.tsx
@@ -341,6 +341,7 @@ export function _SignInStart(): JSX.Element {
 const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> }) => {
   const [autofilled, setAutofilled] = useState(false);
   const ref = useRef<HTMLInputElement>(null);
+  const show = !!(autofilled || field?.value);
 
   // show password if it's autofilled by the browser
   useLayoutEffect(() => {
@@ -373,14 +374,12 @@ const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> })
   return (
     <Form.ControlRow
       elementId={field.id}
-      sx={
-        !field.value && !autofilled ? { opacity: 0, height: 0, pointerEvents: 'none', marginTop: '-1rem' } : undefined
-      }
+      sx={show ? undefined : { opacity: 0, height: 0, pointerEvents: 'none', marginTop: '-1rem' }}
     >
       <Form.PasswordInput
         {...field.props}
         ref={ref}
-        tabIndex={!field.value ? -1 : undefined}
+        tabIndex={show ? undefined : -1}
       />
     </Form.ControlRow>
   );

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -341,6 +341,7 @@ export function _SignInStart(): JSX.Element {
 const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> }) => {
   const [autofilled, setAutofilled] = useState(false);
   const ref = useRef<HTMLInputElement>(null);
+  const show = !!(autofilled || field?.value);
 
   // show password if it's autofilled by the browser
   useLayoutEffect(() => {
@@ -373,14 +374,12 @@ const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> })
   return (
     <Form.ControlRow
       elementId={field.id}
-      sx={
-        !field.value && !autofilled ? { opacity: 0, height: 0, pointerEvents: 'none', marginTop: '-1rem' } : undefined
-      }
+      sx={show ? undefined : { opacity: 0, height: 0, pointerEvents: 'none', marginTop: '-1rem' }}
     >
       <Form.PasswordInput
         {...field.props}
         ref={ref}
-        tabIndex={!field.value ? -1 : undefined}
+        tabIndex={show ? undefined : -1}
       />
     </Form.ControlRow>
   );


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
When the instant password field was autofilled, we were showing it based on styles we were detecting, but we had no access to the value via js yet. This means we also need to make it focusable even if it does not have a value, but we have detected it has been autofilled.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
