### PR TITLE
fix(nextjs): Ensure package works with next 12

### DIFF
--- a/.changeset/dry-bugs-flash.md
+++ b/.changeset/dry-bugs-flash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Adjust how we are importing `next/navigation` to ensure it can function in versions of next that don't have this export.

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -3,7 +3,6 @@ import type {
   CheckAuthorizationParamsWithCustomPermissions,
   CheckAuthorizationWithCustomPermissions,
 } from '@clerk/types';
-import { notFound, redirect } from 'next/navigation';
 
 import { buildClerkProps } from '../../server/buildClerkProps';
 import { createGetAuth } from '../../server/createGetAuth';
@@ -52,6 +51,9 @@ export const auth = () => {
     noAuthStatusMessage: authAuthHeaderMissing(),
   })(buildRequestLike());
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { notFound, redirect } = require('next/navigation');
+
   (authObject as unknown as ProtectGeneric).protect = (params: any, options: any) => {
     const paramsOrFunction = params?.redirectUrl
       ? undefined
@@ -60,7 +62,7 @@ export const auth = () => {
           | ((has: CheckAuthorizationWithCustomPermissions) => boolean));
     const redirectUrl = (params?.redirectUrl || options?.redirectUrl) as string | undefined;
 
-    const handleUnauthorized = (): never => {
+    const handleUnauthorized = (): any => {
       if (redirectUrl) {
         redirect(redirectUrl);
       }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Adjust how we import `next/navigation` in the `auth()` helper to ensure our package can be safely imported in Next.js v12. The [current recommended approach](https://clerk.com/docs/references/nextjs/usage-with-older-versions) to use `webpack.IgnorePlugin` doesn't when the package is externally required in a CJS environment.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
