### PR TITLE
fix(elements): Prevent multiple verification codes from being sent

### DIFF
--- a/.changeset/violet-lobsters-scream.md
+++ b/.changeset/violet-lobsters-scream.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Fixes a bug where multiple verification codes were sent at once.

--- a/packages/elements/src/react/sign-in/context/router.context.ts
+++ b/packages/elements/src/react/sign-in/context/router.context.ts
@@ -35,6 +35,8 @@ export function useSignInRouteRegistration<
     isMounted.current = true;
 
     return () => {
+      if (isMounted.current) return;
+
       routerRef.send({
         type: 'ROUTE.UNREGISTER',
         id,

--- a/packages/elements/src/react/sign-in/context/router.context.ts
+++ b/packages/elements/src/react/sign-in/context/router.context.ts
@@ -35,8 +35,6 @@ export function useSignInRouteRegistration<
     isMounted.current = true;
 
     return () => {
-      if (isMounted.current) return;
-
       routerRef.send({
         type: 'ROUTE.UNREGISTER',
         id,


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Fixes an issue where multiple prepare calls were being fired, resulting in multiple verification codes being sent. We're doing this by relying on the response from FAPI, which contains an `expireAt` property indicating when the code is expired. If it's not expired, we won't send a new prepare call by default.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
