### PR TITLE
chore(backend): Use devBrowser from auth context instead of retrieving from clerkUrl

### DIFF
--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -245,7 +245,7 @@ ${error.getFullMessage()}`,
     /**
      * Otherwise, check for "known unknown" auth states that we can resolve with a handshake.
      */
-    if (instanceType === 'development' && authenticateContext.clerkUrl.searchParams.has(constants.Cookies.DevBrowser)) {
+    if (instanceType === 'development' && authenticateContext.devBrowserToken) {
       return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.DevBrowserSync, '');
     }
 


### PR DESCRIPTION
## Description

Minor refactor to re-use authContext.devBrowser instead of retrieving it manually from the query params of the url. With this change we will keep the retrieval of the dev browser token centralized (in the authContext).

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
