### PR TITLE
fix(clerk-js): Check if legacy property has value before display warning

### DIFF
--- a/.changeset/chilly-tips-smash.md
+++ b/.changeset/chilly-tips-smash.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-fix(clerk-js): Check if legacy property has value before display warning
+Check if any legacy properties have value before displaying a warning

--- a/.changeset/chilly-tips-smash.md
+++ b/.changeset/chilly-tips-smash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+fix(clerk-js): Check if legacy property has value before display warning

--- a/packages/clerk-js/src/utils/assertNoLegacyProp.ts
+++ b/packages/clerk-js/src/utils/assertNoLegacyProp.ts
@@ -2,7 +2,7 @@ export function assertNoLegacyProp(props: Record<string, any>) {
   const legacyProps = ['redirectUrl', 'afterSignInUrl', 'afterSignUpUrl', 'after_sign_in_url', 'after_sign_up_url'];
   const legacyProp = Object.keys(props).find(key => legacyProps.includes(key));
 
-  if (legacyProp) {
+  if (legacyProp && props[legacyProp]) {
     // TODO: @nikos update with the docs link
     console.warn(
       `Clerk: The prop "${legacyProp}" is deprecated and should be replaced with the new "fallbackRedirectUrl" or "forceRedirectUrl" props instead.`,


### PR DESCRIPTION
## Description
 Check if legacy property has a value and display a warning if present.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

 

-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
