### PR TITLE
chore(repo, clerk-react, clerk-js): Remove references to deprecated `clerk_frontend_api` key

### DIFF
--- a/.changeset/few-colts-boil.md
+++ b/.changeset/few-colts-boil.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+---
+
+Remove deprecated `__clerk_frontend_api` from `Window` interface

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -119,7 +119,6 @@ export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 declare global {
   interface Window {
     Clerk?: Clerk;
-    __clerk_frontend_api?: string;
     __clerk_publishable_key?: string;
     __clerk_proxy_url?: ClerkInterface['proxyUrl'];
     __clerk_domain?: ClerkInterface['domain'];

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,7 +15,6 @@ import type React from 'react';
 
 declare global {
   interface Window {
-    __clerk_frontend_api?: string;
     __clerk_publishable_key?: string;
     __clerk_proxy_url?: Clerk['proxyUrl'];
     __clerk_domain?: Clerk['domain'];

--- a/playground/vanillajs/index.html
+++ b/playground/vanillajs/index.html
@@ -96,7 +96,7 @@
     <main>
       <p class="text">
         A simple playground for tinkering with vanilla js clerk and testing changes to components. To get started,
-        create an application on Clerk and set your API key to the <code>window.__clerk_frontend_api</code> variable at
+        create an application on Clerk and set your API key to the <code>window.__clerk_publishable_key</code> variable at
         the top of the source code.
       </p>
       <p>Use the buttons below to trigger basic functionality. Feel free to add more buttons as well!</p>

--- a/playground/vanillajs/index.html
+++ b/playground/vanillajs/index.html
@@ -3,7 +3,7 @@
   <head>
     <script>
       // 👇 PUT YOUR API KEY HERE 👇
-      window.__clerk_frontend_api = '';
+      window.__clerk_publishable_key = '';
       // 👆 PUT YOUR API KEY HERE 👆
     </script>
     <script src="../../packages/clerk-js/dist/clerk.browser.js"></script>


### PR DESCRIPTION
## Description

Removes references from deprecated `clerk_frontend_api`, `clerk_publishable_key` should be used instead. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
