### PR TITLE
fix(clerk-js): Prevent submitting on enter in Organization Profile form

### DIFF
--- a/.changeset/hot-ducks-wink.md
+++ b/.changeset/hot-ducks-wink.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Prevent submitting on enter in Organization Profile form when submit button is disabled.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileForm.tsx
@@ -39,7 +39,7 @@ export const ProfileForm = withCardStateProvider((props: ProfileFormProps) => {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    return (dataChanged ? organization.update({ name: nameField.value, slug: slugField.value }) : Promise.resolve())
+    return (canSubmit ? organization.update({ name: nameField.value, slug: slugField.value }) : Promise.resolve())
       .then(onSuccess)
       .catch(err => {
         handleError(err, [nameField, slugField], card.setError);


### PR DESCRIPTION
## Description
We still have a lot of places in clerk-js where we call `setError(undefined)` instead of `clearFeedback`
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
