### PR TITLE
Close issues without a reproduction specified after 8 days

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -57,6 +57,19 @@ jobs:
             After 60 days of no activity, we'll close this PR. Keep in mind, I'm just a robot, so if I've closed this PR in error, please reply here and my human colleagues will reopen it.
 
             Thanks for being a part of the Clerk community! 🙏
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.CLERK_COOKIE_PAT }}
+          days-before-issue-stale: 7
+          days-before-issue-close: 1
+          exempt-all-assignees: true
+          only-issue-labels: 'needs-reproduction'
+          stale-issue-message: |
+            In an effort to keep our GitHub issues clean and focused, we close any issues that are awaiting a reproduction after 8 days on inactivity, and it has been 7 days. This issue will be closed tomorrow unless a reproduction is produced. If it takes longer than this to get a reproduction, that's ok, just drop a comment and we will re-open the issue then.
+
+            Thanks for being a part of the Clerk community! 🙏
+          close-issue-message: |
+            After 8 days without a reproduction being supplied, we are closing this issue. Keep in mind, I'm just a robot, so if I've closed this issue in error, please reply here and my human colleagues will reopen it. Likewise if a reproduction is prepared after it has been closed.
       - uses: dessant/lock-threads@v4
         with:
           github-token: ${{ secrets.CLERK_COOKIE_PAT }}


### PR DESCRIPTION
## Description

We have a lot of issues that have been awaiting reproduction for months - in an effort to keep our issues section clean, we'd like to close these issues faster. If it's taking a while to produce a reproduction, that's ok, we can always re-open once one is provided.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
