### PR TITLE
fix(shared): Do not display telemetry notice in CI

### DIFF
--- a/.changeset/cold-points-carry.md
+++ b/.changeset/cold-points-carry.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Do not display telemetry notice in CI

--- a/package-lock.json
+++ b/package-lock.json
@@ -29476,6 +29476,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+    },
     "node_modules/steno": {
       "version": "0.4.4",
       "dev": true,
@@ -33988,6 +33993,7 @@
       "dependencies": {
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.1",
+        "std-env": "^3.7.0",
         "swr": "2.2.0"
       },
       "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,6 +89,7 @@
   "dependencies": {
     "glob-to-regexp": "0.4.1",
     "js-cookie": "3.0.1",
+    "std-env": "^3.7.0",
     "swr": "2.2.0"
   },
   "devDependencies": {

--- a/packages/shared/scripts/postinstall.mjs
+++ b/packages/shared/scripts/postinstall.mjs
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { isCI } from 'std-env';
+
 // If we make significant changes to how telemetry is collected in the future, bump this version.
 const TELEMETRY_NOTICE_VERSION = '1';
 
@@ -57,7 +59,9 @@ async function notifyAboutTelemetry() {
 
   config.telemetryNoticeVersion = TELEMETRY_NOTICE_VERSION;
 
-  telemetryNotice();
+  if (!isCI) {
+    telemetryNotice();
+  }
 
   await fs.writeFile(configFile, JSON.stringify(config, null, '\t'));
 }


### PR DESCRIPTION
## Description

One thing I noticed over the holiday break was that we still print the message in CI even though it's not actionable and relevant. With a simple check we can hide it.

This PR adds a new dep to `shared`: https://github.com/unjs/std-env

It's a really helpful package and we can refactor some of our code in the future to use more of this. We might want to re-export it from `shared` in the future, too. But to keep this PR slim I didn't do that just yet.

Bundle size wise it's a small addition with tree-shaking: https://bundlejs.com/?q=std-env&treeshake=%5B%7B+isCI+%7D%5D

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
