### PR TITLE
chore(clerk-js): Fix misalignment of icons in account switcher

### DIFF
--- a/.changeset/modern-hounds-push.md
+++ b/.changeset/modern-hounds-push.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an icon misalignment in account switcher.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
@@ -110,6 +110,9 @@ const _SignInAccountSwitcher = () => {
               iconElementDescriptor={descriptors.accountSwitcherActionButtonIcon}
               iconElementId={descriptors.accountSwitcherActionButtonIcon.setId('signOutAll')}
               label={localizationKeys('signIn.accountSwitcher.action__signOutAll')}
+              sx={t => ({
+                padding: `${t.space.$2} ${t.space.$1x5}`,
+              })}
             />
           </Card.Action>
         </Card.Footer>

--- a/packages/clerk-js/src/ui/components/UserButton/SessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/SessionActions.tsx
@@ -1,5 +1,7 @@
 import type { ActiveSessionResource } from '@clerk/types';
 
+import type { ThemableCssProp } from '~ui/styledSystem/types';
+
 import type { ElementDescriptor, ElementId } from '../../../ui/customizables/elementDescriptors';
 import type { LocalizationKey } from '../../customizables';
 import { descriptors, Flex, localizationKeys } from '../../customizables';
@@ -172,6 +174,7 @@ type SignOutAllActionsProps = {
   iconElementDescriptor?: ElementDescriptor;
   iconElementId?: ElementId;
   label?: LocalizationKey;
+  sx?: ThemableCssProp;
 };
 
 export const SignOutAllActions = (props: SignOutAllActionsProps) => {
@@ -184,13 +187,17 @@ export const SignOutAllActions = (props: SignOutAllActionsProps) => {
     iconElementDescriptor,
     iconElementId,
     label,
+    sx,
   } = props;
   return (
     <Actions
       role='menu'
-      sx={t => ({
-        padding: t.space.$2,
-      })}
+      sx={[
+        t => ({
+          padding: t.space.$2,
+        }),
+        sx,
+      ]}
     >
       <Action
         elementDescriptor={elementDescriptor || descriptors.userButtonPopoverActionButton}


### PR DESCRIPTION
## Description

This PR fixes a very small misalignment between icons of the "Add account" and "Sign out of all accounts" buttons in the account switcher screen.

## Before
![CleanShot 2024-04-03 at 22 04 54@2x](https://github.com/clerk/javascript/assets/6823226/12429972-c61d-419c-813d-c2b58e966975)

## After
![CleanShot 2024-04-03 at 22 04 21@2x](https://github.com/clerk/javascript/assets/6823226/67cea58c-23ee-4563-9b80-589c68914be3)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
