### PR TITLE
feat(clerk-js,localizations,shared,types): Prompt user to reset pwned…

### DIFF
--- a/.changeset/flat-geese-applaud.md
+++ b/.changeset/flat-geese-applaud.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/types': minor
+---
+
+Support for prompting a user to reset their password if it is found to be compromised during sign-in.

--- a/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
@@ -12,11 +12,13 @@ import { SignInSocialButtons } from './SignInSocialButtons';
 import { useResetPasswordFactor } from './useResetPasswordFactor';
 import { withHavingTrouble } from './withHavingTrouble';
 
+type AlternativeMethodsMode = 'forgot' | 'pwned' | 'default';
+
 export type AlternativeMethodsProps = {
   onBackLinkClick: React.MouseEventHandler | undefined;
   onFactorSelected: (factor: SignInFactor) => void;
   currentFactor: SignInFactor | undefined | null;
-  asForgotPassword?: boolean;
+  mode?: AlternativeMethodsMode;
 };
 
 export type AlternativeMethodListProps = AlternativeMethodsProps & { onHavingTroubleClick: React.MouseEventHandler };
@@ -28,26 +30,24 @@ export const AlternativeMethods = (props: AlternativeMethodsProps) => {
 };
 
 const AlternativeMethodsList = (props: AlternativeMethodListProps) => {
-  const { onBackLinkClick, onHavingTroubleClick, onFactorSelected, asForgotPassword = false } = props;
+  const { onBackLinkClick, onHavingTroubleClick, onFactorSelected, mode = 'default' } = props;
   const card = useCardState();
   const resetPasswordFactor = useResetPasswordFactor();
   const { firstPartyFactors, hasAnyStrategy } = useAlternativeStrategies({
     filterOutFactor: props?.currentFactor,
   });
 
+  const flowPart = determineFlowPart(mode);
+  const cardTitleKey = determineTitle(mode);
+  const isReset = determineIsReset(mode);
+
   return (
-    <Flow.Part part={asForgotPassword ? 'forgotPasswordMethods' : 'alternativeMethods'}>
+    <Flow.Part part={flowPart}>
       <Card.Root>
         <Card.Content>
           <Header.Root showLogo>
-            <Header.Title
-              localizationKey={localizationKeys(
-                asForgotPassword ? 'signIn.forgotPasswordAlternativeMethods.title' : 'signIn.alternativeMethods.title',
-              )}
-            />
-            {!asForgotPassword && (
-              <Header.Subtitle localizationKey={localizationKeys('signIn.alternativeMethods.subtitle')} />
-            )}
+            <Header.Title localizationKey={cardTitleKey} />
+            {!isReset && <Header.Subtitle localizationKey={localizationKeys('signIn.alternativeMethods.subtitle')} />}
           </Header.Root>
           <Card.Alert>{card.error}</Card.Alert>
           {/*TODO: extract main in its own component */}
@@ -56,15 +56,18 @@ const AlternativeMethodsList = (props: AlternativeMethodListProps) => {
             elementDescriptor={descriptors.main}
             gap={6}
           >
-            {asForgotPassword && resetPasswordFactor && (
+            {isReset && resetPasswordFactor && (
               <Button
                 localizationKey={getButtonLabel(resetPasswordFactor)}
                 elementDescriptor={descriptors.alternativeMethodsBlockButton}
                 isDisabled={card.isLoading}
-                onClick={() => onFactorSelected(resetPasswordFactor)}
+                onClick={() => {
+                  card.setError(undefined);
+                  onFactorSelected(resetPasswordFactor);
+                }}
               />
             )}
-            {asForgotPassword && hasAnyStrategy && (
+            {isReset && hasAnyStrategy && (
               <Divider
                 dividerText={localizationKeys('signIn.forgotPasswordAlternativeMethods.label__alternativeMethods')}
               />
@@ -90,7 +93,10 @@ const AlternativeMethodsList = (props: AlternativeMethodListProps) => {
                       key={i}
                       textVariant='buttonLarge'
                       isDisabled={card.isLoading}
-                      onClick={() => onFactorSelected(factor)}
+                      onClick={() => {
+                        card.setError(undefined);
+                        onFactorSelected(factor);
+                      }}
                     />
                   ))}
                 </Flex>
@@ -160,4 +166,36 @@ export function getButtonIcon(factor: SignInFactor) {
   } as const;
 
   return icons[factor.strategy as keyof typeof icons];
+}
+
+function determineFlowPart(mode: AlternativeMethodsMode) {
+  switch (mode) {
+    case 'forgot':
+      return 'forgotPasswordMethods';
+    case 'pwned':
+      return 'passwordPwnedMethods';
+    default:
+      return 'alternativeMethods';
+  }
+}
+
+function determineTitle(mode: AlternativeMethodsMode): LocalizationKey {
+  switch (mode) {
+    case 'forgot':
+      return localizationKeys('signIn.forgotPasswordAlternativeMethods.title');
+    case 'pwned':
+      return localizationKeys('signIn.passwordPwned.title');
+    default:
+      return localizationKeys('signIn.alternativeMethods.title');
+  }
+}
+
+function determineIsReset(mode: AlternativeMethodsMode): boolean {
+  switch (mode) {
+    case 'forgot':
+    case 'pwned':
+      return true;
+    default:
+      return false;
+  }
 }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -1,4 +1,4 @@
-import { isUserLockedError } from '@clerk/shared/error';
+import { isPasswordPwnedError, isUserLockedError } from '@clerk/shared/error';
 import { useClerk } from '@clerk/shared/react';
 import type { ResetPasswordCodeFactor } from '@clerk/types';
 import React from 'react';
@@ -17,6 +17,7 @@ type SignInFactorOnePasswordProps = {
   onForgotPasswordMethodClick: React.MouseEventHandler | undefined;
   onShowAlternativeMethodsClick: React.MouseEventHandler | undefined;
   onFactorPrepare: (f: ResetPasswordCodeFactor) => void;
+  onPasswordPwned?: () => void;
 };
 
 const usePasswordControl = (props: SignInFactorOnePasswordProps) => {
@@ -45,7 +46,7 @@ const usePasswordControl = (props: SignInFactorOnePasswordProps) => {
 };
 
 export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps) => {
-  const { onShowAlternativeMethodsClick } = props;
+  const { onShowAlternativeMethodsClick, onPasswordPwned } = props;
   const card = useCardState();
   const { setActive } = useClerk();
   const signIn = useCoreSignIn();
@@ -79,6 +80,12 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
         if (isUserLockedError(err)) {
           // @ts-expect-error -- private method for the time being
           return clerk.__internal_navigateWithError('..', err.errors[0]);
+        }
+
+        if (isPasswordPwnedError(err) && onPasswordPwned) {
+          card.setError({ ...err.errors[0], code: 'form_password_pwned__sign_in' });
+          onPasswordPwned();
+          return;
         }
 
         handleError(err, [passwordControl], card.setError);

--- a/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
@@ -25,6 +25,7 @@ type FlowMetadata = {
     | 'emailLinkStatus'
     | 'alternativeMethods'
     | 'forgotPasswordMethods'
+    | 'passwordPwnedMethods'
     | 'havingTrouble'
     | 'ssoCallback'
     | 'popover'

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const arSA: LocalizationResource = {
   locale: 'ar-SA',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'الرجوع',
   badge__default: 'الأفتراضي',
   badge__otherImpersonatorDevice: 'جهاز منتحل آخر',
@@ -279,6 +280,7 @@ export const arSA: LocalizationResource = {
       blockButton__backupCode: 'استخدم رمز النسخ الاحتياطي',
       blockButton__emailCode: 'رمز البريد الإلكتروني ل  {{identifier}}',
       blockButton__emailLink: 'رابط البريد الإلكتروني ل {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'تسجيل الدخول بكلمة السر الخاصة بك',
       blockButton__phoneCode: 'أرسال رسالة نصية ل{{identifier}}',
       blockButton__totp: 'استخدم تطبيق المصادقة الخاص بك',
@@ -350,10 +352,17 @@ export const arSA: LocalizationResource = {
       subtitle: 'حدث خطأ',
       title: 'لا يمكن تسجيل الدخول',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'أستعمل طريقة أخرى',
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'ادخل كلمة المرور',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'رمز التحقق',
@@ -381,6 +390,7 @@ export const arSA: LocalizationResource = {
       actionLink: 'إنشاء حساب جديد',
       actionLink__use_email: 'استخدم البريد الإلكتروني',
       actionLink__use_email_username: 'استخدم البريد الإلكتروني أو اسم المستخدم',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'استخدم رقم الجوال',
       actionLink__use_username: 'استخدم اسم المستخدم',
       actionText: 'ليس لديك حساب؟',
@@ -460,6 +470,7 @@ export const arSA: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'كلمة المرور ليست قوية',
     form_password_pwned: 'لا يمكن أستعمال كلمة السر هذه لانها غير أمنة, الرجاء اختيار كلمة مرور أخرى',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'تجاوزت كلمة المرور الحد الأقصى للحروف المدخلة, الرجاء أدخال كلمة مرور أقصر أو حذف بعض الأحرف الخاصة',
     form_password_validation_failed: 'كلمة مرور خاطئة',
@@ -467,6 +478,11 @@ export const arSA: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'لا يمكن حذف هويتك الآخيرة ',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'أقل من {{length}} حروف',
       minimumLength: '{{length}} حروف أو أكثر',
@@ -524,6 +540,14 @@ export const arSA: LocalizationResource = {
     action__signOutAll: 'تسجيل الخروج من جميع الحسابات',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'تم النسخ',
       actionLabel__copy: 'نسخ الكل',
@@ -675,6 +699,11 @@ export const arSA: LocalizationResource = {
       title: 'تحديث الملف الشخصي',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'قم بتسجيل الخروج من الجهاز',
         title: 'الأجهزة النشطة',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const bgBG: LocalizationResource = {
   locale: 'bg-BG',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Назад',
   badge__default: 'По подразбиране',
   badge__otherImpersonatorDevice: 'Друго устройство за имитация',
@@ -282,6 +283,7 @@ export const bgBG: LocalizationResource = {
       blockButton__backupCode: 'Използвай резервен код',
       blockButton__emailCode: 'Изпрати код по имейл до {{identifier}}',
       blockButton__emailLink: 'Изпрати линк по имейл до {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Влез с парола',
       blockButton__phoneCode: 'Изпрати SMS код до {{identifier}}',
       blockButton__totp: 'Използвай приложение за удостоверяване',
@@ -353,10 +355,17 @@ export const bgBG: LocalizationResource = {
       subtitle: 'Възникна грешка',
       title: 'Неуспешно влизане',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Използвайте друг метод',
       subtitle: 'Въведете паролата, свързана с вашия акаунт',
       title: 'Въведете вашата парола',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Код за потвърждение',
@@ -383,6 +392,7 @@ export const bgBG: LocalizationResource = {
       actionLink: 'Регистрирайте се',
       actionLink__use_email: 'Използвайте имейл',
       actionLink__use_email_username: 'Използвайте имейл или потребителско име',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Използвайте телефон',
       actionLink__use_username: 'Използвайте потребителско име',
       actionText: 'Нямате акаунт?',
@@ -463,6 +473,7 @@ export const bgBG: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Вашата парола не е достатъчно сигурна.',
     form_password_pwned: 'Тази парола е част от изтекли данни и не може да се използва. Моля, опитайте с друга парола.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Паролата ви надвиши максималния брой байтове, позволен, моля, я скратете или премахнете някои специални знаци.',
     form_password_validation_failed: 'Неправилна парола',
@@ -470,6 +481,11 @@ export const bgBG: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Не можете да изтриете последната си идентификация.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'по-малко от {{length}} символа',
       minimumLength: '{{length}} или повече символа',
@@ -527,6 +543,14 @@ export const bgBG: LocalizationResource = {
     action__signOutAll: 'Изход от всички акаунти',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Копирано!',
       actionLabel__copy: 'Копиране на всички',
@@ -684,6 +708,11 @@ export const bgBG: LocalizationResource = {
       title: 'Актуализиране на профила',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Излез от устройството',
         title: 'Активни устройства',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const csCZ: LocalizationResource = {
   locale: 'cs-CZ',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Zpět',
   badge__default: 'Výchozí',
   badge__otherImpersonatorDevice: 'Jiné zařízení představitele',
@@ -280,6 +281,7 @@ export const csCZ: LocalizationResource = {
       blockButton__backupCode: 'Použít záložní kód',
       blockButton__emailCode: 'Odeslat ověřovací kód na email {{identifier}}',
       blockButton__emailLink: 'Odeslat odkaz na email {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Přihlásit se pomocí hesla',
       blockButton__phoneCode: 'Poslat SMS kód na telefonní číslo {{identifier}}',
       blockButton__totp: 'Použít autentizační aplikaci',
@@ -351,10 +353,17 @@ export const csCZ: LocalizationResource = {
       subtitle: 'Došlo k chybě',
       title: 'Nelze se přihlásit',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Použít jinou metodu',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Zadejte své heslo',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Ověřovací kód',
@@ -381,6 +390,7 @@ export const csCZ: LocalizationResource = {
       actionLink: 'Registrovat se',
       actionLink__use_email: 'Použít email',
       actionLink__use_email_username: 'Použít email nebo uživatelské jméno',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Použít telefon',
       actionLink__use_username: 'Použít uživatelské jméno',
       actionText: 'Nemáte účet?',
@@ -460,6 +470,7 @@ export const csCZ: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Vaše heslo není dostatečně silné.',
     form_password_pwned: 'Toto heslo bylo nalezeno v rámci uniku dat a nemůže být použito, prosím zvolte jiné heslo.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Vaše heslo překročilo maximální povolený počet bytů, prosím zkrátit ho nebo odstranit některé speciální znaky.',
     form_password_validation_failed: 'Nesprávné heslo',
@@ -467,6 +478,11 @@ export const csCZ: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'méně než {{length}} znaků',
       minimumLength: '{{length}} nebo více znaků',
@@ -524,6 +540,14 @@ export const csCZ: LocalizationResource = {
     action__signOutAll: 'Odhlásit se ze všech účtů',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Zkopírováno!',
       actionLabel__copy: 'Zkopírovat vše',
@@ -679,6 +703,11 @@ export const csCZ: LocalizationResource = {
       title: 'Aktualizovat profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Odhlásit se z zařízení',
         title: 'Aktivní zařízení',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const daDK: LocalizationResource = {
   locale: 'da-DK',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Tilbage',
   badge__default: 'Standard',
   badge__otherImpersonatorDevice: '',
@@ -281,6 +282,7 @@ export const daDK: LocalizationResource = {
       blockButton__backupCode: 'Brug en backup-kode',
       blockButton__emailCode: 'Send kode til {{identifier}}',
       blockButton__emailLink: 'Send link til {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Log ind med din adgangskode',
       blockButton__phoneCode: 'Send kode til {{identifier}}',
       blockButton__totp: 'Brug din godkendelsesapp',
@@ -352,10 +354,17 @@ export const daDK: LocalizationResource = {
       subtitle: 'En fejl opstod',
       title: 'Kan ikke logge ind',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Brug en anden metode',
       subtitle: 'Fortsæt til {{applicationName}}',
       title: 'Indtast din adgangskode',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Bekræftelseskode',
@@ -382,6 +391,7 @@ export const daDK: LocalizationResource = {
       actionLink: 'Tilmeld dig',
       actionLink__use_email: 'Brug email',
       actionLink__use_email_username: 'Brug email eller brugernavn',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Brug telefon',
       actionLink__use_username: 'Brug brugenravn',
       actionText: 'Ingen konto?',
@@ -461,6 +471,7 @@ export const daDK: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -468,6 +479,11 @@ export const daDK: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'less than {{length}} characters',
       minimumLength: '{{length}} or more characters',
@@ -525,6 +541,14 @@ export const daDK: LocalizationResource = {
     action__signOutAll: 'Log ud af alle konti',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Kopieret!',
       actionLabel__copy: 'Kopier alle',
@@ -680,6 +704,11 @@ export const daDK: LocalizationResource = {
       title: '',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Log ud af enhed',
         title: 'Aktive enheder',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const deDE: LocalizationResource = {
   locale: 'de-DE',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Zurück',
   badge__default: 'Standard',
   badge__otherImpersonatorDevice: 'Anderes Imitationsgerät',
@@ -285,6 +286,7 @@ export const deDE: LocalizationResource = {
       blockButton__backupCode: 'Verwenden Sie einen Backup-Code',
       blockButton__emailCode: 'Code an {{identifier}} senden',
       blockButton__emailLink: 'Link senden an {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Melden Sie sich mit Ihrem Passwort an',
       blockButton__phoneCode: 'Code an {{identifier}} senden',
       blockButton__totp: 'Verwenden Sie Ihre Authentifizierungs-App',
@@ -356,10 +358,17 @@ export const deDE: LocalizationResource = {
       subtitle: 'Ein Fehler ist aufgetreten',
       title: 'Anmeldung nicht möglich',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Verwenden Sie eine andere Methode',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Geben Sie Ihr Passwort ein',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Bestätigungscode',
@@ -387,6 +396,7 @@ export const deDE: LocalizationResource = {
       actionLink: 'Anmelden',
       actionLink__use_email: 'E-mail nutzen',
       actionLink__use_email_username: 'E-mail oder Benutzernamen nutzen',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Mobiltelefon nutzen',
       actionLink__use_username: 'Benutzername nutzen',
       actionText: 'Kein Account?',
@@ -467,6 +477,7 @@ export const deDE: LocalizationResource = {
     form_password_not_strong_enough: 'Passwort nicht stark genug',
     form_password_pwned:
       'Das gewählte Passwort wurde durch eine Datenpanne im Internet offengelegt. Wählen Sie aus Sicherheitsgründen bitte ein anderes Passwort',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Das Passwort hat die maximale Anzahl an Bytes überschritten. Bitte kürzen oder Sonderzeichen entfernen.',
     form_password_validation_failed: 'Falsches Passwort',
@@ -474,6 +485,11 @@ export const deDE: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: '',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'weniger als {{length}} Zeichen lang sein',
       minimumLength: 'mindestens {{length}} Zeichen lang sein',
@@ -532,6 +548,14 @@ export const deDE: LocalizationResource = {
     action__signOutAll: 'Melden Sie sich von allen Konten ab',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Kopiert!',
       actionLabel__copy: 'Kopiere alle',
@@ -690,6 +714,11 @@ export const deDE: LocalizationResource = {
       title: 'Profil aktualisieren',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Vom Gerät abmelden',
         title: 'Aktive Geräte',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const elGR: LocalizationResource = {
   locale: 'el-GR',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Πίσω',
   badge__default: 'Προεπιλογή',
   badge__otherImpersonatorDevice: 'Άλλη συσκευή υποδυόμενου',
@@ -282,6 +283,7 @@ export const elGR: LocalizationResource = {
       blockButton__backupCode: 'Χρήση ενός εφεδρικού κωδικού',
       blockButton__emailCode: 'Αποστολή κωδικού με email στο {{identifier}}',
       blockButton__emailLink: 'Αποστολή συνδέσμου στο {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Σύνδεση με τον κωδικό πρόσβασής σας',
       blockButton__phoneCode: 'Αποστολή κωδικού SMS στο {{identifier}}',
       blockButton__totp: 'Χρήση της εφαρμογής αυθεντικοποίησης',
@@ -353,10 +355,17 @@ export const elGR: LocalizationResource = {
       subtitle: 'Προέκυψε σφάλμα',
       title: 'Δεν είναι δυνατή η σύνδεση',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Χρήση άλλης μεθόδου',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Εισαγωγή κωδικού πρόσβασης',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Κωδικός επαλήθευσης',
@@ -384,6 +393,7 @@ export const elGR: LocalizationResource = {
       actionLink: 'Εγγραφή',
       actionLink__use_email: 'Χρήση email',
       actionLink__use_email_username: 'Χρήση email ή ονόματος χρήστη',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Χρήση τηλεφώνου',
       actionLink__use_username: 'Χρήση ονόματος χρήστη',
       actionText: 'Δεν έχετε λογαριασμό;',
@@ -464,6 +474,7 @@ export const elGR: LocalizationResource = {
     form_password_not_strong_enough: 'Ο κωδικός πρόσβασής σας δεν είναι αρκετά ισχυρός.',
     form_password_pwned:
       'Αυτός ο κωδικός πρόσβασης έχει διαρρεύσει online στο παρελθόν και δεν μπορεί να χρησιμοποιηθεί. Δοκιμάστε έναν άλλο κωδικό πρόσβασης αντί για αυτόν.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Ο κωδικός πρόσβασής σας έχει υπερβεί το μέγιστο αριθμό bytes που επιτρέπεται. Παρακαλούμε, συντομεύστε τον ή αφαιρέστε μερικούς ειδικούς χαρακτήρες.',
     form_password_validation_failed: 'Λανθασμένος κωδικός',
@@ -471,6 +482,11 @@ export const elGR: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Δεν μπορείτε να διαγράψετε το τελευταίο στοιχείο ταυτοποιησής σας.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'λιγότερους από {{length}} χαρακτήρες',
       minimumLength: '{{length}} ή περισσότερους χαρακτήρες',
@@ -531,6 +547,14 @@ export const elGR: LocalizationResource = {
     action__signOutAll: 'Αποσύνδεση από όλους τους λογαριασμούς',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Αντιγράφηκαν!',
       actionLabel__copy: 'Αντιγραφή όλων',
@@ -690,6 +714,11 @@ export const elGR: LocalizationResource = {
       title: 'Ενημέρωση προφίλ',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Αποσύνδεση από τη συσκευή',
         title: 'Ενεργές συσκευές',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -2,6 +2,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const enUS: LocalizationResource = {
   locale: 'en-US',
+  __experimental_formFieldLabel__passkeyName: 'Name of passkey',
   backButton: 'Back',
   badge__default: 'Default',
   badge__otherImpersonatorDevice: 'Other impersonator device',
@@ -76,7 +77,6 @@ export const enUS: LocalizationResource = {
   formFieldLabel__role: 'Role',
   formFieldLabel__signOutOfOtherSessions: 'Sign out of all other devices',
   formFieldLabel__username: 'Username',
-  __experimental_formFieldLabel__passkeyName: 'Name of passkey',
   impersonationFab: {
     action__signOut: 'Sign out',
     title: 'Signed in as {{identifier}}',
@@ -270,8 +270,8 @@ export const enUS: LocalizationResource = {
       blockButton__backupCode: 'Use a backup code',
       blockButton__emailCode: 'Email code to {{identifier}}',
       blockButton__emailLink: 'Email link to {{identifier}}',
-      blockButton__password: 'Sign in with your password',
       blockButton__passkey: 'Sign in with your passkey',
+      blockButton__password: 'Sign in with your password',
       blockButton__phoneCode: 'Send SMS code to {{identifier}}',
       blockButton__totp: 'Use your authenticator app',
       getHelp: {
@@ -342,14 +342,17 @@ export const enUS: LocalizationResource = {
       subtitle: 'An error occurred',
       title: 'Cannot sign in',
     },
+    passkey: {
+      subtitle: "Using your passkey confirms it's you. Your device may ask for your fingerprint, face or screen lock.",
+      title: 'Use your passkey',
+    },
     password: {
       actionLink: 'Use another method',
       subtitle: 'Enter the password associated with your account',
       title: 'Enter your password',
     },
-    passkey: {
-      title: 'Use your passkey',
-      subtitle: "Using your passkey confirms it's you. Your device may ask for your fingerprint, face or screen lock.",
+    passwordPwned: {
+      title: 'Password compromised',
     },
     phoneCode: {
       formTitle: 'Verification code',
@@ -442,11 +445,6 @@ export const enUS: LocalizationResource = {
       'Sign up unsuccessful due to failed security validations. Please refresh the page to try again or reach out to support for more assistance.',
     captcha_unavailable:
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
-    passkey_not_supported: 'Passkeys are not supported on this device.',
-    passkeys_pa_not_supported: 'Registration requires a platform authenticator but the device does not support it.',
-    passkey_retrieval_cancelled: 'Passkey verification was cancelled or timed out.',
-    passkey_registration_cancelled: 'Passkey registration was cancelled or timed out.',
-    passkey_already_exists: 'A passkey is already registered with this device.',
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_not_found: '',
@@ -462,6 +460,8 @@ export const enUS: LocalizationResource = {
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned:
       'This password has been found as part of a breach and can not be used, please try another password instead.',
+    form_password_pwned__sign_in:
+      'This password has been found as part of a breach and can not be used, please reset your password.',
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -469,6 +469,11 @@ export const enUS: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: 'A passkey is already registered with this device.',
+    passkey_not_supported: 'Passkeys are not supported on this device.',
+    passkey_registration_cancelled: 'Passkey registration was cancelled or timed out.',
+    passkey_retrieval_cancelled: 'Passkey verification was cancelled or timed out.',
+    passkeys_pa_not_supported: 'Registration requires a platform authenticator but the device does not support it.',
     passwordComplexity: {
       maximumLength: 'less than {{length}} characters',
       minimumLength: '{{length}} or more characters',
@@ -526,6 +531,14 @@ export const enUS: LocalizationResource = {
     action__signOutAll: 'Sign out of all accounts',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: '{{name}} will be removed from this account.',
+        title: 'Remove passkey',
+      },
+      subtitle__rename: 'You can change the passkey name to make it easier to find.',
+      title__rename: 'Rename Passkey',
+    },
     backupCodePage: {
       actionLabel__copied: 'Copied!',
       actionLabel__copy: 'Copy all',
@@ -682,6 +695,11 @@ export const enUS: LocalizationResource = {
       title: 'Update profile',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: 'Remove',
+        menuAction__rename: 'Rename',
+        title: 'Passkeys',
+      },
       activeDevicesSection: {
         destructiveAction: 'Sign out of device',
         title: 'Active devices',
@@ -736,11 +754,6 @@ export const enUS: LocalizationResource = {
         primaryButton__updatePassword: 'Update password',
         title: 'Password',
       },
-      __experimental_passkeysSection: {
-        title: 'Passkeys',
-        menuAction__rename: 'Rename',
-        menuAction__destructive: 'Remove',
-      },
       phoneNumbersSection: {
         destructiveAction: 'Remove phone number',
         detailsAction__nonPrimary: 'Set as primary',
@@ -768,14 +781,6 @@ export const enUS: LocalizationResource = {
       successMessage: 'Your username has been updated.',
       title__set: 'Set username',
       title__update: 'Update username',
-    },
-    __experimental_passkeyScreen: {
-      title__rename: 'Rename Passkey',
-      subtitle__rename: 'You can change the passkey name to make it easier to find.',
-      removeResource: {
-        title: 'Remove passkey',
-        messageLine1: '{{name}} will be removed from this account.',
-      },
     },
     web3WalletPage: {
       removeResource: {

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const esES: LocalizationResource = {
   locale: 'es-ES',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Atrás',
   badge__default: 'Por defecto',
   badge__otherImpersonatorDevice: 'Otro dispositivo de imitación',
@@ -282,6 +283,7 @@ export const esES: LocalizationResource = {
       blockButton__backupCode: 'Usa un código de respaldo',
       blockButton__emailCode: 'Enviar código a{{identifier}}',
       blockButton__emailLink: 'Enviar enlace a{{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Entra con tu contraseña',
       blockButton__phoneCode: 'Enviar código a{{identifier}}',
       blockButton__totp: 'Usa tu aplicación de autenticación',
@@ -353,10 +355,17 @@ export const esES: LocalizationResource = {
       subtitle: 'Ocurrió un error',
       title: 'No puedo iniciar sesión',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Use otro método',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Introduzca su contraseña',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Código de verificación',
@@ -383,6 +392,7 @@ export const esES: LocalizationResource = {
       actionLink: 'Regístrese',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: '¿No tiene cuenta?',
@@ -462,6 +472,7 @@ export const esES: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -469,6 +480,11 @@ export const esES: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '',
       minimumLength: '',
@@ -526,6 +542,14 @@ export const esES: LocalizationResource = {
     action__signOutAll: 'Salir de todas las cuentas',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiado!',
       actionLabel__copy: 'Copiar todo',
@@ -683,6 +707,11 @@ export const esES: LocalizationResource = {
       title: 'Actualizar Cuenta',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Cerrar sesión en el dispositivo',
         title: 'Dispositivos activos',
@@ -697,8 +726,8 @@ export const esES: LocalizationResource = {
         title: 'Cuentas conectadas',
       },
       dangerSection: {
-        title: 'Eliminar cuenta',
         deleteAccountButton: 'Eliminar cuenta',
+        title: 'Eliminar cuenta',
       },
       emailAddressesSection: {
         destructiveAction: 'Eliminar dirección de correo electrónico',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const esMX: LocalizationResource = {
   locale: 'es-MX',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Atrás',
   badge__default: 'Por defecto',
   badge__otherImpersonatorDevice: 'Otro dispositivo de imitación',
@@ -282,6 +283,7 @@ export const esMX: LocalizationResource = {
       blockButton__backupCode: 'Usa un código de respaldo',
       blockButton__emailCode: 'Enviar código a{{identifier}}',
       blockButton__emailLink: 'Enviar enlace a{{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Entra con tu contraseña',
       blockButton__phoneCode: 'Enviar código a{{identifier}}',
       blockButton__totp: 'Usa tu aplicación de autenticación',
@@ -353,10 +355,17 @@ export const esMX: LocalizationResource = {
       subtitle: 'Ocurrió un error',
       title: 'No puedo iniciar sesión',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Use otro método',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Introduzca su contraseña',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Código de verificación',
@@ -383,6 +392,7 @@ export const esMX: LocalizationResource = {
       actionLink: 'Regístrese',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: '¿No tiene cuenta?',
@@ -463,6 +473,7 @@ export const esMX: LocalizationResource = {
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned:
       'Esta contraseña se encontró como parte de una infracción y no se puede usar; pruebe con otra contraseña.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -470,6 +481,11 @@ export const esMX: LocalizationResource = {
     form_username_invalid_length: 'Longitud de usuario muy corta.',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'less than {{length}} characters',
       minimumLength: '{{length}} o mas caracteres',
@@ -527,6 +543,14 @@ export const esMX: LocalizationResource = {
     action__signOutAll: 'Salir de todas las cuentas',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiado!',
       actionLabel__copy: 'Copiar todo',
@@ -684,6 +708,11 @@ export const esMX: LocalizationResource = {
       title: 'Actualizar Cuenta',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Cerrar sesión en el dispositivo',
         title: 'Dispositivos activos',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const frFR: LocalizationResource = {
   locale: 'fr-FR',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Retour',
   badge__default: 'Défaut',
   badge__otherImpersonatorDevice: "Autre dispositif d'imitation",
@@ -282,6 +283,7 @@ export const frFR: LocalizationResource = {
       blockButton__backupCode: 'Utiliser un code de récupération',
       blockButton__emailCode: 'Envoyer le code à {{identifier}}',
       blockButton__emailLink: 'Envoyer le lien à {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Connectez-vous avec votre mot de passe',
       blockButton__phoneCode: 'Envoyer le code à {{identifier}}',
       blockButton__totp: "Utilisez votre application d'authentification",
@@ -353,10 +355,17 @@ export const frFR: LocalizationResource = {
       subtitle: "Une erreur s'est produite",
       title: 'Impossible de se connecter',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Utiliser une autre méthode',
       subtitle: 'pour continuer à {{applicationName}}',
       title: 'Tapez votre mot de passe',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Code de vérification',
@@ -384,6 +393,7 @@ export const frFR: LocalizationResource = {
       actionLink: "S'inscrire",
       actionLink__use_email: 'Utiliser e-mail',
       actionLink__use_email_username: "Utiliser l'e-mail ou le nom d'utilisateur",
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Utiliser téléphone',
       actionLink__use_username: "Utiliser le nom d'utilisateur",
       actionText: "Vous n'avez pas encore de compte ?",
@@ -464,6 +474,7 @@ export const frFR: LocalizationResource = {
     form_password_not_strong_enough: "Votre mot de passe n'est pas assez fort.",
     form_password_pwned:
       'Ce mot de passe a été compromis et ne peut pas être utilisé. Veuillez essayer un autre mot de passe à la place.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       "Votre mot de passe a dépassé le nombre maximum d'octets autorisés. Veuillez le raccourcir ou supprimer certains caractères spéciaux.",
     form_password_validation_failed: 'Mot de passe incorrect',
@@ -471,6 +482,11 @@ export const frFR: LocalizationResource = {
     form_username_invalid_length: "Le nombre de caractères de l'identifiant est invalide.",
     identification_deletion_failed: 'Vous ne pouvez pas supprimer votre dernière identification.',
     not_allowed_access: 'Accès non autorisé',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'moins de {{length}} caractères',
       minimumLength: '{{length}} caractères ou plus',
@@ -529,6 +545,14 @@ export const frFR: LocalizationResource = {
     action__signOutAll: 'Se déconnecter de tous les comptes',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copié !',
       actionLabel__copy: 'Copier tous les codes',
@@ -686,6 +710,11 @@ export const frFR: LocalizationResource = {
       title: 'Mettre à jour le profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: "Se déconnecter de l'appareil",
         title: 'Appareils actifs',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const heIL: LocalizationResource = {
   locale: 'he-IL',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'חזור',
   badge__default: 'ברירת מחדל',
   badge__otherImpersonatorDevice: 'מכשיר מחקה אחר',
@@ -279,6 +280,7 @@ export const heIL: LocalizationResource = {
       blockButton__backupCode: 'השתמש בקוד גיבוי',
       blockButton__emailCode: 'שלח קוד באימייל ל-{{identifier}}',
       blockButton__emailLink: 'שלח קישור באימייל ל-{{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'התחבר עם הסיסמה שלך',
       blockButton__phoneCode: 'שלח קוד SMS ל-{{identifier}}',
       blockButton__totp: 'השתמש באפליקציית האימות שלך',
@@ -349,10 +351,17 @@ export const heIL: LocalizationResource = {
       subtitle: 'An error occurred',
       title: 'Cannot sign in',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'השתמש בשיטה אחרת',
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'הכנס את סיסמתך',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'קוד אימות',
@@ -379,6 +388,7 @@ export const heIL: LocalizationResource = {
       actionLink: 'הרשמה',
       actionLink__use_email: 'השתמש בדוא"ל',
       actionLink__use_email_username: 'השתמש בדוא"ל או שם משתמש',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'השתמש בטלפון',
       actionLink__use_username: 'השתמש בשם משתמש',
       actionText: 'אין לך חשבון?',
@@ -458,6 +468,7 @@ export const heIL: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'הסיסמה שלך אינה מספיק חזקה.',
     form_password_pwned: 'הסיסמה הזו נמצאה כחלק מהפרטים שנחשפו בהפרת נתונים ולא ניתן להשתמש בה, נסה סיסמה אחרת במקום.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'הסיסמה שלך חורגת ממספר הבייטים המרבי המותר, נסה לקצר אותה או להסיר כמה תווים מיוחדים.',
     form_password_validation_failed: 'סיסמה שגויה',
@@ -465,6 +476,11 @@ export const heIL: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'פחות מ-{{length}} תווים',
       minimumLength: '{{length}} תווים או יותר',
@@ -522,6 +538,14 @@ export const heIL: LocalizationResource = {
     action__signOutAll: 'התנתק מכל החשבונות',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'הועתק!',
       actionLabel__copy: 'העתק הכל',
@@ -670,6 +694,11 @@ export const heIL: LocalizationResource = {
       title: 'עדכן פרופיל',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'התנתק מהמכשיר',
         title: 'מכשירים פעילים',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const itIT: LocalizationResource = {
   locale: 'it-IT',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Indietro',
   badge__default: 'Predefinito',
   badge__otherImpersonatorDevice: 'Altro dispositivo impersonato',
@@ -281,6 +282,7 @@ export const itIT: LocalizationResource = {
       blockButton__backupCode: 'Usa in codice di backup',
       blockButton__emailCode: 'Invia codice a {{identifier}}',
       blockButton__emailLink: 'Invia link a {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Accedi con la tua password',
       blockButton__phoneCode: 'Invia codice a {{identifier}}',
       blockButton__totp: 'Usa la tua app di autenticazione',
@@ -352,10 +354,17 @@ export const itIT: LocalizationResource = {
       subtitle: 'Si é verificato un errore',
       title: 'Impossibile accedere',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Usa un altro metodo',
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Inserisci la tua password',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Codice di verifica',
@@ -382,6 +391,7 @@ export const itIT: LocalizationResource = {
       actionLink: 'Registrati',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: 'Non hai un account?',
@@ -461,6 +471,7 @@ export const itIT: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -468,6 +479,11 @@ export const itIT: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '',
       minimumLength: '',
@@ -525,6 +541,14 @@ export const itIT: LocalizationResource = {
     action__signOutAll: 'Disconnetti da tutti gli accounts',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiati!',
       actionLabel__copy: 'Copia tutti',
@@ -681,6 +705,11 @@ export const itIT: LocalizationResource = {
       title: 'Aggiorna profilo',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Disconnetti dal dispositivo',
         title: 'Dispositivi attivi',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const jaJP: LocalizationResource = {
   locale: 'ja-JP',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: '戻る',
   badge__default: 'デフォルト',
   badge__otherImpersonatorDevice: '他の模倣者デバイス',
@@ -282,6 +283,7 @@ export const jaJP: LocalizationResource = {
       blockButton__backupCode: 'バックアップコードを使用する',
       blockButton__emailCode: '{{identifier}}にメールコードを送信',
       blockButton__emailLink: '{{identifier}}にメールリンクを送信',
+      blockButton__passkey: undefined,
       blockButton__password: 'パスワードでサインインする',
       blockButton__phoneCode: '{{identifier}}にSMSコードを送信',
       blockButton__totp: '認証アプリを使用する',
@@ -353,10 +355,17 @@ export const jaJP: LocalizationResource = {
       subtitle: 'エラーが発生しました',
       title: 'サインインできません',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: '別の方法を使用',
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'パスワードを入力',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: '検証コード',
@@ -384,6 +393,7 @@ export const jaJP: LocalizationResource = {
       actionLink: 'サインアップ',
       actionLink__use_email: 'メールアドレスを使用',
       actionLink__use_email_username: 'メールアドレスまたはユーザー名を使用',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: '電話番号を使用',
       actionLink__use_username: 'ユーザー名を使用',
       actionText: 'アカウントをお持ちでないですか？',
@@ -464,6 +474,7 @@ export const jaJP: LocalizationResource = {
     form_password_not_strong_enough: 'パスワードの強度が不十分です。',
     form_password_pwned:
       'このパスワードは侵害の一部として見つかったため使用できません。別のパスワードを試してください。',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'パスワードのバイト数が上限を超えています。短くするか、一部の特殊文字を削除してください。',
     form_password_validation_failed: 'パスワードが間違っています',
@@ -471,6 +482,11 @@ export const jaJP: LocalizationResource = {
     form_username_invalid_length: 'ユーザー名の長さが無効です。',
     identification_deletion_failed: '最後の識別情報は削除できません。',
     not_allowed_access: 'アクセスが許可されていません。',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '{{length}}文字未満',
       minimumLength: '{{length}}文字以上',
@@ -528,6 +544,14 @@ export const jaJP: LocalizationResource = {
     action__signOutAll: '全てのアカウントからサインアウト',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'コピー済み！',
       actionLabel__copy: 'すべてコピー',
@@ -679,6 +703,11 @@ export const jaJP: LocalizationResource = {
       title: 'プロフィールの更新',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'デバイスからサインアウト',
         title: 'アクティブなデバイス',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const koKR: LocalizationResource = {
   locale: 'ko-KR',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: '돌아가기',
   badge__default: '기본값',
   badge__otherImpersonatorDevice: '기타 사칭 장치',
@@ -279,6 +280,7 @@ export const koKR: LocalizationResource = {
       blockButton__backupCode: '백업 코드 사용하기',
       blockButton__emailCode: '{{identifier}}로 이메일 코드 보내기',
       blockButton__emailLink: '{{identifier}}로 이메일 링크 보내기',
+      blockButton__passkey: undefined,
       blockButton__password: '비밀번호로 로그인',
       blockButton__phoneCode: '{{identifier}}로 SMS 코드 보내기',
       blockButton__totp: '인증 앱 사용하기',
@@ -349,10 +351,17 @@ export const koKR: LocalizationResource = {
       subtitle: '오류가 발생했습니다',
       title: '로그인할 수 없습니다',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: '다른 방법 사용하기',
       subtitle: '계정에 등록된 비밀번호를 입력해 주세요',
       title: '비밀번호를 입력하세요',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: '인증 코드',
@@ -379,6 +388,7 @@ export const koKR: LocalizationResource = {
       actionLink: '회원가입',
       actionLink__use_email: '이메일 사용하기',
       actionLink__use_email_username: '이메일 또는 사용자 이름 사용하기',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: '휴대폰 번호 사용하기',
       actionLink__use_username: '사용자 이름 사용하기',
       actionText: '계정이 없으신가요?',
@@ -458,6 +468,7 @@ export const koKR: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: '비밀번호가 충분히 안전하지 않습니다.',
     form_password_pwned: '이 비밀번호는 유출사항이 발견되어 사용할 수 없으므로 대신 다른 비밀번호를 사용해 보세요.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       '비밀번호가 허용되는 최대 바이트 수를 초과했습니다. 비밀번호를 줄이거나 일부 특수 문자를 제거해 주세요.',
     form_password_validation_failed: '잘못된 비밀번호',
@@ -465,6 +476,11 @@ export const koKR: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '{{length}} 보다 짧은 문자열',
       minimumLength: '{{length}} 또는 그 이상의 문자열',
@@ -522,6 +538,14 @@ export const koKR: LocalizationResource = {
     action__signOutAll: '모든 계정에서 로그아웃',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: '복사 완료!',
       actionLabel__copy: '전체 복사',
@@ -671,6 +695,11 @@ export const koKR: LocalizationResource = {
       title: '프로필 업데이트',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: '이 장치에서 로그아웃',
         title: '활성화된 장치',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -1,7 +1,20 @@
+/*
+ * =====================================================================================
+ * DISCLAIMER:
+ * =====================================================================================
+ * This localization file is a community contribution and is not officially maintained
+ * by Clerk. It has been provided by the community and may not be fully aligned
+ * with the current or future states of the main application. Clerk does not guarantee
+ * the accuracy, completeness, or timeliness of the translations in this file.
+ * Use of this file is at your own risk and discretion.
+ * =====================================================================================
+ */
+
 import type { LocalizationResource } from '@clerk/types';
 
 export const mnMN: LocalizationResource = {
   locale: 'mn-MN',
+  __experimental_formFieldLabel__passkeyName: 'Name of passkey',
   backButton: 'Буцах',
   badge__default: 'Анхдагч',
   badge__otherImpersonatorDevice: 'Бусад дуурайгч төхөөрөмж',
@@ -77,7 +90,6 @@ export const mnMN: LocalizationResource = {
   formFieldLabel__role: 'Үүрэг',
   formFieldLabel__signOutOfOtherSessions: 'Бусад бүх төхөөрөмжөөс гарах',
   formFieldLabel__username: 'Хэрэглэгчийн нэр',
-  __experimental_formFieldLabel__passkeyName: 'Name of passkey',
   impersonationFab: {
     action__signOut: 'Гарах',
     title: '{{identifier}}-р нэвтэрсэн',
@@ -272,8 +284,8 @@ export const mnMN: LocalizationResource = {
       blockButton__backupCode: 'Нөөц код ашиглана уу',
       blockButton__emailCode: '{{identifier}} имэйлруу код илгээх',
       blockButton__emailLink: '{{identifier}} имэйлруу холбоос силгээх ',
-      blockButton__password: 'Нууц үгээрээ нэвтэрнэ үү',
       blockButton__passkey: 'Passkey-р нэвтэрнэ үү',
+      blockButton__password: 'Нууц үгээрээ нэвтэрнэ үү',
       blockButton__phoneCode: '{{identifier}} руу SMS илгээх',
       blockButton__totp: 'Authenticator програмаа ашиглана уу',
       getHelp: {
@@ -344,15 +356,18 @@ export const mnMN: LocalizationResource = {
       subtitle: 'Алдаа гарлаа',
       title: 'Нэвтрэх боломжгүй',
     },
+    passkey: {
+      subtitle:
+        'Passkey-ээ ашигласнаар таныг мөн болохыг баталгаажуулна. Таны төхөөрөмж хурууны хээ, нүүр эсвэл дэлгэцийн түгжээг асууж магадгүй.',
+      title: 'Passkey ашиглана уу',
+    },
     password: {
       actionLink: 'Өөр аргыг ашигла',
       subtitle: 'Бүртгэлтэй холбоотой нууц үгээ оруулна уу',
       title: 'Нууц үгээ оруулна уу',
     },
-    passkey: {
-      title: 'Passkey ашиглана уу',
-      subtitle:
-        'Passkey-ээ ашигласнаар таныг мөн болохыг баталгаажуулна. Таны төхөөрөмж хурууны хээ, нүүр эсвэл дэлгэцийн түгжээг асууж магадгүй.',
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Баталгаажуулах код',
@@ -460,6 +475,7 @@ export const mnMN: LocalizationResource = {
     form_password_not_strong_enough: 'Таны нууц үг хангалттай хүчтэй биш байна.',
     form_password_pwned:
       'Энэ нууц үгийг зөрчлийн нэг хэсэг гэж олсон тул ашиглах боломжгүй, оронд нь өөр нууц үг оролдоно уу.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Энэ нууц үгийг зөрчлийн нэг хэсэг гэж олсон тул ашиглах боломжгүй. Өөр нууц үг оруулж үзнэ үү.',
     form_password_validation_failed: 'Нууц үг буруу',
@@ -467,6 +483,11 @@ export const mnMN: LocalizationResource = {
     form_username_invalid_length: 'Хэрэглэгчийн нэр буруу байна.',
     identification_deletion_failed: 'Та өөрийн сүүлчийн таниулбараа устгах боломжгүй.',
     not_allowed_access: 'Хандалтыг зөвшөөрөгдөөгүй',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '{{length}} тэмдэгтээс бага',
       minimumLength: '{{length}} буюу түүнээс олон тэмдэгт',
@@ -524,6 +545,14 @@ export const mnMN: LocalizationResource = {
     action__signOutAll: 'Бүх бүртгэлээс гарна уу',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: '{{name}} энэ бүртгэлээс хасагдана.',
+        title: 'Passkey устгах',
+      },
+      subtitle__rename: 'Та олоход хялбар болгохын тулд нэвтрэх түлхүүрийн нэрийг өөрчилж болно.',
+      title__rename: 'Passkey өөрчлөх',
+    },
     backupCodePage: {
       actionLabel__copied: 'Хуулсан!',
       actionLabel__copy: 'Бүгдийг хуулах',
@@ -680,6 +709,11 @@ export const mnMN: LocalizationResource = {
       title: 'Профайлыг шинэчлэх',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: 'Устгэх',
+        menuAction__rename: 'Засах',
+        title: 'Passkeys',
+      },
       activeDevicesSection: {
         destructiveAction: 'Төхөөрөмжөөс гарах',
         title: 'Идэвхтэй төхөөрөмжүүд',
@@ -734,11 +768,6 @@ export const mnMN: LocalizationResource = {
         primaryButton__updatePassword: 'Нууц үг шинэчлэх',
         title: 'Нууц үг',
       },
-      __experimental_passkeysSection: {
-        title: 'Passkeys',
-        menuAction__rename: 'Засах',
-        menuAction__destructive: 'Устгэх',
-      },
       phoneNumbersSection: {
         destructiveAction: 'Утасны дугаар устгах',
         detailsAction__nonPrimary: 'Үндсэн болгох',
@@ -766,14 +795,6 @@ export const mnMN: LocalizationResource = {
       successMessage: 'Таны хэрэглэгчийн нэр шинэчлэгдсэн.',
       title__set: 'Хэрэглэгчийн нэрийг тохируулах',
       title__update: 'эрэглэгчийн нэрийг шинэчлэх',
-    },
-    __experimental_passkeyScreen: {
-      title__rename: 'Passkey өөрчлөх',
-      subtitle__rename: 'Та олоход хялбар болгохын тулд нэвтрэх түлхүүрийн нэрийг өөрчилж болно.',
-      removeResource: {
-        title: 'Passkey устгах',
-        messageLine1: '{{name}} энэ бүртгэлээс хасагдана.',
-      },
     },
     web3WalletPage: {
       removeResource: {

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const nbNO: LocalizationResource = {
   locale: 'nb-NO',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Tilbake',
   badge__default: 'Standard',
   badge__otherImpersonatorDevice: 'Annen imitators enhet',
@@ -282,6 +283,7 @@ export const nbNO: LocalizationResource = {
       blockButton__backupCode: 'Bruk en sikkerhetskopi-kode',
       blockButton__emailCode: 'Send e-postkode til {{identifier}}',
       blockButton__emailLink: 'Send lenke til {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Logg inn med passordet ditt',
       blockButton__phoneCode: 'Send SMS-kode til {{identifier}}',
       blockButton__totp: 'Bruk autentiseringsappen din',
@@ -353,10 +355,17 @@ export const nbNO: LocalizationResource = {
       subtitle: 'En feil oppstod',
       title: 'Kan ikke logge inn',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Bruk en annen metode',
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Skriv inn passordet ditt',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Verifiseringskode',
@@ -384,6 +393,7 @@ export const nbNO: LocalizationResource = {
       actionLink: 'Opprett konto',
       actionLink__use_email: 'Bruk e-post',
       actionLink__use_email_username: 'Bruk e-post eller brukernavn',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Bruk telefon',
       actionLink__use_username: 'Bruk brukernavn',
       actionText: 'Ingen konto?',
@@ -464,6 +474,7 @@ export const nbNO: LocalizationResource = {
     form_password_not_strong_enough: 'Passordet ditt er ikke sterkt nok.',
     form_password_pwned:
       'Dette passordet er funnet som en del av et datainnbrudd og kan ikke brukes. Vennligst prøv et annet passord.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Passordet ditt har overskredet maksimalt antall byte tillatt. Vennligst forkort det eller fjern noen spesialtegn.',
     form_password_validation_failed: 'Feil passord',
@@ -471,6 +482,11 @@ export const nbNO: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'mindre enn {{length}} tegn',
       minimumLength: '{{length}} eller flere tegn',
@@ -528,6 +544,14 @@ export const nbNO: LocalizationResource = {
     action__signOutAll: 'Logg ut av alle kontoer',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Kopiert!',
       actionLabel__copy: 'Kopier alle',
@@ -684,6 +708,11 @@ export const nbNO: LocalizationResource = {
       title: 'Oppdater profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Logg ut fra enhet',
         title: 'Aktive enheter',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const nlNL: LocalizationResource = {
   locale: 'nl-NL',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Terug',
   badge__default: 'Standaard',
   badge__otherImpersonatorDevice: 'Ander immitatie apparaat',
@@ -282,6 +283,7 @@ export const nlNL: LocalizationResource = {
       blockButton__backupCode: 'Gebruik een backupcode',
       blockButton__emailCode: 'Verzend code naar {{identifier}}',
       blockButton__emailLink: 'Verzend link naar {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Inloggen met je wachtwoord',
       blockButton__phoneCode: 'Verzend code naar {{identifier}}',
       blockButton__totp: 'Gebruik je authenticator app',
@@ -352,10 +354,17 @@ export const nlNL: LocalizationResource = {
       subtitle: 'Er heeft zich een fout voorgedaan',
       title: 'Inloggen onmogelijk',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Gebruik een andere methode',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Vul je wachtwoord in',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Verificatie code',
@@ -382,6 +391,7 @@ export const nlNL: LocalizationResource = {
       actionLink: 'Registreren',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: 'Geen account?',
@@ -461,6 +471,7 @@ export const nlNL: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -468,6 +479,11 @@ export const nlNL: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '',
       minimumLength: '',
@@ -525,6 +541,14 @@ export const nlNL: LocalizationResource = {
     action__signOutAll: 'Uitloggen uit alle accounts',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Gekopieerd!',
       actionLabel__copy: 'Kopieer',
@@ -679,6 +703,11 @@ export const nlNL: LocalizationResource = {
       title: 'Profiel bijwerken',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Log uit op apparaat',
         title: 'Actieve apparaten',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const plPL: LocalizationResource = {
   locale: 'pl-PL',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Powrót',
   badge__default: 'Domyślny',
   badge__otherImpersonatorDevice: 'Inne urządzenie osobiste',
@@ -281,6 +282,7 @@ export const plPL: LocalizationResource = {
       blockButton__backupCode: 'Użyj kodu zapasowego',
       blockButton__emailCode: 'Wyślij kod do {{identifier}}',
       blockButton__emailLink: 'Wyślij link do {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Zaloguj się za pomocą hasła',
       blockButton__phoneCode: 'Wyślij kod do {{identifier}}',
       blockButton__totp: 'Użyj aplikacji uwierzytelniającej',
@@ -352,10 +354,17 @@ export const plPL: LocalizationResource = {
       subtitle: 'Wystąpił błąd',
       title: 'Nie można się zalogować',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Użyj innego sposobu',
       subtitle: 'aby kontynuować w {{applicationName}}',
       title: 'Wprowadź swoje hasło',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Kod weryfikacyjny',
@@ -382,6 +391,7 @@ export const plPL: LocalizationResource = {
       actionLink: 'Zarejestruj się',
       actionLink__use_email: 'Użyj adresu e-mail',
       actionLink__use_email_username: 'Użyj adresu e-mail lub nazwy użytkownika',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Użyj numeru telefonu',
       actionLink__use_username: 'Użyj nazwy użytkownika',
       actionText: 'Nie masz konta?',
@@ -461,6 +471,7 @@ export const plPL: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Podane hasło jest nieprawidłowe',
@@ -468,6 +479,11 @@ export const plPL: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'mniej niż {{length}} znaków',
       minimumLength: '{{length}} lub więcej znaków',
@@ -525,6 +541,14 @@ export const plPL: LocalizationResource = {
     action__signOutAll: 'Wyloguj ze wszystkich kont',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Skopiowane!',
       actionLabel__copy: 'Skopiuj wszystkie',
@@ -682,6 +706,11 @@ export const plPL: LocalizationResource = {
       title: 'Edytuj profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Wyloguj z urządzenia',
         title: 'Aktywne urządzenia',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const ptBR: LocalizationResource = {
   locale: 'pt-BR',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Voltar',
   badge__default: 'Padrão',
   badge__otherImpersonatorDevice: 'Personificar outro dispositivo',
@@ -281,6 +282,7 @@ export const ptBR: LocalizationResource = {
       blockButton__backupCode: 'Utilize um código de backup',
       blockButton__emailCode: 'Enviar código para {{identifier}}',
       blockButton__emailLink: 'Enviar link para {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Fazer login com sua senha',
       blockButton__phoneCode: 'Enviar código para {{identifier}}',
       blockButton__totp: 'Utilize seu aplicativo autenticador',
@@ -352,10 +354,17 @@ export const ptBR: LocalizationResource = {
       subtitle: 'Aconteceu um erro',
       title: 'Não foi possível fazer login',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Utilize outro método',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Insira sua senha',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Código de verificação',
@@ -382,6 +391,7 @@ export const ptBR: LocalizationResource = {
       actionLink: 'Registre-se',
       actionLink__use_email: 'Usar e-mail',
       actionLink__use_email_username: 'Usar e-mail ou nome de usuário',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Usar telefone',
       actionLink__use_username: 'Usar nome de usuário',
       actionText: 'Não possui uma conta?',
@@ -462,6 +472,7 @@ export const ptBR: LocalizationResource = {
     form_password_not_strong_enough: 'Sua senha não é forte o suficiente.',
     form_password_pwned:
       'Esta senha foi encontrada como parte de uma violação e não pode ser usada, por favor, tente outra senha.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Sua senha excedeu o número máximo de bytes permitidos, por favor, encurte-a ou remova alguns caracteres especiais.',
     form_password_validation_failed: 'Senha incorreta',
@@ -469,6 +480,11 @@ export const ptBR: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Você não pode excluir sua última identificação.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'menos de {{length}} caracteres',
       minimumLength: '{{length}} ou mais caracteres',
@@ -526,6 +542,14 @@ export const ptBR: LocalizationResource = {
     action__signOutAll: 'Sair de todas as contas',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiado!',
       actionLabel__copy: 'Copiar tudo',
@@ -684,6 +708,11 @@ export const ptBR: LocalizationResource = {
       title: 'Atualizar perfil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Sair do dispositivo',
         title: 'Dispositivos ativos',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const ptPT: LocalizationResource = {
   locale: 'pt-PT',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Voltar',
   badge__default: 'Padrão',
   badge__otherImpersonatorDevice: 'Personificar outro dispositivo',
@@ -281,6 +282,7 @@ export const ptPT: LocalizationResource = {
       blockButton__backupCode: 'Utilize um código de backup',
       blockButton__emailCode: 'Enviar código para {{identifier}}',
       blockButton__emailLink: 'Enviar link para {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Fazer login com palavra-passe',
       blockButton__phoneCode: 'Enviar código para {{identifier}}',
       blockButton__totp: 'Utilize o seu autenticador',
@@ -352,10 +354,17 @@ export const ptPT: LocalizationResource = {
       subtitle: 'Ocorreu um erro',
       title: 'Não foi possível fazer login',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Utilize outro método',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Insira a sua palavra-passe',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Código de verificação',
@@ -382,6 +391,7 @@ export const ptPT: LocalizationResource = {
       actionLink: 'Registre-se',
       actionLink__use_email: 'Usar e-mail',
       actionLink__use_email_username: 'Usar e-mail ou nome de utilizador',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Usar telemóvel',
       actionLink__use_username: 'Usar nome de utilizador',
       actionText: 'Não possui uma conta?',
@@ -462,6 +472,7 @@ export const ptPT: LocalizationResource = {
     form_password_not_strong_enough: 'A sua palavra-passe não é forte o suficiente.',
     form_password_pwned:
       'Esta palavra-passe foi encontrada como parte de uma violação e não pode ser usada, por favor, tente outra palavra-passe.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'A sua palavra-passe excedeu o número máximo de bytes permitidos, por favor, encurte-a ou remova alguns caracteres especiais.',
     form_password_validation_failed: 'Palavra-passe incorreta',
@@ -469,6 +480,11 @@ export const ptPT: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Você não pode excluir a sua última identificação.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'menos de {{length}} caracteres',
       minimumLength: '{{length}} ou mais caracteres',
@@ -526,6 +542,14 @@ export const ptPT: LocalizationResource = {
     action__signOutAll: 'Terminar sessão de todas as contas',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiado!',
       actionLabel__copy: 'Copiar tudo',
@@ -681,6 +705,11 @@ export const ptPT: LocalizationResource = {
       title: 'Atualizar perfil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Terminar sessão',
         title: 'Dispositivos ativos',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const roRO: LocalizationResource = {
   locale: 'ro-RO',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Înapoi',
   badge__default: 'Implicit',
   badge__otherImpersonatorDevice: 'Alt dispozitiv de imitație',
@@ -284,6 +285,7 @@ export const roRO: LocalizationResource = {
       blockButton__backupCode: 'Utilizați un cod de rezervă',
       blockButton__emailCode: 'Codul de e-mail către {{identifier}}',
       blockButton__emailLink: 'Trimiteți un link prin e-mail către {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Conectați-vă cu parola dvs',
       blockButton__phoneCode: 'Trimiteți codul SMS la {{identifier}}',
       blockButton__totp: 'Utilizați aplicația de autentificare',
@@ -355,10 +357,17 @@ export const roRO: LocalizationResource = {
       subtitle: 'S-a produs o eroare',
       title: 'Nu se poate autentifica',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Utilizați o altă metodă',
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Introduceți parola dvs',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Cod de verificare',
@@ -386,6 +395,7 @@ export const roRO: LocalizationResource = {
       actionLink: 'Înscrieți-vă',
       actionLink__use_email: 'Utilizați e-mailul',
       actionLink__use_email_username: 'Utilizați e-mail sau nume de utilizator',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Utilizați telefonul',
       actionLink__use_username: 'Utilizați numele de utilizator',
       actionText: 'Nu aveți cont?',
@@ -466,6 +476,7 @@ export const roRO: LocalizationResource = {
     form_password_not_strong_enough: 'Parola dvs. nu este suficient de puternică.',
     form_password_pwned:
       'Această parolă a fost descoperită ca parte a unei încălcări și nu poate fi utilizată, vă rugăm să încercați o altă parolă.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Parola dvs. a depășit numărul maxim de octeți permis, vă rugăm să o scurtați sau să eliminați unele caractere speciale.',
     form_password_validation_failed: 'Parolă incorectă',
@@ -473,6 +484,11 @@ export const roRO: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Nu vă puteți șterge ultima identificare.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'mai puțin de {{length}} caractere',
       minimumLength: '{{length}} sau mai multe caractere',
@@ -532,6 +548,14 @@ export const roRO: LocalizationResource = {
     action__signOutAll: 'Deconectați-vă din toate conturile',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Copiat!',
       actionLabel__copy: 'Copiați toate',
@@ -692,6 +716,11 @@ export const roRO: LocalizationResource = {
       title: 'Actualizarea profilului',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Deconectați-vă de la dispozitiv',
         title: 'Dispozitive active',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const ruRU: LocalizationResource = {
   locale: 'ru-RU',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Назад',
   badge__default: 'По-умолчанию',
   badge__otherImpersonatorDevice: 'Другое устройство',
@@ -285,6 +286,7 @@ export const ruRU: LocalizationResource = {
       blockButton__backupCode: 'Используйте код восстановления',
       blockButton__emailCode: 'Отправить код на {{identifier}}',
       blockButton__emailLink: 'Отправить ссылку на {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Войти с паролем',
       blockButton__phoneCode: 'Отправить код на {{identifier}}',
       blockButton__totp: 'Используйте аутентификатор',
@@ -356,10 +358,17 @@ export const ruRU: LocalizationResource = {
       subtitle: 'Произошла ошибка',
       title: 'Невозможно войти',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Использовать другой метод',
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Введите пароль',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Верификационный код',
@@ -386,6 +395,7 @@ export const ruRU: LocalizationResource = {
       actionLink: 'Зарегистрироваться',
       actionLink__use_email: 'Использовать почту',
       actionLink__use_email_username: 'Использовать почту или имя пользователя',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Использовать номер телефона',
       actionLink__use_username: 'Использовать имя пользователя',
       actionText: 'Нет аккаунта?',
@@ -465,6 +475,7 @@ export const ruRU: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Ваш пароль недостаточно надежный.',
     form_password_pwned: 'Этот пароль был взломан и не может быть использован, попробуйте другой пароль.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Ваш пароль превышает максимально допустимое количество байтов, сократите его или удалите некоторые специальные символы.',
     form_password_validation_failed: 'Неверный пароль',
@@ -472,6 +483,11 @@ export const ruRU: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'менее {{length}} символов',
       minimumLength: '{{length}} или более символов',
@@ -529,6 +545,14 @@ export const ruRU: LocalizationResource = {
     action__signOutAll: 'Выйти из всех аккаунтов',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Скопировано!',
       actionLabel__copy: 'Копировать все',
@@ -685,6 +709,11 @@ export const ruRU: LocalizationResource = {
       title: 'Обновить профиль',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Выйти из устройства',
         title: 'Активные устройства',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const skSK: LocalizationResource = {
   locale: 'sk-SK',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Späť',
   badge__default: 'Predvolené',
   badge__otherImpersonatorDevice: 'Iné zariadenie zástupcu',
@@ -281,6 +282,7 @@ export const skSK: LocalizationResource = {
       blockButton__backupCode: 'Použiť záložný kód',
       blockButton__emailCode: 'Odoslať overovací kód na email {{identifier}}',
       blockButton__emailLink: 'Odoslať odkaz na email {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Prihlásiť sa pomocou hesla',
       blockButton__phoneCode: 'Poslať SMS kód na telefónne číslo {{identifier}}',
       blockButton__totp: 'Použiť autentifikačnú aplikáciu',
@@ -352,10 +354,17 @@ export const skSK: LocalizationResource = {
       subtitle: 'Došlo k chybe',
       title: 'Nie je možné sa prihlásiť',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Použiť inú metódu',
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Zadajte svoje heslo',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Overovací kód',
@@ -382,6 +391,7 @@ export const skSK: LocalizationResource = {
       actionLink: 'Registrovať sa',
       actionLink__use_email: 'Použiť email',
       actionLink__use_email_username: 'Použiť email alebo užívateľské meno',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Použiť telefón',
       actionLink__use_username: 'Použiť užívateľské meno',
       actionText: 'Nemáte účet?',
@@ -461,6 +471,7 @@ export const skSK: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Vaše heslo nie je dostatočne silné.',
     form_password_pwned: 'Toto heslo bolo nájdené v rámci úniku dát a nemôže byť použité, prosím zvoľte iné heslo.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Vaše heslo prekročilo maximálny povolený počet bytov, prosím skráťte ho alebo odstráňte niektoré špeciálne znaky.',
     form_password_validation_failed: 'Nesprávne heslo',
@@ -468,6 +479,11 @@ export const skSK: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'menej ako {{length}} znakov',
       minimumLength: '{{length}} alebo viac znakov',
@@ -525,6 +541,14 @@ export const skSK: LocalizationResource = {
     action__signOutAll: 'Odhlásiť sa zo všetkých účtov',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Skopírované!',
       actionLabel__copy: 'Kopírovať všetko',
@@ -680,6 +704,11 @@ export const skSK: LocalizationResource = {
       title: 'Aktualizovať profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Odhlásiť sa zo zariadenia',
         title: 'Aktívne zariadenia',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const svSE: LocalizationResource = {
   locale: 'sv-SE',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Tillbaka',
   badge__default: 'Standard',
   badge__otherImpersonatorDevice: 'Annans imitatörenhet',
@@ -281,6 +282,7 @@ export const svSE: LocalizationResource = {
       blockButton__backupCode: 'Använd en reservkod',
       blockButton__emailCode: 'Skicka kod till {{identifier}}',
       blockButton__emailLink: 'Skicka länk till {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Logga in med ditt lösenord',
       blockButton__phoneCode: 'Skicka kod till {{identifier}}',
       blockButton__totp: 'Använd din autentiseringsapp',
@@ -352,10 +354,17 @@ export const svSE: LocalizationResource = {
       subtitle: 'Ett fel inträffade',
       title: 'Kan inte logga in',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Använd en annan metod',
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Ange ditt lösenord',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Verifieringskod',
@@ -382,6 +391,7 @@ export const svSE: LocalizationResource = {
       actionLink: 'Skapa konto',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: 'Har du inget konto?',
@@ -461,6 +471,7 @@ export const svSE: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_pwned: '',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     form_password_validation_failed: 'Incorrect Password',
@@ -468,6 +479,11 @@ export const svSE: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '',
       minimumLength: '',
@@ -525,6 +541,14 @@ export const svSE: LocalizationResource = {
     action__signOutAll: 'Logga ut från alla konton',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Kopierat!',
       actionLabel__copy: 'Kopiera alla',
@@ -679,6 +703,11 @@ export const svSE: LocalizationResource = {
       title: 'Uppdatera profil',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Logga ut från enhet',
         title: 'Aktiva enheter',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const thTH: LocalizationResource = {
   locale: 'th-TH',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'กลับ',
   badge__default: 'ค่าเริ่มต้น',
   badge__otherImpersonatorDevice: 'อุปกรณ์ปลอมตัวอื่น',
@@ -279,6 +280,7 @@ export const thTH: LocalizationResource = {
       blockButton__backupCode: 'ใช้รหัสสำรอง',
       blockButton__emailCode: 'ส่งรหัสไปที่อีเมล {{identifier}}',
       blockButton__emailLink: 'ส่งลิงก์ไปที่อีเมล {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'เข้าสู่ระบบด้วยรหัสผ่านของคุณ',
       blockButton__phoneCode: 'ส่งรหัส SMS ไปยัง {{identifier}}',
       blockButton__totp: 'ใช้แอปตัวตรวจสอบความถูกต้อง',
@@ -350,10 +352,17 @@ export const thTH: LocalizationResource = {
       subtitle: 'เกิดข้อผิดพลาด',
       title: 'ไม่สามารถเข้าสู่ระบบได้',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'ใช้วิธีอื่น',
       subtitle: 'ใส่รหัสผ่านที่เชื่อมโยงกับบัญชีของคุณ',
       title: 'ใส่รหัสผ่านของคุณ',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'รหัสการตรวจสอบ',
@@ -380,6 +389,7 @@ export const thTH: LocalizationResource = {
       actionLink: 'สมัครสมาชิก',
       actionLink__use_email: 'ใช้อีเมล',
       actionLink__use_email_username: 'ใช้อีเมลหรือชื่อผู้ใช้',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'ใช้โทรศัพท์',
       actionLink__use_username: 'ใช้ชื่อผู้ใช้',
       actionText: 'ไม่มีบัญชีหรือ?',
@@ -459,6 +469,7 @@ export const thTH: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'รหัสผ่านของคุณไม่เพียงพอต่อความปลอดภัย',
     form_password_pwned: 'รหัสผ่านนี้ถูกพบว่าเป็นส่วนหนึ่งของการรั่วไหลและไม่สามารถใช้ได้ กรุณาลองรหัสผ่านอื่นแทน',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'รหัสผ่านของคุณเกินจำนวนไบต์สูงสุดที่อนุญาต กรุณาลดความยาวหรือลบอักขระพิเศษบางตัว',
     form_password_validation_failed: 'รหัสผ่านไม่ถูกต้อง',
@@ -466,6 +477,11 @@ export const thTH: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'คุณไม่สามารถลบรูปแบบการยืนยันตัวตนสุดท้ายของคุณได้',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'น้อยกว่า {{length}} ตัวอักษร',
       minimumLength: '{{length}} ตัวอักษรหรือมากกว่า',
@@ -523,6 +539,14 @@ export const thTH: LocalizationResource = {
     action__signOutAll: 'ออกจากระบบทุกบัญชี',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'คัดลอกแล้ว!',
       actionLabel__copy: 'คัดลอกทั้งหมด',
@@ -674,6 +698,11 @@ export const thTH: LocalizationResource = {
       title: 'อัปเดตโปรไฟล์',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'ลงชื่อออกจากอุปกรณ์',
         title: 'อุปกรณ์ที่ใช้งานอยู่',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const trTR: LocalizationResource = {
   locale: 'tr-TR',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Geri',
   badge__default: 'Varsayılan',
   badge__otherImpersonatorDevice: 'Farklı bir kılıkçı cihazı',
@@ -281,6 +282,7 @@ export const trTR: LocalizationResource = {
       blockButton__backupCode: 'Yedekleme kodu kullan',
       blockButton__emailCode: '{{identifier}} adresine doğrulama kodu gönder',
       blockButton__emailLink: '{{identifier}} adresine doğrulama bağlantısı gönder',
+      blockButton__passkey: undefined,
       blockButton__password: 'Şifreyle giriş yap',
       blockButton__phoneCode: '{{identifier}} numarasına doğrulama kodu gönder',
       blockButton__totp: 'Authenticator uygulaması kullan',
@@ -352,10 +354,17 @@ export const trTR: LocalizationResource = {
       subtitle: 'Bir hata oluştu',
       title: 'Giriş yapılamıyor',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Başka bir yöntem kullan',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Şifrenizi girin',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Doğrulama kodu',
@@ -382,6 +391,7 @@ export const trTR: LocalizationResource = {
       actionLink: 'Kayıt ol',
       actionLink__use_email: 'E-posta kullan',
       actionLink__use_email_username: 'E-posta veya kullanıcı adı kullan',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Telefon kullan',
       actionLink__use_username: 'Kullanıcı adı kullan',
       actionText: 'Hesabınız yok mu?',
@@ -462,6 +472,7 @@ export const trTR: LocalizationResource = {
     form_password_not_strong_enough: 'Şifreniz fazla zayıf',
     form_password_pwned:
       'Bu şifre bir veri saldırısında ele geçirildiği için kullanılamaz. Lütfen başka bir şifre deneyin.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Şifrenize ayrılan depolama alanını aştınız. Lütfen daha kısa bir şifre deneyin.',
     form_password_validation_failed: 'Geçersiz şifre',
@@ -469,6 +480,11 @@ export const trTR: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '{{length}} karakterden kısa olmalı',
       minimumLength: '{{length}} veya daha fazla karakter içermeli',
@@ -526,6 +542,14 @@ export const trTR: LocalizationResource = {
     action__signOutAll: 'Tüm hesaplardan çıkış yap',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Kopyalandı!',
       actionLabel__copy: 'Hepsini kopayala',
@@ -681,6 +705,11 @@ export const trTR: LocalizationResource = {
       title: 'Profili güncelle',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Cihaz oturumunu sonlandır',
         title: 'Aktif cihazlar',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const ukUA: LocalizationResource = {
   locale: 'uk-UA',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Назад',
   badge__default: 'За замовчуванням',
   badge__otherImpersonatorDevice: 'Інший пристрій-двійник',
@@ -281,6 +282,7 @@ export const ukUA: LocalizationResource = {
       blockButton__backupCode: 'Використовуйте код відновлення',
       blockButton__emailCode: 'Надіслати код на {{identifier}}',
       blockButton__emailLink: 'Надіслати посилання на {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Увійти з паролем',
       blockButton__phoneCode: 'Надіслати код на {{identifier}}',
       blockButton__totp: 'Використовуйте аутентифікатор',
@@ -352,10 +354,17 @@ export const ukUA: LocalizationResource = {
       subtitle: 'Виникла помилка',
       title: 'Не вдалося увійти',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Використати інший метод',
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Введіть пароль',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Код підтвердження',
@@ -382,6 +391,7 @@ export const ukUA: LocalizationResource = {
       actionLink: 'Зареєструватися',
       actionLink__use_email: 'Використовувати пошту',
       actionLink__use_email_username: "Використовувати пошту або ім'я користувача",
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Використовувати номер телефону',
       actionLink__use_username: "Використовувати ім'я користувача",
       actionText: 'Немає акаунта?',
@@ -461,6 +471,7 @@ export const ukUA: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'Ваш пароль недостатньо надійний.',
     form_password_pwned: 'Цей пароль було зламано і його не можна використовувати, спробуйте інший пароль.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Ваш пароль перевищує максимально допустиму кількість байтів, скоротіть його або видаліть деякі спеціальні символи.',
     form_password_validation_failed: 'Невірний пароль',
@@ -468,6 +479,11 @@ export const ukUA: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'менше {{length}} символів',
       minimumLength: '{{length}} або більше символів',
@@ -525,6 +541,14 @@ export const ukUA: LocalizationResource = {
     action__signOutAll: 'Вийти з усіх акаунтів',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Скопійовано!',
       actionLabel__copy: 'Копіювати все',
@@ -681,6 +705,11 @@ export const ukUA: LocalizationResource = {
       title: 'Оновити профіль',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Вийти з пристрою',
         title: 'Активні пристрої',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const viVN: LocalizationResource = {
   locale: 'vi-VN',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: 'Quay lại',
   badge__default: 'Mặc định',
   badge__otherImpersonatorDevice: 'Thiết bị nhân danh khác',
@@ -281,6 +282,7 @@ export const viVN: LocalizationResource = {
       blockButton__backupCode: 'Sử dụng mã sao lưu',
       blockButton__emailCode: 'Gửi mã qua email cho {{identifier}}',
       blockButton__emailLink: 'Gửi liên kết qua email cho {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: 'Đăng nhập bằng mật khẩu của bạn',
       blockButton__phoneCode: 'Gửi mã SMS cho {{identifier}}',
       blockButton__totp: 'Sử dụng ứng dụng xác thực của bạn',
@@ -352,10 +354,17 @@ export const viVN: LocalizationResource = {
       subtitle: 'Đã xảy ra lỗi',
       title: 'Không thể đăng nhập',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: 'Sử dụng phương pháp khác',
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Nhập mật khẩu của bạn',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: 'Mã xác nhận',
@@ -382,6 +391,7 @@ export const viVN: LocalizationResource = {
       actionLink: 'Đăng ký',
       actionLink__use_email: 'Sử dụng email',
       actionLink__use_email_username: 'Sử dụng email hoặc tên đăng nhập',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Sử dụng số điện thoại',
       actionLink__use_username: 'Sử dụng tên đăng nhập',
       actionText: 'Chưa có tài khoản?',
@@ -462,6 +472,7 @@ export const viVN: LocalizationResource = {
     form_password_not_strong_enough: 'Mật khẩu của bạn không đủ mạnh.',
     form_password_pwned:
       'Mật khẩu này đã được phát hiện trong một cuộc tấn công và không thể sử dụng, vui lòng thử mật khẩu khác.',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded:
       'Mật khẩu của bạn đã vượt quá số byte tối đa cho phép, vui lòng rút ngắn hoặc loại bỏ một số ký tự đặc biệt.',
     form_password_validation_failed: 'Mật khẩu không đúng',
@@ -469,6 +480,11 @@ export const viVN: LocalizationResource = {
     form_username_invalid_length: '',
     identification_deletion_failed: 'Bạn không thể xóa thông tin nhận dạng cuối cùng của bạn.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: 'ít hơn {{length}} ký tự',
       minimumLength: '{{length}} hoặc nhiều ký tự',
@@ -526,6 +542,14 @@ export const viVN: LocalizationResource = {
     action__signOutAll: 'Đăng xuất khỏi tất cả các tài khoản',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: 'Đã sao chép!',
       actionLabel__copy: 'Sao chép tất cả',
@@ -681,6 +705,11 @@ export const viVN: LocalizationResource = {
       title: 'Cập nhật hồ sơ',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: 'Đăng xuất khỏi thiết bị',
         title: 'Thiết bị hoạt động',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const zhCN: LocalizationResource = {
   locale: 'zh-CN',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: '返回',
   badge__default: '默认',
   badge__otherImpersonatorDevice: '其他模拟器设备',
@@ -279,6 +280,7 @@ export const zhCN: LocalizationResource = {
       blockButton__backupCode: '使用备用代码',
       blockButton__emailCode: '电子邮件验证码到 {{identifier}}',
       blockButton__emailLink: '电子邮件链接到 {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: '使用您的密码登录',
       blockButton__phoneCode: '发送短信代码到 {{identifier}}',
       blockButton__totp: '使用您的验证应用程序',
@@ -349,10 +351,17 @@ export const zhCN: LocalizationResource = {
       subtitle: '出现错误',
       title: '无法登录',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: '使用其他方法',
       subtitle: '继续使用 {{applicationName}}',
       title: '输入您的密码',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: '验证码',
@@ -379,6 +388,7 @@ export const zhCN: LocalizationResource = {
       actionLink: '注册',
       actionLink__use_email: '使用电子邮件',
       actionLink__use_email_username: '使用电子邮件或用户名',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: '使用电话',
       actionLink__use_username: '使用用户名',
       actionText: '还没有账户？',
@@ -457,12 +467,18 @@ export const zhCN: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: '您的密码强度不够。',
     form_password_pwned: '这个密码在数据泄露中被发现，不能使用，请换一个密码试试。',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded: '您的密码超过了允许的最大字节数，请缩短它或去掉一些特殊字符。',
     form_password_validation_failed: '密码错误',
     form_username_invalid_character: '',
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '少于{{length}}个字符',
       minimumLength: '{{length}}个或更多字符',
@@ -520,6 +536,14 @@ export const zhCN: LocalizationResource = {
     action__signOutAll: '退出所有账户',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: '已复制！',
       actionLabel__copy: '复制全部',
@@ -666,6 +690,11 @@ export const zhCN: LocalizationResource = {
       title: '更新个人资料',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: '退出设备',
         title: '活动设备',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -14,6 +14,7 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const zhTW: LocalizationResource = {
   locale: 'zh-TW',
+  __experimental_formFieldLabel__passkeyName: undefined,
   backButton: '返回',
   badge__default: '默認',
   badge__otherImpersonatorDevice: '其他模擬器設備',
@@ -279,6 +280,7 @@ export const zhTW: LocalizationResource = {
       blockButton__backupCode: '使用備用代碼',
       blockButton__emailCode: '電子郵件驗證碼到 {{identifier}}',
       blockButton__emailLink: '電子郵件連結到 {{identifier}}',
+      blockButton__passkey: undefined,
       blockButton__password: '使用您的密碼登錄',
       blockButton__phoneCode: '發送簡訊代碼到 {{identifier}}',
       blockButton__totp: '使用您的驗證應用程式',
@@ -349,10 +351,17 @@ export const zhTW: LocalizationResource = {
       subtitle: '出現錯誤',
       title: '無法登錄',
     },
+    passkey: {
+      subtitle: undefined,
+      title: undefined,
+    },
     password: {
       actionLink: '使用其他方法',
       subtitle: '繼續使用 {{applicationName}}',
       title: '輸入您的密碼',
+    },
+    passwordPwned: {
+      title: undefined,
     },
     phoneCode: {
       formTitle: '驗證碼',
@@ -379,6 +388,7 @@ export const zhTW: LocalizationResource = {
       actionLink: '註冊',
       actionLink__use_email: '使用電子郵件',
       actionLink__use_email_username: '使用電子郵件或使用者名稱',
+      actionLink__use_passkey: undefined,
       actionLink__use_phone: '使用電話',
       actionLink__use_username: '使用使用者名稱',
       actionText: '還沒有帳戶？',
@@ -457,12 +467,18 @@ export const zhTW: LocalizationResource = {
     form_password_length_too_short: '',
     form_password_not_strong_enough: '您的密碼強度不夠。',
     form_password_pwned: '這個密碼在數據洩露中被發現，不能使用，請換一個密碼試試。',
+    form_password_pwned__sign_in: undefined,
     form_password_size_in_bytes_exceeded: '您的密碼超過了允許的最大位元組數，請縮短它或去掉一些特殊字元。',
     form_password_validation_failed: '密碼錯誤',
     form_username_invalid_character: '',
     form_username_invalid_length: '',
     identification_deletion_failed: 'You cannot delete your last identification.',
     not_allowed_access: '',
+    passkey_already_exists: undefined,
+    passkey_not_supported: undefined,
+    passkey_registration_cancelled: undefined,
+    passkey_retrieval_cancelled: undefined,
+    passkeys_pa_not_supported: undefined,
     passwordComplexity: {
       maximumLength: '少於{{length}}個字元',
       minimumLength: '{{length}}個或更多字元',
@@ -520,6 +536,14 @@ export const zhTW: LocalizationResource = {
     action__signOutAll: '退出所有帳戶',
   },
   userProfile: {
+    __experimental_passkeyScreen: {
+      removeResource: {
+        messageLine1: undefined,
+        title: undefined,
+      },
+      subtitle__rename: undefined,
+      title__rename: undefined,
+    },
     backupCodePage: {
       actionLabel__copied: '已複製！',
       actionLabel__copy: '複製全部',
@@ -666,6 +690,11 @@ export const zhTW: LocalizationResource = {
       title: '更新個人資料',
     },
     start: {
+      __experimental_passkeysSection: {
+        menuAction__destructive: undefined,
+        menuAction__rename: undefined,
+        title: undefined,
+      },
       activeDevicesSection: {
         destructiveAction: '退出設備',
         title: '活動設備',

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -67,6 +67,10 @@ export function isUserLockedError(err: any) {
   return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'user_locked';
 }
 
+export function isPasswordPwnedError(err: any) {
+  return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'form_password_pwned';
+}
+
 export function parseErrors(data: ClerkAPIErrorJSON[] = []): ClerkAPIError[] {
   return data.length > 0 ? data.map(parseError) : [];
 }

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -157,6 +157,9 @@ type _LocalizationResource = {
       subtitle: LocalizationValue;
       actionLink: LocalizationValue;
     };
+    passwordPwned: {
+      title: LocalizationValue;
+    };
     passkey: {
       title: LocalizationValue;
       subtitle: LocalizationValue;
@@ -729,6 +732,7 @@ type UnstableErrors = WithParamName<{
   passkey_registration_cancelled: LocalizationValue;
   passkey_already_exists: LocalizationValue;
   form_password_pwned: LocalizationValue;
+  form_password_pwned__sign_in: LocalizationValue;
   form_username_invalid_length: LocalizationValue;
   form_username_invalid_character: LocalizationValue;
   form_param_format_invalid: LocalizationValue;


### PR DESCRIPTION
… password at sign-in

## Description

If admin has enabled `password_settings.enforce_on_sign_in` and HIBP is enabled, then a password could potentially be detected as pwned at a subsequent sign-in.

The API will respond with error code `form_password_pwned`, in which case we will show a corresponding error and show the alternative method list, prompting them to reset their password.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


