### PR TITLE
fix(clerk-js): Fix button font size for alternative methods on <SignIn/>

### DIFF
--- a/.changeset/great-seals-punch.md
+++ b/.changeset/great-seals-punch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix font size inconsistencies when selecting method to sign in.

--- a/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
@@ -88,6 +88,7 @@ const AlternativeMethodsList = (props: AlternativeMethodListProps) => {
                       textElementDescriptor={descriptors.alternativeMethodsBlockButtonText}
                       arrowElementDescriptor={descriptors.alternativeMethodsBlockButtonArrow}
                       key={i}
+                      textVariant='buttonLarge'
                       isDisabled={card.isLoading}
                       onClick={() => onFactorSelected(factor)}
                     />

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -22,6 +22,7 @@ type ArrowBlockButtonProps = PropsOfComponent<typeof Button> & {
   spinnerElementDescriptor?: ElementDescriptor;
   spinnerElementId?: ElementId;
   textLocalizationKey?: LocalizationKey | string;
+  textVariant?: PropsOfComponent<typeof Text>['variant'];
 };
 
 export const ArrowBlockButton = React.forwardRef<HTMLButtonElement, ArrowBlockButtonProps>((props, ref) => {
@@ -43,6 +44,7 @@ export const ArrowBlockButton = React.forwardRef<HTMLButtonElement, ArrowBlockBu
     textLocalizationKey,
     childrenSx,
     badge,
+    textVariant = 'buttonSmall',
     ...rest
   } = props;
 
@@ -116,7 +118,7 @@ export const ArrowBlockButton = React.forwardRef<HTMLButtonElement, ArrowBlockBu
           elementId={textElementId}
           as='span'
           truncate
-          variant='buttonSmall'
+          variant={textVariant}
           localizationKey={textLocalizationKey}
         >
           {children}


### PR DESCRIPTION
## Description

## Before
![CleanShot 2024-03-14 at 17 14 10@2x](https://github.com/clerk/javascript/assets/6823226/356770ff-5239-426f-8c4a-9f2a11742f95)

## After
![CleanShot 2024-03-14 at 17 13 44@2x](https://github.com/clerk/javascript/assets/6823226/00450a3e-70be-41db-ba1f-f554d1c512fd)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
