### PR TITLE
chore(eslint-config-custom): Set package.json properties for publishing

### DIFF
--- a/.changeset/strong-snakes-search.md
+++ b/.changeset/strong-snakes-search.md
@@ -1,0 +1,5 @@
+---
+'@clerk/eslint-config-custom': patch
+---
+
+Set correct properties in `package.json` for publishing

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,7 +1,18 @@
 {
   "name": "@clerk/eslint-config-custom",
   "version": "0.0.0",
+  "description": "Internal ESLint configuration for Clerk",
+  "homepage": "https://clerk.com/",
+  "bugs": {
+    "url": "https://github.com/clerk/javascript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clerk/javascript.git",
+    "directory": "packages/eslint-config-custom"
+  },
   "license": "MIT",
+  "author": "Clerk",
   "dependencies": {
     "@next/eslint-plugin-next": "^12.3.0",
     "@vercel/style-guide": "^5.0.1",
@@ -16,5 +27,8 @@
   },
   "peerDependencies": {
     "typescript": "*"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Description

Canary release for eslint-config-custom failed in https://github.com/clerk/javascript/actions/runs/8984793785/job/24677395550. This PR adds the missing properties to its `package.json` to hopefully make it work 🤞 

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
