### PR TITLE
fix(backend): Fix infinite redirect loops on handshake for invalid secret key

### DIFF
--- a/.changeset/perfect-pumpkins-beg.md
+++ b/.changeset/perfect-pumpkins-beg.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix infinite redirect loops for production instances with incorrect secret keys

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -230,7 +230,10 @@ ${error.getFullMessage()}`,
             throw new Error(`Clerk: Handshake token verification failed: ${error.getFullMessage()}.`);
           }
 
-          if (error.reason === TokenVerificationErrorReason.TokenInvalidSignature) {
+          if (
+            error.reason === TokenVerificationErrorReason.TokenInvalidSignature ||
+            error.reason === TokenVerificationErrorReason.InvalidSecretKey
+          ) {
             // Avoid infinite redirect loops due to incorrect secret-keys
             return signedOut(
               authenticateContext,


### PR DESCRIPTION
## Description

By returning a signed-out state for production instances and throwing an error on development instances when the secret key is incorrect we avoid infinite redirect loops.

Similar case: https://github.com/clerk/javascript/pull/2994

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
