### PR TITLE
fix(clerk-js): Fix the input box-shadow on iOS 16 devices

### DIFF
--- a/.changeset/light-doors-teach.md
+++ b/.changeset/light-doors-teach.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix the input box-shadow on iOS 16 devices

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -21,9 +21,12 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     accentColor: theme.colors.$primary500,
     ...common.textVariants(theme).body,
     ...common.disabled(theme),
+    // This is a workaround to prevent zooming on iOS when focusing an input
     [mqu.ios]: {
       fontSize: theme.fontSizes.$lg,
     },
+    // This is a fix for iOS webkit on iOS below 16, where the input is not respecting the box-shadow
+    WebkitAppearance: 'none',
     ':autofill': {
       animationName: 'onAutoFillStart',
     },


### PR DESCRIPTION
## Description

This PR addresses an issue in iOS Webkit for iOS versions <=16.x with the `box-shadow` on input elements.
We added the `-webkit-appearance: none` to all the input elements.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
