### PR TITLE
fix(clerk-js): Give application logo correct CSS width

### DIFF
--- a/.changeset/witty-eggs-punch.md
+++ b/.changeset/witty-eggs-punch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Give application logo correct CSS width to prevent incorrect widths

--- a/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
+++ b/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
@@ -49,6 +49,7 @@ export const ApplicationLogo = (props: ApplicationLogoProps) => {
       sx={{
         display: loaded ? 'inline-block' : 'none',
         height: '100%',
+        width: 'auto',
       }}
     />
   );


### PR DESCRIPTION
## Description

Go to [SDK 1298](https://linear.app/clerk/issue/SDK-1298/logo-in-sign-in-component-is-squished) and visit the preview URL with Firefox or Safari. The application logo should be too wide/squished.

Apply the fix of this PR to the `<img />` with `.logoImage` class and it should look fine.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
