### PR TITLE
fix(backend): Preserve url protocol when joining paths (#2745)

### DIFF
--- a/.changeset/yellow-walls-worry.md
+++ b/.changeset/yellow-walls-worry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Preserve url protocol when joining paths.

--- a/packages/backend/src/util/path.test.ts
+++ b/packages/backend/src/util/path.test.ts
@@ -10,4 +10,18 @@ export default (QUnit: QUnit) => {
   test('joins the provides paths safely', assert => {
     assert.equal(joinPaths('foo', '/bar', '/qux//'), 'foo/bar/qux/');
   });
+
+  test('does not affect url scheme', assert => {
+    assert.equal(
+      joinPaths('https://api.clerk.com', 'v1', '/organizations/org_xxxxxxxxxxxxxxxxx'),
+      'https://api.clerk.com/v1/organizations/org_xxxxxxxxxxxxxxxxx',
+    );
+  });
+
+  test('does not affect url scheme and removes duplicate separators', assert => {
+    assert.equal(
+      joinPaths('https://api.clerk.com//', '/v1/', '//organizations/org_xxxxxxxxxxxxxxxxx//'),
+      'https://api.clerk.com/v1/organizations/org_xxxxxxxxxxxxxxxxx/',
+    );
+  });
 };

--- a/packages/backend/src/util/path.ts
+++ b/packages/backend/src/util/path.ts
@@ -1,5 +1,5 @@
 const SEPARATOR = '/';
-const MULTIPLE_SEPARATOR_REGEX = new RegExp(SEPARATOR + '{1,}', 'g');
+const MULTIPLE_SEPARATOR_REGEX = new RegExp('(?<!:)' + SEPARATOR + '{1,}', 'g');
 
 type PathString = string | null | undefined;
 


### PR DESCRIPTION
Backporting #2745 to the release/v4 branch

(cherry picked from commit c2b98274970bac5af33c9bb2e84c70ad90225180)