### PR TITLE
fix(clerk-react): Properly fire onLoad event when clerk-js is already loaded

### DIFF
--- a/.changeset/brown-lemons-film.md
+++ b/.changeset/brown-lemons-film.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Properly fire onLoad event when clerk-js is already loaded.

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -83,5 +83,11 @@ const useLoadedIsomorphicClerk = (options: IsomorphicClerkOptions) => {
     isomorphicClerk.addOnLoaded(() => setLoaded(true));
   }, []);
 
+  React.useEffect(() => {
+    return () => {
+      IsomorphicClerk.clearInstance();
+    };
+  }, []);
+
   return { isomorphicClerk, loaded };
 };

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -164,7 +164,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     return this.#loaded;
   }
 
-  static #instance: IsomorphicClerk;
+  static #instance: IsomorphicClerk | null | undefined;
 
   static getOrCreateInstance(options: IsomorphicClerkOptions) {
     // During SSR: a new instance should be created for every request
@@ -175,6 +175,10 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       this.#instance = new IsomorphicClerk(options);
     }
     return this.#instance;
+  }
+
+  static clearInstance() {
+    this.#instance = null;
   }
 
   get domain(): string {
@@ -417,6 +421,12 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
 
   public addOnLoaded = (cb: () => void) => {
     this.loadedListeners.push(cb);
+    /**
+     * When IsomorphicClerk is loaded execute the callback directly
+     */
+    if (this.loaded) {
+      this.emitLoaded();
+    }
   };
 
   public emitLoaded = () => {


### PR DESCRIPTION
In case of mounting-unmounting-mounting the `IsomorphicClerk.addOnLoaded` would not fire correctly, hence `derivedState` would return the initialState instead of the client side state.

In addition to the above fix, we are now cleaning up the IsomorphicClerk instance when the provider is unmounted.

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
