### PR TITLE
fix(clerk-js): Remove ~ui path alias

### DIFF
--- a/.changeset/fresh-turkeys-sit.md
+++ b/.changeset/fresh-turkeys-sit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Resolve type issues when importing `@clerk/clerk-js` directly

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -56,8 +56,7 @@ import type {
   UserResource,
 } from '@clerk/types';
 
-import type { MountComponentRenderer } from '~ui/Components';
-
+import type { MountComponentRenderer } from '../ui/Components';
 import {
   appendAsQueryParams,
   buildURL,

--- a/packages/clerk-js/src/emotion.d.ts
+++ b/packages/clerk-js/src/emotion.d.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import '@emotion/react';
 
-import type { InternalTheme } from '~ui/foundations';
+import type { InternalTheme } from './ui/foundations';
 
 declare module '@emotion/react' {
   export interface Theme extends InternalTheme {}

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -7,7 +7,7 @@ import 'regenerator-runtime/runtime';
 
 import { Clerk } from './core/clerk';
 
-import { mountComponentRenderer } from '~ui/Components';
+import { mountComponentRenderer } from './ui/Components';
 
 Clerk.mountComponentRenderer = mountComponentRenderer;
 

--- a/packages/clerk-js/src/index.ts
+++ b/packages/clerk-js/src/index.ts
@@ -1,8 +1,7 @@
 import 'regenerator-runtime/runtime';
 
-import { mountComponentRenderer } from '~ui/Components';
-
 import { Clerk } from './core/clerk';
+import { mountComponentRenderer } from './ui/Components';
 
 export * from './core/resources/Error';
 

--- a/packages/clerk-js/src/ui/components/UserButton/SessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/SessionActions.tsx
@@ -1,12 +1,11 @@
 import type { ActiveSessionResource } from '@clerk/types';
 
-import type { ThemableCssProp } from '~ui/styledSystem/types';
-
 import type { ElementDescriptor, ElementId } from '../../../ui/customizables/elementDescriptors';
 import type { LocalizationKey } from '../../customizables';
 import { descriptors, Flex, localizationKeys } from '../../customizables';
 import { Action, Actions, PreviewButton, SmallAction, SmallActions, UserPreview } from '../../elements';
 import { Add, CogFilled, SignOut, SwitchArrowRight } from '../../icons';
+import type { ThemableCssProp } from '../../styledSystem';
 
 type SingleSessionActionsProps = {
   handleManageAccountClicked: () => Promise<unknown> | void;

--- a/packages/clerk-js/tsconfig.json
+++ b/packages/clerk-js/tsconfig.json
@@ -20,10 +20,7 @@
     "useUnknownInCatchVariables": false,
     "declaration": false,
     "jsx": "react-jsx",
-    "jsxImportSource": "@emotion/react",
-    "paths": {
-      "~ui/*": ["./ui/*"]
-    }
+    "jsxImportSource": "@emotion/react"
   },
   "include": [
     "src/index.ts",

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -31,9 +31,6 @@ const common = ({ mode }) => {
       // Attempt to resolve these extensions in order
       // @see https://webpack.js.org/configuration/resolve/#resolveextensions
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
-      alias: {
-        '~ui': './ui',
-      },
     },
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
We no longer have a use case for it and with the current bundling configuration it is causing issues when clerk-js is imported as a ESM or CJS package.

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
