### PR TITLE
feat(clerk-js): Added an optional redirect_url to the invitation query

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
@@ -22,13 +22,22 @@ export class OrganizationInvitation extends BaseResource implements Organization
 
   static async create(
     organizationId: string,
-    { emailAddress, role }: CreateOrganizationInvitationParams,
+    params: CreateOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource> {
+    const body: Record<string, any> = {
+      email_address: params.emailAddress,
+      role: params.role,
+    };
+
+    if (params.redirectUrl) {
+      body.redirect_url = params.redirectUrl;
+    }
+
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
         path: `/organizations/${organizationId}/invitations`,
         method: 'POST',
-        body: { email_address: emailAddress, role } as any,
+        body: body as any,
       })
     )?.response as unknown as OrganizationInvitationJSON;
     return new OrganizationInvitation(json);
@@ -38,12 +47,20 @@ export class OrganizationInvitation extends BaseResource implements Organization
     organizationId: string,
     params: CreateBulkOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource[]> {
-    const { emailAddresses, role } = params;
+    const body: Record<string, any> = {
+      email_address: params.emailAddresses,
+      role: params.role,
+    };
+
+    if (params.redirectUrl) {
+      body.redirect_url = params.redirectUrl;
+    }
+
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
         path: `/organizations/${organizationId}/invitations/bulk`,
         method: 'POST',
-        body: { email_address: emailAddresses, role } as any,
+        body: body as any,
       })
     )?.response as unknown as OrganizationInvitationJSON[];
     return json.map(invitationJson => new OrganizationInvitation(invitationJson));

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -944,11 +944,13 @@ export interface HandleEmailLinkVerificationParams {
 export type CreateOrganizationInvitationParams = {
   emailAddress: string;
   role: OrganizationCustomRoleKey;
+  redirectUrl?: string;
 };
 
 export type CreateBulkOrganizationInvitationParams = {
   emailAddresses: string[];
   role: OrganizationCustomRoleKey;
+  redirectUrl?: string;
 };
 
 export interface CreateOrganizationParams {


### PR DESCRIPTION
## Description

I've implemented a custom member invite UI in my NextJS app, but when I went to send the `redirect_url` outlined [in the docs](https://clerk.com/docs/custom-flows/invitations#custom-flow), I found that the parameter wasn't supported in the SDK. This PR adds support for passing in a custom redirect_url

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
