### PR TITLE
feat(nextjs): Accept `redirectUrl` as option for `auth().protect()` #2329

### DIFF
--- a/.changeset/thirty-chicken-divide.md
+++ b/.changeset/thirty-chicken-divide.md
@@ -2,4 +2,15 @@
 '@clerk/nextjs': patch
 ---
 
-Accept `redirectUrl` as option for `auth().protect()`
+Accept `redirectUrl` as an option for `auth().protect()`.
+
+For example:
+
+```ts
+// Authorization
+auth().protect({ role:'org:admin' }, { redirectUrl: "/any-page" })
+auth().protect({ permission:'org:settings:manage' }, { redirectUrl: "/any-page" })
+
+// Authentication
+auth().protect({ redirectUrl: "/any-page" })
+```

--- a/.changeset/thirty-chicken-divide.md
+++ b/.changeset/thirty-chicken-divide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Accept `redirectUrl` as option for `auth().protect()`

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -17,14 +17,22 @@ type AuthSignedIn = AuthObjectWithDeprecatedResources<
      * This function is experimental as it throws a Nextjs notFound error if user is not authenticated or authorized.
      * In the future we would investigate a way to throw a more appropriate error that clearly describes the not authorized of authenticated status.
      */
-    protect: (
-      params?:
-        | CheckAuthorizationParamsWithCustomPermissions
-        | ((has: CheckAuthorizationWithCustomPermissions) => boolean),
-      options?: { redirectUrl: string },
-    ) => AuthObjectWithDeprecatedResources<SignedInAuthObject>;
+    protect: {
+      (
+        params?:
+          | CheckAuthorizationParamsWithCustomPermissions
+          | ((has: CheckAuthorizationWithCustomPermissions) => boolean),
+        options?: { redirectUrl: string },
+      ): AuthObjectWithDeprecatedResources<SignedInAuthObject>;
+
+      (params?: { redirectUrl: string }): AuthObjectWithDeprecatedResources<SignedInAuthObject>;
+    };
   }
 >;
+
+type ProtectGeneric = {
+  protect: (params?: unknown, options?: unknown) => AuthObjectWithDeprecatedResources<SignedInAuthObject>;
+};
 
 type AuthSignedOut = AuthObjectWithDeprecatedResources<
   SignedOutAuthObject & {
@@ -43,13 +51,21 @@ export const auth = () => {
     noAuthStatusMessage: authAuthHeaderMissing(),
   })(buildRequestLike());
 
-  (authObject as AuthSignedIn).protect = (params, options) => {
+  (authObject as unknown as ProtectGeneric).protect = (params: any, options: any) => {
+    const paramsOrFunction = params?.redirectUrl
+      ? undefined
+      : (params as
+          | CheckAuthorizationParamsWithCustomPermissions
+          | ((has: CheckAuthorizationWithCustomPermissions) => boolean));
+    const redirectUrl = (params?.redirectUrl || options?.redirectUrl) as string | undefined;
+
     const handleUnauthorized = (): never => {
-      if (options?.redirectUrl) {
-        redirect(options.redirectUrl);
+      if (redirectUrl) {
+        redirect(redirectUrl);
       }
       notFound();
     };
+
     /**
      * User is not authenticated
      */
@@ -60,15 +76,15 @@ export const auth = () => {
     /**
      * User is authenticated
      */
-    if (!params) {
+    if (!paramsOrFunction) {
       return { ...authObject };
     }
 
     /**
      * if a function is passed and returns false then throw not found
      */
-    if (typeof params === 'function') {
-      if (params(authObject.has)) {
+    if (typeof paramsOrFunction === 'function') {
+      if (paramsOrFunction(authObject.has)) {
         return { ...authObject };
       }
       return handleUnauthorized();
@@ -77,7 +93,7 @@ export const auth = () => {
     /**
      * Checking if user is authorized when permission or role is passed
      */
-    if (authObject.has(params)) {
+    if (authObject.has(paramsOrFunction)) {
       return { ...authObject };
     }
 


### PR DESCRIPTION
## Description

Backport of #2329
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
