### PR TITLE
feat(types,clerk-js,clerk-react,nextjs): Treat `plan` as authorization parameter

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -1,6 +1,7 @@
 import type {
   ClerkPaginatedResponse,
   ClerkResourceReloadParams,
+  CustomPlanKey,
   GetUserOrganizationMembershipParams,
   OrganizationCustomRoleKey,
   OrganizationMembershipJSON,
@@ -20,6 +21,7 @@ export class OrganizationMembership extends BaseResource implements Organization
   organization!: Organization;
   permissions: OrganizationPermissionKey[] = [];
   role!: OrganizationCustomRoleKey;
+  orgPlan: CustomPlanKey | undefined;
   createdAt!: Date;
   updatedAt!: Date;
 
@@ -76,6 +78,9 @@ export class OrganizationMembership extends BaseResource implements Organization
     this.role = data.role;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
+    if (data.org_plan) {
+      this.orgPlan = data.org_plan;
+    }
     return this;
   }
 

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -14,6 +14,7 @@ import type {
   CreateWeb3WalletParams,
   CurrentBillingPlanJSON,
   CurrentBillingPlanResource,
+  CustomPlanKey,
   DeletedObjectJSON,
   DeletedObjectResource,
   EmailAddressResource,
@@ -69,6 +70,7 @@ export class User extends BaseResource implements UserResource {
   id = '';
   externalId: string | null = null;
   username: string | null = null;
+  plan: CustomPlanKey | undefined;
   emailAddresses: EmailAddressResource[] = [];
   phoneNumbers: PhoneNumberResource[] = [];
   web3Wallets: Web3WalletResource[] = [];
@@ -427,6 +429,10 @@ export class User extends BaseResource implements UserResource {
 
     if (data.last_sign_in_at) {
       this.lastSignInAt = unixEpochToDate(data.last_sign_in_at);
+    }
+
+    if (data.plan) {
+      this.plan = data.plan;
     }
 
     this.updatedAt = unixEpochToDate(data.updated_at);

--- a/packages/nextjs/src/app-router/server/controlComponents.tsx
+++ b/packages/nextjs/src/app-router/server/controlComponents.tsx
@@ -52,7 +52,7 @@ export function Protect(props: ProtectProps): React.JSX.Element | null {
     return unauthorized;
   }
 
-  if (restAuthorizedParams.role || restAuthorizedParams.permission) {
+  if (restAuthorizedParams.role || restAuthorizedParams.permission || restAuthorizedParams.plan) {
     if (has(restAuthorizedParams)) {
       return authorized;
     }

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -98,7 +98,7 @@ export const createProtect = (opts: {
     }
 
     /**
-     * Checking if user is authorized when permission or role is passed
+     * Checking if user is authorized when permission or role or plan is passed
      */
     if (authObject.has(paramsOrFunction)) {
       return authObject;

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -1,5 +1,6 @@
 import type {
   CheckAuthorizationWithCustomPermissions,
+  CustomPlanKey,
   HandleOAuthCallbackParams,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
@@ -60,21 +61,31 @@ export type ProtectProps = React.PropsWithChildren<
         condition?: never;
         role: OrganizationCustomRoleKey;
         permission?: never;
+        plan?: never;
       }
     | {
         condition?: never;
         role?: never;
+        plan?: never;
         permission: OrganizationCustomPermissionKey;
+      }
+    | {
+        condition?: never;
+        role?: never;
+        plan: CustomPlanKey;
+        permission?: never;
       }
     | {
         condition: (has: CheckAuthorizationWithCustomPermissions) => boolean;
         role?: never;
         permission?: never;
+        plan?: never;
       }
     | {
         condition?: never;
         role?: never;
         permission?: never;
+        plan?: never;
       }
   ) & {
     fallback?: React.ReactNode;
@@ -126,7 +137,7 @@ export const Protect = ({ children, fallback, ...restAuthorizedParams }: Protect
     return unauthorized;
   }
 
-  if (restAuthorizedParams.role || restAuthorizedParams.permission) {
+  if (restAuthorizedParams.role || restAuthorizedParams.permission || restAuthorizedParams.plan) {
     if (has(restAuthorizedParams)) {
       return authorized;
     }

--- a/packages/react/src/contexts/AuthContext.ts
+++ b/packages/react/src/contexts/AuthContext.ts
@@ -1,14 +1,19 @@
 import { createContextAndHook } from '@clerk/shared/react';
-import type { ActJWTClaim, OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from '@clerk/types';
+import type {
+  ActJWTClaim,
+  CustomPlanKey,
+  OrganizationCustomPermissionKey,
+  OrganizationCustomRoleKey,
+} from '@clerk/types';
 
 export const [AuthContext, useAuthContext] = createContextAndHook<{
   userId: string | null | undefined;
-  plan: string | null | undefined;
+  plan: CustomPlanKey | null | undefined;
   sessionId: string | null | undefined;
   actor: ActJWTClaim | null | undefined;
   orgId: string | null | undefined;
   orgRole: OrganizationCustomRoleKey | null | undefined;
   orgSlug: string | null | undefined;
   orgPermissions: OrganizationCustomPermissionKey[] | null | undefined;
-  orgPlan: string | null | undefined;
+  orgPlan: CustomPlanKey | null | undefined;
 }>('AuthContext');

--- a/packages/react/src/contexts/AuthContext.ts
+++ b/packages/react/src/contexts/AuthContext.ts
@@ -3,10 +3,12 @@ import type { ActJWTClaim, OrganizationCustomPermissionKey, OrganizationCustomRo
 
 export const [AuthContext, useAuthContext] = createContextAndHook<{
   userId: string | null | undefined;
+  plan: string | null | undefined;
   sessionId: string | null | undefined;
   actor: ActJWTClaim | null | undefined;
   orgId: string | null | undefined;
   orgRole: OrganizationCustomRoleKey | null | undefined;
   orgSlug: string | null | undefined;
   orgPermissions: OrganizationCustomPermissionKey[] | null | undefined;
+  orgPlan: string | null | undefined;
 }>('AuthContext');

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -35,11 +35,23 @@ export function ClerkContextProvider(props: ClerkContextProvider): JSX.Element |
   const clerkCtx = React.useMemo(() => ({ value: clerk }), [clerkLoaded]);
   const clientCtx = React.useMemo(() => ({ value: state.client }), [state.client]);
 
-  const { sessionId, session, userId, user, orgId, actor, organization, orgRole, orgSlug, orgPermissions } =
-    derivedState;
+  const {
+    sessionId,
+    session,
+    userId,
+    user,
+    plan,
+    orgId,
+    actor,
+    organization,
+    orgRole,
+    orgSlug,
+    orgPermissions,
+    orgPlan,
+  } = derivedState;
 
   const authCtx = React.useMemo(() => {
-    const value = { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions };
+    const value = { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions, orgPlan, plan };
     return { value };
   }, [sessionId, userId, actor, orgId, orgRole, orgSlug]);
   const userCtx = React.useMemo(() => ({ value: user }), [userId, user]);

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import type {
   ActJWTClaim,
   CheckAuthorizationWithCustomPermissions,
+  CustomPlanKey,
   GetToken,
   OrganizationCustomRoleKey,
   SignOut,
@@ -58,7 +59,7 @@ type UseAuthReturn =
       orgRole: null;
       orgSlug: null;
       orgPlan: null;
-      plan: string | undefined;
+      plan: CustomPlanKey | undefined;
       has: CheckAuthorizationWithoutOrgOrUser;
       signOut: SignOut;
       getToken: GetToken;
@@ -72,8 +73,8 @@ type UseAuthReturn =
       orgId: string;
       orgRole: OrganizationCustomRoleKey;
       orgSlug: string | null;
-      orgPlan: string | undefined;
-      plan: string | undefined;
+      orgPlan: CustomPlanKey | undefined;
+      plan: CustomPlanKey | undefined;
       has: CheckAuthorizationWithCustomPermissions;
       signOut: SignOut;
       getToken: GetToken;

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -27,6 +27,8 @@ type UseAuthReturn =
       orgId: undefined;
       orgRole: undefined;
       orgSlug: undefined;
+      orgPlan: undefined;
+      plan: undefined;
       has: CheckAuthorizationSignedOut;
       signOut: SignOut;
       getToken: GetToken;
@@ -40,6 +42,8 @@ type UseAuthReturn =
       orgId: null;
       orgRole: null;
       orgSlug: null;
+      orgPlan: null;
+      plan: null;
       has: CheckAuthorizationWithoutOrgOrUser;
       signOut: SignOut;
       getToken: GetToken;
@@ -53,6 +57,8 @@ type UseAuthReturn =
       orgId: null;
       orgRole: null;
       orgSlug: null;
+      orgPlan: null;
+      plan: string | undefined;
       has: CheckAuthorizationWithoutOrgOrUser;
       signOut: SignOut;
       getToken: GetToken;
@@ -66,6 +72,8 @@ type UseAuthReturn =
       orgId: string;
       orgRole: OrganizationCustomRoleKey;
       orgSlug: string | null;
+      orgPlan: string | undefined;
+      plan: string | undefined;
       has: CheckAuthorizationWithCustomPermissions;
       signOut: SignOut;
       getToken: GetToken;
@@ -112,7 +120,7 @@ type UseAuth = () => UseAuthReturn;
 export const useAuth: UseAuth = () => {
   useAssertWrappedByClerkProvider('useAuth');
 
-  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = useAuthContext();
+  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions, orgPlan, plan } = useAuthContext();
   const isomorphicClerk = useIsomorphicClerkContext();
 
   const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
@@ -120,15 +128,18 @@ export const useAuth: UseAuth = () => {
 
   const has = useCallback(
     (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
-      if (!params?.permission && !params?.role) {
+      if (!params?.permission && !params?.role && !params.plan) {
         errorThrower.throw(useAuthHasRequiresRoleOrPermission);
       }
 
-      if (!orgId || !userId || !orgRole || !orgPermissions) {
+      if (!orgId && !userId) {
         return false;
       }
 
       if (params.permission) {
+        if (!orgPermissions) {
+          return false;
+        }
         return orgPermissions.includes(params.permission);
       }
 
@@ -136,9 +147,12 @@ export const useAuth: UseAuth = () => {
         return orgRole === params.role;
       }
 
+      if (params.plan) {
+        return orgPlan === params.plan || plan === params.plan;
+      }
       return false;
     },
-    [orgId, orgRole, userId, orgPermissions],
+    [orgId, orgRole, userId, orgPermissions, plan, orgPlan],
   );
 
   if (sessionId === undefined && userId === undefined) {
@@ -152,6 +166,8 @@ export const useAuth: UseAuth = () => {
       orgRole: undefined,
       orgSlug: undefined,
       has: undefined,
+      orgPlan: undefined,
+      plan: undefined,
       signOut,
       getToken,
     };
@@ -167,6 +183,8 @@ export const useAuth: UseAuth = () => {
       orgId: null,
       orgRole: null,
       orgSlug: null,
+      orgPlan: null,
+      plan: null,
       has: () => false,
       signOut,
       getToken,
@@ -183,6 +201,8 @@ export const useAuth: UseAuth = () => {
       orgId,
       orgRole,
       orgSlug: orgSlug || null,
+      plan: plan || undefined,
+      orgPlan: orgPlan || undefined,
       has,
       signOut,
       getToken,
@@ -199,6 +219,8 @@ export const useAuth: UseAuth = () => {
       orgId: null,
       orgRole: null,
       orgSlug: null,
+      plan: plan || undefined,
+      orgPlan: null,
       has: () => false,
       signOut,
       getToken,

--- a/packages/react/src/utils/deriveState.ts
+++ b/packages/react/src/utils/deriveState.ts
@@ -18,18 +18,21 @@ export const deriveState = (clerkLoaded: boolean, state: Resources, initialState
 const deriveFromSsrInitialState = (initialState: InitialState) => {
   const userId = initialState.userId;
   const user = initialState.user as UserResource;
+  const plan = initialState.plan;
   const sessionId = initialState.sessionId;
   const session = initialState.session as ActiveSessionResource;
   const organization = initialState.organization as OrganizationResource;
   const orgId = initialState.orgId;
   const orgRole = initialState.orgRole as OrganizationCustomRoleKey;
   const orgPermissions = initialState.orgPermissions as OrganizationCustomPermissionKey[];
+  const orgPlan = initialState.orgPlan;
   const orgSlug = initialState.orgSlug;
   const actor = initialState.actor;
 
   return {
     userId,
     user,
+    plan,
     sessionId,
     session,
     organization,
@@ -38,12 +41,14 @@ const deriveFromSsrInitialState = (initialState: InitialState) => {
     orgPermissions,
     orgSlug,
     actor,
+    orgPlan,
   };
 };
 
 const deriveFromClientSideState = (state: Resources) => {
   const userId: string | null | undefined = state.user ? state.user.id : state.user;
   const user = state.user;
+  const plan = state.user ? state.user.plan : state.user;
   const sessionId: string | null | undefined = state.session ? state.session.id : state.session;
   const session = state.session;
   const actor = session?.actor;
@@ -55,10 +60,12 @@ const deriveFromClientSideState = (state: Resources) => {
     : organization;
   const orgPermissions = membership ? membership.permissions : membership;
   const orgRole = membership ? membership.role : membership;
+  const orgPlan = membership ? membership.orgPlan : membership;
 
   return {
     userId,
     user,
+    plan,
     sessionId,
     session,
     organization,
@@ -67,5 +74,6 @@ const deriveFromClientSideState = (state: Resources) => {
     orgSlug,
     orgPermissions,
     actor,
+    orgPlan,
   };
 };

--- a/packages/types/src/authorization.ts
+++ b/packages/types/src/authorization.ts
@@ -1,0 +1,36 @@
+export interface Base {
+  permission: string;
+  role: string;
+  plan: string;
+}
+
+export interface Placeholder {
+  permission: unknown;
+  role: unknown;
+  plan: unknown;
+}
+
+declare global {
+  interface ClerkAuthorization {}
+}
+
+export type CustomPlanKey = ClerkAuthorization extends Placeholder
+  ? ClerkAuthorization['plan'] extends string
+    ? ClerkAuthorization['plan']
+    : Base['plan']
+  : Base['plan'];
+
+export type CustomPermissionKey = ClerkAuthorization extends Placeholder
+  ? ClerkAuthorization['permission'] extends string
+    ? ClerkAuthorization['permission']
+    : Base['permission']
+  : Base['permission'];
+
+/**
+ * OrganizationCustomRoleKey will be string unless the developer has provided their own types through `ClerkAuthorization`
+ */
+export type CustomRoleKey = ClerkAuthorization extends Placeholder
+  ? ClerkAuthorization['role'] extends string
+    ? ClerkAuthorization['role']
+    : Base['role']
+  : Base['role'];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
+export { CustomPlanKey } from './authorization';
 export * from './api';
 export * from './appearance';
 export * from './elementIds';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -2,6 +2,7 @@
  * Currently representing API DTOs in their JSON form.
  */
 
+import type { CustomPlanKey } from './authorization';
 import type { DisplayConfigJSON } from './displayConfig';
 import type { ActJWTClaim } from './jwt';
 import type { OAuthProvider } from './oauth';
@@ -189,6 +190,7 @@ export interface UserJSON extends ClerkResourceJSON {
   image_url: string;
   has_image: boolean;
   username: string;
+  plan: CustomPlanKey | undefined;
   email_addresses: EmailAddressJSON[];
   phone_numbers: PhoneNumberJSON[];
   web3_wallets: Web3WalletJSON[];
@@ -313,6 +315,7 @@ export interface OrganizationMembershipJSON extends ClerkResourceJSON {
   public_metadata: OrganizationMembershipPublicMetadata;
   public_user_data: PublicUserDataJSON;
   role: OrganizationCustomRoleKey;
+  org_plan: CustomPlanKey | undefined;
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -82,6 +82,11 @@ export interface JwtPayload extends CustomJwtSessionClaims {
   act?: ActClaim;
 
   /**
+   * Active user plan
+   */
+  plan?: string;
+
+  /**
    * Active organization id.
    */
   org_id?: string;
@@ -100,6 +105,11 @@ export interface JwtPayload extends CustomJwtSessionClaims {
    * Active organization role
    */
   org_permissions?: OrganizationCustomPermissionKey[];
+
+  /**
+   * Active organization plan
+   */
+  org_plan?: string;
 
   /**
    * Any other JWT Claim Set member.

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -1,21 +1,8 @@
+import type { CustomPermissionKey, CustomPlanKey, CustomRoleKey, Placeholder } from './authorization';
 import type { OrganizationResource } from './organization';
 import type { ClerkResource } from './resource';
 import type { PublicUserData } from './session';
 import type { Autocomplete } from './utils';
-
-interface Base {
-  permission: string;
-  role: string;
-}
-
-interface Placeholder {
-  permission: unknown;
-  role: unknown;
-}
-
-declare global {
-  interface ClerkAuthorization {}
-}
 
 declare global {
   /**
@@ -44,26 +31,18 @@ export interface OrganizationMembershipResource extends ClerkResource {
   publicMetadata: OrganizationMembershipPublicMetadata;
   publicUserData: PublicUserData;
   role: OrganizationCustomRoleKey;
+  orgPlan?: CustomPlanKey;
   createdAt: Date;
   updatedAt: Date;
   destroy: () => Promise<OrganizationMembershipResource>;
   update: (updateParams: UpdateOrganizationMembershipParams) => Promise<OrganizationMembershipResource>;
 }
 
-export type OrganizationCustomPermissionKey = ClerkAuthorization extends Placeholder
-  ? ClerkAuthorization['permission'] extends string
-    ? ClerkAuthorization['permission']
-    : Base['permission']
-  : Base['permission'];
-
+export type OrganizationCustomPermissionKey = CustomPermissionKey;
 /**
  * OrganizationCustomRoleKey will be string unless the developer has provided their own types through `ClerkAuthorization`
  */
-export type OrganizationCustomRoleKey = ClerkAuthorization extends Placeholder
-  ? ClerkAuthorization['role'] extends string
-    ? ClerkAuthorization['role']
-    : Base['role']
-  : Base['role'];
+export type OrganizationCustomRoleKey = CustomRoleKey;
 
 export type OrganizationSystemPermissionKey =
   | 'org:sys_domains:manage'

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -1,3 +1,4 @@
+import type { CustomPlanKey } from './authorization';
 import type { ActJWTClaim } from './jwt';
 import type {
   OrganizationCustomPermissionKey,
@@ -17,10 +18,17 @@ export type CheckAuthorizationParamsWithCustomPermissions =
   | {
       role: OrganizationCustomRoleKey;
       permission?: never;
+      plan?: never;
     }
   | {
       role?: never;
+      plan?: never;
       permission: OrganizationCustomPermissionKey;
+    }
+  | {
+      plan: CustomPlanKey;
+      role?: never;
+      permission?: never;
     };
 
 export type CheckAuthorization = CheckAuthorizationFn<CheckAuthorizationParams>;
@@ -29,10 +37,17 @@ type CheckAuthorizationParams =
   | {
       role: OrganizationCustomRoleKey;
       permission?: never;
+      plan?: never;
     }
   | {
       role?: never;
+      plan?: never;
       permission: OrganizationPermissionKey;
+    }
+  | {
+      plan: CustomPlanKey;
+      role?: never;
+      permission?: never;
     };
 
 export interface SessionResource extends ClerkResource {

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -15,9 +15,11 @@ export type InitialState = Serializable<{
   actor: ActClaim | undefined;
   userId: string | undefined;
   user: UserResource | undefined;
+  plan: string | undefined;
   orgId: string | undefined;
   orgRole: OrganizationCustomRoleKey | undefined;
   orgSlug: string | undefined;
+  orgPlan: string | undefined;
   orgPermissions: OrganizationCustomPermissionKey[] | undefined;
   organization: OrganizationResource | undefined;
 }>;

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -1,3 +1,4 @@
+import type { CustomPlanKey } from './authorization';
 import type { ActClaim, JwtPayload } from './jwtv2';
 import type { OrganizationResource } from './organization';
 import type { OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from './organizationMembership';
@@ -15,11 +16,11 @@ export type InitialState = Serializable<{
   actor: ActClaim | undefined;
   userId: string | undefined;
   user: UserResource | undefined;
-  plan: string | undefined;
+  plan: CustomPlanKey | undefined;
   orgId: string | undefined;
   orgRole: OrganizationCustomRoleKey | undefined;
   orgSlug: string | undefined;
-  orgPlan: string | undefined;
+  orgPlan: CustomPlanKey | undefined;
   orgPermissions: OrganizationCustomPermissionKey[] | undefined;
   organization: OrganizationResource | undefined;
 }>;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,3 +1,4 @@
+import type { CustomPlanKey } from './authorization';
 import type { BackupCodeResource } from './backupCode';
 import type {
   BillingPlanResource,
@@ -67,6 +68,7 @@ export interface UserResource extends ClerkResource {
   primaryWeb3WalletId: string | null;
   primaryWeb3Wallet: Web3WalletResource | null;
   username: string | null;
+  plan: CustomPlanKey | undefined;
   fullName: string | null;
   firstName: string | null;
   lastName: string | null;


### PR DESCRIPTION
## Description
- Update `has()`, `protect()` and `<Protect/>` to handle `plan` in the app and organization context for a user

- Expect `plan` in ClerkAuthorization in order developers to provide custom types for improved typesafety

- Update the User and OrganizationMembership resources in order to support the functionality described above.


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
