### PR TITLE
fix(clerk-js): Define priority for strategy passkey when user is missing that first factor

### DIFF
--- a/.changeset/odd-rats-smash.md
+++ b/.changeset/odd-rats-smash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix: fallback to other first factors when preferred strategy is passkey but the user has not registered a passkey yet.

--- a/packages/clerk-js/src/ui/components/SignIn/utils.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/utils.ts
@@ -1,6 +1,7 @@
 import { titleize } from '@clerk/shared';
 import type { PreferredSignInStrategy, SignInFactor, SignInResource, SignInStrategy } from '@clerk/types';
 
+import { isWebAuthnSupported } from '../../../utils/passkeys';
 import { PREFERRED_SIGN_IN_STRATEGIES } from '../../common/constants';
 import { otpPrefFactorComparator, passwordPrefFactorComparator } from '../../utils/factorSorting';
 
@@ -55,6 +56,22 @@ const factorForIdentifier = (i: string | null) => (f: SignInFactor) => {
   return 'safeIdentifier' in f && f.safeIdentifier === i;
 };
 
+function determineStrategyWhenPasskeyIsPreferred(
+  factors: SignInFactor[],
+  identifier: string | null,
+): SignInFactor | null {
+  if (isWebAuthnSupported()) {
+    // @ts-ignore
+    const passkeyFactor = factors.find(({ strategy }) => strategy === 'passkey');
+
+    if (passkeyFactor) {
+      return passkeyFactor;
+    }
+  }
+
+  return determineStrategyWhenOTPIsPreferred(factors, identifier);
+}
+
 function determineStrategyWhenPasswordIsPreferred(
   factors: SignInFactor[],
   identifier: string | null,
@@ -90,10 +107,8 @@ export function determineStartingSignInFactor(
     return null;
   }
 
-  //TODO: Create proper function like `determineStrategyWhenOTPIsPreferred`
   if (preferredSignInStrategy === PREFERRED_SIGN_IN_STRATEGIES.Passkey) {
-    // @ts-ignore
-    return firstFactors.find(f => f.strategy === PREFERRED_SIGN_IN_STRATEGIES.Passkey);
+    return determineStrategyWhenPasskeyIsPreferred(firstFactors, identifier);
   }
   return preferredSignInStrategy === PREFERRED_SIGN_IN_STRATEGIES.Password
     ? determineStrategyWhenPasswordIsPreferred(firstFactors, identifier)


### PR DESCRIPTION
## Description

Previously a readable UI error would appear to users. 

Now we treat them a "passwordless" attempt to sign in so we display the otp factors first.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
