### PR TITLE
fix(remix): Ensure headers with the same name do not get overwritten

### DIFF
--- a/.changeset/empty-cobras-sit.md
+++ b/.changeset/empty-cobras-sit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Fixes a bug in the Remix SDK where headers passed from Clerk with the same name would get overwritten.

--- a/.changeset/empty-cobras-sit.md
+++ b/.changeset/empty-cobras-sit.md
@@ -2,4 +2,4 @@
 '@clerk/remix': patch
 ---
 
-Fixes a bug in the Remix SDK where headers passed from Clerk with the same name would get overwritten.
+Fixes a bug where headers passed from Clerk with the same name would get overwritten.

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -45,7 +45,7 @@ export const injectRequestStateIntoResponse = async (
   // without setting the header, instead of using the `json()` helper
   clone.headers.set(constants.Headers.ContentType, constants.ContentTypes.Json);
   headers.forEach((value, key) => {
-    clone.headers.set(key, value);
+    clone.headers.append(key, value);
   });
 
   return json({ ...(data || {}), ...clerkState }, clone);
@@ -66,7 +66,7 @@ export function injectRequestStateIntoDeferredData(
 
     headers.forEach((value, key) => {
       // @ts-expect-error -- We are ensuring headers is defined above
-      data.init.headers.set(key, value);
+      data.init.headers.append(key, value);
     });
   }
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
When authenticating a request, it's possible we may pass multiple headers with the same name (e.g. multiple `Set-Cookie` headers). By using `headers.set()`, we were only accepting the last header of that name. Switching to `headers.append()` should fix this.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
