### PR TITLE
fix(clerk-js): Hide "Add passkey" button in UP when app is satellite

### DIFF
--- a/.changeset/wicked-pumpkins-repair.md
+++ b/.changeset/wicked-pumpkins-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide "Add passkey" button in UP when app is satellite.

--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -1,4 +1,4 @@
-import { useUser } from '@clerk/shared/react';
+import { useClerk, useUser } from '@clerk/shared/react';
 import type { PasskeyResource } from '@clerk/types';
 import React from 'react';
 
@@ -100,32 +100,30 @@ export const PasskeySection = () => {
       centered={false}
       id='passkeys'
     >
-      <Action.Root>
-        <ProfileSection.ItemList id='passkeys'>
-          {user.__experimental_passkeys.map(passkey => (
-            <Action.Root key={passkey.id}>
-              <PasskeyItem
-                key={passkey.id}
-                {...passkey}
-              />
+      <ProfileSection.ItemList id='passkeys'>
+        {user.__experimental_passkeys.map(passkey => (
+          <Action.Root key={passkey.id}>
+            <PasskeyItem
+              key={passkey.id}
+              {...passkey}
+            />
 
-              <Action.Open value='remove'>
-                <Action.Card variant='destructive'>
-                  <RemovePasskeyScreen passkey={passkey} />
-                </Action.Card>
-              </Action.Open>
+            <Action.Open value='remove'>
+              <Action.Card variant='destructive'>
+                <RemovePasskeyScreen passkey={passkey} />
+              </Action.Card>
+            </Action.Open>
 
-              <Action.Open value='rename'>
-                <Action.Card>
-                  <PasskeyScreen passkey={passkey} />
-                </Action.Card>
-              </Action.Open>
-            </Action.Root>
-          ))}
+            <Action.Open value='rename'>
+              <Action.Card>
+                <PasskeyScreen passkey={passkey} />
+              </Action.Card>
+            </Action.Open>
+          </Action.Root>
+        ))}
 
-          <AddPasskeyButton />
-        </ProfileSection.ItemList>
-      </Action.Root>
+        <AddPasskeyButton />
+      </ProfileSection.ItemList>
     </ProfileSection.Root>
   );
 };
@@ -191,6 +189,7 @@ const ActiveDeviceMenu = () => {
 // TODO-PASSKEYS: Should the error be scope to the section ?
 const AddPasskeyButton = () => {
   const card = useCardState();
+  const { isSatellite } = useClerk();
   const { user } = useUser();
 
   const handleCreatePasskey = async () => {
@@ -200,6 +199,10 @@ const AddPasskeyButton = () => {
       handleError(e, [], card.setError);
     }
   };
+
+  if (isSatellite) {
+    return null;
+  }
 
   return (
     <ProfileSection.ArrowButton

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasskeysSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasskeysSection.test.tsx
@@ -18,7 +18,6 @@ const passkeys = [
     last_used_at: Date.now(),
     verification: null,
     updated_at: Date.now(),
-    credential_id: 'some_id',
   },
 ] satisfies PasskeyJSON[];
 


### PR DESCRIPTION
## Description
RP ID for web credentials need to match the domain they are registered in but also the domain where they will be used for authentication.

In satellite app we redirect the user to the primary for signing in. Hence, the user needs to register the passkey in the primary's UserProfile.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
