### PR TITLE
feat(clerk-react,shared): Add telemetry events for React hooks

### DIFF
--- a/.changeset/chatty-jeans-fry.md
+++ b/.changeset/chatty-jeans-fry.md
@@ -1,0 +1,8 @@
+---
+'@clerk/shared': patch
+'@clerk/clerk-react': patch
+---
+
+The following are all internal changes and not relevant to any end-user:
+
+Add telemetry events for `useSignIn`, `useSignUp`, `useOrganizations` and `useOrganizationList`

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -1,5 +1,7 @@
 import { useClientContext } from '@clerk/shared/react';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignInResource } from '@clerk/types';
+import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -23,6 +25,10 @@ export const useSignIn: UseSignIn = () => {
 
   const isomorphicClerk = useIsomorphicClerkContext();
   const client = useClientContext();
+
+  useEffect(() => {
+    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignIn'));
+  }, [isomorphicClerk.telemetry]);
 
   if (!client) {
     return { isLoaded: false, signIn: undefined, setActive: undefined };

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -1,7 +1,6 @@
 import { useClientContext } from '@clerk/shared/react';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignInResource } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -26,9 +25,7 @@ export const useSignIn: UseSignIn = () => {
   const isomorphicClerk = useIsomorphicClerkContext();
   const client = useClientContext();
 
-  useEffect(() => {
-    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignIn'));
-  }, [isomorphicClerk.telemetry]);
+  isomorphicClerk.telemetry?.record(eventMethodCalled('useSignIn'));
 
   if (!client) {
     return { isLoaded: false, signIn: undefined, setActive: undefined };

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -1,5 +1,7 @@
 import { useClientContext } from '@clerk/shared/react';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignUpResource } from '@clerk/types';
+import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -23,6 +25,10 @@ export const useSignUp: UseSignUp = () => {
 
   const isomorphicClerk = useIsomorphicClerkContext();
   const client = useClientContext();
+
+  useEffect(() => {
+    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignUp'));
+  }, [isomorphicClerk.telemetry]);
 
   if (!client) {
     return { isLoaded: false, signUp: undefined, setActive: undefined };

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -1,7 +1,6 @@
 import { useClientContext } from '@clerk/shared/react';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { SetActive, SignUpResource } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
@@ -26,9 +25,7 @@ export const useSignUp: UseSignUp = () => {
   const isomorphicClerk = useIsomorphicClerkContext();
   const client = useClientContext();
 
-  useEffect(() => {
-    isomorphicClerk.telemetry?.record(eventMethodCalled('useSignUp'));
-  }, [isomorphicClerk.telemetry]);
+  isomorphicClerk.telemetry?.record(eventMethodCalled('useSignUp'));
 
   if (!client) {
     return { isLoaded: false, signUp: undefined, setActive: undefined };

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -10,7 +10,9 @@ import type {
   OrganizationMembershipResource,
   OrganizationResource,
 } from '@clerk/types';
+import { useEffect } from 'react';
 
+import { eventMethodCalled } from '../../telemetry/events/method-called';
 import {
   useAssertWrappedByClerkProvider,
   useClerkInstanceContext,
@@ -134,6 +136,10 @@ export const useOrganization: UseOrganization = params => {
   });
 
   const clerk = useClerkInstanceContext();
+
+  useEffect(() => {
+    clerk.telemetry?.record(eventMethodCalled('useOrganization'));
+  }, [clerk.telemetry]);
 
   const domainParams =
     typeof domainListParams === 'undefined'

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -10,7 +10,6 @@ import type {
   OrganizationMembershipResource,
   OrganizationResource,
 } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { eventMethodCalled } from '../../telemetry/events/method-called';
 import {
@@ -137,9 +136,7 @@ export const useOrganization: UseOrganization = params => {
 
   const clerk = useClerkInstanceContext();
 
-  useEffect(() => {
-    clerk.telemetry?.record(eventMethodCalled('useOrganization'));
-  }, [clerk.telemetry]);
+  clerk.telemetry?.record(eventMethodCalled('useOrganization'));
 
   const domainParams =
     typeof domainListParams === 'undefined'

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -10,7 +10,9 @@ import type {
   SetActive,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
+import { useEffect } from 'react';
 
+import { eventMethodCalled } from '../../telemetry/events/method-called';
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts';
 import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDefault } from '../types';
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
@@ -98,6 +100,10 @@ export const useOrganizationList: UseOrganizationList = params => {
 
   const clerk = useClerkInstanceContext();
   const user = useUserContext();
+
+  useEffect(() => {
+    clerk.telemetry?.record(eventMethodCalled('useOrganizationList'));
+  }, [clerk.telemetry]);
 
   const userMembershipsParams =
     typeof userMemberships === 'undefined'

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -10,7 +10,6 @@ import type {
   SetActive,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { eventMethodCalled } from '../../telemetry/events/method-called';
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useUserContext } from '../contexts';
@@ -101,9 +100,7 @@ export const useOrganizationList: UseOrganizationList = params => {
   const clerk = useClerkInstanceContext();
   const user = useUserContext();
 
-  useEffect(() => {
-    clerk.telemetry?.record(eventMethodCalled('useOrganizationList'));
-  }, [clerk.telemetry]);
+  clerk.telemetry?.record(eventMethodCalled('useOrganizationList'));
 
   const userMembershipsParams =
     typeof userMemberships === 'undefined'


### PR DESCRIPTION
## Description

Resolves SDK-1672

Add telemetry events for `useSignIn`, `useSignUp`, `useOrganizations` and `useOrganizationList`. This will allow us to track the usage of hooks for custom flows.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
