### PR TITLE
fix(clerk-sdk-node): Fix forgotten Clerk instead of createClerkClient

### DIFF
--- a/.changeset/weak-bears-cover.md
+++ b/.changeset/weak-bears-cover.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': minor
+---
+
+Fix error thrown for undefined `Clerk` in case of using default clerkClient from `@clerk/clerk-sdk-node` without secretKey caused by replaced import.

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -31,7 +31,7 @@ export function createClerkClient(options: ClerkOptions): ClerkClient {
 let clerkClientSingleton = {} as unknown as ReturnType<typeof createClerkClient>;
 
 export const clerkClient = new Proxy(clerkClientSingleton, {
-  get(_target, property) {
+  get(_target, property: string) {
     const hasBeenInitialised = !!clerkClientSingleton.authenticateRequest;
     if (hasBeenInitialised) {
       // @ts-expect-error - Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type 'ExtendedClerk'.
@@ -40,13 +40,14 @@ export const clerkClient = new Proxy(clerkClientSingleton, {
 
     const env = { ...loadApiEnv(), ...loadClientEnv() };
     if (env.secretKey) {
-      clerkClientSingleton = createClerkClient({ ...env, userAgent: '@clerk/clerk-sdk-node' });
+      clerkClientSingleton = createClerkClient({ ...env, userAgent: PACKAGE_NAME });
       // @ts-expect-error - Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type 'ExtendedClerk'.
       return clerkClientSingleton[property];
     }
 
+    const c = createClerkClient({ ...env, userAgent: PACKAGE_NAME });
     // @ts-expect-error - Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type 'ExtendedClerk'.
-    return Clerk({ ...env, userAgent: '@clerk/clerk-sdk-node' })[property];
+    return c[property];
   },
   set() {
     return false;


### PR DESCRIPTION
## Description

This error was silent due to an existing ts-expect-error that was added in the past for a different reason. To allow type checking for the import, we splitted it to 2 different lines and added the ts-expect-error only to the part that we wanted to.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
