### PR TITLE
fix(clerk-js): Fix FAPI initiated redirect flow for OAuth2 IDP flow with email_link verification

### DIFF
--- a/.changeset/twenty-lamps-rule.md
+++ b/.changeset/twenty-lamps-rule.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix redirect flow for OAuth2 IDP flow with email_link verification.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1613,11 +1613,13 @@ export class Clerk implements ClerkInterface {
     }
 
     const userSignedIn = this.session;
-    const signInUrl = this.#environment?.displayConfig.signInUrl;
+    const signInUrl = this.#options.signInUrl || this.#environment?.displayConfig.signInUrl;
     const referrerIsSignInUrl = signInUrl && window.location.href.startsWith(signInUrl);
+    const signUpUrl = this.#options.signUpUrl || this.#environment?.displayConfig.signUpUrl;
+    const referrerIsSignUpUrl = signUpUrl && window.location.href.startsWith(signUpUrl);
 
-    // don't redirect if user is not signed in and referrer is sign in url
-    if (requiresUserInput(redirectUrl) && !userSignedIn && referrerIsSignInUrl) {
+    // don't redirect if user is not signed in and referrer is sign in/up url
+    if (requiresUserInput(redirectUrl) && !userSignedIn && (referrerIsSignInUrl || referrerIsSignUpUrl)) {
       return false;
     }
 


### PR DESCRIPTION
## Description

For the OAuth2 IDP flow, we should not redirect when the referrer is the sign up url. This way, a second factor can be completed after a first factor like email verification link. Previously, users were being redirected back to `FAPI /oauth/authorize` prematurely. This change ensures that users will not be redirected as such and have the chance to complete their second factor verification, like phone code.

Fixes CORE-1567

Video of fix below (there's a jump in the middle because I cut out retrieving the email link from my inbox):
https://github.com/clerk/javascript/assets/27433835/63e4ec43-1107-4c90-8ee5-f9196be7210c

Previously, the user would be redirected back to the sign in page without being able to complete sign up. 

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
