### PR TITLE
Fix docs links on main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 This repository contains all the Clerk JavaScript SDKs under the `@clerk` namespace. Visit [clerk.com](https://clerk.com) to signup for an account.
 
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
+[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs)
 [![twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 ---
@@ -34,7 +34,7 @@ Would you like to work on Open Source software and help maintain this repository
 
 1. [Sign up for an account](https://dashboard.clerk.com/sign-up?utm_source=github&utm_medium=clerk_js_repo_readme)
 1. Create an application in your Clerk dashboard
-1. Spin up a new codebase with one of the [quickstart guides](https://clerk.com/docs/quickstarts/overview?utm_source=github&utm_medium=clerk_js_repo_readme)
+1. Spin up a new codebase with one of the [quickstart guides](https://beta.clerk.com/docs/quickstarts/overview?utm_source=github&utm_medium=clerk_js_repo_readme)
 
 This repository contains the SDKs for environment/platforms that Clerk supports. For example, if you want to use Clerk with Node.js you can install:
 
@@ -48,10 +48,10 @@ pnpm add @clerk/clerk-sdk-node
 
 ## 🎓 Learning Clerk
 
-Clerk's full documentation is available at [clerk.com/docs](https://clerk.com/docs?utm_source=github&utm_medium=clerk_js_repo_readme).
+Clerk's full documentation is available at [clerk.com/docs](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_js_repo_readme).
 
-- **We recommend starting with the [Quickstart guides](https://clerk.com/docs/quickstarts/overview).** It'll enable you to quickly add Clerk to your application. If you're starting a new project and are not sure what to pick, use [Next.js](https://nextjs.org/docs/getting-started/installation) and [@clerk/nextjs](https://clerk.com/docs/quickstarts/nextjs).
-- **To learn more about Clerk's components and features, checkout the rest of the [Clerk documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_js_repo_readme).** You'll be able to e.g. browse the [component reference](https://clerk.com/docs/components/overview?utm_source=github&utm_medium=clerk_js_repo_readme) page.
+- **We recommend starting with the [Quickstart guides](https://beta.clerk.com/docs/quickstarts/overview).** It'll enable you to quickly add Clerk to your application. If you're starting a new project and are not sure what to pick, use [Next.js](https://nextjs.org/docs/getting-started/installation) and [@clerk/nextjs](https://beta.clerk.com/docs/quickstarts/nextjs).
+- **To learn more about Clerk's components and features, checkout the rest of the [Clerk documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_js_repo_readme).** You'll be able to e.g. browse the [component reference](https://beta.clerk.com/docs/components/overview?utm_source=github&utm_medium=clerk_js_repo_readme) page.
 
 ## 🚢 Release Notes
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_backend)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_backend)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/backend/CHANGELOG.md)

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_chrome_extension)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_chrome_extension)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/chrome-extension/CHANGELOG.md)
@@ -31,7 +31,7 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_chrome_extension) is the easiest way to add authentication and user management to your chrome extension. To gain a better understanding of the Clerk React SDK and [Frontend API](https://reference.clerk.com/reference/frontend-api-reference), refer to
-the <a href="https://clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_chrome_extension" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_chrome_extension" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting Started
 

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -31,7 +31,7 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_chrome_extension) is the easiest way to add authentication and user management to your chrome extension. To gain a better understanding of the Clerk React SDK and [Frontend API](https://reference.clerk.com/reference/frontend-api-reference), refer to
-the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_chrome_extension" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_chrome_extension" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting Started
 

--- a/packages/clerk-js/README.md
+++ b/packages/clerk-js/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_js)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_js)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/clerk-js/CHANGELOG.md)
@@ -122,7 +122,7 @@ npm run build
 </script>
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_js)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_js)._
 
 ## Support
 

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_elements)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_elements)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/elements/CHANGELOG.md)

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_expo)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_expo)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/expo/CHANGELOG.md)
@@ -146,7 +146,7 @@ const styles = StyleSheet.create({
 
 ```
 
-_The section above covers the basic setup. For further details and examples, please refer to our [Clerk Expo Documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_expo)._
+_The section above covers the basic setup. For further details and examples, please refer to our [Clerk Expo Documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_expo)._
 
 ## Support
 

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -31,7 +31,7 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_fastify) is the easiest way to add authentication and user management to your Fastify application. To gain a better understanding of the Clerk Backend API and SDK, refer to
-the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_fastify" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_fastify" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting Started
 

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_fastify)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_fastify)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/fastify/CHANGELOG.md)
@@ -31,11 +31,11 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_fastify) is the easiest way to add authentication and user management to your Fastify application. To gain a better understanding of the Clerk Backend API and SDK, refer to
-the <a href="https://clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_fastify" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_fastify" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting Started
 
-To use this plugin you should first create a Clerk application and retrieve a `Secret Key` and a `Publishable Key` for you application (see [here](https://clerk.com/docs/reference/node/getting-started#set-c-l-e-r-k-s-e-c-r-e-t-key)) to be used as environment variables `CLERK_PUBLISHABLE_KEY` & `CLERK_SECRET_KEY`.
+To use this plugin you should first create a Clerk application and retrieve a `Secret Key` and a `Publishable Key` for you application (see [here](https://beta.clerk.com/docs/reference/node/getting-started#set-c-l-e-r-k-s-e-c-r-e-t-key)) to be used as environment variables `CLERK_PUBLISHABLE_KEY` & `CLERK_SECRET_KEY`.
 
 ### Prerequisites
 

--- a/packages/gatsby-plugin-clerk/README.md
+++ b/packages/gatsby-plugin-clerk/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=gatsby_plugin_clerk)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=gatsby_plugin_clerk)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/gatsby-plugin-clerk/CHANGELOG.md)
@@ -144,7 +144,7 @@ const handler = withAuth(async (req, res) => {
 export default handler;
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs/get-started/gatsby?utm_source=github&utm_medium=gatsby_plugin_clerk)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs/get-started/gatsby?utm_source=github&utm_medium=gatsby_plugin_clerk)._
 
 ### Build
 

--- a/packages/localizations/README.md
+++ b/packages/localizations/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_localizations)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_localizations)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/localizations/CHANGELOG.md)

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_nextjs)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_nextjs)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/nextjs/CHANGELOG.md)
@@ -102,7 +102,7 @@ export default MyApp;
 ```
 
 _For further details and examples, please refer to
-our [Documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_nextjs)._
+our [Documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_nextjs)._
 
 ## Support
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_react)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_react)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/react/CHANGELOG.md)
@@ -92,7 +92,7 @@ function App() {
 }
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_react)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_react)._
 
 ## Support
 

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_remix)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_remix)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/remix/CHANGELOG.md)
@@ -117,7 +117,7 @@ export default function Index() {
 }
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs/quickstarts/remix?utm_source=github&utm_medium=clerk_remix)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs/quickstarts/remix?utm_source=github&utm_medium=clerk_remix)._
 
 ## Support
 

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_sdk_node)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_sdk_node)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/sdk-node/CHANGELOG.md)
@@ -31,7 +31,7 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_sdk_node) is the easiest way to add authentication and user management to your Node.js application. To gain a better understanding of the Clerk Backend API and SDK, refer to
-the <a href="https://clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting started
 
@@ -69,7 +69,7 @@ import clerk from '@clerk/clerk-sdk-node';
 const { data: userList } = await clerk.users.getUserList();
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node)._
 
 ## Support
 

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -31,7 +31,7 @@
 ## Overview
 
 [Clerk](https://clerk.com?utm_source=github&utm_medium=clerk_sdk_node) is the easiest way to add authentication and user management to your Node.js application. To gain a better understanding of the Clerk Backend API and SDK, refer to
-the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node" target="_blank">Node SDK</a> and <a href="https://beta.clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
+the <a href="https://beta.clerk.com/docs/reference/node/getting-started?utm_source=github&utm_medium=clerk_sdk_node" target="_blank">Node SDK</a> and <a href="https://clerk.com/docs/reference/backend-api" target="_blank">Backend API</a> documentation.
 
 ## Getting started
 

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_themes)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_themes)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/themes/CHANGELOG.md)

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![Chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs?utm_source=github&utm_medium=clerk_types)
+[![Clerk documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_types)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 [Changelog](https://github.com/clerk/javascript/blob/main/packages/types/CHANGELOG.md)
@@ -68,7 +68,7 @@ export type OAuthProps = {
 };
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.com/docs?utm_source=github&utm_medium=clerk_types)._
+_For further details and examples, please refer to our [Documentation](https://beta.clerk.com/docs?utm_source=github&utm_medium=clerk_types)._
 
 ## Support
 


### PR DESCRIPTION
## Description

Since the main branch is for the beta version, links to the docs should accurately represent this.

Fixes SDK-1566

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
