### PR TITLE
feat(clerk-js): Allow localization of text in social buttons when many are listed

### DIFF
--- a/.changeset/new-swans-fix.md
+++ b/.changeset/new-swans-fix.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Allow localization of text in social buttons when many are listed.

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -3,6 +3,8 @@ import { OAUTH_PROVIDERS } from '@clerk/types';
 import { waitFor } from '@testing-library/react';
 
 import { act, fireEvent, mockWebAuthn, render, screen } from '../../../../testUtils';
+import { OptionsProvider } from '../../../contexts';
+import { AppearanceProvider } from '../../../customizables';
 import { CardStateProvider } from '../../../elements';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { SignInStart } from '../SignInStart';
@@ -105,6 +107,44 @@ describe('SignInStart', () => {
 
       const socialOAuth = screen.getByText(`Continue with ${name}`);
       expect(socialOAuth).toBeDefined();
+    });
+
+    it('shows the "Join with $name" social OAuth button', async () => {
+      const providers = OAUTH_PROVIDERS.filter(({ provider }) => provider !== 'linkedin_oidc');
+      const { wrapper: Wrapper } = await createFixtures(f => {
+        providers.forEach(({ provider }) => {
+          f.withSocialProvider({ provider });
+        });
+      });
+
+      const wrapperBefore = ({ children }) => (
+        <Wrapper>
+          <AppearanceProvider
+            appearanceKey={'signIn'}
+            appearance={{
+              layout: {
+                socialButtonsVariant: 'blockButton',
+              },
+            }}
+          >
+            <OptionsProvider
+              value={{
+                localization: {
+                  socialButtonsBlockButtonManyInView: 'Join with {{provider}}',
+                },
+              }}
+            >
+              {children}
+            </OptionsProvider>
+          </AppearanceProvider>
+        </Wrapper>
+      );
+
+      render(<SignInStart />, { wrapper: wrapperBefore });
+
+      providers.forEach(providerData => {
+        screen.getByText(`Join with ${providerData.name}`);
+      });
     });
 
     it('uses the "cl-socialButtonsIconButton__SOCIALOAUTHNAME" classname when rendering the social button icon only', async () => {

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -2,6 +2,8 @@ import type { SignUpResource } from '@clerk/types';
 import { OAUTH_PROVIDERS } from '@clerk/types';
 
 import { act, render, screen } from '../../../../testUtils';
+import { OptionsProvider } from '../../../contexts';
+import { AppearanceProvider } from '../../../customizables';
 import { CardStateProvider } from '../../../elements';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { SignUpStart } from '../SignUpStart';
@@ -122,6 +124,44 @@ describe('SignUpStart', () => {
 
       render(<SignUpStart />, { wrapper });
       screen.getByText(`Continue with ${name}`);
+    });
+
+    it('shows the "Join with $name" social OAuth button', async () => {
+      const providers = OAUTH_PROVIDERS.filter(({ provider }) => provider !== 'linkedin_oidc');
+      const { wrapper: Wrapper } = await createFixtures(f => {
+        providers.forEach(({ provider }) => {
+          f.withSocialProvider({ provider });
+        });
+      });
+
+      const wrapperBefore = ({ children }) => (
+        <Wrapper>
+          <AppearanceProvider
+            appearanceKey={'signUp'}
+            appearance={{
+              layout: {
+                socialButtonsVariant: 'blockButton',
+              },
+            }}
+          >
+            <OptionsProvider
+              value={{
+                localization: {
+                  socialButtonsBlockButtonManyInView: 'Join with {{provider}}',
+                },
+              }}
+            >
+              {children}
+            </OptionsProvider>
+          </AppearanceProvider>
+        </Wrapper>
+      );
+
+      render(<SignUpStart />, { wrapper: wrapperBefore });
+
+      providers.forEach(providerData => {
+        screen.getByText(`Join with ${providerData.name}`);
+      });
     });
 
     it('displays the "or" divider when using oauth and email options', async () => {

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -115,7 +115,9 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
                 ? localizationKeys('socialButtonsBlockButton', {
                     provider: strategyToDisplayData[strategy].name,
                   })
-                : undefined;
+                : localizationKeys('socialButtonsBlockButtonManyInView', {
+                    provider: strategyToDisplayData[strategy].name,
+                  });
 
             // When strategies break into 2 rows or more, use the first item of the first
             // row as reference for the width of the buttons in the second row and beyond

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -442,6 +442,7 @@ export const enUS: LocalizationResource = {
     },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',
+  socialButtonsBlockButtonManyInView: '{{provider|titleize}}',
   unstable__errors: {
     captcha_invalid:
       'Sign up unsuccessful due to failed security validations. Please refresh the page to try again or reach out to support for more assistance.',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -25,6 +25,7 @@ type _LocalizationResource = {
     [r: string]: LocalizationValue;
   };
   socialButtonsBlockButton: LocalizationValue;
+  socialButtonsBlockButtonManyInView: LocalizationValue;
   dividerText: LocalizationValue;
   formFieldLabel__emailAddress: LocalizationValue;
   formFieldLabel__emailAddresses: LocalizationValue;


### PR DESCRIPTION
## Description

### Before
![Screenshot 2024-04-29 at 2 02 21 PM](https://github.com/clerk/javascript/assets/19269911/3fc5f8d6-b608-4bae-a3de-197e35b44219)
### After

![Screenshot 2024-04-29 at 2 01 40 PM](https://github.com/clerk/javascript/assets/19269911/d40fb426-ce54-4757-9ac7-a362499cabef)
![Screenshot 2024-04-29 at 2 01 50 PM](https://github.com/clerk/javascript/assets/19269911/71a099e1-89c4-42c6-97ff-eb28ff410223)


Example code on how to achieve this behaviour
```tsx 
<ClerkProvider
      localization={{
        // This is now supported
        socialButtonsBlockButtonManyInView: 'Join with {{provider}}',
      }}
      appearance={{
        layout: {
          socialButtonsVariant: 'blockButton',
        },
        elements: {
          socialButtons: {
            display: 'flex',
            flexDirection: 'column',
          },
        },
      }}
    >
```
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
