### PR TITLE
fix(clerk-js): Correct chunk loading logic in clerk.headless.browser variant (#3062)

### DIFF
--- a/.changeset/lazy-games-destroy.md
+++ b/.changeset/lazy-games-destroy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Correct chunk loading logic in `clerk.headless.browser` variant

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -1,3 +1,8 @@
+// It's crucial this is the first import,
+// otherwise chunk loading will not work
+// eslint-disable-next-line
+import './utils/setWebpackChunkPublicPath';
+
 import 'regenerator-runtime/runtime';
 
 import Clerk from './core/clerk';


### PR DESCRIPTION
Backporting #3062 to the release/v4 branch

(cherry picked from commit d1dc44cc771c27c95fac96e6ffa805cd6d36c3f7)