### PR TITLE
chore(clerk-js): Add Turnstile retry for all 300xxx error codes (#2738)

### DIFF
--- a/.changeset/many-bottles-watch.md
+++ b/.changeset/many-bottles-watch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Allow retries for all 300xxx error codes for CF Turnstile. 

--- a/packages/clerk-js/src/utils/__tests__/captcha.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/captcha.test.ts
@@ -11,7 +11,7 @@ describe('shouldRetryTurnstileErrorCode', () => {
     ['104xxx', true],
     ['106xxx', true],
     ['110600', true],
-    ['300100', true],
+    ['300xxx', true],
     ['600xxx', true],
     ['200010', false],
     ['100405', false],

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -53,7 +53,7 @@ declare global {
 const WIDGET_CLASSNAME = 'clerk-captcha';
 
 export const shouldRetryTurnstileErrorCode = (errorCode: string) => {
-  const codesWithRetries = ['crashed', 'undefined_error', '102', '103', '104', '106', '110600', '300100', '600'];
+  const codesWithRetries = ['crashed', 'undefined_error', '102', '103', '104', '106', '110600', '300', '600'];
 
   return !!codesWithRetries.find(w => errorCode.startsWith(w));
 };


### PR DESCRIPTION
Backporting #2738 to the release/v4 branch

(cherry picked from commit 0ee1777e030916ad5111f0f817c71ff5a78a8ed6)