### PR TITLE
chore(types,clerk-js,clerk-react): Deprecate `Clerk.isReady()` in favor of `Clerk.loaded`

### DIFF
--- a/.changeset/six-carrots-type.md
+++ b/.changeset/six-carrots-type.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+Deprecate `Clerk.isReady()` in favor of `Clerk.loaded`

--- a/integration/testUtils/appPageObject.ts
+++ b/integration/testUtils/appPageObject.ts
@@ -32,7 +32,7 @@ export const createAppPageObject = (testArgs: { page: Page }, app: Application) 
     waitForClerkJsLoaded: async () => {
       return page.waitForFunction(() => {
         // @ts-ignore
-        return window.Clerk?.isReady();
+        return window.Clerk?.loaded;
       });
     },
     waitForClerkComponentMounted: async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -173,7 +173,7 @@ export default class Clerk implements ClerkInterface {
   #environment?: EnvironmentResource | null;
   #fapiClient: FapiClient;
   #instanceType: InstanceType;
-  #isReady = false;
+  #loaded = false;
 
   /**
    * @deprecated Although this being a private field, this is a reminder to drop it with the next major release
@@ -200,7 +200,7 @@ export default class Clerk implements ClerkInterface {
   }
 
   get loaded(): boolean {
-    return this.#isReady;
+    return this.#loaded;
   }
 
   get isSatellite(): boolean {
@@ -319,10 +319,13 @@ export default class Clerk implements ClerkInterface {
 
   public getFapiClient = (): FapiClient => this.#fapiClient;
 
-  public isReady = (): boolean => this.#isReady;
+  public isReady = (): boolean => {
+    deprecated('Clerk.isReady()', 'Use `Clerk.loaded` instead.');
+    return this.#loaded;
+  };
 
   public load = async (options?: ClerkOptions): Promise<void> => {
-    if (this.#isReady) {
+    if (this.#loaded) {
       return;
     }
 
@@ -332,9 +335,9 @@ export default class Clerk implements ClerkInterface {
     };
 
     if (this.#options.standardBrowser) {
-      this.#isReady = await this.#loadInStandardBrowser();
+      this.#loaded = await this.#loadInStandardBrowser();
     } else {
-      this.#isReady = await this.#loadInNonStandardBrowser();
+      this.#loaded = await this.#loadInNonStandardBrowser();
     }
   };
 
@@ -949,7 +952,7 @@ export default class Clerk implements ClerkInterface {
     params: HandleOAuthCallbackParams = {},
     customNavigate?: (to: string) => Promise<unknown>,
   ): Promise<unknown> => {
-    if (!this.#isReady || !this.#environment || !this.client) {
+    if (!this.loaded || !this.#environment || !this.client) {
       return;
     }
     const { signIn, signUp } = this.client;
@@ -1619,7 +1622,7 @@ export default class Clerk implements ClerkInterface {
   };
 
   #buildUrl = (key: 'signInUrl' | 'signUpUrl', options?: SignInRedirectOptions | SignUpRedirectOptions): string => {
-    if (!this.#isReady || !this.#environment || !this.#environment.displayConfig) {
+    if (!this.loaded || !this.#environment || !this.#environment.displayConfig) {
       return '';
     }
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -363,7 +363,7 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
           // Otherwise use the instantiated Clerk object
           c = this.Clerk;
 
-          if (!c.isReady()) {
+          if (!c.loaded) {
             await c.load(this.options);
           }
         }
@@ -390,7 +390,7 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
 
       global.Clerk.sdkMetadata = this.options.sdkMetadata ?? { name: PACKAGE_NAME, version: PACKAGE_VERSION };
 
-      if (global.Clerk?.loaded || global.Clerk?.isReady()) {
+      if (global.Clerk?.loaded) {
         return this.hydrateClerkJS(global.Clerk);
       }
       return;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -459,6 +459,7 @@ export interface Clerk {
 
   /**
    * Returns true if bootstrapping with Clerk.load has completed successfully. Otherwise, returns false.
+   * @deprecated Use `loaded` instead.
    */
   isReady: () => boolean;
 }


### PR DESCRIPTION
## Description

 Deprecate `Clerk.isReady()` in favor of `Clerk.loaded`

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
