### PR TITLE
fix(shared): Remove legacy __dev_session from URL search params

### DIFF
--- a/.changeset/witty-jokes-repair.md
+++ b/.changeset/witty-jokes-repair.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/clerk-js': patch
+---
+
+Remove legacy \_\_dev_session from URL search params

--- a/packages/shared/src/devBrowser.ts
+++ b/packages/shared/src/devBrowser.ts
@@ -37,7 +37,7 @@ const readDevBrowserJwtFromSearchParams = (url: URL) => {
 };
 
 const removeDevBrowserJwt = (url: URL) => {
-  return removeDevBrowserJwtFromURLSearchParams(removeLegacyDevBrowserJwtFromURLHash(new URL(url)));
+  return removeDevBrowserJwtFromURLSearchParams(removeLegacyDevBrowserJwt(url));
 };
 
 const removeDevBrowserJwtFromURLSearchParams = (_url: URL) => {
@@ -47,7 +47,8 @@ const removeDevBrowserJwtFromURLSearchParams = (_url: URL) => {
 };
 
 /**
- * Removes the __clerk_db_jwt JWT from the URL hash.
+ * Removes the __clerk_db_jwt JWT from the URL hash, as well as
+ * the legacy __dev_session JWT from the URL searchParams
  * We no longer need to use this value, however, we should remove it from the URL
  * Existing v4 apps will write the JWT to the hash and the search params in order to ensure
  * backwards compatibility with older v4 apps.
@@ -56,9 +57,11 @@ const removeDevBrowserJwtFromURLSearchParams = (_url: URL) => {
  * In this scenario, the AP@4 -> localhost@5 redirect will still have the JWT in the hash,
  * in which case we need to remove it.
  */
-const removeLegacyDevBrowserJwtFromURLHash = (_url: URL) => {
+const removeLegacyDevBrowserJwt = (_url: URL) => {
   const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
+  const DEV_BROWSER_JWT_LEGACY_KEY = '__dev_session';
   const url = new URL(_url);
+  url.searchParams.delete(DEV_BROWSER_JWT_LEGACY_KEY);
   url.hash = url.hash.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
   if (url.href.endsWith('#')) {
     url.hash = '';


### PR DESCRIPTION
## Description
Even though we're not using the legacy jwt anymore, we need to remove it from the URL to keep the URL clean

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
