### PR TITLE
fix(localizations): Fix typos from pt-BR localization

### DIFF
--- a/.changeset/quiet-pears-joke.md
+++ b/.changeset/quiet-pears-joke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Fix typos from pt-BR localization

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -343,7 +343,7 @@ export const ptBR: LocalizationResource = {
       subtitle: 'para redefinir sua senha',
       subtitle_email: 'Primeiro, digite o código enviado para seu email',
       subtitle_phone: 'Primeiro, digite o código enviado para seu telefone',
-      title: 'Reset password',
+      title: 'Resetar senha',
     },
     forgotPasswordAlternativeMethods: {
       blockButton__resetPassword: 'Redefinir sua senha',
@@ -382,7 +382,7 @@ export const ptBR: LocalizationResource = {
     },
     resetPassword: {
       formButtonPrimary: 'Redefinir Senha',
-      requiredMessage: 'Por rasões de segurança, é necessário redefinir sua senha.',
+      requiredMessage: 'Por razões de segurança, é necessário redefinir sua senha.',
       successMessage: 'Sua senha foi alterada com sucesso. Entrando, por favor aguarde um momento.',
       title: 'Redefinir Senha',
     },
@@ -699,8 +699,8 @@ export const ptBR: LocalizationResource = {
       },
       successMessage: '{{identifier}} foi adicionado na sua conta.',
       title: 'Adicionar telefone',
-      verifySubtitle: 'Enter the verification code sent to {{identifier}}',
-      verifyTitle: 'Verify phone number',
+      verifySubtitle: 'Insira o código de verificação enviado para {{identifier}}',
+      verifyTitle: 'Verificar número de telefone',
     },
     profilePage: {
       fileDropAreaHint: 'Carregue uma imagem JPG, PNG, GIF ou WEBP menor que 10 MB',


### PR DESCRIPTION
## Description

Fixes typos from `pt-BR` localization module, and also translates a couple of English snippets to Portuguese.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
