### PR TITLE
Telemetry: Append `__clerk_framework_hint` if a known framework is detected

### DIFF
--- a/.changeset/happy-beers-push.md
+++ b/.changeset/happy-beers-push.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Telemetry: Append `__clerk_framework_hint` if a known framework is detected

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1297,6 +1297,23 @@ export default class Clerk implements ClerkInterface {
     return this.navigate(to);
   }
 
+  public __internal_getFrameworkHint(): { framework: string | undefined; version: string | undefined } {
+    try {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return { framework: undefined, version: undefined };
+      }
+      const win = window as any;
+      const isNextJsApp = !!(win.__NEXT_DATA__ || !!win.document.querySelector('#__next') || win.next?.version);
+      if (isNextJsApp) {
+        return { framework: 'nextjs', version: win.next?.version };
+      }
+      return { framework: undefined, version: undefined };
+    } catch (e: unknown) {
+      // Make sure to result in an no-op if anything goes terribly wrong
+      return { framework: undefined, version: undefined };
+    }
+  }
+
   #hasJustSynced = () => getClerkQueryParam(CLERK_SYNCED) === 'true';
   #clearJustSynced = () => removeClerkQueryParam(CLERK_SYNCED);
 

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -100,6 +100,16 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
       searchParams.append('_clerk_js_version', clerkInstance.version);
     }
 
+    // @ts-ignore Internal util on clerk-js
+    if (clerkInstance.__internal_getFrameworkHint) {
+      // @ts-ignore Internal util on clerk-js
+      const { framework, version } = clerkInstance.__internal_getFrameworkHint();
+      if (framework) {
+        searchParams.append('__clerk_framework_hint', framework);
+        version && searchParams.append('__clerk_framework_version', version);
+      }
+    }
+
     if (rotatingTokenNonce) {
       searchParams.append('rotating_token_nonce', rotatingTokenNonce);
     }


### PR DESCRIPTION
## Description

Detects whether clerk-js runs in the context of a known framework and appends `__clerk_framework_hint` and `__clerk_framework_version`, if available. 

Currently, NextJs is the only framework that can be detected. We will add support for the rest in an upcoming PR.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
