### PR TITLE
feat(backend): Add support for the Testing Token API

### DIFF
--- a/.changeset/mean-planets-share.md
+++ b/.changeset/mean-planets-share.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add support for the Testing Tokens API

--- a/packages/backend/src/api/endpoints/TestingTokenApi.ts
+++ b/packages/backend/src/api/endpoints/TestingTokenApi.ts
@@ -1,0 +1,13 @@
+import type { TestingToken } from '../resources/TestingToken';
+import { AbstractAPI } from './AbstractApi';
+
+const basePath = '/testing_tokens';
+
+export class TestingTokenAPI extends AbstractAPI {
+  public async createTestingToken() {
+    return this.request<TestingToken>({
+      method: 'POST',
+      path: basePath,
+    });
+  }
+}

--- a/packages/backend/src/api/endpoints/index.ts
+++ b/packages/backend/src/api/endpoints/index.ts
@@ -11,3 +11,4 @@ export * from './SessionApi';
 export * from './SignInTokenApi';
 export * from './UserApi';
 export * from './SamlConnectionApi';
+export * from './TestingTokenApi';

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -10,6 +10,7 @@ import {
   SamlConnectionAPI,
   SessionAPI,
   SignInTokenAPI,
+  TestingTokenAPI,
   UserAPI,
 } from './endpoints';
 import { buildRequest } from './request';
@@ -34,5 +35,6 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
     users: new UserAPI(request),
     domains: new DomainAPI(request),
     samlConnections: new SamlConnectionAPI(request),
+    testingTokens: new TestingTokenAPI(request),
   };
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -32,6 +32,7 @@ export const ObjectType = {
   Web3Wallet: 'web3_wallet',
   Token: 'token',
   TotalCount: 'total_count',
+  TestingToken: 'testing_token',
 } as const;
 
 export type ObjectType = (typeof ObjectType)[keyof typeof ObjectType];
@@ -228,6 +229,7 @@ export interface SignInJSON extends ClerkResourceJSON {
 }
 
 export interface SignInTokenJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.SignInToken;
   user_id: string;
   token: string;
   status: 'pending' | 'accepted' | 'revoked';
@@ -355,4 +357,10 @@ export interface AttributeMappingJSON {
   email_address: string;
   first_name: string;
   last_name: string;
+}
+
+export interface TestingTokenJSON {
+  object: typeof ObjectType.TestingToken;
+  token: string;
+  expires_at: number;
 }

--- a/packages/backend/src/api/resources/TestingToken.ts
+++ b/packages/backend/src/api/resources/TestingToken.ts
@@ -1,0 +1,9 @@
+import type { TestingTokenJSON } from './JSON';
+
+export class TestingToken {
+  constructor(readonly token: string, readonly expiresAt: number) {}
+
+  static fromJSON(data: TestingTokenJSON): TestingToken {
+    return new TestingToken(data.token, data.expires_at);
+  }
+}

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -31,6 +31,7 @@ export * from './Token';
 export * from './User';
 export * from './Verification';
 export * from './SamlConnection';
+export * from './TestingToken';
 
 export type {
   EmailWebhookEvent,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -80,6 +80,7 @@ export type {
   Web3WalletJSON,
   DeletedObjectJSON,
   PaginatedResponseJSON,
+  TestingTokenJSON,
 } from './api/resources/JSON';
 
 /**
@@ -102,6 +103,7 @@ export type {
   SMSMessage,
   Token,
   User,
+  TestingToken,
 } from './api/resources';
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for the [Testing Tokens API](https://clerk.com/docs/reference/backend-api/tag/Testing-Tokens) to `@clerk/backend`

Introduces the `testingTokens` resource and the `createTestingToken()` method.


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
