### PR TITLE
fix(backend): Deprecate Organization.members_count

### DIFF
--- a/.changeset/slimy-games-cover.md
+++ b/.changeset/slimy-games-cover.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Deprecate `organization.members_count`. Use `organization.membersCount` instead.

--- a/packages/backend/src/api/resources/Organization.ts
+++ b/packages/backend/src/api/resources/Organization.ts
@@ -19,7 +19,11 @@ export class Organization {
     readonly privateMetadata: OrganizationPrivateMetadata = {},
     readonly maxAllowedMemberships: number,
     readonly adminDeleteEnabled: boolean,
+    /**
+     * @deprecated  Use `membersCount` instead.
+     */
     readonly members_count?: number,
+    readonly membersCount?: number,
   ) {}
 
   static fromJSON(data: OrganizationJSON): Organization {
@@ -38,8 +42,10 @@ export class Organization {
       data.max_allowed_memberships,
       data.admin_delete_enabled,
       data.members_count,
+      data.members_count,
     );
   }
 }
 
 deprecatedProperty(Organization, 'logoUrl', 'Use `imageUrl` instead.');
+deprecatedProperty(Organization, 'members_count', 'Use `membersCount` instead.');


### PR DESCRIPTION
## Description

Backport https://github.com/clerk/javascript/pull/3094 by introducing the `membersCount` property and deprecating the `members_count`.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
