### PR TITLE
fix(clerk-js): Avoid depending on `count` as it can be zero but invitations may still exist

### DIFF
--- a/.changeset/five-shoes-promise.md
+++ b/.changeset/five-shoes-promise.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Avoid depending on `count` as it can be zero but invitations may still exist.

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -219,11 +219,11 @@ export const UserInvitationSuggestionList = (props: UserInvitationSuggestionList
   const { ref, userSuggestions, userInvitations } = useFetchInvitations();
   const isLoading = userInvitations.isLoading || userSuggestions.isLoading;
   const hasNextPage = userInvitations.hasNextPage || userSuggestions.hasNextPage;
-  const hasAnyData = !!(userInvitations.count || userSuggestions.count);
 
   // Solve weird bug with swr while running unit tests
-  const userInvitationsData = userInvitations.data?.filter(a => !!a);
-  const userSuggestionsData = userSuggestions.data?.filter(a => !!a);
+  const userInvitationsData = userInvitations.data?.filter(a => !!a) || [];
+  const userSuggestionsData = userSuggestions.data?.filter(a => !!a) || [];
+  const hasAnyData = userInvitationsData.length > 0 || userSuggestionsData.length > 0;
 
   if (!hasAnyData && !isLoading) {
     return null;


### PR DESCRIPTION
## Description

**Background**: In order to provide a better UX, we are manually updating the cache where userInvitations are stored. This allows us to update the invitation in place and avoid layout shifts, if we would simply revalidate this would not be possible.

We are also manually updating `count` in the local cache in order to display the correct number of invitations available, without revalidating as this would cause a layout shift.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
