### PR TITLE
fix(clerk-js,types): Fix the redirection that happens when SSO fails

### DIFF
--- a/.changeset/tame-coats-repeat.md
+++ b/.changeset/tame-coats-repeat.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Return to localhost when SSO callback fails on SignIn or SignUp

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -968,9 +968,9 @@ export class Clerk implements ClerkInterface {
 
     const makeNavigate = (to: string) => () => navigate(to);
 
-    const navigateToSignIn = makeNavigate(displayConfig.signInUrl);
+    const navigateToSignIn = makeNavigate(params.signInUrl || displayConfig.signInUrl);
 
-    const navigateToSignUp = makeNavigate(displayConfig.signUpUrl);
+    const navigateToSignUp = makeNavigate(params.signUpUrl || displayConfig.signUpUrl);
 
     const navigateToFactorOne = makeNavigate(
       params.firstFactorUrl ||

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -42,6 +42,8 @@ function SignInRoutes(): JSX.Element {
         </Route>
         <Route path='sso-callback'>
           <SignInSSOCallback
+            signUpUrl={signInContext.signUpUrl}
+            signInUrl={signInContext.signInUrl}
             afterSignInUrl={signInContext.afterSignInUrl}
             afterSignUpUrl={signInContext.afterSignUpUrl}
             redirectUrl={signInContext.redirectUrl}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -40,6 +40,8 @@ function SignUpRoutes(): JSX.Element {
         </Route>
         <Route path='sso-callback'>
           <SignUpSSOCallback
+            signUpUrl={signUpContext.signUpUrl}
+            signInUrl={signUpContext.signInUrl}
             afterSignUpUrl={signUpContext.afterSignUpUrl}
             afterSignInUrl={signUpContext.afterSignInUrl}
             redirectUrl={signUpContext.redirectUrl}

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -91,7 +91,9 @@ export const useSignUpContext = (): SignUpContextType => {
     displayConfig: displayConfig,
   });
 
-  let signUpUrl = pickRedirectionProp('signUpUrl', { ctx, options, displayConfig }, false);
+  let signUpUrl =
+    (ctx.routing === 'path' ? ctx.path : undefined) ||
+    pickRedirectionProp('signUpUrl', { options, displayConfig }, false);
   if (authQs && ctx.routing !== 'virtual') {
     signUpUrl += `#/?${authQs}`;
   }
@@ -175,7 +177,9 @@ export const useSignInContext = (): SignInContextType => {
     signUpUrl += `#/?${authQs}`;
   }
 
-  let signInUrl = pickRedirectionProp('signInUrl', { ctx, options, displayConfig }, false);
+  let signInUrl =
+    (ctx.routing === 'path' ? ctx.path : undefined) ||
+    pickRedirectionProp('signInUrl', { options, displayConfig }, false);
   if (authQs && ctx.routing !== 'virtual') {
     signInUrl += `#/?${authQs}`;
   }

--- a/packages/elements/src/internals/machines/third-party/actors.ts
+++ b/packages/elements/src/internals/machines/third-party/actors.ts
@@ -88,6 +88,8 @@ export const handleRedirectCallback = fromCallback<AnyEventObject, HandleRedirec
         secondFactorUrl: ClerkJSNavigationEvent.signIn,
         verifyEmailAddressUrl: ClerkJSNavigationEvent.verification,
         verifyPhoneNumberUrl: ClerkJSNavigationEvent.verification,
+        signUpUrl: ClerkJSNavigationEvent.signUp,
+        signInUrl: ClerkJSNavigationEvent.signIn,
       } satisfies Required<HandleOAuthCallbackParams>,
       customNavigate,
     );

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -452,6 +452,14 @@ export interface Clerk {
 
 export type HandleOAuthCallbackParams = AfterActionURLs & {
   /**
+   * Full URL or path where the SignIn component is mounted.
+   */
+  signInUrl?: string;
+  /**
+   * Full URL or path where the SignUp component is mounted.
+   */
+  signUpUrl?: string;
+  /**
    * Full URL or path to navigate after successful sign in
    * or sign up.
    *


### PR DESCRIPTION
## Description

Current Behaviour:
If a SignIn or SignUp SSO fails and needs to redirect back to the component, it always redirects to the Account Portal.

Expected Behaviour:
If the component is mounted on the user's app, then it should redirect back to the user's app.

Video coming soon...

Tech Details:
This happens because in the `handleRedirectCallback` we extract the `signInUrl` and `signUpUrl` from the displayConfig, without taking into account the env vars or the props that the user has passed.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
