### PR TITLE
feat(backend): Add scrypt_werkzeug to supported hashers (#3060)

### DIFF
--- a/.changeset/wet-toes-knock.md
+++ b/.changeset/wet-toes-knock.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add support for `scrypt_werkzeug` in `UserAPI` `PasswordHasher`.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -37,7 +37,9 @@ type PasswordHasher =
   | 'pbkdf2_sha256'
   | 'pbkdf2_sha256_django'
   | 'pbkdf2_sha1'
-  | 'scrypt_firebase';
+  | 'scrypt_firebase'
+  | 'scrypt_werkzeug'
+  | 'sha256';
 
 type UserPasswordHashingParams = {
   passwordDigest: string;


### PR DESCRIPTION
Backporting #3060 to the release/v4 branch

(cherry picked from commit 9879949)

Also included `sha256` from #1941 (It wasn't back ported and caused a conflict).