### PR TITLE
chore(clerk-js,clerk-react): Revert change to support ClerkJS@v3 in Account Portal with latest @clerk/nextjs

### DIFF
--- a/.changeset/tough-cherries-smoke.md
+++ b/.changeset/tough-cherries-smoke.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+---
+
+Fix support of Clerk@v3 instance from `<ClerkProvider />`

--- a/integration/testUtils/appPageObject.ts
+++ b/integration/testUtils/appPageObject.ts
@@ -32,7 +32,7 @@ export const createAppPageObject = (testArgs: { page: Page }, app: Application) 
     waitForClerkJsLoaded: async () => {
       return page.waitForFunction(() => {
         // @ts-ignore
-        return window.Clerk?.loaded;
+        return window.Clerk?.isReady();
       });
     },
     waitForClerkComponentMounted: async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -173,7 +173,7 @@ export default class Clerk implements ClerkInterface {
   #environment?: EnvironmentResource | null;
   #fapiClient: FapiClient;
   #instanceType: InstanceType;
-  #loaded = false;
+  #isReady = false;
 
   /**
    * @deprecated Although this being a private field, this is a reminder to drop it with the next major release
@@ -200,7 +200,7 @@ export default class Clerk implements ClerkInterface {
   }
 
   get loaded(): boolean {
-    return this.#loaded;
+    return this.#isReady;
   }
 
   get isSatellite(): boolean {
@@ -319,13 +319,10 @@ export default class Clerk implements ClerkInterface {
 
   public getFapiClient = (): FapiClient => this.#fapiClient;
 
-  public isReady = (): boolean => {
-    deprecated('Clerk.isReady()', 'Use `Clerk.loaded` instead.');
-    return this.#loaded;
-  };
+  public isReady = (): boolean => this.#isReady;
 
   public load = async (options?: ClerkOptions): Promise<void> => {
-    if (this.#loaded) {
+    if (this.#isReady) {
       return;
     }
 
@@ -335,9 +332,9 @@ export default class Clerk implements ClerkInterface {
     };
 
     if (this.#options.standardBrowser) {
-      this.#loaded = await this.#loadInStandardBrowser();
+      this.#isReady = await this.#loadInStandardBrowser();
     } else {
-      this.#loaded = await this.#loadInNonStandardBrowser();
+      this.#isReady = await this.#loadInNonStandardBrowser();
     }
   };
 
@@ -952,7 +949,7 @@ export default class Clerk implements ClerkInterface {
     params: HandleOAuthCallbackParams = {},
     customNavigate?: (to: string) => Promise<unknown>,
   ): Promise<unknown> => {
-    if (!this.loaded || !this.#environment || !this.client) {
+    if (!this.#isReady || !this.#environment || !this.client) {
       return;
     }
     const { signIn, signUp } = this.client;
@@ -1622,7 +1619,7 @@ export default class Clerk implements ClerkInterface {
   };
 
   #buildUrl = (key: 'signInUrl' | 'signUpUrl', options?: SignInRedirectOptions | SignUpRedirectOptions): string => {
-    if (!this.loaded || !this.#environment || !this.#environment.displayConfig) {
+    if (!this.#isReady || !this.#environment || !this.#environment.displayConfig) {
       return '';
     }
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -363,7 +363,7 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
           // Otherwise use the instantiated Clerk object
           c = this.Clerk;
 
-          if (!c.loaded) {
+          if (!c.isReady()) {
             await c.load(this.options);
           }
         }
@@ -390,7 +390,7 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
 
       global.Clerk.sdkMetadata = this.options.sdkMetadata ?? { name: PACKAGE_NAME, version: PACKAGE_VERSION };
 
-      if (global.Clerk?.loaded) {
+      if (global.Clerk?.loaded || global.Clerk?.isReady()) {
         return this.hydrateClerkJS(global.Clerk);
       }
       return;


### PR DESCRIPTION

## Description

This reverts commit a624798102236f77a667d8da13363b77486640f8.

Using a `Clerk@v3` instance in `IsomorphichClerk` of `@clerk/clerk-react@v4` was failing to render the components because the latest v4 `IsomorphicClerk` depends on `Clerk.loaded` and Clerk@v3 does not have that property defined.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
