### PR TITLE
fix(clerk-js,clerk-react): Make UI-triggered redirects default to hash-based routing

### DIFF
--- a/.changeset/two-paws-search.md
+++ b/.changeset/two-paws-search.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Make UI-triggered redirects default to hash-based routing. If a routing strategy is not provided, default to hash routing. All routing strategies know how to convert a hash-based url to their own format.

--- a/packages/clerk-js/src/ui/common/__tests__/redirects.test.ts
+++ b/packages/clerk-js/src/ui/common/__tests__/redirects.test.ts
@@ -1,8 +1,8 @@
 import { buildEmailLinkRedirectUrl, buildSSOCallbackURL } from '../redirects';
 
 describe('buildEmailLinkRedirectUrl(routing, baseUrl)', () => {
-  it('defaults to path based routing strategy on empty routing', function () {
-    expect(buildEmailLinkRedirectUrl({ path: '', authQueryString: '' } as any, '')).toBe('http://localhost/verify');
+  it('defaults to hash based routing strategy on empty routing', function () {
+    expect(buildEmailLinkRedirectUrl({ path: '', authQueryString: '' } as any, '')).toBe('http://localhost/#/verify');
   });
 
   it('returns the magic link redirect url for components using path based routing ', function () {
@@ -129,10 +129,10 @@ describe('buildEmailLinkRedirectUrl(routing, baseUrl)', () => {
 describe('buildSSOCallbackURL(ctx, baseUrl)', () => {
   it('returns the SSO callback URL based on sign in|up component routing or the provided base URL', () => {
     // Default callback URLS
-    expect(buildSSOCallbackURL({}, '')).toBe('http://localhost/sso-callback');
-    expect(buildSSOCallbackURL({}, 'http://test.host')).toBe('http://localhost/sso-callback');
+    expect(buildSSOCallbackURL({}, '')).toBe('http://localhost/#/sso-callback');
+    expect(buildSSOCallbackURL({}, 'http://test.host')).toBe('http://localhost/#/sso-callback');
     expect(buildSSOCallbackURL({ authQueryString: 'redirect_url=%2Ffoo' }, 'http://test.host')).toBe(
-      'http://localhost/sso-callback?redirect_url=%2Ffoo',
+      'http://localhost/#/sso-callback?redirect_url=%2Ffoo',
     );
 
     // Components mounted with hash routing

--- a/packages/clerk-js/src/ui/common/redirects.ts
+++ b/packages/clerk-js/src/ui/common/redirects.ts
@@ -33,6 +33,7 @@ export function buildSSOCallbackURL(
 }
 
 type AuthQueryString = string | null | undefined;
+
 type BuildRedirectUrlParams = {
   routing: string | undefined;
   authQueryString: AuthQueryString;
@@ -42,11 +43,16 @@ type BuildRedirectUrlParams = {
 };
 
 const buildRedirectUrl = ({ routing, authQueryString, baseUrl, path, endpoint }: BuildRedirectUrlParams): string => {
-  if (routing === 'hash') {
+  // If a routing strategy is not provided, default to hash routing
+  // All routing strategies know how to convert a hash-based url to their own format
+  // Example: navigating from a hash-based to a path-based component,
+  // the path-based component can parse and fix the URL automatically
+  // /#/sso-callback?code=123 -> /sso-callback?code=123
+  if (!routing || routing === 'hash') {
     return buildHashBasedUrl(authQueryString, endpoint);
   }
 
-  if (!routing || routing === 'path') {
+  if (routing === 'path') {
     return buildPathBasedUrl(path || '', authQueryString, endpoint);
   }
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -199,7 +199,7 @@ describe('SignInStart', () => {
       expect(fixtures.signIn.create).toHaveBeenCalled();
       expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalledWith({
         strategy: 'saml',
-        redirectUrl: 'http://localhost/sso-callback?redirect_url=http%3A%2F%2Flocalhost%2F',
+        redirectUrl: 'http://localhost/#/sso-callback?redirect_url=http%3A%2F%2Flocalhost%2F',
         redirectUrlComplete: '/',
       });
     });

--- a/packages/react/src/errors/messages.ts
+++ b/packages/react/src/errors/messages.ts
@@ -40,4 +40,4 @@ export const noPathProvidedError = (componentName: string) =>
   `The <${componentName}/> component uses path-based routing by default unless a different routing strategy is provided using the \`routing\` prop. When path-based routing is used, you need to provide the path where the component is mounted on by using the \`path\` prop. Example: <${componentName} path={'/my-path'} />`;
 
 export const incompatibleRoutingWithPathProvidedError = (componentName: string) =>
-  `The \`path\` prop will only be respected when the Clerk component uses path-based routing. Please update the  <${componentName}/> component and either drop the \`path\` prop or update the routing strategy using the \`routing\` prop. For more details please refer to our docs: https://clerk.com/docs`;
+  `The \`path\` prop will only be respected when the Clerk component uses path-based routing. To resolve this error, pass \`routing='path'\` to the <${componentName}/> component, oreither drop the \`path\` prop to switch to hash-based routing. For more details please refer to our docs: https://clerk.com/docs`;

--- a/packages/react/src/errors/messages.ts
+++ b/packages/react/src/errors/messages.ts
@@ -40,4 +40,4 @@ export const noPathProvidedError = (componentName: string) =>
   `The <${componentName}/> component uses path-based routing by default unless a different routing strategy is provided using the \`routing\` prop. When path-based routing is used, you need to provide the path where the component is mounted on by using the \`path\` prop. Example: <${componentName} path={'/my-path'} />`;
 
 export const incompatibleRoutingWithPathProvidedError = (componentName: string) =>
-  `The \`path\` prop will only be respected when the Clerk component uses path-based routing. To resolve this error, pass \`routing='path'\` to the <${componentName}/> component, oreither drop the \`path\` prop to switch to hash-based routing. For more details please refer to our docs: https://clerk.com/docs`;
+  `The \`path\` prop will only be respected when the Clerk component uses path-based routing. To resolve this error, pass \`routing='path'\` to the <${componentName}/> component, or drop the \`path\` prop to switch to hash-based routing. For more details please refer to our docs: https://clerk.com/docs`;


### PR DESCRIPTION
If a routing strategy is not provided, default to hash routing. All routing strategies know how to convert a hash-based url to their own format Example: navigating from a hash-based to a path-based component, the path-based component can parse and fix the URL automatically /#/sso-callback?code=123 -> /sso-callback?code=123

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
