### PR TITLE
feat(clerk-js): Support different CAPTCHA widget types

### DIFF
--- a/.changeset/eighty-pens-mix.md
+++ b/.changeset/eighty-pens-mix.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add support for different CAPTCHA widget types

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -14,6 +14,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   backendHost!: string;
   branded!: boolean;
   captchaPublicKey: string | null = null;
+  captchaWidgetType: string | null = null;
   homeUrl!: string;
   instanceEnvironmentType!: string;
   faviconImageUrl!: string;
@@ -59,6 +60,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.afterSwitchSessionUrl = data.after_switch_session_url;
     this.branded = data.branded;
     this.captchaPublicKey = data.captcha_public_key;
+    this.captchaWidgetType = data.captcha_widget_type;
     this.supportEmail = data.support_email || '';
     this.clerkJSVersion = data.clerk_js_version;
     this.organizationProfileUrl = data.organization_profile_url;

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -1,4 +1,10 @@
-import type { DisplayConfigJSON, DisplayConfigResource, DisplayThemeJSON, PreferredSignInStrategy } from '@clerk/types';
+import type {
+  CaptchaWidgetType,
+  DisplayConfigJSON,
+  DisplayConfigResource,
+  DisplayThemeJSON,
+  PreferredSignInStrategy,
+} from '@clerk/types';
 
 import { BaseResource } from './internal';
 
@@ -14,7 +20,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   backendHost!: string;
   branded!: boolean;
   captchaPublicKey: string | null = null;
-  captchaWidgetType: string | null = null;
+  captchaWidgetType: CaptchaWidgetType = null;
   homeUrl!: string;
   instanceEnvironmentType!: string;
   faviconImageUrl!: string;

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -68,12 +68,13 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   create = async (params: SignUpCreateParams): Promise<SignUpResource> => {
     const paramsWithCaptcha: Record<string, unknown> = params;
-    const { captchaSiteKey, canUseCaptcha, captchaURL } = retrieveCaptchaInfo(SignUp.clerk);
+    const { captchaSiteKey, canUseCaptcha, captchaURL, captchaWidgetType } = retrieveCaptchaInfo(SignUp.clerk);
 
     if (canUseCaptcha && captchaSiteKey && captchaURL) {
       try {
         paramsWithCaptcha.captchaToken = await getCaptchaToken({
           siteKey: captchaSiteKey,
+          widgetType: captchaWidgetType,
           scriptUrl: captchaURL,
         });
       } catch (e) {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { CAPTCHA_ELEMENT_ID } from '../../../utils';
-import { Box, Col, localizationKeys, useAppearance } from '../../customizables';
+import { Col, localizationKeys, useAppearance } from '../../customizables';
 import { Form } from '../../elements';
+import { CaptchaElement } from '../../elements/CaptchaElement';
 import { mqu } from '../../styledSystem';
 import type { FormControlState } from '../../utils';
 import type { ActiveIdentifier, Fields } from './signUpFormHelpers';
@@ -103,10 +103,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
         )}
       </Col>
       <Col center>
-        <Box
-          id={CAPTCHA_ELEMENT_ID}
-          sx={t => ({ display: 'none', marginBottom: t.space.$6 })}
-        />
+        <CaptchaElement />
         <Form.SubmitButton
           hasArrow
           localizationKey={localizationKeys('formButtonPrimary')}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Col, localizationKeys, useAppearance } from '../../customizables';
+import { CAPTCHA_ELEMENT_ID } from '../../../utils';
+import { Box, Col, localizationKeys, useAppearance } from '../../customizables';
 import { Form } from '../../elements';
 import { mqu } from '../../styledSystem';
 import type { FormControlState } from '../../utils';
@@ -101,10 +102,16 @@ export const SignUpForm = (props: SignUpFormProps) => {
           </Form.ControlRow>
         )}
       </Col>
-      <Form.SubmitButton
-        hasArrow
-        localizationKey={localizationKeys('formButtonPrimary')}
-      />
+      <Col center>
+        <Box
+          id={CAPTCHA_ELEMENT_ID}
+          sx={t => ({ display: 'none', marginBottom: t.space.$6 })}
+        />
+        <Form.SubmitButton
+          hasArrow
+          localizationKey={localizationKeys('formButtonPrimary')}
+        />
+      </Col>
     </Form.Root>
   );
 };

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -13,6 +13,7 @@ import {
   SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
 } from '../../elements';
+import { CaptchaElement } from '../../elements/CaptchaElement';
 import { useCardState } from '../../elements/contexts';
 import { useLoadingStatus } from '../../hooks';
 import { useRouter } from '../../router';
@@ -277,6 +278,7 @@ function _SignUpStart(): JSX.Element {
                 />
               )}
             </SocialButtonsReversibleContainerWithDivider>
+            {!shouldShowForm && <CaptchaElement />}
           </Flex>
         </Card.Content>
 

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -1,0 +1,9 @@
+import { CAPTCHA_ELEMENT_ID } from '../../utils';
+import { Box } from '../customizables';
+
+export const CaptchaElement = () => (
+  <Box
+    id={CAPTCHA_ELEMENT_ID}
+    sx={t => ({ display: 'none', marginBottom: t.space.$6 })}
+  />
+);

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -1,4 +1,5 @@
 import { loadScript } from '@clerk/shared/loadScript';
+import type { CaptchaWidgetType } from '@clerk/types';
 
 import { clerkFailedToLoadThirdPartyScript } from '../core/errors';
 
@@ -82,7 +83,7 @@ export async function loadCaptcha(url: string) {
 export const getCaptchaToken = async (captchaOptions: {
   siteKey: string;
   scriptUrl: string;
-  widgetType: string | null;
+  widgetType: CaptchaWidgetType;
 }) => {
   const { siteKey: sitekey, scriptUrl, widgetType } = captchaOptions;
   let captchaToken = '',
@@ -117,7 +118,7 @@ export const getCaptchaToken = async (captchaOptions: {
       try {
         const id = captcha.render(invisibleWidget ? `.${CAPTCHA_INVISIBLE_CLASSNAME}` : `#${CAPTCHA_ELEMENT_ID}`, {
           sitekey,
-          appearance: 'interaction-only',
+          appearance: widgetType === 'always_visible' ? 'always' : 'interaction-only',
           retry: 'never',
           'refresh-expired': 'auto',
           callback: function (token: string) {

--- a/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
@@ -6,6 +6,7 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
   const fapiClient = createFapiClient(clerk);
   return {
     captchaSiteKey: _environment ? _environment.displayConfig.captchaPublicKey : null,
+    captchaWidgetType: _environment ? _environment.displayConfig.captchaWidgetType : null,
     canUseCaptcha: _environment
       ? _environment.userSettings.signUp.captcha_enabled &&
         clerk.isStandardBrowser &&

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -2,6 +2,7 @@ import type { DisplayThemeJSON } from './json';
 import type { ClerkResource } from './resource';
 
 export type PreferredSignInStrategy = 'password' | 'otp';
+export type CaptchaWidgetType = 'smart' | 'always_visible' | 'invisible' | null;
 
 export interface DisplayConfigJSON {
   object: 'display_config';
@@ -14,7 +15,7 @@ export interface DisplayConfigJSON {
   application_name: string;
   branded: boolean;
   captcha_public_key: string | null;
-  captcha_widget_type: string | null;
+  captcha_widget_type: CaptchaWidgetType;
   home_url: string;
   instance_environment_type: string;
   logo_image_url: string;
@@ -43,7 +44,7 @@ export interface DisplayConfigResource extends ClerkResource {
   backendHost: string;
   branded: boolean;
   captchaPublicKey: string | null;
-  captchaWidgetType: string | null;
+  captchaWidgetType: CaptchaWidgetType;
   homeUrl: string;
   instanceEnvironmentType: string;
   logoImageUrl: string;

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -14,6 +14,7 @@ export interface DisplayConfigJSON {
   application_name: string;
   branded: boolean;
   captcha_public_key: string | null;
+  captcha_widget_type: string | null;
   home_url: string;
   instance_environment_type: string;
   logo_image_url: string;
@@ -42,6 +43,7 @@ export interface DisplayConfigResource extends ClerkResource {
   backendHost: string;
   branded: boolean;
   captchaPublicKey: string | null;
+  captchaWidgetType: string | null;
   homeUrl: string;
   instanceEnvironmentType: string;
   logoImageUrl: string;


### PR DESCRIPTION
## Description
This PR adds support for different CAPTCHA widgets coming from the FAPI.

### Current behavior:
Currently, we support only an invisible captcha widget. This widget gets rendered in an injected div element at the end of the document body.

### After this PR:
For backward compatibility, we will support the previous functionality when the user has selected the `"invisible"` widget. This is the setting to which all current users will be migrated.

This PR adds support for a visible challenge if needed on sign-up. This challenge gets rendered on the `<div id="clerk-captcha" />` element in the SignUp form.

Users with custom sign-up flows must have the `<div id="clerk-captcha" />` element inside their DOM when calling the `signUp.create` function.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
