### PR TITLE
fix(nextjs): Apply response headers on redirect

### DIFF
--- a/.changeset/fair-months-camp.md
+++ b/.changeset/fair-months-camp.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix a bug where response headers from `@clerk/backend` would not be applied to the response when a redirect was triggered from a custom middleware handler.

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -136,6 +136,14 @@ export const clerkMiddleware: ClerkMiddleware = withLogger('clerkMiddleware', lo
       handlerResult = handleControlFlowErrors(e, clerkRequest, requestState);
     }
 
+    // TODO @nikos: we need to make this more generic
+    // and move the logic in clerk/backend
+    if (requestState.headers) {
+      requestState.headers.forEach((value, key) => {
+        handlerResult.headers.append(key, value);
+      });
+    }
+
     if (isRedirect(handlerResult)) {
       logger.debug('handlerResult is redirect');
       return serverRedirectWithAuth(clerkRequest, handlerResult, options);
@@ -146,14 +154,6 @@ export const clerkMiddleware: ClerkMiddleware = withLogger('clerkMiddleware', lo
     }
 
     decorateRequest(clerkRequest, handlerResult, requestState, options.secretKey);
-
-    // TODO @nikos: we need to make this more generic
-    // and move the logic in clerk/backend
-    if (requestState.headers) {
-      requestState.headers.forEach((value, key) => {
-        handlerResult.headers.append(key, value);
-      });
-    }
 
     return handlerResult;
   };


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
In situations where a redirect is triggered from a custom middleware handler, usually the result of using `auth().protect()`, we were not applying response headers from the `authenticateRequest()` result. This caused a bug where a handshake was not resolved, resulting in a broken auth state.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
