### PR TITLE
fix(clerk-js): Show counter of members/invitations/requests even if it is 0

### DIFF
--- a/.changeset/sweet-queens-tan.md
+++ b/.changeset/sweet-queens-tan.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Show counter of members/invitations/requests even if it is 0.

--- a/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
+++ b/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
@@ -1,35 +1,26 @@
 import { formatToCompactNumber } from '../../ui/utils/intl';
 import { Flex, localizationKeys, NotificationBadge, useLocalizations } from '../customizables';
-import { useDelayedVisibility, usePrefersReducedMotion } from '../hooks';
+import { usePrefersReducedMotion } from '../hooks';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { animations } from '../styledSystem';
 
 type NotificationCountBadgeProps = PropsOfComponent<typeof NotificationBadge> & {
   notificationCount: number;
-  shouldDelayVisibility?: boolean;
   containerSx?: ThemableCssProp;
 };
 
 export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
-  const { notificationCount, containerSx, shouldDelayVisibility, ...restProps } = props;
+  const { notificationCount, containerSx, ...restProps } = props;
   const prefersReducedMotion = usePrefersReducedMotion();
-  const delayVisibility = shouldDelayVisibility || notificationCount > 0;
-  const showNotification = useDelayedVisibility(delayVisibility, 350) || false;
   const { t } = useLocalizations();
   const localeKey = t(localizationKeys('locale'));
-  const formatedNotificationCount = formatToCompactNumber(notificationCount, localeKey);
+  const formattedNotificationCount = formatToCompactNumber(notificationCount, localeKey);
 
   const enterExitAnimation: ThemableCssProp = t => ({
     animation: prefersReducedMotion
       ? 'none'
-      : `${showNotification ? animations.notificationAnimation : animations.outAnimation} ${
-          t.transitionDuration.$textField
-        } ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
+      : `${animations.notificationAnimation} ${t.transitionDuration.$textField} ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
   });
-
-  if (!showNotification) {
-    return null;
-  }
 
   return (
     <Flex
@@ -46,7 +37,7 @@ export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
         sx={enterExitAnimation}
         {...restProps}
       >
-        {formatedNotificationCount}
+        {formattedNotificationCount}
       </NotificationBadge>
     </Flex>
   );

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -71,32 +71,37 @@ export const OrganizationMembers = withCardStateProvider(() => {
           </Animated>
           <Card.Alert>{card.error}</Card.Alert>
           <Tabs>
-            <TabsList sx={t => ({ gap: t.space.$4 })}>
+            <TabsList sx={t => ({ gap: t.space.$2 })}>
               {canReadMemberships && (
                 <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__members')}>
-                  <NotificationCountBadge
-                    notificationCount={memberships?.count || 0}
-                    shouldDelayVisibility
-                    colorScheme='outline'
-                  />
+                  {memberships?.data && !memberships.isLoading && (
+                    <NotificationCountBadge
+                      notificationCount={memberships.count}
+                      colorScheme='outline'
+                    />
+                  )}
                 </Tab>
               )}
               {canManageMemberships && (
                 <Tab
                   localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__invitations')}
                 >
-                  <NotificationCountBadge
-                    notificationCount={invitations?.count || 0}
-                    colorScheme='outline'
-                  />
+                  {invitations?.data && !invitations.isLoading && (
+                    <NotificationCountBadge
+                      notificationCount={invitations.count}
+                      colorScheme='outline'
+                    />
+                  )}
                 </Tab>
               )}
               {canManageMemberships && isDomainsEnabled && (
                 <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')}>
-                  <NotificationCountBadge
-                    notificationCount={membershipRequests?.count || 0}
-                    colorScheme='outline'
-                  />
+                  {membershipRequests?.data && !membershipRequests.isLoading && (
+                    <NotificationCountBadge
+                      notificationCount={membershipRequests.count}
+                      colorScheme='outline'
+                    />
+                  )}
                 </Tab>
               )}
             </TabsList>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -37,8 +37,8 @@ describe('OrganizationMembers', () => {
     expect(getByRole('heading', { name: /members/i })).toBeInTheDocument();
 
     // Tabs
-    expect(getByRole('tab', { name: 'Members' })).toBeInTheDocument();
-    expect(getByRole('tab', { name: 'Invitations' })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /Members/i })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /Invitations/i })).toBeInTheDocument();
   });
 
   it('shows requests if domains is turned on', async () => {
@@ -54,7 +54,7 @@ describe('OrganizationMembers', () => {
 
     await waitForLoadingCompleted(container);
 
-    expect(getByRole('tab', { name: 'Requests' })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /Requests/i })).toBeInTheDocument();
   });
 
   it('shows an invite button inside invitations tab if the current user is an admin', async () => {
@@ -67,7 +67,7 @@ describe('OrganizationMembers', () => {
 
     const { getByRole, findByText } = render(<OrganizationMembers />, { wrapper });
 
-    await userEvent.click(getByRole('tab', { name: 'Invitations' }));
+    await userEvent.click(getByRole('tab', { name: /Invitations/i }));
     expect(await findByText('Invited')).toBeInTheDocument();
     expect(getByRole('button', { name: 'Invite' })).toBeInTheDocument();
   });
@@ -87,9 +87,9 @@ describe('OrganizationMembers', () => {
 
     await waitForLoadingCompleted(container);
 
-    expect(queryByRole('tab', { name: 'Members' })).toBeInTheDocument();
-    expect(queryByRole('tab', { name: 'Invitations' })).not.toBeInTheDocument();
-    expect(queryByRole('tab', { name: 'Requests' })).not.toBeInTheDocument();
+    expect(queryByRole('tab', { name: /Members/i })).toBeInTheDocument();
+    expect(queryByRole('tab', { name: /Invitations/i })).not.toBeInTheDocument();
+    expect(queryByRole('tab', { name: /Requests/i })).not.toBeInTheDocument();
   });
 
   it('does not show members tab or navbar route if user is lacking permissions', async () => {
@@ -378,7 +378,7 @@ describe('OrganizationMembers', () => {
     const { container, getByRole, getByText, findByText } = render(<OrganizationMembers />, { wrapper });
 
     await waitForLoadingCompleted(container);
-    await userEvent.click(getByRole('tab', { name: 'Invitations' }));
+    await userEvent.click(getByRole('tab', { name: /Invitations/i }));
 
     expect(await findByText('admin1@clerk.com')).toBeInTheDocument();
     expect(getByText('Admin')).toBeInTheDocument();
@@ -432,7 +432,7 @@ describe('OrganizationMembers', () => {
     const { queryByText, getByRole } = render(<OrganizationMembers />, { wrapper });
 
     await waitFor(async () => {
-      await userEvent.click(getByRole('tab', { name: 'Requests' }));
+      await userEvent.click(getByRole('tab', { name: /Requests/i }));
     });
 
     expect(fixtures.clerk.organization?.getMembershipRequests).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Show counter of members/invitations/requests even if it is 0. Remove some unnecessary logic from the `<NotificationBadge />` and fix the spacing to match designs.
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
