### PR TITLE
fix(nextjs,clerk-js): Make useAwaitableNavigate handle navigations be…

### DIFF
--- a/.changeset/silly-tips-cry.md
+++ b/.changeset/silly-tips-cry.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/nextjs': patch
+---
+
+Make useAwaitableNavigate handle navigations between pages reliably

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -618,7 +618,7 @@ export class Clerk implements ClerkInterface {
       );
     }
 
-    type SetActiveHook = () => void;
+    type SetActiveHook = () => void | Promise<void>;
     const onBeforeSetActive: SetActiveHook =
       typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
         ? window.__unstable__onBeforeSetActive
@@ -653,7 +653,7 @@ export class Clerk implements ClerkInterface {
       this.#broadcastSignOutEvent();
     }
 
-    onBeforeSetActive();
+    await onBeforeSetActive();
 
     //1. setLastActiveSession to passed user session (add a param).
     //   Note that this will also update the session's active organization
@@ -685,7 +685,7 @@ export class Clerk implements ClerkInterface {
 
     this.#setAccessors(newSession);
     this.#emit();
-    onAfterSetActive();
+    await onAfterSetActive();
     this.#resetComponentsState();
   };
 

--- a/packages/clerk-js/src/globals.d.ts
+++ b/packages/clerk-js/src/globals.d.ts
@@ -4,8 +4,8 @@ declare global {
   const __PKG_VERSION__: string;
 
   interface Window {
-    __unstable__onBeforeSetActive: () => void;
-    __unstable__onAfterSetActive: () => void;
+    __unstable__onBeforeSetActive: () => Promise<void> | void;
+    __unstable__onAfterSetActive: () => Promise<void> | void;
   }
 }
 

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useTransition } from 'react';
 
 import { ClerkNextOptionsProvider } from '../../client-boundary/NextOptionsContext';
 import { useSafeLayoutEffect } from '../../client-boundary/useSafeLayoutEffect';
@@ -13,6 +13,7 @@ declare global {
   export interface Window {
     __clerk_nav_await: Array<(value: void) => void>;
     __clerk_nav: (to: string) => Promise<void>;
+    __clerk_internal_invalidateCachePromise: () => void | undefined;
   }
 }
 
@@ -20,17 +21,47 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
   const { __unstable_invokeMiddlewareOnAuthStateChange = true, children } = props;
   const router = useRouter();
   const navigate = useAwaitableNavigate();
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!isPending) {
+      window.__clerk_internal_invalidateCachePromise?.();
+    }
+  }, [isPending]);
 
   useSafeLayoutEffect(() => {
     window.__unstable__onBeforeSetActive = () => {
-      if (__unstable_invokeMiddlewareOnAuthStateChange) {
-        router.refresh();
-        router.push(window.location.href);
-      }
+      /**
+       * We need to invalidate the cache in case the user is navigating to a page that
+       * was previously cached using the auth state that was active at the time.
+       *
+       *  We also need to await for the invalidation to happen before we navigate,
+       * otherwise the navigation will use the cached page.
+       *
+       * For example, if we did not invalidate the flow, the following scenario would be broken:
+       * - The middleware is configured in such a way that it redirects you back to the same page if a certain condition is true (eg, you need to pick an org)
+       * - The user has a <Link href=/> component in the page
+       * - The UB is mounted with afterSignOutUrl=/
+       * - The user clicks the Link. A nav to / happens, a 307 to the current page is returned so a navigation does not take place. The / navigation is now cached as a 307 to the current page
+       * - The user clicks sign out
+       * - We call router.refresh()
+       * - We navigate to / but its cached and instead, we 'redirect' to the current page
+       *
+       *  For more information on cache invalidation, see:
+       * https://nextjs.org/docs/app/building-your-application/caching#invalidation-1
+       */
+      return new Promise(res => {
+        window.__clerk_internal_invalidateCachePromise = res;
+        startTransition(() => {
+          router.refresh();
+        });
+      });
     };
 
     window.__unstable__onAfterSetActive = () => {
-      router.refresh();
+      if (__unstable_invokeMiddlewareOnAuthStateChange) {
+        return router.refresh();
+      }
     };
   }, []);
 

--- a/packages/nextjs/src/global.d.ts
+++ b/packages/nextjs/src/global.d.ts
@@ -1,7 +1,7 @@
 declare global {
   interface Window {
-    __unstable__onBeforeSetActive: () => void;
-    __unstable__onAfterSetActive: () => void;
+    __unstable__onBeforeSetActive: () => void | Promise<void>;
+    __unstable__onAfterSetActive: () => void | Promise<void>;
   }
 }
 


### PR DESCRIPTION
…tween pages reliably

We need to use window to store the reference to the buffer, as ClerkProvider might be unmounted and remounted during navigations. If we use a ref, it will be reset when ClerkProvider is unmounted

v5 port of https://github.com/clerk/javascript/pull/2889

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
