### PR TITLE
fix(clerk-expo): Use atob polyfill when using Hermes JS engine

### DIFF
--- a/.changeset/plenty-comics-matter.md
+++ b/.changeset/plenty-comics-matter.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Use a polyfill for the `atob` function to prevent errors when using the Hermes JS engine, since the engine's `atob` implementation is stricter than it should be.

--- a/packages/expo/src/polyfills/base64Polyfill.ts
+++ b/packages/expo/src/polyfills/base64Polyfill.ts
@@ -1,9 +1,14 @@
 import { decode, encode } from 'base-64';
 
-if (!global.btoa) {
+//@ts-expect-error HermesInternal is added by the Hermes JS Engine
+const isHermes = !!global.HermesInternal;
+
+// See Default Expo 51 engine Hermes' issue: https://github.com/facebook/hermes/issues/1379
+if (!global.btoa || isHermes) {
   global.btoa = encode;
 }
 
-if (!global.atob) {
+// See Default Expo 51 engine Hermes' issue: https://github.com/facebook/hermes/issues/1379
+if (!global.atob || isHermes) {
   global.atob = decode;
 }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Use a polyfill for the `atob` function to prevent errors when using the Hermes JS engine, since the engine's implementation is stricter than it should be and errors when the publishable key's base64 encoded part's length is not divisible by 4.

Related issue by the default JS engine for expo 51: https://github.com/facebook/hermes/issues/1379
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
