### PR TITLE
fix(clerk-js): Disable emailAdress field in SignUp if `fields.emailAddress.disabled` is true

### DIFF
--- a/.changeset/loud-pianos-compete.md
+++ b/.changeset/loud-pianos-compete.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Disable emailAdress field in SignUp if fields.emailAddress.disabled is true

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -74,6 +74,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
               {...formState.emailAddress.props}
               isRequired={fields.emailAddress!.required}
               isOptional={!fields.emailAddress!.required}
+              isDisabled={fields.emailAddress!.disabled}
               actionLabel={canToggleEmailPhone ? 'Use phone instead' : undefined}
               onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
             />


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

### BEFORE
![Screenshot 2024-03-13 at 2 04 07 PM](https://github.com/clerk/javascript/assets/14893769/ecd89aff-d904-438e-9f63-58c2272fa416)

###
![Screenshot 2024-03-13 at 2 03 31 PM](https://github.com/clerk/javascript/assets/14893769/b651ee63-1b11-45b4-924e-cb101fa5d854)


