### PR TITLE
fix(clerk-react): Properly fire onLoad event when clerk-js is already loaded (#2757)

### DIFF
--- a/.changeset/brown-lemons-film.md
+++ b/.changeset/brown-lemons-film.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Properly fire onLoad event when clerk-js is already loaded.

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -107,5 +107,11 @@ const useLoadedIsomorphicClerk = (options: IsomorphicClerkOptions) => {
     isomorphicClerk.addOnLoaded(() => setLoaded(true));
   }, []);
 
+  React.useEffect(() => {
+    return () => {
+      IsomorphicClerk.clearInstance();
+    };
+  }, []);
+
   return { isomorphicClerk, loaded };
 };

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -174,7 +174,7 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
     return this.#loaded;
   }
 
-  static #instance: IsomorphicClerk;
+  static #instance: IsomorphicClerk | null | undefined;
 
   static getOrCreateInstance(options: IsomorphicClerkOptions) {
     // During SSR: a new instance should be created for every request
@@ -185,6 +185,10 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
       this.#instance = new IsomorphicClerk(options);
     }
     return this.#instance;
+  }
+
+  static clearInstance() {
+    this.#instance = null;
   }
 
   get domain(): string {
@@ -410,6 +414,12 @@ export default class IsomorphicClerk implements IsomorphicLoadedClerk {
 
   public addOnLoaded = (cb: () => void) => {
     this.loadedListeners.push(cb);
+    /**
+     * When IsomorphicClerk is loaded execute the callback directly
+     */
+    if (this.loaded) {
+      this.emitLoaded();
+    }
   };
 
   public emitLoaded = () => {


### PR DESCRIPTION
Backporting #2757 to the release/v4 branch

(cherry picked from commit 6ac9e717a7ce8f09c1604f324add5e7e02041c07)