### PR TITLE
fix(fastify): Re-export @clerk/backend

### DIFF
--- a/.changeset/famous-bugs-tell.md
+++ b/.changeset/famous-bugs-tell.md
@@ -1,0 +1,32 @@
+---
+'@clerk/fastify': minor
+---
+
+Re-export everything from `@clerk/backend` in `@clerk/fastify` to support common backend types and functionality without adding `@clerk/backend` as dependency.
+
+New exports:
+- `verifyToken()`
+
+New exported types:
+- `ClerkOptions`
+- `ClerkClient`
+- `OrganizationMembershipRole`
+- `VerifyTokenOptions`
+- `WebhookEvent`
+- `WebhookEventType`
+- `AllowlistIdentifier`
+- `Client`
+- `EmailAddress`
+- `ExternalAccount`
+- `Invitation`
+- `OauthAccessToken`
+- `Organization`
+- `OrganizationInvitation`
+- `OrganizationMembership`
+- `OrganizationMembershipPublicUserData`
+- `PhoneNumber`
+- `Session`
+- `SignInToken`
+- `SMSMessage`
+- `Token`
+- `User`

--- a/packages/fastify/src/__snapshots__/exports.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/exports.test.ts.snap
@@ -6,5 +6,6 @@ exports[`/api public exports should not include a breaking change 1`] = `
   "clerkPlugin",
   "createClerkClient",
   "getAuth",
+  "verifyToken",
 ]
 `;

--- a/packages/fastify/src/clerkClient.ts
+++ b/packages/fastify/src/clerkClient.ts
@@ -2,8 +2,6 @@ import { createClerkClient } from '@clerk/backend';
 
 import { API_URL, API_VERSION, JWT_KEY, SDK_METADATA, SECRET_KEY } from './constants';
 
-export { createClerkClient };
-
 export const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
   apiUrl: API_URL,

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -1,5 +1,7 @@
+export * from '@clerk/backend';
+
 export type { ClerkFastifyOptions } from './types';
 
 export { clerkPlugin } from './clerkPlugin';
 export { getAuth } from './getAuth';
-export { clerkClient, createClerkClient } from './clerkClient';
+export { clerkClient } from './clerkClient';


### PR DESCRIPTION
## Description

Re-export `@clerk/backend` from `@clerk/fastify`

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
