### PR TITLE
feat(nextjs): Infer the path the component is mounted at automatically in pages and app router

### DIFF
--- a/.changeset/early-cars-cross.md
+++ b/.changeset/early-cars-cross.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Infer the path the component is mounted at automatically in pages and app router

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -17,7 +17,7 @@ import type {
 } from '@clerk/types';
 import React from 'react';
 
-import { useClerkNextOptions } from './NextOptionsContext';
+import { usePathnameWithoutWithCatchAll } from './usePathnameWithoutCatchAll';
 
 export {
   OrganizationList,
@@ -35,13 +35,15 @@ export {
 // "The inferred type of 'UserProfile' cannot be named without a reference to ..."
 export const UserProfile: typeof BaseUserProfile = Object.assign(
   (props: UserProfileProps) => {
-    return <BaseUserProfile {...useRoutingProps('UserProfile', props)} />;
+    const path = usePathnameWithoutWithCatchAll();
+    return <BaseUserProfile {...useRoutingProps('UserProfile', props, { path })} />;
   },
   { ...BaseUserProfile },
 );
 
 export const CreateOrganization = (props: CreateOrganizationProps) => {
-  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props)} />;
+  const path = usePathnameWithoutWithCatchAll();
+  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props, { path })} />;
 };
 
 // The assignment of OrganizationProfile with BaseOrganizationProfile props is used
@@ -50,17 +52,18 @@ export const CreateOrganization = (props: CreateOrganizationProps) => {
 // "The inferred type of 'OrganizationProfile' cannot be named without a reference to ..."
 export const OrganizationProfile: typeof BaseOrganizationProfile = Object.assign(
   (props: OrganizationProfileProps) => {
-    return <BaseOrganizationProfile {...useRoutingProps('OrganizationProfile', props)} />;
+    const path = usePathnameWithoutWithCatchAll();
+    return <BaseOrganizationProfile {...useRoutingProps('OrganizationProfile', props, { path })} />;
   },
   { ...BaseOrganizationProfile },
 );
 
 export const SignIn = (props: SignInProps) => {
-  const { signInUrl } = useClerkNextOptions();
-  return <BaseSignIn {...useRoutingProps('SignIn', props, { path: signInUrl })} />;
+  const path = usePathnameWithoutWithCatchAll();
+  return <BaseSignIn {...useRoutingProps('SignIn', props, { path })} />;
 };
 
 export const SignUp = (props: SignUpProps) => {
-  const { signUpUrl } = useClerkNextOptions();
-  return <BaseSignUp {...useRoutingProps('SignUp', props, { path: signUpUrl })} />;
+  const path = usePathnameWithoutWithCatchAll();
+  return <BaseSignUp {...useRoutingProps('SignUp', props, { path })} />;
 };

--- a/packages/nextjs/src/client-boundary/usePathnameWithoutCatchAll.tsx
+++ b/packages/nextjs/src/client-boundary/usePathnameWithoutCatchAll.tsx
@@ -1,0 +1,42 @@
+import { useRouter } from 'next/compat/router';
+
+export const usePathnameWithoutWithCatchAll = () => {
+  // The compat version of useRouter returns null instead of throwing an error
+  // when used inside app router instead of pages router
+  // we use it to detect if the component is used inside pages or app router
+  // so we can use the correct algorithm to get the path
+  const pagesRouter = useRouter();
+
+  if (pagesRouter) {
+    // in pages router things are simpler as the pathname includes the catch all route
+    // which starts with [[... and we can just remove it
+    return pagesRouter.pathname.replace(/\/\[\[\.\.\..*/, '');
+  }
+
+  // require is used to avoid importing next/navigation when the pages router is used,
+  // as it will throw an error. We cannot use dynamic import as it is async
+  // and we need the hook to be sync
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const usePathname = require('next/navigation').usePathname;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const useParams = require('next/navigation').useParams;
+
+  // Get the pathname that includes any named or catch all params
+  // eg:
+  // the filesystem route /user/[id]/profile/[[...rest]]/page.tsx
+  // could give us the following pathname /user/123/profile/security
+  // if the user navigates to the security section of the user profile
+  const pathname = usePathname() || '';
+  const pathParts = pathname.split('/').filter(Boolean);
+  // the useParams hook returns an object with all named and catch all params
+  // for named params, the key in the returned object always contains a single value
+  // for catch all params, the key in the returned object contains an array of values
+  // we find the catch all params by checking if the value is an array
+  // and then we remove one path part for each catch all param
+  const catchAllParams = Object.values(useParams() || {})
+    .filter(v => Array.isArray(v))
+    .flat(Infinity);
+  // so we end up with the pathname where the components are mounted at
+  // eg /user/123/profile/security will return /user/123/profile as the path
+  return `/${pathParts.slice(0, pathParts.length - catchAllParams.length).join('/')}`;
+};


### PR DESCRIPTION
## Description

Detailed explanation is in the comments, please take a look at the code itself.
This PR allows using all components with path routing without passing the path manually

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
