### PR TITLE
chore(nextjs): Adds telemetry event to clerkMiddleware initialization

### DIFF
--- a/.changeset/khaki-poems-press.md
+++ b/.changeset/khaki-poems-press.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Adds telemetry event to clerkMiddleware initialization, passes publishableKey to `createClerkClient()` internally.

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -6,6 +6,7 @@ import {
   DOMAIN,
   IS_SATELLITE,
   PROXY_URL,
+  PUBLISHABLE_KEY,
   SDK_METADATA,
   SECRET_KEY,
   TELEMETRY_DEBUG,
@@ -14,6 +15,7 @@ import {
 
 const clerkClient = createClerkClient({
   secretKey: SECRET_KEY,
+  publishableKey: PUBLISHABLE_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
   userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -6,6 +6,7 @@ import type {
   RequestState,
 } from '@clerk/backend/internal';
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { NextMiddleware } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -63,6 +64,14 @@ interface ClerkMiddleware {
 export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   const [request, event] = parseRequestAndEvent(args);
   const [handler, options] = parseHandlerAndOptions(args);
+
+  clerkClient.telemetry.record(
+    eventMethodCalled('clerkMiddleware', {
+      handler: Boolean(handler),
+      satellite: Boolean(options.isSatellite),
+      proxy: Boolean(options.proxyUrl),
+    }),
+  );
 
   const nextMiddleware: NextMiddleware = async (request, event) => {
     const clerkRequest = createClerkRequest(request);


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

Adds a telemetry event to `clerkMiddleware` initialization so we can get better insight into usage, also passes `publishableKey` to the internal `createClerkClient` call so it can get passed along.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
