### PR TITLE
refactor(elements): Reduce Sign Up reliance on useEffect [SDK-1715]

### DIFF
--- a/packages/elements/src/internals/machines/sign-up/continue.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/continue.machine.ts
@@ -1,6 +1,6 @@
 import { snakeToCamel } from '@clerk/shared/underscore';
 import type { SignUpResource } from '@clerk/types';
-import type { ActorRefFrom, DoneActorEvent } from 'xstate';
+import type { DoneActorEvent } from 'xstate';
 import { fromPromise, setup } from 'xstate';
 
 import { SIGN_UP_DEFAULT_BASE_PATH } from '~/internals/constants';
@@ -10,7 +10,7 @@ import { fieldsToSignUpParams } from '~/internals/machines/sign-up/utils';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
 import type { SignUpContinueSchema } from './continue.types';
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 
 export type TSignUpContinueMachine = typeof SignUpContinueMachine;
 
@@ -18,7 +18,7 @@ export const SignUpContinueMachineId = 'SignUpContinue';
 
 export const SignUpContinueMachine = setup({
   actors: {
-    attempt: fromPromise<SignUpResource, { parent: ActorRefFrom<TSignUpRouterMachine>; fields: FormFields }>(
+    attempt: fromPromise<SignUpResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const params = fieldsToSignUpParams(fields);
         return parent.getSnapshot().context.clerk.client.signUp.update(params);

--- a/packages/elements/src/internals/machines/sign-up/continue.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/continue.types.ts
@@ -3,7 +3,7 @@ import type { ActorRefFrom, ErrorActorEvent } from 'xstate';
 
 import type { FormMachine } from '~/internals/machines/form';
 
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 
 // ---------------------------------- Tags ---------------------------------- //
 
@@ -20,7 +20,7 @@ export type SignUpContinueEvents = ErrorActorEvent | SignUpContinueSubmitEvent;
 export type SignUpContinueInput = {
   basePath?: string;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 };
 
 // ---------------------------------- Context ---------------------------------- //
@@ -29,7 +29,7 @@ export interface SignUpContinueContext {
   basePath: string;
   error?: Error | ClerkAPIResponseError;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
   loadingStep: 'continue';
 }
 

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -1,7 +1,7 @@
 import { joinURL } from '@clerk/shared/url';
 import type { SignUpStatus, VerificationStatus } from '@clerk/types';
 import type { NonReducibleUnknown } from 'xstate';
-import { and, assign, enqueueActions, log, not, or, sendTo, setup, spawnChild, stopChild } from 'xstate';
+import { and, assign, log, not, or, raise, sendTo, setup, spawnChild } from 'xstate';
 
 import {
   ERROR_CODES,
@@ -14,12 +14,18 @@ import { ClerkElementsError, ClerkElementsRuntimeError } from '~/internals/error
 import { ThirdPartyMachine, ThirdPartyMachineId } from '~/internals/machines/third-party';
 import { shouldUseVirtualRouting } from '~/internals/machines/utils/next';
 
+import { SignUpContinueMachine } from './continue.machine';
 import type {
   SignUpRouterContext,
   SignUpRouterEvents,
   SignUpRouterNextEvent,
   SignUpRouterSchema,
 } from './router.types';
+import { SignUpStartMachine } from './start.machine';
+import { SignUpVerificationMachine } from './verification.machine';
+
+export const SignUpRouterMachineId = 'SignUpRouter';
+export type TSignUpRouterMachine = typeof SignUpRouterMachine;
 
 const isCurrentPath =
   (path: `/${string}`) =>
@@ -31,12 +37,12 @@ const needsStatus =
   ({ context, event }: { context: SignUpRouterContext; event?: SignUpRouterEvents }, _?: NonReducibleUnknown) =>
     (event as SignUpRouterNextEvent)?.resource?.status === status || context.clerk?.client?.signUp?.status === status;
 
-export const SignUpRouterMachineId = 'SignUpRouter';
-export type TSignUpRouterMachine = typeof SignUpRouterMachine;
-
 export const SignUpRouterMachine = setup({
   actors: {
-    thirdParty: ThirdPartyMachine,
+    continueMachine: SignUpContinueMachine,
+    startMachine: SignUpStartMachine,
+    thirdPartyMachine: ThirdPartyMachine,
+    verificationMachine: SignUpVerificationMachine,
   },
   actions: {
     clearFormErrors: sendTo(({ context }) => context.formRef, { type: 'ERRORS.CLEAR' }),
@@ -52,6 +58,7 @@ export const SignUpRouterMachine = setup({
       context.router.shallowPush(resolvedPath);
     },
     navigateExternal: ({ context }, { path }: { path: string }) => context.router?.push(path),
+    raiseNext: raise({ type: 'NEXT' }),
     setActive({ context, event }, params?: { sessionId?: string; useLastActiveSession?: boolean }) {
       const session =
         params?.sessionId ||
@@ -166,24 +173,6 @@ export const SignUpRouterMachine = setup({
     },
     'NAVIGATE.PREVIOUS': '.Hist',
     'NAVIGATE.START': '.Start',
-    'ROUTE.REGISTER': {
-      actions: enqueueActions(({ context, enqueue, event, self, system }) => {
-        const { id, logic, input } = event;
-
-        if (!system.get(id)) {
-          // @ts-expect-error - This is valid (See: https://discord.com/channels/795785288994652170/1203714033190969405/1205595237293096960)
-          enqueue.spawnChild(logic, {
-            id,
-            systemId: id,
-            input: { basePath: context.router?.basePath, parent: self, formRef: context.formRef, ...input },
-            syncSnapshot: true, // Subscribes to the spawned actor and send back snapshot events
-          });
-        }
-      }),
-    },
-    'ROUTE.UNREGISTER': {
-      actions: stopChild(({ event }) => event.id),
-    },
     LOADING: {
       actions: assign(({ event }) => ({
         loading: {
@@ -213,7 +202,7 @@ export const SignUpRouterMachine = setup({
       },
     },
     Init: {
-      entry: spawnChild('thirdParty', {
+      entry: spawnChild('thirdPartyMachine', {
         id: ThirdPartyMachineId,
         systemId: ThirdPartyMachineId,
         input: ({ context, self }) => ({
@@ -258,6 +247,21 @@ export const SignUpRouterMachine = setup({
     Start: {
       tags: 'route:start',
       exit: 'clearFormErrors',
+      invoke: {
+        id: 'start',
+        src: 'startMachine',
+        input: ({ context, self }) => ({
+          basePath: context.router?.basePath,
+          formRef: context.formRef,
+          parent: self,
+        }),
+        onDone: {
+          actions: 'raiseNext',
+        },
+        onError: {
+          actions: 'raiseNext', // TODO: Update
+        },
+      },
       on: {
         NEXT: [
           {
@@ -279,6 +283,21 @@ export const SignUpRouterMachine = setup({
     },
     Continue: {
       tags: 'route:continue',
+      invoke: {
+        id: 'continue',
+        src: 'continueMachine',
+        input: ({ context, self }) => ({
+          basePath: context.router?.basePath,
+          formRef: context.formRef,
+          parent: self,
+        }),
+        onDone: {
+          actions: 'raiseNext',
+        },
+        onError: {
+          actions: 'raiseNext', // TODO: Update
+        },
+      },
       on: {
         NEXT: [
           {
@@ -295,6 +314,21 @@ export const SignUpRouterMachine = setup({
     },
     Verification: {
       tags: 'route:verification',
+      invoke: {
+        id: 'verification',
+        src: 'verificationMachine',
+        input: ({ context, self }) => ({
+          basePath: context.router?.basePath,
+          formRef: context.formRef,
+          parent: self,
+        }),
+        onDone: {
+          actions: 'raiseNext',
+        },
+        onError: {
+          actions: 'raiseNext', // TODO: Update
+        },
+      },
       always: [
         {
           guard: 'hasCreatedSession',

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -1,5 +1,5 @@
 import type { SignUpResource } from '@clerk/types';
-import type { ActorRefFrom, AnyActorLogic } from 'xstate';
+import type { ActorRefFrom, SnapshotFrom, StateMachine } from 'xstate';
 
 import type { TFormMachine } from '~/internals/machines/form';
 import type {
@@ -10,8 +10,6 @@ import type {
   BaseRouterNextEvent,
   BaseRouterPrevEvent,
   BaseRouterRedirectEvent,
-  BaseRouterRouteRegisterEvent,
-  BaseRouterRouteUnregisterEvent,
   BaseRouterSetClerkEvent,
   BaseRouterStartEvent,
   BaseRouterTransferEvent,
@@ -57,14 +55,6 @@ export interface SignUpRouterInitEvent extends BaseRouterInput {
   signInPath?: string;
 }
 
-export type SignUpRouterRouteRegisterEvent<TLogic extends AnyActorLogic = AnyActorLogic> = BaseRouterRouteRegisterEvent<
-  SignUpRouterSystemId,
-  TLogic
->;
-export type SignUpRouterRouteUnregisterEvent = BaseRouterRouteUnregisterEvent<SignUpRouterSystemId>;
-
-export type SignUpRouterRouteEvents = SignUpRouterRouteRegisterEvent | SignUpRouterRouteUnregisterEvent;
-
 export type SignUpRouterNavigationEvents = SignUpRouterStartEvent | SignUpRouterPrevEvent;
 
 export type SignUpRouterEvents =
@@ -74,7 +64,6 @@ export type SignUpRouterEvents =
   | SignUpRouterErrorEvent
   | SignUpRouterTransferEvent
   | SignUpRouterRedirectEvent
-  | SignUpRouterRouteEvents
   | SignUpRouterLoadingEvent
   | SignUpRouterSetClerkEvent;
 
@@ -104,3 +93,33 @@ export interface SignUpRouterSchema {
   tags: SignUpRouterTags;
   delays: SignUpRouterDelays;
 }
+
+// ---------------------------------- Machine Type ---------------------------------- //
+
+export type SignUpRouterChildren = any; // TODO: Update
+export type SignUpRouterOuptut = any; // TODO: Update
+export type SignUpRouterStateValue = any; // TODO: Update
+
+export type TSignUpRouterParentMachine = StateMachine<
+  SignUpRouterContext, // context
+  SignUpRouterEvents, // event
+  SignUpRouterChildren, // children
+  any, // actor
+  any, // action
+  any, // guard
+  any, // delay
+  SignUpRouterStateValue, // state value
+  string, // tag
+  any, // input
+  SignUpRouterOuptut, // output
+  any, // emitted
+  any // meta - Introduced in XState 5.12.x
+>;
+
+// ---------------------------------- Machine Actor Ref ---------------------------------- //
+
+export type SignInRouterMachineActorRef = ActorRefFrom<TSignUpRouterParentMachine>;
+
+// ---------------------------------- Snapshot ---------------------------------- //
+
+export type SignUpRouterSnapshot = SnapshotFrom<TSignUpRouterParentMachine>;

--- a/packages/elements/src/internals/machines/sign-up/start.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/start.machine.ts
@@ -1,5 +1,4 @@
 import type { SignUpResource } from '@clerk/types';
-import type { ActorRefFrom } from 'xstate';
 import { fromPromise, not, sendTo, setup } from 'xstate';
 
 import { SIGN_UP_DEFAULT_BASE_PATH } from '~/internals/constants';
@@ -9,7 +8,7 @@ import { fieldsToSignUpParams } from '~/internals/machines/sign-up/utils';
 import { ThirdPartyMachine } from '~/internals/machines/third-party';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 import type { SignUpStartSchema } from './start.types';
 
 export type TSignUpStartMachine = typeof SignUpStartMachine;
@@ -18,7 +17,7 @@ export const SignUpStartMachineId = 'SignUpStart';
 
 export const SignUpStartMachine = setup({
   actors: {
-    attempt: fromPromise<SignUpResource, { parent: ActorRefFrom<TSignUpRouterMachine>; fields: FormFields }>(
+    attempt: fromPromise<SignUpResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const params = fieldsToSignUpParams(fields);
         return parent.getSnapshot().context.clerk.client.signUp.create(params);

--- a/packages/elements/src/internals/machines/sign-up/start.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/start.types.ts
@@ -4,7 +4,7 @@ import type { ActorRefFrom, ErrorActorEvent } from 'xstate';
 
 import type { FormMachine } from '~/internals/machines/form';
 
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 
 // ---------------------------------- Tags ---------------------------------- //
 
@@ -31,7 +31,7 @@ export type SignUpStartEvents = ErrorActorEvent | SignUpStartSubmitEvent | SignU
 export type SignUpStartInput = {
   basePath?: string;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 };
 
 // ---------------------------------- Context ---------------------------------- //
@@ -40,7 +40,7 @@ export interface SignUpStartContext {
   basePath: string;
   error?: Error | ClerkAPIResponseError;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
   loadingStep: 'start';
 }
 

--- a/packages/elements/src/internals/machines/sign-up/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/verification.machine.ts
@@ -9,7 +9,6 @@ import type {
   VerificationStrategy,
 } from '@clerk/types';
 import type { Writable } from 'type-fest';
-import type { ActorRefFrom } from 'xstate';
 import { and, assign, enqueueActions, fromCallback, fromPromise, log, raise, sendParent, sendTo, setup } from 'xstate';
 
 import {
@@ -22,7 +21,7 @@ import type { WithParams } from '~/internals/machines/shared';
 import { sendToLoading } from '~/internals/machines/shared';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 import {
   type SignUpVerificationContext,
   SignUpVerificationDelays,
@@ -36,7 +35,7 @@ export type TSignUpVerificationMachine = typeof SignUpVerificationMachine;
 
 export type StartSignUpEmailLinkFlowEvents = { type: 'STOP' };
 export type StartSignUpEmailLinkFlowInput = {
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 };
 
 export const SignUpVerificationMachineId = 'SignUpVerification';
@@ -65,10 +64,10 @@ const shouldVerify = (field: SignUpVerifiableField, strategy?: VerificationStrat
 };
 
 export type PrepareVerificationInput = {
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 } & WithParams<PrepareVerificationParams>;
 export type AttemptVerificationInput = {
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 } & WithParams<AttemptVerificationParams>;
 
 export const SignUpVerificationMachine = setup({

--- a/packages/elements/src/internals/machines/sign-up/verification.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/verification.types.ts
@@ -4,7 +4,7 @@ import type { ActorRefFrom, DoneActorEvent, ErrorActorEvent } from 'xstate';
 
 import type { FormMachine } from '~/internals/machines/form';
 
-import type { TSignUpRouterMachine } from './router.machine';
+import type { SignInRouterMachineActorRef } from './router.types';
 
 // ---------------------------------- Tags ---------------------------------- //
 
@@ -65,7 +65,7 @@ export type SignUpVerificationEvents =
 export type SignUpVerificationInput = {
   basePath?: string;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
 };
 
 // ---------------------------------- Delays ---------------------------------- //
@@ -84,7 +84,7 @@ export interface SignUpVerificationContext {
   resource: SignUpResource;
   error?: Error | ClerkAPIResponseError;
   formRef: ActorRefFrom<typeof FormMachine>;
-  parent: ActorRefFrom<TSignUpRouterMachine>;
+  parent: SignInRouterMachineActorRef;
   loadingStep: 'verifications';
   resendable: boolean;
   resendableAfter: number;

--- a/packages/elements/src/internals/machines/types/router.types.ts
+++ b/packages/elements/src/internals/machines/types/router.types.ts
@@ -1,5 +1,3 @@
-// ---------------------------------- Events ---------------------------------- //
-
 import type {
   ClerkResource,
   LoadedClerk,
@@ -8,7 +6,6 @@ import type {
   SignInStrategy,
   Web3Strategy,
 } from '@clerk/types';
-import type { AnyActorLogic, InputFrom } from 'xstate';
 
 import type { ClerkElementsError } from '~/internals/errors';
 import type { ClerkRouter } from '~/react/router';
@@ -32,15 +29,6 @@ export type BaseRouterLoadingEvent<TSteps extends BaseRouterLoadingStep> = (
       strategy: SignInStrategy | undefined;
     }
 ) & { type: 'LOADING'; isLoading: boolean };
-
-export type BaseRouterRouteRegisterEvent<TSystemId extends string, TLogic extends AnyActorLogic = AnyActorLogic> = {
-  type: 'ROUTE.REGISTER';
-  id: TSystemId;
-  logic: TLogic;
-  input: Omit<InputFrom<TLogic>, 'basePath' | 'clerk' | 'form' | 'router'>;
-};
-
-export type BaseRouterRouteUnregisterEvent<T extends string> = { type: 'ROUTE.UNREGISTER'; id: T };
 
 export type BaseRouterRedirectOauthEvent = { type: 'AUTHENTICATE.OAUTH'; strategy: OAuthStrategy };
 export type BaseRouterRedirectSamlEvent = { type: 'AUTHENTICATE.SAML'; strategy?: SamlStrategy };

--- a/packages/elements/src/react/sign-up/context/index.ts
+++ b/packages/elements/src/react/sign-up/context/index.ts
@@ -1,6 +1,11 @@
 // export { StrategiesContext, useStrategy } from './strategies.context';
 
-export { SignUpRouterCtx, useSignUpRouteRegistration } from './router.context';
+export {
+  SignUpRouterCtx,
+  useSignUpStartStep,
+  useSignUpContinueStep,
+  useSignUpVerificationStep,
+} from './router.context';
 export { StrategiesContext } from './strategies.context';
 
 export type { StrategiesContextValue } from './strategies.context';

--- a/packages/elements/src/react/sign-up/context/router.context.ts
+++ b/packages/elements/src/react/sign-up/context/router.context.ts
@@ -1,48 +1,21 @@
-import { useClerk } from '@clerk/clerk-react';
-import { useEffect, useRef } from 'react';
-import type { ActorRefFrom, AnyActorLogic, SnapshotFrom } from 'xstate';
+import type { ActorRefFrom, AnyActorRef, AnyStateMachine, SnapshotFrom } from 'xstate';
 
-import type { SignUpRouterRouteRegisterEvent, TSignUpRouterMachine } from '~/internals/machines/sign-up';
+import type {
+  TSignUpContinueMachine,
+  TSignUpRouterMachine,
+  TSignUpStartMachine,
+  TSignUpVerificationMachine,
+} from '~/internals/machines/sign-up';
 import { createContextFromActorRef } from '~/react/utils/create-context-from-actor-ref';
 
 export type SnapshotState = SnapshotFrom<TSignUpRouterMachine>;
 
 export const SignUpRouterCtx = createContextFromActorRef<TSignUpRouterMachine>('SignUpRouterCtx');
 
-export function useSignUpRouteRegistration<
-  TLogic extends AnyActorLogic,
-  TEvent extends SignUpRouterRouteRegisterEvent<TLogic>,
->(id: TEvent['id'], logic: TLogic, input?: TEvent['input']): ActorRefFrom<TLogic> | undefined {
-  const isMounted = useRef(!process.env.NODE_ENV || process.env.NODE_ENV !== 'development');
-
-  const clerk = useClerk();
-  const routerRef = SignUpRouterCtx.useActorRef();
-
-  const ref = routerRef.system.get(id);
-
-  useEffect(() => {
-    if ((!routerRef || ref) && isMounted.current) {
-      return;
-    }
-
-    routerRef.send({
-      type: 'ROUTE.REGISTER',
-      id,
-      logic,
-      input: { clerk, ...input },
-    });
-
-    isMounted.current = true;
-
-    return () => {
-      if (isMounted.current) return;
-
-      routerRef.send({
-        type: 'ROUTE.UNREGISTER',
-        id,
-      });
-    };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return ref || routerRef.system.get(id);
+function useSignUpStep<M extends AnyStateMachine, T = ActorRefFrom<M>>(name: string) {
+  return SignUpRouterCtx.useSelector(state => state.children[name] as AnyActorRef) as T;
 }
+
+export const useSignUpStartStep = () => useSignUpStep<TSignUpStartMachine>('start');
+export const useSignUpContinueStep = () => useSignUpStep<TSignUpContinueMachine>('continue');
+export const useSignUpVerificationStep = () => useSignUpStep<TSignUpVerificationMachine>('verification');

--- a/packages/elements/src/react/sign-up/continue.tsx
+++ b/packages/elements/src/react/sign-up/continue.tsx
@@ -1,9 +1,8 @@
 import type { TSignUpContinueMachine } from '~/internals/machines/sign-up';
-import { SignUpContinueMachine } from '~/internals/machines/sign-up';
 import type { FormProps } from '~/react/common/form';
 import { Form } from '~/react/common/form';
 import { useActiveTags } from '~/react/hooks';
-import { SignUpRouterCtx, useSignUpRouteRegistration } from '~/react/sign-up/context';
+import { SignUpRouterCtx, useSignUpContinueStep } from '~/react/sign-up/context';
 import { createContextFromActorRef } from '~/react/utils/create-context-from-actor-ref';
 
 export type SignUpContinueProps = FormProps;
@@ -18,7 +17,7 @@ export function SignUpContinue(props: SignUpContinueProps) {
 }
 
 function SignUpContinueInner(props: SignUpContinueProps) {
-  const ref = useSignUpRouteRegistration('continue', SignUpContinueMachine);
+  const ref = useSignUpContinueStep();
 
   if (!ref) {
     return null;

--- a/packages/elements/src/react/sign-up/start.tsx
+++ b/packages/elements/src/react/sign-up/start.tsx
@@ -1,9 +1,8 @@
 import type { TSignUpStartMachine } from '~/internals/machines/sign-up';
-import { SignUpStartMachine } from '~/internals/machines/sign-up';
 import type { FormProps } from '~/react/common/form';
 import { Form } from '~/react/common/form';
 import { useActiveTags } from '~/react/hooks';
-import { SignUpRouterCtx, useSignUpRouteRegistration } from '~/react/sign-up/context';
+import { SignUpRouterCtx, useSignUpStartStep } from '~/react/sign-up/context';
 import { createContextFromActorRef } from '~/react/utils/create-context-from-actor-ref';
 
 export type SignUpStartProps = FormProps;
@@ -18,7 +17,7 @@ export function SignUpStart(props: SignUpStartProps) {
 }
 
 function SignUpStartInner(props: SignUpStartProps) {
-  const ref = useSignUpRouteRegistration('start', SignUpStartMachine);
+  const ref = useSignUpStartStep();
 
   if (!ref) {
     return null;

--- a/packages/elements/src/react/sign-up/verifications.tsx
+++ b/packages/elements/src/react/sign-up/verifications.tsx
@@ -3,11 +3,10 @@ import type {
   SignUpVerificationTags,
   TSignUpVerificationMachine,
 } from '~/internals/machines/sign-up';
-import { SignUpVerificationMachine } from '~/internals/machines/sign-up';
 import type { FormProps } from '~/react/common/form';
 import { Form } from '~/react/common/form';
 import { useActiveTags } from '~/react/hooks';
-import { SignUpRouterCtx, useSignUpRouteRegistration } from '~/react/sign-up/context';
+import { SignUpRouterCtx, useSignUpVerificationStep } from '~/react/sign-up/context';
 
 import { createContextFromActorRef } from '../utils/create-context-from-actor-ref';
 
@@ -38,7 +37,7 @@ export function SignUpVerifications(props: SignUpVerificationsProps) {
 }
 
 function SignUpVerifyInner(props: SignUpVerificationsProps) {
-  const ref = useSignUpRouteRegistration('verification', SignUpVerificationMachine);
+  const ref = useSignUpVerificationStep();
 
   if (!ref) {
     return null;


### PR DESCRIPTION
## Description

As development of Elements progressed certain decisions were made which invalidated the benefits of spawning the child machines the way we were. As-such, this PR serves to do the following for Sign Up:

- [x] Remove the need to manually manage spawning of child machines
- [x]  Eliminate issues surrounding useEffect mounting/unmounting/race conditions (especially with regards to React Strict Mode)
- [x]  Begin making the codebase simpler



Fixes SDK-1715

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
