### PR TITLE
chore(repo): Adjust npmrc and VSCode settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+legacy-peer-deps=false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit",
   },
   "eslint.workingDirectories": [
     {
@@ -15,20 +15,5 @@
       "fileMatch": ["manifest.json"],
       "url": "https://json.schemastore.org/chrome-manifest.json"
     }
-  ],
-  "cSpell.words": [
-    "accountsstage",
-    "adduser",
-    "arethetypeswrong",
-    "attw",
-    "BAPI",
-    "citty",
-    "execa",
-    "FAPI",
-    "jwks",
-    "lclclerk",
-    "lclstage",
-    "nextjs",
-    "publint"
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33308,7 +33308,7 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "1.0.0-alpha-v5.6",
+      "version": "1.0.0-alpha-v5.7",
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.0.0-alpha-v5.5",
@@ -33317,7 +33317,7 @@
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@cloudflare/workers-types": "^3.18.0",
         "@types/chai": "^4.3.3",
         "@types/cookie": "^0.5.1",
@@ -33347,11 +33347,11 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "1.0.0-alpha-v5.8",
+      "version": "1.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.8",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.8"
+        "@clerk/clerk-js": "5.0.0-alpha-v5.9",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.9"
       },
       "devDependencies": {
         "@types/chrome": "*",
@@ -33372,12 +33372,12 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "5.0.0-alpha-v5.8",
+      "version": "5.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
         "@clerk/localizations": "2.0.0-alpha-v5.6",
         "@clerk/shared": "2.0.0-alpha-v5.5",
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
         "@floating-ui/react": "0.25.4",
@@ -33713,17 +33713,17 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "1.0.0-alpha-v5.8",
+      "version": "1.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.8",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.8",
+        "@clerk/clerk-js": "5.0.0-alpha-v5.9",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.9",
         "@clerk/shared": "2.0.0-alpha-v5.5",
         "base-64": "^1.0.0",
         "react-native-url-polyfill": "2.0.0"
       },
       "devDependencies": {
-        "@clerk/types": "^4.0.0-alpha-v5.8",
+        "@clerk/types": "^4.0.0-alpha-v5.9",
         "@types/base-64": "^1.0.2",
         "@types/node": "^18.17.0",
         "@types/react": "*",
@@ -33746,12 +33746,12 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "1.0.0-alpha-v5.8",
+      "version": "1.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.6",
+        "@clerk/backend": "1.0.0-alpha-v5.7",
         "@clerk/shared": "2.0.0-alpha-v5.5",
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "cookies": "0.8.0"
       },
       "devDependencies": {
@@ -33769,17 +33769,17 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "5.0.0-alpha-v5.8",
+      "version": "5.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.6",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.8",
-        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.6",
+        "@clerk/backend": "1.0.0-alpha-v5.7",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.9",
+        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.7",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/cookie": "^0.5.0",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
@@ -33802,7 +33802,7 @@
       "version": "2.0.0-alpha-v5.6",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "tsup": "*",
@@ -33818,16 +33818,16 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "5.0.0-alpha-v5.8",
+      "version": "5.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.6",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.8",
+        "@clerk/backend": "1.0.0-alpha-v5.7",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.9",
         "@clerk/shared": "2.0.0-alpha-v5.5",
         "path-to-regexp": "6.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/node": "^18.17.0",
         "@types/react": "*",
         "@types/react-dom": "*",
@@ -33852,11 +33852,11 @@
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
-      "version": "5.0.0-alpha-v5.8",
+      "version": "5.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.0.0-alpha-v5.5",
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "eslint-config-custom": "*",
         "semver": "^7.5.4",
         "tslib": "2.4.1"
@@ -33884,17 +33884,17 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "4.0.0-alpha-v5.8",
+      "version": "4.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.6",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.8",
+        "@clerk/backend": "1.0.0-alpha-v5.7",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.9",
         "@clerk/shared": "2.0.0-alpha-v5.5",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@remix-run/react": "^2.0.0",
         "@remix-run/server-runtime": "^2.0.0",
         "@types/cookie": "^0.5.0",
@@ -33920,16 +33920,16 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "5.0.0-alpha-v5.6",
+      "version": "5.0.0-alpha-v5.7",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.6",
+        "@clerk/backend": "1.0.0-alpha-v5.7",
         "@clerk/shared": "2.0.0-alpha-v5.5",
         "camelcase-keys": "6.2.2",
         "snakecase-keys": "3.2.1"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/express": "4.17.14",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
@@ -33971,7 +33971,7 @@
         "swr": "2.2.0"
       },
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
         "@types/node": "^18.17.0",
@@ -33990,6 +33990,9 @@
       "peerDependenciesMeta": {
         "react": {
           "optional": true
+        },
+        "react-dom": {
+          "optional": true
         }
       }
     },
@@ -34007,7 +34010,7 @@
       "version": "2.0.0-alpha-v5.2",
       "license": "MIT",
       "devDependencies": {
-        "@clerk/types": "4.0.0-alpha-v5.8",
+        "@clerk/types": "4.0.0-alpha-v5.9",
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "typescript": "*"
@@ -34022,7 +34025,7 @@
     },
     "packages/types": {
       "name": "@clerk/types",
-      "version": "4.0.0-alpha-v5.8",
+      "version": "4.0.0-alpha-v5.9",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.1"


### PR DESCRIPTION
## Description

This applies three changes to `.npmrc` and `.vscode/settings.json`:

- Add `legacy-peer-deps=false` since I have this globally set to `true` so every time I did `npm install` I changed the lockfile due to my global setting. By defining this in the repo it overrides my global setting and I'm not annoyed anymore 😬 
- Latest VSCode changed `codeActionsOnSave` and my editor always wants to change it: https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto
- Remove cspell since we don't use it

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
