### PR TITLE
chore(clerk-js): Remove fallback data for paginated endpoint methods

### DIFF
--- a/.changeset/modern-plums-invent.md
+++ b/.changeset/modern-plums-invent.md
@@ -1,0 +1,13 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Remove fallback data and allow promise to throw for paginated endpoint methods.
+Affected methods:
+- Organization.getDomains
+- Organization.getInvitations
+- Organization.getMembershipRequests
+- Organization.getMemberships
+- User.getOrganizationInvitations
+- User.getOrganizationSuggestions
+- User.getOrganizationMemberships

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -114,20 +114,14 @@ export class Organization extends BaseResource implements OrganizationResource {
       {
         forceUpdateClient: true,
       },
-    )
-      .then(res => {
-        const { data: invites, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<OrganizationDomainJSON>;
+    ).then(res => {
+      const { data: invites, total_count } = res?.response as unknown as ClerkPaginatedResponse<OrganizationDomainJSON>;
 
-        return {
-          total_count,
-          data: invites.map(domain => new OrganizationDomain(domain)),
-        };
-      })
-      .catch(() => ({
-        total_count: 0,
-        data: [],
-      }));
+      return {
+        total_count,
+        data: invites.map(domain => new OrganizationDomain(domain)),
+      };
+    });
   };
 
   getDomain = async ({ domainId }: { domainId: string }): Promise<OrganizationDomainResource> => {
@@ -147,20 +141,15 @@ export class Organization extends BaseResource implements OrganizationResource {
       path: `/organizations/${this.id}/membership_requests`,
       method: 'GET',
       search: convertPageToOffset(getRequestParam),
-    })
-      .then(res => {
-        const { data: requests, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<OrganizationMembershipRequestJSON>;
+    }).then(res => {
+      const { data: requests, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<OrganizationMembershipRequestJSON>;
 
-        return {
-          total_count,
-          data: requests.map(request => new OrganizationMembershipRequest(request)),
-        };
-      })
-      .catch(() => ({
-        total_count: 0,
-        data: [],
-      }));
+      return {
+        total_count,
+        data: requests.map(request => new OrganizationMembershipRequest(request)),
+      };
+    });
   };
 
   createDomain = async (name: string): Promise<OrganizationDomainResource> => {
@@ -174,22 +163,15 @@ export class Organization extends BaseResource implements OrganizationResource {
       // `paginated` is used in some legacy endpoints to support clerk paginated responses
       // The parameter will be dropped in FAPI v2
       search: convertPageToOffset({ ...getMembershipsParams, paginated: true }),
-    })
-      .then(res => {
-        const { data: suggestions, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<OrganizationMembershipJSON>;
+    }).then(res => {
+      const { data: suggestions, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<OrganizationMembershipJSON>;
 
-        return {
-          total_count,
-          data: suggestions.map(suggestion => new OrganizationMembership(suggestion)),
-        };
-      })
-      .catch(() => {
-        return {
-          total_count: 0,
-          data: [],
-        };
-      });
+      return {
+        total_count,
+        data: suggestions.map(suggestion => new OrganizationMembership(suggestion)),
+      };
+    });
   };
 
   getInvitations = async (
@@ -204,20 +186,15 @@ export class Organization extends BaseResource implements OrganizationResource {
       {
         forceUpdateClient: true,
       },
-    )
-      .then(res => {
-        const { data: requests, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<OrganizationInvitationJSON>;
+    ).then(res => {
+      const { data: requests, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<OrganizationInvitationJSON>;
 
-        return {
-          total_count,
-          data: requests.map(request => new OrganizationInvitation(request)),
-        };
-      })
-      .catch(() => ({
-        total_count: 0,
-        data: [],
-      }));
+      return {
+        total_count,
+        data: requests.map(request => new OrganizationInvitation(request)),
+      };
+    });
   };
 
   addMember = async ({ userId, role }: AddMemberParams) => {

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -34,30 +34,16 @@ export class OrganizationMembership extends BaseResource implements Organization
       // `paginated` is used in some legacy endpoints to support clerk paginated responses
       // The parameter will be dropped in FAPI v2
       search: convertPageToOffset({ ...retrieveMembershipsParams, paginated: true }),
-    })
-      .then(res => {
-        if (!res?.response) {
-          return {
-            total_count: 0,
-            data: [],
-          };
-        }
+    }).then(res => {
+      // TODO: Fix typing
+      const { data: suggestions, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<OrganizationMembershipJSON>;
 
-        // TODO: Fix typing
-        const { data: suggestions, total_count } =
-          res.response as unknown as ClerkPaginatedResponse<OrganizationMembershipJSON>;
-
-        return {
-          total_count,
-          data: suggestions.map(suggestion => new OrganizationMembership(suggestion)),
-        };
-      })
-      .catch(() => {
-        return {
-          total_count: 0,
-          data: [],
-        };
-      });
+      return {
+        total_count,
+        data: suggestions.map(suggestion => new OrganizationMembership(suggestion)),
+      };
+    });
   };
 
   destroy = async (): Promise<OrganizationMembership> => {

--- a/packages/clerk-js/src/core/resources/OrganizationSuggestion.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSuggestion.ts
@@ -30,20 +30,15 @@ export class OrganizationSuggestion extends BaseResource implements Organization
       path: '/me/organization_suggestions',
       method: 'GET',
       search: convertPageToOffset(params),
-    })
-      .then(res => {
-        const { data: suggestions, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<OrganizationSuggestionJSON>;
+    }).then(res => {
+      const { data: suggestions, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<OrganizationSuggestionJSON>;
 
-        return {
-          total_count,
-          data: suggestions.map(suggestion => new OrganizationSuggestion(suggestion)),
-        };
-      })
-      .catch(() => ({
-        total_count: 0,
-        data: [],
-      }));
+      return {
+        total_count,
+        data: suggestions.map(suggestion => new OrganizationSuggestion(suggestion)),
+      };
+    });
   }
 
   accept = async (): Promise<OrganizationSuggestionResource> => {

--- a/packages/clerk-js/src/core/resources/UserOrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/UserOrganizationInvitation.ts
@@ -28,20 +28,15 @@ export class UserOrganizationInvitation extends BaseResource implements UserOrga
       path: '/me/organization_invitations',
       method: 'GET',
       search: convertPageToOffset(params),
-    })
-      .then(res => {
-        const { data: invites, total_count } =
-          res?.response as unknown as ClerkPaginatedResponse<UserOrganizationInvitationJSON>;
+    }).then(res => {
+      const { data: invites, total_count } =
+        res?.response as unknown as ClerkPaginatedResponse<UserOrganizationInvitationJSON>;
 
-        return {
-          total_count,
-          data: invites.map(invitation => new UserOrganizationInvitation(invitation)),
-        };
-      })
-      .catch(() => ({
-        total_count: 0,
-        data: [],
-      }));
+      return {
+        total_count,
+        data: invites.map(invitation => new UserOrganizationInvitation(invitation)),
+      };
+    });
   }
 
   constructor(data: UserOrganizationInvitationJSON) {


### PR DESCRIPTION
## Description

Remove fallback data and allow promise to throw for paginated endpoint methods.
Affected methods:
- Organization.getDomains
- Organization.getInvitations
- Organization.getMembershipRequests
- Organization.getMemberships
- User.getOrganizationInvitations
- User.getOrganizationSuggestions
- User.getOrganizationMemberships


The react hooks will continue to fallback to `total_count:0` and `data = []` in case of an error, but the `isError` property will be correctly populated as `true`
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
