### PR TITLE
chore(clerk-js,shared,nextjs): Support `__clerk_db_jwt` and `__dev_session` query params

### DIFF
--- a/.changeset/chatty-insects-run.md
+++ b/.changeset/chatty-insects-run.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/nextjs': minor
+'@clerk/shared': minor
+---
+
+Support reading from `__clerk_db_jwt` and `__dev_session` the dev browser jwt in development

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -12,6 +12,7 @@ import {
   noop,
   parsePublishableKey,
   proxyUrlToAbsoluteURL,
+  setDevBrowserJWTInURL,
   stripScheme,
 } from '@clerk/shared';
 import type {
@@ -84,7 +85,6 @@ import {
   removeClerkQueryParam,
   requiresUserInput,
   sessionExistsAndSingleSessionModeEnabled,
-  setDevBrowserJWTInURL,
   stripOrigin,
   stripSameOrigin,
   toURL,

--- a/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
@@ -1,30 +1,6 @@
-import { getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
+import { getDevBrowserJWTFromURL } from '../devBrowser';
 
 const DUMMY_URL_BASE = 'http://clerk-dummy';
-
-describe('setDevBrowserJWTInURL(url, jwt)', () => {
-  const testCases: Array<[string, string, boolean, string]> = [
-    ['', 'deadbeef', false, '#__clerk_db_jwt[deadbeef]'],
-    ['foo', 'deadbeef', false, 'foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
-    ['#foo', 'deadbeef', false, '#foo__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
-    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
-    ['/foo', 'deadbeef', true, '/foo?__dev_session=deadbeef'],
-    ['/foo?bar=42', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
-  ];
-
-  test.each(testCases)(
-    'sets the dev browser JWT at the end of the provided url. Params: url=(%s), jwt=(%s), expected url=(%s)',
-    (input, paramName, asQueryParam, expected) => {
-      expect(setDevBrowserJWTInURL(new URL(input, DUMMY_URL_BASE), paramName, asQueryParam).href).toEqual(
-        new URL(expected, DUMMY_URL_BASE).href,
-      );
-    },
-  );
-});
-
 const oldHistory = globalThis.history;
 
 describe('getDevBrowserJWTFromURL(url,)', () => {

--- a/packages/clerk-js/src/utils/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/utils/cookies/devBrowser.ts
@@ -1,5 +1,4 @@
+import { DEV_BROWSER_JWT_MARKER } from '@clerk/shared';
 import { createCookieHandler } from '@clerk/shared/cookie';
-
-import { DEV_BROWSER_JWT_MARKER } from '../devBrowser';
 
 export const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_MARKER);

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -1,6 +1,7 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import type { AuthObject, RequestState } from '@clerk/backend';
 import { buildRequestUrl, constants } from '@clerk/backend';
+import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from '@clerk/shared/devBrowser';
 import type Link from 'next/link';
 import type { NextFetchEvent, NextMiddleware, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -9,7 +10,6 @@ import { isRedirect, mergeResponses, paths, setHeader, stringifyHeaders } from '
 import { withLogger } from '../utils/debugLogger';
 import { authenticateRequest, handleInterstitialState, handleUnknownState } from './authenticateRequest';
 import { SECRET_KEY } from './clerkClient';
-import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from './devBrowser';
 import {
   clockSkewDetected,
   infiniteRedirectLoopDetected,

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -4,6 +4,7 @@ color
 cookie
 date
 deprecated
+devBrowser
 error
 file
 globs

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,6 +51,7 @@
     "cookie",
     "date",
     "deprecated",
+    "devBrowser",
     "error",
     "file",
     "globs",

--- a/packages/shared/src/__tests__/devbrowser.test.ts
+++ b/packages/shared/src/__tests__/devbrowser.test.ts
@@ -13,6 +13,8 @@ describe('setDevBrowserJWTInURL(url, jwt)', () => {
     ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
     ['/foo', 'deadbeef', true, '/foo?__dev_session=deadbeef'],
     ['/foo?bar=42', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
+    ['/foo?bar=42&__clerk_db_jwt=deadbeef', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
+    ['/foo?bar=42&__dev_session=deadbeef', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
   ];
 
   test.each(testCases)(

--- a/packages/shared/src/__tests__/devbrowser.test.ts
+++ b/packages/shared/src/__tests__/devbrowser.test.ts
@@ -1,0 +1,26 @@
+import { setDevBrowserJWTInURL } from '../devBrowser';
+
+const DUMMY_URL_BASE = 'http://clerk-dummy';
+
+describe('setDevBrowserJWTInURL(url, jwt)', () => {
+  const testCases: Array<[string, string, boolean, string]> = [
+    ['', 'deadbeef', false, '#__clerk_db_jwt[deadbeef]'],
+    ['foo', 'deadbeef', false, 'foo#__clerk_db_jwt[deadbeef]'],
+    ['/foo', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
+    ['#foo', 'deadbeef', false, '#foo__clerk_db_jwt[deadbeef]'],
+    ['/foo?bar=42#qux', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
+    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+    ['/foo', 'deadbeef', true, '/foo?__dev_session=deadbeef'],
+    ['/foo?bar=42', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
+  ];
+
+  test.each(testCases)(
+    'sets the dev browser JWT at the end of the provided url. Params: url=(%s), jwt=(%s), expected url=(%s)',
+    (input, paramName, asQueryParam, expected) => {
+      expect(setDevBrowserJWTInURL(new URL(input, DUMMY_URL_BASE), paramName, asQueryParam).href).toEqual(
+        new URL(expected, DUMMY_URL_BASE).href,
+      );
+    },
+  );
+});

--- a/packages/shared/src/devBrowser.ts
+++ b/packages/shared/src/devBrowser.ts
@@ -1,12 +1,4 @@
-// TODO: This is a partial duplicate of part of packages/clerk-js/src/utils/devBrowser.ts
-// TODO: To be removed when we can extract this utility to @clerk/shared
-
 export const DEV_BROWSER_SSO_JWT_PARAMETER = '__dev_session';
-
-//
-// Below this line should be identical to clerk-js version
-//
-
 export const DEV_BROWSER_JWT_MARKER = '__clerk_db_jwt';
 const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
 
@@ -14,17 +6,8 @@ const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
 export function setDevBrowserJWTInURL(url: URL, jwt: string, asQueryParam: boolean): URL {
   const resultURL = new URL(url);
 
-  // extract & strip existing jwt from hash
-  const jwtFromHash = extractDevBrowserJWTFromHash(resultURL.hash);
-  resultURL.hash = resultURL.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
-  if (resultURL.href.endsWith('#')) {
-    resultURL.hash = '';
-  }
-
-  // extract & strip existing jwt from search
-  const jwtFromSearch = resultURL.searchParams.get(DEV_BROWSER_SSO_JWT_PARAMETER);
-  resultURL.searchParams.delete(DEV_BROWSER_SSO_JWT_PARAMETER);
-
+  const jwtFromHash = extractDevBrowserJWTFromURLHash(resultURL);
+  const jwtFromSearch = extractDevBrowserJWTFromURLSearchParams(resultURL);
   // Existing jwt takes precedence
   const jwtToSet = jwtFromHash || jwtFromSearch || jwt;
 
@@ -42,4 +25,29 @@ export function setDevBrowserJWTInURL(url: URL, jwt: string, asQueryParam: boole
 function extractDevBrowserJWTFromHash(hash: string): string {
   const matches = hash.match(DEV_BROWSER_JWT_MARKER_REGEXP);
   return matches ? matches[1] : '';
+}
+
+/**
+ * Extract & strip existing jwt from hash
+ * Side effect: Removes dev browser from the url hash
+ **/
+export function extractDevBrowserJWTFromURLHash(url: URL) {
+  const jwt = extractDevBrowserJWTFromHash(url.hash);
+  url.hash = url.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
+  if (url.href.endsWith('#')) {
+    url.hash = '';
+  }
+
+  return jwt;
+}
+
+/**
+ * Extract & strip existing jwt from search params
+ * Side effect: Removes dev browser from the search params
+ **/
+export function extractDevBrowserJWTFromURLSearchParams(url: URL) {
+  const jwtFromDevSession = url.searchParams.get(DEV_BROWSER_SSO_JWT_PARAMETER);
+  url.searchParams.delete(DEV_BROWSER_SSO_JWT_PARAMETER);
+
+  return jwtFromDevSession || '';
 }

--- a/packages/shared/src/devBrowser.ts
+++ b/packages/shared/src/devBrowser.ts
@@ -49,5 +49,8 @@ export function extractDevBrowserJWTFromURLSearchParams(url: URL) {
   const jwtFromDevSession = url.searchParams.get(DEV_BROWSER_SSO_JWT_PARAMETER);
   url.searchParams.delete(DEV_BROWSER_SSO_JWT_PARAMETER);
 
-  return jwtFromDevSession || '';
+  const jwtFromClerkDbJwt = url.searchParams.get(DEV_BROWSER_JWT_MARKER);
+  url.searchParams.delete(DEV_BROWSER_JWT_MARKER);
+
+  return jwtFromDevSession || jwtFromClerkDbJwt || '';
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,12 +10,12 @@
 
 export * from './utils';
 
-export { createWorkerTimers } from './workerTimers';
 export * from './browser';
 export { callWithRetry } from './callWithRetry';
 export * from './color';
 export * from './date';
 export * from './deprecated';
+export * from './devBrowser';
 export * from './error';
 export * from './file';
 export { handleValueOrFn } from './handleValueOrFn';
@@ -27,3 +27,4 @@ export * from './poller';
 export * from './proxy';
 export * from './underscore';
 export * from './url';
+export { createWorkerTimers } from './workerTimers';

--- a/packages/shared/subpaths.mjs
+++ b/packages/shared/subpaths.mjs
@@ -8,6 +8,7 @@ export const subpathNames = [
   'cookie',
   'date',
   'deprecated',
+  'devBrowser',
   'error',
   'file',
   'globs',


### PR DESCRIPTION
## Description

Support reading from `__clerk_db_jwt` and `__dev_session` query param the dev browser jwt. This is a preparation step to support Account Portal with v5 version.

2 more PRs will follow:
- in AP to bump to this `@clerk/nextjs` version
- in ClerkJS to replace `__dev_session` with `__clerk_db_jwt`

REVIEW IT PER COMMIT

SDK-746

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
