### PR TITLE
fix(clerk-js): UI fixes for phone input and OTP inputs

### DIFF
--- a/.changeset/short-llamas-remember.md
+++ b/.changeset/short-llamas-remember.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix UI for Phone Input and OTP inputs

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -320,7 +320,7 @@ const SingleCharInput = React.forwardRef<
         textAlign: 'center',
         ...common.textVariants(theme).h2,
         padding: `${theme.space.$0x5} 0`,
-        boxSizing: 'content-box',
+        boxSizing: 'border-box',
         height: theme.space.$10,
         width: theme.space.$10,
         borderRadius: theme.radii.$md,

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -190,7 +190,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
                 borderWidth: 0,
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,
-                paddingLeft: `${`+${selectedCountryOption.country.code}`.length + 1}ch`,
+                paddingLeft: `${`+${selectedCountryOption.country.code}`.length + 1.5}ch`,
                 '&:focus': {
                   borderColor: 'unset',
                   boxShadow: 'unset',

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -160,10 +160,11 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
       >
         <Text
           sx={t => ({
-            display: 'flex',
-            alignItems: 'center',
+            position: 'absolute',
+            left: '1ch',
+            top: '50%',
+            transform: 'translateY(-50%)',
             pointerEvents: 'none',
-            paddingRight: t.space.$0x5,
             opacity: props.isDisabled ? t.opacity.$disabled : 1,
           })}
         >
@@ -179,13 +180,22 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           sx={[
             t => ({
               boxShadow: 'none',
-              borderRadius: t.radii.$md,
               height: '100%',
-              borderTopLeftRadius: '0',
-              borderBottomLeftRadius: '0',
               transitionProperty: t.transitionProperty.$common,
               transitionTimingFunction: t.transitionTiming.$common,
               transitionDuration: t.transitionDuration.$focusRing,
+              // This ensures that this input will never have any border or boxShadow styles.
+              '&[type=tel]': {
+                borderRadius: t.radii.$md,
+                borderWidth: 0,
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                paddingLeft: `${`+${selectedCountryOption.country.code}`.length + 1}ch`,
+                '&:focus': {
+                  borderColor: 'unset',
+                  boxShadow: 'unset',
+                },
+              },
             }),
             sx,
           ]}

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -160,11 +160,10 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
       >
         <Text
           sx={t => ({
-            position: 'absolute',
-            left: '1ch',
-            top: '50%',
-            transform: 'translateY(-50%)',
+            display: 'flex',
+            alignItems: 'center',
             pointerEvents: 'none',
+            paddingLeft: t.space.$0x5,
             opacity: props.isDisabled ? t.opacity.$disabled : 1,
           })}
         >
@@ -190,7 +189,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
                 borderWidth: 0,
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,
-                paddingLeft: `${`+${selectedCountryOption.country.code}`.length + 1.5}ch`,
+                paddingLeft: t.space.$1,
                 '&:focus': {
                   borderColor: 'unset',
                   boxShadow: 'unset',

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -160,11 +160,10 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
       >
         <Text
           sx={t => ({
-            position: 'absolute',
-            left: '1ch',
-            top: '51%',
-            transform: 'translateY(-50%)',
+            display: 'flex',
+            alignItems: 'center',
             pointerEvents: 'none',
+            paddingRight: t.space.$0x5,
             opacity: props.isDisabled ? t.opacity.$disabled : 1,
           })}
         >
@@ -184,7 +183,6 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
               height: '100%',
               borderTopLeftRadius: '0',
               borderBottomLeftRadius: '0',
-              paddingLeft: `${`+${selectedCountryOption.country.code}`.length + 1.5}ch`,
               transitionProperty: t.transitionProperty.$common,
               transitionTimingFunction: t.transitionTiming.$common,
               transitionDuration: t.transitionDuration.$focusRing,


### PR DESCRIPTION
## Description

This PR fixes 2 UI issues that were found when using `@tailwindcss/forms`, the first problem was that phone number had the country code flowing over the phone input and the other one was that the OTP where huge due to `box-sizing: content-box`

<!-- Fixes #(issue number) -->

## Before
![CleanShot 2024-05-01 at 21 17 01@2x](https://github.com/clerk/javascript/assets/6823226/fb2afab2-36ae-4615-9091-c0a1bee515e7)

![CleanShot 2024-05-01 at 21 16 23@2x](https://github.com/clerk/javascript/assets/6823226/439cb6c3-1691-4b6a-864f-62dee30a9383)


# After
![CleanShot 2024-05-01 at 21 31 45@2x](https://github.com/clerk/javascript/assets/6823226/f871c9c6-d703-4d7f-a2d0-4a4fb61ed25b)

![CleanShot 2024-05-01 at 21 15 53@2x](https://github.com/clerk/javascript/assets/6823226/b04539dd-8340-4f60-b9b9-88705226db1a)


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
