### PR TITLE
fix(clerk-js): Clear feedback when `undefined` is passed to `setError` (#2399)

### DIFF
--- a/.changeset/thick-doors-smile.md
+++ b/.changeset/thick-doors-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Clear feedback of input field if `setError` is called with undefined.

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -106,6 +106,8 @@ export const useFormControl = <Id extends string>(
   const setError: FormControlState['setError'] = error => {
     if (error) {
       setFeedback({ message: translateError(error), type: 'error' });
+    } else {
+      clearFeedback();
     }
   };
   const setSuccess: FormControlState['setSuccess'] = message => {


### PR DESCRIPTION



## Description
We still have a lot of places in clerk-js where we call `setError(undefined)` instead of `clearFeedback`

(cherry picked from commit bf09d18d6408ac89f8b9207d05e0f3660d27a6cf)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
