### PR TITLE
fix(clerk-js): Fix same site in ClerkJS cookies

### DIFF
--- a/.changeset/slow-carrots-eat.md
+++ b/.changeset/slow-carrots-eat.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update cookie setting to ensure cookies can be set to be read when an application is embedded in an iframe.

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -9,11 +9,6 @@ import { devBrowserCookie } from './devBrowser';
 import { inittedCookie } from './initted';
 import { sessionCookie } from './session';
 
-const DEFAULT_SAME_SITE = 'Lax';
-const IFRAME_SAME_SITE = 'None';
-
-const COOKIE_PATH = '/';
-
 export type CookieHandler = ReturnType<typeof createCookieHandler>;
 export const createCookieHandler = () => {
   // First party cookie helpers
@@ -22,16 +17,16 @@ export const createCookieHandler = () => {
   const setDevBrowserInittedCookie = () =>
     inittedCookie.set('1', {
       expires: addYears(Date.now(), 1),
-      sameSite: inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE,
+      sameSite: inSecureCrossOriginIframe() ? 'None' : 'Lax',
       secure: inSecureCrossOriginIframe() ? true : undefined,
-      path: COOKIE_PATH,
+      path: '/',
     });
 
   const removeSessionCookie = () => sessionCookie.remove();
 
   const setSessionCookie = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE;
+    const sameSite = inSecureCrossOriginIframe() ? 'None' : 'Lax';
     const secure = inSecureCrossOriginIframe() || window.location.protocol === 'https:';
 
     return sessionCookie.set(token, {
@@ -47,7 +42,7 @@ export const createCookieHandler = () => {
 
   const setClientUatCookie = (client: ClientResource | undefined) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE;
+    const sameSite = inSecureCrossOriginIframe() ? 'None' : 'strict';
     const secure = inSecureCrossOriginIframe() || window.location.protocol === 'https:';
 
     // '0' indicates the user is signed out
@@ -67,7 +62,7 @@ export const createCookieHandler = () => {
 
   const setDevBrowserCookie = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE;
+    const sameSite = inSecureCrossOriginIframe() ? 'None' : 'Lax';
     const secure = inSecureCrossOriginIframe() || window.location.protocol === 'https:';
 
     return devBrowserCookie.set(jwt, {

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -82,9 +82,9 @@ export const createCookieHandler = () => {
   const ssoCookie = clientCookie;
 
   const removeAllDevBrowserCookies = () => {
-    inittedCookie.remove({ path: COOKIE_PATH });
+    inittedCookie.remove({ path: '/' });
     // Delete cookie in a best-effort way by iterating all ETLDs
-    getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: COOKIE_PATH }));
+    getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: '/' }));
   };
 
   return {


### PR DESCRIPTION
## Description

```
__client_uat is samesite=none
__session is samesite=lax
__clerk_db_jwt is samesite=lax
__initted is samesite=lax
```

Fixes https://github.com/clerk/javascript/pull/2668

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
