### PR TITLE
fix(clerk-js): Throws FAPI errors during dev browser creation

### DIFF
--- a/.changeset/clever-hounds-flow.md
+++ b/.changeset/clever-hounds-flow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Inform developers who are using legacy Clerk development instances that in V5 URL Based Session Syncing must be enabled. For more information refer to https://clerk.com/docs/upgrade-guides/url-based-session-syncing.

--- a/packages/clerk-js/src/core/devBrowser.test.ts
+++ b/packages/clerk-js/src/core/devBrowser.test.ts
@@ -1,8 +1,57 @@
-describe.skip('detBrowserHandler', () => {
-  // TODO: Add devbrowser tests
-  describe('get', () => {
-    it('todo', () => {
-      expect(true).toBeTruthy();
+import { createDevBrowser } from './devBrowser';
+import type { FapiClient } from './fapiClient';
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
+describe('Thrown errors', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve<RecursivePartial<Response>>({
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            errors: [
+              {
+                message: 'URL-based session syncing is disabled for this instance',
+                long_message:
+                  'This is a development instance operating with legacy, third-party cookies. To enable URL-based session syncing refer to https://clerk.com/docs/upgrade-guides/url-based-session-syncing.',
+                code: 'url_based_session_syncing_disabled',
+              },
+            ],
+            clerk_trace_id: 'ff1048d1cb5a74da3ebd660877680ba3',
+          }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    global.fetch?.mockClear();
+  });
+
+  // Note: The test runs without any initial or mocked values on __clerk_db_jwt cookies.
+  // It is expected to modify the test accordingly if cookies are mocked for future extra testing.
+  it('throws any FAPI errors during dev browser creation', async () => {
+    const mockCreateFapiClient = jest.fn().mockImplementation(() => {
+      return {
+        buildUrl: jest.fn(() => 'https://white-koala-42.clerk.accounts.dev/dev_browser'),
+        onAfterResponse: jest.fn(),
+        onBeforeRequest: jest.fn(),
+      };
     });
+
+    const mockFapiClient = mockCreateFapiClient() as FapiClient;
+
+    const devBrowserHandler = createDevBrowser({
+      frontendApi: 'white-koala-42.clerk.accounts.dev',
+      fapiClient: mockFapiClient,
+    });
+
+    await expect(devBrowserHandler.setup()).rejects.toThrow(
+      'ClerkJS: Something went wrong initializing Clerk in development mode. This is a development instance operating with legacy, third-party cookies. To enable URL-based session syncing refer to https://clerk.com/docs/upgrade-guides/url-based-session-syncing.',
+    );
   });
 });

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -8,8 +8,8 @@ export function clerkErrorInitFailed(): never {
   throw new Error(`${errorPrefix} Something went wrong initializing Clerk.`);
 }
 
-export function clerkErrorDevInitFailed(msg?: string): never {
-  throw new Error(`${errorPrefix} Something went wrong initializing Clerk in development mode${msg && ` - ${msg}`}.`);
+export function clerkErrorDevInitFailed(msg: string = ''): never {
+  throw new Error(`${errorPrefix} Something went wrong initializing Clerk in development mode.${msg && ` ${msg}`}`);
 }
 
 export function clerkErrorPathRouterMissingPath(componentName: string): never {


### PR DESCRIPTION
## Description

This fix informs users of legacy Clerk development instances to migrate to URL Based Sessing syncing if they want to upgrade to ClerkJS v5

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
