### PR TITLE
fix(clerk-js): Set card error on prepare code verification

### DIFF
--- a/.changeset/grumpy-rings-sleep.md
+++ b/.changeset/grumpy-rings-sleep.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Set the card error when encountering an error on preparing verification via code for email or phone on sign up.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.organizeImports": true
+    "source.organizeImports": "explicit",
+    "source.fixAll.eslint": "explicit",
   }
 }

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -1,10 +1,13 @@
 import { useCoreSignUp } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
+import { useCardState } from '../../elements';
 import { useFetch } from '../../hooks';
+import { handleError } from '../../utils';
 import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 
 export const SignUpEmailCodeCard = () => {
   const signUp = useCoreSignUp();
+  const card = useCardState();
 
   const emailVerificationStatus = signUp.verifications.emailAddress.status;
   const shouldAvoidPrepare = !signUp.status || emailVerificationStatus === 'verified';
@@ -13,12 +16,19 @@ export const SignUpEmailCodeCard = () => {
     if (shouldAvoidPrepare) {
       return;
     }
-    return signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
+    return signUp
+      .prepareEmailAddressVerification({ strategy: 'email_code' })
+      .catch(err => handleError(err, [], card.setError));
   };
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    shouldAvoidPrepare ? undefined : () => signUp.prepareEmailAddressVerification({ strategy: 'email_code' }),
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signUp
+            .prepareEmailAddressVerification({ strategy: 'email_code' })
+            .catch(err => handleError(err, [], card.setError)),
     {
       name: 'prepare',
       strategy: 'email_code',

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -1,11 +1,13 @@
 import { useCoreSignUp } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
-import { withCardStateProvider } from '../../elements';
+import { useCardState, withCardStateProvider } from '../../elements';
 import { useFetch } from '../../hooks';
+import { handleError } from '../../utils';
 import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 
 export const SignUpPhoneCodeCard = withCardStateProvider(() => {
   const signUp = useCoreSignUp();
+  const card = useCardState();
 
   const phoneVerificationStatus = signUp.verifications.phoneNumber.status;
   const shouldAvoidPrepare = !signUp.status || phoneVerificationStatus === 'verified';
@@ -13,12 +15,19 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     if (shouldAvoidPrepare) {
       return;
     }
-    return signUp.preparePhoneNumberVerification({ strategy: 'phone_code' });
+    return signUp
+      .preparePhoneNumberVerification({ strategy: 'phone_code' })
+      .catch(err => handleError(err, [], card.setError));
   };
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    shouldAvoidPrepare ? undefined : () => signUp.preparePhoneNumberVerification({ strategy: 'phone_code' }),
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signUp
+            .preparePhoneNumberVerification({ strategy: 'phone_code' })
+            .catch(err => handleError(err, [], card.setError)),
     {
       name: 'signUp.preparePhoneNumberVerification',
       strategy: 'phone_code',

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -13,7 +13,7 @@ type SignInFactorOneCodeFormProps = {
   formTitle: LocalizationKey;
   formSubtitle: LocalizationKey;
   resendButton: LocalizationKey;
-  prepare: () => Promise<SignUpResource> | undefined;
+  prepare: () => Promise<SignUpResource | void> | undefined;
   attempt: (code: string) => Promise<SignUpResource>;
   safeIdentifier?: string | undefined | null;
 };


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
<img width="421" alt="Screenshot 2024-04-24 at 16 41 33" src="https://github.com/clerk/javascript/assets/73396808/14d3655a-6c16-42d7-91d5-932c38df342d">

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
