### PR TITLE
fix(clerk-react): Avoid error on `useRoutingOptions()` when `path` passed from options

### DIFF
--- a/.changeset/spotty-nails-double.md
+++ b/.changeset/spotty-nails-double.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Fixes error thrown for missing path & routing props when path was passed from context.
+This change affects  components `<SignIn />`, `<SignUp />` from `@clerk/nextjs` and `@clerk/remix`.

--- a/packages/react/src/hooks/__tests__/__snapshots__/useRoutingProps.test.tsx.snap
+++ b/packages/react/src/hooks/__tests__/__snapshots__/useRoutingProps.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRoutingProps() returns passed props and options for routing different than path 1`] = `
+<body>
+  <div>
+    <div>
+      {"routing":"virtual","prop1":"1","prop2":"2"}
+    </div>
+  </div>
+</body>
+`;
+
+exports[`useRoutingProps() returns passed props and options if path is passed from routing options 1`] = `
+<body>
+  <div>
+    <div>
+      {"path":"/aloha","prop1":"1","prop2":"2"}
+    </div>
+  </div>
+</body>
+`;
+
+exports[`useRoutingProps() returns path routing with passed props and options if path prop is passed 1`] = `
+<body>
+  <div>
+    <div>
+      {"path":"/aloha","prop1":"1","prop2":"2","routing":"path"}
+    </div>
+  </div>
+</body>
+`;

--- a/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
+++ b/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { useRoutingProps } from '../useRoutingProps';
+
+const originalError = console.error;
+
+describe('useRoutingProps()', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  it('throws error without routing & path props', () => {
+    const TestingComponent = props => {
+      const options = useRoutingProps('TestingComponent', props);
+      return <div>{JSON.stringify(options)}</div>;
+    };
+
+    expect(() => {
+      render(<TestingComponent />);
+    }).toThrowError('<TestingComponent/> is missing a path prop to work with path based routing');
+  });
+
+  it('returns path routing with passed props and options if path prop is passed', () => {
+    const TestingComponent = props => {
+      const options = useRoutingProps('TestingComponent', props);
+      return <div>{JSON.stringify(options)}</div>;
+    };
+
+    const { baseElement } = render(
+      <TestingComponent
+        path='/aloha'
+        prop1='1'
+        prop2='2'
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('returns passed props and options for routing different than path', () => {
+    const TestingComponent = props => {
+      const options = useRoutingProps('TestingComponent', props);
+      return <div>{JSON.stringify(options)}</div>;
+    };
+
+    const { baseElement } = render(
+      <TestingComponent
+        routing='virtual'
+        prop1='1'
+        prop2='2'
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('returns passed props and options if path is passed from routing options', () => {
+    const TestingComponent = props => {
+      const options = useRoutingProps('TestingComponent', props, { path: '/aloha' });
+      return <div>{JSON.stringify(options)}</div>;
+    };
+
+    const { baseElement } = render(
+      <TestingComponent
+        prop1='1'
+        prop2='2'
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/hooks/useRoutingProps.ts
+++ b/packages/react/src/hooks/useRoutingProps.ts
@@ -8,7 +8,8 @@ export function useRoutingProps<T extends RoutingOptions>(
   props: T,
   routingOptions?: RoutingOptions,
 ): T {
-  if (!props.path && !props.routing) {
+  const path = routingOptions?.path || props.path;
+  if (!path && !props.routing) {
     errorThrower.throw(noPathProvidedError(componentName));
   }
 


### PR DESCRIPTION
## Description

Avoid raising error when eg `<SignIn />` and `<SignUp />` path is passed from the env via the ClerkProvider options hook.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
