### PR TITLE
fix(clerk-js): Renaming a passkey leaves stale name

### DIFF
--- a/.changeset/wicked-chefs-reflect.md
+++ b/.changeset/wicked-chefs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue with stale names when updating passkey name.

--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -102,9 +102,9 @@ export const PasskeySection = () => {
     >
       <ProfileSection.ItemList id='passkeys'>
         {user.__experimental_passkeys.map(passkey => (
-          <Action.Root key={passkey.id}>
+          <Action.Root key={[passkey.id, passkey.name].join('_')}>
             <PasskeyItem
-              key={passkey.id}
+              key={[passkey.id, passkey.name].join('_')}
               {...passkey}
             />
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
