### PR TITLE
fix(nextjs,backend): Replace `error` with `errors` for jwt / token helpers return value

### DIFF
--- a/.changeset/unlucky-frogs-tap.md
+++ b/.changeset/unlucky-frogs-tap.md
@@ -1,0 +1,41 @@
+---
+'@clerk/backend': major
+'@clerk/nextjs': major
+---
+
+Replace return the value of the following jwt helpers to match the format of backend API client return values (for consistency).
+
+```diff
+import { signJwt } from '@clerk/backend/jwt';
+
+- const { data, error } = await signJwt(...);
++ const { data, errors: [error] = [] } = await signJwt(...);
+```
+
+```diff
+import { verifyJwt } from '@clerk/backend/jwt';
+
+- const { data, error } = await verifyJwt(...);
++ const { data, errors: [error] = [] } = await verifyJwt(...);
+```
+
+```diff
+import { hasValidSignature } from '@clerk/backend/jwt';
+
+- const { data, error } = await hasValidSignature(...);
++ const { data, errors: [error] = [] } = await hasValidSignature(...);
+```
+
+```diff
+import { decodeJwt } from '@clerk/backend/jwt';
+
+- const { data, error } = await decodeJwt(...);
++ const { data, errors: [error] = [] } = await decodeJwt(...);
+```
+
+```diff
+import { verifyToken } from '@clerk/backend';
+
+- const { data, error } = await verifyToken(...);
++ const { data, errors: [error] = [] } = await verifyToken(...);
+```

--- a/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
+++ b/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
@@ -56,27 +56,27 @@ export default (QUnit: QUnit) => {
     });
 
     test('returns an error if null is given as jwt', assert => {
-      const { error } = decodeJwt('null');
+      const { errors: [error] = [] } = decodeJwt('null');
       assert.propContains(error, invalidTokenError);
     });
 
     test('returns an error if undefined is given as jwt', assert => {
-      const { error } = decodeJwt('undefined');
+      const { errors: [error] = [] } = decodeJwt('undefined');
       assert.propContains(error, invalidTokenError);
     });
 
     test('returns an error if empty string is given as jwt', assert => {
-      const { error } = decodeJwt('');
+      const { errors: [error] = [] } = decodeJwt('');
       assert.propContains(error, invalidTokenError);
     });
 
     test('throws an error if invalid string is given as jwt', assert => {
-      const { error } = decodeJwt('whatever');
+      const { errors: [error] = [] } = decodeJwt('whatever');
       assert.propContains(error, invalidTokenError);
     });
 
     test('throws an error if number is given as jwt', assert => {
-      const { error } = decodeJwt('42');
+      const { errors: [error] = [] } = decodeJwt('42');
       assert.propContains(error, invalidTokenError);
     });
   });
@@ -127,7 +127,7 @@ export default (QUnit: QUnit) => {
         issuer: mockJwtPayload.iss,
         authorizedParties: ['', 'https://accounts.inspired.puma-74.lcl.dev'],
       };
-      const { error } = await verifyJwt('invalid-jwt', inputVerifyJwtOptions);
+      const { errors: [error] = [] } = await verifyJwt('invalid-jwt', inputVerifyJwtOptions);
       assert.propContains(error, invalidTokenError);
     });
   });

--- a/packages/backend/src/jwt/signJwt.ts
+++ b/packages/backend/src/jwt/signJwt.ts
@@ -60,6 +60,6 @@ export async function signJwt(
     const encodedSignature = `${firstPart}.${base64url.stringify(new Uint8Array(signature), { pad: false })}`;
     return { data: encodedSignature };
   } catch (error) {
-    return { error: new SignJWTError((error as Error)?.message) };
+    return { errors: [new SignJWTError((error as Error)?.message)] };
   }
 }

--- a/packages/backend/src/jwt/types.ts
+++ b/packages/backend/src/jwt/types.ts
@@ -1,9 +1,9 @@
 export type JwtReturnType<R, E extends Error> =
   | {
       data: R;
-      error?: undefined;
+      errors?: undefined;
     }
   | {
       data?: undefined;
-      error: E;
+      errors: [E];
     };

--- a/packages/backend/src/tokens/handshake.ts
+++ b/packages/backend/src/tokens/handshake.ts
@@ -6,9 +6,9 @@ import { loadClerkJWKFromLocal, loadClerkJWKFromRemote } from './keys';
 import type { VerifyTokenOptions } from './verify';
 
 async function verifyHandshakeJwt(token: string, { key }: VerifyJwtOptions): Promise<{ handshake: string[] }> {
-  const { data: decoded, error } = decodeJwt(token);
-  if (error) {
-    throw error;
+  const { data: decoded, errors } = decodeJwt(token);
+  if (errors) {
+    throw errors[0];
   }
 
   const { header, payload } = decoded;
@@ -19,11 +19,11 @@ async function verifyHandshakeJwt(token: string, { key }: VerifyJwtOptions): Pro
   assertHeaderType(typ);
   assertHeaderAlgorithm(alg);
 
-  const { data: signatureValid, error: signatureError } = await hasValidSignature(decoded, key);
-  if (signatureError) {
+  const { data: signatureValid, errors: signatureErrors } = await hasValidSignature(decoded, key);
+  if (signatureErrors) {
     throw new TokenVerificationError({
       reason: TokenVerificationErrorReason.TokenVerificationFailed,
-      message: `Error verifying handshake token. ${signatureError}`,
+      message: `Error verifying handshake token. ${signatureErrors[0]}`,
     });
   }
 
@@ -46,9 +46,9 @@ export async function verifyHandshakeToken(
 ): Promise<{ handshake: string[] }> {
   const { secretKey, apiUrl, apiVersion, jwksCacheTtlInMs, jwtKey, skipJwksCache } = options;
 
-  const { data, error } = decodeJwt(token);
-  if (error) {
-    throw error;
+  const { data, errors } = decodeJwt(token);
+  if (errors) {
+    throw errors[0];
   }
 
   const { kid } = data.header;

--- a/packages/nextjs/src/server/createGetAuth.ts
+++ b/packages/nextjs/src/server/createGetAuth.ts
@@ -46,9 +46,9 @@ export const createGetAuth = ({
       logger.debug('Options debug', options);
 
       if (authStatus === AuthStatus.SignedIn) {
-        const { data: jwt, error } = decodeJwt(authToken as string);
-        if (error) {
-          throw error;
+        const { data: jwt, errors } = decodeJwt(authToken as string);
+        if (errors) {
+          throw errors[0];
         }
 
         logger.debug('JWT debug', jwt.raw.text);
@@ -68,10 +68,10 @@ export const getAuth = createGetAuth({
 export const parseJwt = (req: RequestLike) => {
   const cookieToken = getCookie(req, constants.Cookies.Session);
   const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
-  const { data, error } = decodeJwt(cookieToken || headerToken || '');
+  const { data, errors } = decodeJwt(cookieToken || headerToken || '');
 
-  if (error) {
-    throw error;
+  if (errors) {
+    throw errors[0];
   }
 
   return data;


### PR DESCRIPTION
## Description

Affected helpers:
- signJwt
- verifyJwt
- hasValidSignature
- decodeJwt
- verifyToken

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
