### PR TITLE
fix(clerk-js): Make it work in Iframes for dev instances

### DIFF
--- a/packages/clerk-js/src/utils/cookies/clientUat.ts
+++ b/packages/clerk-js/src/utils/cookies/clientUat.ts
@@ -2,6 +2,8 @@ import { createCookieHandler } from '@clerk/shared/cookie';
 import { addYears } from '@clerk/shared/date';
 import type { ClientResource } from '@clerk/types';
 
+import { inCrossOriginIframe } from '../../utils';
+
 const CLIENT_UAT_COOKIE_NAME = '__client_uat';
 
 export const clientUatCookie = createCookieHandler(CLIENT_UAT_COOKIE_NAME);
@@ -12,8 +14,8 @@ export const getClientUatCookie = (): number => {
 
 export const setClientUatCookie = (client: ClientResource | undefined) => {
   const expires = addYears(Date.now(), 1);
-  const sameSite = 'Strict';
-  const secure = false;
+  const sameSite = inCrossOriginIframe() ? 'None' : 'Strict';
+  const secure = window.location.protocol === 'https:';
 
   // '0' indicates the user is signed out
   let val = '0';

--- a/packages/clerk-js/src/utils/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/utils/cookies/devBrowser.ts
@@ -2,14 +2,16 @@ import { createCookieHandler } from '@clerk/shared/cookie';
 import { addYears } from '@clerk/shared/date';
 import { DEV_BROWSER_JWT_KEY } from '@clerk/shared/devBrowser';
 
+import { inCrossOriginIframe } from '../../utils';
+
 export const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_KEY);
 
 export const getDevBrowserCookie = () => devBrowserCookie.get();
 
 export const setDevBrowserCookie = (jwt: string) => {
   const expires = addYears(Date.now(), 1);
-  const sameSite = 'Lax';
-  const secure = false;
+  const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
+  const secure = window.location.protocol === 'https:';
 
   return devBrowserCookie.set(jwt, {
     expires,

--- a/packages/clerk-js/src/utils/cookies/session.ts
+++ b/packages/clerk-js/src/utils/cookies/session.ts
@@ -1,7 +1,7 @@
 import { createCookieHandler } from '@clerk/shared/cookie';
 import { addYears } from '@clerk/shared/date';
 
-import { inSecureCrossOriginIframe } from '../../utils';
+import { inCrossOriginIframe } from '../../utils';
 
 const SESSION_COOKIE_NAME = '__session';
 
@@ -16,8 +16,8 @@ export const removeSessionCookie = () => sessionCookie.remove();
 
 export const setSessionCookie = (token: string) => {
   const expires = addYears(Date.now(), 1);
-  const sameSite = inSecureCrossOriginIframe() ? 'None' : 'Lax';
-  const secure = inSecureCrossOriginIframe() || window.location.protocol === 'https:';
+  const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
+  const secure = window.location.protocol === 'https:';
 
   return sessionCookie.set(token, {
     expires,


### PR DESCRIPTION
## Description

The __clerk_db_jwt non secure Lax cookie is not set in an Iframe. As a result Clerk doesn't work in Iframes including containers such as Replit, Codepen, etc...

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
