### PR TITLE
feat(clerk-js): Experimental method for authenticating with a passkey

### DIFF
--- a/.changeset/light-ligers-beam.md
+++ b/.changeset/light-ligers-beam.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Experimental support for authenticating with a passkey.
+Example usage: `await signIn.authenticateWithPasskey()`.

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -58,6 +58,12 @@ export function clerkVerifyWeb3WalletCalledBeforeCreate(type: 'SignIn' | 'SignUp
   );
 }
 
+export function clerkVerifyPasskeyCalledBeforeCreate(): never {
+  throw new Error(
+    `${errorPrefix} You need to start a SignIn flow by calling SignIn.create({ strategy: 'passkey' }) first`,
+  );
+}
+
 export function clerkMissingOptionError(name = ''): never {
   throw new Error(`${errorPrefix} Missing '${name}' option`);
 }

--- a/packages/clerk-js/src/core/resources/Passkey.ts
+++ b/packages/clerk-js/src/core/resources/Passkey.ts
@@ -1,4 +1,5 @@
 import type {
+  __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse,
   DeletedObjectJSON,
   DeletedObjectResource,
   PasskeyJSON,
@@ -8,7 +9,6 @@ import type {
 } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
-import type { PublicKeyCredentialWithAuthenticatorAttestationResponse } from '../../utils/passkeys';
 import {
   isWebAuthnPlatformAuthenticatorSupported,
   isWebAuthnSupported,
@@ -41,7 +41,7 @@ export class Passkey extends BaseResource implements PasskeyResource {
 
   private static async attemptVerification(
     passkeyId: string,
-    credential: PublicKeyCredentialWithAuthenticatorAttestationResponse,
+    credential: __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse,
   ) {
     const jsonPublicKeyCredential = serializePublicKeyCredential(credential);
     return BaseResource._fetch({

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -1,5 +1,6 @@
 import { ClerkRuntimeError, deepSnakeToCamel, Poller } from '@clerk/shared';
 import type {
+  __experimental_PasskeyFactor,
   AttemptFirstFactorParams,
   AttemptSecondFactorParams,
   AuthenticateWithRedirectParams,
@@ -7,8 +8,6 @@ import type {
   CreateEmailLinkFlowReturn,
   EmailCodeConfig,
   EmailLinkConfig,
-  PassKeyConfig,
-  PasskeyFactor,
   PhoneCodeConfig,
   PrepareFirstFactorParams,
   PrepareSecondFactorParams,
@@ -84,7 +83,9 @@ export class SignIn extends BaseResource implements SignInResource {
   prepareFirstFactor = (factor: PrepareFirstFactorParams): Promise<SignInResource> => {
     let config;
     switch (factor.strategy) {
+      // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
       case 'passkey':
+        // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
         config = {} as PassKeyConfig;
         break;
       case 'email_link':
@@ -129,8 +130,10 @@ export class SignIn extends BaseResource implements SignInResource {
   attemptFirstFactor = (attemptFactor: AttemptFirstFactorParams): Promise<SignInResource> => {
     let config;
     switch (attemptFactor.strategy) {
+      // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
       case 'passkey':
         config = {
+          // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
           publicKeyCredential: serializePublicKeyCredentialAssertion(attemptFactor.publicKeyCredential),
         };
         break;
@@ -258,7 +261,7 @@ export class SignIn extends BaseResource implements SignInResource {
     });
   };
 
-  public authenticateWithPasskey = async (): Promise<SignInResource> => {
+  public __experimental_authenticateWithPasskey = async (): Promise<SignInResource> => {
     /**
      * The UI should always prevent from this method being called if WebAuthn is not supported.
      * As a precaution we need to check if WebAuthn is supported.
@@ -270,15 +273,21 @@ export class SignIn extends BaseResource implements SignInResource {
     }
 
     if (!this.firstFactorVerification.nonce) {
+      // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
       await this.create({ strategy: 'passkey' });
     }
 
-    const passKeyFactor = this.supportedFirstFactors.find(f => f.strategy === 'passkey') as PasskeyFactor;
+    // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
+    const passKeyFactor = this.supportedFirstFactors.find(
+      // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
+      f => f.strategy === 'passkey',
+    ) as __experimental_PasskeyFactor;
 
     if (!passKeyFactor) {
       clerkVerifyPasskeyCalledBeforeCreate();
     }
 
+    // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
     await this.prepareFirstFactor(passKeyFactor);
 
     const { nonce } = this.firstFactorVerification;
@@ -301,6 +310,7 @@ export class SignIn extends BaseResource implements SignInResource {
 
     return this.attemptFirstFactor({
       publicKeyCredential,
+      // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
       strategy: 'passkey',
     });
   };

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -134,7 +134,7 @@ export class SignIn extends BaseResource implements SignInResource {
       case 'passkey':
         config = {
           // @ts-ignore As this is experimental we want to support it at runtime, but not at the type level
-          publicKeyCredential: serializePublicKeyCredentialAssertion(attemptFactor.publicKeyCredential),
+          publicKeyCredential: JSON.stringify(serializePublicKeyCredentialAssertion(attemptFactor.publicKeyCredential)),
         };
         break;
       default:

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -31,7 +31,6 @@ import type {
 
 import { generateSignatureWithMetamask, getMetamaskIdentifier, windowNavigate } from '../../utils';
 import {
-  bufferToBase64Url,
   convertJSONToPublicKeyRequestOptions,
   isWebAuthnAutofillSupported,
   isWebAuthnSupported,
@@ -300,26 +299,8 @@ export class SignIn extends BaseResource implements SignInResource {
       throw error;
     }
 
-    const { id, rawId, type } = publicKeyCredential;
-    const response = publicKeyCredential.response;
-
-    const credential = {
-      id,
-      rawId: bufferToBase64Url(rawId),
-      type,
-      // clientExtensionResults: publicKeyCredential.getClientExtensionResults(),
-      authenticatorAttachment: publicKeyCredential.authenticatorAttachment,
-      response: {
-        authenticatorData: bufferToBase64Url(response.authenticatorData),
-        clientDataJSON: bufferToBase64Url(response.clientDataJSON),
-        signature: bufferToBase64Url(response.signature),
-        userHandle: response.userHandle ? bufferToBase64Url(response.userHandle) : null,
-      },
-    };
-
     return this.attemptFirstFactor({
-      // @ts-ignore
-      credential,
+      publicKeyCredential,
       strategy: 'passkey',
     });
   };

--- a/packages/clerk-js/src/core/resources/Verification.ts
+++ b/packages/clerk-js/src/core/resources/Verification.ts
@@ -1,9 +1,9 @@
 import { parseError } from '@clerk/shared/error';
 import type {
+  __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions,
   ClerkAPIError,
   PasskeyVerificationResource,
   PublicKeyCredentialCreationOptionsJSON,
-  PublicKeyCredentialCreationOptionsWithoutExtensions,
   SignUpVerificationJSON,
   SignUpVerificationResource,
   SignUpVerificationsJSON,
@@ -58,7 +58,7 @@ export class Verification extends BaseResource implements VerificationResource {
 }
 
 export class PasskeyVerification extends Verification implements PasskeyVerificationResource {
-  publicKey: PublicKeyCredentialCreationOptionsWithoutExtensions | null = null;
+  publicKey: __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions | null = null;
 
   constructor(data: VerificationJSON | null) {
     super(data);

--- a/packages/clerk-js/src/utils/__tests__/passkeys.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/passkeys.test.ts
@@ -1,7 +1,17 @@
-import type { PublicKeyCredentialCreationOptionsJSON } from '@clerk/types';
+import type {
+  type __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse,
+  type __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+} from '@clerk/types';
 
-import type { PublicKeyCredentialWithAuthenticatorAttestationResponse } from '../passkeys';
-import { bufferToBase64Url, convertJSONToPublicKeyCreateOptions, serializePublicKeyCredential } from '../passkeys';
+import {
+  bufferToBase64Url,
+  convertJSONToPublicKeyCreateOptions,
+  convertJSONToPublicKeyRequestOptions,
+  serializePublicKeyCredential,
+  serializePublicKeyCredentialAssertion,
+} from '../passkeys';
 
 describe('Passkey utils', () => {
   describe('serialization', () => {
@@ -57,8 +67,29 @@ describe('Passkey utils', () => {
       expect(bufferToBase64Url(result.excludeCredentials[0].id)).toEqual(pkCreateOptions.excludeCredentials[0].id);
     });
 
+    it('convertJSONToPublicKeyCreateOptions()', () => {
+      const pkCreateOptions: PublicKeyCredentialRequestOptionsJSON = {
+        rpId: 'clerk.com',
+        allowCredentials: [
+          {
+            type: 'public-key',
+            id: 'cmFuZG9tX2lk',
+          },
+        ],
+        userVerification: 'required',
+        timeout: 10000,
+        challenge: 'Y2hhbGxlbmdlXzEyMw', // challenge_123 encoded as base64url
+      };
+
+      const result = convertJSONToPublicKeyRequestOptions(pkCreateOptions);
+
+      expect(result.rpId).toEqual('clerk.com');
+      expect(result.userVerification).toEqual('required');
+      expect(bufferToBase64Url(result.allowCredentials[0].id)).toEqual(pkCreateOptions.allowCredentials[0].id);
+    });
+
     it('serializePublicKeyCredential()', () => {
-      const publicKeyCredential: PublicKeyCredentialWithAuthenticatorAttestationResponse = {
+      const publicKeyCredential: __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse = {
         type: 'public-key',
         id: 'credentialId_123',
         rawId: new Uint8Array([99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 73, 100, 95, 49, 50, 51]),
@@ -79,6 +110,31 @@ describe('Passkey utils', () => {
       expect(result.response.clientDataJSON).toEqual('bnRpYQ');
       expect(result.response.attestationObject).toEqual('bElkXzE');
       expect(result.response.transports).toEqual(['usb']);
+    });
+
+    it('serializePublicKeyCredentialAssertion()', () => {
+      const publicKeyCredential: __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse = {
+        type: 'public-key',
+        id: 'credentialId_123',
+        rawId: new Uint8Array([99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 73, 100, 95, 49, 50, 51]),
+        authenticatorAttachment: 'cross-platform',
+        response: {
+          clientDataJSON: new Uint8Array([110, 116, 105, 97]),
+          signature: new Uint8Array([108, 73, 100, 95, 49]),
+          authenticatorData: new Uint8Array([108, 73, 100, 95, 49]),
+          userHandle: null,
+        },
+      };
+
+      const result = serializePublicKeyCredentialAssertion(publicKeyCredential);
+
+      expect(result.type).toEqual('public-key');
+      expect(result.id).toEqual('credentialId_123');
+      expect(result.rawId).toEqual('Y3JlZGVudGlhbElkXzEyMw');
+
+      expect(result.response.clientDataJSON).toEqual('bnRpYQ');
+      expect(result.response.signature).toEqual('bElkXzE');
+      expect(result.response.userHandle).toEqual(null);
     });
   });
 });

--- a/packages/clerk-js/src/utils/passkeys.ts
+++ b/packages/clerk-js/src/utils/passkeys.ts
@@ -1,12 +1,12 @@
 import { isValidBrowser } from '@clerk/shared/browser';
 import { ClerkRuntimeError } from '@clerk/shared/error';
 import type {
+  __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions,
+  __experimental_PublicKeyCredentialRequestOptionsWithoutExtensions,
+  __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse,
+  __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse,
   PublicKeyCredentialCreationOptionsJSON,
-  PublicKeyCredentialCreationOptionsWithoutExtensions,
   PublicKeyCredentialRequestOptionsJSON,
-  PublicKeyCredentialRequestOptionsWithoutExtensions,
-  PublicKeyCredentialWithAuthenticatorAssertionResponse,
-  PublicKeyCredentialWithAuthenticatorAttestationResponse,
 } from '@clerk/types';
 
 type CredentialReturn<T> =
@@ -19,8 +19,10 @@ type CredentialReturn<T> =
       error: ClerkWebAuthnError | Error;
     };
 
-type WebAuthnCreateCredentialReturn = CredentialReturn<PublicKeyCredentialWithAuthenticatorAttestationResponse>;
-type WebAuthnGetCredentialReturn = CredentialReturn<PublicKeyCredentialWithAuthenticatorAssertionResponse>;
+type WebAuthnCreateCredentialReturn =
+  CredentialReturn<__experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse>;
+type WebAuthnGetCredentialReturn =
+  CredentialReturn<__experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse>;
 
 type ClerkWebAuthnErrorCode =
   | 'passkey_exists'
@@ -77,7 +79,7 @@ class Base64Converter {
 }
 
 async function webAuthnCreateCredential(
-  publicKeyOptions: PublicKeyCredentialCreationOptionsWithoutExtensions,
+  publicKeyOptions: __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions,
 ): Promise<WebAuthnCreateCredentialReturn> {
   try {
     // Typescript types are not aligned with the spec. These type assertions are required to comply with the spec.
@@ -102,7 +104,7 @@ async function webAuthnGetCredential({
   publicKeyOptions,
   conditionalUI,
 }: {
-  publicKeyOptions: PublicKeyCredentialRequestOptionsWithoutExtensions;
+  publicKeyOptions: __experimental_PublicKeyCredentialRequestOptionsWithoutExtensions;
   conditionalUI: boolean;
 }): Promise<WebAuthnGetCredentialReturn> {
   try {
@@ -169,7 +171,7 @@ function convertJSONToPublicKeyCreateOptions(jsonPublicKey: PublicKeyCredentialC
       ...jsonPublicKey.user,
       id: userIdBuffer,
     },
-  } as PublicKeyCredentialCreationOptionsWithoutExtensions;
+  } as __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions;
 }
 
 function convertJSONToPublicKeyRequestOptions(jsonPublicKey: PublicKeyCredentialRequestOptionsJSON) {
@@ -184,7 +186,7 @@ function convertJSONToPublicKeyRequestOptions(jsonPublicKey: PublicKeyCredential
     ...jsonPublicKey,
     allowCredentials: allowCredentialsWithBuffer,
     challenge: challengeBuffer,
-  } as PublicKeyCredentialRequestOptionsWithoutExtensions;
+  } as __experimental_PublicKeyCredentialRequestOptionsWithoutExtensions;
 }
 
 function __serializePublicKeyCredential<T extends Omit<PublicKeyCredential, 'getClientExtensionResults'>>(pkc: T) {
@@ -196,7 +198,7 @@ function __serializePublicKeyCredential<T extends Omit<PublicKeyCredential, 'get
   };
 }
 
-function serializePublicKeyCredential(pkc: PublicKeyCredentialWithAuthenticatorAttestationResponse) {
+function serializePublicKeyCredential(pkc: __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse) {
   const response = pkc.response;
   return {
     ...__serializePublicKeyCredential(pkc),
@@ -208,7 +210,9 @@ function serializePublicKeyCredential(pkc: PublicKeyCredentialWithAuthenticatorA
   };
 }
 
-function serializePublicKeyCredentialAssertion(pkc: PublicKeyCredentialWithAuthenticatorAssertionResponse) {
+function serializePublicKeyCredentialAssertion(
+  pkc: __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse,
+) {
   const response = pkc.response;
   return {
     ...__serializePublicKeyCredential(pkc),
@@ -250,5 +254,3 @@ export {
   serializePublicKeyCredential,
   serializePublicKeyCredentialAssertion,
 };
-
-export type { PublicKeyCredentialWithAuthenticatorAttestationResponse };

--- a/packages/clerk-js/src/utils/passkeys.ts
+++ b/packages/clerk-js/src/utils/passkeys.ts
@@ -89,7 +89,9 @@ async function webAuthnCreateCredential(
 
     if (!credential) {
       return {
-        error: new ClerkWebAuthnError('Browser failed to create credential', { code: 'passkey_credential_get_failed' }),
+        error: new ClerkWebAuthnError('Browser failed to create credential', {
+          code: 'passkey_credential_create_failed',
+        }),
         publicKeyCredential: null,
       };
     }

--- a/packages/clerk-js/src/utils/passkeys.ts
+++ b/packages/clerk-js/src/utils/passkeys.ts
@@ -85,7 +85,7 @@ async function webAuthnCreateCredential(
     // Typescript types are not aligned with the spec. These type assertions are required to comply with the spec.
     const credential = (await navigator.credentials.create({
       publicKey: publicKeyOptions,
-    })) as PublicKeyCredentialWithAuthenticatorAttestationResponse | null;
+    })) as __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse | null;
 
     if (!credential) {
       return {
@@ -112,7 +112,7 @@ async function webAuthnGetCredential({
     const credential = (await navigator.credentials.get({
       publicKey: publicKeyOptions,
       mediation: conditionalUI ? 'conditional' : 'optional',
-    })) as PublicKeyCredential | null;
+    })) as __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse | null;
 
     if (!credential) {
       return {
@@ -121,10 +121,7 @@ async function webAuthnGetCredential({
       };
     }
 
-    // Typescript types are not aligned with the spec. These type assertions are required to comply with the spec.
-    const res = credential.response as AuthenticatorAssertionResponse;
-
-    return { publicKeyCredential: { ...credential, response: res }, error: null };
+    return { publicKeyCredential: credential, error: null };
   } catch (e) {
     return { error: handlePublicKeyGetError(e), publicKeyCredential: null };
   }

--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -1,10 +1,10 @@
-import type { PublicKeyCredentialWithAuthenticatorAssertionResponse } from './passkey';
+import type { __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse } from './passkey';
 import type {
+  __experimental_PasskeyStrategy,
   BackupCodeStrategy,
   EmailCodeStrategy,
   EmailLinkStrategy,
   OAuthStrategy,
-  PasskeyStrategy,
   PasswordStrategy,
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
@@ -46,8 +46,11 @@ export type PasswordFactor = {
   strategy: PasswordStrategy;
 };
 
-export type PasskeyFactor = {
-  strategy: PasskeyStrategy;
+/**
+ * @experimental
+ */
+export type __experimental_PasskeyFactor = {
+  strategy: __experimental_PasskeyStrategy;
 };
 
 export type OauthFactor = {
@@ -91,7 +94,10 @@ export type EmailLinkConfig = Omit<EmailLinkFactor, 'safeIdentifier'> & {
 };
 export type PhoneCodeConfig = Omit<PhoneCodeFactor, 'safeIdentifier'>;
 export type Web3SignatureConfig = Web3SignatureFactor;
-export type PassKeyConfig = PasskeyFactor;
+/**
+ * @experimental
+ */
+export type __experimental_PassKeyConfig = __experimental_PasskeyFactor;
 export type OAuthConfig = OauthFactor & {
   redirectUrl: string;
   actionCompleteRedirectUrl: string;
@@ -122,9 +128,12 @@ export type PasswordAttempt = {
   password: string;
 };
 
-export type PasskeyAttempt = {
-  strategy: PasskeyStrategy;
-  publicKeyCredential: PublicKeyCredentialWithAuthenticatorAssertionResponse;
+/**
+ * @experimental
+ */
+export type __experimental_PasskeyAttempt = {
+  strategy: __experimental_PasskeyStrategy;
+  publicKeyCredential: __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse;
 };
 
 export type Web3Attempt = {

--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -1,8 +1,10 @@
+import type { PublicKeyCredentialWithAuthenticatorAssertionResponse } from './passkey';
 import type {
   BackupCodeStrategy,
   EmailCodeStrategy,
   EmailLinkStrategy,
   OAuthStrategy,
+  PasskeyStrategy,
   PasswordStrategy,
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
@@ -42,6 +44,10 @@ export type Web3SignatureFactor = {
 
 export type PasswordFactor = {
   strategy: PasswordStrategy;
+};
+
+export type PasskeyFactor = {
+  strategy: PasskeyStrategy;
 };
 
 export type OauthFactor = {
@@ -85,6 +91,7 @@ export type EmailLinkConfig = Omit<EmailLinkFactor, 'safeIdentifier'> & {
 };
 export type PhoneCodeConfig = Omit<PhoneCodeFactor, 'safeIdentifier'>;
 export type Web3SignatureConfig = Web3SignatureFactor;
+export type PassKeyConfig = PasskeyFactor;
 export type OAuthConfig = OauthFactor & {
   redirectUrl: string;
   actionCompleteRedirectUrl: string;
@@ -113,6 +120,11 @@ export type PhoneCodeAttempt = {
 export type PasswordAttempt = {
   strategy: PasswordStrategy;
   password: string;
+};
+
+export type PasskeyAttempt = {
+  strategy: PasskeyStrategy;
+  publicKeyCredential: PublicKeyCredentialWithAuthenticatorAssertionResponse;
 };
 
 export type Web3Attempt = {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -461,7 +461,7 @@ interface PublicKeyCredentialUserEntityJSON {
   id: Base64UrlString;
 }
 
-export interface ExcludedCredentialJSON {
+interface PublicKeyCredentialDescriptorJSON {
   type: 'public-key';
   id: Base64UrlString;
   transports?: ('ble' | 'hybrid' | 'internal' | 'nfc' | 'usb')[];
@@ -479,9 +479,17 @@ export interface PublicKeyCredentialCreationOptionsJSON {
   challenge: Base64UrlString;
   pubKeyCredParams: PublicKeyCredentialParameters[];
   timeout: number;
-  excludeCredentials: ExcludedCredentialJSON[];
+  excludeCredentials: PublicKeyCredentialDescriptorJSON[];
   authenticatorSelection: AuthenticatorSelectionCriteriaJSON;
   attestation: 'direct' | 'enterprise' | 'indirect' | 'none';
+}
+
+export interface PublicKeyCredentialRequestOptionsJSON {
+  allowCredentials: PublicKeyCredentialDescriptorJSON[];
+  challenge: Base64UrlString;
+  rpId: string;
+  timeout: number;
+  userVerification: 'discouraged' | 'preferred' | 'required';
 }
 
 // TODO-PASSKEYS: Decide if we are keeping this

--- a/packages/types/src/passkey.ts
+++ b/packages/types/src/passkey.ts
@@ -20,3 +20,27 @@ export interface PasskeyResource extends ClerkResource {
   update: (params: UpdatePasskeyParams) => Promise<PasskeyResource>;
   delete: () => Promise<DeletedObjectResource>;
 }
+
+export type PublicKeyCredentialCreationOptionsWithoutExtensions = Omit<
+  Required<PublicKeyCredentialCreationOptions>,
+  'extensions'
+>;
+
+export type PublicKeyCredentialRequestOptionsWithoutExtensions = Omit<
+  Required<PublicKeyCredentialRequestOptions>,
+  'extensions'
+>;
+
+export type PublicKeyCredentialWithAuthenticatorAttestationResponse = Omit<
+  PublicKeyCredential,
+  'response' | 'getClientExtensionResults'
+> & {
+  response: Omit<AuthenticatorAttestationResponse, 'getAuthenticatorData' | 'getPublicKey' | 'getPublicKeyAlgorithm'>;
+};
+
+export type PublicKeyCredentialWithAuthenticatorAssertionResponse = Omit<
+  PublicKeyCredential,
+  'response' | 'getClientExtensionResults'
+> & {
+  response: AuthenticatorAssertionResponse;
+};

--- a/packages/types/src/passkey.ts
+++ b/packages/types/src/passkey.ts
@@ -21,24 +21,33 @@ export interface PasskeyResource extends ClerkResource {
   delete: () => Promise<DeletedObjectResource>;
 }
 
-export type PublicKeyCredentialCreationOptionsWithoutExtensions = Omit<
+/**
+ * @experimental
+ */
+export type __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions = Omit<
   Required<PublicKeyCredentialCreationOptions>,
   'extensions'
 >;
-
-export type PublicKeyCredentialRequestOptionsWithoutExtensions = Omit<
+/**
+ * @experimental
+ */
+export type __experimental_PublicKeyCredentialRequestOptionsWithoutExtensions = Omit<
   Required<PublicKeyCredentialRequestOptions>,
   'extensions'
 >;
-
-export type PublicKeyCredentialWithAuthenticatorAttestationResponse = Omit<
+/**
+ * @experimental
+ */
+export type __experimental_PublicKeyCredentialWithAuthenticatorAttestationResponse = Omit<
   PublicKeyCredential,
   'response' | 'getClientExtensionResults'
 > & {
   response: Omit<AuthenticatorAttestationResponse, 'getAuthenticatorData' | 'getPublicKey' | 'getPublicKeyAlgorithm'>;
 };
-
-export type PublicKeyCredentialWithAuthenticatorAssertionResponse = Omit<
+/**
+ * @experimental
+ */
+export type __experimental_PublicKeyCredentialWithAuthenticatorAssertionResponse = Omit<
   PublicKeyCredential,
   'response' | 'getClientExtensionResults'
 > & {

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -8,9 +8,6 @@ import type {
   EmailLinkFactor,
   OAuthConfig,
   OauthFactor,
-  PasskeyAttempt,
-  PassKeyConfig,
-  PasskeyFactor,
   PasswordAttempt,
   PasswordFactor,
   PhoneCodeAttempt,
@@ -52,7 +49,6 @@ import type {
   EmailCodeStrategy,
   EmailLinkStrategy,
   OAuthStrategy,
-  PasskeyStrategy,
   PasswordStrategy,
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
@@ -94,7 +90,7 @@ export interface SignInResource extends ClerkResource {
 
   authenticateWithMetamask: () => Promise<SignInResource>;
 
-  authenticateWithPasskey: () => Promise<SignInResource>;
+  __experimental_authenticateWithPasskey: () => Promise<SignInResource>;
 
   createEmailLinkFlow: () => CreateEmailLinkFlowReturn<SignInStartEmailLinkFlowParams, SignInResource>;
 
@@ -119,7 +115,8 @@ export type SignInFirstFactor =
   | EmailLinkFactor
   | PhoneCodeFactor
   | PasswordFactor
-  | PasskeyFactor
+  // TODO-PASSKEYS: Include this when the feature is not longer considered experimental
+  // | __experimental_PasskeyFactor
   | ResetPasswordPhoneCodeFactor
   | ResetPasswordEmailCodeFactor
   | Web3SignatureFactor
@@ -142,14 +139,16 @@ export type PrepareFirstFactorParams =
   | EmailLinkConfig
   | PhoneCodeConfig
   | Web3SignatureConfig
-  | PassKeyConfig
+  // TODO-PASSKEYS: Include this when the feature is not longer considered experimental
+  // | __experimental_PassKeyConfig
   | ResetPasswordPhoneCodeFactorConfig
   | ResetPasswordEmailCodeFactorConfig
   | OAuthConfig
   | SamlConfig;
 
 export type AttemptFirstFactorParams =
-  | PasskeyAttempt
+  // TODO-PASSKEYS: Include this when the feature is not longer considered experimental
+  // | __experimental_PasskeyAttempt
   | EmailCodeAttempt
   | PhoneCodeAttempt
   | PasswordAttempt
@@ -177,7 +176,8 @@ export type SignInCreateParams = (
       password: string;
       identifier: string;
     }
-  | { strategy: PasskeyStrategy }
+  // TODO-PASSKEYS: Include this when the feature is not longer considered experimental
+  // | { strategy: __experimental_PasskeyStrategy }
   | {
       strategy:
         | PhoneCodeStrategy
@@ -208,7 +208,8 @@ export interface SignInStartEmailLinkFlowParams extends StartEmailLinkFlowParams
 }
 
 export type SignInStrategy =
-  | PasskeyStrategy
+  // TODO-PASSKEYS: Include this when the feature is not longer considered experimental
+  // | __experimental_PasskeyStrategy
   | PasswordStrategy
   | ResetPasswordPhoneCodeStrategy
   | ResetPasswordEmailCodeStrategy

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -8,6 +8,9 @@ import type {
   EmailLinkFactor,
   OAuthConfig,
   OauthFactor,
+  PasskeyAttempt,
+  PassKeyConfig,
+  PasskeyFactor,
   PasswordAttempt,
   PasswordFactor,
   PhoneCodeAttempt,
@@ -49,6 +52,7 @@ import type {
   EmailCodeStrategy,
   EmailLinkStrategy,
   OAuthStrategy,
+  PasskeyStrategy,
   PasswordStrategy,
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
@@ -90,6 +94,8 @@ export interface SignInResource extends ClerkResource {
 
   authenticateWithMetamask: () => Promise<SignInResource>;
 
+  authenticateWithPasskey: () => Promise<SignInResource>;
+
   createEmailLinkFlow: () => CreateEmailLinkFlowReturn<SignInStartEmailLinkFlowParams, SignInResource>;
 
   validatePassword: (password: string, callbacks?: ValidatePasswordCallbacks) => void;
@@ -113,6 +119,7 @@ export type SignInFirstFactor =
   | EmailLinkFactor
   | PhoneCodeFactor
   | PasswordFactor
+  | PasskeyFactor
   | ResetPasswordPhoneCodeFactor
   | ResetPasswordEmailCodeFactor
   | Web3SignatureFactor
@@ -135,12 +142,14 @@ export type PrepareFirstFactorParams =
   | EmailLinkConfig
   | PhoneCodeConfig
   | Web3SignatureConfig
+  | PassKeyConfig
   | ResetPasswordPhoneCodeFactorConfig
   | ResetPasswordEmailCodeFactorConfig
   | OAuthConfig
   | SamlConfig;
 
 export type AttemptFirstFactorParams =
+  | PasskeyAttempt
   | EmailCodeAttempt
   | PhoneCodeAttempt
   | PasswordAttempt
@@ -168,6 +177,7 @@ export type SignInCreateParams = (
       password: string;
       identifier: string;
     }
+  | { strategy: PasskeyStrategy }
   | {
       strategy:
         | PhoneCodeStrategy
@@ -198,6 +208,7 @@ export interface SignInStartEmailLinkFlowParams extends StartEmailLinkFlowParams
 }
 
 export type SignInStrategy =
+  | PasskeyStrategy
   | PasswordStrategy
   | ResetPasswordPhoneCodeStrategy
   | ResetPasswordEmailCodeStrategy

--- a/packages/types/src/strategies.ts
+++ b/packages/types/src/strategies.ts
@@ -1,6 +1,7 @@
 import type { OAuthProvider } from './oauth';
 import type { Web3Provider } from './web3';
 
+export type PasskeyStrategy = 'passkey';
 export type PasswordStrategy = 'password';
 export type PhoneCodeStrategy = 'phone_code';
 export type EmailCodeStrategy = 'email_code';

--- a/packages/types/src/strategies.ts
+++ b/packages/types/src/strategies.ts
@@ -1,7 +1,10 @@
 import type { OAuthProvider } from './oauth';
 import type { Web3Provider } from './web3';
 
-export type PasskeyStrategy = 'passkey';
+/**
+ * @experimental
+ */
+export type __experimental_PasskeyStrategy = 'passkey';
 export type PasswordStrategy = 'password';
 export type PhoneCodeStrategy = 'phone_code';
 export type EmailCodeStrategy = 'email_code';

--- a/packages/types/src/verification.ts
+++ b/packages/types/src/verification.ts
@@ -1,5 +1,5 @@
 import type { ClerkAPIError } from './api';
-import type { PublicKeyCredentialCreationOptionsWithoutExtensions } from './passkey';
+import type { __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions } from './passkey';
 import type { ClerkResource } from './resource';
 
 export interface VerificationResource extends ClerkResource {
@@ -15,7 +15,7 @@ export interface VerificationResource extends ClerkResource {
 }
 
 export interface PasskeyVerificationResource extends VerificationResource {
-  publicKey: PublicKeyCredentialCreationOptionsWithoutExtensions | null;
+  publicKey: __experimental_PublicKeyCredentialCreationOptionsWithoutExtensions | null;
 }
 
 export type VerificationStatus = 'unverified' | 'verified' | 'transferable' | 'failed' | 'expired';

--- a/packages/types/src/verification.ts
+++ b/packages/types/src/verification.ts
@@ -1,4 +1,5 @@
 import type { ClerkAPIError } from './api';
+import type { PublicKeyCredentialCreationOptionsWithoutExtensions } from './passkey';
 import type { ClerkResource } from './resource';
 
 export interface VerificationResource extends ClerkResource {
@@ -13,10 +14,6 @@ export interface VerificationResource extends ClerkResource {
   verifiedFromTheSameClient: () => boolean;
 }
 
-export type PublicKeyCredentialCreationOptionsWithoutExtensions = Omit<
-  Required<PublicKeyCredentialCreationOptions>,
-  'extensions'
->;
 export interface PasskeyVerificationResource extends VerificationResource {
   publicKey: PublicKeyCredentialCreationOptionsWithoutExtensions | null;
 }


### PR DESCRIPTION
## Description

This PR exposes the `SignIn.__experimental_authenticateWithPasskey()` method.

### Usage

https://github.com/clerk/javascript/assets/19269911/ceaa87b6-e2f3-40af-b17e-68a2f096961e


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
