### PR TITLE
refactor(clerk-js,nextjs,clerk-react,shared,types): Remove hashing and third-party cookie based session syncing for development instances. [SDK-645]

### DIFF
--- a/.changeset/famous-penguins-bow.md
+++ b/.changeset/famous-penguins-bow.md
@@ -1,0 +1,7 @@
+---
+'@clerk/types': major
+---
+
+- Remove `BuildUrlWithAuthParams` type
+- `AuthConfigResource` no longer has a `urlBasedSessionSyncing` property
+- `buildUrlWithAuth` no longer accepts an `options` argument of `BuildUrlWithAuthParams`.

--- a/.changeset/modern-buses-sort.md
+++ b/.changeset/modern-buses-sort.md
@@ -1,0 +1,10 @@
+---
+'@clerk/chrome-extension': major
+'@clerk/clerk-js': major
+'@clerk/nextjs': major
+'@clerk/shared': major
+'@clerk/clerk-react': major
+'@clerk/types': major
+---
+
+Remove hashing and third-party cookie functionality related to development instance session syncing in favor of URL-based session syncing with query parameters.

--- a/.changeset/modern-mayflies-sort.md
+++ b/.changeset/modern-mayflies-sort.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': major
+'@clerk/clerk-react': major
+---
+
+- `buildUrlWithAuth` no longer accepts an `options` argument.

--- a/packages/clerk-js/src/core/devBrowser.ts
+++ b/packages/clerk-js/src/core/devBrowser.ts
@@ -48,7 +48,7 @@ export function createDevBrowser({ frontendApi, fapiClient }: CreateDevBrowserOp
     fapiClient.onBeforeRequest(request => {
       const devBrowserJWT = getDevBrowserJWT();
       if (devBrowserJWT && request?.url) {
-        request.url = setDevBrowserJWTInURL(request.url, devBrowserJWT, true);
+        request.url = setDevBrowserJWTInURL(request.url, devBrowserJWT);
       }
     });
 

--- a/packages/clerk-js/src/core/resources/AuthConfig.ts
+++ b/packages/clerk-js/src/core/resources/AuthConfig.ts
@@ -4,7 +4,6 @@ import { BaseResource } from './internal';
 
 export class AuthConfig extends BaseResource implements AuthConfigResource {
   singleSessionMode!: boolean;
-  urlBasedSessionSyncing!: boolean;
 
   public constructor(data: AuthConfigJSON) {
     super();
@@ -13,7 +12,6 @@ export class AuthConfig extends BaseResource implements AuthConfigResource {
 
   protected fromJSON(data: AuthConfigJSON | null): this {
     this.singleSessionMode = data ? data.single_session_mode : true;
-    this.urlBasedSessionSyncing = data ? data.url_based_session_syncing : false;
     return this;
   }
 }

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -15,7 +15,6 @@ import { PUBLISHABLE_KEY, SECRET_KEY } from './constants';
 import { informAboutProtectedRouteInfo, receivedRequestForIgnoredRoute } from './errors';
 import { redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
-import { isDevAccountPortalOrigin } from './url';
 import {
   apiEndpointUnauthorizedNextResponse,
   decorateRequest,
@@ -327,10 +326,7 @@ const appendDevBrowserOnCrossOrigin = (req: WithClerkUrl<NextRequest>, res: Resp
     // Next.js 12.1+ allows redirects only to absolute URLs
     const url = new URL(location);
 
-    // Use query param for Account Portal pages so that SSR can access the dev_browser JWT
-    const asQueryParam = isDevAccountPortalOrigin(url.hostname);
-
-    const urlWithDevBrowser = setDevBrowserJWTInURL(url, dbJwt, asQueryParam);
+    const urlWithDevBrowser = setDevBrowserJWTInURL(url, dbJwt);
 
     return NextResponse.redirect(urlWithDevBrowser.href, res);
   }

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -4,7 +4,6 @@ import type { TelemetryCollector } from '@clerk/shared/telemetry';
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
-  BuildUrlWithAuthParams,
   Clerk,
   ClientResource,
   CreateOrganizationParams,
@@ -112,8 +111,6 @@ type IsomorphicLoadedClerk = Without<
   buildCreateOrganizationUrl: () => string | void;
   // TODO: Align return type
   buildOrganizationProfileUrl: () => string | void;
-  // TODO: Align return type
-  buildUrlWithAuth: (to: string, opts?: BuildUrlWithAuthParams | undefined) => string | void;
   // TODO: Align return type
   buildAfterSignInUrl: () => string | void;
   // TODO: Align return type
@@ -308,8 +305,8 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
-  buildUrlWithAuth = (to: string, opts?: BuildUrlWithAuthParams | undefined): string | void => {
-    const callback = () => this.clerkjs?.buildUrlWithAuth(to, opts) || '';
+  buildUrlWithAuth = (to: string): string | void => {
+    const callback = () => this.clerkjs?.buildUrlWithAuth(to) || '';
     if (this.clerkjs && this.#loaded) {
       return callback();
     } else {

--- a/packages/shared/src/__tests__/devbrowser.test.ts
+++ b/packages/shared/src/__tests__/devbrowser.test.ts
@@ -3,22 +3,26 @@ import { getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
 const DUMMY_URL_BASE = 'http://clerk-dummy';
 
 describe('setDevBrowserJWTInURL(url, jwt)', () => {
-  const testCases: Array<[string, string, boolean, string]> = [
-    ['', 'deadbeef', false, '#__clerk_db_jwt[deadbeef]'],
-    ['foo', 'deadbeef', false, 'foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
-    ['#foo', 'deadbeef', false, '#foo__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
-    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
-    ['/foo', 'deadbeef', true, '/foo?__clerk_db_jwt=deadbeef'],
-    ['/foo?bar=42', 'deadbeef', true, '/foo?bar=42&__clerk_db_jwt=deadbeef'],
+  const testCases: Array<[string, string, string]> = [
+    ['', 'deadbeef', '?__clerk_db_jwt=deadbeef'],
+    ['foo', 'deadbeef', 'foo?__clerk_db_jwt=deadbeef'],
+    ['/foo', 'deadbeef', '/foo?__clerk_db_jwt=deadbeef'],
+    ['#foo', 'deadbeef', '?__clerk_db_jwt=deadbeef#foo'],
+    ['/foo?bar=42#qux', 'deadbeef', '/foo?bar=42&__clerk_db_jwt=deadbeef#qux'],
+    ['/foo#__clerk_db_jwt[deadbeef2]', 'deadbeef', '/foo?__clerk_db_jwt=deadbeef#__clerk_db_jwt[deadbeef2]'],
+    [
+      '/foo?bar=42#qux__clerk_db_jwt[deadbeef2]',
+      'deadbeef',
+      '/foo?bar=42&__clerk_db_jwt=deadbeef#qux__clerk_db_jwt[deadbeef2]',
+    ],
+    ['/foo', 'deadbeef', '/foo?__clerk_db_jwt=deadbeef'],
+    ['/foo?bar=42', 'deadbeef', '/foo?bar=42&__clerk_db_jwt=deadbeef'],
   ];
 
   test.each(testCases)(
     'sets the dev browser JWT at the end of the provided url. Params: url=(%s), jwt=(%s), expected url=(%s)',
-    (input, paramName, asQueryParam, expected) => {
-      expect(setDevBrowserJWTInURL(new URL(input, DUMMY_URL_BASE), paramName, asQueryParam).href).toEqual(
+    (input, paramName, expected) => {
+      expect(setDevBrowserJWTInURL(new URL(input, DUMMY_URL_BASE), paramName).href).toEqual(
         new URL(expected, DUMMY_URL_BASE).href,
       );
     },
@@ -27,7 +31,7 @@ describe('setDevBrowserJWTInURL(url, jwt)', () => {
 
 const oldHistory = globalThis.history;
 
-describe('getDevBrowserJWTFromURL(url,)', () => {
+describe('getDevBrowserJWTFromURL(url)', () => {
   const replaceStateMock = jest.fn();
 
   beforeEach(() => {
@@ -53,11 +57,15 @@ describe('getDevBrowserJWTFromURL(url,)', () => {
   const testCases: Array<[string, string, null | string]> = [
     ['', '', null],
     ['foo', '', null],
-    ['#__clerk_db_jwt[deadbeef]', 'deadbeef', ''],
-    ['foo#__clerk_db_jwt[deadbeef]', 'deadbeef', 'foo'],
-    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo'],
-    ['#foo__clerk_db_jwt[deadbeef]', 'deadbeef', '#foo'],
-    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo?bar=42#qux'],
+    ['?__clerk_db_jwt=deadbeef', 'deadbeef', ''],
+    ['foo?__clerk_db_jwt=deadbeef', 'deadbeef', 'foo'],
+    ['/foo?__clerk_db_jwt=deadbeef', 'deadbeef', '/foo'],
+    ['?__clerk_db_jwt=deadbeef#foo', 'deadbeef', '#foo'],
+    [
+      '/foo?bar=42&__clerk_db_jwt=deadbeef#qux__clerk_db_jwt[deadbeef2]',
+      'deadbeef',
+      '/foo?bar=42#qux__clerk_db_jwt[deadbeef2]',
+    ],
   ];
 
   test.each(testCases)(

--- a/packages/shared/src/devBrowser.ts
+++ b/packages/shared/src/devBrowser.ts
@@ -1,32 +1,19 @@
 export const DEV_BROWSER_JWT_KEY = '__clerk_db_jwt';
 export const DEV_BROWSER_JWT_HEADER = 'Clerk-Db-Jwt';
 
-const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
-
 // Sets the dev_browser JWT in the hash or the search
-export function setDevBrowserJWTInURL(url: URL, jwt: string, asQueryParam: boolean): URL {
+export function setDevBrowserJWTInURL(url: URL, jwt: string): URL {
   const resultURL = new URL(url);
-
-  // extract & strip existing jwt from hash
-  const jwtFromHash = extractDevBrowserJWTFromHash(resultURL.hash);
-  resultURL.hash = resultURL.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
-  if (resultURL.href.endsWith('#')) {
-    resultURL.hash = '';
-  }
 
   // extract & strip existing jwt from search
   const jwtFromSearch = resultURL.searchParams.get(DEV_BROWSER_JWT_KEY);
   resultURL.searchParams.delete(DEV_BROWSER_JWT_KEY);
 
   // Existing jwt takes precedence
-  const jwtToSet = jwtFromHash || jwtFromSearch || jwt;
+  const jwtToSet = jwtFromSearch || jwt;
 
   if (jwtToSet) {
-    if (asQueryParam) {
-      resultURL.searchParams.append(DEV_BROWSER_JWT_KEY, jwtToSet);
-    } else {
-      resultURL.hash = resultURL.hash + `${DEV_BROWSER_JWT_KEY}[${jwtToSet}]`;
-    }
+    resultURL.searchParams.set(DEV_BROWSER_JWT_KEY, jwtToSet);
   }
 
   return resultURL;
@@ -38,18 +25,9 @@ export function setDevBrowserJWTInURL(url: URL, jwt: string, asQueryParam: boole
 export function getDevBrowserJWTFromURL(url: URL): string {
   const resultURL = new URL(url);
 
-  // extract & strip existing jwt from hash
-  const jwtFromHash = extractDevBrowserJWTFromHash(resultURL.hash);
-  resultURL.hash = resultURL.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
-  if (resultURL.href.endsWith('#')) {
-    resultURL.hash = '';
-  }
-
   // extract & strip existing jwt from search
-  const jwtFromSearch = resultURL.searchParams.get(DEV_BROWSER_JWT_KEY) || '';
+  const jwt = resultURL.searchParams.get(DEV_BROWSER_JWT_KEY) || '';
   resultURL.searchParams.delete(DEV_BROWSER_JWT_KEY);
-
-  const jwt = jwtFromHash || jwtFromSearch;
 
   // eslint-disable-next-line valid-typeof
   if (jwt && typeof globalThis.history !== undefined) {
@@ -57,9 +35,4 @@ export function getDevBrowserJWTFromURL(url: URL): string {
   }
 
   return jwt;
-}
-
-function extractDevBrowserJWTFromHash(hash: string): string {
-  const matches = hash.match(DEV_BROWSER_JWT_MARKER_REGEXP);
-  return matches ? matches[1] : '';
 }

--- a/packages/types/src/authConfig.ts
+++ b/packages/types/src/authConfig.ts
@@ -5,10 +5,4 @@ export interface AuthConfigResource extends ClerkResource {
    * Enabled single session configuration at the instance level.
    */
   singleSessionMode: boolean;
-
-  /**
-   * Denotes if the instance will use the new mode for syncing development sessions which uses URL
-   * decoration instead of third-party cookies.
-   */
-  urlBasedSessionSyncing: boolean;
 }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -308,9 +308,8 @@ export interface Clerk {
    * Decorates the provided url with the auth token for development instances.
    *
    * @param {string} to
-   * @param opts A {@link BuildUrlWithAuthParams} object
    */
-  buildUrlWithAuth(to: string, opts?: BuildUrlWithAuthParams): string;
+  buildUrlWithAuth(to: string): string;
 
   /**
    * Returns the configured url where <SignIn/> is mounted or a custom sign-in page is rendered.
@@ -491,13 +490,6 @@ export type HandleOAuthCallbackParams = {
 };
 
 export type HandleSamlCallbackParams = HandleOAuthCallbackParams;
-
-export type BuildUrlWithAuthParams = {
-  /**
-   * Controls if dev browser JWT is added as a query param
-   */
-  useQueryParam?: boolean | null;
-};
 
 export type CustomNavigation = (to: string, options?: NavigateOptions) => Promise<unknown> | void;
 


### PR DESCRIPTION
## Description

Remove hashing and third-party cookie based session syncing for development instances in favor of URL-based session syncing.

<!-- Fixes #(issue number) -->

SDK-645

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
