### PR TITLE
chore(repo): Remove dry-run from Clerk Elements Alpha workflow

### DIFF
--- a/.github/workflows/alpha.elements.yml
+++ b/.github/workflows/alpha.elements.yml
@@ -57,7 +57,7 @@ jobs:
         run: npx turbo build $TURBO_ARGS
 
       - name: Publish to NPM
-        run: npm publish --workspace=$PACKAGE_NAME --tag=$PACKAGE_TAG --dry-run
+        run: npm publish --workspace=$PACKAGE_NAME --tag=$PACKAGE_TAG
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -68,4 +68,4 @@ jobs:
           git commit -m "chore(repo): Publish alpha of $PACKAGE_NAME" --no-verify
       
       - name: Push changes
-        run: git push origin main --dry-run
+        run: git push origin main


### PR DESCRIPTION
## Description

Follow up to https://github.com/clerk/javascript/pull/2686 - the dry run worked in https://github.com/clerk/javascript/actions/runs/7726668169/job/21063401975 so 🤞 that this now will also work

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
