### PR TITLE
chore(backend): Replace `Clerk` with `createClerkClient` [SDK-1058]

### DIFF
--- a/.changeset/eight-badgers-speak.md
+++ b/.changeset/eight-badgers-speak.md
@@ -2,11 +2,9 @@
 '@clerk/clerk-sdk-node': major
 ---
 
-## Breaking Changes
-
 (Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/clerk-sdk-node` directly. If not, you can safely ignore this change.)
 
-Remove the named `Clerk` import from `@clerk/clerk-sdk-node` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+Remove the named `Clerk` import from `@clerk/clerk-sdk-node` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future.
 
 ```js
 import { Clerk } from '@clerk/clerk-sdk-node';

--- a/.changeset/eight-badgers-speak.md
+++ b/.changeset/eight-badgers-speak.md
@@ -1,0 +1,21 @@
+---
+'@clerk/clerk-sdk-node': major
+---
+
+## Breaking Changes
+
+(Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/clerk-sdk-node` directly. If not, you can safely ignore this change.)
+
+Remove the named `Clerk` import from `@clerk/clerk-sdk-node` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+
+```js
+import { Clerk } from '@clerk/clerk-sdk-node';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
+
+```js
+import { createClerkClient } from '@clerk/clerk-sdk-node';
+const clerk = createClerkClient({ secretKey: '...' });
+```

--- a/.changeset/fuzzy-years-taste.md
+++ b/.changeset/fuzzy-years-taste.md
@@ -2,9 +2,7 @@
 '@clerk/backend': major
 ---
 
-## Breaking Changes
-
-Remove the named `Clerk` import from `@clerk/backend` and import `createClerkClient` instead. The latter is a factory method that will create a Clerk client instance for you. This aligns usage across our SDKs and will enable us to better ship DX improvements in the future. [SDK-1058]
+Remove the named `Clerk` import from `@clerk/backend` and import `createClerkClient` instead. The latter is a factory method that will create a Clerk client instance for you. This aligns usage across our SDKs and will enable us to better ship DX improvements in the future.
 
 
 Inside your code, search for occurrences like these:

--- a/.changeset/fuzzy-years-taste.md
+++ b/.changeset/fuzzy-years-taste.md
@@ -1,0 +1,37 @@
+---
+'@clerk/backend': major
+'@clerk/gatsby-plugin-clerk': major
+'@clerk/nextjs': major
+'@clerk/remix': major
+---
+
+## Breaking Changes
+
+### @clerk/backend
+
+Replace `Clerk` with `createClerkClient` [SDK-1058]
+
+
+```js
+import { Clerk } from '@clerk/backend';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+now becomes:
+
+```js
+import { createClerkClient } from '@clerk/backend';
+const clerk = createClerkClient({ secretKey: '...' });
+```
+
+### @clerk/gatsby-plugin-clerk
+
+No longer returning `Clerk`. Please replace with `createClerkClient`
+
+### @clerk/nextjs
+
+No longer returning `Clerk`. Please replace with `createClerkClient`
+
+### @clerk/remix
+
+No longer returning `Clerk`. Please replace with `createClerkClient`

--- a/.changeset/fuzzy-years-taste.md
+++ b/.changeset/fuzzy-years-taste.md
@@ -1,37 +1,22 @@
 ---
 '@clerk/backend': major
-'@clerk/nextjs': major
-'@clerk/remix': major
-'gatsby-plugin-clerk': major
 ---
 
 ## Breaking Changes
 
-### @clerk/backend
-
-Replace `Clerk` with `createClerkClient` [SDK-1058]
+Remove the named `Clerk` import from `@clerk/backend` and import `createClerkClient` instead. The latter is a factory method that will create a Clerk client instance for you. This aligns usage across our SDKs and will enable us to better ship DX improvements in the future. [SDK-1058]
 
 
+Inside your code, search for occurrences like these:
+	
 ```js
 import { Clerk } from '@clerk/backend';
 const clerk = Clerk({ secretKey: '...' });
 ```
 
-now becomes:
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
 
 ```js
 import { createClerkClient } from '@clerk/backend';
 const clerk = createClerkClient({ secretKey: '...' });
 ```
-
-### @clerk/gatsby-plugin-clerk
-
-No longer returning `Clerk`. Please replace with `createClerkClient`
-
-### @clerk/nextjs
-
-No longer returning `Clerk`. Please replace with `createClerkClient`
-
-### @clerk/remix
-
-No longer returning `Clerk`. Please replace with `createClerkClient`

--- a/.changeset/fuzzy-years-taste.md
+++ b/.changeset/fuzzy-years-taste.md
@@ -1,8 +1,8 @@
 ---
 '@clerk/backend': major
-'@clerk/gatsby-plugin-clerk': major
 '@clerk/nextjs': major
 '@clerk/remix': major
+'gatsby-plugin-clerk': major
 ---
 
 ## Breaking Changes

--- a/.changeset/metal-ears-cheat.md
+++ b/.changeset/metal-ears-cheat.md
@@ -1,0 +1,21 @@
+---
+'gatsby-plugin-clerk': major
+---
+
+## Breaking Changes
+
+Remove the named `Clerk` import from `gatsby-plugin-clerk` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+
+Inside your code, search for occurrences like these:
+	
+```js
+import { Clerk } from 'gatsby-plugin-clerk';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
+
+```js
+import { createClerkClient } from 'gatsby-plugin-clerk';
+const clerk = createClerkClient({ secretKey: '...' });
+```

--- a/.changeset/metal-ears-cheat.md
+++ b/.changeset/metal-ears-cheat.md
@@ -2,9 +2,7 @@
 'gatsby-plugin-clerk': major
 ---
 
-## Breaking Changes
-
-Remove the named `Clerk` import from `gatsby-plugin-clerk` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+Remove the named `Clerk` import from `gatsby-plugin-clerk` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future.
 
 Inside your code, search for occurrences like these:
 	

--- a/.changeset/shiny-pumas-share.md
+++ b/.changeset/shiny-pumas-share.md
@@ -2,11 +2,9 @@
 '@clerk/remix': major
 ---
 
-## Breaking Changes
-
 (Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/remix` directly. If not, you can safely ignore this change.)
 
-Remove the named `Clerk` import from `@clerk/remix` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+Remove the named `Clerk` import from `@clerk/remix` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future.
 
 ```js
 import { Clerk } from '@clerk/remix';

--- a/.changeset/shiny-pumas-share.md
+++ b/.changeset/shiny-pumas-share.md
@@ -1,0 +1,22 @@
+---
+'@clerk/remix': major
+---
+
+## Breaking Changes
+
+(Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/remix` directly. If not, you can safely ignore this change.)
+
+Remove the named `Clerk` import from `@clerk/remix` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+
+```js
+import { Clerk } from '@clerk/remix';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
+
+```js
+import { createClerkClient } from '@clerk/remix';
+const clerk = createClerkClient({ secretKey: '...' });
+```
+

--- a/.changeset/small-cats-check.md
+++ b/.changeset/small-cats-check.md
@@ -1,0 +1,23 @@
+---
+'@clerk/fastify': major
+---
+
+## Breaking Changes
+
+(Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/fastify` directly. If not, you can safely ignore this change.)
+
+Remove the named `Clerk` import from `@clerk/fastify` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+
+
+```js
+import { Clerk } from '@clerk/fastify';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
+
+```js
+import { createClerkClient } from '@clerk/fastify';
+const clerk = createClerkClient({ secretKey: '...' });
+```
+

--- a/.changeset/small-cats-check.md
+++ b/.changeset/small-cats-check.md
@@ -2,11 +2,9 @@
 '@clerk/fastify': major
 ---
 
-## Breaking Changes
-
 (Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/fastify` directly. If not, you can safely ignore this change.)
 
-Remove the named `Clerk` import from `@clerk/fastify` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+Remove the named `Clerk` import from `@clerk/fastify` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future.
 
 
 ```js

--- a/.changeset/sour-avocados-sin.md
+++ b/.changeset/sour-avocados-sin.md
@@ -1,0 +1,22 @@
+---
+'@clerk/nextjs': major
+---
+
+## Breaking Changes
+
+(Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/nextjs` directly. If not, you can safely ignore this change.)
+
+Remove the named `Clerk` import from `@clerk/nextjs` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+
+```js
+import { Clerk } from '@clerk/nextjs';
+const clerk = Clerk({ secretKey: '...' });
+```
+
+You need to rename the import from `Clerk` to `createClerkClient` and change its usage:
+
+```js
+import { createClerkClient } from '@clerk/nextjs';
+const clerk = createClerkClient({ secretKey: '...' });
+```
+

--- a/.changeset/sour-avocados-sin.md
+++ b/.changeset/sour-avocados-sin.md
@@ -2,11 +2,9 @@
 '@clerk/nextjs': major
 ---
 
-## Breaking Changes
-
 (Note: This is only relevant if, in the unlikely case, you are using `Clerk` from `@clerk/nextjs` directly. If not, you can safely ignore this change.)
 
-Remove the named `Clerk` import from `@clerk/nextjs` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future. [SDK-1058]
+Remove the named `Clerk` import from `@clerk/nextjs` and import `createClerkClient` instead. The latter is a factory method to create a Clerk client instance for you. This update aligns usage across our SDKs and will enable us to ship DX improvements better in the future.
 
 ```js
 import { Clerk } from '@clerk/nextjs';

--- a/integration/cleanup/cleanup.setup.ts
+++ b/integration/cleanup/cleanup.setup.ts
@@ -1,5 +1,5 @@
 import type { User } from '@clerk/backend';
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 import { test as setup } from '@playwright/test';
 
 import { appConfigs } from '../presets/';
@@ -13,7 +13,7 @@ setup('cleanup instances ', async () => {
 
   for (const secretKey of secretKeys) {
     console.log(`Cleanup for ${secretKey.replace(/(sk_test_)(.+)(...)/, '$1***$3')}`);
-    const clerkClient = Clerk({ secretKey });
+    const clerkClient = createClerkClient({ secretKey });
     const { data: users, errors } = await clerkClient.users.getUserList({
       orderBy: '-created_at',
       query: 'clerkcookie',

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -1,4 +1,4 @@
-import { Clerk } from '@clerk/backend';
+import { createClerkClient as backendCreateClerkClient } from '@clerk/backend';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
 
 import type { Application } from '../models/application';
@@ -13,7 +13,7 @@ import { createUserService } from './usersService';
 
 export type { FakeUser };
 const createClerkClient = (app: Application) => {
-  return Clerk({
+  return backendCreateClerkClient({
     secretKey: app.env.privateVariables.get('CLERK_SECRET_KEY'),
     publishableKey: app.env.publicVariables.get('CLERK_PUBLISHABLE_KEY'),
   });

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -55,23 +55,23 @@ npm install @clerk/backend
 ```
 
 ```
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
-const clerk = Clerk({ secretKey: '...' });
+const clerk = createClerkClient({ secretKey: '...' });
 
 await clerk.users.getUser("user_...");
 ```
 
 ### API
 
-#### Clerk(options: ClerkOptions)
+#### createClerkClient(options: ClerkOptions)
 
 Create Clerk SDK that includes an HTTP Rest client for the Backend API and session verification helpers. The clerk object contains the following APIs and methods:
 
 ```js
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
-const clerk = Clerk({ secretKey: '...' });
+const clerk = createClerkClient({ secretKey: '...' });
 
 await clerk.users.getUser('user_...');
 

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -19,8 +19,8 @@ type GetInvitationListParams = {
    * @example
    * get all revoked invitations
    *
-   * import { Clerk } from '@clerk/backend';
-   * const clerkClient = Clerk(...)
+   * import { createClerkClient } from '@clerk/backend';
+   * const clerkClient = createClerkClient(...)
    * await clerkClient.invitations.getInvitationList({ status: 'revoked })
    *
    */

--- a/packages/backend/src/exports.test.ts
+++ b/packages/backend/src/exports.test.ts
@@ -10,7 +10,6 @@ export default (QUnit: QUnit) => {
       const exportedApiKeys = [
         'AllowlistIdentifier',
         'AuthStatus',
-        'Clerk',
         'Client',
         'DeletedObject',
         'Email',
@@ -37,6 +36,7 @@ export default (QUnit: QUnit) => {
         'buildRequestUrl',
         'constants',
         'createAuthenticateRequest',
+        'createClerkClient',
         'createIsomorphicRequest',
         'debugRequestState',
         'decodeJwt',

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -25,7 +25,7 @@ export type ClerkOptions = CreateBackendApiOptions &
     >
   > & { sdkMetadata?: SDKMetadata; telemetry?: Pick<TelemetryCollectorOptions, 'disabled' | 'debug'> };
 
-export function Clerk(options: ClerkOptions) {
+export function createClerkClient(options: ClerkOptions) {
   const opts = { ...options };
   const apiClient = createBackendApiClient(opts);
   const requestState = createAuthenticateRequest({ options: opts, apiClient });

--- a/packages/fastify/src/clerkClient.test.ts
+++ b/packages/fastify/src/clerkClient.test.ts
@@ -1,11 +1,11 @@
-const ClerkMock = jest.fn(() => {
+const createClerkClientMock = jest.fn(() => {
   return 'clerkClient';
 });
 
 jest.mock('@clerk/backend', () => {
   return {
     ...jest.requireActual('@clerk/backend'),
-    Clerk: ClerkMock,
+    createClerkClient: createClerkClientMock,
   };
 });
 
@@ -17,7 +17,7 @@ describe('clerk', () => {
   });
 
   test('initializes clerk with constants', () => {
-    expect(ClerkMock.mock.calls).toMatchSnapshot();
+    expect(createClerkClientMock.mock.calls).toMatchSnapshot();
     expect(clerkClient).toEqual('clerkClient');
   });
 });

--- a/packages/fastify/src/clerkClient.ts
+++ b/packages/fastify/src/clerkClient.ts
@@ -1,8 +1,8 @@
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
 import { API_URL, API_VERSION, JWT_KEY, SDK_METADATA, SECRET_KEY } from './constants';
 
-export const createClerkClient = Clerk;
+export { createClerkClient };
 
 export const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,

--- a/packages/fastify/src/withClerkMiddleware.test.ts
+++ b/packages/fastify/src/withClerkMiddleware.test.ts
@@ -9,7 +9,7 @@ const localInterstitialMock = jest.fn();
 jest.mock('@clerk/backend', () => {
   return {
     ...jest.requireActual('@clerk/backend'),
-    Clerk: () => {
+    createClerkClient: () => {
       return {
         authenticateRequest: (...args: any) => authenticateRequestMock(...args),
         localInterstitial: (...args: any) => localInterstitialMock(...args),

--- a/packages/gatsby-plugin-clerk/src/ssr/clerkClient.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/clerkClient.ts
@@ -1,8 +1,8 @@
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
 import { API_URL, API_VERSION, SDK_METADATA, SECRET_KEY, TELEMETRY_DEBUG, TELEMETRY_DISABLED } from '../constants';
 
-const clerkClient = Clerk({
+const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
@@ -15,10 +15,5 @@ const clerkClient = Clerk({
   },
 });
 
-const createClerkClient = Clerk;
-
-// eslint-disable-next-line import/export
-export { Clerk, clerkClient, createClerkClient };
-
-// eslint-disable-next-line import/export
+export { clerkClient };
 export * from '@clerk/backend';

--- a/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
@@ -4,7 +4,6 @@ exports[`/server public exports should not include a breaking change 1`] = `
 [
   "AllowlistIdentifier",
   "AuthStatus",
-  "Clerk",
   "Client",
   "DeletedObject",
   "Email",

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -1,4 +1,4 @@
-import { Clerk } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
 import {
   API_URL,
@@ -12,7 +12,7 @@ import {
   TELEMETRY_DISABLED,
 } from './constants';
 
-const clerkClient = Clerk({
+const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
@@ -28,10 +28,5 @@ const clerkClient = Clerk({
   },
 });
 
-const createClerkClient = Clerk;
-
-// eslint-disable-next-line import/export
-export { Clerk, clerkClient, createClerkClient };
-
-// eslint-disable-next-line import/export
+export { clerkClient };
 export * from '@clerk/backend';

--- a/packages/remix/src/api/index.ts
+++ b/packages/remix/src/api/index.ts
@@ -1,7 +1,1 @@
-import { Clerk } from '@clerk/backend';
-
-const createClerkClient = Clerk;
-
-export { createClerkClient };
-
 export * from '@clerk/backend';

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,5 +1,5 @@
 import type { RequestState } from '@clerk/backend';
-import { buildRequestUrl, Clerk } from '@clerk/backend';
+import { buildRequestUrl, createClerkClient } from '@clerk/backend';
 import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
 import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
@@ -73,7 +73,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     throw new Error(satelliteAndMissingSignInUrl);
   }
 
-  return Clerk({ apiUrl, secretKey, jwtKey, proxyUrl, isSatellite, domain }).authenticateRequest({
+  return createClerkClient({ apiUrl, secretKey, jwtKey, proxyUrl, isSatellite, domain }).authenticateRequest({
     audience,
     secretKey,
     jwtKey,

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -1,4 +1,4 @@
-import type { Clerk } from '@clerk/backend';
+import type { createClerkClient } from '@clerk/backend';
 
 import {
   authenticateRequest,
@@ -10,7 +10,7 @@ import {
 import type { ClerkMiddlewareOptions, MiddlewareRequireAuthProp, RequireAuthProp } from './types';
 
 export type CreateClerkExpressMiddlewareOptions = {
-  clerkClient: ReturnType<typeof Clerk>;
+  clerkClient: ReturnType<typeof createClerkClient>;
   secretKey?: string;
   publishableKey?: string;
   apiUrl?: string;

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -1,4 +1,4 @@
-import type { AuthenticateRequestOptions, AuthObject, Clerk, SignedInAuthObject } from '@clerk/backend';
+import type { AuthenticateRequestOptions, AuthObject, createClerkClient, SignedInAuthObject } from '@clerk/backend';
 import type { MultiDomainAndOrProxy } from '@clerk/types';
 import type { NextFunction, Request, Response } from 'express';
 import type { IncomingMessage } from 'http';
@@ -36,7 +36,7 @@ export type ClerkMiddlewareOptions = {
   signInUrl?: string;
 } & MultiDomainAndOrProxy;
 
-export type ClerkClient = ReturnType<typeof Clerk>;
+export type ClerkClient = ReturnType<typeof createClerkClient>;
 
 export type AuthenticateRequestParams = {
   clerkClient: ClerkClient;


### PR DESCRIPTION
## Description

Replace `Clerk` with `createClerkClient` [SDK-1058]

## Breaking Changes

### @clerk/backend

```js
import { Clerk } from '@clerk/backend';
const clerk = Clerk({ secretKey: '...' });
```

now becomes:

```js
import { createClerkClient } from '@clerk/backend';
const clerk = createClerkClient({ secretKey: '...' });
```

### @clerk/nextjs

No longer returning `Clerk`. Please replace with `createClerkClient`

### @clerk/remix

No longer returning `Clerk`. Please replace with `createClerkClient`

### gatsby-plugin-clerk

No longer returning `Clerk`. Please replace with `createClerkClient`

SDK-1058

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
