### PR TITLE
fix(shared): Fix detection of legacy publishable keys in apiUrlFromPublishableKey

### DIFF
--- a/.changeset/nine-grapes-add.md
+++ b/.changeset/nine-grapes-add.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix detection of legacy publishable keys when determining the default Clerk API URL. Previously, legacy keys would be treated as local.

--- a/packages/shared/src/__tests__/apiUrlFromPublishableKey.test.ts
+++ b/packages/shared/src/__tests__/apiUrlFromPublishableKey.test.ts
@@ -1,18 +1,23 @@
 import { apiUrlFromPublishableKey } from '../apiUrlFromPublishableKey';
 
 describe('apiUrlFromPublishableKey', () => {
-  test('returns the prod api url when given a prod publishable key', async () => {
+  test('returns the prod API URL when given a prod publishable key', async () => {
     const apiUrl = apiUrlFromPublishableKey('pk_test_bWFueS1zZWFsLTkwLmNsZXJrLmFjY291bnRzLmRldiQ');
     expect(apiUrl).toBe('https://api.clerk.com');
   });
 
-  test('returns the prod api url when given a staging publishable key', async () => {
+  test('returns the stage API URL when given a staging publishable key', async () => {
     const apiUrl = apiUrlFromPublishableKey('pk_test_aW1tdW5lLWhhd2stNjUuY2xlcmsuYWNjb3VudHNzdGFnZS5kZXYk');
     expect(apiUrl).toBe('https://api.clerkstage.dev');
   });
 
-  test('returns the prod api url when given a local publishable key', async () => {
+  test('returns the local API URL when given a local publishable key', async () => {
     const apiUrl = apiUrlFromPublishableKey('pk_test_cGF0aWVudC1nb29zZS01LmNsZXJrLmFjY291bnRzLmxjbGNsZXJrLmNvbSQ');
     expect(apiUrl).toBe('https://api.lclclerk.com');
+  });
+
+  test('returns prod API URL when given a legacy publishable key', async () => {
+    const apiUrl = apiUrlFromPublishableKey('pk_test_Y2xlcmsucHlpMTcucWJqNngubGNsLmRldiQ');
+    expect(apiUrl).toBe('https://api.clerk.com');
   });
 });

--- a/packages/shared/src/apiUrlFromPublishableKey.ts
+++ b/packages/shared/src/apiUrlFromPublishableKey.ts
@@ -1,8 +1,20 @@
-import { LOCAL_API_URL, LOCAL_ENV_SUFFIXES, PROD_API_URL, STAGING_API_URL, STAGING_ENV_SUFFIXES } from './constants';
+import {
+  LEGACY_DEV_INSTANCE_SUFFIXES,
+  LOCAL_API_URL,
+  LOCAL_ENV_SUFFIXES,
+  PROD_API_URL,
+  STAGING_API_URL,
+  STAGING_ENV_SUFFIXES,
+} from './constants';
 import { parsePublishableKey } from './keys';
 
 export const apiUrlFromPublishableKey = (publishableKey: string) => {
   const frontendApi = parsePublishableKey(publishableKey)?.frontendApi;
+
+  if (frontendApi?.startsWith('clerk.') && LEGACY_DEV_INSTANCE_SUFFIXES.some(suffix => frontendApi?.endsWith(suffix))) {
+    return PROD_API_URL;
+  }
+
   if (LOCAL_ENV_SUFFIXES.some(suffix => frontendApi?.endsWith(suffix))) {
     return LOCAL_API_URL;
   }


### PR DESCRIPTION
…g the backend API URL

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

In Core 2, we have logic that determines the default Clerk API URL from the publishable key. This logic didn't account for the legacy FAPI URL scheme, and so they were being treated as "local". This PR updates the logic to account for the legacy keys, properly defaulting to the production Clerk API URL.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
