### PR TITLE
feat(types,localizations): Add translation keys for form_identifier_exists error

### DIFF
--- a/.changeset/forty-lizards-cheat.md
+++ b/.changeset/forty-lizards-cheat.md
@@ -7,3 +7,4 @@ Adds translation keys to be able to customize error messages when an identifier 
 
 - form_identifier_exists__email_address
 - form_identifier_exists__username
+- form_identifier_exists__phone_number

--- a/.changeset/forty-lizards-cheat.md
+++ b/.changeset/forty-lizards-cheat.md
@@ -3,7 +3,7 @@
 '@clerk/types': patch
 ---
 
-Adds translation keys for form_identifier_exists error:
+Adds translation keys to be able to customize error messages when an identifier already exists:
 
 - form_identifier_exists__email_address
 - form_identifier_exists__username

--- a/.changeset/forty-lizards-cheat.md
+++ b/.changeset/forty-lizards-cheat.md
@@ -1,0 +1,9 @@
+---
+'@clerk/localizations': patch
+'@clerk/types': patch
+---
+
+Adds translation keys for form_identifier_exists error:
+
+- form_identifier_exists__email_address
+- form_identifier_exists__username

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -459,6 +459,7 @@ export const arSA: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'يجب أستعمال بريد إلكتروني صالح',

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -458,6 +458,7 @@ export const arSA: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'يجب أستعمال بريد إلكتروني صالح',

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -459,6 +459,7 @@ export const arSA: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -461,6 +461,7 @@ export const bgBG: LocalizationResource = {
       'Регистрацията неуспешна поради неуспешна валидация на бот. Моля, презаредете страницата, за да опитате отново, или се свържете с поддръжката за повече помощ.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Имейл адресът трябва да бъде във валиден имейл адрес.',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -462,6 +462,7 @@ export const bgBG: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Имейл адресът трябва да бъде във валиден имейл адрес.',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -462,6 +462,7 @@ export const bgBG: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -459,6 +459,7 @@ export const csCZ: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -458,6 +458,7 @@ export const csCZ: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -459,6 +459,7 @@ export const csCZ: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -460,6 +460,7 @@ export const daDK: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -459,6 +459,7 @@ export const daDK: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -460,6 +460,7 @@ export const daDK: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -465,6 +465,7 @@ export const deDE: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: 'Diese E-Mail-Adresse ist bereits vergeben. Bitte wählen Sie eine Andere.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -465,6 +465,7 @@ export const deDE: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: 'Diese E-Mail-Adresse ist bereits vergeben. Bitte wählen Sie eine Andere.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Bitte geben Sie eine gültige E-Mail-Adresse ein.',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -464,6 +464,7 @@ export const deDE: LocalizationResource = {
       'Die Anmeldung ist aufgrund einer fehlgeschlagenen Bot-Validierung fehlgeschlagen. Bitte aktualisieren Sie die Seite, um es erneut zu versuchen, oder wenden Sie sich an den Support, um weitere Unterstützung zu erhalten.',
     form_code_incorrect: '',
     form_identifier_exists: 'Diese E-Mail-Adresse ist bereits vergeben. Bitte wählen Sie eine Andere.',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Bitte geben Sie eine gültige E-Mail-Adresse ein.',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -462,6 +462,7 @@ export const elGR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Η διεύθυνση email πρέπει να είναι μια έγκυρη διεύθυνση email.',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -461,6 +461,7 @@ export const elGR: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Η διεύθυνση email πρέπει να είναι μια έγκυρη διεύθυνση email.',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -462,6 +462,7 @@ export const elGR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -448,6 +448,7 @@ export const enUS: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: 'This email address is taken. Please try another.',
+    form_identifier_exists__username: 'This username is taken. Please try another.',
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -447,6 +447,7 @@ export const enUS: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: 'This email address is taken. Please try another.',
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -448,6 +448,7 @@ export const enUS: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: 'This email address is taken. Please try another.',
+    form_identifier_exists__phone_number: 'This phone number is taken. Please try another.',
     form_identifier_exists__username: 'This username is taken. Please try another.',
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -461,6 +461,7 @@ export const esES: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -460,6 +460,7 @@ export const esES: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -461,6 +461,7 @@ export const esES: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -460,6 +460,7 @@ export const esMX: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: 'No encontrado, puede estar mal escrito.',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'La dirección del correo electronico debe ser valida.',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -461,6 +461,7 @@ export const esMX: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: 'No encontrado, puede estar mal escrito.',
     form_param_format_invalid: '',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -461,6 +461,7 @@ export const esMX: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: 'No encontrado, puede estar mal escrito.',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'La dirección del correo electronico debe ser valida.',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -462,6 +462,7 @@ export const frFR: LocalizationResource = {
     form_code_incorrect: 'Code incorrect',
     form_identifier_exists: 'Cet identifiant existe déjà. Veuillez en renseigner un différent.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: 'Identifiant introuvable',
     form_param_format_invalid: 'Le format est invalide',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -461,6 +461,7 @@ export const frFR: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: 'Code incorrect',
     form_identifier_exists: 'Cet identifiant existe déjà. Veuillez en renseigner un différent.',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: 'Identifiant introuvable',
     form_param_format_invalid: 'Le format est invalide',
     form_param_format_invalid__email_address: "L'adresse e-mail doit être une adresse e-mail valide.",

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -462,6 +462,7 @@ export const frFR: LocalizationResource = {
     form_code_incorrect: 'Code incorrect',
     form_identifier_exists: 'Cet identifiant existe déjà. Veuillez en renseigner un différent.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: 'Identifiant introuvable',
     form_param_format_invalid: 'Le format est invalide',
     form_param_format_invalid__email_address: "L'adresse e-mail doit être une adresse e-mail valide.",

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -456,6 +456,7 @@ export const heIL: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -457,6 +457,7 @@ export const heIL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -457,6 +457,7 @@ export const heIL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -460,6 +460,7 @@ export const itIT: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -459,6 +459,7 @@ export const itIT: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -460,6 +460,7 @@ export const itIT: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -461,6 +461,7 @@ export const jaJP: LocalizationResource = {
       'ボット検証に失敗したため、サインアップに失敗しました。ページを更新して再試行するか、サポートに連絡してさらに支援を受けてください。',
     form_code_incorrect: 'フォームコードが正しくありません。',
     form_identifier_exists: '識別子が既に存在します。',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '識別子が見つかりません。',
     form_param_format_invalid: 'パラメータ形式が無効です。',
     form_param_format_invalid__email_address: 'メールアドレスは有効なメールアドレスである必要があります。',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -462,6 +462,7 @@ export const jaJP: LocalizationResource = {
     form_code_incorrect: 'フォームコードが正しくありません。',
     form_identifier_exists: '識別子が既に存在します。',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '識別子が見つかりません。',
     form_param_format_invalid: 'パラメータ形式が無効です。',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -462,6 +462,7 @@ export const jaJP: LocalizationResource = {
     form_code_incorrect: 'フォームコードが正しくありません。',
     form_identifier_exists: '識別子が既に存在します。',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '識別子が見つかりません。',
     form_param_format_invalid: 'パラメータ形式が無効です。',
     form_param_format_invalid__email_address: 'メールアドレスは有効なメールアドレスである必要があります。',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -456,6 +456,7 @@ export const koKR: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -457,6 +457,7 @@ export const koKR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -457,6 +457,7 @@ export const koKR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -462,6 +462,7 @@ export const mnMN: LocalizationResource = {
       'Ботын баталгаажуулалт амжилтгүй болсны улмаас бүртгүүлж чадсангүй. Дахин оролдохын тулд хуудсыг сэргээнэ үү эсвэл нэмэлт тусламж авахын тулд тусламж авахаар холбогдоно уу.',
     form_code_incorrect: 'Маягтын код буруу байна',
     form_identifier_exists: 'Тодорхойлогч аль хэдийн байна.',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: 'Тодорхойлогч олдсонгүй.',
     form_param_format_invalid: 'Параметрийн формат буруу.',
     form_param_format_invalid__email_address: 'Имэйл хаяг нь хүчинтэй имэйл хаяг байх ёстой.',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -463,6 +463,7 @@ export const mnMN: LocalizationResource = {
     form_code_incorrect: 'Маягтын код буруу байна',
     form_identifier_exists: 'Тодорхойлогч аль хэдийн байна.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: 'Тодорхойлогч олдсонгүй.',
     form_param_format_invalid: 'Параметрийн формат буруу.',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -463,6 +463,7 @@ export const mnMN: LocalizationResource = {
     form_code_incorrect: 'Маягтын код буруу байна',
     form_identifier_exists: 'Тодорхойлогч аль хэдийн байна.',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: 'Тодорхойлогч олдсонгүй.',
     form_param_format_invalid: 'Параметрийн формат буруу.',
     form_param_format_invalid__email_address: 'Имэйл хаяг нь хүчинтэй имэйл хаяг байх ёстой.',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -462,6 +462,7 @@ export const nbNO: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -462,6 +462,7 @@ export const nbNO: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'E-postadressen må være en gyldig e-postadresse',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -461,6 +461,7 @@ export const nbNO: LocalizationResource = {
       'Registreringen mislyktes på grunn av mislykkede bot-valideringer. Vennligst oppdater siden og prøv igjen, eller ta kontakt med brukerstøtte for mer hjelp.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'E-postadressen må være en gyldig e-postadresse',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -459,6 +459,7 @@ export const nlNL: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -460,6 +460,7 @@ export const nlNL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -460,6 +460,7 @@ export const nlNL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -460,6 +460,7 @@ export const plPL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -460,6 +460,7 @@ export const plPL: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -459,6 +459,7 @@ export const plPL: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -460,6 +460,7 @@ export const ptBR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -459,6 +459,7 @@ export const ptBR: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'O endereço de e-mail deve ser um endereço de e-mail válido.',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -460,6 +460,7 @@ export const ptBR: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'O endereço de e-mail deve ser um endereço de e-mail válido.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -460,6 +460,7 @@ export const ptPT: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -459,6 +459,7 @@ export const ptPT: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'O endereço de e-mail deve ser válido.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -460,6 +460,7 @@ export const ptPT: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'O endereço de e-mail deve ser válido.',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -464,6 +464,7 @@ export const roRO: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Adresa de e-mail trebuie să fie o adresă de e-mail validă.',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -464,6 +464,7 @@ export const roRO: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -463,6 +463,7 @@ export const roRO: LocalizationResource = {
       'Înscrierea a eșuat din cauza unei validări nereușite a robotului. Vă rugăm să reîmprospătați pagina pentru a încerca din nou sau contactați serviciul de asistență pentru mai multă asistență.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Adresa de e-mail trebuie să fie o adresă de e-mail validă.',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -464,6 +464,7 @@ export const ruRU: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -463,6 +463,7 @@ export const ruRU: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -464,6 +464,7 @@ export const ruRU: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -460,6 +460,7 @@ export const skSK: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -460,6 +460,7 @@ export const skSK: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -459,6 +459,7 @@ export const skSK: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -459,6 +459,7 @@ export const svSE: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -460,6 +460,7 @@ export const svSE: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -460,6 +460,7 @@ export const svSE: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -458,6 +458,7 @@ export const thTH: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'ที่อยู่อีเมลต้องเป็นที่อยู่อีเมลที่ถูกต้อง',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -457,6 +457,7 @@ export const thTH: LocalizationResource = {
       'การสมัครไม่สำเร็จเนื่องจากการตรวจสอบบอทไม่ผ่าน กรุณารีเฟรชหน้าเว็บเพื่อลองใหม่หรือติดต่อสนับสนุนเพื่อขอความช่วยเหลือเพิ่มเติม',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'ที่อยู่อีเมลต้องเป็นที่อยู่อีเมลที่ถูกต้อง',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -458,6 +458,7 @@ export const thTH: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -460,6 +460,7 @@ export const trTR: LocalizationResource = {
     form_code_incorrect: 'Hatalı kod',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -460,6 +460,7 @@ export const trTR: LocalizationResource = {
     form_code_incorrect: 'Hatalı kod',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -459,6 +459,7 @@ export const trTR: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: 'Hatalı kod',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -460,6 +460,7 @@ export const ukUA: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -460,6 +460,7 @@ export const ukUA: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -459,6 +459,7 @@ export const ukUA: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -459,6 +459,7 @@ export const viVN: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Địa chỉ email phải là một địa chỉ email hợp lệ',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -460,6 +460,7 @@ export const viVN: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -460,6 +460,7 @@ export const viVN: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Địa chỉ email phải là một địa chỉ email hợp lệ',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -456,6 +456,7 @@ export const zhCN: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -455,6 +455,7 @@ export const zhCN: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -456,6 +456,7 @@ export const zhCN: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -456,6 +456,7 @@ export const zhTW: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -456,6 +456,7 @@ export const zhTW: LocalizationResource = {
     form_code_incorrect: '',
     form_identifier_exists: '',
     form_identifier_exists__email_address: undefined,
+    form_identifier_exists__phone_number: undefined,
     form_identifier_exists__username: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -455,6 +455,7 @@ export const zhTW: LocalizationResource = {
       'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     form_code_incorrect: '',
     form_identifier_exists: '',
+    form_identifier_exists__email_address: undefined,
     form_identifier_not_found: '',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Email address must be a valid email address.',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -746,6 +746,7 @@ type UnstableErrors = WithParamName<{
   form_identifier_exists: LocalizationValue;
   form_identifier_exists__email_address: LocalizationValue;
   form_identifier_exists__username: LocalizationValue;
+  form_identifier_exists__phone_number: LocalizationValue;
   form_password_not_strong_enough: LocalizationValue;
   form_password_size_in_bytes_exceeded: LocalizationValue;
   passwordComplexity: {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -744,6 +744,7 @@ type UnstableErrors = WithParamName<{
   form_password_validation_failed: LocalizationValue;
   not_allowed_access: LocalizationValue;
   form_identifier_exists: LocalizationValue;
+  form_identifier_exists__email_address: LocalizationValue;
   form_password_not_strong_enough: LocalizationValue;
   form_password_size_in_bytes_exceeded: LocalizationValue;
   passwordComplexity: {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -745,6 +745,7 @@ type UnstableErrors = WithParamName<{
   not_allowed_access: LocalizationValue;
   form_identifier_exists: LocalizationValue;
   form_identifier_exists__email_address: LocalizationValue;
+  form_identifier_exists__username: LocalizationValue;
   form_password_not_strong_enough: LocalizationValue;
   form_password_size_in_bytes_exceeded: LocalizationValue;
   passwordComplexity: {


### PR DESCRIPTION
## Description

This PR adds three new translation keys for error messages when an identifier already exists:
- form_identifier_exists__email_address
- form_identifier_exists__username
- form_identifier_exists__phone_number
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
