### PR TITLE
chore(clerk-react): Send telemetry events for React hooks

### DIFF
--- a/.changeset/angry-rings-invent.md
+++ b/.changeset/angry-rings-invent.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Send telemetry events for React hooks

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,3 +1,4 @@
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type {
   ActJWTClaim,
   CheckAuthorizationWithCustomPermissions,
@@ -5,7 +6,7 @@ import type {
   OrganizationCustomRoleKey,
   SignOut,
 } from '@clerk/types';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useAuthContext } from '../contexts/AuthContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
@@ -140,6 +141,10 @@ export const useAuth: UseAuth = () => {
     },
     [orgId, orgRole, userId, orgPermissions],
   );
+
+  useEffect(() => {
+    isomorphicClerk.telemetry?.record(eventMethodCalled('useAuth'));
+  }, [isomorphicClerk?.telemetry]);
 
   if (sessionId === undefined && userId === undefined) {
     return {

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -1,5 +1,7 @@
 import { useClientContext } from '@clerk/shared/react';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignInResource } from '@clerk/types';
+import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -27,6 +29,10 @@ export const useSignIn: UseSignIn = () => {
   if (!client) {
     return { isLoaded: false, signIn: undefined, setActive: undefined };
   }
+
+  useEffect(() => {
+    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignIn'));
+  }, [isomorphicClerk?.telemetry]);
 
   return {
     isLoaded: true,

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -1,5 +1,7 @@
 import { useClientContext } from '@clerk/shared/react';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignUpResource } from '@clerk/types';
+import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -27,6 +29,10 @@ export const useSignUp: UseSignUp = () => {
   if (!client) {
     return { isLoaded: false, signUp: undefined, setActive: undefined };
   }
+
+  useEffect(() => {
+    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignUp'));
+  }, [isomorphicClerk?.telemetry]);
 
   return {
     isLoaded: true,


### PR DESCRIPTION
## Description

Resolves SDK-1672

Sends telemetry events for React hooks. This will be useful to track regarding the creation of custom flows with hooks such as `useSignUp`. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
