### PR TITLE
fix(clerk-js): Set eTLD+1 as the domain for client_uat

### DIFF
--- a/.changeset/thirty-seas-agree.md
+++ b/.changeset/thirty-seas-agree.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Specify an explicit domain when setting the client_uat and clerk_db_jwt cookies. This ensures there are no duplicate cookie issues when also recieving cookies from the API.

--- a/.changeset/thirty-seas-agree.md
+++ b/.changeset/thirty-seas-agree.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Specify an explicit domain when setting the client_uat and clerk_db_jwt cookies. This ensures there are no duplicate cookie issues when also recieving cookies from the API.
+Specify an explicit domain when setting the client_uat cookie. This ensures there are no duplicate cookie issues when also receiving cookies from the API.

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -4,7 +4,6 @@ import {
   appendAsQueryParams,
   buildURL,
   createAllowedRedirectOrigins,
-  getAllETLDs,
   getETLDPlusOneFromFrontendApi,
   getSearchParameterFromHash,
   hasBannedProtocol,
@@ -326,12 +325,6 @@ describe('appendQueryParams(base,url)', () => {
     const url = new URL('https://www.google.com/something').href;
     const res = appendAsQueryParams(base, { redirect_url: url });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fwww.google.com%2Fsomething');
-  });
-});
-
-describe('getAllETLDs(hostname)', () => {
-  it('returns all ETLDs for a give hostname', () => {
-    expect(getAllETLDs('foo.bar.qux.baz')).toEqual(['baz', 'qux.baz', 'bar.qux.baz']);
   });
 });
 

--- a/packages/clerk-js/src/utils/cookies/__tests__/getCookieDomain.test.ts
+++ b/packages/clerk-js/src/utils/cookies/__tests__/getCookieDomain.test.ts
@@ -1,0 +1,53 @@
+import { getCookieDomain } from '../getCookieDomain';
+
+type CookieHandler = NonNullable<Parameters<typeof getCookieDomain>[1]>;
+
+describe('getCookieDomain', () => {
+  it('returns the eTLD+1 domain based on where the cookie can be set', () => {
+    // This unit tests relies on browser APIs that we can't mock without
+    // rendering this test useless.
+    // This logic will be covered by a separate E2E test suite, however, for
+    // we will pretend that the fr.hosting.co.uk is the eTLD of a hosting provider
+    // and app.fr.hosting.co.uk is the actual eTLD+1 domain.
+    // This test mostly covers the iteration logic and the cookie setting logic, we
+    // assume that the Public Suffix List is correctly handled by the browser.
+    const hostname = 'app.fr.hosting.co.uk';
+    const handler: CookieHandler = {
+      get: jest
+        .fn()
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce('1'),
+      set: jest.fn().mockReturnValue(undefined),
+      remove: jest.fn().mockReturnValue(undefined),
+    };
+    const result = getCookieDomain(hostname, handler);
+    expect(result).toBe('hostname');
+  });
+
+  it('handles localhost', () => {
+    const hostname = 'localhost';
+    const result = getCookieDomain(hostname);
+    expect(result).toBe('localhost');
+  });
+
+  it('handles common addresses pointing to localhost', () => {
+    const commonAddresses = ['0.0.0.0', '127.0.0.1'];
+    for (const commonAddress of commonAddresses) {
+      const result = getCookieDomain(commonAddress);
+      expect(result).toBe(commonAddress);
+    }
+  });
+
+  it('returns undefined if the domain could not be determined', () => {
+    const handler: CookieHandler = {
+      get: jest.fn().mockReturnValue(undefined),
+      set: jest.fn().mockReturnValue(undefined),
+      remove: jest.fn().mockReturnValue(undefined),
+    };
+    const hostname = 'app.hello.co.uk';
+    const result = getCookieDomain(hostname, handler);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/clerk-js/src/utils/cookies/clientUat.ts
+++ b/packages/clerk-js/src/utils/cookies/clientUat.ts
@@ -27,6 +27,9 @@ export const setClientUatCookie = (client: ClientResource | undefined) => {
     val = Math.floor(client.updatedAt.getTime() / 1000).toString();
   }
 
+  // Removes any existing cookies without a domain specified to ensure the change doesn't break existing sessions.
+  clientUatCookie.remove();
+
   return clientUatCookie.set(val, {
     expires,
     sameSite,

--- a/packages/clerk-js/src/utils/cookies/clientUat.ts
+++ b/packages/clerk-js/src/utils/cookies/clientUat.ts
@@ -3,6 +3,7 @@ import { addYears } from '@clerk/shared/date';
 import type { ClientResource } from '@clerk/types';
 
 import { inCrossOriginIframe } from '../../utils';
+import { getCookieDomain } from './getCookieDomain';
 
 const CLIENT_UAT_COOKIE_NAME = '__client_uat';
 
@@ -16,6 +17,7 @@ export const setClientUatCookie = (client: ClientResource | undefined) => {
   const expires = addYears(Date.now(), 1);
   const sameSite = inCrossOriginIframe() ? 'None' : 'Strict';
   const secure = window.location.protocol === 'https:';
+  const domain = getCookieDomain();
 
   // '0' indicates the user is signed out
   let val = '0';
@@ -28,6 +30,7 @@ export const setClientUatCookie = (client: ClientResource | undefined) => {
   return clientUatCookie.set(val, {
     expires,
     sameSite,
+    domain,
     secure,
   });
 };

--- a/packages/clerk-js/src/utils/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/utils/cookies/devBrowser.ts
@@ -3,6 +3,7 @@ import { addYears } from '@clerk/shared/date';
 import { DEV_BROWSER_JWT_KEY } from '@clerk/shared/devBrowser';
 
 import { inCrossOriginIframe } from '../../utils';
+import { getCookieDomain } from './getCookieDomain';
 
 export const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_KEY);
 
@@ -12,10 +13,12 @@ export const setDevBrowserCookie = (jwt: string) => {
   const expires = addYears(Date.now(), 1);
   const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
   const secure = window.location.protocol === 'https:';
+  const domain = getCookieDomain();
 
   return devBrowserCookie.set(jwt, {
     expires,
     sameSite,
+    domain,
     secure,
   });
 };

--- a/packages/clerk-js/src/utils/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/utils/cookies/devBrowser.ts
@@ -3,7 +3,6 @@ import { addYears } from '@clerk/shared/date';
 import { DEV_BROWSER_JWT_KEY } from '@clerk/shared/devBrowser';
 
 import { inCrossOriginIframe } from '../../utils';
-import { getCookieDomain } from './getCookieDomain';
 
 export const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_KEY);
 
@@ -13,12 +12,10 @@ export const setDevBrowserCookie = (jwt: string) => {
   const expires = addYears(Date.now(), 1);
   const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
   const secure = window.location.protocol === 'https:';
-  const domain = getCookieDomain();
 
   return devBrowserCookie.set(jwt, {
     expires,
     sameSite,
-    domain,
     secure,
   });
 };

--- a/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
+++ b/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
@@ -13,6 +13,10 @@ export function getCookieDomain(hostname = window.location.hostname) {
     return eTLDPlusOne;
   }
 
+  if (hostname === 'localhost') {
+    return hostname;
+  }
+
   const hostnameParts = hostname.split('.');
 
   // we know for sure that the first entry is definitely a TLD, skip it

--- a/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
+++ b/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
@@ -7,13 +7,14 @@ import { createCookieHandler } from '@clerk/shared/cookie';
  */
 let eTLDPlusOne: string;
 const eTLDCookie = createCookieHandler('__clerk_test_etld');
-export function getCookieDomain(hostname = window.location.hostname) {
+
+export function getCookieDomain(hostname = window.location.hostname, cookieHandler = eTLDCookie) {
   // only compute it once per session to avoid unnecessary cookie ops
   if (eTLDPlusOne) {
     return eTLDPlusOne;
   }
 
-  if (hostname === 'localhost') {
+  if (['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname)) {
     return hostname;
   }
 
@@ -22,14 +23,15 @@ export function getCookieDomain(hostname = window.location.hostname) {
   // we know for sure that the first entry is definitely a TLD, skip it
   for (let i = hostnameParts.length - 2; i >= 0; i--) {
     const eTLD = hostnameParts.slice(i).join('.');
-    eTLDCookie.set('1', { domain: eTLD });
+    cookieHandler.set('1', { domain: eTLD });
 
-    if (eTLDCookie.get() === '1') {
-      eTLDCookie.remove({ domain: eTLD });
+    const res = cookieHandler.get();
+    if (res === '1') {
+      cookieHandler.remove({ domain: eTLD });
       return eTLD;
     }
 
-    eTLDCookie.remove({ domain: eTLD });
+    cookieHandler.remove({ domain: eTLD });
   }
 
   return;

--- a/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
+++ b/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
@@ -1,0 +1,35 @@
+import { createCookieHandler } from '@clerk/shared/cookie';
+
+/**
+ * Determines the eTLD+1 domain, which is where we want the cookies to be set.
+ * This aligns with logic in FAPI, which is important to ensure we don't run into
+ * a scenario where two __client_uat cookies are present.
+ */
+let eTLDPlusOne: string;
+const eTLDCookie = createCookieHandler('__clerk_test_etld');
+export function getCookieDomain(hostname = window.location.hostname) {
+  // only compute it once per session to avoid unnecessary cookie ops
+  if (eTLDPlusOne) {
+    return eTLDPlusOne;
+  }
+
+  // For each segment of the hostname, construct a potential domain
+  // e.g. clerk.vercel.app -> [app, vercel.app, clerk.vercel.app]
+  const eTLDs = hostname
+    .split('.')
+    .reduceRight<string[]>((res, cur) => [...res, [cur, ...res.slice(-1)].join('.')], []);
+
+  // we know for sure that the first entry is definitely a TLD, skip it
+  for (const eTLD of eTLDs.slice(1)) {
+    eTLDCookie.set('1', { domain: eTLD });
+
+    if (eTLDCookie.get() === '1') {
+      eTLDCookie.remove({ domain: eTLD });
+      return eTLD;
+    }
+
+    eTLDCookie.remove({ domain: eTLD });
+  }
+
+  return;
+}

--- a/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
+++ b/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
@@ -5,13 +5,13 @@ import { createCookieHandler } from '@clerk/shared/cookie';
  * This aligns with logic in FAPI, which is important to ensure we don't run into
  * a scenario where two __client_uat cookies are present.
  */
-let eTLDPlusOne: string;
+let cachedETLDPlusOne: string;
 const eTLDCookie = createCookieHandler('__clerk_test_etld');
 
 export function getCookieDomain(hostname = window.location.hostname, cookieHandler = eTLDCookie) {
   // only compute it once per session to avoid unnecessary cookie ops
-  if (eTLDPlusOne) {
-    return eTLDPlusOne;
+  if (cachedETLDPlusOne) {
+    return cachedETLDPlusOne;
   }
 
   if (['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname)) {
@@ -28,6 +28,7 @@ export function getCookieDomain(hostname = window.location.hostname, cookieHandl
     const res = cookieHandler.get();
     if (res === '1') {
       cookieHandler.remove({ domain: eTLD });
+      cachedETLDPlusOne = eTLD;
       return eTLD;
     }
 

--- a/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
+++ b/packages/clerk-js/src/utils/cookies/getCookieDomain.ts
@@ -13,14 +13,11 @@ export function getCookieDomain(hostname = window.location.hostname) {
     return eTLDPlusOne;
   }
 
-  // For each segment of the hostname, construct a potential domain
-  // e.g. clerk.vercel.app -> [app, vercel.app, clerk.vercel.app]
-  const eTLDs = hostname
-    .split('.')
-    .reduceRight<string[]>((res, cur) => [...res, [cur, ...res.slice(-1)].join('.')], []);
+  const hostnameParts = hostname.split('.');
 
   // we know for sure that the first entry is definitely a TLD, skip it
-  for (const eTLD of eTLDs.slice(1)) {
+  for (let i = hostnameParts.length - 2; i >= 0; i--) {
+    const eTLD = hostnameParts.slice(i).join('.');
     eTLDCookie.set('1', { domain: eTLD });
 
     if (eTLDCookie.get() === '1') {

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -43,19 +43,6 @@ export function getETLDPlusOneFromFrontendApi(frontendApi: string): string {
   return frontendApi.replace('clerk.', '');
 }
 
-export function getAllETLDs(hostname: string = window.location.hostname): string[] {
-  const parts = hostname.split('.');
-  const memo = [];
-  const domains = [];
-
-  for (let i = parts.length - 1; i > 0; i--) {
-    memo.unshift(parts[i]);
-    domains.push(memo.join('.'));
-  }
-
-  return domains;
-}
-
 interface BuildURLParams extends Partial<URL> {
   base?: string;
   hashPath?: string;


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Set an explicit domain value for our `clientUat`  cookie. This mirrors logic in FAPI. Without this, we were seeing duplicate `__client_uat` cookies, which causes issues when they get out of sync. I also removed an unused helper method, `getAllETLDs()`, that I stumbled across.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
