### PR TITLE
fix(clerk-js): Fix the conditional render condition for organizationPreviewSecondaryIdentifier

### DIFF
--- a/.changeset/four-crabs-sneeze.md
+++ b/.changeset/four-crabs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+The organizationPreviewSecondaryIdentifier element will no longer be rendered empty inside the organization switcher's list.

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -42,6 +42,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
 
   const membership = user?.organizationMemberships.find(membership => membership.organization.id === organization.id);
   const unlocalizedRoleLabel = options?.find(a => a.value === membership?.role)?.label;
+  const roleLabel = localizeCustomRole(membership?.role) || unlocalizedRoleLabel;
 
   const mainTextSize =
     mainIdentifierVariant || ({ xs: 'subtitle', sm: 'caption', md: 'subtitle', lg: 'h1' } as const)[size];
@@ -91,12 +92,13 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
         >
           {organization.name} {badge}
         </Text>
-        {organization.name && (
+
+        {roleLabel && (
           <Text
             elementDescriptor={descriptors.organizationPreviewSecondaryIdentifier}
             elementId={descriptors.organizationPreviewSecondaryIdentifier.setId(elementId)}
-            localizationKey={localizeCustomRole(membership?.role) || unlocalizedRoleLabel}
             as='span'
+            localizationKey={roleLabel}
             truncate
           />
         )}


### PR DESCRIPTION
## Description
The organizationPreviewSecondaryIdentifier element will no longer be rendered empty inside the organization switcher's list.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
