### PR TITLE
fix(clerk-js): Align country code position with phone number input

### DIFF
--- a/.changeset/curly-cheetahs-act.md
+++ b/.changeset/curly-cheetahs-act.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Align country code position with phone number input.

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -162,7 +162,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           sx={t => ({
             position: 'absolute',
             left: '1ch',
-            top: '50%',
+            top: '51%',
             transform: 'translateY(-50%)',
             pointerEvents: 'none',
             opacity: props.isDisabled ? t.opacity.$disabled : 1,


### PR DESCRIPTION
## Description

This PR aligns country code text position to be fully aligned with the phone number input

## Before
![image](https://github.com/clerk/javascript/assets/6823226/de1a388f-867f-4213-b87b-14b8faa0913b)

# After
![CleanShot 2024-04-16 at 15 18 31@2x](https://github.com/clerk/javascript/assets/6823226/33049aff-4567-4ddb-94df-9cc2cfb5470c)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
