### PR TITLE
fix(repo): Fix incorrect regex for public paths in NextJs playground

### DIFF
--- a/playground/nextjs/middleware.ts
+++ b/playground/nextjs/middleware.ts
@@ -1,7 +1,7 @@
 import { authMiddleware } from '@clerk/nextjs/server';
 
 // Set the paths that don't require the user to be signed in
-const publicPaths = ['/', /^(?!\/(sign-in|sign-up|app-dir|custom)\/*).*$/];
+const publicPaths = ['/', /^(\/(sign-in|sign-up|app-dir|custom)\/*).*$/];
 
 export default authMiddleware({
   publicRoutes: publicPaths,


### PR DESCRIPTION
## Description

This PR fixes the Regex for public paths in the Next.js Playground

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
