### PR TITLE
fix(clerk-js): Fixed issue that prevented backup codes showing up for TOTP

### DIFF
--- a/.changeset/wise-dogs-swim.md
+++ b/.changeset/wise-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixed issue that prevented backup codes showing up for TOTP

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
@@ -132,9 +132,7 @@ export const MfaSection = () => {
             </Action.Root>
           )}
 
-          {secondFactorsAvailableToAdd.length > 0 && (
-            <MfaAddMenu secondFactorsAvailableToAdd={secondFactorsAvailableToAdd} />
-          )}
+          <MfaAddMenu secondFactorsAvailableToAdd={secondFactorsAvailableToAdd} />
         </ProfileSection.ItemList>
       </Action.Root>
     </ProfileSection.Root>
@@ -241,28 +239,30 @@ const MfaAddMenu = (props: MfaAddMenuProps) => {
 
   return (
     <>
-      <Action.Closed value='multi-factor'>
-        <ProfileSection.ActionMenu
-          id='mfa'
-          triggerLocalizationKey={localizationKeys('userProfile.start.mfaSection.primaryButton')}
-        >
-          {strategies.map(
-            method =>
-              method && (
-                <ProfileSection.ActionMenuItem
-                  key={method.key}
-                  id={method.key}
-                  localizationKey={method.text}
-                  leftIcon={method.icon}
-                  onClick={() => {
-                    setSelectedStrategy(method.key);
-                    open('multi-factor');
-                  }}
-                />
-              ),
-          )}
-        </ProfileSection.ActionMenu>
-      </Action.Closed>
+      {secondFactorsAvailableToAdd.length > 0 && (
+        <Action.Closed value='multi-factor'>
+          <ProfileSection.ActionMenu
+            id='mfa'
+            triggerLocalizationKey={localizationKeys('userProfile.start.mfaSection.primaryButton')}
+          >
+            {strategies.map(
+              method =>
+                method && (
+                  <ProfileSection.ActionMenuItem
+                    key={method.key}
+                    id={method.key}
+                    localizationKey={method.text}
+                    leftIcon={method.icon}
+                    onClick={() => {
+                      setSelectedStrategy(method.key);
+                      open('multi-factor');
+                    }}
+                  />
+                ),
+            )}
+          </ProfileSection.ActionMenu>
+        </Action.Closed>
+      )}
       <Action.Open value='multi-factor'>
         <Action.Card>{selectedStrategy && <MfaScreen selectedStrategy={selectedStrategy} />}</Action.Card>
       </Action.Open>


### PR DESCRIPTION
## Description

This PR fixes a bug that was introduced with the re-theme of our components, when you were adding TOTP as your MFA without having any other factor available the backup codes where not showing up, after this fix this will work correctly.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
