### PR TITLE
fix(backend): Fix `getToken()` from `getAuth()` return value in v5

### DIFF
--- a/.changeset/eight-cherries-tan.md
+++ b/.changeset/eight-cherries-tan.md
@@ -1,0 +1,16 @@
+---
+'@clerk/backend': major
+---
+
+Change `SessionApi.getToken()` to return consistent `{ data, errors }` return value 
+and fix the `getToken()` from requestState to have the same return behavior as v4 
+(return Promise<string> or throw error).
+This change will fix issues in `@clerk/nextjs` / `@clerk/remix` with `getToken()`:
+
+Example:
+```typescript
+import { getAuth } from '@clerk/remix';
+
+const { getToken } = getAuth(...);
+const jwtString = await getToken();
+```

--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -49,11 +49,9 @@ export class SessionAPI extends AbstractAPI {
 
   public async getToken(sessionId: string, template: string) {
     this.requireId(sessionId);
-    return (
-      (await this.request<Token>({
-        method: 'POST',
-        path: joinPaths(basePath, sessionId, 'tokens', template || ''),
-      })) as any
-    ).jwt;
+    return this.request<Token>({
+      method: 'POST',
+      path: joinPaths(basePath, sessionId, 'tokens', template || ''),
+    });
   }
 }


### PR DESCRIPTION
## Description

Change `SessionApi.getToken()` to return consistent `{ data, errors }` return value 
and fix the `getToken()` from requestState to have the same return behavior as v4 
(return Promise<string> or throw error).
This change will fix issues in `@clerk/nextjs` / `@clerk/remix` with `getToken()`:

Example:
```typescript
import { getAuth } from '@clerk/remix';

const { getToken } = await getAuth(...);
const jwtString = await getToken(...);
```

Also a breaking change in the `clerkClient.sessions.getToken()`  was introduced as the return value was changed. To keep the existing behavior use the following:
```typescript
const { data, errors } = await clerkClient.sessions.getToken(...);
if (errors) {
  throw errors;
}
const jwt = data.jwt;
```

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
