### PR TITLE
fix(themes): Add tslib and @clerk/types as dependencies to @clerk/themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37687,7 +37687,7 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.0.0-beta.19",
@@ -37726,10 +37726,10 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "1.0.0-beta.33",
+      "version": "1.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-beta.33",
+        "@clerk/clerk-js": "5.0.0-beta.34",
         "@clerk/clerk-react": "5.0.0-beta.30",
         "@clerk/shared": "2.0.0-beta.19",
         "webextension-polyfill": "^0.10.0"
@@ -37775,7 +37775,7 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "5.0.0-beta.33",
+      "version": "5.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
         "@clerk/localizations": "2.0.0-beta.17",
@@ -38514,10 +38514,10 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "1.0.0-beta.33",
+      "version": "1.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "5.0.0-beta.33",
+        "@clerk/clerk-js": "5.0.0-beta.34",
         "@clerk/clerk-react": "5.0.0-beta.30",
         "@clerk/shared": "2.0.0-beta.19",
         "base-64": "^1.0.0",
@@ -38858,10 +38858,10 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "1.0.0-beta.33",
+      "version": "1.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-beta.27",
+        "@clerk/backend": "1.0.0-beta.28",
         "@clerk/shared": "2.0.0-beta.19",
         "@clerk/types": "4.0.0-beta.20",
         "cookies": "0.8.0"
@@ -38881,12 +38881,12 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "5.0.0-beta.33",
+      "version": "5.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-beta.27",
+        "@clerk/backend": "1.0.0-beta.28",
         "@clerk/clerk-react": "5.0.0-beta.30",
-        "@clerk/clerk-sdk-node": "5.0.0-beta.28",
+        "@clerk/clerk-sdk-node": "5.0.0-beta.29",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
@@ -38930,10 +38930,10 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "5.0.0-beta.33",
+      "version": "5.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-beta.27",
+        "@clerk/backend": "1.0.0-beta.28",
         "@clerk/clerk-react": "5.0.0-beta.30",
         "@clerk/shared": "2.0.0-beta.19",
         "path-to-regexp": "6.2.1"
@@ -38995,10 +38995,10 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "4.0.0-beta.33",
+      "version": "4.0.0-beta.34",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-beta.27",
+        "@clerk/backend": "1.0.0-beta.28",
         "@clerk/clerk-react": "5.0.0-beta.30",
         "@clerk/shared": "2.0.0-beta.19",
         "cookie": "0.5.0",
@@ -39031,10 +39031,10 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "5.0.0-beta.28",
+      "version": "5.0.0-beta.29",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.0.0-beta.27",
+        "@clerk/backend": "1.0.0-beta.28",
         "@clerk/shared": "2.0.0-beta.19",
         "camelcase-keys": "6.2.2",
         "snakecase-keys": "3.2.1"
@@ -39120,8 +39120,11 @@
       "name": "@clerk/themes",
       "version": "2.0.0-beta.5",
       "license": "MIT",
-      "devDependencies": {
+      "dependencies": {
         "@clerk/types": "4.0.0-beta.20",
+        "tslib": "2.4.1"
+      },
+      "devDependencies": {
         "@types/node": "^18.17.0",
         "eslint-config-custom": "*",
         "typescript": "*"
@@ -39133,6 +39136,11 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "packages/themes/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "packages/types": {
       "name": "@clerk/types",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -36,8 +36,11 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint src/"
   },
-  "devDependencies": {
+  "dependencies": {
     "@clerk/types": "4.0.0-beta.20",
+    "tslib": "2.4.1"
+  },
+  "devDependencies": {
     "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "typescript": "*"


### PR DESCRIPTION
## Description

There is an issue with Yarn PNP requiring a package extension to safely resolve @clerk/themes. This patch resolves this issue.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
