### PR TITLE
fix(clerk-js): Throw error for unsupported method `OrganizationMembership.reload`

### DIFF
--- a/.changeset/gold-shrimps-behave.md
+++ b/.changeset/gold-shrimps-behave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Throw error for unsupported method `OrganizationMembership.reload`

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -119,3 +119,7 @@ export function clerkFailedToLoadThirdPartyScript(name?: string): never {
 export function clerkInvalidRoutingStrategy(strategy?: string): never {
   throw new Error(`${errorPrefix} Invalid routing strategy, path cannot be used in tandem with ${strategy}.`);
 }
+
+export function clerkUnsupportedReloadMethod(className: string): never {
+  throw new Error(`${errorPrefix} Calling ${className}.reload is not currently supported. Please contact support.`);
+}

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -10,6 +10,7 @@ import type {
 
 import { unixEpochToDate } from '../../utils/date';
 import { convertPageToOffset } from '../../utils/pagesToOffset';
+import { clerkUnsupportedReloadMethod } from '../errors';
 import { BaseResource, Organization, PublicUserData } from './internal';
 
 export class OrganizationMembership extends BaseResource implements OrganizationMembershipResource {
@@ -78,27 +79,8 @@ export class OrganizationMembership extends BaseResource implements Organization
     return this;
   }
 
-  public async reload(params?: ClerkResourceReloadParams): Promise<this> {
-    const { rotatingTokenNonce } = params || {};
-    const json = await BaseResource._fetch(
-      {
-        method: 'GET',
-        path: `/me/organization_memberships`,
-        rotatingTokenNonce,
-      },
-      { forceUpdateClient: true },
-    );
-
-    if (!json?.response) {
-      return this.fromJSON(null);
-    }
-
-    // TODO: Fix typing
-    const currentMembership = (json.response as unknown as OrganizationMembershipJSON[]).find(
-      orgMem => orgMem.id === this.id,
-    );
-
-    return this.fromJSON(currentMembership as OrganizationMembershipJSON);
+  public reload(_?: ClerkResourceReloadParams): Promise<this> {
+    clerkUnsupportedReloadMethod('OrganizationMembership');
   }
 }
 


### PR DESCRIPTION
## Description

The only class that overrides the reload method from Base is OrganizationMembership. And it is broken, because the logic inside it no longer makes sense with the paginated endpoints. There is no endpoint to fetch by id so we need to notify developers with a descriptive error

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
