### PR TITLE
fix(testing): Use .mjs for esm exports

### DIFF
--- a/.changeset/gorgeous-ladybugs-sit.md
+++ b/.changeset/gorgeous-ladybugs-sit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Use the .mjs extension to export esm modules instead of relying on tsup's legacy output directory structure

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -28,7 +28,7 @@
     "./playwright": {
       "import": {
         "types": "./dist/types/index.d.ts",
-        "default": "./dist/esm/index.js"
+        "default": "./dist/index.mjs"
       },
       "require": {
         "types": "./dist/types/index.d.ts",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -1,5 +1,5 @@
 {
   "main": "../dist/index.js",
-  "module": "../dist/esm/index.js",
+  "module": "../dist/index.mjs",
   "types": "../dist/types/index.d.ts"
 }

--- a/packages/testing/tsup.config.ts
+++ b/packages/testing/tsup.config.ts
@@ -13,7 +13,6 @@ export default defineConfig(overrideOptions => {
     clean: true,
     sourcemap: true,
     format: ['cjs', 'esm'],
-    legacyOutput: true,
     define: {
       PACKAGE_NAME: `"${name}"`,
       PACKAGE_VERSION: `"${version}"`,


### PR DESCRIPTION
## Description

ESM imports from the testing package currently fail with e.g.

`SyntaxError: The requested module '@clerk/testing/playwright' does not provide an export named 'clerkSetup'`

A reproduction can be found [here](https://github.com/gcascio/playwright-clerk-nextjs-example) which is a clone of the official [clerk](https://github.com/clerk/playwright-clerk-nextjs-example) example changed to `type: "module"`.

This PR removes the `legacyOutput` flag from the tsup config and instead exports ESM modules with the `.mjs` extension.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
