### PR TITLE
feat(clerk-js,localizations,shared,types): Prompt user to reset pwned…

### DIFF
--- a/.changeset/sour-kings-fry.md
+++ b/.changeset/sour-kings-fry.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/types': minor
+---
+
+Support for prompting a user to reset their password if it is found to be compromised during sign-in.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36691,10 +36691,10 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "0.6.14",
+      "version": "0.6.16",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "4.70.4",
+        "@clerk/clerk-js": "4.70.6",
         "@clerk/clerk-react": "4.30.7"
       },
       "devDependencies": {
@@ -36711,7 +36711,7 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "4.70.4",
+      "version": "4.70.6",
       "license": "MIT",
       "dependencies": {
         "@clerk/localizations": "1.26.16",
@@ -37050,10 +37050,10 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "0.20.9",
+      "version": "0.20.11",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "4.70.4",
+        "@clerk/clerk-js": "4.70.6",
         "@clerk/clerk-react": "4.30.7",
         "@clerk/shared": "1.3.3",
         "base-64": "1.0.0",
@@ -37216,7 +37216,7 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "3.1.21",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@clerk/backend": "0.38.3",
@@ -37317,7 +37317,7 @@
     },
     "packages/themes": {
       "name": "@clerk/themes",
-      "version": "1.7.9",
+      "version": "1.7.10",
       "license": "MIT",
       "dependencies": {
         "@clerk/types": "3.62.1",

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { withRedirectToHomeSingleSessionGuard } from '../../common';
 import { useCoreSignIn, useEnvironment } from '../../contexts';
-import { ErrorCard, LoadingCard, withCardStateProvider } from '../../elements';
+import { ErrorCard, LoadingCard, useCardState, withCardStateProvider } from '../../elements';
 import { useAlternativeStrategies } from '../../hooks/useAlternativeStrategies';
 import { localizationKeys } from '../../localization';
 import { useRouter } from '../../router';
@@ -35,6 +35,7 @@ export function _SignInFactorOne(): JSX.Element {
   const { preferredSignInStrategy } = useEnvironment().displayConfig;
   const availableFactors = signIn.supportedFirstFactors;
   const router = useRouter();
+  const card = useCardState();
 
   const lastPreparedFactorKeyRef = React.useRef('');
   const [{ currentFactor }, setFactor] = React.useState<{
@@ -56,6 +57,8 @@ export function _SignInFactorOne(): JSX.Element {
   const resetPasswordFactor = useResetPasswordFactor();
 
   const [showForgotPasswordStrategies, setShowForgotPasswordStrategies] = React.useState(false);
+
+  const [isPasswordPwned, setIsPasswordPwned] = React.useState(false);
 
   React.useEffect(() => {
     // Handle the case where a user lands on alternative methods screen,
@@ -93,11 +96,18 @@ export function _SignInFactorOne(): JSX.Element {
     const canGoBack = factorHasLocalStrategy(currentFactor);
 
     const toggle = showAllStrategies ? toggleAllStrategies : toggleForgotPasswordStrategies;
+    const backHandler = () => {
+      card.setError(undefined);
+      setIsPasswordPwned(false);
+      toggle?.();
+    };
+
+    const mode = showForgotPasswordStrategies ? (isPasswordPwned ? 'pwned' : 'forgot') : 'default';
 
     return (
       <AlternativeMethods
-        asForgotPassword={showForgotPasswordStrategies}
-        onBackLinkClick={canGoBack ? toggle : undefined}
+        mode={mode}
+        onBackLinkClick={canGoBack ? backHandler : undefined}
         onFactorSelected={f => {
           selectFactor(f);
           toggle?.();
@@ -126,6 +136,10 @@ export function _SignInFactorOne(): JSX.Element {
           }}
           onForgotPasswordMethodClick={resetPasswordFactor ? toggleForgotPasswordStrategies : toggleAllStrategies}
           onShowAlternativeMethodsClick={toggleAllStrategies}
+          onPasswordPwned={() => {
+            setIsPasswordPwned(true);
+            toggleForgotPasswordStrategies();
+          }}
         />
       );
     case 'email_code':

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -226,6 +226,153 @@ describe('SignInFactorOne', () => {
           });
         });
       });
+
+      it('Prompts the user to reset their password via email if it has been pwned', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPassword();
+          f.withPreferredSignInStrategy({ strategy: 'password' });
+          f.startSignInWithEmailAddress({
+            supportPassword: true,
+            supportEmailCode: true,
+            supportResetPassword: true,
+          });
+        });
+        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+        const errJSON = {
+          code: 'form_password_pwned',
+          long_message:
+            'Password has been found in an online data breach. For account safety, please reset your password.',
+          message: 'Password has been found in an online data breach. For account safety, please reset your password.',
+          meta: { param_name: 'password' },
+        };
+
+        fixtures.signIn.attemptFirstFactor.mockRejectedValueOnce(
+          new ClerkAPIResponseError('Error', {
+            data: [errJSON],
+            status: 422,
+          }),
+        );
+
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText('Password'), '123456');
+          await userEvent.click(screen.getByText('Continue'));
+
+          await waitFor(() => {
+            screen.getByText('Password compromised');
+            screen.getByText(
+              'This password has been found as part of a breach and can not be used, please reset your password.',
+            );
+            screen.getByText('Or, sign in with another method.');
+          });
+
+          await userEvent.click(screen.getByText('Reset your password'));
+          screen.getByText('Enter the code sent to your email address');
+        });
+      });
+
+      it('Prompts the user to reset their password via phone if it has been pwned', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPassword();
+          f.withPreferredSignInStrategy({ strategy: 'password' });
+          f.startSignInWithPhoneNumber({
+            supportPassword: true,
+            supportPhoneCode: true,
+            supportResetPassword: true,
+          });
+        });
+        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+        const errJSON = {
+          code: 'form_password_pwned',
+          long_message:
+            'Password has been found in an online data breach. For account safety, please reset your password.',
+          message: 'Password has been found in an online data breach. For account safety, please reset your password.',
+          meta: { param_name: 'password' },
+        };
+
+        fixtures.signIn.attemptFirstFactor.mockRejectedValueOnce(
+          new ClerkAPIResponseError('Error', {
+            data: [errJSON],
+            status: 422,
+          }),
+        );
+
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText('Password'), '123456');
+          await userEvent.click(screen.getByText('Continue'));
+
+          await waitFor(() => {
+            screen.getByText('Password compromised');
+            screen.getByText(
+              'This password has been found as part of a breach and can not be used, please reset your password.',
+            );
+            screen.getByText('Or, sign in with another method.');
+          });
+
+          await userEvent.click(screen.getByText('Reset your password'));
+          screen.getByText('Enter the code sent to your phone number');
+        });
+      });
+
+      it('entering a pwned password, then going back and clicking forgot password should result in the correct title', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPassword();
+          f.withPreferredSignInStrategy({ strategy: 'password' });
+          f.startSignInWithEmailAddress({
+            supportPassword: true,
+            supportEmailCode: true,
+            supportResetPassword: true,
+          });
+        });
+        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+        const errJSON = {
+          code: 'form_password_pwned',
+          long_message:
+            'Password has been found in an online data breach. For account safety, please reset your password.',
+          message: 'Password has been found in an online data breach. For account safety, please reset your password.',
+          meta: { param_name: 'password' },
+        };
+
+        fixtures.signIn.attemptFirstFactor.mockRejectedValueOnce(
+          new ClerkAPIResponseError('Error', {
+            data: [errJSON],
+            status: 422,
+          }),
+        );
+
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText('Password'), '123456');
+          await userEvent.click(screen.getByText('Continue'));
+
+          await waitFor(() => {
+            screen.getByText('Password compromised');
+            screen.getByText(
+              'This password has been found as part of a breach and can not be used, please reset your password.',
+            );
+            screen.getByText('Or, sign in with another method.');
+          });
+
+          // Go back
+          await userEvent.click(screen.getByText('Back'));
+
+          // Choose to reset password via "Forgot password" instead
+          await userEvent.click(screen.getByText(/Forgot password/i));
+          screen.getByText('Forgot Password?');
+          expect(
+            screen.queryByText(
+              'This password has been found as part of a breach and can not be used, please reset your password.',
+            ),
+          ).not.toBeInTheDocument();
+        });
+      });
     });
 
     describe('Forgot Password', () => {

--- a/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
@@ -25,6 +25,7 @@ type FlowMetadata = {
     | 'emailLinkStatus'
     | 'alternativeMethods'
     | 'forgotPasswordMethods'
+    | 'passwordPwnedMethods'
     | 'havingTrouble'
     | 'ssoCallback'
     | 'popover'

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -149,6 +149,9 @@ export const enUS: LocalizationResource = {
       subtitle: 'to continue to {{applicationName}}',
       actionLink: 'Use another method',
     },
+    passwordPwned: {
+      title: 'Password compromised',
+    },
     forgotPasswordAlternativeMethods: {
       title: 'Forgot Password?',
       label__alternativeMethods: 'Or, sign in with another method.',
@@ -722,6 +725,8 @@ export const enUS: LocalizationResource = {
       'Sign up unsuccessful due to failed security validations. Please refresh the page to try again or reach out to support for more assistance.',
     form_password_pwned:
       'This password has been found as part of a breach and can not be used, please try another password instead.',
+    form_password_pwned__sign_in:
+      'This password has been found as part of a breach and can not be used, please reset your password.',
     form_username_invalid_length: '',
     form_username_invalid_character: '',
     form_param_format_invalid: '',

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -73,6 +73,10 @@ export function parseErrors(data: ClerkAPIErrorJSON[] = []): ClerkAPIError[] {
   return data.length > 0 ? data.map(parseError) : [];
 }
 
+export function isPasswordPwnedError(err: any) {
+  return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'form_password_pwned';
+}
+
 export function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
   return {
     code: error.code,

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -174,6 +174,9 @@ type _LocalizationResource = {
       subtitle: LocalizationValue;
       actionLink: LocalizationValue;
     };
+    passwordPwned: {
+      title: LocalizationValue;
+    };
     forgotPasswordAlternativeMethods: {
       title: LocalizationValue;
       label__alternativeMethods: LocalizationValue;
@@ -760,6 +763,7 @@ type UnstableErrors = WithParamName<{
   captcha_unavailable: LocalizationValue;
   captcha_invalid: LocalizationValue;
   form_password_pwned: LocalizationValue;
+  form_password_pwned__sign_in: LocalizationValue;
   form_username_invalid_length: LocalizationValue;
   form_username_invalid_character: LocalizationValue;
   form_param_format_invalid: LocalizationValue;


### PR DESCRIPTION
… password at sign-in

If admin has enabled `password_settings.enforce_on_sign_in` and HIBP is enabled, then a password could potentially be detected as pwned at a subsequent sign-in.

The API will respond with error code `form_password_pwned`, in which case we will show a corresponding error and show the alternative method list, prompting them to reset their password.

Back-port of https://github.com/clerk/javascript/pull/3034

## Description

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
