### PR TITLE
chore(clerk-js): Remove legacy roles fallback

### DIFF
--- a/.changeset/lovely-experts-deny.md
+++ b/.changeset/lovely-experts-deny.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove legacy roles fallback
+After the release of Custom Roles, roles should always be dynamically fetched. 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -1,5 +1,5 @@
 import type { MembershipRole } from '@clerk/types';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import type { LocalizationKey } from '../../customizables';
 import { Col, descriptors, Flex, Spinner, Table, Tbody, Td, Text, Th, Thead, Tr } from '../../customizables';
@@ -129,24 +129,20 @@ export const RoleSelect = (props: {
 }) => {
   const { value, roles, onChange, isDisabled, triggerSx, optionListSx } = props;
 
-  const shouldDisplayLegacyRoles = !roles;
-
-  const legacyRoles: Array<{ label: string; value: MembershipRole }> = [
-    { label: 'admin', value: 'admin' },
-    { label: 'basic_member', value: 'basic_member' },
-  ];
-
-  const legacyExcludedRoles: Array<{ label: string; value: MembershipRole }> = [
-    { label: 'guest_member', value: 'guest_member' },
-  ];
   const { localizeCustomRole } = useLocalizeCustomRoles();
 
-  const selectedRole = [...(roles || []), ...legacyRoles, ...legacyExcludedRoles].find(r => r.value === value);
+  const fetchedRoles = useMemo(() => [...(roles || [])], [roles]);
 
-  const localizedOptions = (!shouldDisplayLegacyRoles ? roles : legacyRoles).map(role => ({
-    value: role.value,
-    label: localizeCustomRole(role.value) || role.label,
-  }));
+  const selectedRole = useMemo(() => fetchedRoles.find(r => r.value === value), [fetchedRoles]);
+
+  const localizedOptions = useMemo(
+    () =>
+      fetchedRoles.map(role => ({
+        value: role.value,
+        label: localizeCustomRole(role.value) || role.label,
+      })),
+    [fetchedRoles, localizeCustomRole],
+  );
 
   return (
     <Select


### PR DESCRIPTION
## Description
After the release of Custom Roles, roles should always be dynamically fetched. 
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
