### PR TITLE
fix(types,localizations): Added translation keys and Hu translations

### DIFF
--- a/.changeset/long-days-retire.md
+++ b/.changeset/long-days-retire.md
@@ -1,0 +1,6 @@
+---
+'@clerk/localizations': minor
+'@clerk/types': minor
+---
+
+Added missing translation keys in \_LocalizationResource, so I added those.

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -283,8 +283,8 @@ export const huHU: LocalizationResource = {
       actionLink: 'Segítség kérése',
       actionText: 'Nincs ezekből egyik sem ?',
       blockButton__backupCode: 'Tartalék kód használata',
-      blockButton__emailCode: 'Email kód a {{identifier}}-nak/nek',
-      blockButton__emailLink: 'Email link a {{identifier}}-nak/nek',
+      blockButton__emailCode: 'Email kód a(z) {{identifier}} címre',
+      blockButton__emailLink: 'Email link a(z) {{identifier}} címre',
       blockButton__passkey: 'Bejelentkezés passkey-vel',
       blockButton__password: 'Bejelentkezés jelszóval',
       blockButton__phoneCode: 'SMS kód {{identifier}}-nak/nek',
@@ -346,6 +346,7 @@ export const huHU: LocalizationResource = {
       subtitle_email: 'Először, írd be a kódot amit emailben kaptál',
       subtitle_phone: 'Először, írd be a kódot amit a telefonodra kaptál',
       title: 'Jelszó visszaállítás',
+      formSubtitle_email: 'Írd be a kódot, amit az email címedre küldtünk',
     },
     forgotPasswordAlternativeMethods: {
       blockButton__resetPassword: 'Állítsd vissza a jelszavad',
@@ -451,11 +452,11 @@ export const huHU: LocalizationResource = {
     start: {
       actionLink: 'Bejelentkezés',
       actionText: 'Van már fiókod?',
-      subtitle: 'Üdv! Kérlek add meg az adatokat, hogy elkezdhesd.',
-      title: 'Fiók létrehozása',
+      title: 'Hozz létre egy fiókot',
+      subtitle: 'hogy folytathasd a {{applicationName}} használatát',
     },
   },
-  socialButtonsBlockButton: 'Folytatás {{provider|titleize}} segítségével',
+  socialButtonsBlockButton: 'Folytatás {{provider|titleize}} fiókkal',
   unstable__errors: {
     captcha_invalid:
       'Biztonsági okokból a regisztráció sikertelen volt. Kérlek frissítsd az oldalt, hogy újra próbálhasd, vagy kérj támogatást.',
@@ -466,7 +467,7 @@ export const huHU: LocalizationResource = {
     form_identifier_exists__email_address: 'Ez az email cím már foglalt. Kérlek próbálj egy másikat.',
     form_identifier_exists__phone_number: 'Ez a telefonszám már foglalt. Kérlek próbálj egy másikat.',
     form_identifier_exists__username: 'Ez a felhasználónév már foglalt. Kérlek próbálj egy másikat.',
-    form_identifier_not_found: '',
+    form_identifier_not_found: 'Ezt a felhasználót nem találtuk',
     form_param_format_invalid: '',
     form_param_format_invalid__email_address: 'Az email címnek érvényes email címnek kell lennie.',
     form_param_format_invalid__phone_number: 'A telefonszámnak érvényes telefonszámnak kell lennie.',
@@ -474,7 +475,7 @@ export const huHU: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'A vezetéknév nem lehet hosszabb, mint 256 karakter.',
     form_param_max_length_exceeded__name: 'A név nem lehet hosszabb mint 256 karakter.',
     form_param_nil: '',
-    form_password_incorrect: '',
+    form_password_incorrect: 'Hibás jelszó. Kérlek próbálkozz újra, vagy próbálj más módon bejelentkezni',
     form_password_length_too_short: '',
     form_password_not_strong_enough: 'A jelszó nem elég erős',
     form_password_pwned:
@@ -494,13 +495,13 @@ export const huHU: LocalizationResource = {
     passkey_retrieval_cancelled: 'Passkey visszaigazolás megszakadt vagy lejárt.',
     passkey_pa_not_supported: 'A regisztrációhoz egy platform hitelesítő kell, de ez az eszköz ezt nem támogatja.',
     passwordComplexity: {
-      maximumLength: 'kevesebb mint {{length}} karaktert',
-      minimumLength: '{{length}} vagy több karaktert',
-      requireLowercase: 'egy kisbetűt',
-      requireNumbers: 'egy számot',
-      requireSpecialCharacter: 'egy speciális karaktert',
-      requireUppercase: 'egy nagybetű',
-      sentencePrefix: 'A jelszavadnak tartalmaznia kell',
+      maximumLength: 'jelszó nem lehet hosszabb, mint {{length}} karakter',
+      minimumLength: 'jelszó nem lehet rövidebb, mint {{length}} karakter',
+      requireLowercase: 'jelszónak legalább egy kisbetűt tartalmaznia kell',
+      requireNumbers: 'jelszónak legalább egy számot tartalmaznia kell',
+      requireSpecialCharacter: 'jelszónak legalább egy speciális karaktert tartalmaznia kell',
+      requireUppercase: 'jelszónak legalább egy nagybetűt tartalmaznia kell',
+      sentencePrefix: 'A',
     },
     phone_number_exists: 'Ez a telefonszám már foglalt. Kérlek próbálj meg egy másikat.',
     zxcvbn: {
@@ -589,7 +590,7 @@ export const huHU: LocalizationResource = {
       title: 'Kapcsolt fiók hozzáadása',
     },
     deletePage: {
-      actionDescription: 'Írd be, hogy "Delete account" a folytatáshoz.',
+      actionDescription: 'Írd be, hogy "Fiók törlése" a folytatáshoz.',
       confirm: 'Fiók törlése',
       messageLine1: 'Biztos vagy benne, hogy törölni szeretnéd a fiókod?',
       messageLine2: 'Ez a művelet végleges és visszafordíthatatlan.',
@@ -699,6 +700,8 @@ export const huHU: LocalizationResource = {
       successMessage__update: 'A jelszavad frissítésre került.',
       title__set: 'Jelszó beállítása',
       title__update: 'Jelszó frissítése',
+      changePasswordTitle: 'Jelszó megváltoztatása',
+      changePasswordSuccessMessage: 'A jelszavad sikeresen megváltoztattad. Minden más eszköz ki lett jelentkeztetve.',
     },
     phoneNumberPage: {
       infoText:
@@ -730,8 +733,12 @@ export const huHU: LocalizationResource = {
         title: 'Passkey-k',
       },
       activeDevicesSection: {
-        destructiveAction: 'Kijelentkezés az eszközről',
+        destructiveAction: 'Munkamenet megszüntetése',
         title: 'Aktív eszközök',
+        detailsTitle: 'Jelenlegi eszköz',
+        detailsSubtitle: 'Jelenleg ezt az eszközt használod',
+        destructiveActionTitle: 'Kijelentkeztetés',
+        destructiveActionSubtitle: 'Szüntesd meg a jelenlegi munkamenetet ezen az eszközön',
       },
       connectedAccountsSection: {
         actionLabel__connectionFailed: 'Próbáld újra',
@@ -741,9 +748,13 @@ export const huHU: LocalizationResource = {
         subtitle__reauthorize:
           'A szükséges hatáskörök megváltozták, előfordulhat, hogy limitált funkcionalitást tapasztalhatsz. Kérlek, újra engedélyezd az alkalmazást, hogy elkerüld a hibákat.',
         title: 'Kapcsolt fiókok',
+        destructiveActionSubtitle: 'Töröld ki ezt a kapcsolt fiókot a fiókodból.',
+        destructiveActionAccordionSubtitle: 'Kapcsolt fiók eltávolítása',
       },
       dangerSection: {
         deleteAccountButton: 'Fiók törlése',
+        deleteAccountDescription: 'Töröld ki a fiókod és minden hozzátartozó adatot.',
+        deleteAccountTitle: 'Fiók törlése',
         title: 'Fiók törlése',
       },
       emailAddressesSection: {
@@ -753,12 +764,21 @@ export const huHU: LocalizationResource = {
         detailsAction__unverified: 'Visszaigazolás',
         primaryButton: 'Email cím hozzáadása',
         title: 'Email címek',
+        detailsSubtitle__primary: 'Ez az email cím az elsődleges címed.',
+        detailsTitle__primary: 'Elsődleges email cím',
+        destructiveActionTitle: 'Eltávolítás',
+        destructiveActionSubtitle: 'Töröld ki ezt az email címet, és távolítsd el a fiókodból.',
+        detailsTitle__nonPrimary: 'Beállítás elsődleges email címként',
+        detailsSubtitle__nonPrimary:
+          'Állítsd be ezt az email címet elsődlegesként, hogy erre kapd a fiókoddal kapcsolatos üzeneteket',
       },
       enterpriseAccountsSection: {
         title: 'Vállalati fiókok',
       },
       headerTitle__account: 'Profil adatok',
+      headerSubtitle__account: 'Fiók adatok kezelése',
       headerTitle__security: 'Biztonság',
+      headerSubtitle__security: 'Biztonsági beállítások',
       mfaSection: {
         backupCodes: {
           actionLabel__regenerate: 'Újra generálás',
@@ -787,6 +807,7 @@ export const huHU: LocalizationResource = {
         primaryButton__setPassword: 'Jelszó beállítása',
         primaryButton__updatePassword: 'Jelszó frissítése',
         title: 'Jelszó',
+        primaryButton__changePassword: 'Jelszó megváltoztatása',
       },
       phoneNumbersSection: {
         destructiveAction: 'Teleofnszám eltávolítása',
@@ -795,6 +816,13 @@ export const huHU: LocalizationResource = {
         detailsAction__unverified: 'Teleofnszám visszaigazolása',
         primaryButton: 'Telefonszám hozzáadása',
         title: 'Telefonszámok',
+        detailsTitle__primary: 'Elsődleges telefonszám',
+        detailsSubtitle__primary: 'Ez az elsődleges telefonszámod',
+        destructiveActionTitle: 'Eltávolítás',
+        destructiveActionSubtitle: 'Töröld ki ezt a telefonszámot, és távolítsd el a fiókodból',
+        detailsTitle__unverified: 'Telefonszám visszaigazolása',
+        detailsSubtitle__unverified:
+          'Fejezd be a telefonszámod visszaigazolását, hogy minden funkciót kihasználhass ezzel a számmal',
       },
       profileSection: {
         primaryButton: 'Profil frissítése',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -179,6 +179,7 @@ type _LocalizationResource = {
       subtitle_phone: LocalizationValue;
       formTitle: LocalizationValue;
       resendButton: LocalizationValue;
+      formSubtitle_email: LocalizationValue;
     };
     resetPassword: {
       title: LocalizationValue;
@@ -293,7 +294,9 @@ type _LocalizationResource = {
     };
     start: {
       headerTitle__account: LocalizationValue;
+      headerSubtitle__account: LocalizationValue;
       headerTitle__security: LocalizationValue;
+      headerSubtitle__security: LocalizationValue;
       profileSection: {
         title: LocalizationValue;
         primaryButton: LocalizationValue;
@@ -310,6 +313,12 @@ type _LocalizationResource = {
         detailsAction__nonPrimary: LocalizationValue;
         detailsAction__unverified: LocalizationValue;
         destructiveAction: LocalizationValue;
+        detailsSubtitle__primary: LocalizationValue;
+        detailsTitle__primary: LocalizationValue;
+        destructiveActionTitle: LocalizationValue;
+        destructiveActionSubtitle: LocalizationValue;
+        detailsTitle__nonPrimary: LocalizationValue;
+        detailsSubtitle__nonPrimary: LocalizationValue;
       };
       phoneNumbersSection: {
         title: LocalizationValue;
@@ -318,6 +327,12 @@ type _LocalizationResource = {
         detailsAction__nonPrimary: LocalizationValue;
         detailsAction__unverified: LocalizationValue;
         destructiveAction: LocalizationValue;
+        detailsTitle__primary: LocalizationValue;
+        detailsSubtitle__primary: LocalizationValue;
+        destructiveActionTitle: LocalizationValue;
+        destructiveActionSubtitle: LocalizationValue;
+        detailsTitle__unverified: LocalizationValue;
+        detailsSubtitle__unverified: LocalizationValue;
       };
       connectedAccountsSection: {
         title: LocalizationValue;
@@ -326,6 +341,8 @@ type _LocalizationResource = {
         actionLabel__reauthorize: LocalizationValue;
         subtitle__reauthorize: LocalizationValue;
         destructiveActionTitle: LocalizationValue;
+        destructiveActionSubtitle: LocalizationValue;
+        destructiveActionAccordionSubtitle: LocalizationValue;
       };
       enterpriseAccountsSection: {
         title: LocalizationValue;
@@ -334,6 +351,7 @@ type _LocalizationResource = {
         title: LocalizationValue;
         primaryButton__updatePassword: LocalizationValue;
         primaryButton__setPassword: LocalizationValue;
+        primaryButton__changePassword: LocalizationValue;
       };
       // TODO-PASSKEYS: Remove in the next minor
       /**
@@ -370,6 +388,10 @@ type _LocalizationResource = {
       activeDevicesSection: {
         title: LocalizationValue;
         destructiveAction: LocalizationValue;
+        detailsTitle: LocalizationValue;
+        detailsSubtitle: LocalizationValue;
+        destructiveActionTitle: LocalizationValue;
+        destructiveActionSubtitle: LocalizationValue;
       };
       web3WalletsSection: {
         title: LocalizationValue;
@@ -379,6 +401,8 @@ type _LocalizationResource = {
       dangerSection: {
         title: LocalizationValue;
         deleteAccountButton: LocalizationValue;
+        deleteAccountDescription: LocalizationValue;
+        deleteAccountTitle: LocalizationValue;
       };
     };
     profilePage: {
@@ -479,10 +503,12 @@ type _LocalizationResource = {
       };
     };
     passwordPage: {
+      changePasswordTitle: LocalizationValue;
       successMessage__set: LocalizationValue;
       successMessage__update: LocalizationValue;
       successMessage__signOutOfOtherSessions: LocalizationValue;
       checkboxInfoText__signOutOfOtherSessions: LocalizationValue;
+      changePasswordSuccessMessage: LocalizationValue;
       readonly: LocalizationValue;
       title__set: LocalizationValue;
       title__update: LocalizationValue;


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

I've found that after applying translations there are a bunch of english text left on profile, login pages etc.
Not sure if these were kept english on purpose, but I added them, so they can be translated.
I've also changed some of the translations to be better.

<!-- Fixes #(issue number) -->

## Checklist

- [ X ] `npm test` runs as expected.
- [ X ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ X ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
