### PR TITLE
Fix backend error message details

### DIFF
--- a/.changeset/lucky-snails-help.md
+++ b/.changeset/lucky-snails-help.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fixed a bug where backend API responses where missing error details. This was caused by parsing the errors twice once in the response error handling code and again when initializing the ClerkAPIResponseError.

--- a/packages/backend/src/api/factory.test.ts
+++ b/packages/backend/src/api/factory.test.ts
@@ -150,7 +150,14 @@ export default (QUnit: QUnit) => {
     });
 
     test('executes a failed backend API request and parses the error response', async assert => {
-      const mockErrorPayload = { code: 'whatever_error', message: 'whatever error', meta: {} };
+      const mockErrorPayload = {
+        code: 'whatever_error',
+        message: 'whatever error',
+        long_message: 'some long message',
+        meta: {
+          param_name: 'whatever_param',
+        },
+      };
       const traceId = 'trace_id_123';
       fakeFetch = sinon.stub(runtime, 'fetch');
       fakeFetch.onCall(0).returns(jsonNotOk({ errors: [mockErrorPayload], clerk_trace_id: traceId }));
@@ -162,6 +169,9 @@ export default (QUnit: QUnit) => {
         assert.equal(e.clerkError, true);
         assert.equal(e.status, 422);
         assert.equal(e.errors[0].code, 'whatever_error');
+        assert.equal(e.errors[0].message, 'whatever error');
+        assert.equal(e.errors[0].longMessage, 'some long message');
+        assert.equal(e.errors[0].meta.paramName, 'whatever_param');
       }
 
       assert.ok(


### PR DESCRIPTION
## Description

This was caused by API errors being parsed twice. Once in the response  error handling code and again when initializing a new `ClerkAPIResponseError`. 

This is was fixed in v5 with the removal of `ClerkAPIResponseError`. 

`ClerkAPIResponseError` is also used by clerk-js the change was to the backend package.        

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
