### PR TITLE
fix(shared): Disable telemetry collection from browsers controlled via automation

### DIFF
--- a/.changeset/happy-dolls-taste.md
+++ b/.changeset/happy-dolls-taste.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Disable telemetry collection when window.navigator.webdriver is defined, indicating traffic from an automation tool.

--- a/packages/shared/src/telemetry/collector.ts
+++ b/packages/shared/src/telemetry/collector.ts
@@ -91,6 +91,13 @@ export class TelemetryCollector {
       return false;
     }
 
+    // navigator.webdriver is a property generally set by headless browsers that are running in an automated testing environment.
+    // Data from these environments is not meaningful for us and has the potential to produce a large volume of events, so we disable
+    // collection in this case. (ref: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver)
+    if (typeof window !== 'undefined' && !!window?.navigator?.webdriver) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Browsers controlled via automation regularly set the `navigator.webdriver` property. This gives us a reasonable signal to disable telemetry collection in those cases. Tests and automation have the potential to send a large volume of events that won't be meaningful to us, so we're disabling collection.

<!-- Fixes #(issue number) -->
fixes SDK-1127

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
