### PR TITLE
fix(shared): Invitations depends on wrong options (useOrganization)

### DIFF
--- a/.changeset/thirty-cooks-cheer.md
+++ b/.changeset/thirty-cooks-cheer.md
@@ -2,4 +2,4 @@
 '@clerk/shared': patch
 ---
 
-Bug fix: Invitations from useOrganization depends on options of membership.}
+Fixes a bug where Invitations from `useOrganization` incorrectly depended on options for memberships.

--- a/.changeset/thirty-cooks-cheer.md
+++ b/.changeset/thirty-cooks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Bug fix: Invitations from useOrganization depends on options of membership.}

--- a/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganization.test.tsx
@@ -4,6 +4,7 @@ import { describe } from '@jest/globals';
 import { act, renderHook, waitFor } from '../../../testUtils';
 import {
   createFakeDomain,
+  createFakeOrganizationInvitation,
   createFakeOrganizationMembershipRequest,
 } from '../../components/OrganizationProfile/__tests__/utils';
 import { createFakeUserOrganizationMembership } from '../../components/OrganizationSwitcher/__tests__/utlis';
@@ -14,6 +15,9 @@ const { createFixtures } = bindCreateFixtures('OrganizationProfile');
 const defaultRenderer = () =>
   useOrganization({
     domains: {
+      pageSize: 2,
+    },
+    invitations: {
       pageSize: 2,
     },
     membershipRequests: {
@@ -398,6 +402,206 @@ describe('useOrganization', () => {
             publicUserData: expect.objectContaining({
               userId: 'test_user4',
             }),
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('invitations', () => {
+    it('fetch with pages', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getInvitations.mockReturnValue(
+        Promise.resolve({
+          data: [
+            createFakeOrganizationInvitation({
+              id: '1',
+              emailAddress: 'admin1@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+            createFakeOrganizationInvitation({
+              id: '2',
+              emailAddress: 'member2@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+          ],
+          total_count: 4,
+        }),
+      );
+      const { result } = renderHook(defaultRenderer, { wrapper });
+      expect(result.current.invitations?.isLoading).toBe(true);
+      expect(result.current.invitations?.isFetching).toBe(true);
+      expect(result.current.invitations?.count).toBe(0);
+
+      await waitFor(() => expect(result.current.invitations?.isLoading).toBe(false));
+
+      expect(result.current.invitations?.isFetching).toBe(false);
+      expect(result.current.invitations?.count).toBe(4);
+      expect(result.current.invitations?.page).toBe(1);
+      expect(result.current.invitations?.pageCount).toBe(2);
+      expect(result.current.invitations?.hasNextPage).toBe(true);
+
+      fixtures.clerk.organization?.getInvitations.mockReturnValue(
+        Promise.resolve({
+          data: [
+            createFakeOrganizationInvitation({
+              id: '3',
+              emailAddress: 'admin3@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+            createFakeOrganizationInvitation({
+              id: '4',
+              emailAddress: 'member4@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+          ],
+          total_count: 4,
+        }),
+      );
+
+      act(() => result.current.invitations?.fetchNext?.());
+
+      await waitFor(() => expect(result.current.invitations?.isLoading).toBe(true));
+      await waitFor(() => expect(result.current.invitations?.isLoading).toBe(false));
+
+      expect(result.current.invitations?.page).toBe(2);
+      expect(result.current.invitations?.hasNextPage).toBe(false);
+      expect(result.current.invitations?.data).toEqual(
+        expect.arrayContaining([
+          expect.not.objectContaining({
+            id: '1',
+          }),
+          expect.not.objectContaining({
+            id: '2',
+          }),
+          expect.objectContaining({
+            organizationId: '1',
+            id: '3',
+            emailAddress: 'admin3@clerk.com',
+          }),
+          expect.objectContaining({
+            organizationId: '1',
+            id: '4',
+            emailAddress: 'member4@clerk.com',
+          }),
+        ]),
+      );
+    });
+
+    it('infinite fetch', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getInvitations.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeOrganizationInvitation({
+              id: '1',
+              emailAddress: 'admin1@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+            createFakeOrganizationInvitation({
+              id: '2',
+              emailAddress: 'member2@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+          ],
+          total_count: 4,
+        }),
+      );
+      const { result } = renderHook(
+        () =>
+          useOrganization({
+            invitations: {
+              pageSize: 2,
+              infinite: true,
+            },
+          }),
+        { wrapper },
+      );
+      expect(result.current.invitations?.isLoading).toBe(true);
+      expect(result.current.invitations?.isFetching).toBe(true);
+
+      await waitFor(() => expect(result.current.invitations?.isLoading).toBe(false));
+      expect(result.current.invitations?.isFetching).toBe(false);
+
+      fixtures.clerk.organization?.getInvitations.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeOrganizationInvitation({
+              id: '1',
+              emailAddress: 'admin1@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+            createFakeOrganizationInvitation({
+              id: '2',
+              emailAddress: 'member2@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+          ],
+          total_count: 4,
+        }),
+      );
+
+      fixtures.clerk.organization?.getInvitations.mockReturnValueOnce(
+        Promise.resolve({
+          data: [
+            createFakeOrganizationInvitation({
+              id: '3',
+              emailAddress: 'admin3@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+            createFakeOrganizationInvitation({
+              id: '4',
+              emailAddress: 'member4@clerk.com',
+              organizationId: '1',
+              createdAt: new Date('2022-01-01'),
+            }),
+          ],
+          total_count: 4,
+        }),
+      );
+
+      act(() => result.current.invitations?.fetchNext?.());
+
+      await waitFor(() => expect(result.current.invitations?.isFetching).toBe(true));
+      expect(result.current.invitations?.isLoading).toBe(false);
+
+      await waitFor(() => expect(result.current.invitations?.isFetching).toBe(false));
+      expect(result.current.invitations?.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: '1',
+          }),
+          expect.objectContaining({
+            id: '2',
+          }),
+          expect.objectContaining({
+            id: '3',
+          }),
+          expect.objectContaining({
+            id: '4',
           }),
         ]),
       );

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -246,8 +246,8 @@ export const useOrganization: UseOrganization = params => {
     },
     organization?.getInvitations,
     {
-      keepPreviousData: membersSafeValues.keepPreviousData,
-      infinite: membersSafeValues.infinite,
+      keepPreviousData: invitationsSafeValues.keepPreviousData,
+      infinite: invitationsSafeValues.infinite,
       enabled: !!invitationsParams,
     },
     {


### PR DESCRIPTION
## Description
This PR fixes a bug which would make the `useOrganization` with the `invitations` param to work unexpectedly. 
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
