### PR TITLE
fix(remix): Automatically infer path to where component is mounted

### DIFF
--- a/.changeset/wicked-worms-draw.md
+++ b/.changeset/wicked-worms-draw.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Automatically infer the path for where the component is mounted.

--- a/packages/remix/src/client/uiComponents.tsx
+++ b/packages/remix/src/client/uiComponents.tsx
@@ -13,9 +13,8 @@ import type {
   SignUpProps,
   UserProfileProps,
 } from '@clerk/types';
+import { useLocation } from '@remix-run/react';
 import React from 'react';
-
-import { useClerkRemixOptions } from './RemixOptionsContext';
 
 // The assignment of UserProfile with BaseUserProfile props is used
 // to support the CustomPage functionality (eg UserProfile.Page)
@@ -23,13 +22,15 @@ import { useClerkRemixOptions } from './RemixOptionsContext';
 // "The inferred type of 'UserProfile' cannot be named without a reference to ..."
 export const UserProfile: typeof BaseUserProfile = Object.assign(
   (props: UserProfileProps) => {
-    return <BaseUserProfile {...useRoutingProps('UserProfile', props)} />;
+    const { pathname: path } = useLocation();
+    return <BaseUserProfile {...useRoutingProps('UserProfile', props, { path })} />;
   },
   { ...BaseUserProfile },
 );
 
 export const CreateOrganization = (props: CreateOrganizationProps) => {
-  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props)} />;
+  const { pathname: path } = useLocation();
+  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props, { path })} />;
 };
 
 // The assignment of OrganizationProfile with BaseOrganizationProfile props is used
@@ -38,17 +39,18 @@ export const CreateOrganization = (props: CreateOrganizationProps) => {
 // "The inferred type of 'OrganizationProfile' cannot be named without a reference to ..."
 export const OrganizationProfile: typeof BaseOrganizationProfile = Object.assign(
   (props: OrganizationProfileProps) => {
-    return <BaseOrganizationProfile {...useRoutingProps('OrganizationProfile', props)} />;
+    const { pathname: path } = useLocation();
+    return <BaseOrganizationProfile {...useRoutingProps('OrganizationProfile', props, { path })} />;
   },
   { ...BaseOrganizationProfile },
 );
 
 export const SignIn = (props: SignInProps) => {
-  const { signInUrl } = useClerkRemixOptions();
-  return <BaseSignIn {...useRoutingProps('SignIn', props, { path: signInUrl })} />;
+  const { pathname: path } = useLocation();
+  return <BaseSignIn {...useRoutingProps('SignIn', props, { path })} />;
 };
 
 export const SignUp = (props: SignUpProps) => {
-  const { signUpUrl } = useClerkRemixOptions();
-  return <BaseSignUp {...useRoutingProps('SignUp', props, { path: signUpUrl })} />;
+  const { pathname: path } = useLocation();
+  return <BaseSignUp {...useRoutingProps('SignUp', props, { path })} />;
 };

--- a/packages/remix/src/client/uiComponents.tsx
+++ b/packages/remix/src/client/uiComponents.tsx
@@ -13,8 +13,9 @@ import type {
   SignUpProps,
   UserProfileProps,
 } from '@clerk/types';
-import { useLocation } from '@remix-run/react';
 import React from 'react';
+
+import { usePathnameWithoutSplatRouteParams } from './usePathnameWithoutSplatRouteParams';
 
 // The assignment of UserProfile with BaseUserProfile props is used
 // to support the CustomPage functionality (eg UserProfile.Page)
@@ -22,14 +23,14 @@ import React from 'react';
 // "The inferred type of 'UserProfile' cannot be named without a reference to ..."
 export const UserProfile: typeof BaseUserProfile = Object.assign(
   (props: UserProfileProps) => {
-    const { pathname: path } = useLocation();
+    const path = usePathnameWithoutSplatRouteParams();
     return <BaseUserProfile {...useRoutingProps('UserProfile', props, { path })} />;
   },
   { ...BaseUserProfile },
 );
 
 export const CreateOrganization = (props: CreateOrganizationProps) => {
-  const { pathname: path } = useLocation();
+  const path = usePathnameWithoutSplatRouteParams();
   return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props, { path })} />;
 };
 
@@ -39,18 +40,18 @@ export const CreateOrganization = (props: CreateOrganizationProps) => {
 // "The inferred type of 'OrganizationProfile' cannot be named without a reference to ..."
 export const OrganizationProfile: typeof BaseOrganizationProfile = Object.assign(
   (props: OrganizationProfileProps) => {
-    const { pathname: path } = useLocation();
+    const path = usePathnameWithoutSplatRouteParams();
     return <BaseOrganizationProfile {...useRoutingProps('OrganizationProfile', props, { path })} />;
   },
   { ...BaseOrganizationProfile },
 );
 
 export const SignIn = (props: SignInProps) => {
-  const { pathname: path } = useLocation();
+  const path = usePathnameWithoutSplatRouteParams();
   return <BaseSignIn {...useRoutingProps('SignIn', props, { path })} />;
 };
 
 export const SignUp = (props: SignUpProps) => {
-  const { pathname: path } = useLocation();
+  const path = usePathnameWithoutSplatRouteParams();
   return <BaseSignUp {...useRoutingProps('SignUp', props, { path })} />;
 };

--- a/packages/remix/src/client/usePathnameWithoutSplatRouteParams.tsx
+++ b/packages/remix/src/client/usePathnameWithoutSplatRouteParams.tsx
@@ -1,0 +1,18 @@
+import { useLocation, useParams } from '@remix-run/react';
+
+export const usePathnameWithoutSplatRouteParams = () => {
+  const params = useParams();
+  const { pathname } = useLocation();
+
+  // Get the splat route params
+  // Remix store splat route params in an object with a key of '*'
+  // If there are no splat route params, we fallback to an empty string
+  const splatRouteParam = params['*'] || '';
+
+  // Remove the splat route param from the pathname
+  // so we end up with the pathname where the components are mounted at
+  // eg /user/123/profile/security will return /user/123/profile as the path
+  const path = pathname.replace(splatRouteParam, '').replace(/\/$/, '').replace(/^\//, '').trim();
+
+  return `/${path}`;
+};


### PR DESCRIPTION
## Description

This PR allows to automatically infer the path for where the component is mounted.

This functionality is already introduced for `@clerk/nextjs` (#2634)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
