### PR TITLE
fix(clerk-js,shared): Remove __clerk_db_jwt from hash on clerk-js init

### DIFF
--- a/.changeset/happy-points-relax.md
+++ b/.changeset/happy-points-relax.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Update the debBrowser handling logic to remove hash-based devBrowser JWTs from the URL. Even if v5 does not use the hash-based JWT at all, we still need to remove it from the URL in case clerk-js is initialised on a page after a redirect from an older clerk-js version, such as an AccountPortal using the v4 components

--- a/packages/clerk-js/src/core/devBrowser.ts
+++ b/packages/clerk-js/src/core/devBrowser.ts
@@ -1,4 +1,4 @@
-import { DEV_BROWSER_JWT_HEADER, getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '@clerk/shared/devBrowser';
+import { DEV_BROWSER_JWT_HEADER, extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '@clerk/shared/devBrowser';
 import { parseErrors } from '@clerk/shared/error';
 import type { ClerkAPIErrorJSON } from '@clerk/types';
 
@@ -61,8 +61,8 @@ export function createDevBrowser({ frontendApi, fapiClient }: CreateDevBrowserOp
       }
     });
 
-    // 1. Get the JWT from hash or search parameters when the redirection comes from AP
-    const devBrowserToken = getDevBrowserJWTFromURL(new URL(window.location.href));
+    // 1. Get the JWT from search parameters when the redirection comes from AP
+    const devBrowserToken = extractDevBrowserJWTFromURL(new URL(window.location.href));
     if (devBrowserToken) {
       setDevBrowserJWT(devBrowserToken);
       return;

--- a/packages/shared/src/__tests__/devbrowser.test.ts
+++ b/packages/shared/src/__tests__/devbrowser.test.ts
@@ -1,4 +1,4 @@
-import { getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
+import { extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
 
 const DUMMY_URL_BASE = 'http://clerk-dummy';
 
@@ -50,34 +50,29 @@ describe('getDevBrowserJWTFromURL(url)', () => {
   });
 
   it('does not replaceState if the url does not contain a dev browser JWT', () => {
-    expect(getDevBrowserJWTFromURL(new URL('/foo', DUMMY_URL_BASE))).toEqual('');
+    expect(extractDevBrowserJWTFromURL(new URL('/foo', DUMMY_URL_BASE))).toEqual('');
     expect(replaceStateMock).not.toHaveBeenCalled();
   });
 
-  const testCases: Array<[string, string, null | string]> = [
-    ['', '', null],
-    ['foo', '', null],
-    ['?__clerk_db_jwt=deadbeef', 'deadbeef', ''],
-    ['foo?__clerk_db_jwt=deadbeef', 'deadbeef', 'foo'],
-    ['/foo?__clerk_db_jwt=deadbeef', 'deadbeef', '/foo'],
-    ['?__clerk_db_jwt=deadbeef#foo', 'deadbeef', '#foo'],
-    [
-      '/foo?bar=42&__clerk_db_jwt=deadbeef#qux__clerk_db_jwt[deadbeef2]',
-      'deadbeef',
-      '/foo?bar=42#qux__clerk_db_jwt[deadbeef2]',
-    ],
+  it('does call replaceState if the url contains a dev browser JWT', () => {
+    expect(extractDevBrowserJWTFromURL(new URL('/foo?__clerk_db_jwt=token', DUMMY_URL_BASE))).toEqual('token');
+    expect(replaceStateMock).toHaveBeenCalled();
+  });
+
+  const testCases: Array<[string, string]> = [
+    ['', ''],
+    ['foo', ''],
+    ['?__clerk_db_jwt=token', 'token'],
+    ['foo?__clerk_db_jwt=token', 'token'],
+    ['/foo?__clerk_db_jwt=token', 'token'],
+    ['?__clerk_db_jwt=token#foo', 'token'],
+    ['/foo?bar=42&__clerk_db_jwt=token#qux__clerk_db_jwt[token2]', 'token'],
   ];
 
   test.each(testCases)(
-    'returns the dev browser JWT from a url. Params: url=(%s), jwt=(%s)',
-    (input, jwt, calledWith) => {
-      expect(getDevBrowserJWTFromURL(new URL(input, DUMMY_URL_BASE))).toEqual(jwt);
-
-      if (calledWith === null) {
-        expect(replaceStateMock).not.toHaveBeenCalled();
-      } else {
-        expect(replaceStateMock).toHaveBeenCalledWith(null, '', new URL(calledWith, DUMMY_URL_BASE).href);
-      }
+    'returns the dev browser JWT from a url and cleans all dev . Params: url=(%s), jwt=(%s)',
+    (input, jwt) => {
+      expect(extractDevBrowserJWTFromURL(new URL(input, DUMMY_URL_BASE))).toEqual(jwt);
     },
   );
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,4 +31,4 @@ export * from './underscore';
 export * from './url';
 export * from './object';
 export { createWorkerTimers } from './workerTimers';
-export { DEV_BROWSER_JWT_KEY, getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from './devBrowser';
+export { DEV_BROWSER_JWT_KEY, extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from './devBrowser';


### PR DESCRIPTION
Update the debBrowser handling logic to remove hash-based devBrowser JWTs from the URL. Even if v5 does not use the hash-based JWT at all, we still need to remove it from the URL in case clerk-js is initialised on a page after a redirect from an older clerk-js version, such as an AccountPortal using the v4 components

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
