### PR TITLE
feat(clerk-js,localizations): Nav to `reset-password` if `needs_new_password`

### DIFF
--- a/.changeset/four-ties-yawn.md
+++ b/.changeset/four-ties-yawn.md
@@ -1,0 +1,6 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+---
+
+Navigate to reset-password from the password form if password_settings.enforce_on_sign_in is enabled and sign_in.needs_new_password is true.

--- a/.changeset/four-ties-yawn.md
+++ b/.changeset/four-ties-yawn.md
@@ -3,4 +3,6 @@
 '@clerk/clerk-js': minor
 ---
 
-Navigate to reset-password from the password form if password_settings.enforce_on_sign_in is enabled and sign_in.needs_new_password is true.
+During sign in, navigate to the `reset-password` route if the user needs a new password. This happens when you enforce password usage during sign-in in your dashboard. Previously this case wasn't handled in the password form.
+
+The `signIn.resetPassword.requiredMessage` localization was updated to `'For security reasons, it is required to reset your password.'`.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -71,6 +71,8 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
             return setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignIn });
           case 'needs_second_factor':
             return navigate('../factor-two');
+          case 'needs_new_password':
+            return navigate('../reset-password');
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -148,7 +148,7 @@ describe('ResetPassword', () => {
       } as SignInResource);
       const { userEvent } = render(<ResetPassword />, { wrapper });
 
-      expect(screen.queryByText(/account already exists/i)).toBeInTheDocument();
+      expect(screen.queryByText('For security reasons, it is required to reset your password.')).toBeInTheDocument();
       expect(screen.queryByRole('checkbox', { name: /sign out of all other devices/i })).not.toBeInTheDocument();
       await userEvent.type(screen.getByLabelText(/New password/i), 'testtest');
       await userEvent.type(screen.getByLabelText(/Confirm password/i), 'testtest');

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -227,6 +227,29 @@ describe('SignInFactorOne', () => {
           });
         });
       });
+
+      it('redirects to `reset-password` if signIn requires a new password', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPassword();
+          f.withPreferredSignInStrategy({ strategy: 'password' });
+          f.startSignInWithPhoneNumber({ supportPassword: true });
+        });
+        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+        fixtures.signIn.attemptFirstFactor.mockReturnValueOnce(
+          Promise.resolve({ status: 'needs_new_password' } as SignInResource),
+        );
+
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText('Password'), '123456');
+          await userEvent.click(screen.getByText('Continue'));
+          await waitFor(() => {
+            expect(fixtures.router.navigate).toHaveBeenCalledWith('../reset-password');
+          });
+        });
+      });
     });
 
     describe('Forgot Password', () => {

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -370,8 +370,7 @@ export const csCZ: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Obnovit heslo',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Vaše heslo bylo úspěšně změněno. Přihlašuji vás, prosím počkejte okamžik.',
       title: 'Obnovit heslo',
     },

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -371,8 +371,7 @@ export const daDK: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -360,8 +360,7 @@ export const enUS: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -372,8 +372,7 @@ export const esES: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -372,8 +372,7 @@ export const esMX: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -372,8 +372,7 @@ export const frFR: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Réinitialiser',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage:
         'Votre mot de passe a été modifié avec succès. Nous vous reconnectons, veuillez patienter un instant.',
       title: 'Réinitialiser le mot de passe',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -368,8 +368,7 @@ export const heIL: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'אפס סיסמה',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'הסיסמה שלך שונתה בהצלחה. מחבר אותך, אנא המתן רגע.',
       title: 'אפס סיסמה',
     },

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -371,8 +371,7 @@ export const itIT: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -368,8 +368,7 @@ export const koKR: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: '비밀번호 재설정',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: '비밀번호가 성공적으로 변경되었습니다. 로그인하는 중입니다. 잠시만 기다려주세요.',
       title: '비밀번호 재설정',
     },

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -371,8 +371,7 @@ export const nlNL: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -371,8 +371,7 @@ export const plPL: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -371,8 +371,7 @@ export const ptBR: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Redefinir Senha',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Sua senha foi alterada com sucesso. Entrando, por favor aguarde um momento.',
       title: 'Redefinir Senha',
     },

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -371,8 +371,7 @@ export const ptPT: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Repor Palavra-passe',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'A sua palavra-passe foi alterada com sucesso. Entrando, por favor aguarde um momento.',
       title: 'Repor Palavra-passe',
     },

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -375,8 +375,7 @@ export const ruRU: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Сбросить пароль',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Ваш пароль успешно изменен. Выполняется вход, подождите.',
       title: 'Сбросить пароль',
     },

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -371,8 +371,7 @@ export const skSK: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Obnoviť heslo',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Vaše heslo bolo úspešne zmenené. Prihlasujem vás, prosím počkajte okamžite.',
       title: 'Obnoviť heslo',
     },

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -371,8 +371,7 @@ export const svSE: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Reset Password',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
       title: 'Set new password',
     },

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -371,8 +371,7 @@ export const trTR: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Şifremi sıfırla',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Şifreniz başarıyla sıfırlandı. Oturumunuz açılıyor...',
       title: 'Şifre sıfırlama',
     },

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -371,8 +371,7 @@ export const ukUA: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Скинути пароль',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Ваш пароль успішно змінено. Виконується вхід, зачекайте.',
       title: 'Скинути пароль',
     },

--- a/packages/localizations/src/utils/enUS_v4.ts
+++ b/packages/localizations/src/utils/enUS_v4.ts
@@ -165,8 +165,7 @@ export const enUS_v4: any = {
       title: 'Reset Password',
       formButtonPrimary: 'Reset Password',
       successMessage: 'Your password was successfully changed. Signing you in, please wait a moment.',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
     },
     resetPasswordMfa: {
       detailsLabel: 'We need to verify your identity before resetting your password.',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -371,8 +371,7 @@ export const viVN: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Đặt lại mật khẩu',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: 'Mật khẩu của bạn đã được thay đổi thành công. Đang đăng nhập, vui lòng chờ một chút.',
       title: 'Đặt lại mật khẩu',
     },

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -368,8 +368,7 @@ export const zhCN: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: '重置密码',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: '您的密码已成功更改。正在为您登录，请稍等。',
       title: '重置密码',
     },

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -368,8 +368,7 @@ export const zhTW: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: '重設密碼',
-      requiredMessage:
-        'An account already exists with an unverified email address. Please reset your password for security.',
+      requiredMessage: 'For security reasons, it is required to reset your password.',
       successMessage: '您的密碼已成功更改。正在為您登錄，請稍等。',
       title: '重設密碼',
     },


### PR DESCRIPTION
## Description

If password_settings.enforce_on_sign_in is true, then it will be possible for a password sign-in to succeed but require a new password that conforms to updated password requirements.

Hence, if sign_in.needs_new_password is true, the password form will navigate to reset-password.

Since we are reusing a flow initially created for resetting passwords after an oauth flow, the error message has been made more generic.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
