### PR TITLE
chore(nextjs): Rename to NEXT_PUBLIC_CLERK_JS_URL

### DIFF
--- a/.changeset/wise-scissors-know.md
+++ b/.changeset/wise-scissors-know.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': major
+---
+
+Use `NEXT_PUBLIC_CLERK_JS` instead of `NEXT_PUBLIC_CLERK_JS_URL` to pin a specific @clerk/clerk-js version.

--- a/.github/workflows/preview.retheme.yml
+++ b/.github/workflows/preview.retheme.yml
@@ -58,7 +58,7 @@ jobs:
           cd $FULL_TMP_FOLDER
           vercel build --yes --prod
         env:
-          NEXT_PUBLIC_CLERK_JS: /clerk-js/clerk.browser.js
+          NEXT_PUBLIC_CLERK_JS_URL: /clerk-js/clerk.browser.js
 
       - name: Deploy to Vercel (prebuilt)
         id: vercel-deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -82,7 +82,7 @@ jobs:
           cd $FULL_TMP_FOLDER
           vercel build --yes
         env:
-          NEXT_PUBLIC_CLERK_JS: /clerk-js/clerk.browser.js
+          NEXT_PUBLIC_CLERK_JS_URL: /clerk-js/clerk.browser.js
 
       - name: Deploy to Vercel (prebuilt)
         id: vercel-deploy

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -2,7 +2,7 @@ import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey
 import { isTruthy } from '@clerk/shared/underscore';
 
 export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
-export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
+export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS_URL || '';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';

--- a/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
+++ b/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
@@ -8,7 +8,7 @@ export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, '
   return {
     ...props,
     publishableKey: props.publishableKey || process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '',
-    clerkJSUrl: props.clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS,
+    clerkJSUrl: props.clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS_URL,
     clerkJSVersion: props.clerkJSVersion || process.env.NEXT_PUBLIC_CLERK_JS_VERSION,
     proxyUrl: props.proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '',
     domain: props.domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || '',


### PR DESCRIPTION
## Description

## Checklist

- [x] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
