### PR TITLE
fix(types): Fix the `appearance.baseTheme` type to accept array of `BaseTheme`

### DIFF
--- a/.changeset/curvy-kids-sip.md
+++ b/.changeset/curvy-kids-sip.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': patch
+---
+
+Fix the appearance.baseTheme type to accept array of BaseTheme

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -517,7 +517,7 @@ export type Theme = {
    * import { dark } from "@clerk/themes";
    * appearance={{ baseTheme: dark }}
    */
-  baseTheme?: BaseTheme;
+  baseTheme?: BaseTheme | BaseTheme[];
   /**
    * Configuration options that affect the layout of the components, allowing
    * customizations that hard to implement with just CSS.


### PR DESCRIPTION
## Description

We already have the functionality to support an array of `BaseTheme` items that stack on each other. We also document examples of usage here: https://clerk.com/docs/components/customization/overview#using-a-pre-built-theme

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
