### PR TITLE
fix(clerk-js): Fix PhoneInput country ISO text color

### DIFF
--- a/.changeset/cool-ties-grin.md
+++ b/.changeset/cool-ties-grin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix the PhoneInput country ISO text color

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -134,6 +134,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           })}
         >
           <Text
+            colorScheme='primary'
             sx={{
               textTransform: 'uppercase',
             }}


### PR DESCRIPTION
## Description

Before:
<img width="405" alt="Screenshot 2024-02-29 at 13 40 44" src="https://github.com/clerk/javascript/assets/15199353/133678dd-7d52-4d09-b4e7-f7a690ba3af9">

After:
<img width="405" alt="Screenshot 2024-02-29 at 13 40 32" src="https://github.com/clerk/javascript/assets/15199353/88985820-0b78-4c83-b794-642e6f7ce8c4">


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
