### PR TITLE
feat(backend): Add scrypt_werkzeug to supported hashers

### DIFF
--- a/.changeset/wet-toes-knock.md
+++ b/.changeset/wet-toes-knock.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add support for `scrypt_werkzeug` in `UserAPI` `PasswordHasher`.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -50,6 +50,7 @@ type PasswordHasher =
   | 'pbkdf2_sha256_django'
   | 'pbkdf2_sha1'
   | 'scrypt_firebase'
+  | 'scrypt_werkzeug'
   | 'sha256';
 
 type UserPasswordHashingParams = {


### PR DESCRIPTION
## Description

Add a new enum value for `scrypt_werkzeug` in `UserAPI` -> `PasswordHasher`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
