### PR TITLE
fix(backend): Added missing types to create invitation (#2268)

### DIFF
--- a/.changeset/fast-swans-smile.md
+++ b/.changeset/fast-swans-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Added missing types for `clerkClient.invitations.createInvitation`

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -8,6 +8,8 @@ type CreateParams = {
   emailAddress: string;
   redirectUrl?: string;
   publicMetadata?: UserPublicMetadata;
+  notify?: boolean;
+  ignoreExisting?: boolean;
 };
 
 type GetInvitationListParams = {


### PR DESCRIPTION
Backporting #2268 to the release/v4 branch

(cherry picked from commit de6519daa84732023bcfd74ad816a2654f457952)