### PR TITLE
Export webhook types

### DIFF
--- a/.changeset/mighty-timers-end.md
+++ b/.changeset/mighty-timers-end.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+---
+
+Export all Webhook event types and related JSON types. The newly exported types are: `DeletedObjectJSON`, `EmailJSON`, `OrganizationInvitationJSON`, `OrganizationJSON`, `OrganizationMembershipJSON`, `SessionJSON`, `SMSMessageJSON`, `UserJSON`, `UserWebhookEvent`, `EmailWebhookEvent`, `SMSWebhookEvent`, `SessionWebhookEvent`, `OrganizationWebhookEvent`, `OrganizationMembershipWebhookEvent`, `OrganizationInvitationWebhookEvent`

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,12 +49,6 @@ export function createClerkClient(options: ClerkOptions): ClerkClient {
  */
 export type { OrganizationMembershipRole } from './api/resources';
 export type { VerifyTokenOptions } from './tokens/verify';
-
-/**
- * Webhook event types
- */
-export type { WebhookEvent, WebhookEventType } from './api/resources';
-
 /**
  * JSON types
  */
@@ -109,3 +103,18 @@ export type {
   Token,
   User,
 } from './api/resources';
+
+/**
+ * Webhooks event types
+ */
+export type {
+  UserWebhookEvent,
+  EmailWebhookEvent,
+  SMSWebhookEvent,
+  SessionWebhookEvent,
+  OrganizationWebhookEvent,
+  OrganizationMembershipWebhookEvent,
+  OrganizationInvitationWebhookEvent,
+  WebhookEvent,
+  WebhookEventType,
+} from './api/resources/Webhooks';

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -7,6 +7,29 @@ export { verifyToken, createClerkClient } from '@clerk/backend';
 export { clerkClient } from './clerkClient';
 
 /**
+ * Webhook-specific exports
+ */
+export type {
+  DeletedObjectJSON,
+  EmailJSON,
+  OrganizationInvitationJSON,
+  OrganizationJSON,
+  OrganizationMembershipJSON,
+  SessionJSON,
+  SMSMessageJSON,
+  UserJSON,
+  WebhookEvent,
+  WebhookEventType,
+  UserWebhookEvent,
+  EmailWebhookEvent,
+  SMSWebhookEvent,
+  SessionWebhookEvent,
+  OrganizationWebhookEvent,
+  OrganizationMembershipWebhookEvent,
+  OrganizationInvitationWebhookEvent,
+} from '@clerk/backend';
+
+/**
  * NextJS-specific exports
  */
 export { getAuth } from './createGetAuth';
@@ -22,8 +45,6 @@ export type { ClerkMiddlewareAuth, ClerkMiddlewareAuthObject, ClerkMiddlewareOpt
 export type {
   OrganizationMembershipRole,
   // Webhook event types
-  WebhookEvent,
-  WebhookEventType,
   // Resources
   AllowlistIdentifier,
   Client,


### PR DESCRIPTION
## Description
- Export webhook events and types from `@clerk/backend`
- Export webhook events and types from `@clerk/nextjs/server`

As requested by multiple users, these types are useful when extracting webhook handler behavior into smaller functions, eg: 

```
export handleUserUpdated(data: UserJSON) {}
```

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

Closes SDK1678