### PR TITLE
fix(clerk-js): Fix height misalignment of Password section in UP

### DIFF
--- a/.changeset/two-ways-buy.md
+++ b/.changeset/two-ways-buy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Height misalignment fixes for Password section in `<UserProfile/>`

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -103,7 +103,7 @@ export const ConnectedAccountsSection = withCardStateProvider(() => {
                 {(error || reauthorizationRequired) && (
                   <Text
                     colorScheme='danger'
-                    sx={t => ({ padding: `${t.sizes.$none} ${t.sizes.$4} ${t.sizes.$1x5} ${t.sizes.$10}` })}
+                    sx={t => ({ padding: `${t.sizes.$none} ${t.sizes.$4} ${t.sizes.$1x5} ${t.sizes.$8x5}` })}
                     localizationKey={errorMessage}
                   />
                 )}

--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordSection.tsx
@@ -4,7 +4,6 @@ import { localizationKeys, Text } from '../../customizables';
 import { ProfileSection } from '../../elements';
 import { Action } from '../../elements/Action';
 import { useActionContext } from '../../elements/Action/ActionRoot';
-import { mqu } from '../../styledSystem';
 import { PasswordForm } from './PasswordForm';
 
 const PasswordScreen = () => {
@@ -28,19 +27,21 @@ export const PasswordSection = () => {
 
   return (
     <ProfileSection.Root
+      centered={false}
       title={localizationKeys('userProfile.start.passwordSection.title')}
       id='password'
-      sx={{ alignItems: 'center', [mqu.md]: { alignItems: 'flex-start' } }}
     >
       <Action.Root>
         <Action.Closed value='edit'>
           <ProfileSection.Item
             id='password'
-            sx={{
+            sx={t => ({
               paddingLeft: !passwordEnabled ? '0' : undefined,
-            }}
+              paddingTop: t.space.$0x25,
+              paddingBottom: t.space.$0x25,
+            })}
           >
-            {passwordEnabled && <Text sx={t => ({ fontSize: t.fontSizes.$xl })}>••••••••••</Text>}
+            {passwordEnabled && <Text variant='h2'>••••••••••</Text>}
 
             <Action.Trigger value='edit'>
               <ProfileSection.Button

--- a/packages/clerk-js/src/ui/elements/Section.tsx
+++ b/packages/clerk-js/src/ui/elements/Section.tsx
@@ -138,10 +138,9 @@ const ProfileSectionItem = (props: ProfileSectionItemProps) => {
           justifyContent: 'space-between',
           width: '100%',
           alignItems: 'center',
-          padding: `${t.space.$2} ${t.space.$3} ${t.space.$1x5} ${t.space.$2x5}`,
+          padding: `${t.space.$1} ${t.space.$1} ${t.space.$1} ${t.space.$2x5}`,
           gap: t.space.$2,
           ...(hoverable && {
-            padding: `${t.space.$1} ${t.space.$1} ${t.space.$1} ${t.space.$2x5}`,
             borderRadius: t.radii.$lg,
             ':hover': { backgroundColor: t.colors.$neutralAlpha50 },
           }),
@@ -166,7 +165,6 @@ const ProfileSectionButton = (props: ProfileSectionButtonProps) => {
       elementDescriptor={descriptors.profileSectionPrimaryButton}
       elementId={descriptors.profileSectionPrimaryButton.setId(id)}
       variant='ghost'
-      textVariant='buttonSmall'
       sx={[
         t => ({
           whiteSpace: 'nowrap',


### PR DESCRIPTION
## Description

This PR fixes some height misalignment of the **Password Section** with the designs.

## Before
![CleanShot 2024-04-01 at 13 12 59@2x](https://github.com/clerk/javascript/assets/6823226/23f59906-e677-4f4c-a9f7-d9306cc8da32)

## After
![CleanShot 2024-04-01 at 13 12 00@2x](https://github.com/clerk/javascript/assets/6823226/5325940f-69b2-459c-8e8a-8dfc803221b4)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
