### PR TITLE
chore(clerk-js): Fix issue where checkbox styling seems broken

### DIFF
--- a/.changeset/forty-cows-attend.md
+++ b/.changeset/forty-cows-attend.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix checkbox styling issues

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -25,7 +25,7 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     [mqu.ios]: {
       fontSize: theme.fontSizes.$lg,
       '&:not([type="checkbox"]):not([type="radio"])': {
-        appearance: 'none',
+        WebkitAppearance: 'none',
       },
     },
     ':autofill': {

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -24,8 +24,8 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     // This is a workaround to prevent zooming on iOS when focusing an input
     [mqu.ios]: {
       fontSize: theme.fontSizes.$lg,
-      'input:not([type="checkbox"]):not([type="radio"])': {
-        WebkitAppearance: 'none',
+      '&:not([type="checkbox"]):not([type="radio"])': {
+        appearance: 'none',
       },
     },
     ':autofill': {

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -24,9 +24,10 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     // This is a workaround to prevent zooming on iOS when focusing an input
     [mqu.ios]: {
       fontSize: theme.fontSizes.$lg,
+      'input:not([type="checkbox"]):not([type="radio"])': {
+        WebkitAppearance: 'none',
+      },
     },
-    // This is a fix for iOS webkit on iOS below 16, where the input is not respecting the box-shadow
-    WebkitAppearance: 'none',
     ':autofill': {
       animationName: 'onAutoFillStart',
     },


### PR DESCRIPTION
## Description

This PR fixes a styling issue for checkboxes, where it appears that the checkbox is not working at all when clicked, the issue is caused by another fix we applied couple days ago to fix some other issues with inputs on iOS =< 16

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
