### PR TITLE
feat(shared,clerk-react,clerk-js): Auto-revalidation of paginated resources based on events

### DIFF
--- a/.changeset/wise-gorillas-wonder.md
+++ b/.changeset/wise-gorillas-wonder.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/clerk-react': minor
+---
+
+Auto-revalidation of useOrganizationList paginated resources based on events.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -100,6 +100,7 @@ import {
   clerkOAuthCallbackDidNotCompleteSignInSignUp,
   clerkRedirectUrlIsMissingScheme,
 } from './errors';
+import { eventBus } from './events';
 import type { FapiClient, FapiRequestCallback } from './fapiClient';
 import { createFapiClient } from './fapiClient';
 import {
@@ -1244,6 +1245,10 @@ export class Clerk implements ClerkInterface {
     // in the v4 build. This will be removed when v4 becomes the main stable version
     return this.#componentControls?.ensureMounted().then(controls => controls.updateProps(props));
   };
+
+  __unstable__eventBus_on = eventBus.on;
+
+  __unstable__eventBus_off = eventBus.off;
 
   __internal_navigateWithError(to: string, err: ClerkAPIError) {
     this.__internal_last_error = err;

--- a/packages/clerk-js/src/core/events.ts
+++ b/packages/clerk-js/src/core/events.ts
@@ -2,7 +2,9 @@ import type { TokenResource } from '@clerk/types';
 
 export const events = {
   TokenUpdate: 'token:update',
-  OrganizationDestroy: 'organization:destroy',
+  OrganizationDeleted: 'organization:deleted',
+  OrganizationCreated: 'organization:created',
+  UserMembershipDeleted: 'user:membership_deleted',
 } as const;
 
 type ClerkEvent = (typeof events)[keyof typeof events];
@@ -12,7 +14,9 @@ type TokenUpdatePayload = { token: TokenResource | null };
 
 type EventPayload = {
   [events.TokenUpdate]: TokenUpdatePayload;
-  [events.OrganizationDestroy]: null;
+  [events.OrganizationDeleted]: null;
+  [events.OrganizationCreated]: null;
+  [events.UserMembershipDeleted]: null;
 };
 
 const createEventBus = () => {
@@ -40,6 +44,7 @@ const createEventBus = () => {
         event,
         handlers.filter(h => h !== handler),
       );
+      return;
     }
 
     eventToHandlersMap.set(event, []);

--- a/packages/clerk-js/src/core/events.ts
+++ b/packages/clerk-js/src/core/events.ts
@@ -2,6 +2,7 @@ import type { TokenResource } from '@clerk/types';
 
 export const events = {
   TokenUpdate: 'token:update',
+  OrganizationDestroy: 'organization:destroy',
 } as const;
 
 type ClerkEvent = (typeof events)[keyof typeof events];
@@ -11,6 +12,7 @@ type TokenUpdatePayload = { token: TokenResource | null };
 
 type EventPayload = {
   [events.TokenUpdate]: TokenUpdatePayload;
+  [events.OrganizationDestroy]: null;
 };
 
 const createEventBus = () => {

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -63,6 +63,7 @@ export class Organization extends BaseResource implements OrganizationResource {
       })
     )?.response as unknown as OrganizationJSON;
 
+    eventBus.dispatch('organization:created', null);
     return new Organization(json);
   }
 
@@ -231,7 +232,7 @@ export class Organization extends BaseResource implements OrganizationResource {
 
   destroy = async (): Promise<void> => {
     const deletedObj = await this._baseDelete();
-    eventBus.dispatch('organization:destroy', null);
+    eventBus.dispatch('organization:deleted', null);
     return deletedObj;
   };
 

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -27,6 +27,7 @@ import type {
 
 import { convertPageToOffsetSearchParams } from '../../utils/convertPageToOffsetSearchParams';
 import { unixEpochToDate } from '../../utils/date';
+import { eventBus } from '../events';
 import { BaseResource, OrganizationInvitation, OrganizationMembership } from './internal';
 import { OrganizationDomain } from './OrganizationDomain';
 import { OrganizationMembershipRequest } from './OrganizationMembershipRequest';
@@ -229,7 +230,9 @@ export class Organization extends BaseResource implements OrganizationResource {
   };
 
   destroy = async (): Promise<void> => {
-    return this._baseDelete();
+    const deletedObj = await this._baseDelete();
+    eventBus.dispatch('organization:destroy', null);
+    return deletedObj;
   };
 
   setLogo = async ({ file }: SetOrganizationLogoParams): Promise<OrganizationResource> => {

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -32,6 +32,7 @@ import type {
 import { unixEpochToDate } from '../../utils/date';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
 import { getFullName } from '../../utils/user';
+import { eventBus } from '../events';
 import { BackupCode } from './BackupCode';
 import {
   BaseResource,
@@ -270,6 +271,7 @@ export class User extends BaseResource implements UserResource {
       })
     )?.response as unknown as DeletedObjectJSON;
 
+    eventBus.dispatch('user:membership_deleted', null);
     return new DeletedObject(json);
   };
 

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -21,7 +21,6 @@ import { createSlug, handleError, useFormControl } from '../../utils';
 import { InviteMembersForm } from '../OrganizationProfile/InviteMembersForm';
 import { InvitationsSentMessage } from '../OrganizationProfile/InviteMembersScreen';
 import { OrganizationProfileAvatarUploader } from '../OrganizationProfile/OrganizationProfileAvatarUploader';
-import { organizationListParams } from '../OrganizationSwitcher/utils';
 
 type CreateOrganizationFormProps = {
   skipInvitationScreen: boolean;
@@ -40,9 +39,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
   const wizard = useWizard({ onNextStep: () => card.setError(undefined) });
 
   const lastCreatedOrganizationRef = React.useRef<OrganizationResource | null>(null);
-  const { createOrganization, isLoaded, setActive, userMemberships } = useOrganizationList({
-    userMemberships: organizationListParams.userMemberships,
-  });
+  const { createOrganization, isLoaded, setActive } = useOrganizationList();
   const { organization } = useOrganization();
   const [file, setFile] = React.useState<File | null>();
 
@@ -79,8 +76,6 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
 
       lastCreatedOrganizationRef.current = organization;
       await setActive({ organization });
-
-      void userMemberships.revalidate?.();
 
       if (props.skipInvitationScreen ?? organization.maxAllowedMemberships === 1) {
         return completeFlow();

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActionConfirmationPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActionConfirmationPage.tsx
@@ -1,4 +1,4 @@
-import { useOrganization, useOrganizationList, useUser } from '@clerk/shared/react';
+import { useOrganization, useUser } from '@clerk/shared/react';
 
 import { useWizard, Wizard } from '../../common';
 import { useOrganizationProfileContext } from '../../contexts';
@@ -14,35 +14,26 @@ import {
   withCardStateProvider,
 } from '../../elements';
 import { handleError, useFormControl } from '../../utils';
-import { organizationListParams } from '../OrganizationSwitcher/utils';
 
 type LeaveOrganizationFormProps = FormProps;
 
-const useLeaveWithRevalidations = (leavePromise: (() => Promise<any>) | undefined) => {
+const useLeaveWithNavigation = (leavePromise: (() => Promise<any>) | undefined) => {
   const card = useCardState();
   const { navigateAfterLeaveOrganization } = useOrganizationProfileContext();
-  const { userMemberships, userInvitations } = useOrganizationList({
-    userMemberships: organizationListParams.userMemberships,
-    userInvitations: organizationListParams.userInvitations,
-  });
 
   return () =>
     card
       .runAsync(async () => {
         await leavePromise?.();
       })
-      .then(() => {
-        void userMemberships.revalidate?.();
-        void userInvitations.revalidate?.();
-        void navigateAfterLeaveOrganization();
-      });
+      .then(navigateAfterLeaveOrganization);
 };
 
 export const LeaveOrganizationForm = (props: LeaveOrganizationFormProps) => {
   const { organization } = useOrganization();
   const { user } = useUser();
 
-  const leaveOrg = useLeaveWithRevalidations(() => user!.leaveOrganization(organization!.id));
+  const leaveOrg = useLeaveWithNavigation(() => user!.leaveOrganization(organization!.id));
 
   if (!organization || !user) {
     return null;
@@ -72,7 +63,7 @@ type DeleteOrganizationFormProps = FormProps;
 export const DeleteOrganizationForm = (props: DeleteOrganizationFormProps) => {
   const { organization, membership } = useOrganization();
 
-  const deleteOrg = useLeaveWithRevalidations(organization?.destroy);
+  const deleteOrg = useLeaveWithNavigation(organization?.destroy);
 
   if (!organization || !membership) {
     return null;

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -32,6 +32,7 @@ export const ActiveMembersList = () => {
     return card
       .runAsync(async () => {
         const destroyedMembership = await membership.destroy();
+        // TODO: AUTO-REVALIDATIONS
         await memberships?.revalidate?.();
         return destroyedMembership;
       })

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/AddDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/AddDomainForm.tsx
@@ -46,6 +46,7 @@ export const AddDomainForm = withCardStateProvider((props: AddDomainFormProps) =
       .createDomain(nameField.value)
       .then(async res => {
         setDomainId(res.id);
+        // TODO: AUTO-REVALIDATIONS
         domains?.revalidate?.();
         if (res.verification && res.verification.status === 'verified') {
           setVerified(true);
@@ -82,6 +83,7 @@ export const AddDomainForm = withCardStateProvider((props: AddDomainFormProps) =
       <VerifyDomainForm
         domainId={domainId}
         onSuccess={() => {
+          // TODO: AUTO-REVALIDATIONS
           domains?.revalidate?.();
           onSuccess?.();
         }}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -81,6 +81,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
         role: submittedData.get('role') as string,
       })
       .then(async () => {
+        // TODO: AUTO-REVALIDATIONS
         await invitations?.revalidate?.();
         return onSuccess?.();
       })

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -28,6 +28,7 @@ export const InvitedMembersList = () => {
     return card
       .runAsync(async () => {
         await invitation.revoke();
+        // TODO: AUTO-REVALIDATIONS
         await invitations?.revalidate?.();
         return invitation;
       })

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainForm.tsx
@@ -66,6 +66,7 @@ export const RemoveDomainForm = (props: RemoveDomainFormProps) => {
       messageLine2={localizationKeys('organizationProfile.removeDomainPage.messageLine2')}
       deleteResource={() =>
         domain?.delete().then(async () => {
+          // TODO: AUTO-REVALIDATIONS
           await domains?.revalidate?.();
           onSuccess();
         })

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
@@ -59,6 +59,7 @@ const RequestRow = withCardStateProvider(
       return card
         .runAsync(async () => {
           await request.accept();
+          // TODO: AUTO-REVALIDATIONS
           await membershipRequests.revalidate();
         }, 'accept')
         .catch(err => handleError(err, [], onError));

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainForm.tsx
@@ -145,6 +145,7 @@ export const VerifiedDomainForm = withCardStateProvider((props: VerifiedDomainFo
         deletePending: deletePending.checked,
       });
 
+      // TODO: AUTO-REVALIDATIONS
       await domains.revalidate();
 
       onSuccess();

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -551,6 +551,24 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   }
 
+  __unstable__eventBus_on(...args: any): void {
+    const callback = () => (this.clerkjs as any)?.__unstable__eventBus_on(...args);
+    if (this.clerkjs && this.#loaded && '__unstable__eventBus_on' in this.clerkjs) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('__unstable__eventBus_on' as any, callback);
+    }
+  }
+
+  __unstable__eventBus_off(...args: any): void {
+    const callback = () => (this.clerkjs as any)?.__unstable__eventBus_off(...args);
+    if (this.clerkjs && this.#loaded && '__unstable__eventBus_off' in this.clerkjs) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('__unstable__eventBus_off' as any, callback);
+    }
+  }
+
   __unstable__updateProps = (props: any): any => {
     // Handle case where accounts has clerk-react@4 installed, but clerk-js@3 is manually loaded
     if (this.clerkjs && '__unstable__updateProps' in this.clerkjs) {

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -10,7 +10,6 @@ import type {
   SetActive,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts';
 import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types';
@@ -69,6 +68,11 @@ type UseOrganizationList = <T extends UseOrganizationListParams>(
       >;
     };
 
+const __unstable__revalidationParams = {
+  __unstable__dependencyRevalidation: true,
+  __unstable__defaultRevalidateOnEvents: ['organization:deleted', 'organization:created', 'user:membership_deleted'],
+};
+
 export const useOrganizationList: UseOrganizationList = params => {
   const { userMemberships, userInvitations, userSuggestions } = params || {};
 
@@ -79,6 +83,7 @@ export const useOrganizationList: UseOrganizationList = params => {
     pageSize: 10,
     keepPreviousData: false,
     infinite: false,
+    ...__unstable__revalidationParams,
   });
 
   const userInvitationsSafeValues = useWithSafeValues(userInvitations, {
@@ -87,6 +92,7 @@ export const useOrganizationList: UseOrganizationList = params => {
     status: 'pending',
     keepPreviousData: false,
     infinite: false,
+    ...__unstable__revalidationParams,
   });
 
   const userSuggestionsSafeValues = useWithSafeValues(userSuggestions, {
@@ -95,6 +101,7 @@ export const useOrganizationList: UseOrganizationList = params => {
     status: 'pending',
     keepPreviousData: false,
     infinite: false,
+    ...__unstable__revalidationParams,
   });
 
   const clerk = useClerkInstanceContext();
@@ -138,6 +145,8 @@ export const useOrganizationList: UseOrganizationList = params => {
       keepPreviousData: userMembershipsSafeValues.keepPreviousData,
       infinite: userMembershipsSafeValues.infinite,
       enabled: !!userMembershipsParams,
+      __unstable__dependencyRevalidation: userMembershipsSafeValues.__unstable__dependencyRevalidation,
+      __unstable__defaultRevalidateOnEvents: userMembershipsSafeValues.__unstable__defaultRevalidateOnEvents,
     },
     {
       type: 'userMemberships',
@@ -157,6 +166,8 @@ export const useOrganizationList: UseOrganizationList = params => {
       keepPreviousData: userInvitationsSafeValues.keepPreviousData,
       infinite: userInvitationsSafeValues.infinite,
       enabled: !!userInvitationsParams,
+      __unstable__dependencyRevalidation: userInvitationsSafeValues.__unstable__dependencyRevalidation,
+      __unstable__defaultRevalidateOnEvents: userInvitationsSafeValues.__unstable__defaultRevalidateOnEvents,
     },
     {
       type: 'userInvitations',
@@ -176,24 +187,14 @@ export const useOrganizationList: UseOrganizationList = params => {
       keepPreviousData: userSuggestionsSafeValues.keepPreviousData,
       infinite: userSuggestionsSafeValues.infinite,
       enabled: !!userSuggestionsParams,
+      __unstable__dependencyRevalidation: userSuggestionsSafeValues.__unstable__dependencyRevalidation,
+      __unstable__defaultRevalidateOnEvents: userSuggestionsSafeValues.__unstable__defaultRevalidateOnEvents,
     },
     {
       type: 'userSuggestions',
       userId: user?.id,
     },
   );
-
-  useEffect(() => {
-    const handler = () => {
-      console.log('Organization destroyed');
-      void memberships.revalidate?.();
-    };
-    (clerk as any).__unstable__eventBus_on('organization:destroy', handler);
-
-    return () => {
-      (clerk as any).__unstable__eventBus_off('organization:destroy', handler);
-    };
-  }, []);
 
   // TODO: Properly check for SSR user values
   if (!isClerkLoaded) {

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -10,6 +10,7 @@ import type {
   SetActive,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
+import { useEffect } from 'react';
 
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts';
 import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types';
@@ -181,6 +182,18 @@ export const useOrganizationList: UseOrganizationList = params => {
       userId: user?.id,
     },
   );
+
+  useEffect(() => {
+    const handler = () => {
+      console.log('Organization destroyed');
+      void memberships.revalidate?.();
+    };
+    (clerk as any).__unstable__eventBus_on('organization:destroy', handler);
+
+    return () => {
+      (clerk as any).__unstable__eventBus_off('organization:destroy', handler);
+    };
+  }, []);
 
   // TODO: Properly check for SSR user values
   if (!isClerkLoaded) {

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -44,6 +44,9 @@ export type PaginatedHookConfig<T> = T & {
    * Return the previous key's data until the new data has been loaded
    */
   keepPreviousData?: boolean;
+
+  __unstable__dependencyRevalidation?: boolean;
+  __unstable__defaultRevalidateOnEvents?: string[];
 };
 
 export type PagesOrInfiniteConfig = PaginatedHookConfig<{


### PR DESCRIPTION
## Description

Three new events were added to `eventBus` in order to describe the action that was taken and broadcast it to subscribers.

This ensures that specific clerk-js methods can broadcast an event and our hooks can listen to that event and in this case revalidate the cache.

### Why do we need this
This is extremely useful of situations where our UI components are used in conjunction with custom implementations. For example, let's say that an application is using the Organization Profile and CreateOrganization components, but it has a custom implementation of OrganizationSwitcher. Until now there was no way to notify the custom switcher to refetch data when an organization was created via the component.

### Before
"test2" is not getting removed from custom switcher

https://github.com/clerk/javascript/assets/19269911/da74d1c3-6373-40f0-8ec4-55ab30b74eba


### After
"dwadaw" is getting correctly removed from custom switcher

https://github.com/clerk/javascript/assets/19269911/92df255d-dd68-44ea-8604-8062935a5257


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
