### PR TITLE
v5: NextJS improvements

### DIFF
--- a/.changeset/chilled-bikes-rule.md
+++ b/.changeset/chilled-bikes-rule.md
@@ -1,0 +1,24 @@
+---
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+---
+
+The `auth().redirectToSignIn()` helper no longer needs to be explicitly returned when called within the middleware. The following examples are now equivalent:
+
+```js
+// Before
+export default clerkMiddleware(auth => {
+  if (protectedRoute && !auth.user) {
+    return auth().redirectToSignIn()
+  }
+})
+
+// After
+export default clerkMiddleware(auth => {
+  if (protectedRoute && !auth.user) {
+    auth().redirectToSignIn()
+  }
+})
+```
+
+Calling `auth().protect()` from a page will now automatically redirect back to the same page by setting `redirect_url` to the request url before the redirect to the sign-in URL takes place.

--- a/integration/templates/next-app-router/package.json
+++ b/integration/templates/next-app-router/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^18.17.0",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
-    "next": "13.5.4",
+    "next": "13",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.6"

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -10,6 +10,7 @@ const Attributes = {
   AuthStatus: '__clerkAuthStatus',
   AuthReason: '__clerkAuthReason',
   AuthMessage: '__clerkAuthMessage',
+  ClerkUrl: '__clerkUrl',
 } as const;
 
 const Cookies = {
@@ -29,6 +30,7 @@ const Headers = {
   AuthStatus: 'x-clerk-auth-status',
   AuthReason: 'x-clerk-auth-reason',
   AuthMessage: 'x-clerk-auth-message',
+  ClerkUrl: 'x-clerk-clerk-url',
   EnableDebug: 'x-clerk-debug',
   ClerkRedirectTo: 'x-clerk-redirect-to',
   CloudFrontForwardedProto: 'cloudfront-forwarded-proto',

--- a/packages/backend/src/createRedirect.ts
+++ b/packages/backend/src/createRedirect.ts
@@ -1,6 +1,6 @@
 import { errorThrower, parsePublishableKey } from './util/shared';
 
-const buildUrl = (_baseUrl: string | URL, _targetUrl: string | URL, _returnBackUrl?: string | URL) => {
+const buildUrl = (_baseUrl: string | URL, _targetUrl: string | URL, _returnBackUrl?: string | URL | null) => {
   if (_baseUrl === '') {
     return legacyBuildUrl(_targetUrl.toString(), _returnBackUrl?.toString());
   }
@@ -58,7 +58,7 @@ const buildAccountsBaseUrl = (frontendApi?: string) => {
 };
 
 type RedirectAdapter<RedirectReturn> = (url: string) => RedirectReturn;
-type RedirectToParams = { returnBackUrl?: string | URL };
+type RedirectToParams = { returnBackUrl?: string | URL | null };
 export type RedirectFun<ReturnType> = (params?: RedirectToParams) => ReturnType;
 
 /**

--- a/packages/fastify/src/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/constants.test.ts.snap
@@ -18,6 +18,7 @@ exports[`constants from environment variables 1`] = `
     "AuthToken": "x-clerk-auth-token",
     "Authorization": "authorization",
     "ClerkRedirectTo": "x-clerk-redirect-to",
+    "ClerkUrl": "x-clerk-clerk-url",
     "CloudFrontForwardedProto": "cloudfront-forwarded-proto",
     "ContentType": "content-type",
     "EnableDebug": "x-clerk-debug",

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -215,7 +215,7 @@ const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
       logger.debug(`Added ${constants.Headers.EnableDebug} on request`);
     }
 
-    const result = decorateRequest(nextRequest, finalRes, requestState) || NextResponse.next();
+    const result = decorateRequest(clerkRequest, finalRes, requestState) || NextResponse.next();
 
     if (requestState.headers) {
       requestState.headers.forEach((value, key) => {

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -1,4 +1,4 @@
-import type { AuthObject, SignedInAuthObject } from '@clerk/backend/internal';
+import type { AuthObject, RedirectFun, SignedInAuthObject } from '@clerk/backend/internal';
 import { constants } from '@clerk/backend/internal';
 import type {
   CheckAuthorizationParamsWithCustomPermissions,
@@ -6,7 +6,6 @@ import type {
 } from '@clerk/types';
 
 import { constants as nextConstants } from '../constants';
-import { SIGN_IN_URL } from './constants';
 
 type AuthProtectOptions = { unauthorizedUrl?: string; unauthenticatedUrl?: string };
 
@@ -44,7 +43,7 @@ export const createProtect = (opts: {
    * protect() in pages throws a notFound error if signed out
    * use this callback to customise the behavior
    */
-  redirectToSignIn?: () => void;
+  redirectToSignIn: RedirectFun<unknown>;
 }): AuthProtect => {
   const { redirectToSignIn, authObject, redirect, notFound, request } = opts;
 
@@ -64,7 +63,7 @@ export const createProtect = (opts: {
       }
       if (isPageRequest(request)) {
         // TODO: Handle runtime values. What happens if runtime values are set in middleware and in ClerkProvider as well?
-        return redirectToSignIn ? redirectToSignIn() : redirect(SIGN_IN_URL);
+        return redirectToSignIn();
       }
       return notFound();
     };

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -108,7 +108,7 @@ export const injectSSRStateIntoObject = <O, T>(obj: O, authObject: T) => {
 };
 
 // Auth result will be set as both a query param & header when applicable
-export function decorateRequest(req: Request, res: Response, requestState: RequestState): Response {
+export function decorateRequest(req: ClerkRequest, res: Response, requestState: RequestState): Response {
   const { reason, message, status, token } = requestState;
   // pass-through case, convert to next()
   if (!res) {
@@ -147,6 +147,7 @@ export function decorateRequest(req: Request, res: Response, requestState: Reque
       [constants.Headers.AuthToken]: token || '',
       [constants.Headers.AuthMessage]: message || '',
       [constants.Headers.AuthReason]: reason || '',
+      [constants.Headers.ClerkUrl]: req.clerkUrl.toString(),
     });
     res.headers.set(nextConstants.Headers.NextRewrite, rewriteURL.href);
   }

--- a/packages/nextjs/src/utils/response.ts
+++ b/packages/nextjs/src/utils/response.ts
@@ -43,7 +43,7 @@ export const isRedirect = (res: Response) => {
   return res.headers.get(nextConstants.Headers.NextRedirect);
 };
 
-export const setHeader = (res: Response, name: string, val: string) => {
+export const setHeader = <T extends Response>(res: T, name: string, val: string): T => {
   res.headers.set(name, val);
   return res;
 };


### PR DESCRIPTION
## Description
The `auth().redirectToSignIn()` helper no longer needs to be explicitly returned when called within the middleware. The following examples are now equivalent:

```js
// Before
export default clerkMiddleware(auth => {
  if (protectedRoute && !auth.user) {
    return auth().redirectToSignIn()
  }
})

// After
export default clerkMiddleware(auth => {
  if (protectedRoute && !auth.user) {
    auth().redirectToSignIn()
  }
})
```

Calling `auth().protect()` from a page will now automatically redirect back to the same page by setting `redirect_url` to the request url before the redirect to the sign-in URL takes place.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
