### PR TITLE
chore(localizations,themes): Drop react as peer dependency

### DIFF
--- a/.changeset/mean-snakes-appear.md
+++ b/.changeset/mean-snakes-appear.md
@@ -3,4 +3,4 @@
 '@clerk/themes': minor
 ---
 
-Drop react as peer dependency from `@clerk/localizations` and `@clerk/themes`.
+Drop `react` and `react-dom` as peer dependencies since they are not necessary for this package.

--- a/.changeset/mean-snakes-appear.md
+++ b/.changeset/mean-snakes-appear.md
@@ -1,0 +1,6 @@
+---
+'@clerk/localizations': minor
+'@clerk/themes': minor
+---
+
+Drop react as peer dependency from `@clerk/localizations` and `@clerk/themes`.

--- a/packages/localizations/package.json
+++ b/packages/localizations/package.json
@@ -96,14 +96,9 @@
   },
   "devDependencies": {
     "@clerk/types": "4.1.0",
-    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "tsup": "*",
     "typescript": "*"
-  },
-  "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -41,13 +41,8 @@
     "tslib": "2.4.1"
   },
   "devDependencies": {
-    "@types/node": "^18.17.0",
     "eslint-config-custom": "*",
     "typescript": "*"
-  },
-  "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
   },
   "engines": {
     "node": ">=18.17.0"


### PR DESCRIPTION
## Description

- Also drops `@type/nodes` as devDependency

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
