### PR TITLE
fix(backend): Preserve url protocol when joining paths

### DIFF
--- a/.changeset/yellow-walls-worry.md
+++ b/.changeset/yellow-walls-worry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Preserve url protocol when joining paths.

--- a/packages/backend/src/util/__tests__/path.test.ts
+++ b/packages/backend/src/util/__tests__/path.test.ts
@@ -10,4 +10,18 @@ export default (QUnit: QUnit) => {
   test('joins the provides paths safely', assert => {
     assert.equal(joinPaths('foo', '/bar', '/qux//'), 'foo/bar/qux/');
   });
+
+  test('does not affect url scheme', assert => {
+    assert.equal(
+      joinPaths('https://api.clerk.com', 'v1', '/organizations/org_xxxxxxxxxxxxxxxxx'),
+      'https://api.clerk.com/v1/organizations/org_xxxxxxxxxxxxxxxxx',
+    );
+  });
+
+  test('does not affect url scheme and removes duplicate separators', assert => {
+    assert.equal(
+      joinPaths('https://api.clerk.com//', '/v1/', '//organizations/org_xxxxxxxxxxxxxxxxx//'),
+      'https://api.clerk.com/v1/organizations/org_xxxxxxxxxxxxxxxxx/',
+    );
+  });
 };

--- a/packages/backend/src/util/path.ts
+++ b/packages/backend/src/util/path.ts
@@ -1,5 +1,5 @@
 const SEPARATOR = '/';
-const MULTIPLE_SEPARATOR_REGEX = new RegExp(SEPARATOR + '{1,}', 'g');
+const MULTIPLE_SEPARATOR_REGEX = new RegExp('(?<!:)' + SEPARATOR + '{1,}', 'g');
 
 type PathString = string | null | undefined;
 


### PR DESCRIPTION
## Description

Internally when `joinPaths` was used to join strings that included a url protocol like `https://` the utility function would remove the duplicate `/` from the protocol resulting in a string with this form `'https:/api.lclclerk.com/v1/organizations/org_2YRy2Bcrc05EMTY0nMY3qHTjbwj'`

When this string was passed in a `URL` constructor like `new URL(...)` the URL would either be fixed automatically or throw an "Invalid URL" error. 

I believe it came down to node version and different implementations of the URL class under the hood. In any case this PR ensures that absolute url string that is generated from `joinPaths` will keep the protocol intact.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Fixes https://github.com/clerk/javascript/issues/2706

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
