### PR TITLE
Fix(backend,remix): Issues with v5 and resources loading in request object

### DIFF
--- a/.changeset/afraid-experts-eat.md
+++ b/.changeset/afraid-experts-eat.md
@@ -1,0 +1,51 @@
+---
+'@clerk/backend': major
+---
+
+Drop `user` / `organization` / `session` from auth object on **signed-out** state (current value was `null`). Eg
+
+```diff
+    // Backend
+    import { createClerkClient } from '@clerk/backend';
+
+    const clerkClient = createClerkClient({...});
+    const requestState = clerkClient.authenticateRequest(request, {...});
+
+    - const { user, organization, session } = requestState.toAuth();
+    + const { userId, organizationId, sessionId } = requestState.toAuth();
+
+    // Remix
+    import { getAuth } from '@clerk/remix/ssr.server';
+    
+    - const { user, organization, session } = await getAuth(args);
+    + const { userId, organizationId, sessionId } = await getAuth(args);
+
+    // or 
+    rootAuthLoader(
+        args,
+        ({ request }) => {
+            - const { user, organization, session } = request.auth;
+            + const { userId, organizationId, sessionId } = request.auth;
+            // ...
+        },
+        { loadUser: true },
+    );
+
+    // NextJS
+    import { getAuth } from '@clerk/nextjs/server';
+    
+    - const { user, organization, session } = getAuth(args);
+    + const { userId, organizationId, sessionId } = getAuth(req, opts);
+
+    // Gatsby
+    import { withServerAuth } from 'gatsby-plugin-clerk';
+
+    export const getServerData: GetServerData<any> = withServerAuth(
+        async props => {
+            - const { user, organization, session } =  props;
+            + const { userId, organizationId, sessionId } = props;
+            return { props: { data: '1', auth: props.auth, userId, organizationId, sessionId } };
+        },
+        { loadUser: true },
+    );
+```

--- a/.changeset/strange-trains-bow.md
+++ b/.changeset/strange-trains-bow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Fix adding `user`/`sessions`/`organization` resources into request.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -41,13 +41,10 @@ function assertSignedOutToAuth(assert, requestState: RequestState) {
   assert.propContains(requestState.toAuth(), {
     sessionClaims: null,
     sessionId: null,
-    session: null,
     userId: null,
-    user: null,
     orgId: null,
     orgRole: null,
     orgSlug: null,
-    organization: null,
     getToken: {},
   });
 }

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -47,15 +47,12 @@ export type SignedInAuthObject = {
 export type SignedOutAuthObject = {
   sessionClaims: null;
   sessionId: null;
-  session: null;
   actor: null;
   userId: null;
-  user: null;
   orgId: null;
   orgRole: null;
   orgSlug: null;
   orgPermissions: null;
-  organization: null;
   getToken: ServerGetToken;
   has: CheckAuthorizationWithCustomPermissions;
   debug: AuthObjectDebug;
@@ -148,15 +145,12 @@ export function signedOutAuthObject(debugData?: AuthObjectDebugData): SignedOutA
   return {
     sessionClaims: null,
     sessionId: null,
-    session: null,
     userId: null,
-    user: null,
     actor: null,
     orgId: null,
     orgRole: null,
     orgSlug: null,
     orgPermissions: null,
-    organization: null,
     getToken: () => Promise.resolve(null),
     has: () => false,
     debug: createDebug(debugData),

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -2,6 +2,7 @@ import { stripPrivateDataFromObject } from '@clerk/backend/internal';
 
 import { noLoaderArgsPassedInGetAuth } from '../errors';
 import { authenticateRequest } from './authenticateRequest';
+import { loadOptions } from './loadOptions';
 import type { GetAuthReturn, LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 
 type GetAuthOptions = Pick<RootAuthLoaderOptions, 'secretKey'>;
@@ -11,8 +12,9 @@ export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): 
     throw new Error(noLoaderArgsPassedInGetAuth);
   }
 
+  const loadedOptions = loadOptions(args, opts);
   // Note: authenticateRequest() will throw a redirect if the auth state is determined to be handshake
-  const requestState = await authenticateRequest(args, opts || {});
+  const requestState = await authenticateRequest(args, loadedOptions);
 
   return stripPrivateDataFromObject(requestState.toAuth());
 }

--- a/packages/remix/src/ssr/loadOptions.ts
+++ b/packages/remix/src/ssr/loadOptions.ts
@@ -1,0 +1,72 @@
+import { createClerkRequest } from '@clerk/backend/internal';
+import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey';
+import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
+import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
+import { isTruthy } from '@clerk/shared/underscore';
+
+import { noSecretKeyError, satelliteAndMissingProxyUrlAndDomain, satelliteAndMissingSignInUrl } from '../errors';
+import { getEnvVariable } from '../utils';
+import type { LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
+
+export const loadOptions = (args: LoaderFunctionArgs, overrides: RootAuthLoaderOptions = {}) => {
+  const { request, context } = args;
+  const clerkRequest = createClerkRequest(request);
+
+  // Fetch environment variables across Remix runtime.
+  // 1. First check if the user passed the key in the getAuth function or the rootAuthLoader.
+  // 2. Then try from process.env if exists (Node).
+  // 3. Then try from globalThis (Cloudflare Workers).
+  // 4. Then from loader context (Cloudflare Pages).
+  const secretKey = overrides.secretKey || getEnvVariable('CLERK_SECRET_KEY', context) || '';
+  const publishableKey = overrides.publishableKey || getEnvVariable('CLERK_PUBLISHABLE_KEY', context) || '';
+  const jwtKey = overrides.jwtKey || getEnvVariable('CLERK_JWT_KEY', context);
+  const apiUrl = getEnvVariable('CLERK_API_URL', context) || apiUrlFromPublishableKey(publishableKey);
+  const domain =
+    handleValueOrFn(overrides.domain, new URL(request.url)) || getEnvVariable('CLERK_DOMAIN', context) || '';
+  const isSatellite =
+    handleValueOrFn(overrides.isSatellite, new URL(request.url)) ||
+    isTruthy(getEnvVariable('CLERK_IS_SATELLITE', context));
+  const relativeOrAbsoluteProxyUrl = handleValueOrFn(
+    overrides?.proxyUrl,
+    clerkRequest.clerkUrl,
+    getEnvVariable('CLERK_PROXY_URL', context),
+  );
+  const signInUrl = overrides.signInUrl || getEnvVariable('CLERK_SIGN_IN_URL', context) || '';
+  const signUpUrl = overrides.signUpUrl || getEnvVariable('CLERK_SIGN_UP_URL', context) || '';
+  const afterSignInUrl = overrides.afterSignInUrl || getEnvVariable('CLERK_AFTER_SIGN_IN_URL', context) || '';
+  const afterSignUpUrl = overrides.afterSignUpUrl || getEnvVariable('CLERK_AFTER_SIGN_UP_URL', context) || '';
+
+  let proxyUrl;
+  if (!!relativeOrAbsoluteProxyUrl && isProxyUrlRelative(relativeOrAbsoluteProxyUrl)) {
+    proxyUrl = new URL(relativeOrAbsoluteProxyUrl, clerkRequest.clerkUrl).toString();
+  } else {
+    proxyUrl = relativeOrAbsoluteProxyUrl;
+  }
+
+  if (!secretKey) {
+    throw new Error(noSecretKeyError);
+  }
+  if (isSatellite && !proxyUrl && !domain) {
+    throw new Error(satelliteAndMissingProxyUrlAndDomain);
+  }
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromSecretKey(secretKey)) {
+    throw new Error(satelliteAndMissingSignInUrl);
+  }
+
+  return {
+    // used to append options that are not initialized from env
+    ...overrides,
+    secretKey,
+    publishableKey,
+    jwtKey,
+    apiUrl,
+    domain,
+    isSatellite,
+    proxyUrl,
+    signInUrl,
+    signUpUrl,
+    afterSignInUrl,
+    afterSignUpUrl,
+  };
+};

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -4,6 +4,7 @@ import { isDeferredData } from '@remix-run/server-runtime/dist/responses';
 
 import { invalidRootLoaderCallbackReturn } from '../errors';
 import { authenticateRequest } from './authenticateRequest';
+import { loadOptions } from './loadOptions';
 import type { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootAuthLoaderOptions } from './types';
 import {
   assertValidHandlerResult,
@@ -46,8 +47,9 @@ export const rootAuthLoader: RootAuthLoader = async (
     ? handlerOrOptions
     : {};
 
+  const loadedOptions = loadOptions(args, opts);
   // Note: authenticateRequest() will throw a redirect if the auth state is determined to be handshake
-  const requestState = await authenticateRequest(args, opts);
+  const requestState = await authenticateRequest(args, loadedOptions);
 
   if (!handler) {
     // if the user did not provide a handler, simply inject requestState into an empty response
@@ -55,8 +57,9 @@ export const rootAuthLoader: RootAuthLoader = async (
   }
 
   const authObj = requestState.toAuth();
-  Object.assign(args.request, { auth: authObj });
-  const handlerResult = await handler(await decorateObjectWithResources(args, authObj, opts));
+  const requestWithAuth = Object.assign(args.request, { auth: authObj });
+  await decorateObjectWithResources(requestWithAuth, authObj, loadedOptions);
+  const handlerResult = await handler(args);
   assertValidHandlerResult(handlerResult, invalidRootLoaderCallbackReturn);
 
   // When using defer(), we need to inject the clerk auth state into its internal data object.

--- a/playground/remix-node/app/entry.server.tsx
+++ b/playground/remix-node/app/entry.server.tsx
@@ -1,6 +1,5 @@
 import { PassThrough } from 'stream';
 import type { EntryContext } from '@remix-run/node';
-import { Response } from '@remix-run/node';
 import { RemixServer } from '@remix-run/react';
 import isbot from 'isbot';
 import { renderToPipeableStream } from 'react-dom/server';

--- a/playground/remix-node/app/root.tsx
+++ b/playground/remix-node/app/root.tsx
@@ -1,8 +1,8 @@
-import { defer, type DataFunctionArgs, type Headers } from '@remix-run/node';
+import { defer, type DataFunctionArgs } from '@remix-run/node';
 import type { MetaFunction } from '@remix-run/react';
 import { Await, Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from '@remix-run/react';
-import { getClerkDebugHeaders, rootAuthLoader } from '@clerk/remix/ssr.server';
-import { ClerkApp, ClerkErrorBoundary } from '@clerk/remix';
+import { rootAuthLoader } from '@clerk/remix/ssr.server';
+import { ClerkApp } from '@clerk/remix';
 import { Suspense } from 'react';
 
 export const loader = (args: DataFunctionArgs) => {
@@ -45,8 +45,6 @@ export const meta: MetaFunction = () => {
     },
   ];
 };
-
-export const ErrorBoundary = ClerkErrorBoundary();
 
 function App() {
   const loaderData = useLoaderData<typeof loader>();

--- a/playground/remix-node/app/routes/sign-in.$.tsx
+++ b/playground/remix-node/app/routes/sign-in.$.tsx
@@ -5,6 +5,7 @@ export default function SignInPage() {
     <div style={{ border: '2px solid blue', padding: '2rem' }}>
       <h1>Sign In route</h1>
       <SignIn
+        path='/sign-in'
         signUpUrl='/sign-up'
       />
     </div>

--- a/playground/remix-node/package.json
+++ b/playground/remix-node/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "eslint": "^8.27.0",
-    "typescript": "^4.8.4"
+    "typescript": "^5"
   },
   "engines": {
     "node": ">=18"

--- a/playground/remix-node/remix.config.js
+++ b/playground/remix-node/remix.config.js
@@ -2,12 +2,4 @@
 module.exports = {
   ignoredRouteFiles: ['**/.*'],
   serverModuleFormat: 'cjs',
-  future: {
-    v2_errorBoundary: true,
-    v2_meta: true,
-    v2_normalizeFormMethod: true,
-    v2_routeConvention: true,
-    v2_headers: true,
-    v2_dev: true,
-  },
 };


### PR DESCRIPTION
## Description

As part of this PR the following changes were applied:
- Dropped `user`, `session`, `organization` resources from the SignedOut authObject
- Fix setting the `user`, `session`, `organization` resources in remix `remix`

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
