### PR TITLE
feat(backend): Deprecate createEmail

### DIFF
--- a/.changeset/rich-years-help.md
+++ b/.changeset/rich-years-help.md
@@ -1,0 +1,7 @@
+---
+'@clerk/backend': patch
+---
+
+Add deprecation warning for `EmailAPI.createEmail`.
+
+This endpoint is no longer available and the function will be removed in the next major version.

--- a/packages/backend/src/api/endpoints/EmailApi.ts
+++ b/packages/backend/src/api/endpoints/EmailApi.ts
@@ -1,3 +1,5 @@
+import { deprecated } from '@clerk/shared/deprecated';
+
 import type { Email } from '../resources/Email';
 import { AbstractAPI } from './AbstractApi';
 
@@ -10,8 +12,18 @@ type EmailParams = {
 
 const basePath = '/emails';
 
+/**
+ * @deprecated This endpoint is no longer available and the function will be removed in the next major version.
+ */
 export class EmailAPI extends AbstractAPI {
+  /**
+   * @deprecated This endpoint is no longer available and the function will be removed in the next major version.
+   */
   public async createEmail(params: EmailParams) {
+    deprecated(
+      'EmailAPI.createEmail',
+      'This endpoint is no longer available and the function will be removed in the next major version.',
+    );
     return this.request<Email>({
       method: 'POST',
       path: basePath,


### PR DESCRIPTION
## Description

Add a deprecation warning for `EmailAPI.createEmail`.

PR that removes the method for v5 https://github.com/clerk/javascript/pull/2548

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Deprecation warning

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
