### PR TITLE
fix(clerk-js): Avoid triggering prepare verification twice

### DIFF
--- a/.changeset/flat-bugs-visit.md
+++ b/.changeset/flat-bugs-visit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Avoid triggering prepare verification twice. (Affects only dev mode)

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -1,17 +1,10 @@
-import React from 'react';
-
 import { useCoreSignUp } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
+import { useFetch } from '../../hooks';
 import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 
 export const SignUpEmailCodeCard = () => {
   const signUp = useCoreSignUp();
-
-  React.useEffect(() => {
-    // TODO: This prepare method is not idempotent.
-    // We need to make sure that R18 won't trigger this twice
-    void prepare();
-  }, []);
 
   const prepare = () => {
     const emailVerificationStatus = signUp.verifications.emailAddress.status;
@@ -20,6 +13,20 @@ export const SignUpEmailCodeCard = () => {
     }
     return signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
   };
+
+  // TODO: Introduce a useMutation to handle mutating requests
+  useFetch(
+    // @ts-ignore Typescript complains because prepare may return undefined
+    prepare,
+    {
+      name: 'prepare',
+      strategy: 'email_code',
+      number: signUp.emailAddress,
+    },
+    {
+      staleTime: 100,
+    },
+  );
 
   const attempt = (code: string) => signUp.attemptEmailAddressVerification({ code });
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -6,9 +6,11 @@ import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 export const SignUpEmailCodeCard = () => {
   const signUp = useCoreSignUp();
 
+  const emailVerificationStatus = signUp.verifications.emailAddress.status;
+  const shouldAvoidPrepare = !signUp.status || emailVerificationStatus === 'verified';
+
   const prepare = () => {
-    const emailVerificationStatus = signUp.verifications.emailAddress.status;
-    if (!signUp.status || emailVerificationStatus === 'verified') {
+    if (shouldAvoidPrepare) {
       return;
     }
     return signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
@@ -16,8 +18,7 @@ export const SignUpEmailCodeCard = () => {
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    // @ts-ignore Typescript complains because prepare may return undefined
-    prepare,
+    shouldAvoidPrepare ? undefined : () => signUp.prepareEmailAddressVerification({ strategy: 'email_code' }),
     {
       name: 'prepare',
       strategy: 'email_code',

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -7,9 +7,10 @@ import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 export const SignUpPhoneCodeCard = withCardStateProvider(() => {
   const signUp = useCoreSignUp();
 
+  const phoneVerificationStatus = signUp.verifications.phoneNumber.status;
+  const shouldAvoidPrepare = !signUp.status || phoneVerificationStatus === 'verified';
   const prepare = () => {
-    const phoneVerificationStatus = signUp.verifications.phoneNumber.status;
-    if (!signUp.status || phoneVerificationStatus === 'verified') {
+    if (shouldAvoidPrepare) {
       return;
     }
     return signUp.preparePhoneNumberVerification({ strategy: 'phone_code' });
@@ -17,10 +18,9 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    // @ts-ignore Typescript complains because prepare may return undefined
-    prepare,
+    shouldAvoidPrepare ? undefined : () => signUp.preparePhoneNumberVerification({ strategy: 'phone_code' }),
     {
-      name: 'prepare',
+      name: 'signUp.preparePhoneNumberVerification',
       strategy: 'phone_code',
       number: signUp.phoneNumber,
     },

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -1,18 +1,11 @@
-import React from 'react';
-
 import { useCoreSignUp } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
 import { withCardStateProvider } from '../../elements';
+import { useFetch } from '../../hooks';
 import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 
 export const SignUpPhoneCodeCard = withCardStateProvider(() => {
   const signUp = useCoreSignUp();
-
-  React.useEffect(() => {
-    // TODO: This prepare method is not idempotent.
-    // We need to make sure that R18 won't trigger this twice
-    void prepare();
-  }, []);
 
   const prepare = () => {
     const phoneVerificationStatus = signUp.verifications.phoneNumber.status;
@@ -21,6 +14,20 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     }
     return signUp.preparePhoneNumberVerification({ strategy: 'phone_code' });
   };
+
+  // TODO: Introduce a useMutation to handle mutating requests
+  useFetch(
+    // @ts-ignore Typescript complains because prepare may return undefined
+    prepare,
+    {
+      name: 'prepare',
+      strategy: 'phone_code',
+      number: signUp.phoneNumber,
+    },
+    {
+      staleTime: 100,
+    },
+  );
 
   const attempt = (code: string) => signUp.attemptPhoneNumberVerification({ code });
 

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyEmail.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyEmail.test.tsx
@@ -14,10 +14,11 @@ describe('SignUpVerifyEmail', () => {
   });
 
   it('shows the email associated with the sign up', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true });
       f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
+    fixtures.signUp.prepareEmailAddressVerification.mockRejectedValue(null);
     render(<SignUpVerifyEmail />, { wrapper });
     screen.getByText('test@clerk.com');
   });
@@ -44,13 +45,8 @@ describe('SignUpVerifyEmail', () => {
       f.withEmailAddress({ required: true, verifications: ['email_code'] });
       f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
-    fixtures.signUp.createEmailLinkFlow.mockImplementation(
-      () =>
-        ({
-          startEmailLinkFlow: jest.fn(() => new Promise(() => ({}))),
-          cancelEmailLinkFlow: jest.fn(() => new Promise(() => ({}))),
-        } as any),
-    );
+
+    fixtures.signUp.prepareEmailAddressVerification.mockRejectedValue(null);
 
     render(<SignUpVerifyEmail />, { wrapper });
     screen.getByText(/Verify your email/i);
@@ -62,6 +58,8 @@ describe('SignUpVerifyEmail', () => {
       f.withEmailAddress({ required: true });
       f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
+    fixtures.signUp.prepareEmailAddressVerification.mockRejectedValue(null);
+
     const { userEvent } = render(<SignUpVerifyEmail />, { wrapper });
     await userEvent.click(
       screen.getByRole('button', {
@@ -94,13 +92,8 @@ describe('SignUpVerifyEmail', () => {
       f.withEmailAddress({ required: true, verifications: ['email_code'] });
       f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
-    fixtures.signUp.createEmailLinkFlow.mockImplementation(
-      () =>
-        ({
-          startEmailLinkFlow: jest.fn(() => new Promise(() => ({}))),
-          cancelEmailLinkFlow: jest.fn(() => new Promise(() => ({}))),
-        } as any),
-    );
+
+    fixtures.signUp.prepareEmailAddressVerification.mockRejectedValue(null);
 
     render(<SignUpVerifyEmail />, { wrapper });
     const resendButton = screen.getByText(/Resend/i);

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyPhone.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyPhone.test.tsx
@@ -14,19 +14,21 @@ describe('SignUpVerifyPhone', () => {
   });
 
   it('shows the phone number associated with the sign up', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withPhoneNumber({ required: true });
       f.startSignUpWithPhoneNumber({ phoneNumber: '+306911111111' });
     });
+    fixtures.signUp.preparePhoneNumberVerification.mockRejectedValue(null);
     render(<SignUpVerifyPhone />, { wrapper });
     screen.getByText('+30 691 1111111');
   });
 
   it('shows the verify with code message', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withPhoneNumber({ required: true });
       f.startSignUpWithPhoneNumber();
     });
+    fixtures.signUp.preparePhoneNumberVerification.mockRejectedValue(null);
     render(<SignUpVerifyPhone />, { wrapper });
     screen.getByText(/Verify your phone/i);
     screen.getByText(/Enter the verification code sent to your phone/i);
@@ -37,6 +39,7 @@ describe('SignUpVerifyPhone', () => {
       f.withPhoneNumber({ required: true });
       f.startSignUpWithPhoneNumber();
     });
+    fixtures.signUp.preparePhoneNumberVerification.mockRejectedValue(null);
     const { userEvent } = render(<SignUpVerifyPhone />, { wrapper });
     await userEvent.click(
       screen.getByRole('button', {
@@ -47,10 +50,11 @@ describe('SignUpVerifyPhone', () => {
   });
 
   it('Resend code button exists', async () => {
-    const { wrapper } = await createFixtures(f => {
+    const { wrapper, fixtures } = await createFixtures(f => {
       f.withPhoneNumber({ required: true });
       f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
+    fixtures.signUp.preparePhoneNumberVerification.mockRejectedValue(null);
     render(<SignUpVerifyPhone />, { wrapper });
     const resendButton = screen.getByText(/Resend/i);
     expect(resendButton.tagName.toUpperCase()).toBe('BUTTON');


### PR DESCRIPTION
## Description



### Before

https://github.com/clerk/javascript/assets/19269911/5a94d861-be69-4007-addd-bb239924f5b3


### After

https://github.com/clerk/javascript/assets/19269911/5af85b9d-ea13-42c5-8b03-31d007278664


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
