### PR TITLE
Improve catch-all detection

### DIFF
--- a/.changeset/empty-wombats-invite.md
+++ b/.changeset/empty-wombats-invite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Notify users when catch-all route and all of its children routes are being protected by the middleware

--- a/packages/nextjs/src/client-boundary/hooks/useEnforceCatchAllRoute.tsx
+++ b/packages/nextjs/src/client-boundary/hooks/useEnforceCatchAllRoute.tsx
@@ -30,7 +30,16 @@ export const useEnforceCatchAllRoute = (component: string, path: string, routing
     const error = () => {
       const correctPath = pagesRouter ? `${path}/[[...index]].tsx` : `${path}/[[...rest]]/page.tsx`;
       throw new Error(
-        `Clerk: The "${path}" route is not a catch-all route. It is recommended to convert this route to a catch-all route, eg: "${correctPath}". Alternatively, update the ${component} component to use hash-based routing by setting the "routing" prop to "hash".`,
+        `
+Clerk: The <${component}/> component is not configured correctly. The most likely reasons for this error are:
+
+1. The <${component}/> component is mounted in a catch-all route, but all routes under "${path}" are protected by the middleware.
+To resolve this, ensure that the middleware does not protect the catch-all route or any of its children. If you are using the "createRouteMatcher" helper, consider adding "(.*)" to the end of the route pattern, eg: "${path}(.*)". For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#create-route-matcher
+
+
+2. The "${path}" route is not a catch-all route.
+It is recommended to convert this route to a catch-all route, eg: "${correctPath}". Alternatively, you can update the <${component}/> component to use hash-based routing by setting the "routing" prop to "hash".
+`,
       );
     };
 

--- a/packages/nextjs/src/client-boundary/hooks/useEnforceRoutingProps.tsx
+++ b/packages/nextjs/src/client-boundary/hooks/useEnforceRoutingProps.tsx
@@ -4,9 +4,13 @@ import type { RoutingOptions } from '@clerk/types';
 import { useEnforceCatchAllRoute } from './useEnforceCatchAllRoute';
 import { usePathnameWithoutCatchAll } from './usePathnameWithoutCatchAll';
 
-export function useEnforceCorrectRoutingProps<T extends RoutingOptions>(componentName: string, props: T): T {
+export function useEnforceCorrectRoutingProps<T extends RoutingOptions>(
+  componentName: string,
+  props: T,
+  requireSessionBeforeCheck = true,
+): T {
   const path = usePathnameWithoutCatchAll();
   const routingProps = useRoutingProps(componentName, props, { path });
-  useEnforceCatchAllRoute(componentName, path, routingProps.routing);
+  useEnforceCatchAllRoute(componentName, path, routingProps.routing, requireSessionBeforeCheck);
   return routingProps;
 }

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -56,9 +56,9 @@ export const OrganizationProfile: typeof BaseOrganizationProfile = Object.assign
 );
 
 export const SignIn = (props: SignInProps) => {
-  return <BaseSignIn {...useEnforceCorrectRoutingProps('SignIn', props)} />;
+  return <BaseSignIn {...useEnforceCorrectRoutingProps('SignIn', props, false)} />;
 };
 
 export const SignUp = (props: SignUpProps) => {
-  return <BaseSignUp {...useEnforceCorrectRoutingProps('SignUp', props)} />;
+  return <BaseSignUp {...useEnforceCorrectRoutingProps('SignUp', props, false)} />;
 };


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

This PR aims to improve the way we detect catch-all routes for the following edge cases: 
1. A component that requires an active session (eg UserProfile) is mounted in a route protected by middleware. Upon signing out, the catch-all route check will always fail with a 404 because of the middleware protection. To resolve this edge case, we only fire the catch-all route request when a session is active. The only exception here is the SignIn and SIgnUp components, which require no active session 

2. We've improved the error message to indicate that if a path-based component is mounted in a route that is completely protected by the middleware, the component will fail to work. The usual mistake is to mount SignIn in /sign-in, but then forget to mark all children routes as public in your middleware.

Note: to further mitigate 2, we will update protect() to skip the known sign-in and sign-up routes in an upcoming PR

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
