### PR TITLE
feat(backend): Signing a JWT respects 'iat' claim

### DIFF
--- a/.changeset/rare-chefs-invent.md
+++ b/.changeset/rare-chefs-invent.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+The signJwt function preserves the value of the 'iat' claim, falling back to the current time if the claim is not present in the payload

--- a/packages/backend/src/jwt/signJwt.ts
+++ b/packages/backend/src/jwt/signJwt.ts
@@ -51,7 +51,7 @@ export async function signJwt(
   const header = options.header || { typ: 'JWT' };
 
   header.alg = options.algorithm;
-  payload.iat = Math.floor(Date.now() / 1000);
+  payload.iat = payload.iat || Math.floor(Date.now() / 1000);
 
   const encodedHeader = encodeJwtData(header);
   const encodedPayload = encodeJwtData(payload);


### PR DESCRIPTION
## Description
Calling the `signJwt` function overrides the 'iat' (issued at) claim of the payload.

```js
import { signJwt } from '@clerk/backend/jwt';

const key = 'the-private-key';
const payload = {
  sub: 'subject',
  // provide the issued_at claim
  iat: 123,
}
const { data } = await signJwt(payload, key, {
  algorithm: 'RS256',
  header: {
    alg: 'RS256',
    typ: 'JWT',
  }
});
data.iat // => returns the current time instead of 123.
```

This PR fixes the problem. 

When calling the signJwt function to generate a JWT the value of the 'iat' claim in the payload will be respected, falling back to the current time if the claim is not present in the payload.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: