### PR TITLE
fix(nextjs): Use shared subpath import in server related utils to avoid bundling unused helpers

### DIFF
--- a/packages/nextjs/src/utils/serverRedirectWithAuth.ts
+++ b/packages/nextjs/src/utils/serverRedirectWithAuth.ts
@@ -1,7 +1,8 @@
 // Middleware runs on the server side, before clerk-js is loaded, that's why we need Cookies.
 import type { AuthenticateRequestOptions, ClerkRequest } from '@clerk/backend/internal';
 import { constants } from '@clerk/backend/internal';
-import { DEV_BROWSER_JWT_KEY, isDevelopmentFromSecretKey, setDevBrowserJWTInURL } from '@clerk/shared';
+import { DEV_BROWSER_JWT_KEY, setDevBrowserJWTInURL } from '@clerk/shared/devBrowser';
+import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { NextResponse } from 'next/server';
 
 import { SECRET_KEY } from '../server/constants';


### PR DESCRIPTION
## Description

Avoid polluting the `@clerk/nextjs/server` subpath with client related imports.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
