### PR TITLE
fix(clerk-js): Pass the whole error object into card.setError (#2957)

### DIFF
--- a/.changeset/popular-monkeys-clap.md
+++ b/.changeset/popular-monkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix the OAuth errors coming from the server to use localizations

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -180,7 +180,7 @@ export function _SignInStart(): JSX.Element {
           case ERROR_CODES.SAML_USER_ATTRIBUTE_MISSING:
           case ERROR_CODES.OAUTH_EMAIL_DOMAIN_RESERVED_BY_SAML:
           case ERROR_CODES.USER_LOCKED:
-            card.setError(error.longMessage);
+            card.setError(error);
             break;
           default:
             // Error from server may be too much information for the end user, so set a generic error

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -151,7 +151,7 @@ function _SignUpStart(): JSX.Element {
           case ERROR_CODES.SAML_USER_ATTRIBUTE_MISSING:
           case ERROR_CODES.OAUTH_EMAIL_DOMAIN_RESERVED_BY_SAML:
           case ERROR_CODES.USER_LOCKED:
-            card.setError(error.longMessage);
+            card.setError(error);
             break;
           default:
             // Error from server may be too much information for the end user, so set a generic error


### PR DESCRIPTION
Backporting #2957 to the release/v4 branch

(cherry picked from commit fe6215deaf44d35a31f760283fc6cfa451845e98)