### PR TITLE
fix(backend): Fix typo in jwk-remote-missing error message

### DIFF
--- a/.changeset/chilly-tips-compete.md
+++ b/.changeset/chilly-tips-compete.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix typo in `jwk-remote-missing` error message

--- a/packages/backend/src/tokens/__tests__/keys.test.ts
+++ b/packages/backend/src/tokens/__tests__/keys.test.ts
@@ -176,7 +176,7 @@ export default (QUnit: QUnit) => {
             action: 'Contact support@clerk.com',
           });
           assert.propContains(err, {
-            message: `Unable to find a signing key in JWKS that matches the kid='${kid}' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT. The following kid are available: ${mockRsaJwkKid}, local`,
+            message: `Unable to find a signing key in JWKS that matches the kid='${kid}' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT. The following kid is available: ${mockRsaJwkKid}, local`,
           });
         } else {
           // This should never be reached. If it does, the suite should fail

--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -154,7 +154,7 @@ export async function loadClerkJWKFromRemote({
     throw new TokenVerificationError({
       action: TokenVerificationErrorAction.ContactSupport,
       message: `Unable to find a signing key in JWKS that matches the kid='${kid}' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT.${
-        jwkKeys ? ` The following kid are available: ${jwkKeys}` : ''
+        jwkKeys ? ` The following kid is available: ${jwkKeys}` : ''
       }`,
       reason: TokenVerificationErrorReason.RemoteJWKMissing,
     });


### PR DESCRIPTION
## Description

Fix typo

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
