### PR TITLE
Parse backend errors that don't throw exceptions.

### DIFF
--- a/.changeset/rude-deers-fetch.md
+++ b/.changeset/rude-deers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fixed an issue where errors returned from backend api requests are not converted to camelCase.

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -187,7 +187,12 @@ export default (QUnit: QUnit) => {
     });
 
     test('executes a failed backend API request and parses the error response', async assert => {
-      const mockErrorPayload = { code: 'whatever_error', message: 'whatever error', meta: {} };
+      const mockErrorPayload = {
+        code: 'whatever_error',
+        message: 'whatever error',
+        long_message: 'some long message',
+        meta: { param_name: 'some param' },
+      };
       const traceId = 'trace_id_123';
       fakeFetch = sinon.stub(runtime, 'fetch');
       fakeFetch.onCall(0).returns(jsonNotOk({ errors: [mockErrorPayload], clerk_trace_id: traceId }));
@@ -199,6 +204,9 @@ export default (QUnit: QUnit) => {
       assert.equal(response.status, 422);
       assert.equal(response.statusText, '422');
       assert.equal(response.errors[0].code, 'whatever_error');
+      assert.equal(response.errors[0].message, 'whatever error');
+      assert.equal(response.errors[0].longMessage, 'some long message');
+      assert.equal(response.errors[0].meta.paramName, 'some param');
 
       assert.ok(
         fakeFetch.calledOnceWith('https://api.clerk.test/v1/users/user_deadbeef', {

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -114,7 +114,7 @@ export function buildRequest(options: BuildRequestOptions) {
       if (!res.ok) {
         return {
           data: null,
-          errors: responseBody?.errors || responseBody,
+          errors: parseErrors(responseBody),
           status: res?.status,
           statusText: res?.statusText,
           clerkTraceId: getTraceId(responseBody, res?.headers),


### PR DESCRIPTION
## Description

This PR fixes an issue where errors returned from backend api requests are not converted to camelCase.

<img width="601" alt="Screenshot 2023-12-19 at 2 03 12 PM" src="https://github.com/clerk/javascript/assets/9081019/e51d4f95-26f0-4538-8fc2-d782ed2895b5">

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
