### PR TITLE
fix(clerk-js): Use pattern for email input fields

### DIFF
--- a/.changeset/rare-bulldogs-cheer.md
+++ b/.changeset/rare-bulldogs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use pattern for email input fields.

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -50,14 +50,26 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref)
     hasError: props.hasError || fieldControlProps.hasError,
   });
   const { onChange } = useInput(propsWithoutVariants.onChange);
-  const { isDisabled, hasError, focusRing, isRequired, ...rest } = propsWithoutVariants;
+  const { isDisabled, hasError, focusRing, isRequired, type, ...rest } = propsWithoutVariants;
   const _disabled = isDisabled || fieldControlProps.isDisabled;
   const _required = isRequired || fieldControlProps.isRequired;
   const _hasError = hasError || fieldControlProps.hasError;
 
+  /**
+   * type="email" will not allow characters like this one "ö", instead remove type email and provide a pattern that accepts any character before the "@" symbol
+   */
+
+  const typeProps =
+    type === 'email'
+      ? {
+          pattern: '^.*@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$',
+        }
+      : { type };
+
   return (
     <input
       {...rest}
+      {...typeProps}
       ref={ref}
       onChange={onChange}
       disabled={isDisabled}


### PR DESCRIPTION

## Description
We would like to support special characters like "ö" in emails. Using type="email" does not allow that.

_I've verified that password managers will still correctly store the email._
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
