### PR TITLE
chore(types): Deprecate `supported_identifiers` and remove `supported_external_accounts`

### DIFF
--- a/.changeset/famous-plums-fold.md
+++ b/.changeset/famous-plums-fold.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Deprecate `supported_identifiers` and remove `supported_external_accounts`.

--- a/packages/clerk-js/src/core/test/fixtures.ts
+++ b/packages/clerk-js/src/core/test/fixtures.ts
@@ -204,9 +204,7 @@ export const createSignIn = (signInParams: Partial<SignInJSON> = {}, user: Parti
     identifier: signInParams.identifier,
     object: 'sign_in',
     second_factor_verification: signInParams.second_factor_verification,
-    supported_external_accounts: signInParams.supported_external_accounts,
     supported_first_factors: signInParams.supported_first_factors,
-    supported_identifiers: signInParams.supported_identifiers,
     supported_second_factors: signInParams.supported_second_factors,
     user_data: {
       first_name: user.first_name,
@@ -235,7 +233,6 @@ export const createSignUp = (signUpParams: Partial<SignUpJSON> = {}) => {
     optional_fields: signUpParams.optional_fields,
     phone_number: signUpParams.phone_number,
     required_fields: signUpParams.required_fields,
-    supported_external_accounts: signUpParams.supported_external_accounts,
     unsafe_metadata: signUpParams.unsafe_metadata,
     unverified_fields: signUpParams.unverified_fields,
     username: signUpParams.username,

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -14,7 +14,6 @@ import type { SamlIdpSlug } from './saml';
 import type { SessionStatus } from './session';
 import type { SignInFirstFactor, SignInJSON, SignInSecondFactor } from './signIn';
 import type { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUp';
-import type { OAuthStrategy } from './strategies';
 import type { BoxShadow, Color, EmUnit, FontWeight, HexColor } from './theme';
 import type { UserSettingsJSON } from './userSettings';
 import type { CamelToSnake } from './utils';
@@ -80,7 +79,6 @@ export interface SignUpJSON extends ClerkResourceJSON {
   optional_fields: SignUpField[];
   missing_fields: SignUpField[];
   unverified_fields: SignUpIdentificationField[];
-  supported_external_accounts: OAuthStrategy[];
   username: string | null;
   first_name: string | null;
   last_name: string | null;

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -63,6 +63,9 @@ import type { AuthenticateWithWeb3Params } from './web3Wallet';
 
 export interface SignInResource extends ClerkResource {
   status: SignInStatus | null;
+  /**
+   * @deprecated This attribute will be removed in the next major version
+   */
   supportedIdentifiers: SignInIdentifier[];
   supportedFirstFactors: SignInFirstFactor[];
   supportedSecondFactors: SignInSecondFactor[];
@@ -227,8 +230,10 @@ export interface SignInJSON extends ClerkResourceJSON {
   object: 'sign_in';
   id: string;
   status: SignInStatus;
+  /**
+   * @deprecated This attribute will be removed in the next major version
+   */
   supported_identifiers: SignInIdentifier[];
-  supported_external_accounts: OAuthStrategy[];
   identifier: string;
   user_data: UserDataJSON;
   supported_first_factors: SignInFirstFactorJSON[];


### PR DESCRIPTION

## Description
Neither are used in their respective classes and `supported_external_accounts` is not inside `/environment` response

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
