### PR TITLE
fix(clerk-js): Prevent account deletion when confirmation value is incorrect

### DIFF
--- a/.changeset/sharp-lies-dream.md
+++ b/.changeset/sharp-lies-dream.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Prevent form submission for deleting user account when confirmation value is incorrect but submisssion is triggered via an "Enter" keystroke.

--- a/packages/clerk-js/src/ui/components/UserProfile/DeleteUserForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/DeleteUserForm.tsx
@@ -1,7 +1,7 @@
 import { useUser } from '@clerk/shared/react';
 
 import { useSignOutContext } from '../../contexts';
-import { Col, localizationKeys, Text } from '../../customizables';
+import { Col, localizationKeys, Text, useLocalizations } from '../../customizables';
 import type { FormProps } from '../../elements';
 import { Form, FormButtons, FormContainer, useCardState, withCardStateProvider } from '../../elements';
 import { handleError, useFormControl } from '../../utils';
@@ -12,8 +12,24 @@ export const DeleteUserForm = withCardStateProvider((props: DeleteUserFormProps)
   const card = useCardState();
   const { navigateAfterSignOut } = useSignOutContext();
   const { user } = useUser();
+  const { t } = useLocalizations();
+
+  const confirmationField = useFormControl('deleteConfirmation', '', {
+    type: 'text',
+    label: localizationKeys('userProfile.deletePage.actionDescription'),
+    isRequired: true,
+    placeholder: localizationKeys('formFieldInputPlaceholder__confirmDeletionUserAccount'),
+  });
+
+  const canSubmit =
+    confirmationField.value ===
+    (t(localizationKeys('formFieldInputPlaceholder__confirmDeletionUserAccount')) || 'Delete account');
 
   const deleteUser = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
     try {
       if (!user) {
         throw Error('user is not defined');
@@ -25,15 +41,6 @@ export const DeleteUserForm = withCardStateProvider((props: DeleteUserFormProps)
       handleError(e, [], card.setError);
     }
   };
-
-  const confirmationField = useFormControl('deleteConfirmation', '', {
-    type: 'text',
-    label: localizationKeys('userProfile.deletePage.actionDescription'),
-    isRequired: true,
-    placeholder: localizationKeys('formFieldInputPlaceholder__confirmDeletionUserAccount'),
-  });
-
-  const canSubmit = confirmationField.value === 'Delete account';
 
   return (
     <FormContainer


### PR DESCRIPTION
## Description


After this PR the form will not be submitted on enter if the confirmation value is incorrect.

This PR also changes the expected value from the hard coded string "Delete Account" to whatever value the localization key of `formFieldInputPlaceholder__confirmDeletionUserAccount` corresponds to.

For example if we have this
```tsx
<ClerkProvider
      localization={{
        formFieldInputPlaceholder__confirmDeletionUserAccount: 'Konto abmelden', // <-- Delete account in german 
      }}
    >
</ClerkProvider>
```

The end user would need to type "Konto abmelden" in order for the submit button to become enabled.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
