### PR TITLE
chore(nextjs): Fix quickstarts link in error msg

### DIFF
--- a/.changeset/silent-comics-roll.md
+++ b/.changeset/silent-comics-roll.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Update NextJS quickstart link in error message

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -36,7 +36,7 @@ export const authAuthHeaderMissing = (helperName = 'auth') =>
 - Your Middleware matcher is configured to match this route or page.
 - If you are using the src directory, make sure the Middleware file is inside of it.
 
-For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs
+For more details, see https://clerk.com/docs/quickstarts/nextjs
 `;
 
 export const clockSkewDetected = (verifyMessage: string) =>


### PR DESCRIPTION
## Description

Update quickstart link in error message as reported in Discord: https://discord.com/channels/856971667393609759/1184865489034432632/1184918430588076243

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
