### PR TITLE
fix(clerk-js): Add padding to app logo inside OrganizationList

### DIFF
--- a/.changeset/friendly-dryers-rush.md
+++ b/.changeset/friendly-dryers-rush.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add padding to app logo inside OrganizationList to align the logo with the rest of the content.

--- a/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
@@ -51,6 +51,9 @@ export const OrganizationListPage = withCardStateProvider(() => {
       sx={t => ({
         padding: `${t.space.$8} ${t.space.$none}`,
       })}
+      insideAppLogoSx={t => ({
+        padding: `${t.space.$none} ${t.space.$8}`,
+      })}
       gap={6}
     >
       <CardAlert>{card.error}</CardAlert>

--- a/packages/clerk-js/src/ui/elements/Card.tsx
+++ b/packages/clerk-js/src/ui/elements/Card.tsx
@@ -4,7 +4,7 @@ import { useEnvironment } from '../contexts';
 import { descriptors, Flex, generateFlowPartClassname, Icon, useAppearance } from '../customizables';
 import type { ElementDescriptor } from '../customizables/elementDescriptors';
 import { Close } from '../icons';
-import type { PropsOfComponent } from '../styledSystem';
+import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { mqu } from '../styledSystem';
 import { ApplicationLogo } from './ApplicationLogo';
 import { useFlowMetadata } from './contexts';
@@ -12,10 +12,13 @@ import { IconButton } from './IconButton';
 import { useUnsafeModalContext } from './Modal';
 import { PoweredByClerkTag } from './PoweredByClerk';
 
-type CardProps = PropsOfComponent<typeof BaseCard> & React.PropsWithChildren<Record<never, never>>;
+type CardProps = PropsOfComponent<typeof BaseCard> &
+  React.PropsWithChildren<Record<never, never>> & {
+    insideAppLogoSx?: ThemableCssProp;
+  };
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
-  const { sx, children, ...rest } = props;
+  const { sx, children, insideAppLogoSx, ...rest } = props;
   const appearance = useAppearance();
   const flowMetadata = useFlowMetadata();
   const { branded } = useEnvironment().displayConfig;
@@ -55,7 +58,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
         ]}
         ref={ref}
       >
-        {appearance.parsedLayout.logoPlacement === 'inside' && <ApplicationLogo />}
+        {appearance.parsedLayout.logoPlacement === 'inside' && <ApplicationLogo sx={insideAppLogoSx} />}
         {children}
         {branded && <PoweredByClerkTag />}
       </BaseCard>


### PR DESCRIPTION
## Description

### Before

<img width="491" alt="Screenshot 2024-02-05 at 2 04 35 PM" src="https://github.com/clerk/javascript/assets/19269911/515989b8-58fd-47f9-8bf1-cd9ce24149e7">

### After

<img width="479" alt="Screenshot 2024-02-05 at 2 01 58 PM" src="https://github.com/clerk/javascript/assets/19269911/96f77d69-a098-4172-bc2d-45e208ad0329">

### Before

<img width="497" alt="Screenshot 2024-02-05 at 2 04 28 PM" src="https://github.com/clerk/javascript/assets/19269911/b7d7e64c-e0e5-4e66-93e2-a52a072b862c">

### After

<img width="486" alt="Screenshot 2024-02-05 at 2 04 40 PM" src="https://github.com/clerk/javascript/assets/19269911/e8dae779-a2bb-4695-9b38-1aa0ae0aac65">

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
