### PR TITLE
fix(clerk-js): Correct chunk loading logic in clerk.headless.browser variant

### DIFF
--- a/.changeset/lazy-games-destroy.md
+++ b/.changeset/lazy-games-destroy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Correct chunk loading logic in `clerk.headless.browser` variant

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -1,3 +1,8 @@
+// It's crucial this is the first import,
+// otherwise chunk loading will not work
+// eslint-disable-next-line
+import './utils/setWebpackChunkPublicPath';
+
 import 'regenerator-runtime/runtime';
 
 import { Clerk } from './core/clerk';


### PR DESCRIPTION
## Description

We were missing the `setWebpackChunkPublicPath` util in the `clerk.headless.browser` variant, making this variant break when there was a difference between latest published version and the pinned version in the cloudflare proxy. The util is necessary to replace chunk loading snippets with the fixed version of its entry file version.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
