### PR TITLE
fix(clerk-js): Remove handshake paramters when clerk-js loads

### DIFF
--- a/.changeset/tender-wasps-hope.md
+++ b/.changeset/tender-wasps-hope.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove handshake-related query parameters on load of clerk-js. It's possible that these parameters will be returned from Clerk's API, but they are only applicable for SSR-compatible frameworks and so on the client they are unused.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1441,6 +1441,8 @@ export class Clerk implements ClerkInterface {
       }
     }
 
+    this.#clearHandshakeFromUrl();
+
     this.#handleImpersonationFab();
     return true;
   };
@@ -1621,5 +1623,18 @@ export class Clerk implements ClerkInterface {
 
     await this.navigate(this.buildUrlWithAuth(redirectUrl));
     return true;
+  };
+
+  /**
+   * The handshake payload is transported in the URL in development. In cases where FAPI is returning the handshake payload, but Clerk is being used in a client-only application,
+   * we remove the handshake associated parameters as they are not necessary.
+   */
+  #clearHandshakeFromUrl = () => {
+    try {
+      removeClerkQueryParam('__clerk_handshake');
+      removeClerkQueryParam('__clerk_help');
+    } catch (_) {
+      // ignore
+    }
   };
 }

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -35,7 +35,9 @@ export function getClerkQueryParam<T extends ClerkQueryParam>(param: T): ClerkQu
 
 export function removeClerkQueryParam<T extends ClerkQueryParam>(param: T) {
   const url = new URL(window.location.href);
-  url.searchParams.delete(param);
-  window.history.replaceState(window.history.state, '', url);
+  if (url.searchParams.has(param)) {
+    url.searchParams.delete(param);
+    window.history.replaceState(window.history.state, '', url);
+  }
   return;
 }

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -6,6 +6,8 @@ const ClerkQueryParams = [
   '__clerk_invitation_token',
   '__clerk_ticket',
   '__clerk_modal_state',
+  '__clerk_handshake',
+  '__clerk_help',
   CLERK_SYNCED,
   CLERK_SATELLITE_URL,
 ] as const;
@@ -20,6 +22,8 @@ type ClerkQueryParamsToValuesMap = {
   __clerk_modal_state: string;
   __clerk_synced: string;
   __clerk_satellite_url: string;
+  __clerk_handshake: string;
+  __clerk_help: string;
 };
 
 export type VerificationStatus = 'expired' | 'failed' | 'loading' | 'verified' | 'verified_switch_tab';


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
On load of clerk-js, clean up any handshake related query parameters. These can exist if we trigger a flow that returns the handshake payload from a client-side-only application.

In the future, we can attempt to detect if the host SDK has SSR support, and if not we can avoid sending the handshake payload. This will likely require passing additional context to FAPI calls.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
