### PR TITLE
fix(nextjs): Use dynamic imports in ClerkProvider

### DIFF
--- a/.changeset/selfish-books-matter.md
+++ b/.changeset/selfish-books-matter.md
@@ -1,0 +1,36 @@
+---
+'@clerk/nextjs': patch
+---
+
+Use dynamic imports in `<ClerkProvider />` which you import from `@clerk/nextjs`.
+
+Users on Next.js 12 and older can run into errors like these:
+
+```shell
+error - ./node_modules/@clerk/nextjs/dist/esm/app-router/client/ClerkProvider.js:10:22
+Module not found: Can't resolve 'next/navigation'
+```
+
+The aforementioned `<ClerkProvider />` component contains code for both Next.js 12 (+ older) and Next.js 13 (+ newer). On older versions it can't find the imports only available in newer versions.
+
+If you're seeing these errors, you have to do two things:
+
+1. Update `@clerk/nextjs` to this version
+1. Update your `next.config.js` to ignore these imports:
+
+    ```js
+    const webpack = require('webpack');
+
+    /** @type {import('next').NextConfig} */
+    const nextConfig = {
+      reactStrictMode: true,
+      webpack(config) {
+        config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^next\/(navigation|headers|compat\/router)$/ }))
+        return config;
+      }
+    }
+
+    module.exports = nextConfig
+    ```
+
+    It is safe to ignore these modules as your Next.js 12 app won't hit these code paths.

--- a/packages/nextjs/src/client-boundary/ClerkProvider.tsx
+++ b/packages/nextjs/src/client-boundary/ClerkProvider.tsx
@@ -15,7 +15,7 @@ export function ClerkProvider(props: NextClerkProviderProps) {
     const { useRouter } = require('next/compat/router');
     const router = useRouter();
 
-    return router ? <AppClerkProvider {...props} /> : <PageClerkProvider {...props} />;
+    return router ? <PageClerkProvider {...props} /> : <AppClerkProvider {...props} />;
   } catch (error) {
     // Silently ignore the error
     return <PageClerkProvider {...props} />;

--- a/packages/nextjs/src/client-boundary/ClerkProvider.tsx
+++ b/packages/nextjs/src/client-boundary/ClerkProvider.tsx
@@ -1,19 +1,30 @@
 'use client';
 
-import { useRouter } from 'next/compat/router';
 import React from 'react';
 
-import { ClientClerkProvider } from '../app-router/client/ClerkProvider';
 import { ClerkProvider as PageClerkProvider } from '../pages/ClerkProvider';
 import { type NextClerkProviderProps } from '../types';
 
 /**
  * This is a compatibility layer to support a single ClerkProvider component in both the app and pages routers.
+ * It also needs to support both Next.js before and after v13, hence the dynamic imports for certain modules.
  */
 export function ClerkProvider(props: NextClerkProviderProps) {
-  const router = useRouter();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { useRouter } = require('next/compat/router');
+    const router = useRouter();
 
-  const Provider = router ? PageClerkProvider : ClientClerkProvider;
+    return router ? <AppClerkProvider {...props} /> : <PageClerkProvider {...props} />;
+  } catch (error) {
+    // Silently ignore the error
+    return <PageClerkProvider {...props} />;
+  }
+}
 
-  return <Provider {...props} />;
+function AppClerkProvider(props: NextClerkProviderProps) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { ClientClerkProvider } = require('../app-router/client/ClerkProvider');
+
+  return <ClientClerkProvider {...props} />;
 }

--- a/packages/nextjs/src/pages/ClerkProvider.tsx
+++ b/packages/nextjs/src/pages/ClerkProvider.tsx
@@ -1,4 +1,5 @@
 import { __internal__setErrorThrowerOptions, ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
+import { useRouter } from 'next/router';
 import React from 'react';
 
 import { ClerkNextOptionsProvider } from '../client-boundary/NextOptionsContext';
@@ -11,8 +12,6 @@ __internal__setErrorThrowerOptions({ packageName: '@clerk/nextjs' });
 
 export function ClerkProvider({ children, ...props }: NextClerkProviderProps): JSX.Element {
   const { __unstable_invokeMiddlewareOnAuthStateChange = true } = props;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { useRouter } = require('next/router');
   const { push } = useRouter();
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 

--- a/packages/nextjs/src/pages/ClerkProvider.tsx
+++ b/packages/nextjs/src/pages/ClerkProvider.tsx
@@ -1,5 +1,4 @@
 import { __internal__setErrorThrowerOptions, ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
-import { useRouter } from 'next/router';
 import React from 'react';
 
 import { ClerkNextOptionsProvider } from '../client-boundary/NextOptionsContext';
@@ -12,6 +11,8 @@ __internal__setErrorThrowerOptions({ packageName: '@clerk/nextjs' });
 
 export function ClerkProvider({ children, ...props }: NextClerkProviderProps): JSX.Element {
   const { __unstable_invokeMiddlewareOnAuthStateChange = true } = props;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { useRouter } = require('next/router');
   const { push } = useRouter();
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 


### PR DESCRIPTION
## Description

Currently users of `@clerk/nextjs` and Next.js 12 (or older) are seeing an error when booting up their app:

```shell
error - ./node_modules/@clerk/nextjs/dist/esm/app-router/client/ClerkProvider.js:3:0
Module not found: Can't resolve 'next/navigation'

Import trace for requested module:
./node_modules/@clerk/nextjs/dist/esm/client-boundary/ClerkProvider.js
./node_modules/@clerk/nextjs/dist/esm/components.client.js
./node_modules/@clerk/nextjs/dist/esm/index.js
<path-to-where-they-mount-clerk-provider>
```

From what I can tell the error must have existed since https://github.com/clerk/javascript/pull/1840 was merged. But we only recently got a report about this so hopefully not too many people where impacted 🤞 

This only needs to be fixed for v4 (as v5 will drop Next.js 12), so that's why the target branch is `release/v4`.

Docs PR: https://github.com/clerk/clerk-docs/pull/543

### Root cause

The `packages/nextjs/src/client-boundary/ClerkProvider.tsx` component imports `next/compat/router` and the `ClerkProvider` for the App router version of Next.js (which uses `next/navigation`).

Both imports only got introduced in Next.js 13 so that's why they fail on older versions. webpack tries to resolve these imports, then it fails.

### Solution

Dynamic imports! Check if `next/compat/router` can be required, if not we're on Next.js 12 or older and we can use the ClerkProvider for Pages.

This works on the client-side, but unfortunately not during compilation of the middleware and other parts of Next.js. So we need to tell our users to let webpack ignore these imports as their code paths won't be hit.

### Testing

You can test this change yourself by:
1. Clone https://github.com/clerk/clerk-nextjs-pages-quickstart
1. Replace the middleware with
	```ts
	import { withClerkMiddleware } from "@clerk/nextjs/server";
	import { NextResponse } from "next/server";
	import type { NextRequest } from "next/server";
	
	export default withClerkMiddleware((req: NextRequest) => {
	  return NextResponse.next();
	});
	
	export const config = {
	  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
	};
	```
1. Replace `next.config.js` with
	```js
	const webpack = require('webpack');
	
	/** @type {import('next').NextConfig} */
	const nextConfig = {
	  reactStrictMode: true,
	  webpack(config) {
	    config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^next\/(navigation|headers|compat\/router)$/ }))
	    return config;
	  }
	}
	
	module.exports = nextConfig
	```
1. Install packages from this PR, e.g. by using [secco](https://secco.lekoarts.de/)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
