### PR TITLE
feat(clerk-js,types): Support `redirectUrl` param in `Clerk.signtOut()` and `Clerk#afterSignOutUrl` property

### DIFF
--- a/.changeset/selfish-flies-care.md
+++ b/.changeset/selfish-flies-care.md
@@ -1,0 +1,18 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+Update `@clerk/clerk-js` and `@clerk/clerk-react` to support the following examples:
+
+```typescript
+Clerk.signOut({ redirectUrl: '/' })
+
+<SignOutButton redirectUrl='/' />
+// uses Clerk.signOut({ redirectUrl: '/' })
+<UserButton afterSignOutUrl='/after' />
+// uses Clerk.signOut({ redirectUrl: '/after' })
+<ClerkProvider afterSignOutUrl='/after' />
+// uses Clerk.signOut({ redirectUrl: '/after' })
+```

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -133,6 +133,7 @@ const defaultOptions: ClerkOptions = {
   signUpUrl: undefined,
   afterSignInUrl: undefined,
   afterSignUpUrl: undefined,
+  afterSignOutUrl: undefined,
 };
 
 export class Clerk implements ClerkInterface {
@@ -303,7 +304,7 @@ export class Clerk implements ClerkInterface {
     }
     const opts = callbackOrOptions && typeof callbackOrOptions === 'object' ? callbackOrOptions : options || {};
 
-    const redirectUrl = opts?.redirectUrl || '/';
+    const redirectUrl = opts?.redirectUrl || this.buildAfterSignOutUrl();
     const defaultCb = () => this.navigate(redirectUrl);
     const cb = typeof callbackOrOptions === 'function' ? callbackOrOptions : defaultCb;
 
@@ -761,6 +762,14 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(this.#options.afterSignUpUrl);
   }
 
+  public buildAfterSignOutUrl(): string {
+    if (!this.#options.afterSignOutUrl) {
+      return '/';
+    }
+
+    return this.buildUrlWithAuth(this.#options.afterSignOutUrl);
+  }
+
   public buildCreateOrganizationUrl(): string {
     if (!this.#environment || !this.#environment.displayConfig) {
       return '';
@@ -847,6 +856,13 @@ export class Clerk implements ClerkInterface {
   public redirectToAfterSignUp = async (): Promise<unknown> => {
     if (inBrowser()) {
       return this.navigate(this.buildAfterSignUpUrl());
+    }
+    return;
+  };
+
+  public redirectToAfterSignOut = async (): Promise<unknown> => {
+    if (inBrowser()) {
+      return this.navigate(this.buildAfterSignOutUrl());
     }
     return;
   };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -301,8 +301,11 @@ export class Clerk implements ClerkInterface {
     if (!this.client || this.client.sessions.length === 0) {
       return;
     }
-    const cb = typeof callbackOrOptions === 'function' ? callbackOrOptions : undefined;
     const opts = callbackOrOptions && typeof callbackOrOptions === 'object' ? callbackOrOptions : options || {};
+
+    const redirectUrl = opts?.redirectUrl || '/';
+    const defaultCb = () => this.navigate(redirectUrl);
+    const cb = typeof callbackOrOptions === 'function' ? callbackOrOptions : defaultCb;
 
     if (!opts.sessionId || this.client.activeSessions.length === 1) {
       await this.client.destroy();

--- a/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
@@ -59,10 +59,34 @@ describe('UserButton', () => {
         email_addresses: ['test@clerk.com'],
       });
     });
+
+    fixtures.clerk.signOut.mockImplementationOnce(callback => callback());
+
     const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
     await userEvent.click(getByRole('button', { name: 'Open user button' }));
     await userEvent.click(getByText('Sign out'));
-    expect(fixtures.clerk.signOut).toHaveBeenCalled();
+
+    expect(fixtures.router.navigate).toHaveBeenCalledWith('/');
+  });
+
+  it('redirects to afterSignOutUrl when "Sign out" is clicked and afterSignOutUrl prop is passed', async () => {
+    const { wrapper, fixtures, props } = await createFixtures(f => {
+      f.withUser({
+        first_name: 'First',
+        last_name: 'Last',
+        username: 'username1',
+        email_addresses: ['test@clerk.com'],
+      });
+    });
+
+    fixtures.clerk.signOut.mockImplementation(callback => callback());
+    props.setProps({ afterSignOutUrl: '/after-sign-out' });
+
+    const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
+    await userEvent.click(getByRole('button', { name: 'Open user button' }));
+    await userEvent.click(getByText('Sign out'));
+
+    expect(fixtures.router.navigate).toHaveBeenCalledWith('/after-sign-out');
   });
 
   it.todo('navigates to sign in url when "Add account" is clicked');

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -232,7 +232,7 @@ export const useUserButtonContext = () => {
   const afterMultiSessionSingleSignOutUrl = ctx.afterMultiSessionSingleSignOutUrl || displayConfig.afterSignOutOneUrl;
   const navigateAfterMultiSessionSingleSignOut = () => clerk.redirectWithAuth(afterMultiSessionSingleSignOutUrl);
 
-  const afterSignOutUrl = ctx.afterSignOutUrl || '/';
+  const afterSignOutUrl = ctx.afterSignOutUrl || clerk.buildAfterSignOutUrl();
   const navigateAfterSignOut = () => navigate(afterSignOutUrl);
 
   const afterSwitchSessionUrl = ctx.afterSwitchSessionUrl || displayConfig.afterSwitchSessionUrl;

--- a/packages/react/src/components/SignOutButton.tsx
+++ b/packages/react/src/components/SignOutButton.tsx
@@ -18,14 +18,7 @@ export const SignOutButton = withClerk(
     children = normalizeWithDefaultValue(children, 'Sign out');
     const child = assertSingleChild(children)('SignOutButton');
 
-    const navigateToRedirectUrl = () => {
-      return clerk.navigate(redirectUrl);
-    };
-
-    const clickHandler = () => {
-      return clerk.signOut(navigateToRedirectUrl, signOutOptions);
-    };
-
+    const clickHandler = () => clerk.signOut({ redirectUrl });
     const wrappedChildClickHandler: React.MouseEventHandler = async e => {
       await safeExecute((child as any).props.onClick)(e);
       return clickHandler();

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -75,6 +75,7 @@ type IsomorphicLoadedClerk = Without<
   | 'buildOrganizationProfileUrl'
   | 'buildAfterSignUpUrl'
   | 'buildAfterSignInUrl'
+  | 'buildAfterSignOutUrl'
   | 'buildUrlWithAuth'
   | 'handleRedirectCallback'
   | 'handleUnauthenticated'
@@ -115,6 +116,8 @@ type IsomorphicLoadedClerk = Without<
   buildAfterSignInUrl: () => string | void;
   // TODO: Align return type
   buildAfterSignUpUrl: () => string | void;
+  // TODO: Align return type
+  buildAfterSignOutUrl: () => string | void;
   // TODO: Align optional props
   mountUserButton: (node: HTMLDivElement, props: UserButtonProps) => void;
   mountOrganizationList: (node: HTMLDivElement, props: OrganizationListProps) => void;
@@ -275,6 +278,15 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return callback();
     } else {
       this.premountMethodCalls.set('buildAfterSignUpUrl', callback);
+    }
+  };
+
+  buildAfterSignOutUrl = (): string | void => {
+    const callback = () => this.clerkjs?.buildAfterSignOutUrl() || '';
+    if (this.clerkjs && this.#loaded) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('buildAfterSignOutUrl', callback);
     }
   };
 
@@ -832,6 +844,15 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       callback();
     } else {
       this.premountMethodCalls.set('redirectToAfterSignIn', callback);
+    }
+  };
+
+  redirectToAfterSignOut = (): void => {
+    const callback = () => this.clerkjs?.redirectToAfterSignOut();
+    if (this.clerkjs && this.#loaded) {
+      callback();
+    } else {
+      this.premountMethodCalls.set('redirectToAfterSignOut', callback);
     }
   };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -39,6 +39,10 @@ export type SignOutOptions = {
    * multi-session applications.
    */
   sessionId?: string;
+  /**
+   * Specify a redirect URL to navigate after sign out is complete.
+   */
+  redirectUrl?: string;
 };
 
 export interface SignOut {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -345,14 +345,19 @@ export interface Clerk {
   buildOrganizationProfileUrl(): string;
 
   /**
-   * Returns the configured afterSignIn url of the instance.
+   * Returns the configured afterSignInUrl of the instance.
    */
   buildAfterSignInUrl(): string;
 
   /**
-   * Returns the configured afterSignIn url of the instance.
+   * Returns the configured afterSignInUrl of the instance.
    */
   buildAfterSignUpUrl(): string;
+
+  /**
+   * Returns the configured afterSignOutUrl of the instance.
+   */
+  buildAfterSignOutUrl(): string;
 
   /**
    *
@@ -402,6 +407,11 @@ export interface Clerk {
   redirectToAfterSignUp: () => void;
 
   /**
+   * Redirects to the configured afterSignOut URL.
+   */
+  redirectToAfterSignOut: () => void;
+
+  /**
    * Completes an OAuth or SAML redirection flow started by
    * {@link Clerk.client.signIn.authenticateWithRedirect} or {@link Clerk.client.signUp.authenticateWithRedirect}
    */
@@ -439,17 +449,7 @@ export interface Clerk {
   handleUnauthenticated: () => Promise<unknown>;
 }
 
-export type HandleOAuthCallbackParams = {
-  /**
-   * Full URL or path to navigate after successful sign up.
-   */
-  afterSignUpUrl?: string | null;
-
-  /**
-   * Full URL or path to navigate after successful sign in.
-   */
-  afterSignInUrl?: string | null;
-
+export type HandleOAuthCallbackParams = AfterActionURLs & {
   /**
    * Full URL or path to navigate after successful sign in
    * or sign up.
@@ -517,35 +517,34 @@ type ClerkOptionsNavigation = ClerkOptionsNavigationFn & {
   routerDebug?: boolean;
 };
 
-export type ClerkOptions = ClerkOptionsNavigation & {
-  appearance?: Appearance;
-  localization?: LocalizationResource;
-  polling?: boolean;
-  selectInitialSession?: (client: ClientResource) => ActiveSessionResource | null;
-  /** Controls if ClerkJS will load with the standard browser setup using Clerk cookies */
-  standardBrowser?: boolean;
-  /** Optional support email for display in authentication screens */
-  supportEmail?: string;
-  touchSession?: boolean;
-  signInUrl?: string;
-  signUpUrl?: string;
-  afterSignInUrl?: string;
-  afterSignUpUrl?: string;
-  allowedRedirectOrigins?: Array<string | RegExp>;
-  isSatellite?: boolean | ((url: URL) => boolean);
+export type ClerkOptions = ClerkOptionsNavigation &
+  AfterActionURLs & {
+    appearance?: Appearance;
+    localization?: LocalizationResource;
+    polling?: boolean;
+    selectInitialSession?: (client: ClientResource) => ActiveSessionResource | null;
+    /** Controls if ClerkJS will load with the standard browser setup using Clerk cookies */
+    standardBrowser?: boolean;
+    /** Optional support email for display in authentication screens */
+    supportEmail?: string;
+    touchSession?: boolean;
+    signInUrl?: string;
+    signUpUrl?: string;
+    allowedRedirectOrigins?: Array<string | RegExp>;
+    isSatellite?: boolean | ((url: URL) => boolean);
 
-  /**
-   * Telemetry options
-   */
-  telemetry?:
-    | false
-    | {
-        disabled?: boolean;
-        debug?: boolean;
-      };
+    /**
+     * Telemetry options
+     */
+    telemetry?:
+      | false
+      | {
+          disabled?: boolean;
+          debug?: boolean;
+        };
 
-  sdkMetadata?: SDKMetadata;
-};
+    sdkMetadata?: SDKMetadata;
+  };
 
 export interface NavigateOptions {
   replace?: boolean;
@@ -576,7 +575,7 @@ export type SignUpInitialValues = {
   username?: string;
 };
 
-export type RedirectOptions = {
+type AfterActionURLs = {
   /**
    * Full URL or path to navigate after successful sign in.
    */
@@ -588,6 +587,13 @@ export type RedirectOptions = {
    */
   afterSignUpUrl?: string | null;
 
+  /**
+   * Full URL or path to navigate after successful sign out.
+   */
+  afterSignOutUrl?: string | null;
+};
+
+export type RedirectOptions = AfterActionURLs & {
   /**
    * Full URL or path to navigate after successful sign in,
    * or sign up.


### PR DESCRIPTION
## Description

Support the examples below:

```typescript
Clerk.signOut({ redirectUrl: '/' })

<SignOutButton redirectUrl='/' />
// uses Clerk.signOut({ redirectUrl: '/' })
<UserButton afterSignOutUrl='/after' />
// uses Clerk.signOut({ redirectUrl: '/after' })
<ClerkProvider afterSignOutUrl='/after' />
// uses Clerk.signOut({ redirectUrl: '/after' })
```

## Checklist

- [ ] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
