### PR TITLE
feat(backend): Add `external_account_id` to OAuth access token response

### DIFF
--- a/.changeset/early-poets-leave.md
+++ b/.changeset/early-poets-leave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add `external_account_id` to OAuth access token response

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -212,5 +212,40 @@ export default (QUnit: QUnit) => {
         }),
       );
     });
+
+    test('successfully retrieves user access tokens from backend API for a specific provider', async assert => {
+      const fakeResponse = [
+        {
+          external_account_id: 'eac_2dYS7stz9bgxQsSRvNqEAHhuxvW',
+          object: 'oauth_access_token',
+          token: '<token>',
+          provider: 'oauth_google',
+          public_metadata: {},
+          label: null,
+          scopes: ['email', 'profile'],
+        },
+      ];
+
+      fakeFetch = sinon.stub(runtime, 'fetch');
+      fakeFetch.onCall(0).returns(jsonOk(fakeResponse));
+
+      const response = await apiClient.users.getUserOauthAccessToken('user_deadbeef', 'oauth_google');
+
+      assert.equal(response[0].externalAccountId, 'eac_2dYS7stz9bgxQsSRvNqEAHhuxvW');
+      assert.equal(response[0].provider, 'oauth_google');
+      assert.equal(response[0].token, '<token>');
+      assert.deepEqual(response[0].scopes, ['email', 'profile']);
+
+      assert.ok(
+        fakeFetch.calledOnceWith('https://api.clerk.test/v1/users/user_deadbeef/oauth_access_tokens/oauth_google', {
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer deadbeef',
+            'Content-Type': 'application/json',
+            'User-Agent': '@clerk/backend@0.0.0-test',
+          },
+        }),
+      );
+    });
   });
 };

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -119,6 +119,7 @@ export interface InvitationJSON extends ClerkResourceJSON {
 }
 
 export interface OauthAccessTokenJSON {
+  external_account_id: string;
   object: typeof ObjectType.OauthAccessToken;
   token: string;
   provider: string;

--- a/packages/backend/src/api/resources/OauthAccessToken.ts
+++ b/packages/backend/src/api/resources/OauthAccessToken.ts
@@ -2,6 +2,7 @@ import type { OauthAccessTokenJSON } from './JSON';
 
 export class OauthAccessToken {
   constructor(
+    readonly externalAccountId: string,
     readonly provider: string,
     readonly token: string,
     readonly publicMetadata: Record<string, unknown> = {},
@@ -12,6 +13,7 @@ export class OauthAccessToken {
 
   static fromJSON(data: OauthAccessTokenJSON) {
     return new OauthAccessToken(
+      data.external_account_id,
       data.provider,
       data.token,
       data.public_metadata,


### PR DESCRIPTION
## Description

This change adds the `external_account_id` field to the OAuth access token response so that it is parity with the Backend API response.

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
