### PR TITLE
fix(clerk-react): Fix build process not catching type errors [SDK-1065]

### DIFF
--- a/.changeset/many-meals-do.md
+++ b/.changeset/many-meals-do.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Re-implement `tsc` type-checking within the build process

--- a/.changeset/many-meals-do.md
+++ b/.changeset/many-meals-do.md
@@ -1,5 +1,9 @@
 ---
 '@clerk/clerk-react': patch
+'@clerk/clerk-sdk-node': patch
+'@clerk/localizations': patch
+'@clerk/shared': patch
+'@clerk/types': patch
 ---
 
 Re-implement `tsc` type-checking within the build process

--- a/packages/localizations/tsup.config.ts
+++ b/packages/localizations/tsup.config.ts
@@ -70,5 +70,6 @@ export default defineConfig(_overrideOptions => {
     sourcemap: true,
     dts: true,
     splitting: false,
+    onSuccess: 'tsc',
   };
 });

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": false,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "importHelpers": true,
     "isolatedModules": true,

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from 'tsup';
 
-// @ts-expect-error for `import module with '.json' extension`
 import { version as clerkJsVersion } from '../clerk-js/package.json';
-// @ts-expect-error for `import module with '.json' extension`
 import { name, version } from './package.json';
 
 export default defineConfig(overrideOptions => {
@@ -13,7 +11,7 @@ export default defineConfig(overrideOptions => {
     entry: {
       index: 'src/index.ts',
     },
-    onSuccess: ['tsc --noEmit', shouldPublish ? 'npm run publish:local' : undefined].filter(Boolean).join(' && '),
+    onSuccess: ['tsc', shouldPublish ? 'npm run publish:local' : undefined].filter(Boolean).join(' && '),
     format: ['cjs', 'esm'],
     bundle: true,
     clean: true,

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(overrideOptions => {
     entry: {
       index: 'src/index.ts',
     },
-    onSuccess: shouldPublish ? 'npm run publish:local' : undefined,
+    onSuccess: ['tsc --noEmit', shouldPublish ? 'npm run publish:local' : undefined].filter(Boolean).join(' && '),
     format: ['cjs', 'esm'],
     bundle: true,
     clean: true,

--- a/packages/sdk-node/tsup.config.ts
+++ b/packages/sdk-node/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(overrideOptions => {
     minify: false,
     sourcemap: true,
     dts: true,
+    onSuccess: 'tsc',
     define: {
       PACKAGE_NAME: `"${name}"`,
       PACKAGE_VERSION: `"${version}"`,

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(overrideOptions => {
     minify: false,
     sourcemap: true,
     dts: true,
+    onSuccess: 'tsc',
     external: ['react', 'react-dom'],
     esbuildPlugins: [WebWorkerMinifyPlugin as any],
     define: {

--- a/packages/types/src/localization.retheme.ts
+++ b/packages/types/src/localization.retheme.ts
@@ -271,6 +271,8 @@ type _LocalizationResource = {
     start: {
       headerTitle__account: LocalizationValue;
       headerTitle__security: LocalizationValue;
+      headerSubtitle__account: LocalizationValue;
+      headerSubtitle__security: LocalizationValue;
       profileSection: {
         title: LocalizationValue;
       };
@@ -554,6 +556,8 @@ type _LocalizationResource = {
     start: {
       headerTitle__members: LocalizationValue;
       headerTitle__settings: LocalizationValue;
+      headerSubtitle__members: LocalizationValue;
+      headerSubtitle__settings: LocalizationValue;
     };
     profilePage: {
       title: LocalizationValue;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -264,6 +264,10 @@ type _LocalizationResource = {
     formButtonPrimary__continue: LocalizationValue;
     formButtonPrimary__finish: LocalizationValue;
     formButtonReset: LocalizationValue;
+    navbar: {
+      title: LocalizationValue;
+      description: LocalizationValue;
+    };
     start: {
       headerTitle__account: LocalizationValue;
       headerTitle__security: LocalizationValue;
@@ -545,6 +549,10 @@ type _LocalizationResource = {
     badge__automaticInvitation: LocalizationValue;
     badge__automaticSuggestion: LocalizationValue;
     badge__manualInvitation: LocalizationValue;
+    navbar: {
+      title: LocalizationValue;
+      description: LocalizationValue;
+    };
     start: {
       headerTitle__members: LocalizationValue;
       headerTitle__settings: LocalizationValue;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig(() => {
     entry: {
       index: uiRetheme ? 'src/index.retheme.ts' : 'src/index.ts',
     },
+    onSuccess: 'tsc',
     minify: false,
     clean: true,
     sourcemap: true,


### PR DESCRIPTION
## Description

`tsup` doesn't reliably handle type-checking, thus we must continue to rely on `tsc`.

<!-- Fixes #(issue number) -->
SDK-1065

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
