### PR TITLE
fix(clerk-js): Rolling back support for sign_in.needs_new_password on…

### DIFF
--- a/.changeset/strange-zoos-tie.md
+++ b/.changeset/strange-zoos-tie.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+We are rolling back support for password complexity / strength checks during sign-in. Feature will be limited to HIBP for now. Hence, the password form need not expect a sign_in status of `needs_new_password`.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -71,8 +71,6 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
             return setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignIn });
           case 'needs_second_factor':
             return navigate('../factor-two');
-          case 'needs_new_password':
-            return navigate('../reset-password');
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -227,29 +227,6 @@ describe('SignInFactorOne', () => {
           });
         });
       });
-
-      it('redirects to `reset-password` if signIn requires a new password', async () => {
-        const { wrapper, fixtures } = await createFixtures(f => {
-          f.withEmailAddress();
-          f.withPassword();
-          f.withPreferredSignInStrategy({ strategy: 'password' });
-          f.startSignInWithPhoneNumber({ supportPassword: true });
-        });
-        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
-
-        fixtures.signIn.attemptFirstFactor.mockReturnValueOnce(
-          Promise.resolve({ status: 'needs_new_password' } as SignInResource),
-        );
-
-        await runFakeTimers(async () => {
-          const { userEvent } = render(<SignInFactorOne />, { wrapper });
-          await userEvent.type(screen.getByLabelText('Password'), '123456');
-          await userEvent.click(screen.getByText('Continue'));
-          await waitFor(() => {
-            expect(fixtures.router.navigate).toHaveBeenCalledWith('../reset-password');
-          });
-        });
-      });
     });
 
     describe('Forgot Password', () => {


### PR DESCRIPTION
… password form

## Description

We are rolling back support for password complexity / strength checks during sign-in. Feature will be limited to HIBP for now. Hence, the password form need not expect a sign_in status of `needs_new_password`.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: revised feature requirements
