### PR TITLE
fix(backend): Trigger handshake in dev when no dev browser present

### DIFF
--- a/.changeset/rare-shoes-hunt.md
+++ b/.changeset/rare-shoes-hunt.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Trigger the handshake when no dev browser token exists in development.

--- a/integration/tests/handshake.test.ts
+++ b/integration/tests/handshake.test.ts
@@ -518,7 +518,10 @@ test.describe('Client handshake @generic', () => {
       }),
       redirect: 'manual',
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe(
+      `https://${config.pkHost}/v1/client/handshake?redirect_url=${encodeURIComponent(`${app.serverUrl}/`)}`,
+    );
   });
 
   test('Test redirect url - path and qs - dev', async () => {

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -58,6 +58,7 @@ export type HandshakeState = Omit<SignedOutState, 'status' | 'toAuth'> & {
 
 export const AuthErrorReason = {
   ClientUATWithoutSessionToken: 'client-uat-but-no-session-token',
+  DevBrowserMissing: 'dev-browser-missing',
   DevBrowserSync: 'dev-browser-sync',
   PrimaryRespondsToSyncing: 'primary-responds-to-syncing',
   SatelliteCookieNeedsSyncing: 'satellite-needs-syncing',

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -203,6 +203,7 @@ ${error.getFullMessage()}`,
   async function authenticateRequestWithTokenInCookie() {
     const hasActiveClient = authenticateContext.clientUat;
     const hasSessionToken = !!authenticateContext.sessionTokenInCookie;
+    const hasDevBrowserToken = !!authenticateContext.devBrowserToken;
 
     const isRequestEligibleForMultiDomainSync =
       authenticateContext.isSatellite &&
@@ -292,6 +293,10 @@ ${error.getFullMessage()}`,
     /**
      * End multi-domain sync flows
      */
+
+    if (instanceType === 'development' && !hasDevBrowserToken) {
+      return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.DevBrowserMissing, '');
+    }
 
     if (!hasActiveClient && !hasSessionToken) {
       return signedOut(authenticateContext, AuthErrorReason.SessionTokenAndUATMissing, '');

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -27,7 +27,10 @@ describe('clerkMiddleware', () => {
     it('works if secretKey is passed as parameter', async () => {
       const options = { secretKey: 'sk_test_....' };
 
-      const response = await runMiddleware(clerkMiddleware(options)).expect(200, 'Hello world!');
+      const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
+        200,
+        'Hello world!',
+      );
 
       assertSignedOutDebugHeaders(response);
     });
@@ -54,7 +57,10 @@ describe('clerkMiddleware', () => {
     it('works if publishableKey is passed as parameter', async () => {
       const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
 
-      const response = await runMiddleware(clerkMiddleware(options)).expect(200, 'Hello world!');
+      const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
+        200,
+        'Hello world!',
+      );
 
       assertSignedOutDebugHeaders(response);
     });
@@ -63,7 +69,10 @@ describe('clerkMiddleware', () => {
   it.todo('supports usage without invocation: app.use(clerkMiddleware)');
 
   it('supports usage without parameters: app.use(clerkMiddleware())', async () => {
-    const response = await runMiddleware(clerkMiddleware()).expect(200, 'Hello world!');
+    const response = await runMiddleware(clerkMiddleware(), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
+      200,
+      'Hello world!',
+    );
 
     assertSignedOutDebugHeaders(response);
   });
@@ -71,7 +80,10 @@ describe('clerkMiddleware', () => {
   it('supports usage with parameters: app.use(clerkMiddleware(options))', async () => {
     const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
 
-    const response = await runMiddleware(clerkMiddleware(options)).expect(200, 'Hello world!');
+    const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
+      200,
+      'Hello world!',
+    );
 
     assertSignedOutDebugHeaders(response);
   });
@@ -82,7 +94,10 @@ describe('clerkMiddleware', () => {
       return next();
     };
 
-    const response = await runMiddleware(clerkMiddleware(handler)).expect(200, 'Hello world!');
+    const response = await runMiddleware(clerkMiddleware(handler), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
+      200,
+      'Hello world!',
+    );
 
     expect(response.header).toHaveProperty('x-clerk-auth-custom', 'custom-value');
     assertSignedOutDebugHeaders(response);
@@ -95,7 +110,9 @@ describe('clerkMiddleware', () => {
     };
     const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
 
-    const response = await runMiddleware(clerkMiddleware(handler, options)).expect(200, 'Hello world!');
+    const response = await runMiddleware(clerkMiddleware(handler, options), {
+      Cookie: '__clerk_db_jwt=deadbeef;',
+    }).expect(200, 'Hello world!');
 
     expect(response.header).toHaveProperty('x-clerk-auth-custom', 'custom-value');
     assertSignedOutDebugHeaders(response);


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Trigger the handshake in development when no dev browser is present. This ensures stale auth state from the account portal is picked up if a redirect happens.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
