### PR TITLE
Backport to Core 1: feat(clerkjs): Add support for different Bot Protection widget types

### DIFF
--- a/.changeset/eighty-pens-mix.md
+++ b/.changeset/eighty-pens-mix.md
@@ -3,4 +3,4 @@
 '@clerk/types': minor
 ---
 
-Add support for different CAPTCHA widget types
+Add support for different Bot Protection widget types

--- a/.changeset/eighty-pens-mix.md
+++ b/.changeset/eighty-pens-mix.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add support for different CAPTCHA widget types

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -1,5 +1,11 @@
 import { deprecatedProperty } from '@clerk/shared/deprecated';
-import type { DisplayConfigJSON, DisplayConfigResource, DisplayThemeJSON, PreferredSignInStrategy } from '@clerk/types';
+import type {
+  CaptchaWidgetType,
+  DisplayConfigJSON,
+  DisplayConfigResource,
+  DisplayThemeJSON,
+  PreferredSignInStrategy,
+} from '@clerk/types';
 
 import { BaseResource } from './internal';
 
@@ -15,6 +21,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   backendHost!: string;
   branded!: boolean;
   captchaPublicKey: string | null = null;
+  captchaWidgetType: CaptchaWidgetType = null;
+  captchaPublicKeyInvisible: string | null = null;
   homeUrl!: string;
   instanceEnvironmentType!: string;
   faviconImageUrl!: string;
@@ -71,6 +79,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.afterSwitchSessionUrl = data.after_switch_session_url;
     this.branded = data.branded;
     this.captchaPublicKey = data.captcha_public_key;
+    this.captchaWidgetType = data.captcha_widget_type;
+    this.captchaPublicKeyInvisible = data.captcha_public_key_invisible;
     this.supportEmail = data.support_email || '';
     this.clerkJSVersion = data.clerk_js_version;
     this.organizationProfileUrl = data.organization_profile_url;

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -71,14 +71,19 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   create = async (params: SignUpCreateParams): Promise<SignUpResource> => {
     const paramsWithCaptcha: Record<string, unknown> = params;
-    const { captchaSiteKey, canUseCaptcha, captchaURL } = retrieveCaptchaInfo(SignUp.clerk);
+    const { captchaSiteKey, canUseCaptcha, captchaURL, captchaWidgetType, captchaPublicKeyInvisible } =
+      retrieveCaptchaInfo(SignUp.clerk);
 
-    if (canUseCaptcha && captchaSiteKey && captchaURL) {
+    if (canUseCaptcha && captchaSiteKey && captchaURL && captchaPublicKeyInvisible) {
       try {
-        paramsWithCaptcha.captchaToken = await getCaptchaToken({
+        const { captchaToken, captchaWidgetTypeUsed } = await getCaptchaToken({
           siteKey: captchaSiteKey,
+          widgetType: captchaWidgetType,
+          invisibleSiteKey: captchaPublicKeyInvisible,
           scriptUrl: captchaURL,
         });
+        paramsWithCaptcha.captchaToken = captchaToken;
+        paramsWithCaptcha.captchaWidgetType = captchaWidgetTypeUsed;
       } catch (e) {
         if (e.captchaError) {
           paramsWithCaptcha.captchaError = e.captchaError;

--- a/packages/clerk-js/src/ui/common/SSOCallback.tsx
+++ b/packages/clerk-js/src/ui/common/SSOCallback.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useCoreClerk } from '../contexts';
 import { Flow } from '../customizables';
 import { Card, CardAlert, LoadingCardContainer, useCardState, withCardStateProvider } from '../elements';
+import { CaptchaElement } from '../elements/CaptchaElement';
 import { useRouter } from '../router';
 import { handleError } from '../utils';
 
@@ -35,6 +36,7 @@ export const SSOCallbackCard = (props: HandleOAuthCallbackParams | HandleSamlCal
       <Card>
         <CardAlert>{card.error}</CardAlert>
         <LoadingCardContainer />
+        <CaptchaElement />
       </Card>
     </Flow.Part>
   );

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { useAppearance } from '../../customizables';
+import { Col, useAppearance } from '../../customizables';
 import { Form } from '../../elements';
+import { CaptchaElement } from '../../elements/CaptchaElement';
 import type { FormControlState } from '../../utils';
 import type { ActiveIdentifier, Fields } from './signUpFormHelpers';
 
@@ -99,7 +100,10 @@ export const SignUpForm = (props: SignUpFormProps) => {
           />
         </Form.ControlRow>
       )}
-      <Form.SubmitButton>Continue</Form.SubmitButton>
+      <Col center>
+        <CaptchaElement />
+        <Form.SubmitButton>Continue</Form.SubmitButton>
+      </Col>
     </Form.Root>
   );
 };

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -14,6 +14,7 @@ import {
   SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
 } from '../../elements';
+import { CaptchaElement } from '../../elements/CaptchaElement';
 import { useCardState } from '../../elements/contexts';
 import { useLoadingStatus } from '../../hooks';
 import { useRouter } from '../../router';
@@ -272,6 +273,7 @@ function _SignUpStart(): JSX.Element {
               />
             )}
           </SocialButtonsReversibleContainerWithDivider>
+          {!shouldShowForm && <CaptchaElement />}
         </Flex>
         <Footer.Root>
           <Footer.Action elementId='signUp'>

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -1,0 +1,9 @@
+import { CAPTCHA_ELEMENT_ID } from '../../utils';
+import { Box } from '../customizables';
+
+export const CaptchaElement = () => (
+  <Box
+    id={CAPTCHA_ELEMENT_ID}
+    sx={t => ({ display: 'none', marginBottom: t.space.$6, alignSelf: 'center' })}
+  />
+);

--- a/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/retrieveCaptchaInfo.ts
@@ -6,6 +6,8 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
   const fapiClient = createFapiClient(clerk);
   return {
     captchaSiteKey: _environment ? _environment.displayConfig.captchaPublicKey : null,
+    captchaWidgetType: _environment ? _environment.displayConfig.captchaWidgetType : null,
+    captchaPublicKeyInvisible: _environment ? _environment.displayConfig.captchaPublicKeyInvisible : null,
     canUseCaptcha: _environment
       ? _environment.userSettings.signUp.captcha_enabled &&
         clerk.isStandardBrowser &&

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -2,6 +2,7 @@ import type { DisplayThemeJSON } from './json';
 import type { ClerkResource } from './resource';
 
 export type PreferredSignInStrategy = 'password' | 'otp';
+export type CaptchaWidgetType = 'smart' | 'invisible' | null;
 
 export interface DisplayConfigJSON {
   object: 'display_config';
@@ -14,6 +15,8 @@ export interface DisplayConfigJSON {
   application_name: string;
   branded: boolean;
   captcha_public_key: string | null;
+  captcha_widget_type: CaptchaWidgetType;
+  captcha_public_key_invisible: string | null;
   home_url: string;
   instance_environment_type: string;
   /* @deprecated */
@@ -47,6 +50,8 @@ export interface DisplayConfigResource extends ClerkResource {
   backendHost: string;
   branded: boolean;
   captchaPublicKey: string | null;
+  captchaWidgetType: CaptchaWidgetType;
+  captchaPublicKeyInvisible: string | null;
   homeUrl: string;
   instanceEnvironmentType: string;
   logoImageUrl: string;


### PR DESCRIPTION
## Description

This PR backports the following PRs to v4 (Core 1):
https://github.com/clerk/javascript/pull/3191
https://github.com/clerk/javascript/pull/3205
https://github.com/clerk/javascript/pull/3202
https://github.com/clerk/javascript/pull/3154

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
