### PR TITLE
chore(types,clerk-js,clerk-react): Drop `Clerk.isReady()` in favor of `Clerk.loaded`

### DIFF
--- a/.changeset/khaki-buttons-march.md
+++ b/.changeset/khaki-buttons-march.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': major
+'@clerk/clerk-react': major
+'@clerk/types': major
+---
+
+Drop `Clerk.isReady(). Use `Clerk.loaded` instead.`

--- a/integration/testUtils/appPageObject.ts
+++ b/integration/testUtils/appPageObject.ts
@@ -31,7 +31,7 @@ export const createAppPageObject = (testArgs: { page: Page }, app: Application) 
     },
     waitForClerkJsLoaded: async () => {
       return page.waitForFunction(() => {
-        return window.Clerk?.isReady();
+        return window.Clerk?.loaded;
       });
     },
     waitForClerkComponentMounted: async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -166,7 +166,7 @@ export class Clerk implements ClerkInterface {
   //@ts-expect-error with being undefined even though it's not possible - related to issue with ts and error thrower
   #fapiClient: FapiClient;
   #instanceType?: InstanceType;
-  #isReady = false;
+  #loaded = false;
 
   #listeners: Array<(emission: Resources) => void> = [];
   #options: ClerkOptions = {};
@@ -189,7 +189,7 @@ export class Clerk implements ClerkInterface {
   }
 
   get loaded(): boolean {
-    return this.#isReady;
+    return this.#loaded;
   }
 
   get isSatellite(): boolean {
@@ -264,10 +264,8 @@ export class Clerk implements ClerkInterface {
 
   public getFapiClient = (): FapiClient => this.#fapiClient;
 
-  public isReady = (): boolean => this.#isReady;
-
   public load = async (options?: ClerkOptions): Promise<void> => {
-    if (this.#isReady) {
+    if (this.loaded) {
       return;
     }
 
@@ -295,9 +293,9 @@ export class Clerk implements ClerkInterface {
     );
 
     if (this.#options.standardBrowser) {
-      this.#isReady = await this.#loadInStandardBrowser();
+      this.#loaded = await this.#loadInStandardBrowser();
     } else {
-      this.#isReady = await this.#loadInNonStandardBrowser();
+      this.#loaded = await this.#loadInNonStandardBrowser();
     }
   };
 
@@ -869,7 +867,7 @@ export class Clerk implements ClerkInterface {
     params: HandleOAuthCallbackParams = {},
     customNavigate?: (to: string) => Promise<unknown>,
   ): Promise<unknown> => {
-    if (!this.#isReady || !this.#environment || !this.client) {
+    if (!this.loaded || !this.#environment || !this.client) {
       return;
     }
     const { signIn, signUp } = this.client;
@@ -1500,7 +1498,7 @@ export class Clerk implements ClerkInterface {
   };
 
   #buildUrl = (key: 'signInUrl' | 'signUpUrl', options?: SignInRedirectOptions | SignUpRedirectOptions): string => {
-    if (!this.#isReady || !this.#environment || !this.#environment.displayConfig) {
+    if (!this.loaded || !this.#environment || !this.#environment.displayConfig) {
       return '';
     }
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -251,8 +251,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     return false;
   }
 
-  isReady = (): boolean => Boolean(this.clerkjs?.isReady());
-
   buildSignInUrl = (opts?: RedirectOptions): string | void => {
     const callback = () => this.clerkjs?.buildSignInUrl(opts) || '';
     if (this.clerkjs && this.#loaded) {
@@ -363,7 +361,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
           // Otherwise use the instantiated Clerk object
           c = this.Clerk;
 
-          if (!c.isReady()) {
+          if (!c.loaded) {
             await c.load(this.options);
           }
         }
@@ -387,7 +385,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
         await global.Clerk.load(this.options);
       }
 
-      if (global.Clerk?.loaded || global.Clerk?.isReady()) {
+      if (global.Clerk?.loaded) {
         return this.hydrateClerkJS(global.Clerk);
       }
       return;

--- a/packages/types/src/clerk.retheme.ts
+++ b/packages/types/src/clerk.retheme.ts
@@ -424,11 +424,6 @@ export interface Clerk {
    * Handles a 401 response from Frontend API by refreshing the client and session object accordingly
    */
   handleUnauthenticated: () => Promise<unknown>;
-
-  /**
-   * Returns true if bootstrapping with Clerk.load has completed successfully. Otherwise, returns false.
-   */
-  isReady: () => boolean;
 }
 
 export type HandleOAuthCallbackParams = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -424,11 +424,6 @@ export interface Clerk {
    * Handles a 401 response from Frontend API by refreshing the client and session object accordingly
    */
   handleUnauthenticated: () => Promise<unknown>;
-
-  /**
-   * Returns true if bootstrapping with Clerk.load has completed successfully. Otherwise, returns false.
-   */
-  isReady: () => boolean;
 }
 
 export type HandleOAuthCallbackParams = {


### PR DESCRIPTION
## Description

Drop deprecated `Clerk.isReady()` in favor of `Clerk.loaded`.
Deprecation PR: https://github.com/clerk/javascript/pull/2293

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
