### PR TITLE
fix(clerk-js,types,nextjs): Allow legacy redirect props as a fallback

### DIFF
--- a/.changeset/cold-files-refuse.md
+++ b/.changeset/cold-files-refuse.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Warn about legacy redirect search params

--- a/.changeset/friendly-masks-obey.md
+++ b/.changeset/friendly-masks-obey.md
@@ -4,4 +4,4 @@
 '@clerk/types': patch
 ---
 
-Introduce forceRedirectUrl and fallbackRedirectUrl
+Support but warn when `afterSignInUrl` and `afterSignUpUrl` are used

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         run: npm run format:check
 
       - name: Build Packages
-        run: npx turbo build $TURBO_ARGS --only
+        run: npx turbo build $TURBO_ARGS --filter=!elements --only
 
       - name: Lint packages using publint
-        run: npx turbo lint:publint $TURBO_ARGS --only
+        run: npx turbo lint:publint $TURBO_ARGS --filter=!elements --only
 
       - name: Lint types using attw
         run: npx turbo lint:attw $TURBO_ARGS --filter=!nextjs --filter=!elements --filter=!backend --only
@@ -66,7 +66,7 @@ jobs:
         continue-on-error: true # TODO: Remove this when all related errors are fixed
 
       - name: Run lint
-        run: npx turbo lint $TURBO_ARGS --only -- --quiet
+        run: npx turbo lint $TURBO_ARGS --filter=!elements --only -- --quiet
 
       - name: Upload Turbo Summary
         uses: actions/upload-artifact@v3
@@ -108,7 +108,7 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Run tests
-        run: npx turbo test $TURBO_ARGS
+        run: npx turbo test $TURBO_ARGS --filter=!elements
         env:
           NODE_VERSION: ${{ matrix.node-version }}
 
@@ -152,7 +152,7 @@ jobs:
         uses: ./.github/actions/verdaccio
         with:
           publish-cmd: |
-            if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS --only && npx changeset publish --no-git-tag; fi
+            if [ "$(npm config get registry)" = "https://registry.npmjs.org/" ]; then echo 'Error: Using default registry' && exit 1; else npx turbo build $TURBO_ARGS --filter=!elements --only && npx changeset publish --no-git-tag; fi
 
       - name: Install @clerk/backend in /integration
         working-directory: ./integration

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "scripts": {
-    "build": "FORCE_COLOR=1 turbo build --concurrency=${TURBO_CONCURRENCY:-80%}",
+    "build": "FORCE_COLOR=1 turbo build --concurrency=${TURBO_CONCURRENCY:-80%} --filter=!elements",
     "bundlewatch": "turbo bundlewatch",
     "changeset": "changeset",
     "changeset:empty": "npm run changeset -- --empty",
@@ -28,7 +28,7 @@
     "release:canary": "changeset publish --tag canary --no-git-tag",
     "release:snapshot": "changeset publish --tag snapshot --no-git-tag",
     "release:verdaccio": "if [ \"$(npm config get registry)\" = \"https://registry.npmjs.org/\" ]; then echo 'Error: Using default registry' && exit 1; else TURBO_CONCURRENCY=1 npm run build && changeset publish --no-git-tag; fi",
-    "test": "FORCE_COLOR=1 turbo test --concurrency=${TURBO_CONCURRENCY:-80%}",
+    "test": "FORCE_COLOR=1 turbo test --concurrency=${TURBO_CONCURRENCY:-80%} --filter=!elements",
     "test:cache:clear": "FORCE_COLOR=1 turbo test:cache:clear --continue --concurrency=${TURBO_CONCURRENCY:-80%}",
     "test:integration:ap-flows": "npm run test:integration:base -- --grep @ap-flows",
     "test:integration:base": "DEBUG=1 npx playwright test --config integration/playwright.config.ts",

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -1,6 +1,8 @@
 // TODO: Do we still have a use for this or can we simply preserve all params?
 export const PRESERVED_QUERYSTRING_PARAMS = [
   'redirect_url',
+  'after_sign_in_url',
+  'after_sign_up_url',
   'sign_in_force_redirect_url',
   'sign_in_fallback_redirect_url',
   'sign_up_force_redirect_url',

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -5,7 +5,6 @@ import React, { useMemo } from 'react';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS, SIGN_UP_INITIAL_VALUE_KEYS } from '../../core/constants';
 import { buildURL, createDynamicParamParser } from '../../utils';
-import { assertNoLegacyProp } from '../../utils/assertNoLegacyProp';
 import { RedirectUrls } from '../../utils/redirectUrls';
 import { ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID } from '../constants';
 import { useEnvironment, useOptions } from '../contexts';
@@ -61,9 +60,6 @@ export const useSignUpContext = (): SignUpContextType => {
   const { queryParams, queryString } = useRouter();
   const options = useOptions();
   const clerk = useClerk();
-
-  assertNoLegacyProp(options);
-  assertNoLegacyProp(ctx);
 
   const initialValuesFromQueryParams = useMemo(
     () => getInitialValuesFromQueryParams(queryString, SIGN_UP_INITIAL_VALUE_KEYS),
@@ -134,9 +130,6 @@ export const useSignInContext = (): SignInContextType => {
   const { queryParams, queryString } = useRouter();
   const options = useOptions();
   const clerk = useClerk();
-
-  assertNoLegacyProp(options);
-  assertNoLegacyProp(ctx);
 
   const initialValuesFromQueryParams = useMemo(
     () => getInitialValuesFromQueryParams(queryString, SIGN_IN_INITIAL_VALUE_KEYS),

--- a/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
@@ -76,6 +76,31 @@ describe('redirectUrls', () => {
   });
 
   describe('get redirect urls', () => {
+    // TODO: v6 - remove this test
+    it('prioritizes new props over legacy props ', () => {
+      const redirectUrls = new RedirectUrls({
+        signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
+        signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
+        afterSignInUrl: 'after-sign-in-url',
+        afterSignUpUrl: 'after-sign-up-url',
+      });
+
+      expect(redirectUrls.getAfterSignInUrl()).toBe(`${mockWindowLocation.href}sign-in-fallback-redirect-url`);
+      expect(redirectUrls.getAfterSignUpUrl()).toBe(`${mockWindowLocation.href}sign-up-fallback-redirect-url`);
+    });
+
+    // TODO: v6 - remove this test
+    it('falls back to legacy props if no new props are found', () => {
+      const redirectUrls = new RedirectUrls({
+        signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
+        afterSignInUrl: 'after-sign-in-url',
+        afterSignUpUrl: 'after-sign-up-url',
+      });
+
+      expect(redirectUrls.getAfterSignInUrl()).toBe(`${mockWindowLocation.href}after-sign-in-url`);
+      expect(redirectUrls.getAfterSignUpUrl()).toBe(`${mockWindowLocation.href}sign-up-fallback-redirect-url`);
+    });
+
     it('prioritizes force urls among other urls in the same group', () => {
       const redirectUrls = new RedirectUrls({
         signInForceRedirectUrl: 'sign-in-force-redirect-url',

--- a/packages/clerk-js/src/utils/assertNoLegacyProp.ts
+++ b/packages/clerk-js/src/utils/assertNoLegacyProp.ts
@@ -1,10 +1,11 @@
 export function assertNoLegacyProp(props: Record<string, any>) {
-  const legacyProps = ['redirectUrl', 'afterSignInUrl', 'afterSignUpUrl'];
+  const legacyProps = ['redirectUrl', 'afterSignInUrl', 'afterSignUpUrl', 'after_sign_in_url', 'after_sign_up_url'];
   const legacyProp = Object.keys(props).find(key => legacyProps.includes(key));
+
   if (legacyProp) {
     // TODO: @nikos update with the docs link
     console.warn(
-      `Clerk: The prop "${legacyProp}" is deprecated and should be removed as it no longer works. Use the new "fallbackRedirectUrl" and "forceRedirectUrl" props instead.`,
+      `Clerk: The prop "${legacyProp}" is deprecated and should be replaced with the new "fallbackRedirectUrl" or "forceRedirectUrl" props instead.`,
     );
   }
 }

--- a/packages/clerk-js/src/utils/redirectUrls.ts
+++ b/packages/clerk-js/src/utils/redirectUrls.ts
@@ -3,6 +3,7 @@ import { camelToSnake } from '@clerk/shared/underscore';
 import type { ClerkOptions, RedirectOptions } from '@clerk/types';
 import type { ParsedQs } from 'qs';
 
+import { assertNoLegacyProp } from './assertNoLegacyProp';
 import { buildURL, isAllowedRedirectOrigin, relativeToAbsoluteUrl } from './url';
 
 export class RedirectUrls {
@@ -11,6 +12,8 @@ export class RedirectUrls {
     'signInFallbackRedirectUrl',
     'signUpForceRedirectUrl',
     'signUpFallbackRedirectUrl',
+    'afterSignInUrl',
+    'afterSignUpUrl',
   ];
 
   private static preserved = ['redirectUrl'];
@@ -68,17 +71,26 @@ export class RedirectUrls {
   #getRedirectUrl(prefix: 'signIn' | 'signUp') {
     const forceKey = `${prefix}ForceRedirectUrl` as const;
     const fallbackKey = `${prefix}FallbackRedirectUrl` as const;
+
+    const legacyPropKey = `after${prefix[0].toUpperCase()}${prefix.slice(1)}Url` as 'afterSignInUrl' | 'afterSignUpUrl';
+
     let result;
     // Prioritize forceRedirectUrl
     result = this.fromSearchParams[forceKey] || this.fromProps[forceKey] || this.fromOptions[forceKey];
-    // Try to get redirect_url that only allowed as a search param
+    // Try to get redirect_url, only allowed as a search param
     result ||= this.fromSearchParams.redirectUrl;
     // Otherwise, fallback to fallbackRedirectUrl
     result ||= this.fromSearchParams[fallbackKey] || this.fromProps[fallbackKey] || this.fromOptions[fallbackKey];
+
+    // TODO: v6
+    // Remove the compatibility layer for afterSignInUrl and afterSignUpUrl
+    result ||= this.fromSearchParams[legacyPropKey] || this.fromProps[legacyPropKey] || this.fromOptions[legacyPropKey];
+
     return result || '/';
   }
 
   #parse(obj: unknown) {
+    assertNoLegacyProp(obj as any);
     const res = {} as RedirectOptions;
     RedirectUrls.keys.forEach(key => {
       // @ts-expect-error
@@ -88,6 +100,7 @@ export class RedirectUrls {
   }
 
   #parseSearchParams(obj: any) {
+    assertNoLegacyProp(obj);
     const res = {} as typeof this.fromSearchParams;
     RedirectUrls.keys.forEach(key => {
       res[key] = obj[camelToSnake(key)];

--- a/packages/nextjs/src/global.d.ts
+++ b/packages/nextjs/src/global.d.ts
@@ -19,6 +19,8 @@ declare global {
       NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL: string | undefined;
       NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL: string | undefined;
       NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL: string | undefined;
+      NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: string | undefined;
+      NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: string | undefined;
     }
   }
 }

--- a/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
+++ b/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
@@ -20,9 +20,15 @@ export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, '
     signUpForceRedirectUrl:
       props.signUpForceRedirectUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL || '',
     signInFallbackRedirectUrl:
-      props.signInFallbackRedirectUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL || '',
+      props.signInFallbackRedirectUrl ||
+      process.env.NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL ||
+      process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL ||
+      '',
     signUpFallbackRedirectUrl:
-      props.signUpFallbackRedirectUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL || '',
+      props.signUpFallbackRedirectUrl ||
+      process.env.NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL ||
+      process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL ||
+      '',
     telemetry: props.telemetry ?? {
       disabled: isTruthy(process.env.NEXT_PUBLIC_CLERK_TELEMETRY_DISABLED),
       debug: isTruthy(process.env.NEXT_PUBLIC_CLERK_TELEMETRY_DEBUG),

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -18,6 +18,7 @@ import type { OrganizationResource } from './organization';
 import type { OrganizationCustomRoleKey } from './organizationMembership';
 import type {
   AfterSignOutUrl,
+  LegacyRedirectProps,
   RedirectOptions,
   RedirectUrlProp,
   SignInFallbackRedirectUrl,
@@ -478,7 +479,8 @@ export interface Clerk {
 export type HandleOAuthCallbackParams = SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &
-  SignUpFallbackRedirectUrl & {
+  SignUpFallbackRedirectUrl &
+  LegacyRedirectProps & {
     /**
      * Full URL or path where the SignIn component is mounted.
      */
@@ -543,6 +545,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &
   SignUpFallbackRedirectUrl &
+  LegacyRedirectProps &
   AfterSignOutUrl & {
     appearance?: Appearance;
     localization?: LocalizationResource;
@@ -686,21 +689,6 @@ export type SignInProps = RoutingOptions & {
    */
   fallbackRedirectUrl?: string | null;
   /**
-   * Full URL or path to navigate after successful sign up, triggered through the <SignIn/> component,
-   * for example, when the user clicks the "Sign up" link or signs up using OAuth.
-   * This value has precedence over other redirect props, environment variables or search params.
-   * Use this prop to override the redirect URL when needed.
-   * @default undefined
-   */
-  signUpForceRedirectUrl?: string | null;
-  /**
-   * Full URL or path to navigate after successful sign up, triggered through the <SignIn/> component,
-   * for example, when the user clicks the "Sign up" link or signs up using OAuth.
-   * This value is used when no other redirect props, environment variables or search params are present.
-   * @default undefined
-   */
-  signUpFallbackRedirectUrl?: string | null;
-  /**
    * Full URL or path to for the sign up process.
    * Used to fill the "Sign up" link in the SignUp component.
    */
@@ -715,7 +703,10 @@ export type SignInProps = RoutingOptions & {
    * Initial values that are used to prefill the sign in form.
    */
   initialValues?: SignInInitialValues;
-} & AfterSignOutUrl;
+} & SignUpForceRedirectUrl &
+  SignUpFallbackRedirectUrl &
+  LegacyRedirectProps &
+  AfterSignOutUrl;
 
 export type SignInModalProps = WithoutRouting<SignInProps>;
 
@@ -739,21 +730,6 @@ export type SignUpProps = RoutingOptions & {
    */
   fallbackRedirectUrl?: string | null;
   /**
-   * Full URL or path to navigate after successful sign up, triggered through the <SignUp/> component,
-   * for example, when the user clicks the "Sign in" link or signs up using OAuth.
-   * This value has precedence over other redirect props, environment variables or search params.
-   * Use this prop to override the redirect URL when needed.
-   * @default undefined
-   */
-  signInForceRedirectUrl?: string | null;
-  /**
-   * Full URL or path to navigate after successful sign up, triggered through the <SignUp/> component,
-   * for example, when the user clicks the "Sign in" link or signs up using OAuth.
-   * This value is used when no other redirect props, environment variables or search params are present.
-   * @default undefined
-   */
-  signInFallbackRedirectUrl?: string | null;
-  /**
    * Full URL or path to for the sign in process.
    * Used to fill the "Sign in" link in the SignUp component.
    */
@@ -773,7 +749,10 @@ export type SignUpProps = RoutingOptions & {
    * Initial values that are used to prefill the sign up form.
    */
   initialValues?: SignUpInitialValues;
-} & AfterSignOutUrl;
+} & SignInFallbackRedirectUrl &
+  SignInForceRedirectUrl &
+  LegacyRedirectProps &
+  AfterSignOutUrl;
 
 export type SignUpModalProps = WithoutRouting<SignUpProps>;
 

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -8,13 +8,30 @@ export type AfterSignOutUrl = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future release.
+ */
+export type LegacyRedirectProps = {
+  /**
+   * @deprecated This is deprecated and will be removed in a future release.
+   * Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
+   */
+  afterSignInUrl?: string | null;
+  /**
+   * @deprecated This is deprecated and will be removed in a future release.
+   * Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
+   */
+  afterSignUpUrl?: string | null;
+};
+
+/**
  * Redirect URLs for different actions.
  * Mainly used to be used to type internal Clerk functions.
  */
 export type RedirectOptions = SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &
-  SignUpFallbackRedirectUrl;
+  SignUpFallbackRedirectUrl &
+  LegacyRedirectProps;
 
 export type AuthenticateWithRedirectParams = {
   /**


### PR DESCRIPTION
## Description

To avoid introducing a huge breaking change, we decided to introduce compat support for the legacy props.
The legacy props are now used as the fallback props unless overridden by *any* of the new props

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
