### PR TITLE
fix(clerk-js): Avoid calling `router.matches()` for external routes

### DIFF
--- a/.changeset/mean-ties-talk.md
+++ b/.changeset/mean-ties-talk.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix: Component breaks after internal navigation when custom links are present.

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -118,6 +118,9 @@ export const NavBar = (props: NavBarProps) => {
 
   useEffect(() => {
     routes.every(route => {
+      if (route.external) {
+        return true;
+      }
       const isRoot = router.currentPath === router.fullPath && route.path === '/';
       const matchesPath = router.matches(route.path);
       if (isRoot || matchesPath) {


### PR DESCRIPTION
## Description

The fix already exists in core-2

Fixes #2919

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
