### PR TITLE
fix(shared): Add missing peerDependenciesMeta key

### DIFF
--- a/.changeset/chatty-beans-fix.md
+++ b/.changeset/chatty-beans-fix.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Add `react-dom` to `peerDependenciesMeta` key inside `package.json`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -108,6 +108,9 @@
   "peerDependenciesMeta": {
     "react": {
       "optional": true
+    },
+    "react-dom": {
+      "optional": true
     }
   },
   "engines": {


### PR DESCRIPTION
## Description

https://github.com/clerk/javascript/pull/2164 added `react-dom` to `@clerk/shared` as a peerDependency. We should also mark this peerDep as optional since `@clerk/shared` can also be used outside of React.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
