### PR TITLE
fix(*): Apply fixes reported before ship week

### DIFF
--- a/.changeset/giant-bags-stare.md
+++ b/.changeset/giant-bags-stare.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+---
+
+Update `@clerk/nextjs` error messages to refer to `clerkMiddleware()` and deprecated `authMiddleware()` and fix a typo in `cannotRenderSignUpComponentWhenSessionExists` error message.

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -1,3 +1,4 @@
+import { parseError } from '@clerk/shared/error';
 import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 import snakecaseKeys from 'snakecase-keys';
 
@@ -167,16 +168,4 @@ function parseErrors(data: unknown): ClerkAPIError[] {
     return errors.length > 0 ? errors.map(parseError) : [];
   }
   return [];
-}
-
-function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
-  return {
-    code: error.code,
-    message: error.message,
-    longMessage: error.long_message,
-    meta: {
-      paramName: error?.meta?.param_name,
-      sessionId: error?.meta?.session_id,
-    },
-  };
 }

--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -9,7 +9,5 @@ export {
   isKnownError,
   isMetamaskError,
   isUserLockedError,
-  parseError,
-  parseErrors,
 } from '@clerk/shared/error';
 export type { MetamaskError } from '@clerk/shared/error';

--- a/packages/clerk-js/src/core/resources/Verification.ts
+++ b/packages/clerk-js/src/core/resources/Verification.ts
@@ -1,3 +1,4 @@
+import { parseError } from '@clerk/shared/error';
 import type {
   ClerkAPIError,
   SignUpVerificationJSON,
@@ -10,7 +11,7 @@ import type {
 } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
-import { BaseResource, parseError } from './internal';
+import { BaseResource } from './internal';
 
 export class Verification extends BaseResource implements VerificationResource {
   pathRoot = '';

--- a/packages/clerk-js/src/core/warnings.ts
+++ b/packages/clerk-js/src/core/warnings.ts
@@ -6,7 +6,7 @@ const warnings = {
   cannotRenderComponentWhenSessionExists:
     'The <SignUp/> and <SignIn/> components cannot render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, Clerk is redirecting to the Home URL instead.',
   cannotRenderSignUpComponentWhenSessionExists:
-    'The <SignUp/> component cannot render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, Clerk is redirecting to the value setted in `afterSignUp` URL instead.',
+    'The <SignUp/> component cannot render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, Clerk is redirecting to the value set in `afterSignUp` URL instead.',
   cannotRenderSignInComponentWhenSessionExists:
     'The <SignIn/> component cannot render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, Clerk is redirecting to the `afterSignIn` URL instead.',
   cannotRenderComponentWhenUserDoesNotExist:

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -31,8 +31,8 @@ Alternatively, you can set your own ignoredRoutes. See https://clerk.com/docs/ne
 export const getAuthAuthHeaderMissing = () => authAuthHeaderMissing('getAuth');
 
 export const authAuthHeaderMissing = (helperName = 'auth') =>
-  `Clerk: ${helperName}() was called but Clerk can't detect usage of authMiddleware(). Please ensure the following:
-- authMiddleware() is used in your Next.js Middleware.
+  `Clerk: ${helperName}() was called but Clerk can't detect usage of clerkMiddleware() (or the deprecated authMiddleware()). Please ensure the following:
+-  clerkMiddleware() (or the deprecated authMiddleware()) is used in your Next.js Middleware.
 - Your Middleware matcher is configured to match this route or page.
 - If you are using the src directory, make sure the Middleware file is inside of it.
 

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -2,7 +2,7 @@ export const missingDomainAndProxy = `
 Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl.
 
 1) With middleware
-   e.g. export default authMiddleware({domain:'YOUR_DOMAIN',isSatellite:true});
+   e.g. export default clerkMiddleware({domain:'YOUR_DOMAIN',isSatellite:true}); // or the deprecated authMiddleware()
 2) With environment variables e.g.
    NEXT_PUBLIC_CLERK_DOMAIN='YOUR_DOMAIN'
    NEXT_PUBLIC_CLERK_IS_SATELLITE='true'
@@ -13,7 +13,7 @@ Invalid signInUrl. A satellite application requires a signInUrl for development 
 Check if signInUrl is missing from your configuration or if it is not an absolute URL
 
 1) With middleware
-   e.g. export default authMiddleware({signInUrl:'SOME_URL', isSatellite:true});
+   e.g. export default clerkMiddleware({signInUrl:'SOME_URL', isSatellite:true}); // or the deprecated authMiddleware()
 2) With environment variables e.g.
    NEXT_PUBLIC_CLERK_SIGN_IN_URL='SOME_URL'
    NEXT_PUBLIC_CLERK_IS_SATELLITE='true'`;


### PR DESCRIPTION
## Description

Update `@clerk/nextjs` error messages to refer to `clerkMiddleware()` and deprecated `authMiddleware()` and fix a typo in `cannotRenderSignUpComponentWhenSessionExists` error message.
There was also some internal refactoring for `parseError` helper.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
