### PR TITLE
feat(clerk-react,clerk-js,shared): Dynamically update props based on …

### DIFF
--- a/.changeset/pink-gifts-retire.md
+++ b/.changeset/pink-gifts-retire.md
@@ -1,0 +1,7 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/clerk-react": patch
+"@clerk/shared": minor
+---
+
+Allow dynamic values components props, even if these values change after the components are rendered. For example, a `SignIn` component with a `redirectUrl` prop passed in will always respect the latest value of `redirectUrl`.

--- a/packages/clerk-js/src/ui/customizables/AppearanceContext.tsx
+++ b/packages/clerk-js/src/ui/customizables/AppearanceContext.tsx
@@ -1,7 +1,6 @@
-import { createContextAndHook } from '@clerk/shared/react';
+import { createContextAndHook, useDeepEqualMemo } from '@clerk/shared/react';
 import React from 'react';
 
-import { useDeepEqualMemo } from '../hooks';
 import type { AppearanceCascade, ParsedAppearance } from './parseAppearance';
 import { parseAppearance } from './parseAppearance';
 

--- a/packages/clerk-js/src/ui/hooks/index.ts
+++ b/packages/clerk-js/src/ui/hooks/index.ts
@@ -17,6 +17,5 @@ export * from './useSafeState';
 export * from './useSearchInput';
 export * from './useDebounce';
 export * from './useScrollLock';
-export * from './useDeepEqualMemo';
 export * from './useClerkModalStateParams';
 export * from './useNavigateToFlowStart';

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -1,4 +1,5 @@
 import { logErrorInDevMode } from '@clerk/shared';
+import { isDeeplyEqual } from '@clerk/shared/react';
 import type {
   CreateOrganizationProps,
   OrganizationListProps,
@@ -90,10 +91,7 @@ class Portal extends React.PureComponent<MountProps> {
   private portalRef = React.createRef<HTMLDivElement>();
 
   componentDidUpdate(prevProps: Readonly<MountProps>) {
-    if (
-      prevProps.props.appearance !== this.props.props.appearance ||
-      prevProps.props?.customPages?.length !== this.props.props?.customPages?.length
-    ) {
+    if (!isDeeplyEqual(prevProps.props, this.props.props)) {
       this.props.updateProps({ node: this.portalRef.current, props: this.props.props });
     }
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,5 +29,6 @@ export * from './poller';
 export * from './proxy';
 export * from './underscore';
 export * from './url';
+export * from './object';
 export { createWorkerTimers } from './workerTimers';
 export { DEV_BROWSER_JWT_KEY, getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from './devBrowser';

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -1,0 +1,7 @@
+export const without = <T extends object, P extends keyof T>(obj: T, ...props: P[]): Omit<T, P> => {
+  const copy = { ...obj };
+  for (const prop of props) {
+    delete copy[prop];
+  }
+  return copy;
+};

--- a/packages/shared/src/react/hooks/index.ts
+++ b/packages/shared/src/react/hooks/index.ts
@@ -6,3 +6,4 @@ export { useSession } from './useSession';
 export { useSessionList } from './useSessionList';
 export { useUser } from './useUser';
 export { useClerk } from './useClerk';
+export { useDeepEqualMemo, isDeeplyEqual } from './useDeepEqualMemo';

--- a/packages/shared/src/react/hooks/useDeepEqualMemo.ts
+++ b/packages/shared/src/react/hooks/useDeepEqualMemo.ts
@@ -16,3 +16,5 @@ const useDeepEqualMemoize = <T>(value: T) => {
 export const useDeepEqualMemo: UseDeepEqualMemo = (factory, dependencyArray) => {
   return React.useMemo(factory, useDeepEqualMemoize(dependencyArray));
 };
+
+export const isDeeplyEqual = deepEqual;


### PR DESCRIPTION
…deep equality

This change was made in an effort to support dynamic values for appearance, localization as modifying this values usually happens during dev where a fast HMR iteration cycle is required. However, we'd also like to support dynamic values for props like redirectUrl, where the value can be calculated based on data available during runtime, even after the Clerk components mount (eg, based on the results of a fetch request).

In order to avoid extra renders, we use the pre-existing dequal utility to make sure that expensive calculations are avoided.

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
