### PR TITLE
feat(backend): Add `unbanUser`, `lockUser`,`unlockUser` to UserApi

### DIFF
--- a/.changeset/brown-masks-wonder.md
+++ b/.changeset/brown-masks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add `unbanUser`, `lockUser`, and `unlockUser` methods to the UserAPI class.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -244,4 +244,28 @@ export class UserAPI extends AbstractAPI {
       path: joinPaths(basePath, userId, 'ban'),
     });
   }
+
+  public async unbanUser(userId: string) {
+    this.requireId(userId);
+    return this.request<User>({
+      method: 'POST',
+      path: joinPaths(basePath, userId, 'unban'),
+    });
+  }
+
+  public async lockUser(userId: string) {
+    this.requireId(userId);
+    return this.request<User>({
+      method: 'POST',
+      path: joinPaths(basePath, userId, 'lock'),
+    });
+  }
+
+  public async unlockUser(userId: string) {
+    this.requireId(userId);
+    return this.request<User>({
+      method: 'POST',
+      path: joinPaths(basePath, userId, 'unlock'),
+    });
+  }
 }


### PR DESCRIPTION
## Description

This PR adds the `unbanUser`, `lockUser` and `unlockUser` methods in the @clerk/backend package in order for developers to perform these administrative operations.

BAPI had them already in place, see [documentation](https://clerk.com/docs/reference/backend-api/tag/Users#operation/UnbanUser)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
