### PR TITLE
chore(clerk-js): Only allow permission authorizations internally

### DIFF
--- a/packages/clerk-js/src/ui/common/Gate.tsx
+++ b/packages/clerk-js/src/ui/common/Gate.tsx
@@ -1,27 +1,25 @@
 import { useSession } from '@clerk/shared/react';
-import type { CheckAuthorization, OrganizationCustomRoleKey, OrganizationPermissionKey } from '@clerk/types';
+import type { CheckAuthorizationFn, OrganizationPermissionKey } from '@clerk/types';
 import type { ComponentType, PropsWithChildren, ReactNode } from 'react';
 import React, { useEffect } from 'react';
 
 import { useRouter } from '../router';
 
-type ProtectParams = Parameters<CheckAuthorization>[0] | ((has: CheckAuthorization) => boolean);
+type CheckAuthorizationInternalParams = {
+  permission: OrganizationPermissionKey;
+};
+
+type CheckAuthorizationInternal = CheckAuthorizationFn<CheckAuthorizationInternalParams>;
+type ProtectParams = Parameters<CheckAuthorizationInternal>[0] | ((has: CheckAuthorizationInternal) => boolean);
 
 type ProtectProps = PropsWithChildren<
   (
     | {
         condition?: never;
-        role: OrganizationCustomRoleKey;
-        permission?: never;
-      }
-    | {
-        condition?: never;
-        role?: never;
         permission: OrganizationPermissionKey;
       }
     | {
-        condition: (has: CheckAuthorization) => boolean;
-        role?: never;
+        condition: (has: CheckAuthorizationInternal) => boolean;
         permission?: never;
       }
   ) & {


### PR DESCRIPTION
## Description

Internally we should **not** depend on roles. Since custom roles was introduced we have updated our internal clerk-js component to work with permissions only.

There are no references to `<Protect role="..."/>` in clerk-js.

This PR narrows the types in order to avoid confusion when protect is used inside clerk-js. Public APIs are not affected.


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
