### PR TITLE
feat(clerk-js): Accept `skipInvitationScreen` as a prop from OrganizationSwitcher

### DIFF
--- a/.changeset/late-geckos-impress.md
+++ b/.changeset/late-geckos-impress.md
@@ -4,3 +4,6 @@
 ---
 
 Accept `skipInvitationScreen` as a prop from OrganizationSwitcher.
+
+`skipInvitationScreen` hides the screen for sending invitations after an organization is created.
+By default, Clerk will automatically hide the screen if the number of max allowed members is equal to 1

--- a/.changeset/late-geckos-impress.md
+++ b/.changeset/late-geckos-impress.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Accept `skipInvitationScreen` as a prop from OrganizationSwitcher.

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -48,6 +48,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       navigateAfterSelectPersonal,
       navigateAfterSelectOrganization,
       organizationProfileProps,
+      skipInvitationScreen,
     } = useOrganizationSwitcherContext();
 
     const { user } = useUser();
@@ -84,7 +85,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       if (createOrganizationMode === 'navigation') {
         return navigateCreateOrganization();
       }
-      return openCreateOrganization({ afterCreateOrganizationUrl });
+      return openCreateOrganization({ afterCreateOrganizationUrl, skipInvitationScreen });
     };
 
     const handleManageOrganizationClicked = () => {

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -335,6 +335,7 @@ export const useOrganizationSwitcherContext = () => {
     hidePersonal: ctx.hidePersonal || false,
     organizationProfileMode: organizationProfileMode || 'modal',
     createOrganizationMode: createOrganizationMode || 'modal',
+    skipInvitationScreen: ctx.skipInvitationScreen || false,
     afterCreateOrganizationUrl,
     afterLeaveOrganizationUrl,
     navigateOrganizationProfile,

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -853,7 +853,6 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
     afterSelectOrganizationUrl?:
       | ((organization: OrganizationResource) => string)
       | LooseExtractedParams<PrimitiveKeys<OrganizationResource>>;
-
     /**
      * Full URL or path to navigate after a successful selection of personal workspace.
      * Accepts a function that returns URL or path
@@ -866,12 +865,17 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
      */
     afterLeaveOrganizationUrl?: string;
     /**
+     * Hides the screen for sending invitations after an organization is created.
+     * @default undefined When left undefined Clerk will automatically hide the screen if
+     * the number of max allowed members is equal to 1
+     */
+    skipInvitationScreen?: boolean;
+    /**
      * Customisation options to fully match the Clerk components to your own brand.
      * These options serve as overrides and will be merged with the global `appearance`
      * prop of ClerkProvided (if one is provided)
      */
     appearance?: OrganizationSwitcherTheme;
-
     /*
      * Specify options for the underlying <OrganizationProfile /> component.
      * e.g. <UserButton userProfileProps={{appearance: {...}}} />


### PR DESCRIPTION
## Description

`skipInvitationScreen` should be something that affects the flow of creating an organization. `<CreateOrganization/>` and `<OrganizationList/>` already handles this correctly. This PR adds this functionality to `<OrganizationSwitcher/>` as well.

This implementation is compatible with v4 and does not introduce breaking changes and will be backported.

Grouping `skipInvitationScreen` and `afterCreateOrganizationUrl` under `createOrganizationProps` could be part of a followup PR only for v5.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
