### PR TITLE
chore(clerk-js,clerk-react,types): Expose environment for better inter-package development

### DIFF
--- a/.changeset/afraid-toes-matter.md
+++ b/.changeset/afraid-toes-matter.md
@@ -1,0 +1,10 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+'@clerk/types': patch
+---
+
+To better facilitate inter-package development, we've made the following changes to `Clerk` and `IsomorphicClerk`:
+
+- `__unstable__environment` is now exposed, typed, marked as deprecated, and commented on about its internal state. (To be removed in a future release.)
+- `__internal_environment` is exposed with the appropriate typing and comments about its internal state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34022,7 +34022,8 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -36435,10 +36436,10 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "1.0.0-alpha-v5.13",
+      "version": "1.0.0-alpha-v5.15",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "cookie": "0.5.0",
         "snakecase-keys": "5.4.4",
         "tslib": "2.4.1"
@@ -36474,12 +36475,12 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "1.0.0-alpha-v5.14",
+      "version": "1.0.0-alpha-v5.16",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.14",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/clerk-js": "5.0.0-alpha-v5.16",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "webextension-polyfill": "^0.10.0"
       },
       "devDependencies": {
@@ -36523,11 +36524,11 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "5.0.0-alpha-v5.14",
+      "version": "5.0.0-alpha-v5.16",
       "license": "MIT",
       "dependencies": {
-        "@clerk/localizations": "2.0.0-alpha-v5.9",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/localizations": "2.0.0-alpha-v5.10",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "@clerk/types": "4.0.0-alpha-v5.12",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
@@ -36646,12 +36647,12 @@
     },
     "packages/elements": {
       "name": "@clerk/elements",
-      "version": "0.0.2-alpha-v5.3",
+      "version": "0.0.2-alpha-v5.5",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/nextjs": "5.0.0-alpha-v5.15",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/nextjs": "5.0.0-alpha-v5.17",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "@radix-ui/react-form": "^0.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@statelyai/inspect": "^0.1.0",
@@ -37036,12 +37037,12 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "1.0.0-alpha-v5.14",
+      "version": "1.0.0-alpha-v5.16",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-alpha-v5.14",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/clerk-js": "5.0.0-alpha-v5.16",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "base-64": "^1.0.0",
         "react-native-url-polyfill": "2.0.0"
       },
@@ -37071,11 +37072,11 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "1.0.0-alpha-v5.15",
+      "version": "1.0.0-alpha-v5.17",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.13",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/backend": "1.0.0-alpha-v5.15",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "@clerk/types": "4.0.0-alpha-v5.12",
         "cookies": "0.8.0"
       },
@@ -37094,12 +37095,12 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "5.0.0-alpha-v5.15",
+      "version": "5.0.0-alpha-v5.17",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.13",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.13",
+        "@clerk/backend": "1.0.0-alpha-v5.15",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/clerk-sdk-node": "5.0.0-alpha-v5.15",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
@@ -37124,7 +37125,7 @@
     },
     "packages/localizations": {
       "name": "@clerk/localizations",
-      "version": "2.0.0-alpha-v5.9",
+      "version": "2.0.0-alpha-v5.10",
       "license": "MIT",
       "devDependencies": {
         "@clerk/types": "4.0.0-alpha-v5.12",
@@ -37143,12 +37144,12 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "5.0.0-alpha-v5.15",
+      "version": "5.0.0-alpha-v5.17",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.13",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/backend": "1.0.0-alpha-v5.15",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "path-to-regexp": "6.2.1"
       },
       "devDependencies": {
@@ -37177,10 +37178,10 @@
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
-      "version": "5.0.0-alpha-v5.14",
+      "version": "5.0.0-alpha-v5.16",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "@clerk/types": "4.0.0-alpha-v5.12",
         "eslint-config-custom": "*",
         "semver": "^7.5.4",
@@ -37209,12 +37210,12 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "4.0.0-alpha-v5.15",
+      "version": "4.0.0-alpha-v5.17",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.13",
-        "@clerk/clerk-react": "5.0.0-alpha-v5.14",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/backend": "1.0.0-alpha-v5.15",
+        "@clerk/clerk-react": "5.0.0-alpha-v5.16",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
@@ -37245,11 +37246,11 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "5.0.0-alpha-v5.13",
+      "version": "5.0.0-alpha-v5.15",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-alpha-v5.13",
-        "@clerk/shared": "2.0.0-alpha-v5.9",
+        "@clerk/backend": "1.0.0-alpha-v5.15",
+        "@clerk/shared": "2.0.0-alpha-v5.10",
         "camelcase-keys": "6.2.2",
         "snakecase-keys": "3.2.1"
       },
@@ -37287,7 +37288,7 @@
     },
     "packages/shared": {
       "name": "@clerk/shared",
-      "version": "2.0.0-alpha-v5.9",
+      "version": "2.0.0-alpha-v5.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1195,6 +1195,10 @@ export class Clerk implements ClerkInterface {
     return this.#environment;
   }
 
+  get __internal_environment(): EnvironmentResource | null | undefined {
+    return this.#environment;
+  }
+
   // TODO: Fix this properly
   // eslint-disable-next-line @typescript-eslint/require-await
   __unstable__setEnvironment = async (env: EnvironmentJSON) => {

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -235,9 +235,9 @@ export class SignIn extends BaseResource implements SignInResource {
   };
 
   validatePassword: ReturnType<typeof createValidatePassword> = (password, cb) => {
-    if (SignIn.clerk.__unstable__environment?.userSettings.passwordSettings) {
+    if (SignIn.clerk.__internal_environment?.userSettings.passwordSettings) {
       return createValidatePassword({
-        ...(SignIn.clerk.__unstable__environment?.userSettings.passwordSettings as any),
+        ...SignIn.clerk.__internal_environment.userSettings.passwordSettings,
         validatePassword: true,
       })(password, cb);
     }

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -227,9 +227,9 @@ export class SignUp extends BaseResource implements SignUpResource {
   };
 
   validatePassword: ReturnType<typeof createValidatePassword> = (password, cb) => {
-    if (SignUp.clerk.__unstable__environment?.userSettings.passwordSettings) {
+    if (SignUp.clerk.__internal_environment?.userSettings.passwordSettings) {
       return createValidatePassword({
-        ...(SignUp.clerk.__unstable__environment?.userSettings.passwordSettings as any),
+        ...SignUp.clerk.__internal_environment.userSettings.passwordSettings,
         validatePassword: true,
       })(password, cb);
     }

--- a/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
@@ -2,7 +2,7 @@ import type { Clerk } from '../core/clerk';
 import { createFapiClient } from '../core/fapiClient';
 
 export const retrieveCaptchaInfo = (clerk: Clerk) => {
-  const _environment = clerk.__unstable__environment;
+  const _environment = clerk.__internal_environment;
   const fapiClient = createFapiClient(clerk);
   return {
     captchaSiteKey: _environment ? _environment.displayConfig.captchaPublicKey : null,

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -9,6 +9,7 @@ import type {
   CreateOrganizationParams,
   CreateOrganizationProps,
   DomainOrProxyUrl,
+  EnvironmentResource,
   HandleEmailLinkVerificationParams,
   HandleOAuthCallbackParams,
   InstanceType,
@@ -523,10 +524,29 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return undefined;
     }
   }
-
-  get __unstable__environment(): any {
+  /**
+   * Clerk Instance Environment.
+   *
+   * @internal This is an internal resource, not intended for public usage. It may be changed or removed at any time.
+   * @deprecated Use `__internal_environment` instead.
+   */
+  get __unstable__environment(): EnvironmentResource | null | undefined {
     if (this.clerkjs) {
-      return (this.clerkjs as any).__unstable__environment;
+      return this.clerkjs.__unstable__environment;
+      // TODO: add ssr condition
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
+   * Clerk Instance Environment.
+   *
+   * @internal This is an internal resource, not intended for public usage. It may be changed or removed at any time.
+   */
+  get __internal_environment(): EnvironmentResource | null | undefined {
+    if (this.clerkjs) {
+      return this.clerkjs.__internal_environment;
       // TODO: add ssr condition
     } else {
       return undefined;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -11,6 +11,7 @@ import type {
 } from './appearance';
 import type { ClientResource } from './client';
 import type { CustomPage } from './customPages';
+import type { EnvironmentResource } from './environment';
 import type { DisplayThemeJSON } from './json';
 import type { LocalizationResource } from './localization';
 import type { OAuthProvider, OAuthScope } from './oauth';
@@ -90,6 +91,21 @@ export interface Clerk {
 
   /** Clerk flag for loading Clerk in a standard browser setup */
   isStandardBrowser: boolean | undefined;
+
+  /**
+   * Clerk Instance Environment.
+   *
+   * @internal This is an internal resource, not intended for public usage. It may be changed or removed at any time.
+   * @deprecated Use `__internal_environment` instead.
+   */
+  __unstable__environment: EnvironmentResource | null | undefined;
+
+  /**
+   * Clerk Instance Environment.
+   *
+   * @internal This is an internal resource, not intended for public usage. It may be changed or removed at any time.
+   */
+  __internal_environment: EnvironmentResource | null | undefined;
 
   /** Client handling most Clerk operations. */
   client: ClientResource | undefined;


### PR DESCRIPTION
## Description

We're utilizing `__unstable__environment` a bunch in `elements` and the current state doesn't enforce type safety and requires us to override types in our own package.

The better facilitate inter-package development, I've made the following changes to `Clerk` and `IsomorphicClerk`:

- `__unstable__environment` is now exposed, typed, marked as deprecated, and commented on about its internal state. (To be removed in a future release.)
- `__internal_environment` is exposed with the appropriate typing and comments about its internal state.

### Notes:
- I left `__unstable__environment` for now, until it's worked out of both `elements` and the [accounts repo](https://github.com/clerk/accounts/blob/fbaf86d13d9540589dd267848ef4be3134cb51b1/hooks/useDisplayConfig.ts#L4-L6).

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
