### PR TITLE
fix(nextjs,clerk-js,types): Stop Clerk component flickering when used in App Router

### DIFF
--- a/.changeset/olive-files-listen.md
+++ b/.changeset/olive-files-listen.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/nextjs': patch
+'@clerk/types': patch
+---
+
+Prevent Clerk component flickering when mounted in a Next.js app using App Router

--- a/packages/clerk-js/src/core/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/clerk.redirects.test.ts
@@ -126,56 +126,56 @@ describe('Clerk singleton - Redirects', () => {
         await clerkForProductionInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
         await clerkForDevelopmentInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
       });
 
       it('redirects to signUpUrl', async () => {
         await clerkForProductionInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
         await clerkForDevelopmentInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
       });
 
       it('redirects to userProfileUrl', async () => {
         await clerkForProductionInstance.redirectToUserProfile();
         await clerkForDevelopmentInstance.redirectToUserProfile();
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/user-profile');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/user-profile');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/user-profile');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/user-profile');
       });
 
       it('redirects to afterSignUp', async () => {
         await clerkForProductionInstance.redirectToAfterSignUp();
         await clerkForDevelopmentInstance.redirectToAfterSignUp();
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/');
       });
 
       it('redirects to afterSignIn', async () => {
         await clerkForProductionInstance.redirectToAfterSignIn();
         await clerkForDevelopmentInstance.redirectToAfterSignIn();
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/');
       });
 
       it('redirects to create organization', async () => {
         await clerkForProductionInstance.redirectToCreateOrganization();
         await clerkForDevelopmentInstance.redirectToCreateOrganization();
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/create-organization');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/create-organization');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/create-organization');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/create-organization');
       });
 
       it('redirects to organization profile', async () => {
         await clerkForProductionInstance.redirectToOrganizationProfile();
         await clerkForDevelopmentInstance.redirectToOrganizationProfile();
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/organization-profile');
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, '/organization-profile');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/organization-profile');
+        expect(mockNavigate.mock.calls[1][0]).toBe('/organization-profile');
       });
     });
 

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -571,7 +571,7 @@ describe('Clerk singleton', () => {
       const res = sut.navigate(toUrl);
       expect(res.then).toBeDefined();
       expect(mockHref).not.toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith('/path#hash');
+      expect(mockNavigate.mock.calls[0][0]).toBe('/path#hash');
       expect(logSpy).not.toBeCalled();
     });
 
@@ -591,7 +591,7 @@ describe('Clerk singleton', () => {
       const res = sut.navigate(toUrl);
       expect(res.then).toBeDefined();
       expect(mockHref).not.toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith('/path#hash');
+      expect(mockNavigate.mock.calls[0][0]).toBe('/path#hash');
 
       expect(logSpy).toBeCalledTimes(1);
       expect(logSpy).toBeCalledWith(`Clerk is navigating to: ${toUrl}`);
@@ -721,7 +721,7 @@ describe('Clerk singleton', () => {
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up#/continue');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up#/continue');
       });
     });
 
@@ -934,7 +934,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/factor-two');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/factor-two');
       });
     });
 
@@ -977,7 +977,7 @@ describe('Clerk singleton', () => {
       });
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/custom-2fa');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/custom-2fa');
       });
     });
 
@@ -1032,7 +1032,7 @@ describe('Clerk singleton', () => {
       });
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/custom-sign-in');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/custom-sign-in');
       });
     });
 
@@ -1088,7 +1088,7 @@ describe('Clerk singleton', () => {
       } as any);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/custom-sign-in');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/custom-sign-in');
       });
     });
 
@@ -1136,7 +1136,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up');
       });
     });
 
@@ -1184,7 +1184,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up');
       });
     });
 
@@ -1226,7 +1226,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up#/continue');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up#/continue');
       });
     });
 
@@ -1273,7 +1273,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up#/verify-email-address');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up#/verify-email-address');
       });
     });
 
@@ -1305,7 +1305,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/factor-one');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/factor-one');
       });
     });
 
@@ -1353,7 +1353,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/factor-one');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/factor-one');
       });
     });
 
@@ -1412,7 +1412,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-up');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up');
       });
     });
 
@@ -1463,7 +1463,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-in');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in');
       });
     });
 
@@ -1501,7 +1501,7 @@ describe('Clerk singleton', () => {
       await sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/reset-password');
+        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/reset-password');
       });
     });
   });
@@ -1568,7 +1568,7 @@ describe('Clerk singleton', () => {
 
       await waitFor(() => {
         expect(mockSetActive).not.toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(redirectUrl);
+        expect(mockNavigate.mock.calls[0][0]).toBe(redirectUrl);
       });
     });
 
@@ -1628,7 +1628,7 @@ describe('Clerk singleton', () => {
 
       await waitFor(() => {
         expect(mockSetActive).not.toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(redirectUrl);
+        expect(mockNavigate.mock.calls[0][0]).toBe(redirectUrl);
       });
     });
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -726,8 +726,9 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
+    const metadata = options?.metadata ? { __internal_metadata: options?.metadata } : undefined;
     // React router only wants the path, search or hash portion.
-    return await customNavigate(stripOrigin(toURL));
+    return await customNavigate(stripOrigin(toURL), metadata);
   };
 
   public buildUrlWithAuth(to: string): string {

--- a/packages/clerk-js/src/ui/router/BaseRouter.tsx
+++ b/packages/clerk-js/src/ui/router/BaseRouter.tsx
@@ -1,4 +1,5 @@
 import { useClerk } from '@clerk/shared/react';
+import type { NavigateOptions } from '@clerk/types';
 import qs from 'qs';
 import React from 'react';
 
@@ -14,7 +15,7 @@ interface BaseRouterProps {
   startPath: string;
   getPath: () => string;
   getQueryString: () => string;
-  internalNavigate: (toURL: URL) => Promise<any> | any;
+  internalNavigate: (toURL: URL, options?: NavigateOptions) => Promise<any> | any;
   onExternalNavigate?: () => any;
   refreshEvents?: Array<keyof WindowEventMap>;
   preservedParams?: string[];
@@ -114,7 +115,7 @@ export const BaseRouter = ({
       });
       toURL.search = qs.stringify(toQueryParams);
     }
-    const internalNavRes = await internalNavigate(toURL);
+    const internalNavRes = await internalNavigate(toURL, { metadata: { navigationType: 'internal' } });
     setRouteParts({ path: toURL.pathname, queryString: toURL.search });
     return internalNavRes;
   };

--- a/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableNavigate.ts
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useTransition } from 'react';
 
-type NavigateFunction = ReturnType<typeof useRouter>['push'];
+import type { NextClerkProviderProps } from '../../types';
 
 /**
  * Creates an "awaitable" navigation function that will do its best effort to wait for Next.js to finish its route transition.
@@ -12,31 +12,48 @@ type NavigateFunction = ReturnType<typeof useRouter>['push'];
  * `isPending` to flush the stored promises and ensure the navigates "resolve".
  */
 export const useAwaitableNavigate = () => {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { push } = useRouter();
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const clerkNavRef = useRef<(...args: Parameters<NavigateFunction>) => Promise<void>>();
+  const clerkNavRef = useRef<NonNullable<NextClerkProviderProps['routerPush']>>();
   const clerkNavPromiseBuffer = useRef<(() => void)[]>([]);
 
   // Set the navigation function reference only once
   if (!clerkNavRef.current) {
-    clerkNavRef.current = (to, opts) => {
+    clerkNavRef.current = ((to, opts) => {
       return new Promise<void>(res => {
         clerkNavPromiseBuffer.current.push(res);
         startTransition(() => {
-          push(to, opts);
+          // If the navigation is internal, we should use the history API to navigate
+          // as this is the way to perform a shallow navigation in Next.js App Router
+          // without unmounting/remounting the page or fetching data from the server.
+          if (opts?.__internal_metadata?.navigationType === 'internal') {
+            // In 14.1.0, useSearchParams becomes reactive to shallow updates,
+            // but only if passing `null` as the history state.
+            // Older versions need to maintain the history state for push to work,
+            // without affecting how the Next router works.
+            const state = ((window as any).next?.version ?? '') < '14.1.0' ? history.state : null;
+            window.history.pushState(state, '', to);
+          } else {
+            // If the navigation is external (usually when navigating away from the component but still within the app),
+            // we should use the Next.js router to navigate as it will handle updating the URL and also
+            // fetching the new page if necessary.
+            router.push(to);
+          }
         });
       });
-    };
+    }) as NextClerkProviderProps['routerPush'];
   }
 
   // Handle flushing the promise buffer when pending is false. If pending is false and there are promises in the buffer we should be able to safely flush them.
   useEffect(() => {
-    if (isPending) return;
+    if (isPending) {
+      return;
+    }
 
     if (clerkNavPromiseBuffer?.current?.length) {
       clerkNavPromiseBuffer.current.forEach(resolve => resolve());
     }
+
     clerkNavPromiseBuffer.current = [];
   }, [isPending]);
 

--- a/packages/nextjs/src/client-boundary/usePathnameWithoutCatchAll.tsx
+++ b/packages/nextjs/src/client-boundary/usePathnameWithoutCatchAll.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/compat/router';
+import React from 'react';
 
 export const usePathnameWithoutWithCatchAll = () => {
+  const pathRef = React.useRef<string>();
   // The compat version of useRouter returns null instead of throwing an error
   // when used inside app router instead of pages router
   // we use it to detect if the component is used inside pages or app router
@@ -8,9 +10,14 @@ export const usePathnameWithoutWithCatchAll = () => {
   const pagesRouter = useRouter();
 
   if (pagesRouter) {
-    // in pages router things are simpler as the pathname includes the catch all route
-    // which starts with [[... and we can just remove it
-    return pagesRouter.pathname.replace(/\/\[\[\.\.\..*/, '');
+    if (pathRef.current) {
+      return pathRef.current;
+    } else {
+      // in pages router things are simpler as the pathname includes the catch all route
+      // which starts with [[... and we can just remove it
+      pathRef.current = pagesRouter.pathname.replace(/\/\[\[\.\.\..*/, '');
+      return pathRef.current;
+    }
   }
 
   // require is used to avoid importing next/navigation when the pages router is used,
@@ -38,5 +45,10 @@ export const usePathnameWithoutWithCatchAll = () => {
     .flat(Infinity);
   // so we end up with the pathname where the components are mounted at
   // eg /user/123/profile/security will return /user/123/profile as the path
-  return `/${pathParts.slice(0, pathParts.length - catchAllParams.length).join('/')}`;
+  if (pathRef.current) {
+    return pathRef.current;
+  } else {
+    pathRef.current = `/${pathParts.slice(0, pathParts.length - catchAllParams.length).join('/')}`;
+    return pathRef.current;
+  }
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -510,8 +510,8 @@ type ClerkOptionsNavigation =
       routerReplace?: never;
     }
   | {
-      routerPush: (to: string) => Promise<unknown> | unknown;
-      routerReplace: (to: string) => Promise<unknown> | unknown;
+      routerPush: RouterFn;
+      routerReplace: RouterFn;
       routerDebug?: boolean;
     };
 
@@ -546,6 +546,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
 
 export interface NavigateOptions {
   replace?: boolean;
+  metadata?: RouterMetadata;
 }
 
 export interface Resources {
@@ -556,6 +557,35 @@ export interface Resources {
 }
 
 export type RoutingStrategy = 'path' | 'hash' | 'virtual';
+
+/**
+ * Internal is a navigation type that affects the component
+ *
+ */
+type NavigationType =
+  /**
+   * Internal navigations affect the components and alter the
+   * part of the URL that comes after the `path` passed to the component.
+   * eg  <SignIn path='sign-in'>
+   * going from /sign-in to /sign-in/factor-one is an internal navigation
+   */
+  | 'internal'
+  /**
+   * Internal navigations affect the components and alter the
+   * part of the URL that comes before the `path` passed to the component.
+   * eg  <SignIn path='sign-in'>
+   * going from /sign-in to / is an external navigation
+   */
+  | 'external'
+  /**
+   * Window navigations are navigations towards a different origin
+   * and are not handled by the Clerk component or the host app router.
+   */
+  | 'window';
+
+type RouterMetadata = { routing?: RoutingStrategy; navigationType?: NavigationType };
+
+type RouterFn = (to: string, metadata?: { __internal_metadata?: RouterMetadata }) => Promise<unknown> | unknown;
 
 export type WithoutRouting<T> = Omit<T, 'path' | 'routing'>;
 


### PR DESCRIPTION
A few things going on in this PR.

### Navigation metadata
When using `router.push` from `next/navigation` (app router) the components in the current page will unmount before the navigation. In our case, if a component uses path-routing all internal navigations (for example `/user` > `/user/security` use `router.push` but that means that the component will unmount and immediately mount again in the new URL.

However, our components are client components and they can support client-side-only navigations. This type of navigation is usually called shallow navigation. App router apps can use the native `window.history` APIs in order to trigger shallow navigations.

We need to differentiate between internal navigations (navigations within the component) and external navigations (navigation outside the scope of the component) as we want to use shallow navigations for the former and normal `router.push` navigations for the latter.

To achieve that, the clerk-js router now sends a `metadata` object with each navigation that can be used by the consuming framework wrapper, enabling more fine-grained control over the type of navigation.

### Shallow navigations and nextjs
We want to be as little intrusive as possible, so when trigger shallow navigations, we need to make sure to preserve the default next router behavior. When calling the `window.history` APIs, we should respect how `windowHistorySupport` and let any changes to the URL update the next hooks as normal.
 
-  windowHistorySupport was enabled by default in `next@14.1.0`.
- For apps >= 14.1.0, we need to call push/replaceState with `null` as the first argument for WHS to work
- For older apps, we need to call the APIs with the `window.history.state`

Refs: 
- https://github.com/vercel/next.js/pull/58335
- https://github.com/vercel/next.js/discussions/48110
- https://github.com/vercel/next.js/discussions/18072
- https://github.com/47ng/nuqs/pull/482/files#diff-713238c17ffa37b63ad76fc5a5d9a2c6e923cc009e6593f86adf8fb32feef493R183

See inline comments for more details. 

### usePathnameWithoutCatchAll
This hook let us automatically determine the path a component is mounted on, while taking into account that components can be mounted in catch-all routes, so simply using `usePathname()` is not enough.
For example, imagine we are using path-based routing and we have a UserProfile component mounted at `/user/[[...rest]]/page.tsx`. The possible paths the component can use would be `/user` and `/user/security`, but the base path needs to be set as `/user` always for our internal router to work. 

We're now saving the initial value in a `ref` so it never gets updated after the initial (browser) navigation to the page. For details on what this hook does, please refer to the inline comments. 

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
