### PR TITLE
chore(shared): Convert shared package to ES Modules

### DIFF
--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   root: true,
   extends: ['custom/browser', 'custom/typescript', 'custom/jest', 'custom/react'],
+  ignorePatterns: ['jest.config.js'],
   overrides: [
     {
       files: ['./src/utils/globs.ts'],

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,8 +1,12 @@
-const { name } = require('./package.json');
+import packageJson from './package.json' assert { type: 'json' };
 
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const config = {
-  displayName: name.replace('@clerk', ''),
+  preset: 'ts-jest/presets/default-esm',
+  moduleNameMapper: {
+    '(.+)\\.js': '$1',
+  },
+  displayName: packageJson.name.replace('@clerk', ''),
   injectGlobals: true,
 
   testEnvironment: 'jsdom',
@@ -14,9 +18,6 @@ const config = {
   coverageDirectory: 'coverage',
 
   moduleDirectories: ['node_modules', '<rootDir>/src'],
-  transform: {
-    '^.+\\.m?tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json', diagnostics: false }],
-  },
 };
 
-module.exports = config;
+export default config;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,40 +9,42 @@
   },
   "license": "MIT",
   "author": "Clerk",
+  "type": "module",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
       }
     },
     "./*": {
       "import": {
-        "types": "./dist/*.d.mts",
-        "default": "./dist/*.mjs"
-      },
-      "require": {
         "types": "./dist/*.d.ts",
         "default": "./dist/*.js"
+      },
+      "require": {
+        "types": "./dist/*.d.cts",
+        "default": "./dist/*.cjs"
       }
     },
     "./react": {
       "import": {
-        "types": "./dist/react/index.d.mts",
-        "default": "./dist/react/index.mjs"
-      },
-      "require": {
         "types": "./dist/react/index.d.ts",
         "default": "./dist/react/index.js"
+      },
+      "require": {
+        "types": "./dist/react/index.d.cts",
+        "default": "./dist/react/index.cjs"
       }
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "files": [
     "dist",
     "browser",
@@ -81,16 +83,16 @@
     "lint:attw": "attw --pack .",
     "lint:publint": "publint",
     "publish:local": "npx yalc push --replace  --sig",
-    "test": "jest",
-    "test:cache:clear": "jest --clearCache --useStderr",
-    "test:ci": "jest --maxWorkers=70%",
-    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html"
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
+    "test:cache:clear": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --clearCache --useStderr",
+    "test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --maxWorkers=70%",
+    "test:coverage": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --collectCoverage && open coverage/lcov-report/index.html"
   },
   "dependencies": {
     "glob-to-regexp": "0.4.1",
     "js-cookie": "3.0.1",
     "std-env": "^3.7.0",
-    "swr": "2.2.0"
+    "swr": "2.2.5"
   },
   "devDependencies": {
     "@clerk/types": "4.0.0-beta.20",

--- a/packages/shared/src/__tests__/apiUrlFromPublishableKey.test.ts
+++ b/packages/shared/src/__tests__/apiUrlFromPublishableKey.test.ts
@@ -1,4 +1,4 @@
-import { apiUrlFromPublishableKey } from '../apiUrlFromPublishableKey';
+import { apiUrlFromPublishableKey } from '../apiUrlFromPublishableKey.js';
 
 describe('apiUrlFromPublishableKey', () => {
   test('returns the prod api url when given a prod publishable key', async () => {

--- a/packages/shared/src/__tests__/browser.test.ts
+++ b/packages/shared/src/__tests__/browser.test.ts
@@ -1,4 +1,6 @@
-import { inBrowser, isValidBrowser, isValidBrowserOnline, userAgentIsRobot } from '../browser';
+import { jest } from '@jest/globals';
+
+import { inBrowser, isValidBrowser, isValidBrowserOnline, userAgentIsRobot } from '../browser.js';
 
 describe('inBrowser()', () => {
   afterEach(() => {

--- a/packages/shared/src/__tests__/callWithRetry.test.ts
+++ b/packages/shared/src/__tests__/callWithRetry.test.ts
@@ -1,23 +1,28 @@
-import { callWithRetry } from '../callWithRetry';
+import { jest } from '@jest/globals';
+
+import { callWithRetry } from '../callWithRetry.js';
 
 describe('callWithRetry', () => {
   test('should return the result of the function if it succeeds', async () => {
-    const fn = jest.fn().mockResolvedValue('result');
-    const result = await callWithRetry(fn);
+    const fn = jest.fn().mockResolvedValue('result' as never);
+    const result = await callWithRetry(fn as any);
     expect(result).toBe('result');
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
   test('should retry the function if it fails', async () => {
-    const fn = jest.fn().mockRejectedValueOnce(new Error('error')).mockResolvedValueOnce('result');
-    const result = await callWithRetry(fn, 1, 2);
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('error') as never)
+      .mockResolvedValueOnce('result' as never);
+    const result = await callWithRetry(fn as any, 1, 2);
     expect(result).toBe('result');
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
   test('should throw an error if the function fails too many times', async () => {
-    const fn = jest.fn().mockRejectedValue(new Error('error'));
-    await expect(callWithRetry(fn, 1, 2)).rejects.toThrow('error');
+    const fn = jest.fn().mockRejectedValue(new Error('error') as never);
+    await expect(callWithRetry(fn as any, 1, 2)).rejects.toThrow('error');
     expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/shared/src/__tests__/color.test.ts
+++ b/packages/shared/src/__tests__/color.test.ts
@@ -1,6 +1,6 @@
 import type { Color } from '@clerk/types';
 
-import { colorToSameTypeString, hexStringToRgbaColor, stringToHslaColor, stringToSameTypeColor } from '../color';
+import { colorToSameTypeString, hexStringToRgbaColor, stringToHslaColor, stringToSameTypeColor } from '../color.js';
 
 describe('stringToHslaColor(color)', function () {
   const hsla = { h: 195, s: 1, l: 0.5 };

--- a/packages/shared/src/__tests__/date.test.ts
+++ b/packages/shared/src/__tests__/date.test.ts
@@ -1,5 +1,5 @@
-import type { RelativeDateCase } from '../date';
-import { addYears, dateTo12HourTime, differenceInCalendarDays, formatRelative } from '../date';
+import type { RelativeDateCase } from '../date.js';
+import { addYears, dateTo12HourTime, differenceInCalendarDays, formatRelative } from '../date.js';
 
 describe('date utils', () => {
   describe('dateTo12HourTime(date)', () => {

--- a/packages/shared/src/__tests__/deprecated.test.ts
+++ b/packages/shared/src/__tests__/deprecated.test.ts
@@ -1,18 +1,19 @@
-jest.mock('../utils/runtimeEnvironment', () => {
+import { jest } from '@jest/globals';
+jest.unstable_mockModule('../utils/runtimeEnvironment.js', async () => {
   return {
     isTestEnvironment: jest.fn(() => false),
     isProductionEnvironment: jest.fn(() => false),
   };
 });
 
-import { deprecated, deprecatedObjectProperty, deprecatedProperty } from '../deprecated';
-import { isProductionEnvironment, isTestEnvironment } from '../utils/runtimeEnvironment';
+const { deprecated, deprecatedObjectProperty, deprecatedProperty } = await import('../deprecated.js');
+const { isProductionEnvironment, isTestEnvironment } = await import('../utils/runtimeEnvironment.js');
 
 describe('deprecated(fnName, warning)', () => {
-  let consoleWarnSpy;
+  let consoleWarnSpy: any;
 
   beforeEach(() => {
-    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
   });
   afterEach(() => {
     consoleWarnSpy.mockRestore();
@@ -20,7 +21,7 @@ describe('deprecated(fnName, warning)', () => {
 
   test('deprecate class method shows warning', () => {
     class Example {
-      getSomeMethod = (arg1?, arg2?) => {
+      getSomeMethod = (arg1?: any, arg2?: any) => {
         deprecated('getSomeMethod', 'Use `getSomeMethodElse` instead.');
         return `getSomeMethodValue:${arg1 || '-'}:${arg2 || '-'}`;
       };
@@ -179,10 +180,10 @@ describe('deprecated(fnName, warning)', () => {
 });
 
 describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
-  let consoleWarnSpy;
+  let consoleWarnSpy: any;
 
   beforeEach(() => {
-    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
   });
   afterEach(() => {
     consoleWarnSpy.mockRestore();
@@ -312,10 +313,10 @@ describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
 });
 
 describe('deprecatedObjectProperty(obj, propName, warning)', () => {
-  let consoleWarnSpy;
+  let consoleWarnSpy: any;
 
   beforeEach(() => {
-    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
   });
   afterEach(() => {
     consoleWarnSpy.mockRestore();

--- a/packages/shared/src/__tests__/devbrowser.test.ts
+++ b/packages/shared/src/__tests__/devbrowser.test.ts
@@ -1,4 +1,6 @@
-import { extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
+import { jest } from '@jest/globals';
+
+import { extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser.js';
 
 const DUMMY_URL_BASE = 'http://clerk-dummy';
 

--- a/packages/shared/src/__tests__/error.test.ts
+++ b/packages/shared/src/__tests__/error.test.ts
@@ -1,5 +1,5 @@
-import type { ErrorThrowerOptions } from '../error';
-import { buildErrorThrower } from '../error';
+import type { ErrorThrowerOptions } from '../error.js';
+import { buildErrorThrower } from '../error.js';
 
 describe('ErrorThrower', () => {
   const errorThrower = buildErrorThrower({ packageName: '@clerk/test-package' });

--- a/packages/shared/src/__tests__/handleValueOrFn.test.ts
+++ b/packages/shared/src/__tests__/handleValueOrFn.test.ts
@@ -1,4 +1,4 @@
-import { handleValueOrFn } from '../handleValueOrFn';
+import { handleValueOrFn } from '../handleValueOrFn.js';
 
 const url = new URL('https://example.com');
 
@@ -12,7 +12,7 @@ describe('handleValueOrFn(opts)', () => {
     ['', ''],
     ['some-domain', 'some-domain'],
     ['clerk.com', 'clerk.com'],
-    [url => url.host, 'example.com'],
+    [(url: URL) => url.host, 'example.com'],
     [() => 'some-other-domain', 'some-other-domain'],
   ])('.handleValueOrFn(%s)', (key, expected) => {
     expect(handleValueOrFn(key, url)).toBe(expected);

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -7,7 +7,7 @@ import {
   isProductionFromSecretKey,
   isPublishableKey,
   parsePublishableKey,
-} from '../keys';
+} from '../keys.js';
 
 describe('buildPublishableKey(frontendApi)', () => {
   const cases = [

--- a/packages/shared/src/__tests__/localStorageBroadcastChannel.test.ts
+++ b/packages/shared/src/__tests__/localStorageBroadcastChannel.test.ts
@@ -1,4 +1,6 @@
-import { LocalStorageBroadcastChannel } from '../localStorageBroadcastChannel';
+import { jest } from '@jest/globals';
+
+import { LocalStorageBroadcastChannel } from '../localStorageBroadcastChannel.js';
 
 const bcName = 'clerk';
 
@@ -8,11 +10,11 @@ describe('LocalStorageBroadcastChannel', () => {
     localStorageMock = (() => {
       const store: Record<string, any> = {};
       return {
-        setItem: jest.fn((key, value) => {
+        setItem: jest.fn((key: string, value: any) => {
           store[key] = value;
           window.dispatchEvent(new StorageEvent('storage', { key, newValue: value }));
         }),
-        removeItem: jest.fn(key => {
+        removeItem: jest.fn((key: string) => {
           store[key] = undefined;
           window.dispatchEvent(new Event('storage'));
         }),

--- a/packages/shared/src/__tests__/proxy.test.ts
+++ b/packages/shared/src/__tests__/proxy.test.ts
@@ -1,4 +1,4 @@
-import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl, proxyUrlToAbsoluteURL } from '../proxy';
+import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl, proxyUrlToAbsoluteURL } from '../proxy.js';
 
 describe('isValidProxyUrl(key)', () => {
   it('returns true if the proxyUrl is valid', () => {

--- a/packages/shared/src/__tests__/telemetry.test.ts
+++ b/packages/shared/src/__tests__/telemetry.test.ts
@@ -1,6 +1,8 @@
 import 'cross-fetch/polyfill';
 
-import { TelemetryCollector } from '../telemetry';
+import { jest } from '@jest/globals';
+
+import { TelemetryCollector } from '../telemetry.js';
 
 jest.useFakeTimers();
 

--- a/packages/shared/src/__tests__/underscore.test.ts
+++ b/packages/shared/src/__tests__/underscore.test.ts
@@ -6,7 +6,7 @@ import {
   isTruthy,
   titleize,
   toSentence,
-} from '../underscore';
+} from '../underscore.js';
 
 describe('toSentence', () => {
   it('returns a single item as-is', () => {

--- a/packages/shared/src/__tests__/url.test.ts
+++ b/packages/shared/src/__tests__/url.test.ts
@@ -8,7 +8,7 @@ import {
   stripScheme,
   withoutTrailingSlash,
   withTrailingSlash,
-} from '../url';
+} from '../url.js';
 
 describe('parseSearchParams(queryString)', () => {
   it('parses query string and returns a URLSearchParams object', () => {
@@ -146,11 +146,11 @@ describe('withTrailingSlash, queryParams: false', () => {
     'foo?123': 'foo?123/',
     'foo/?123': 'foo/?123/',
     'foo/?123#abc': 'foo/?123#abc/',
-  };
+  } as const;
 
   for (const input in tests) {
     test(input, () => {
-      expect(withTrailingSlash(input)).toBe(tests[input]);
+      expect(withTrailingSlash(input)).toBe(tests[input as keyof typeof tests]);
     });
   }
 
@@ -174,7 +174,7 @@ describe('withTrailingSlash, queryParams: true', () => {
 
   for (const input in tests) {
     test(input, () => {
-      expect(withTrailingSlash(input, true)).toBe(tests[input]);
+      expect(withTrailingSlash(input, true)).toBe(tests[input as keyof typeof tests]);
     });
   }
 
@@ -197,7 +197,7 @@ describe('withoutTrailingSlash, queryParams: false', () => {
 
   for (const input in tests) {
     test(input, () => {
-      expect(withoutTrailingSlash(input)).toBe(tests[input]);
+      expect(withoutTrailingSlash(input)).toBe(tests[input as keyof typeof tests]);
     });
   }
 
@@ -223,7 +223,7 @@ describe('withoutTrailingSlash, queryParams: true', () => {
 
   for (const input in tests) {
     test(input, () => {
-      expect(withoutTrailingSlash(input, true)).toBe(tests[input]);
+      expect(withoutTrailingSlash(input, true)).toBe(tests[input as keyof typeof tests]);
     });
   }
 
@@ -242,7 +242,7 @@ describe('cleanDoubleSlashes', () => {
 
   for (const input in tests) {
     test(input, () => {
-      expect(cleanDoubleSlashes(input)).toBe(tests[input]);
+      expect(cleanDoubleSlashes(input)).toBe(tests[input as keyof typeof tests]);
     });
   }
 

--- a/packages/shared/src/apiUrlFromPublishableKey.ts
+++ b/packages/shared/src/apiUrlFromPublishableKey.ts
@@ -1,5 +1,5 @@
-import { LOCAL_API_URL, LOCAL_ENV_SUFFIXES, PROD_API_URL, STAGING_API_URL, STAGING_ENV_SUFFIXES } from './constants';
-import { parsePublishableKey } from './keys';
+import { LOCAL_API_URL, LOCAL_ENV_SUFFIXES, PROD_API_URL, STAGING_API_URL, STAGING_ENV_SUFFIXES } from './constants.js';
+import { parsePublishableKey } from './keys.js';
 
 export const apiUrlFromPublishableKey = (publishableKey: string) => {
   const frontendApi = parsePublishableKey(publishableKey)?.frontendApi;

--- a/packages/shared/src/deprecated.ts
+++ b/packages/shared/src/deprecated.ts
@@ -1,4 +1,4 @@
-import { isProductionEnvironment, isTestEnvironment } from './utils/runtimeEnvironment';
+import { isProductionEnvironment, isTestEnvironment } from './utils/runtimeEnvironment.js';
 /**
  * Mark class method / function as deprecated.
  *

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,27 +8,27 @@
  * People should always use @clerk/shared/<name> instead
  */
 
-export * from './utils';
+export * from './utils/index.js';
 
-export { apiUrlFromPublishableKey } from './apiUrlFromPublishableKey';
-export * from './browser';
-export { callWithRetry } from './callWithRetry';
-export * from './color';
-export * from './constants';
-export * from './date';
-export * from './deprecated';
-export * from './error';
-export * from './file';
-export { handleValueOrFn } from './handleValueOrFn';
-export { isomorphicAtob } from './isomorphicAtob';
-export { isomorphicBtoa } from './isomorphicBtoa';
-export * from './keys';
-export { loadScript } from './loadScript';
-export { LocalStorageBroadcastChannel } from './localStorageBroadcastChannel';
-export * from './poller';
-export * from './proxy';
-export * from './underscore';
-export * from './url';
-export * from './object';
-export { createWorkerTimers } from './workerTimers';
-export { DEV_BROWSER_JWT_KEY, extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from './devBrowser';
+export { apiUrlFromPublishableKey } from './apiUrlFromPublishableKey.js';
+export * from './browser.js';
+export { callWithRetry } from './callWithRetry.js';
+export * from './color.js';
+export * from './constants.js';
+export * from './date.js';
+export * from './deprecated.js';
+export * from './error.js';
+export * from './file.js';
+export { handleValueOrFn } from './handleValueOrFn.js';
+export { isomorphicAtob } from './isomorphicAtob.js';
+export { isomorphicBtoa } from './isomorphicBtoa.js';
+export * from './keys.js';
+export { loadScript } from './loadScript.js';
+export { LocalStorageBroadcastChannel } from './localStorageBroadcastChannel.js';
+export * from './poller.js';
+export * from './proxy.js';
+export * from './underscore.js';
+export * from './url.js';
+export * from './object.js';
+export { createWorkerTimers } from './workerTimers/index.js';
+export { DEV_BROWSER_JWT_KEY, extractDevBrowserJWTFromURL, setDevBrowserJWTInURL } from './devBrowser.js';

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -1,8 +1,8 @@
 import type { PublishableKey } from '@clerk/types';
 
-import { DEV_OR_STAGING_SUFFIXES, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants';
-import { isomorphicAtob } from './isomorphicAtob';
-import { isomorphicBtoa } from './isomorphicBtoa';
+import { DEV_OR_STAGING_SUFFIXES, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants.js';
+import { isomorphicAtob } from './isomorphicAtob.js';
+import { isomorphicBtoa } from './isomorphicBtoa.js';
 
 type ParsePublishableKeyOptions = {
   fatal?: boolean;

--- a/packages/shared/src/poller.ts
+++ b/packages/shared/src/poller.ts
@@ -1,4 +1,4 @@
-import { createWorkerTimers } from './workerTimers';
+import { createWorkerTimers } from './workerTimers/index.js';
 
 export type PollerStop = () => void;
 export type PollerCallback = (stop: PollerStop) => Promise<unknown>;

--- a/packages/shared/src/react/contexts.tsx
+++ b/packages/shared/src/react/contexts.tsx
@@ -10,8 +10,8 @@ import type {
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
-import { SWRConfig } from './clerk-swr';
-import { createContextAndHook } from './hooks/createContextAndHook';
+import { SWRConfig } from './clerk-swr.js';
+import { createContextAndHook } from './hooks/createContextAndHook.js';
 
 const [ClerkInstanceContext, useClerkInstanceContext] = createContextAndHook<LoadedClerk>('ClerkInstanceContext');
 const [UserContext, useUserContext] = createContextAndHook<UserResource | null | undefined>('UserContext');

--- a/packages/shared/src/react/hooks/index.ts
+++ b/packages/shared/src/react/hooks/index.ts
@@ -1,9 +1,9 @@
-export { assertContextExists, createContextAndHook } from './createContextAndHook';
-export { useOrganization } from './useOrganization';
-export { useOrganizationList } from './useOrganizationList';
-export { useSafeLayoutEffect } from './useSafeLayoutEffect';
-export { useSession } from './useSession';
-export { useSessionList } from './useSessionList';
-export { useUser } from './useUser';
-export { useClerk } from './useClerk';
-export { useDeepEqualMemo, isDeeplyEqual } from './useDeepEqualMemo';
+export { assertContextExists, createContextAndHook } from './createContextAndHook.js';
+export { useOrganization } from './useOrganization.js';
+export { useOrganizationList } from './useOrganizationList.js';
+export { useSafeLayoutEffect } from './useSafeLayoutEffect.js';
+export { useSession } from './useSession.js';
+export { useSessionList } from './useSessionList.js';
+export { useUser } from './useUser.js';
+export { useClerk } from './useClerk.js';
+export { useDeepEqualMemo, isDeeplyEqual } from './useDeepEqualMemo.js';

--- a/packages/shared/src/react/hooks/useClerk.ts
+++ b/packages/shared/src/react/hooks/useClerk.ts
@@ -1,6 +1,6 @@
 import type { LoadedClerk } from '@clerk/types';
 
-import { useAssertWrappedByClerkProvider, useClerkInstanceContext } from '../contexts';
+import { useAssertWrappedByClerkProvider, useClerkInstanceContext } from '../contexts.js';
 
 export const useClerk = (): LoadedClerk => {
   useAssertWrappedByClerkProvider('useClerk');

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -16,9 +16,9 @@ import {
   useClerkInstanceContext,
   useOrganizationContext,
   useSessionContext,
-} from '../contexts';
-import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types';
-import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
+} from '../contexts.js';
+import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types.js';
+import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite.js';
 
 type UseOrganizationParams = {
   domains?: true | PaginatedHookConfig<GetDomainsParams>;

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -11,9 +11,9 @@ import type {
   UserOrganizationInvitationResource,
 } from '@clerk/types';
 
-import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts';
-import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types';
-import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
+import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts.js';
+import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types.js';
+import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite.js';
 
 type UseOrganizationListParams = {
   userMemberships?: true | PaginatedHookConfig<GetUserOrganizationMembershipParams>;

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -2,14 +2,14 @@
 
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import { useSWR, useSWRInfinite } from '../clerk-swr';
+import { useSWR, useSWRInfinite } from '../clerk-swr.js';
 import type {
   CacheSetter,
   PagesOrInfiniteConfig,
   PagesOrInfiniteOptions,
   PaginatedResources,
   ValueOrSetter,
-} from '../types';
+} from '../types.js';
 
 function getDifferentKeys(obj1: Record<string, unknown>, obj2: Record<string, unknown>): Record<string, unknown> {
   const keysSet = new Set(Object.keys(obj2));

--- a/packages/shared/src/react/hooks/useSession.ts
+++ b/packages/shared/src/react/hooks/useSession.ts
@@ -1,6 +1,6 @@
 import type { ActiveSessionResource } from '@clerk/types';
 
-import { useAssertWrappedByClerkProvider, useSessionContext } from '../contexts';
+import { useAssertWrappedByClerkProvider, useSessionContext } from '../contexts.js';
 
 type UseSessionReturn =
   | { isLoaded: false; isSignedIn: undefined; session: undefined }

--- a/packages/shared/src/react/hooks/useSessionList.ts
+++ b/packages/shared/src/react/hooks/useSessionList.ts
@@ -1,6 +1,6 @@
 import type { SessionResource, SetActive } from '@clerk/types';
 
-import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useClientContext } from '../contexts';
+import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useClientContext } from '../contexts.js';
 
 type UseSessionListReturn =
   | {

--- a/packages/shared/src/react/hooks/useUser.ts
+++ b/packages/shared/src/react/hooks/useUser.ts
@@ -1,6 +1,6 @@
 import type { UserResource } from '@clerk/types';
 
-import { useAssertWrappedByClerkProvider, useUserContext } from '../contexts';
+import { useAssertWrappedByClerkProvider, useUserContext } from '../contexts.js';
 
 type UseUserReturn =
   | { isLoaded: false; isSignedIn: undefined; user: undefined }

--- a/packages/shared/src/react/index.ts
+++ b/packages/shared/src/react/index.ts
@@ -1,4 +1,4 @@
-export * from './hooks';
+export * from './hooks/index.js';
 
 export {
   ClerkInstanceContext,
@@ -12,4 +12,4 @@ export {
   useSessionContext,
   useUserContext,
   useAssertWrappedByClerkProvider,
-} from './contexts';
+} from './contexts.js';

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -1,6 +1,6 @@
 import type { ClerkPaginatedResponse } from '@clerk/types';
 
-import type { ClerkAPIResponseError } from '../error';
+import type { ClerkAPIResponseError } from '../error.js';
 
 export type ValueOrSetter<T = unknown> = (size: T | ((_size: T) => T)) => void;
 

--- a/packages/shared/src/telemetry.ts
+++ b/packages/shared/src/telemetry.ts
@@ -1,4 +1,4 @@
-export { TelemetryCollector } from './telemetry/collector';
-export type { TelemetryCollectorOptions } from './telemetry/types';
+export { TelemetryCollector } from './telemetry/collector.js';
+export type { TelemetryCollectorOptions } from './telemetry/types.js';
 
-export * from './telemetry/events';
+export * from './telemetry/events/index.js';

--- a/packages/shared/src/telemetry/collector.ts
+++ b/packages/shared/src/telemetry/collector.ts
@@ -12,9 +12,9 @@
  */
 import type { InstanceType } from '@clerk/types';
 
-import { parsePublishableKey } from '../keys';
-import { isTruthy } from '../underscore';
-import type { TelemetryCollectorOptions, TelemetryEvent, TelemetryEventRaw } from './types';
+import { parsePublishableKey } from '../keys.js';
+import { isTruthy } from '../underscore.js';
+import type { TelemetryCollectorOptions, TelemetryEvent, TelemetryEventRaw } from './types.js';
 
 type TelemetryCollectorConfig = Pick<
   TelemetryCollectorOptions,

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -1,4 +1,4 @@
-import type { TelemetryEventRaw } from '../types';
+import type { TelemetryEventRaw } from '../types.js';
 
 const EVENT_COMPONENT_MOUNTED = 'COMPONENT_MOUNTED' as const;
 const EVENT_SAMPLING_RATE = 0.1;

--- a/packages/shared/src/telemetry/events/index.ts
+++ b/packages/shared/src/telemetry/events/index.ts
@@ -1,2 +1,2 @@
-export * from './component-mounted';
-export * from './method-called';
+export * from './component-mounted.js';
+export * from './method-called.js';

--- a/packages/shared/src/telemetry/events/method-called.ts
+++ b/packages/shared/src/telemetry/events/method-called.ts
@@ -1,4 +1,4 @@
-import type { TelemetryEventRaw } from '../types';
+import type { TelemetryEventRaw } from '../types.js';
 
 const EVENT_METHOD_CALLED = 'METHOD_CALLED' as const;
 

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,5 +1,5 @@
-import { CURRENT_DEV_INSTANCE_SUFFIXES, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants';
-import { isStaging } from './utils/instance';
+import { CURRENT_DEV_INSTANCE_SUFFIXES, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants.js';
+import { isStaging } from './utils/instance.js';
 
 export function parseSearchParams(queryString = ''): URLSearchParams {
   if (queryString.startsWith('?')) {

--- a/packages/shared/src/utils/__tests__/createDeferredPromise.test.ts
+++ b/packages/shared/src/utils/__tests__/createDeferredPromise.test.ts
@@ -1,4 +1,4 @@
-import { createDeferredPromise } from '../createDeferredPromise';
+import { createDeferredPromise } from '../createDeferredPromise.js';
 
 describe('createDeferredPromise', () => {
   test('resolves with correct value', async () => {

--- a/packages/shared/src/utils/__tests__/instance.test.ts
+++ b/packages/shared/src/utils/__tests__/instance.test.ts
@@ -1,4 +1,4 @@
-import { isStaging } from '../instance';
+import { isStaging } from '../instance.js';
 
 describe('isStaging', () => {
   it.each([

--- a/packages/shared/src/utils/__tests__/runWithExponentialBackOff.test.ts
+++ b/packages/shared/src/utils/__tests__/runWithExponentialBackOff.test.ts
@@ -1,4 +1,4 @@
-import { runWithExponentialBackOff } from '../runWithExponentialBackOff';
+import { runWithExponentialBackOff } from '../runWithExponentialBackOff.js';
 
 describe('runWithExponentialBackOff', () => {
   test('resolves with the result of the callback', async () => {

--- a/packages/shared/src/utils/createDeferredPromise.ts
+++ b/packages/shared/src/utils/createDeferredPromise.ts
@@ -1,4 +1,4 @@
-import { noop } from './noop';
+import { noop } from './noop.js';
 
 type Callback = (val?: any) => void;
 

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,6 +1,6 @@
-export * from './createDeferredPromise';
-export { isStaging } from './instance';
-export { logErrorInDevMode } from './logErrorInDevMode';
-export { noop } from './noop';
-export * from './runWithExponentialBackOff';
-export * from './runtimeEnvironment';
+export * from './createDeferredPromise.js';
+export { isStaging } from './instance.js';
+export { logErrorInDevMode } from './logErrorInDevMode.js';
+export { noop } from './noop.js';
+export * from './runWithExponentialBackOff.js';
+export * from './runtimeEnvironment.js';

--- a/packages/shared/src/utils/logErrorInDevMode.ts
+++ b/packages/shared/src/utils/logErrorInDevMode.ts
@@ -1,4 +1,4 @@
-import { isDevelopmentEnvironment } from './runtimeEnvironment';
+import { isDevelopmentEnvironment } from './runtimeEnvironment.js';
 
 export const logErrorInDevMode = (message: string) => {
   if (isDevelopmentEnvironment()) {

--- a/packages/shared/src/workerTimers/createWorkerTimers.ts
+++ b/packages/shared/src/workerTimers/createWorkerTimers.ts
@@ -1,4 +1,4 @@
-import { noop } from '../utils/noop';
+import { noop } from '../utils/noop.js';
 import type {
   WorkerClearTimeout,
   WorkerSetTimeout,
@@ -6,9 +6,9 @@ import type {
   WorkerTimerEvent,
   WorkerTimerId,
   WorkerTimerResponseEvent,
-} from './workerTimers.types';
+} from './workerTimers.types.js';
 // @ts-ignore
-import pollerWorkerSource from './workerTimers.worker';
+import pollerWorkerSource from './workerTimers.worker.js';
 
 const createWebWorker = (source: string, opts: ConstructorParameters<typeof Worker>[1] = {}): Worker | null => {
   if (typeof Worker === 'undefined') {

--- a/packages/shared/src/workerTimers/index.ts
+++ b/packages/shared/src/workerTimers/index.ts
@@ -1,1 +1,1 @@
-export { createWorkerTimers } from './createWorkerTimers';
+export { createWorkerTimers } from './createWorkerTimers.js';

--- a/packages/shared/src/workerTimers/workerTimers.worker.ts
+++ b/packages/shared/src/workerTimers/workerTimers.worker.ts
@@ -1,4 +1,4 @@
-import type { WorkerTimerEvent, WorkerTimerId, WorkerTimerResponseEvent } from './workerTimers.types';
+import type { WorkerTimerEvent, WorkerTimerId, WorkerTimerResponseEvent } from './workerTimers.types.js';
 // This file is loaded as TEXT by esbuild during build
 // and fed into a blob so we can easily instantiate the web worker
 // look at the tsup.config.ts file for more details on the loader

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,20 +4,17 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "moduleResolution": "Bundler",
-    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true,
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "declarationDir": "dist/types",
     "jsx": "react",
-    "lib": ["ES6", "DOM", "WebWorker"]
+    "lib": ["ES2020", "DOM", "WebWorker"],
+    "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src/index.ts", "global.d.ts"]
+  "include": ["src/**/*", "global.d.ts"]
 }

--- a/packages/shared/tsconfig.test.json
+++ b/packages/shared/tsconfig.test.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}


### PR DESCRIPTION
## Description

Now that Remix is switching to Vite, ideally all packages used with it are in ES Module format. This is the first step to converting all the Clerk packages to ESM. The module format should be standardized to `NodeNext` as that is the recommended option for libraries.

To land this I need help with one issue, the `clerk-js` tests are failing with `TypeError: (0 , import_swr.default) is not a function at usePagesOrInfinite (/javascript/packages/shared/src/react/hooks/usePagesOrInfinite.ts:102:7)`

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
