### PR TITLE
Fix(clerk-sdk-node): `request.auth` type

### DIFF
--- a/.changeset/neat-crabs-know.md
+++ b/.changeset/neat-crabs-know.md
@@ -1,0 +1,29 @@
+---
+'@clerk/clerk-sdk-node': major
+---
+
+Changes the `request.auth` type from `LegacyAuthObject` to `AuthObject`.
+```typescript
+type LegacyAuthObject = {
+  sessionId: string | null;
+  actor: ActClaim | undefined | null;
+  userId: string | null;
+  getToken: ServerGetToken | null;
+  debug: AuthObjectDebug | null;
+  claims: JwtPayload | null;
+}
+
+type AuthObject = {
+  sessionClaims: JwtPayload | null;
+  sessionId: string | null;
+  actor: ActClaim | undefined | null;
+  userId: string | null;
+  orgId: string | undefined | null;
+  orgRole: OrganizationCustomRoleKey | undefined | null;
+  orgSlug: string | undefined | null;
+  orgPermissions: OrganizationCustomPermissionKey[] | undefined | null;
+  getToken: ServerGetToken | null;
+  has: CheckAuthorizationWithCustomPermissions | null;
+  debug: AuthObjectDebug | null;
+};
+```

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -4,10 +4,6 @@ import type { MultiDomainAndOrProxy } from '@clerk/types';
 import type { NextFunction, Request, Response } from 'express';
 import type { IncomingMessage } from 'http';
 
-type LegacyAuthObject<T extends AuthObject> = Pick<T, 'sessionId' | 'userId' | 'actor' | 'getToken' | 'debug'> & {
-  claims: AuthObject['sessionClaims'];
-};
-
 export type MiddlewareWithAuthProp = (
   // req: WithAuthProp<Request>
   req: Request,
@@ -22,8 +18,8 @@ export type MiddlewareRequireAuthProp = (
   next: NextFunction,
 ) => Promise<void>;
 
-export type LooseAuthProp = { auth: LegacyAuthObject<AuthObject> };
-export type StrictAuthProp = { auth: LegacyAuthObject<SignedInAuthObject> };
+export type LooseAuthProp = { auth: AuthObject };
+export type StrictAuthProp = { auth: SignedInAuthObject };
 export type WithAuthProp<T> = T & LooseAuthProp;
 export type RequireAuthProp<T> = T & StrictAuthProp;
 


### PR DESCRIPTION
## Description

Changes the `request.auth` type from `LegacyAuthObject` to `AuthObject`.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
