### PR TITLE
chore(nextjs): Fix quickstarts link in error msg

### DIFF
--- a/.changeset/polite-mice-live.md
+++ b/.changeset/polite-mice-live.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Update NextJS quickstart link in error message

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -36,7 +36,7 @@ export const authAuthHeaderMissing = (helperName = 'auth') =>
 - Your Middleware matcher is configured to match this route or page.
 - If you are using the src directory, make sure the Middleware file is inside of it.
 
-For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs.
+For more details, see https://clerk.com/docs/quickstarts/nextjs.
 `;
 
 export const clockSkewDetected = (verifyMessage: string) =>

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -36,7 +36,7 @@ export const authAuthHeaderMissing = (helperName = 'auth') =>
 - Your Middleware matcher is configured to match this route or page.
 - If you are using the src directory, make sure the Middleware file is inside of it.
 
-For more details, see https://clerk.com/docs/quickstarts/nextjs.
+For more details, see https://clerk.com/docs/quickstarts/nextjs
 `;
 
 export const clockSkewDetected = (verifyMessage: string) =>


### PR DESCRIPTION
## Description

Backports https://github.com/clerk/javascript/pull/2355

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
