### PR TITLE
fix(clerk-js): Fetching custom role in OrganizationSwitcher  with cache

### DIFF
--- a/.changeset/two-crews-talk.md
+++ b/.changeset/two-crews-talk.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: fetch custom roles in OrganizationSwitcher

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainForm.tsx
@@ -19,7 +19,7 @@ export const RemoveDomainForm = (props: RemoveDomainFormProps) => {
   const { domainId: id, onSuccess, onReset } = props;
 
   const ref = React.useRef<OrganizationDomainResource>();
-  const { data: domain, status: domainStatus } = useFetch(
+  const { data: domain, isLoading: domainIsLoading } = useFetch(
     organization?.getDomain,
     {
       domainId: id,
@@ -41,7 +41,7 @@ export const RemoveDomainForm = (props: RemoveDomainFormProps) => {
     return null;
   }
 
-  if (domainStatus.isLoading || !domain) {
+  if (domainIsLoading || !domain) {
     return (
       <Flex
         direction={'row'}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainForm.tsx
@@ -17,7 +17,7 @@ import { handleError, useFormControl } from '../../utils';
 import { OrganizationProfileBreadcrumbs } from './OrganizationProfileNavbar';
 
 const useCalloutLabel = (
-  domain: OrganizationDomainResource | null,
+  domain: OrganizationDomainResource | undefined | null,
   {
     infoLabel: infoLabelKey,
   }: {
@@ -114,7 +114,7 @@ export const VerifiedDomainForm = withCardStateProvider((props: VerifiedDomainFo
     type: 'checkbox',
   });
 
-  const { data: domain, status: domainStatus } = useFetch(
+  const { data: domain, isLoading: domainIsLoading } = useFetch(
     organization?.getDomain,
     {
       domainId: id,
@@ -161,7 +161,7 @@ export const VerifiedDomainForm = withCardStateProvider((props: VerifiedDomainFo
     return null;
   }
 
-  if (domainStatus.isLoading || !domain) {
+  if (domainIsLoading || !domain) {
     return (
       <Flex
         direction={'row'}
@@ -229,7 +229,7 @@ export const VerifiedDomainForm = withCardStateProvider((props: VerifiedDomainFo
 
           <FormButtons
             localizationKey={localizationKeys('organizationProfile.verifiedDomainPage.enrollmentTab.formButton__save')}
-            isDisabled={domainStatus.isLoading || !domain || !isFormDirty}
+            isDisabled={domainIsLoading || !domain || !isFormDirty}
             onReset={onReset}
           />
         </Form.Root>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifyDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifyDomainForm.tsx
@@ -29,7 +29,7 @@ export const VerifyDomainForm = withCardStateProvider((props: VerifyDomainFormPr
   const { organizationSettings } = useEnvironment();
   const { organization } = useOrganization();
 
-  const { data: domain, status: domainStatus } = useFetch(organization?.getDomain, {
+  const { data: domain, isLoading: domainIsLoading } = useFetch(organization?.getDomain, {
     domainId: id,
   });
   const title = localizationKeys('organizationProfile.verifyDomainPage.title');
@@ -108,7 +108,7 @@ export const VerifyDomainForm = withCardStateProvider((props: VerifyDomainFormPr
       });
   };
 
-  if (domainStatus.isLoading || !domain) {
+  if (domainIsLoading || !domain) {
     return (
       <Flex
         direction={'row'}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -182,7 +182,6 @@ describe('OrganizationMembers', () => {
       }),
     );
 
-    // fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     fixtures.clerk.organization?.getRoles.mockResolvedValue({
       total_count: 2,
       data: [

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 
 import { render } from '../../../../testUtils';
+import { clearFetchCache } from '../../../hooks/useFetch';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { OrganizationMembers } from '../OrganizationMembers';
 import { createFakeMember, createFakeOrganizationInvitation, createFakeOrganizationMembershipRequest } from './utils';
@@ -15,6 +16,13 @@ async function waitForLoadingCompleted(container: HTMLElement) {
 }
 
 describe('OrganizationMembers', () => {
+  /**
+   * `<OrganizationMembers/>` internally uses useFetch which caches the results, be sure to clear the cache before each test
+   */
+  beforeEach(() => {
+    clearFetchCache();
+  });
+
   it('renders the Organization Members page', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
@@ -174,6 +182,7 @@ describe('OrganizationMembers', () => {
       }),
     );
 
+    // fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
     fixtures.clerk.organization?.getRoles.mockResolvedValue({
       total_count: 2,
       data: [

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -146,6 +146,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
             elementId={'organizationSwitcherActiveOrganization'}
             organization={currentOrg}
             user={user}
+            fetchRoles
             mainIdentifierVariant='buttonLarge'
             sx={t => ({
               padding: `${t.space.$4} ${t.space.$5}`,
@@ -178,6 +179,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
             elementId={'organizationSwitcherActiveOrganization'}
             organization={currentOrg}
             user={user}
+            fetchRoles
             mainIdentifierVariant='buttonLarge'
             sx={t => ({
               padding: `${t.space.$4} ${t.space.$5}`,

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -43,6 +43,7 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
             elementId={'organizationSwitcherTrigger'}
             gap={3}
             size='xs'
+            fetchRoles
             organization={organization}
             sx={t => ({ maxWidth: '30ch', color: t.colors.$blackAlpha600 })}
           />

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -56,6 +56,7 @@ describe('OrganizationSwitcher', () => {
         });
       });
 
+      fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
       fixtures.clerk.user?.getOrganizationInvitations.mockReturnValueOnce(
         Promise.resolve({
           data: [],

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -38,9 +38,9 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
   } = props;
 
   const { localizeCustomRole } = useLocalizeCustomRoles();
-  const membership = user?.organizationMemberships.find(membership => membership.organization.id === organization.id);
-
   const { options } = useFetchRoles(fetchRoles);
+
+  const membership = user?.organizationMemberships.find(membership => membership.organization.id === organization.id);
   const unlocalizedRoleLabel = options?.find(a => a.value === membership?.role)?.label;
 
   const mainTextSize =

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -2,8 +2,8 @@ import type { OrganizationPreviewId, UserOrganizationInvitationResource, UserRes
 import React from 'react';
 
 import { descriptors, Flex, Text } from '../customizables';
+import { useFetchRoles, useLocalizeCustomRoles } from '../hooks/useFetchRoles';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
-import { roleLocalizationKey } from '../utils';
 import { OrganizationAvatar } from './OrganizationAvatar';
 
 export type OrganizationPreviewProps = Omit<PropsOfComponent<typeof Flex>, 'elementId'> & {
@@ -34,7 +34,12 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
     elementId,
     ...rest
   } = props;
-  const role = user?.organizationMemberships.find(membership => membership.organization.id === organization.id)?.role;
+
+  const { localizeCustomRole } = useLocalizeCustomRoles();
+  const membership = user?.organizationMemberships.find(membership => membership.organization.id === organization.id);
+
+  const { options } = useFetchRoles();
+  const unlocalizedRoleLabel = options?.find(a => a.value === membership?.role)?.label;
 
   const mainTextSize =
     mainIdentifierVariant || ({ xs: 'subtitle', sm: 'caption', md: 'subtitle', lg: 'h1' } as const)[size];
@@ -84,7 +89,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
           <Text
             elementDescriptor={descriptors.organizationPreviewSecondaryIdentifier}
             elementId={descriptors.organizationPreviewSecondaryIdentifier.setId(elementId)}
-            localizationKey={role && roleLocalizationKey(role)}
+            localizationKey={localizeCustomRole(membership?.role) || unlocalizedRoleLabel}
             colorScheme='neutral'
             truncate
           />

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -17,6 +17,7 @@ export type OrganizationPreviewProps = Omit<PropsOfComponent<typeof Flex>, 'elem
   badge?: React.ReactNode;
   rounded?: boolean;
   elementId?: OrganizationPreviewId;
+  fetchRoles?: boolean;
 };
 
 export const OrganizationPreview = (props: OrganizationPreviewProps) => {
@@ -25,6 +26,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
     size = 'md',
     icon,
     rounded = false,
+    fetchRoles = false,
     badge,
     sx,
     user,
@@ -38,7 +40,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
   const { localizeCustomRole } = useLocalizeCustomRoles();
   const membership = user?.organizationMemberships.find(membership => membership.organization.id === organization.id);
 
-  const { options } = useFetchRoles();
+  const { options } = useFetchRoles(fetchRoles);
   const unlocalizedRoleLabel = options?.find(a => a.value === membership?.role)?.label;
 
   const mainTextSize =

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -15,10 +15,20 @@ export interface Cache<Data = any> {
   set(key: string, value: State<Data>): void;
 
   delete(key: string): void;
+
+  clear(): void;
 }
 
-const map = new WeakMap<Cache, State>();
+let requestCache = new WeakMap<Cache, State>();
 const subscribers = new Set<() => void>();
+
+/**
+ * This utility should only be used in tests to clear previously fetched data
+ */
+export const clearFetchCache = () => {
+  requestCache = new WeakMap<Cache, State>();
+};
+
 const useCache = (
   param: any,
 ): {
@@ -26,12 +36,10 @@ const useCache = (
   set: (state: State) => void;
   subscribe: (callback: () => void) => () => void;
 } => {
-  // const subscribers = useRef(new Set<() => void>());
-
-  const get = useCallback(() => map.get(param), [param]);
+  const get = useCallback(() => requestCache.get(param), [param]);
   const set = useCallback(
     (data: State) => {
-      map.set(param, data);
+      requestCache.set(param, data);
       subscribers.forEach(callback => callback());
     },
     [param],

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -1,7 +1,52 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { useLoadingStatus } from './useLoadingStatus';
-import { useSafeState } from './useSafeState';
+export type State<Data = any, Error = any> = {
+  data?: Data;
+  error?: Error;
+  isLoading?: boolean;
+  cachedAt?: number;
+};
+
+export interface Cache<Data = any> {
+  keys(): IterableIterator<string>;
+
+  get(key: string): State<Data> | undefined;
+
+  set(key: string, value: State<Data>): void;
+
+  delete(key: string): void;
+}
+
+const map = new WeakMap<Cache, State>();
+const subscribers = new Set<() => void>();
+const useCache = (
+  param: any,
+): {
+  get: <T>() => State<T> | undefined;
+  set: (state: State) => void;
+  subscribe: (callback: () => void) => () => void;
+} => {
+  // const subscribers = useRef(new Set<() => void>());
+
+  const get = useCallback(() => map.get(param), [param]);
+  const set = useCallback(
+    (data: State) => {
+      map.set(param, data);
+      subscribers.forEach(callback => callback());
+    },
+    [param],
+  );
+  const subscribe = useCallback((callback: () => void) => {
+    subscribers.add(callback);
+    return () => subscribers.delete(callback);
+  }, []);
+
+  return {
+    get,
+    set,
+    subscribe,
+  };
+};
 
 export const useFetch = <T>(
   fetcher: ((...args: any) => Promise<T>) | undefined,
@@ -10,35 +55,63 @@ export const useFetch = <T>(
     onSuccess?: (data: T) => void;
   },
 ) => {
-  const [data, setData] = useSafeState<T | null>(null);
-  const requestStatus = useLoadingStatus({
-    status: 'loading',
-  });
+  const cache = useCache(params);
 
+  const [state, setState] = useState(cache.get<T>());
   const fetcherRef = useRef(fetcher);
+
+  useEffect(() => {
+    const unsub = cache.subscribe(() => {
+      setState(cache.get<T>());
+    });
+    return () => unsub();
+  }, [cache.subscribe]);
 
   useEffect(() => {
     if (!fetcherRef.current) {
       return;
     }
-    requestStatus.setLoading();
+
+    // Only fetch stale data
+    if (Date.now() - (cache.get()?.cachedAt || 0) < 20000) {
+      return;
+    }
+
+    // No parallel requests for the same resource
+    if (cache.get()?.isLoading) {
+      return;
+    }
+
+    cache.set({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
     fetcherRef
       .current(params)
       .then(result => {
-        requestStatus.setIdle();
         if (typeof result !== 'undefined') {
-          setData(typeof result === 'object' ? { ...result } : result);
-          callbacks?.onSuccess?.(typeof result === 'object' ? { ...result } : result);
+          const data = typeof result === 'object' ? { ...result } : result;
+          cache.set({
+            data,
+            isLoading: false,
+            error: null,
+            cachedAt: Date.now(),
+          });
+          callbacks?.onSuccess?.(data);
         }
       })
       .catch(() => {
-        requestStatus.setError();
-        setData(null);
+        cache.set({
+          data: null,
+          isLoading: false,
+          error: true,
+          cachedAt: Date.now(),
+        });
       });
-  }, [JSON.stringify(params)]);
+  }, [JSON.stringify(params), cache.set, cache.get]);
 
   return {
-    status: requestStatus,
-    data,
+    ...state,
   };
 };

--- a/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
@@ -13,10 +13,10 @@ const getRolesParams = {
 };
 export const useFetchRoles = () => {
   const { organization } = useOrganization();
-  const { data, status } = useFetch(organization?.getRoles, getRolesParams);
+  const { data, isLoading } = useFetch(organization?.getRoles, getRolesParams);
 
   return {
-    isLoading: status.isLoading,
+    isLoading,
     options: data?.data?.map(role => ({ value: role.key, label: role.name })),
   };
 };

--- a/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetchRoles.ts
@@ -11,9 +11,9 @@ const getRolesParams = {
    */
   pageSize: 20,
 };
-export const useFetchRoles = () => {
+export const useFetchRoles = (enabled = true) => {
   const { organization } = useOrganization();
-  const { data, isLoading } = useFetch(organization?.getRoles, getRolesParams);
+  const { data, isLoading } = useFetch(enabled ? organization?.getRoles : undefined, getRolesParams);
 
   return {
     isLoading,


### PR DESCRIPTION
## Description

### Problem
In order to display a custom role we need to fetch them, so far we didn't have a robust way of fetching resources in clerk-js. A while back i had implemented `useFetch`, today I'm extending it in order to use a cache in order to fetch and share resources across components more efficiently.

### Before
When a component need to display the custom roles we had to fetch those each time the component was mounted.

### After
We fetch the resource once, other subscribers will not trigger a refetch unless the data is stale (in cache for 2 mins).

### Goal
The goal of this PR is to provide a good enough fix for the issue with an efficient solution. This is a bug in v4 as well, and a simple solution is better when backporting is necessary. If we think this solution is limiting, we should consider migrating to swr as its bundlesize is minimal and much more robust.



For tests:
- We need to clear cache before each test
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
