### PR TITLE
Switch compilation target to es2019

### DIFF
--- a/.changeset/light-beers-share.md
+++ b/.changeset/light-beers-share.md
@@ -1,0 +1,9 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/clerk-react': patch
+---
+
+Enable support for older browsers starting with Safari 12 by switching the compilation target to es2019 for all client-side SDKs

--- a/package-lock.json
+++ b/package-lock.json
@@ -36723,10 +36723,10 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "4.71.0",
+        "@clerk/clerk-js": "4.71.1",
         "@clerk/clerk-react": "4.30.8"
       },
       "devDependencies": {
@@ -36743,10 +36743,10 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "4.71.0",
+      "version": "4.71.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/localizations": "1.27.0",
+        "@clerk/localizations": "1.28.0",
         "@clerk/shared": "1.4.0",
         "@clerk/types": "3.63.0",
         "@emotion/cache": "11.11.0",
@@ -37083,10 +37083,10 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "0.20.12",
+      "version": "0.20.13",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "4.71.0",
+        "@clerk/clerk-js": "4.71.1",
         "@clerk/clerk-react": "4.30.8",
         "@clerk/shared": "1.4.0",
         "base-64": "1.0.0",
@@ -37166,7 +37166,7 @@
     },
     "packages/localizations": {
       "name": "@clerk/localizations",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "MIT",
       "dependencies": {
         "@clerk/types": "3.63.0"

--- a/packages/clerk-js/tsconfig.dev.json
+++ b/packages/clerk-js/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "sourceMap": true,
-    "target": "ESNext",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true

--- a/packages/clerk-js/tsconfig.json
+++ b/packages/clerk-js/tsconfig.json
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2020",
+    "target": "ES2019",
     "useUnknownInCatchVariables": false,
     "declaration": false,
     "jsx": "react-jsx",

--- a/packages/localizations/tsconfig.json
+++ b/packages/localizations/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "target": "ES2020",
+    "target": "ES2019",
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -19,7 +19,7 @@
     "skipLibCheck": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2020",
+    "target": "ES2019",
     "types": ["jest"]
   },
   "include": ["src"]

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2019"
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2019",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
This enables support for older iOS mobile browsers. The client-side Clerk SDK now support all webkit-based browsers from version iOS 12 and upwards.

This change has minimal impact on the bundle-size and the generated code. From now on, changing the target to a newer version should be considered a breaking change that can only be released after a major version bump.

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
