### PR TITLE
fix(backend): Fix `getToken()` from `getAuth()` return value in v5

### DIFF
--- a/.changeset/eight-cherries-tan.md
+++ b/.changeset/eight-cherries-tan.md
@@ -1,0 +1,38 @@
+---
+'@clerk/backend': major
+---
+
+Change `SessionApi.getToken()` to return consistent `{ data, errors }` return value 
+and fix the `getToken()` from requestState to have the same return behavior as v4 
+(return Promise<string> or throw error).
+This change fixes issues with `getToken()` in `@clerk/nextjs` / `@clerk/remix` / `@clerk/fastify` / `@clerk/sdk-node` / `gatsby-plugin-clerk`:
+
+Example:
+```typescript
+import { getAuth } from '@clerk/nextjs/server';
+
+const { getToken } = await getAuth(...);
+const jwtString = await getToken(...);
+```
+
+The change in `SessionApi.getToken()` return value is a breaking change, to keep the existing behavior use the following:
+```typescript
+import { ClerkAPIResponseError } from '@clerk/shared/error';
+
+const response = await clerkClient.sessions.getToken(...);
+
+if (response.errors) {
+    const { status, statusText, clerkTraceId } = response;
+    const error = new ClerkAPIResponseError(statusText || '', {
+        data: [],
+        status: Number(status || ''),
+        clerkTraceId,
+    });
+    error.errors = response.errors;
+
+    throw error;
+}
+
+// the value of the v4 `clerkClient.sessions.getToken(...)`
+const jwtString = response.data.jwt;
+```

--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -49,11 +49,9 @@ export class SessionAPI extends AbstractAPI {
 
   public async getToken(sessionId: string, template: string) {
     this.requireId(sessionId);
-    return (
-      (await this.request<Token>({
-        method: 'POST',
-        path: joinPaths(basePath, sessionId, 'tokens', template || ''),
-      })) as any
-    ).jwt;
+    return this.request<Token>({
+      method: 'POST',
+      path: joinPaths(basePath, sessionId, 'tokens', template || ''),
+    });
   }
 }


### PR DESCRIPTION
## Description

Change `SessionApi.getToken()` to return consistent `{ data, errors }` return value  and fix the `getToken()` from requestState to have the same return behavior as v4  (return Promise<string> or throw error).
This change fixes issues with `getToken()` in `@clerk/nextjs` / `@clerk/remix` / `@clerk/fastify` / `@clerk/sdk-node` / `gatsby-plugin-clerk`:

Example:
```typescript
import { getAuth } from '@clerk/nextjs/server';

const { getToken } = await getAuth(...);
const jwtString = await getToken(...);
```

The change in `SessionApi.getToken()` return value is a breaking change, to keep the existing behavior use the following:
```typescript
import { ClerkAPIResponseError } from '@clerk/shared/error';

const response = await clerkClient.sessions.getToken(...);

if (response.errors) {
    const { status, statusText, clerkTraceId } = response;
    const error = new ClerkAPIResponseError(statusText || '', {
        data: [],
        status: Number(status || ''),
        clerkTraceId,
    });
    error.errors = response.errors;

    throw error;
}

// the value of the v4 `clerkClient.sessions.getToken(...)`
const jwtString = response.data.jwt;
```

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
