### PR TITLE
tests(repo): Integration tests for Protect

### DIFF
--- a/integration/.keys.json.sample
+++ b/integration/.keys.json.sample
@@ -6,5 +6,9 @@
   "with-email-links": {
     "pk": "",
     "sk": ""
+  },
+  "with-custom-roles": {
+    "pk": "",
+    "sk": ""
   }
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -261,7 +261,7 @@ If you need to run a test suite inside a different environment (e.g. a different
    ```ts
    const yourConciseName = environmentConfig()
      .setId('yourConciseName')
-     .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_CLERK_API_URL)
+     .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_STAGING_CLERK_API_URL)
      .setEnvVariable('private', 'CLERK_SECRET_KEY', envKeys['your-concise-name'].sk)
      .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['your-concise-name'].pk)
      .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
@@ -458,7 +458,7 @@ Inside [`presets/envs.ts`](../integration/presets/envs.ts) you can also create a
 ```ts
 const withCustomRoles = environmentConfig()
   .setId('withCustomRoles')
-  .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_CLERK_API_URL)
+  .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_STAGING_CLERK_API_URL)
   .setEnvVariable('private', 'CLERK_SECRET_KEY', envKeys['with-custom-roles'].sk)
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-custom-roles'].pk)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')

--- a/integration/constants.ts
+++ b/integration/constants.ts
@@ -54,4 +54,12 @@ export const constants = {
    * The version of the dependency to use, controlled programmatically.
    */
   E2E_CLERK_VERSION: process.env.E2E_CLERK_VERSION,
+  /**
+   * The staging BAPI url
+   */
+  E2E_APP_STAGING_CLERK_API_URL: process.env.E2E_APP_STAGING_CLERK_API_URL,
+  /**
+   * PK and SK pairs from the env to use for integration tests.
+   */
+  INTEGRATION_INSTANCE_KEYS: process.env.INTEGRATION_INSTANCE_KEYS,
 } as const;

--- a/integration/constants.ts
+++ b/integration/constants.ts
@@ -55,10 +55,6 @@ export const constants = {
    */
   E2E_CLERK_VERSION: process.env.E2E_CLERK_VERSION,
   /**
-   * The staging BAPI url
-   */
-  E2E_APP_STAGING_CLERK_API_URL: process.env.E2E_APP_STAGING_CLERK_API_URL,
-  /**
    * PK and SK pairs from the env to use for integration tests.
    */
   INTEGRATION_INSTANCE_KEYS: process.env.INTEGRATION_INSTANCE_KEYS,

--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -1,15 +1,15 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
 import { resolve } from 'node:path';
 
 import fs from 'fs-extra';
 
+import { constants } from '../constants';
 import { environmentConfig } from '../models/environment.js';
 
 const getInstanceKeys = () => {
   let keys: Record<string, { pk: string; sk: string }>;
   try {
-    keys = process.env.INTEGRATION_INSTANCE_KEYS
-      ? JSON.parse(process.env.INTEGRATION_INSTANCE_KEYS)
+    keys = constants.INTEGRATION_INSTANCE_KEYS
+      ? JSON.parse(constants.INTEGRATION_INSTANCE_KEYS)
       : fs.readJSONSync(resolve(__dirname, '..', '.keys.json')) || null;
   } catch (e) {
     console.log('Could not find .keys.json file', e);
@@ -28,7 +28,7 @@ const withEmailCodes = environmentConfig()
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-email-codes'].pk)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
   .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
-  .setEnvVariable('public', 'CLERK_JS', process.env.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
+  .setEnvVariable('public', 'CLERK_JS', constants.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
 
 const withEmailLinks = environmentConfig()
   .setId('withEmailLinks')
@@ -36,16 +36,16 @@ const withEmailLinks = environmentConfig()
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-email-links'].pk)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
   .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
-  .setEnvVariable('public', 'CLERK_JS', process.env.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
+  .setEnvVariable('public', 'CLERK_JS', constants.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
 
 const withCustomRoles = environmentConfig()
   .setId('withCustomRoles')
-  .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_CLERK_API_URL)
+  .setEnvVariable('private', 'CLERK_API_URL', constants.E2E_APP_STAGING_CLERK_API_URL)
   .setEnvVariable('private', 'CLERK_SECRET_KEY', envKeys['with-custom-roles'].sk)
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-custom-roles'].pk)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
   .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
-  .setEnvVariable('public', 'CLERK_JS', process.env.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
+  .setEnvVariable('public', 'CLERK_JS', constants.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
 
 export const envs = {
   withEmailCodes,

--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -40,7 +40,8 @@ const withEmailLinks = environmentConfig()
 
 const withCustomRoles = environmentConfig()
   .setId('withCustomRoles')
-  .setEnvVariable('private', 'CLERK_API_URL', constants.E2E_APP_STAGING_CLERK_API_URL)
+  // Temporarily use the stage api until the custom roles feature is released to prod
+  .setEnvVariable('private', 'CLERK_API_URL', 'https://api.clerkstage.dev')
   .setEnvVariable('private', 'CLERK_SECRET_KEY', envKeys['with-custom-roles'].sk)
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-custom-roles'].pk)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')

--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -38,7 +38,17 @@ const withEmailLinks = environmentConfig()
   .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
   .setEnvVariable('public', 'CLERK_JS', process.env.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
 
+const withCustomRoles = environmentConfig()
+  .setId('withCustomRoles')
+  .setEnvVariable('private', 'CLERK_API_URL', process.env.E2E_APP_CLERK_API_URL)
+  .setEnvVariable('private', 'CLERK_SECRET_KEY', envKeys['with-custom-roles'].sk)
+  .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', envKeys['with-custom-roles'].pk)
+  .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
+  .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
+  .setEnvVariable('public', 'CLERK_JS', process.env.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
+
 export const envs = {
   withEmailCodes,
   withEmailLinks,
+  withCustomRoles,
 } as const;

--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -18,6 +18,7 @@ export const createLongRunningApps = () => {
     { id: 'react.vite.withEmailLinks', config: react.vite, env: envs.withEmailLinks },
     { id: 'remix.node.withEmailCodes', config: remix.remixNode, env: envs.withEmailCodes },
     { id: 'next.appRouter.withEmailCodes', config: next.appRouter, env: envs.withEmailCodes },
+    // { id: 'next.appRouter.withCustomRoles', config: next.appRouter, env: envs.withCustomRoles },
   ] as const;
 
   const apps = configs.map(longRunningApplication);

--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -18,7 +18,7 @@ export const createLongRunningApps = () => {
     { id: 'react.vite.withEmailLinks', config: react.vite, env: envs.withEmailLinks },
     { id: 'remix.node.withEmailCodes', config: remix.remixNode, env: envs.withEmailCodes },
     { id: 'next.appRouter.withEmailCodes', config: next.appRouter, env: envs.withEmailCodes },
-    // { id: 'next.appRouter.withCustomRoles', config: next.appRouter, env: envs.withCustomRoles },
+    { id: 'next.appRouter.withCustomRoles', config: next.appRouter, env: envs.withCustomRoles },
   ] as const;
 
   const apps = configs.map(longRunningApplication);

--- a/integration/templates/next-app-router/src/app/api/settings/route.ts
+++ b/integration/templates/next-app-router/src/app/api/settings/route.ts
@@ -1,0 +1,6 @@
+import { auth } from '@clerk/nextjs/server';
+
+export function GET() {
+  const { userId } = auth().protect(has => has({ role: 'admin' }) || has({ role: 'org:editor' }));
+  return new Response(JSON.stringify({ userId }));
+}

--- a/integration/templates/next-app-router/src/app/page.tsx
+++ b/integration/templates/next-app-router/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { SignedIn, SignedOut, SignIn, UserButton } from '@clerk/nextjs';
+import { SignedIn, SignedOut, SignIn, UserButton, Protect } from '@clerk/nextjs';
 
 export default function Home() {
   return (
@@ -6,6 +6,7 @@ export default function Home() {
       <UserButton />
       <SignedIn>SignedIn</SignedIn>
       <SignedOut>SignedOut</SignedOut>
+      <Protect fallback={'SignedOut from protect'}>SignedIn from protect</Protect>
       <SignIn
         path={'/'}
         signUpUrl={'/sign-up'}

--- a/integration/templates/next-app-router/src/app/settings/auth-has/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-has/page.tsx
@@ -1,0 +1,9 @@
+import { auth } from '@clerk/nextjs/server';
+
+export default function Page() {
+  const { userId, has } = auth();
+  if (!userId || !has({ permission: 'org:posts:manage' })) {
+    return <p>User is missing permissions</p>;
+  }
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/settings/auth-protect/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect/page.tsx
@@ -1,0 +1,6 @@
+import { auth } from '@clerk/nextjs/server';
+
+export default function Page() {
+  auth().protect({ role: 'admin' });
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/settings/rcc-protect/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/rcc-protect/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { Protect } from '@clerk/nextjs';
+export default function Page() {
+  return (
+    <Protect
+      permission='org:posts:manage'
+      fallback={<p>User is missing permissions</p>}
+    >
+      <p>User has access</p>
+    </Protect>
+  );
+}

--- a/integration/templates/next-app-router/src/app/settings/rsc-protect/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/rsc-protect/page.tsx
@@ -1,0 +1,12 @@
+import { Protect } from '@clerk/nextjs';
+
+export default function Page() {
+  return (
+    <Protect
+      role='admin'
+      fallback={<p>User is not admin</p>}
+    >
+      <p>User has access</p>
+    </Protect>
+  );
+}

--- a/integration/templates/next-app-router/src/app/settings/useAuth-has/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/useAuth-has/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useAuth } from '@clerk/nextjs';
+
+export default function Page() {
+  const { has, isLoaded } = useAuth();
+  if (!isLoaded) {
+    return <p>Loading</p>;
+  }
+  if (!has({ role: 'admin' })) {
+    return <p>User is not admin</p>;
+  }
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/switcher/page.tsx
+++ b/integration/templates/next-app-router/src/app/switcher/page.tsx
@@ -1,0 +1,5 @@
+import { OrganizationSwitcher } from '@clerk/nextjs';
+
+export default function Page() {
+  return <OrganizationSwitcher hidePersonal={true} />;
+}

--- a/integration/templates/next-app-router/src/middleware.ts
+++ b/integration/templates/next-app-router/src/middleware.ts
@@ -1,7 +1,7 @@
 import { authMiddleware } from '@clerk/nextjs/server';
 
 export default authMiddleware({
-  publicRoutes: ['/', '/hash/sign-in', '/hash/sign-up'],
+  publicRoutes: ['/', '/hash/sign-in', '/hash/sign-up', /^(\/(settings)\/*).*$/],
 });
 
 export const config = {

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -4,6 +4,7 @@ import type { Browser, BrowserContext, Page } from '@playwright/test';
 import type { Application } from '../models/application';
 import { createAppPageObject } from './appPageObject';
 import { createEmailService } from './emailService';
+import { createOrganizationSwitcherComponentPageObject } from './organizationSwitcherPageObject';
 import type { EnchancedPage, TestArgs } from './signInPageObject';
 import { createSignInComponentPageObject } from './signInPageObject';
 import { createSignUpComponentPageObject } from './signUpPageObject';
@@ -67,6 +68,7 @@ export const createTestUtils = <
     signUp: createSignUpComponentPageObject(testArgs),
     signIn: createSignInComponentPageObject(testArgs),
     userProfile: createUserProfileComponentPageObject(testArgs),
+    organizationSwitcher: createOrganizationSwitcherComponentPageObject(testArgs),
     expect: createExpectPageObject(testArgs),
   };
 

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -8,12 +8,13 @@ import type { EnchancedPage, TestArgs } from './signInPageObject';
 import { createSignInComponentPageObject } from './signInPageObject';
 import { createSignUpComponentPageObject } from './signUpPageObject';
 import { createUserProfileComponentPageObject } from './userProfilePageObject';
-import type { FakeUser } from './usersService';
+import type { FakeOrganization, FakeUser } from './usersService';
 import { createUserService } from './usersService';
 
-export type { FakeUser };
+export type { FakeUser, FakeOrganization };
 const createClerkClient = (app: Application) => {
   return backendCreateClerkClient({
+    apiUrl: app.env.privateVariables.get('CLERK_API_URL'),
     secretKey: app.env.privateVariables.get('CLERK_SECRET_KEY'),
     publishableKey: app.env.publicVariables.get('CLERK_PUBLISHABLE_KEY'),
   });

--- a/integration/testUtils/organizationSwitcherPageObject.ts
+++ b/integration/testUtils/organizationSwitcherPageObject.ts
@@ -1,0 +1,30 @@
+import { expect } from '@playwright/test';
+
+import { common } from './commonPageObject';
+import type { TestArgs } from './signInPageObject';
+
+export const createOrganizationSwitcherComponentPageObject = (testArgs: TestArgs) => {
+  const { page } = testArgs;
+
+  const self = {
+    ...common(testArgs),
+    goTo: async (relativePath = '/switcher') => {
+      await page.goToRelative(relativePath);
+      return self.waitForMounted();
+    },
+    waitForMounted: () => {
+      return page.waitForSelector('.cl-organizationSwitcher-root', { state: 'attached' });
+    },
+    expectNoOrganizationSelected: () => {
+      return expect(page.getByText(/No organization selected/i)).toBeVisible();
+    },
+    toggleTrigger: () => {
+      return page.locator('.cl-organizationSwitcherTrigger').click();
+    },
+    waitForAnOrganizationToSelected: () => {
+      return page.waitForSelector('.cl-userPreviewMainIdentifier__personalWorkspace', { state: 'detached' });
+    },
+  };
+
+  return self;
+};

--- a/integration/testUtils/usersService.ts
+++ b/integration/testUtils/usersService.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker';
 import { hash } from '../models/helpers';
 
 export type FakeUser = ReturnType<ReturnType<typeof createUserService>['createFakeUser']>;
+export type FakeOrganization = ReturnType<ReturnType<Awaited<typeof createUserService>>['createFakeOrganization']>;
 
 export const createUserService = (clerkClient: ReturnType<typeof Clerk>) => {
   const self = {
@@ -35,6 +36,18 @@ export const createUserService = (clerkClient: ReturnType<typeof Clerk>) => {
       if (id) {
         await clerkClient.users.deleteUser(id);
       }
+    },
+    createFakeOrganization: async (userId: string) => {
+      const name = faker.animal.dog();
+      const { data: organization } = await clerkClient.organizations.createOrganization({
+        name: faker.animal.dog(),
+        createdBy: userId,
+      });
+      return {
+        name,
+        organization,
+        delete: () => clerkClient.organizations.deleteOrganization(organization.id),
+      };
     },
   };
   return self;

--- a/integration/tests/protect.test.ts
+++ b/integration/tests/protect.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test';
+
+import type { Application } from '../models/application';
+import { appConfigs } from '../presets';
+import type { FakeOrganization, FakeUser } from '../testUtils';
+import { createTestUtils } from '../testUtils';
+
+test.describe('authorization @nextjs', () => {
+  test.describe.configure({ mode: 'parallel' });
+  let app: Application;
+  let fakeUser: FakeUser;
+  let fakeOrganization: FakeOrganization;
+
+  test.beforeAll(async () => {
+    app = await appConfigs.next.appRouter
+      .clone()
+      .addFile(
+        'src/app/settings/rsc-protect/page.tsx',
+        () => `
+      import { Protect } from '@clerk/nextjs';
+      export default function Page() {
+        return (
+          <Protect role="admin" fallback={<p>User is not admin</p>}>
+              <p>User has access</p>
+          </Protect>
+        );
+      }`,
+      )
+      .addFile(
+        'src/app/settings/rcc-protect/page.tsx',
+        () => `
+      "use client";
+      import { Protect } from '@clerk/nextjs';
+      export default function Page() {
+        return (
+          <Protect role="admin" fallback={<p>User is not admin</p>}>
+              <p>User has access</p>
+          </Protect>
+        );
+      }`,
+      )
+      .addFile(
+        'src/app/settings/useAuth-has/page.tsx',
+        () => `
+      "use client";
+      import { useAuth } from '@clerk/nextjs';
+      export default function Page() {
+        const {has} = useAuth()
+        if(!has({role: 'admin'})) {
+            return <p>User is not admin</p>
+        }
+        return <p>User has access</p>
+      }`,
+      )
+      .addFile(
+        'src/app/settings/auth-has/page.tsx',
+        () => `
+      import { auth } from '@clerk/nextjs/server';
+      export default function Page() {
+        const {userId, has} = auth()
+        if(!userId || !has({role: 'admin'})) {
+            return <p>User is not admin</p>
+        }
+        return <p>User has access</p>
+      }`,
+      )
+      .addFile(
+        'src/app/settings/auth-protect/page.tsx',
+        () => `
+      import { auth } from '@clerk/nextjs/server';
+      export default function Page() {
+        const { user } = auth().protect({role: 'admin'})
+        return <p>User has access</p>
+      }`,
+      )
+      .addFile(
+        'src/app/switcher/page.tsx',
+        () => `
+      import { OrganizationSwitcher } from '@clerk/nextjs';
+
+      export default function Page() {
+        return (
+          <OrganizationSwitcher hidePersonal={true}/>
+        );
+      }`,
+      )
+      .commit();
+    await app.setup();
+    await app.withEnv(appConfigs.envs.withCustomRoles);
+    await app.dev();
+
+    const m = createTestUtils({ app });
+    fakeUser = m.services.users.createFakeUser();
+    const { data: user } = await m.services.users.createBapiUser(fakeUser);
+    fakeOrganization = await m.services.users.createFakeOrganization(user.id);
+
+    // await app.serve();
+  });
+
+  test.afterAll(async () => {
+    await fakeOrganization.delete();
+    await fakeUser.deleteIfExists();
+    await app.teardown();
+  });
+
+  test('Protect in RSCs and RCCs', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+
+    await u.po.signIn.goTo();
+    await u.po.signIn.waitForMounted();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+    await u.po.expect.toBeSignedIn();
+
+    await u.page.goToRelative('/switcher');
+    await u.page.waitForSelector('.cl-organizationSwitcher-root', { state: 'attached' });
+    await expect(u.page.getByText(/No organization selected/i)).toBeVisible();
+    await u.page.locator('.cl-organizationSwitcherTrigger').click();
+    await u.page.locator('.cl-organizationSwitcherPreviewButton').click();
+    await u.page.waitForSelector('.cl-userPreviewMainIdentifier__personalWorkspace', { state: 'detached' });
+
+    await u.page.goToRelative('/settings/rsc-protect');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+    await u.page.goToRelative('/settings/rcc-protect');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+    await u.page.goToRelative('/settings/useAuth-has');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+    await u.page.goToRelative('/settings/auth-has');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+    await u.page.goToRelative('/settings/auth-protect');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+  });
+
+  test('Protect in RSCs and RCCs with signed-out user', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+
+    await u.page.goToRelative('/settings/rsc-protect');
+    await expect(u.page.getByText(/User is not admin/i)).toBeVisible();
+    await u.page.goToRelative('/settings/rcc-protect');
+    await expect(u.page.getByText(/User is not admin/i)).toBeVisible();
+    await u.page.goToRelative('/settings/useAuth-has');
+    await expect(u.page.getByText(/User is not admin/i)).toBeVisible();
+    await u.page.goToRelative('/settings/auth-has');
+    await expect(u.page.getByText(/User is not admin/i)).toBeVisible();
+    await u.page.goToRelative('/settings/auth-protect');
+    await expect(u.page.getByText(/this page could not be found/i)).toBeVisible();
+  });
+});

--- a/integration/tests/protect.test.ts
+++ b/integration/tests/protect.test.ts
@@ -130,12 +130,12 @@ test.describe('authorization @nextjs', () => {
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeAdmin.email, password: fakeAdmin.password });
     await u.po.expect.toBeSignedIn();
 
-    await u.page.goToRelative('/switcher');
-    await u.page.waitForSelector('.cl-organizationSwitcher-root', { state: 'attached' });
-    await expect(u.page.getByText(/No organization selected/i)).toBeVisible();
-    await u.page.locator('.cl-organizationSwitcherTrigger').click();
+    await u.po.organizationSwitcher.goTo();
+    await u.po.organizationSwitcher.waitForMounted();
+    await u.po.organizationSwitcher.expectNoOrganizationSelected();
+    await u.po.organizationSwitcher.toggleTrigger();
     await u.page.locator('.cl-organizationSwitcherPreviewButton').click();
-    await u.page.waitForSelector('.cl-userPreviewMainIdentifier__personalWorkspace', { state: 'detached' });
+    await u.po.organizationSwitcher.waitForAnOrganizationToSelected();
 
     await u.page.goToRelative('/settings/rsc-protect');
     await expect(u.page.getByText(/User has access/i)).toBeVisible();
@@ -176,12 +176,12 @@ test.describe('authorization @nextjs', () => {
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeViewer.email, password: fakeViewer.password });
     await u.po.expect.toBeSignedIn();
 
-    await u.page.goToRelative('/switcher');
-    await u.page.waitForSelector('.cl-organizationSwitcher-root', { state: 'attached' });
-    await expect(u.page.getByText(/No organization selected/i)).toBeVisible();
-    await u.page.locator('.cl-organizationSwitcherTrigger').click();
+    await u.po.organizationSwitcher.goTo();
+    await u.po.organizationSwitcher.waitForMounted();
+    await u.po.organizationSwitcher.expectNoOrganizationSelected();
+    await u.po.organizationSwitcher.toggleTrigger();
     await u.page.locator('.cl-organizationSwitcherPreviewButton').click();
-    await u.page.waitForSelector('.cl-userPreviewMainIdentifier__personalWorkspace', { state: 'detached' });
+    await u.po.organizationSwitcher.waitForAnOrganizationToSelected();
 
     await u.page.goToRelative('/settings/rsc-protect');
     await expect(u.page.getByText(/User is not admin/i)).toBeVisible();

--- a/integration/tests/protect.test.ts
+++ b/integration/tests/protect.test.ts
@@ -93,8 +93,6 @@ test.describe('authorization @nextjs', () => {
     fakeUser = m.services.users.createFakeUser();
     const { data: user } = await m.services.users.createBapiUser(fakeUser);
     fakeOrganization = await m.services.users.createFakeOrganization(user.id);
-
-    // await app.serve();
   });
 
   test.afterAll(async () => {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:integration:deployment:nextjs": "DEBUG=1 npx playwright test --config integration/playwright.deployments.config.ts",
     "test:integration:express": "E2E_APP_ID=express.* npm run test:integration:base -- --grep @express",
     "test:integration:generic": "E2E_APP_ID=react.vite.* npm run test:integration:base -- --grep @generic",
-    "test:integration:nextjs": "E2E_APP_ID=next.appRouter.withEmailCodes npm run test:integration:base -- --grep \"@generic|@nextjs\"",
+    "test:integration:nextjs": "E2E_APP_ID=next.appRouter.* npm run test:integration:base -- --grep \"@generic|@nextjs\"",
     "test:integration:remix": "echo 'placeholder'",
     "turbo:clean": "turbo daemon clean",
     "update:lockfile": "npm run nuke && npm install -D --arch=x64 --platform=linux turbo && npm install -D --arch=arm64 --platform=darwin turbo",


### PR DESCRIPTION
## Description

This PR introduces a integration test for `<Protect/>`, `useAuth().has()`, `auth().has()` and `auth().protect()`
- Uses the Nextjs template
- For now is using keys from staging as the feature is behind a feature flag in production
- Checks for `admin`, `viewer`, and a signed-out user

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
