### PR TITLE
fix(clerk-react): Fix routing strategy priority when it's directly passed on the component

### DIFF
--- a/.changeset/tender-phones-explain.md
+++ b/.changeset/tender-phones-explain.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Fixes error when path is passed from context and a routing strategy other than `path` is passed as a prop.
+This change affects  components `<SignIn />`, `<SignUp />` from `@clerk/nextjs` and `@clerk/remix`.

--- a/packages/react/src/hooks/__tests__/__snapshots__/useRoutingProps.test.tsx.snap
+++ b/packages/react/src/hooks/__tests__/__snapshots__/useRoutingProps.test.tsx.snap
@@ -14,7 +14,17 @@ exports[`useRoutingProps() returns passed props and options if path is passed fr
 <body>
   <div>
     <div>
-      {"path":"/aloha","prop1":"1","prop2":"2"}
+      {"path":"/aloha","prop1":"1","prop2":"2","routing":"path"}
+    </div>
+  </div>
+</body>
+`;
+
+exports[`useRoutingProps() returns passed props but omits path prop if path is passed from routing options and a routing strategy other than path is specified 1`] = `
+<body>
+  <div>
+    <div>
+      {"prop1":"1","prop2":"2","routing":"virtual"}
     </div>
   </div>
 </body>

--- a/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
+++ b/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
@@ -71,4 +71,20 @@ describe('useRoutingProps()', () => {
     );
     expect(baseElement).toMatchSnapshot();
   });
+
+  it('returns passed props but omits path prop if path is passed from routing options and a routing strategy other than path is specified', () => {
+    const TestingComponent = props => {
+      const options = useRoutingProps('TestingComponent', props, { path: '/aloha' });
+      return <div>{JSON.stringify(options)}</div>;
+    };
+
+    const { baseElement } = render(
+      <TestingComponent
+        prop1='1'
+        prop2='2'
+        routing='virtual'
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
 });

--- a/packages/react/src/hooks/useRoutingProps.ts
+++ b/packages/react/src/hooks/useRoutingProps.ts
@@ -8,12 +8,20 @@ export function useRoutingProps<T extends RoutingOptions>(
   props: T,
   routingOptions?: RoutingOptions,
 ): T {
-  const path = routingOptions?.path || props.path;
+  const path = props.path || routingOptions?.path;
   if (!path && !props.routing) {
     errorThrower.throw(noPathProvidedError(componentName));
   }
 
-  if (props.path) {
+  if (props.routing && props.routing !== 'path' && routingOptions?.path && !props.path) {
+    return {
+      ...routingOptions,
+      ...props,
+      path: undefined,
+    };
+  }
+
+  if (path && !props.routing) {
     return {
       ...routingOptions,
       ...props,


### PR DESCRIPTION
## Description

This PR error when path is passed from context and a routing strategy other than `path` is passed as a prop. 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
