### PR TITLE
feat(backend): Use `User-Agent` header with package name and version in BAPI requests

### DIFF
--- a/.changeset/thin-coats-serve.md
+++ b/.changeset/thin-coats-serve.md
@@ -1,0 +1,13 @@
+---
+'gatsby-plugin-clerk': minor
+'@clerk/clerk-sdk-node': minor
+'@clerk/backend': minor
+'@clerk/fastify': minor
+'@clerk/nextjs': minor
+'@clerk/remix': minor
+---
+
+Replace the `Clerk-Backend-SDK` header with `User-Agent` in BAPI requests and update it's value to contain both the package name and the package version of the clerk package
+executing the request. Eg request from `@clerk/nextjs` to BAPI with append `User-Agent: @clerk/nextjs@5.0.0-alpha-v5.16` using the latest version.
+
+Miscellaneous changes: The backend test build changed to use tsup.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -81,7 +81,7 @@
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "publish:local": "npx yalc push --replace --sig",
     "build:lib": "tsup --env.NODE_ENV production",
-    "build:tests": "tsup --env.test",
+    "build:tests": "tsup --config tsup.config.test.ts",
     "build:runtime": "cpy 'src/runtime/**/*.{mjs,js,cjs}' dist/runtime",
     "clean": "rimraf ./dist",
     "clean:tests": "rimraf ./tests/dist",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -81,7 +81,7 @@
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "publish:local": "npx yalc push --replace --sig",
     "build:lib": "tsup --env.NODE_ENV production",
-    "build:tests": "tsc -p tsconfig.test.json",
+    "build:tests": "tsup --env.test",
     "build:runtime": "cpy 'src/runtime/**/*.{mjs,js,cjs}' dist/runtime",
     "clean": "rimraf ./dist",
     "clean:tests": "rimraf ./tests/dist",

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -54,7 +54,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -82,7 +82,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -115,7 +115,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -145,7 +145,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -173,7 +173,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
           body: JSON.stringify({
             first_name: 'John',
@@ -214,7 +214,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -237,7 +237,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );
@@ -262,7 +262,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'Clerk-Backend-SDK': '@clerk/backend',
+            'User-Agent': '@clerk/backend',
           },
         }),
       );

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -54,7 +54,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -82,7 +82,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -115,7 +115,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -145,7 +145,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -173,7 +173,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
           body: JSON.stringify({
             first_name: 'John',
@@ -214,7 +214,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -237,7 +237,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );
@@ -262,7 +262,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend',
+            'User-Agent': '@clerk/backend@test',
           },
         }),
       );

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -54,7 +54,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -82,7 +82,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -115,7 +115,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -145,7 +145,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -173,7 +173,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
           body: JSON.stringify({
             first_name: 'John',
@@ -214,7 +214,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -237,7 +237,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );
@@ -262,7 +262,7 @@ export default (QUnit: QUnit) => {
           headers: {
             Authorization: 'Bearer deadbeef',
             'Content-Type': 'application/json',
-            'User-Agent': '@clerk/backend@test',
+            'User-Agent': '@clerk/backend@0.0.0-test',
           },
         }),
       );

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -80,7 +80,7 @@ export function buildRequest(options: BuildRequestOptions) {
     // Build headers
     const headers: Record<string, any> = {
       Authorization: `Bearer ${secretKey}`,
-      'Clerk-Backend-SDK': userAgent,
+      'User-Agent': userAgent,
       ...headerParams,
     };
 

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -1,8 +1,7 @@
 export const API_URL = 'https://api.clerk.com';
 export const API_VERSION = 'v1';
 
-// TODO: Get information from package.json or define them from ESBuild
-export const USER_AGENT = `@clerk/backend`;
+export const USER_AGENT = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
 export const MAX_CACHE_LAST_UPDATED_AT_SECONDS = 5 * 60;
 export const JWKS_CACHE_TTL_MS = 1000 * 60 * 60;
 

--- a/packages/backend/src/tokens/__tests__/keys.test.ts
+++ b/packages/backend/src/tokens/__tests__/keys.test.ts
@@ -67,7 +67,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer deadbeef',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend',
+          'User-Agent': '@clerk/backend@test',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);
@@ -87,7 +87,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer sk_test_deadbeef',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend',
+          'User-Agent': '@clerk/backend@test',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);

--- a/packages/backend/src/tokens/__tests__/keys.test.ts
+++ b/packages/backend/src/tokens/__tests__/keys.test.ts
@@ -67,7 +67,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer deadbeef',
           'Content-Type': 'application/json',
-          'Clerk-Backend-SDK': '@clerk/backend',
+          'User-Agent': '@clerk/backend',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);
@@ -87,7 +87,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer sk_test_deadbeef',
           'Content-Type': 'application/json',
-          'Clerk-Backend-SDK': '@clerk/backend',
+          'User-Agent': '@clerk/backend',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);

--- a/packages/backend/src/tokens/__tests__/keys.test.ts
+++ b/packages/backend/src/tokens/__tests__/keys.test.ts
@@ -67,7 +67,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer deadbeef',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend@test',
+          'User-Agent': '@clerk/backend@0.0.0-test',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);
@@ -87,7 +87,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer sk_test_deadbeef',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend@test',
+          'User-Agent': '@clerk/backend@0.0.0-test',
         },
       });
       assert.propEqual(jwk, mockRsaJwk);

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -49,7 +49,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer a-valid-key',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend',
+          'User-Agent': '@clerk/backend@test',
         },
       });
       assert.propEqual(data, mockJwtPayload);

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -49,7 +49,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer a-valid-key',
           'Content-Type': 'application/json',
-          'User-Agent': '@clerk/backend@test',
+          'User-Agent': '@clerk/backend@0.0.0-test',
         },
       });
       assert.propEqual(data, mockJwtPayload);

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -49,7 +49,7 @@ export default (QUnit: QUnit) => {
         headers: {
           Authorization: 'Bearer a-valid-key',
           'Content-Type': 'application/json',
-          'Clerk-Backend-SDK': '@clerk/backend',
+          'User-Agent': '@clerk/backend',
         },
       });
       assert.propEqual(data, mockJwtPayload);

--- a/packages/backend/tsup.config.test.ts
+++ b/packages/backend/tsup.config.test.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup';
+
+// @ts-ignore
+import { name } from './package.json';
+
+export default defineConfig(overrideOptions => {
+  const isWatch = !!overrideOptions.watch;
+
+  return {
+    entry: ['./src/**/*.{ts,js}'],
+    outDir: 'tests/dist/',
+    define: {
+      PACKAGE_NAME: `"${name}"`,
+      // use "test" instead of actual package version to avoid updating the tests
+      // depending on it (eg userAgent related) on every version bump
+      PACKAGE_VERSION: `"0.0.0-test"`,
+      __DEV__: `${isWatch}`,
+    },
+    external: ['#crypto'],
+    clean: true,
+    minify: false,
+    tsconfig: 'tsconfig.test.json',
+    format: 'cjs',
+  };
+});

--- a/packages/backend/tsup.config.ts
+++ b/packages/backend/tsup.config.ts
@@ -8,6 +8,26 @@ import { name, version } from './package.json';
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
   const shouldPublish = !!overrideOptions.env?.publish;
+  const isTest = !!overrideOptions.env?.test;
+
+  if (isTest) {
+    return {
+      entry: ['./src/**/*.{ts,js}'],
+      outDir: 'tests/dist/',
+      define: {
+        PACKAGE_NAME: `"${name}"`,
+        // use "test" instead of actual package version to avoid updating the tests
+        // depending on it (eg userAgent related) on every version bump
+        PACKAGE_VERSION: `"test"`,
+        __DEV__: `${isWatch}`,
+      },
+      external: ['#crypto'],
+      clean: true,
+      minify: false,
+      tsconfig: 'tsconfig.test.json',
+      format: 'cjs',
+    };
+  }
 
   const common: Options = {
     entry: ['src/index.ts', 'src/errors.ts', 'src/internal.ts', 'src/jwt/index.ts'],

--- a/packages/backend/tsup.config.ts
+++ b/packages/backend/tsup.config.ts
@@ -8,26 +8,6 @@ import { name, version } from './package.json';
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
   const shouldPublish = !!overrideOptions.env?.publish;
-  const isTest = !!overrideOptions.env?.test;
-
-  if (isTest) {
-    return {
-      entry: ['./src/**/*.{ts,js}'],
-      outDir: 'tests/dist/',
-      define: {
-        PACKAGE_NAME: `"${name}"`,
-        // use "test" instead of actual package version to avoid updating the tests
-        // depending on it (eg userAgent related) on every version bump
-        PACKAGE_VERSION: `"test"`,
-        __DEV__: `${isWatch}`,
-      },
-      external: ['#crypto'],
-      clean: true,
-      minify: false,
-      tsconfig: 'tsconfig.test.json',
-      format: 'cjs',
-    };
-  }
 
   const common: Options = {
     entry: ['src/index.ts', 'src/errors.ts', 'src/internal.ts', 'src/jwt/index.ts'],

--- a/packages/fastify/src/__snapshots__/clerkClient.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/clerkClient.test.ts.snap
@@ -12,6 +12,7 @@ exports[`clerk initializes clerk with constants 1`] = `
         "version": "0.0.0-test",
       },
       "secretKey": "TEST_SECRET_KEY",
+      "userAgent": "@clerk/fastify@0.0.0-test",
     },
   ],
 ]

--- a/packages/fastify/src/clerkClient.ts
+++ b/packages/fastify/src/clerkClient.ts
@@ -9,5 +9,6 @@ export const clerkClient = createClerkClient({
   apiUrl: API_URL,
   apiVersion: API_VERSION,
   jwtKey: JWT_KEY,
+  userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
   sdkMetadata: SDK_METADATA,
 });

--- a/packages/gatsby-plugin-clerk/src/ssr/clerkClient.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/clerkClient.ts
@@ -6,8 +6,7 @@ const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
-  // TODO: Fetch version from package.json
-  userAgent: 'gatsby-plugin-clerk',
+  userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
   sdkMetadata: SDK_METADATA,
   telemetry: {
     disabled: TELEMETRY_DISABLED,

--- a/packages/nextjs/src/server/__tests__/clerkClient.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkClient.test.ts
@@ -1,0 +1,16 @@
+global.fetch = jest.fn(() => Promise.resolve(new Response(null)));
+
+import { clerkClient } from '../clerkClient';
+
+describe('clerkClient', () => {
+  it('should pass version package to userAgent', async () => {
+    await clerkClient.users.getUser('user_test');
+
+    expect(global.fetch).toBeCalled();
+    expect((global.fetch as any).mock.calls[0][1].headers).toMatchObject({
+      Authorization: 'Bearer TEST_SECRET_KEY',
+      'Content-Type': 'application/json',
+      'User-Agent': '@clerk/nextjs@0.0.0-test',
+    });
+  });
+});

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -16,8 +16,7 @@ const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
-  // TODO: Fetch version from package.json
-  userAgent: '@clerk/nextjs',
+  userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
   proxyUrl: PROXY_URL,
   domain: DOMAIN,
   isSatellite: IS_SATELLITE,

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -79,6 +79,7 @@ export async function authenticateRequest(
     proxyUrl,
     isSatellite,
     domain,
+    userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
   }).authenticateRequest(request, {
     audience,
     secretKey,

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -40,12 +40,12 @@ export const clerkClient = new Proxy(clerkClientSingleton, {
 
     const env = { ...loadApiEnv(), ...loadClientEnv() };
     if (env.secretKey) {
-      clerkClientSingleton = createClerkClient({ ...env, userAgent: PACKAGE_NAME });
+      clerkClientSingleton = createClerkClient({ ...env, userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}` });
       // @ts-expect-error - Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type 'ExtendedClerk'.
       return clerkClientSingleton[property];
     }
 
-    const c = createClerkClient({ ...env, userAgent: PACKAGE_NAME });
+    const c = createClerkClient({ ...env, userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}` });
     // @ts-expect-error - Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type 'ExtendedClerk'.
     return c[property];
   },


### PR DESCRIPTION
## Description

Changes:
- Update `@clerk/backend` test builds to use tsup to supporting testing with build-time constants
- Replace `Clerk-Backend-SDK` header with `User-Agent` for all server Clerk packages
- Add Clerk package version for each SDK in `User-Agent` header

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/fastify`
- [x] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
