### PR TITLE
fix(clerk-js): Allow members with membership read permissions to see memberships count

### DIFF
--- a/.changeset/cuddly-wasps-cheat.md
+++ b/.changeset/cuddly-wasps-cheat.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes memebership count in `<OrganizationProfile/>` Members page for members with `org:sys_memberships:read` permission

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -32,7 +32,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
   const { membershipRequests, memberships, invitations } = useOrganization({
     membershipRequests: isDomainsEnabled || undefined,
     invitations: canManageMemberships || undefined,
-    memberships: canManageMemberships || undefined,
+    memberships: canReadMemberships || undefined,
   });
 
   // @ts-expect-error This property is not typed. It is used by our dashboard in order to render a billing widget.


### PR DESCRIPTION
## Description

This PR fixes an issue for the `<OrganizationSwitcher/>` component, where organization members with only `org:sys_memberships:read` could not see the counter on the **Members** tab.

## Before
![CleanShot 2024-04-02 at 16 39 16@2x](https://github.com/clerk/javascript/assets/6823226/e7bc850a-cd7a-4ee3-aa30-e2a0e199e519)

## After
![CleanShot 2024-04-02 at 16 38 26@2x](https://github.com/clerk/javascript/assets/6823226/8f40eff9-5fb2-4254-ac03-fa11f87d7bad)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
