### PR TITLE
fix(clerk-js): Default to text type for inputs, fix tailwind forms inconsistencies

### DIFF
--- a/.changeset/poor-onions-retire.md
+++ b/.changeset/poor-onions-retire.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Default to text type for all inputs. This resolved inconsistencies with `@tailwindcss/forms`.

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -80,7 +80,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref)
    * type="email" will not allow characters like this one "ö", instead remove type email and provide a pattern that accepts any character before the "@" symbol
    */
 
-  const typeProps = type === 'email' ? { pattern: '^.*@[a-zA-Z0-9\\-]+\\.[a-zA-Z0-9\\-\\.]+$' } : { type };
+  const typeProps =
+    type === 'email'
+      ? { type: 'text', pattern: '^.*@[a-zA-Z0-9\\-]+\\.[a-zA-Z0-9\\-\\.]+$' }
+      : { type: type || 'text' };
 
   const passwordManagerProps = ignorePasswordManager
     ? {


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Tailwind forms targets via the `type` attribute. By adding this type, we make sure all our inputs are reset by that plugin.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
