### PR TITLE
fix(nextjs): Middleware protect detects internal navigation in pages router

### DIFF
--- a/.changeset/quiet-kings-relate.md
+++ b/.changeset/quiet-kings-relate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Using auth().protect inside clerkMiddleware will perform a redirection instead of throwing a not found error when internal navigation in pages router occurs and the user is unauthenticated.

--- a/packages/nextjs/src/constants.ts
+++ b/packages/nextjs/src/constants.ts
@@ -2,8 +2,11 @@ const Headers = {
   NextRewrite: 'x-middleware-rewrite',
   NextResume: 'x-middleware-next',
   NextRedirect: 'Location',
+  // Used by next to identify internal navigation for app router
   NextUrl: 'next-url',
   NextAction: 'next-action',
+  // Used by next to identify internal navigation for pages router
+  NextjsData: 'x-nextjs-data',
 } as const;
 
 export const constants = {

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -121,7 +121,8 @@ const isPageRequest = (req: Request): boolean => {
   return (
     req.headers.get(constants.Headers.SecFetchDest) === 'document' ||
     req.headers.get(constants.Headers.Accept)?.includes('text/html') ||
-    (!!req.headers.get(nextConstants.Headers.NextUrl) && !isServerActionRequest(req))
+    (!!req.headers.get(nextConstants.Headers.NextUrl) && !isServerActionRequest(req)) ||
+    !!req.headers.get(nextConstants.Headers.NextjsData)
   );
 };
 


### PR DESCRIPTION
## Description

Using auth().protect inside clerkMiddleware will perform a redirection instead of throwing a not found error when internal navigation in pages router occurs and the user is unauthenticated.

Original issue:
Case1: When auth().redirectToSignIn() is used

signing out on the client-side triggers the middleware and the middleware returns a 307 redirect to /sign-in . This is the expected behavior

Case2: When auth().protect() is used

event though signing out on the client-side triggers the middleware, protect() treats the request as an api/route handler request and returns 404, so the redirect does not happen. This should be like case 1.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
