### PR TITLE
fix(clerk-js): Show errors when invalid email submitted when inviting members to an Org

### DIFF
--- a/.changeset/thirty-news-mate.md
+++ b/.changeset/thirty-news-mate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix invite members to an Organization form to show error when invalid email addresses are submitted.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -31,7 +31,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     },
   });
   const card = useCardState();
-  const { t, locale } = useLocalizations();
+  const { t, locale, translateError } = useLocalizations();
   const [isValidUnsubmittedEmail, setIsValidUnsubmittedEmail] = useState(false);
 
   const validateUnsubmittedEmail = (value: string) => setIsValidUnsubmittedEmail(isEmail(value));
@@ -100,8 +100,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
             ),
           );
         } else if (isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'form_param_format_invalid') {
-          const message = err.errors[0]?.longMessage;
-          message && card.setError(message);
+          card.setError(translateError(err.errors[0]));
         } else {
           handleError(err, [], card.setError);
         }

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -99,6 +99,9 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
               }),
             ),
           );
+        } else if (isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'form_param_format_invalid') {
+          const message = err.errors[0]?.longMessage;
+          message && card.setError(message);
         } else {
           handleError(err, [], card.setError);
         }


### PR DESCRIPTION
## Description

This PR handles to show an error when an invalid email is submitted when inviting members to an Organization.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
