### PR TITLE
fix(remix): Get env variables in Cloudflare Pages context

### DIFF
--- a/.changeset/twenty-yaks-behave.md
+++ b/.changeset/twenty-yaks-behave.md
@@ -2,4 +2,4 @@
 '@clerk/remix': patch
 ---
 
-Fix getting env variables in Remix + Cloudflare Pages
+Correctly get environment variables inside Cloudflare Pages by accessing `context.cloudflare`

--- a/.changeset/twenty-yaks-behave.md
+++ b/.changeset/twenty-yaks-behave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Fix getting env variables in Remix + Cloudflare Pages

--- a/packages/remix/src/utils/utils.ts
+++ b/packages/remix/src/utils/utils.ts
@@ -24,6 +24,10 @@ export function assertValidClerkState(val: any): asserts val is ClerkState | und
   }
 }
 
+type CloudflareEnv = {
+  env: Record<string, string>;
+};
+
 /**
  *
  * Utility function to get env variables across Node and Edge runtimes.
@@ -32,6 +36,11 @@ export function assertValidClerkState(val: any): asserts val is ClerkState | und
  * @returns string
  */
 export const getEnvVariable = (name: string, context: AppLoadContext | undefined): string => {
+  // Remix + Cloudflare pages
+  if (typeof (context?.cloudflare as CloudflareEnv)?.env !== 'undefined') {
+    return (context?.cloudflare as CloudflareEnv).env[name] || '';
+  }
+
   // Node envs
   if (typeof process !== 'undefined') {
     return (process.env && process.env[name]) || '';
@@ -39,7 +48,7 @@ export const getEnvVariable = (name: string, context: AppLoadContext | undefined
 
   // Cloudflare pages
   if (typeof context !== 'undefined') {
-    const contextEnv = context?.env as Record<string, string>;
+    const contextEnv = (context as CloudflareEnv)?.env;
 
     return contextEnv[name] || (context[name] as string) || '';
   }


### PR DESCRIPTION
## Description

Fixes #2778

Remix + Cloudflare pages now accesses  environment variables via `context.cloudflare.env` https://remix.run/blog/remix-vite-stable#cloudflare-pages-support  

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
