### PR TITLE
fix(clerk-js): Fix FAPI initiated redirect flow for OAuth2 IDP flow with email_link verification (#2677)

### DIFF
--- a/.changeset/twenty-lamps-rule.md
+++ b/.changeset/twenty-lamps-rule.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix redirect flow for OAuth2 IDP flow with email_link verification.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1681,11 +1681,13 @@ export default class Clerk implements ClerkInterface {
     }
 
     const userSignedIn = this.session;
-    const signInUrl = this.#environment?.displayConfig.signInUrl;
+    const signInUrl = this.#options.signInUrl || this.#environment?.displayConfig.signInUrl;
     const referrerIsSignInUrl = signInUrl && window.location.href.startsWith(signInUrl);
+    const signUpUrl = this.#options.signUpUrl || this.#environment?.displayConfig.signUpUrl;
+    const referrerIsSignUpUrl = signUpUrl && window.location.href.startsWith(signUpUrl);
 
-    // don't redirect if user is not signed in and referrer is sign in url
-    if (requiresUserInput(redirectUrl) && !userSignedIn && referrerIsSignInUrl) {
+    // don't redirect if user is not signed in and referrer is sign in/up url
+    if (requiresUserInput(redirectUrl) && !userSignedIn && (referrerIsSignInUrl || referrerIsSignUpUrl)) {
       return false;
     }
 


### PR DESCRIPTION
Backporting #2677 to the release/v4 branch

(cherry picked from commit 750337633a07bf3bb92d015f558ead2bfdca8613)