### PR TITLE
chore(nextjs): Remove useSearchParams usage

### DIFF
--- a/.changeset/eight-dolphins-float.md
+++ b/.changeset/eight-dolphins-float.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Remove usage of useSearchParams() to avoid CSR de-opt.

--- a/integration/templates/next-app-router/package.json
+++ b/integration/templates/next-app-router/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@types/node": "^18.17.0",
-    "@types/react": "18.2.14",
-    "@types/react-dom": "18.2.6",
+    "@types/react": "18.2.48",
+    "@types/react-dom": "18.2.18",
     "next": "13",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
 
 type NavigateFunction = ReturnType<typeof useRouter>['push'];
@@ -15,10 +15,6 @@ declare global {
 export const useAwaitableNavigate = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { push } = useRouter();
-  const pathname = usePathname();
-  const params = useSearchParams();
-
-  const urlKey = pathname + params.toString();
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -37,7 +33,7 @@ export const useAwaitableNavigate = () => {
         push(to);
       });
     };
-  }, [urlKey]);
+  }, [push]);
 
   useEffect(() => {
     if (window.__clerk_nav_resolves_ref && window.__clerk_nav_resolves_ref.length) {

--- a/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
@@ -1,48 +1,44 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { useEffect, useRef, useTransition } from 'react';
 
 type NavigateFunction = ReturnType<typeof useRouter>['push'];
 
-declare global {
-  interface Window {
-    __clerk_nav_ref: NavigateFunction;
-    __clerk_nav_resolves_ref: Array<(val?: any) => any> | undefined;
-  }
-}
-
+/**
+ * Creates an "awaitable" navigation function that will do its best effort to wait for Next.js to finish its route transition.
+ *
+ * This is accomplished by wrapping the call to `router.push` in `startTransition()`, which should rely on React to coordinate the pending state. We key off of
+ * `isPending` to flush the stored promises and ensure the navigates "resolve".
+ */
 export const useAwaitableNavigate = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { push } = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const clerkNavRef = useRef<(...args: Parameters<NavigateFunction>) => Promise<void>>();
+  const clerkNavPromiseBuffer = useRef<(() => void)[]>([]);
 
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    window.__clerk_nav_ref = (to, opts) => {
-      if (to === window.location.href.replace(window.location.origin, '')) {
-        push(to, opts);
-        return Promise.resolve();
-      }
-
+  // Set the navigation function reference only once
+  if (!clerkNavRef.current) {
+    clerkNavRef.current = (to, opts) => {
       return new Promise<void>(res => {
-        if (window.__clerk_nav_resolves_ref) {
-          window.__clerk_nav_resolves_ref.push(res);
-        } else {
-          window.__clerk_nav_resolves_ref = [res];
-        }
-        push(to);
+        clerkNavPromiseBuffer.current.push(res);
+        startTransition(() => {
+          push(to, opts);
+        });
       });
     };
-  }, [push]);
+  }
 
+  // Handle flushing the promise buffer when pending is false. If pending is false and there are promises in the buffer we should be able to safely flush them.
   useEffect(() => {
-    if (window.__clerk_nav_resolves_ref && window.__clerk_nav_resolves_ref.length) {
-      window.__clerk_nav_resolves_ref.forEach(resolve => resolve());
-    }
-    window.__clerk_nav_resolves_ref = [];
-  });
+    if (isPending) return;
 
-  return useCallback<NavigateFunction>((to, opts) => {
-    return window.__clerk_nav_ref(to, opts);
-  }, []);
+    if (clerkNavPromiseBuffer?.current?.length) {
+      clerkNavPromiseBuffer.current.forEach(resolve => resolve());
+    }
+    clerkNavPromiseBuffer.current = [];
+  }, [isPending]);
+
+  return clerkNavRef.current;
 };


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Attempting to avoid CSR de-opt due to `useSearchParams()` usage. Refactors `useAwaitableNavigate()` to rely on `useTransition` instead of Next's route state hooks. This avoids any potential de-opt and provides a more reliable implementation by relying on React's native transition behavior.

Fixes SDK-1266

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
