### PR TITLE
fix(clerk-js): Legacy integration tokens should not set __session cookie

### DIFF
--- a/.changeset/large-clouds-flash.md
+++ b/.changeset/large-clouds-flash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix setting session cookie with Legacy integration token.

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -15,8 +15,7 @@ import type {
 import { unixEpochToDate } from '../../utils/date';
 import { eventBus, events } from '../events';
 import { SessionTokenCache } from '../tokenCache';
-import { PublicUserData } from './internal';
-import { BaseResource, Token, User } from './internal';
+import { BaseResource, PublicUserData, Token, User } from './internal';
 
 export class Session extends BaseResource implements SessionResource {
   pathRoot = '/client/sessions';
@@ -146,7 +145,6 @@ export class Session extends BaseResource implements SessionResource {
       tokenResolver,
     });
     return tokenResolver.then(token => {
-      eventBus.dispatch(events.TokenUpdate, { token });
       return token.getRawString();
     });
   };


### PR DESCRIPTION
## Description

Avoid persisting a legacy integration token (eg Firebase) into `__session` cookie.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
