### PR TITLE
fix(clerk-js): Remove ticket params after they are consumed

### DIFF
--- a/.changeset/witty-pens-arrive.md
+++ b/.changeset/witty-pens-arrive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove the `__clerk_ticket` and `__clerk_invitation_token` query params after they are consumed.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -4,7 +4,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { ERROR_CODES } from '../../../core/constants';
 import { clerkInvalidFAPIResponse } from '../../../core/errors';
-import { getClerkQueryParam } from '../../../utils';
+import { getClerkQueryParam, removeClerkQueryParam } from '../../../utils';
 import type { SignInStartIdentifier } from '../../common';
 import { getIdentifierControlDisplayValues, groupIdentifiers, withRedirectToAfterSignIn } from '../../common';
 import { buildSSOCallbackURL } from '../../common/redirects';
@@ -138,6 +138,7 @@ export function _SignInStart(): JSX.Element {
         ticket: organizationTicket,
       })
       .then(res => {
+        removeClerkQueryParam('__clerk_ticket');
         switch (res.status) {
           case 'needs_first_factor':
             return navigate('factor-one');

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -2,7 +2,7 @@ import { useClerk } from '@clerk/shared/react';
 import React from 'react';
 
 import { ERROR_CODES } from '../../../core/constants';
-import { getClerkQueryParam } from '../../../utils/getClerkQueryParam';
+import { getClerkQueryParam, removeClerkQueryParam } from '../../../utils/getClerkQueryParam';
 import { buildSSOCallbackURL, withRedirectToAfterSignUp } from '../../common';
 import { useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts';
 import { descriptors, Flex, Flow, localizationKeys, useAppearance, useLocalizations } from '../../customizables';
@@ -109,6 +109,8 @@ function _SignUpStart(): JSX.Element {
     signUp
       .create({ strategy: 'ticket', ticket: formState.ticket.value })
       .then(signUp => {
+        removeClerkQueryParam('__clerk_ticket');
+        removeClerkQueryParam('__clerk_invitation_token');
         formState.emailAddress.setValue(signUp.emailAddress || '');
         // In case we are in a Ticket flow and the sign up is not complete yet, update the state
         // to render properly the SignUp form with other available options to complete it (e.g. OAuth)

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -1,6 +1,8 @@
+import type { SignUpResource } from '@clerk/types';
 import { OAUTH_PROVIDERS } from '@clerk/types';
 
-import { render, screen } from '../../../../testUtils';
+import { act, render, screen } from '../../../../testUtils';
+import { CardStateProvider } from '../../../elements';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { SignUpStart } from '../SignUpStart';
 
@@ -200,6 +202,40 @@ describe('SignUpStart', () => {
       props.setProps({ initialValues: { username: 'foo' } });
       render(<SignUpStart />, { wrapper });
       screen.getByDisplayValue(/foo/i);
+    });
+  });
+
+  describe('ticket flow', () => {
+    it('calls the appropriate resource function upon detecting the ticket', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      fixtures.signUp.create.mockResolvedValueOnce({} as SignUpResource);
+
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { href: 'http://localhost/sign-up?__clerk_ticket=test_ticket' },
+      });
+      Object.defineProperty(window, 'history', {
+        writable: true,
+        value: { replaceState: jest.fn() },
+      });
+
+      await act(() =>
+        render(
+          <CardStateProvider>
+            <SignUpStart />
+          </CardStateProvider>,
+          { wrapper },
+        ),
+      );
+      expect(fixtures.signUp.create).toHaveBeenCalledWith({ strategy: 'ticket', ticket: 'test_ticket' });
+
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        undefined,
+        '',
+        expect.not.stringContaining('__clerk_ticket'),
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
Remove the **clerk_ticket and **clerk_invitation_token query params after they are consumed.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
