### PR TITLE
fix(clerk-js): Fix Smart captcha on Sign Up ticket flow

### DIFF
--- a/.changeset/green-eggs-kiss.md
+++ b/.changeset/green-eggs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix Smart CAPTCHA on ticket flow

--- a/packages/clerk-js/src/ui/elements/LoadingCard.tsx
+++ b/packages/clerk-js/src/ui/elements/LoadingCard.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 import { descriptors, Flex, Spinner } from '../customizables';
+import { CaptchaElement } from './CaptchaElement';
 import { Card } from './Card';
 import { useCardState, withCardStateProvider } from './contexts';
 
@@ -33,6 +34,7 @@ export const LoadingCard = withCardStateProvider(() => {
       <Card.Content>
         <Card.Alert>{card.error}</Card.Alert>
         <LoadingCardContainer />
+        <CaptchaElement />
       </Card.Content>
       <Card.Footer />
     </Card.Root>

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -188,9 +188,9 @@ export const getCaptchaToken = async (captchaOptions: {
   } finally {
     if (widgetDiv) {
       if (isInvisibleWidget) {
-        document.body.removeChild(widgetDiv);
+        document.body.removeChild(widgetDiv as HTMLElement);
       } else {
-        widgetDiv.style.display = 'none';
+        (widgetDiv as HTMLElement).style.display = 'none';
       }
     }
   }


### PR DESCRIPTION
## Description

This PR fixes the logic determining if the captcha should fallback to 'Invisible' if the element for the 'Smart' captcha is not found in the DOM. The widget is now selected and rendered synchronously.

### Explanation:

Previously the order of the events was the following:
1. Determine if clerk-js should use the `Smart` or the `Invisible` Captcha widget.
2. Download the CF Turnstile script.
3. Render the Captcha.

The 2nd step above runs asynchronously and sometimes loading states can remove the `#clerk-captcha` element from the DOM.

After this change, we move the 2nd step to be done first and synchronously decide the widget and render it (step 1 and 3).

The addition of the captcha element on the loading card may solve our current issue. However, the change described above is a better practice for avoiding future issues.


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
