### PR TITLE
feat(types): Add `permissions` to `meta` field of fapi error (#2282)

### DIFF
--- a/.changeset/bright-knives-jump.md
+++ b/.changeset/bright-knives-jump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': patch
+---
+
+Add `permissions` to `meta` field of fapi error.

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -16,6 +16,7 @@ export interface ClerkAPIError {
         message: string;
       }[];
     };
+    permissions?: string[];
   };
 }
 


### PR DESCRIPTION
Backporting #2282 to the release/v4 branch

(cherry picked from commit 1db1f4068466d967df0de39f032a476ca8163651)