### PR TITLE
fix(clerk-js): Correctly call __internal_navigateWithError when authenticating with passkey

### DIFF
--- a/.changeset/modern-bobcats-love.md
+++ b/.changeset/modern-bobcats-love.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug Fix: When authenticating with a passkey and user was looked out an error was thrown for accessing an undefined variable

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -11,7 +11,8 @@ import { handleError } from '../../utils';
 
 function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>) {
   const card = useCardState();
-  const { setActive } = useClerk();
+  // @ts-expect-error -- private method for the time being
+  const { setActive, __internal_navigateWithError } = useClerk();
   const supportEmail = useSupportEmail();
   const { navigateAfterSignIn } = useSignInContext();
   const { authenticateWithPasskey } = useCoreSignIn();
@@ -48,8 +49,7 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
       }
 
       if (isUserLockedError(err)) {
-        // @ts-expect-error -- private method for the time being
-        return clerk.__internal_navigateWithError('..', err.errors[0]);
+        return __internal_navigateWithError('..', err.errors[0]);
       }
       handleError(err, [], card.setError);
     }


### PR DESCRIPTION
## Description

Same as the title
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
