### PR TITLE
fix(clerk-react): Replace semver with custom regex in versionSelector

### DIFF
--- a/.changeset/shiny-games-buy.md
+++ b/.changeset/shiny-games-buy.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/clerk-react": patch
+---
+
+Replace semver with custom regex in versionSelector

--- a/package-lock.json
+++ b/package-lock.json
@@ -37762,7 +37762,6 @@
         "eslint-config-custom": "*",
         "react-refresh": "^0.14.0",
         "react-refresh-typescript": "^2.0.5",
-        "semver": "^7.5.2",
         "ts-loader": "^9.3.0",
         "typescript": "*",
         "webpack": "^5.85.0",
@@ -38601,7 +38600,6 @@
         "@clerk/shared": "2.0.0-beta-v5.11",
         "@clerk/types": "4.0.0-beta-v5.13",
         "eslint-config-custom": "*",
-        "semver": "^7.5.4",
         "tslib": "2.4.1"
       },
       "devDependencies": {

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -87,7 +87,6 @@
     "eslint-config-custom": "*",
     "react-refresh": "^0.14.0",
     "react-refresh-typescript": "^2.0.5",
-    "semver": "^7.5.2",
     "ts-loader": "^9.3.0",
     "typescript": "*",
     "webpack": "^5.85.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,6 @@
     "@clerk/shared": "2.0.0-beta-v5.11",
     "@clerk/types": "4.0.0-beta-v5.13",
     "eslint-config-custom": "*",
-    "semver": "^7.5.4",
     "tslib": "2.4.1"
   },
   "devDependencies": {

--- a/packages/react/src/utils/__tests__/versionSelector.test.ts
+++ b/packages/react/src/utils/__tests__/versionSelector.test.ts
@@ -5,6 +5,7 @@ describe('versionSelector', () => {
   it('should return the clerkJSVersion if it is provided', () => {
     expect(versionSelector('1.0.0')).toEqual('1.0.0');
   });
+
   it('should use the major version if there is no prerelease tag', () => {
     // @ts-ignore
     global.PACKAGE_VERSION = '1.0.0';
@@ -13,6 +14,7 @@ describe('versionSelector', () => {
 
     expect(versionSelector(undefined)).toEqual('1');
   });
+
   it('should use the prerelease tag when it is not snapshot', () => {
     // @ts-ignore
     global.PACKAGE_VERSION = '1.0.0-next.0';
@@ -21,6 +23,7 @@ describe('versionSelector', () => {
 
     expect(versionSelector(undefined)).toEqual('next');
   });
+
   it('should use the exact JS version if tag is snapshot', () => {
     // @ts-ignore
     global.PACKAGE_VERSION = '1.0.0-snapshot.0';
@@ -28,5 +31,26 @@ describe('versionSelector', () => {
     global.JS_PACKAGE_VERSION = '2.0.0-snapshot.0';
 
     expect(versionSelector(undefined)).toEqual('2.0.0-snapshot.0');
+  });
+
+  // We replaced semver with 2 custom regexes
+  // so we're testing the same cases as semver tests
+  // https://github.com/npm/node-semver/blob/main/test/functions/prerelease.js
+  // https://github.com/npm/node-semver/blob/main/test/functions/major.js
+  test.each([
+    ['1.2.3', 1],
+    [' 1.2.3 ', 1],
+    [' 2.2.3-4 ', 4],
+    [' 3.2.3-pre ', 'pre'],
+    ['v5.2.3', 5],
+    [' v8.2.3 ', 8],
+    ['\t13.2.3', 13],
+    ['1.2.2-alpha.1', 'alpha'],
+    ['1.2.2-beta.1', 'beta'],
+    ['1.2.2-rc.1', 'rc'],
+    ['1.2.2', 1],
+    ['1.2.2-pre', 'pre'],
+  ])('versionSelector(%s) should return %i', (version, expected) => {
+    expect(versionSelector(undefined, version)).toEqual(expected.toString());
   });
 });

--- a/packages/react/src/utils/versionSelector.ts
+++ b/packages/react/src/utils/versionSelector.ts
@@ -1,6 +1,3 @@
-import major from 'semver/functions/major';
-import prerelease from 'semver/functions/prerelease';
-
 /**
  * This version selector is a bit complicated, so here is the flow:
  * 1. Use the clerkJSVersion prop on the provider
@@ -8,14 +5,15 @@ import prerelease from 'semver/functions/prerelease';
  * 3. Use the prerelease tag of `@clerk/clerk-react`
  * 4. Fallback to the major version of `@clerk/clerk-react`
  * @param clerkJSVersion - The optional clerkJSVersion prop on the provider
+ * @param packageVersion - The version of `@clerk/clerk-react` that will be used if an explicit version is not provided
  * @returns The npm tag, version or major version to use
  */
-export const versionSelector = (clerkJSVersion: string | undefined) => {
+export const versionSelector = (clerkJSVersion: string | undefined, packageVersion = PACKAGE_VERSION) => {
   if (clerkJSVersion) {
     return clerkJSVersion;
   }
 
-  const prereleaseTag = getPrereleaseTag(PACKAGE_VERSION);
+  const prereleaseTag = getPrereleaseTag(packageVersion);
   if (prereleaseTag) {
     if (prereleaseTag === 'snapshot') {
       return JS_PACKAGE_VERSION;
@@ -24,8 +22,13 @@ export const versionSelector = (clerkJSVersion: string | undefined) => {
     return prereleaseTag;
   }
 
-  return getMajorVersion(PACKAGE_VERSION);
+  return getMajorVersion(packageVersion);
 };
 
-const getPrereleaseTag = (packageVersion: string) => prerelease(packageVersion)?.[0].toString();
-const getMajorVersion = (packageVersion: string) => major(packageVersion).toString();
+const getPrereleaseTag = (packageVersion: string) =>
+  packageVersion
+    .trim()
+    .replace(/^v/, '')
+    .match(/-(.+?)(\.|$)/)?.[1];
+
+const getMajorVersion = (packageVersion: string) => packageVersion.trim().replace(/^v/, '').split('.')[0];


### PR DESCRIPTION
The semver package doesn't provide exports map in its package.json. Vitest is ESM-only and relies more on these things whereas Jest is more forgiving. Instead of tweaking build config for clerk-react and given that we only rely on major() and prerelease() and the bundle-size considerations, we replaced semver with custom regexes

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
