### PR TITLE
fix(chrome-extension): Remove `origin` from API mutation request headers

### DIFF
--- a/.changeset/modern-steaks-think.md
+++ b/.changeset/modern-steaks-think.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': patch
+---
+
+Remove `origin` from API mutation request headers.

--- a/packages/chrome-extension/src/singleton.ts
+++ b/packages/chrome-extension/src/singleton.ts
@@ -76,6 +76,10 @@ export async function buildClerk({
     const jwt = await storageCache.get(CACHE_KEY);
 
     (requestInit.headers as Headers).set('authorization', jwt || '');
+
+    if (requestInit.method !== 'GET') {
+      (requestInit.headers as Headers).delete('origin');
+    }
   });
 
   // Store updated JWT in StorageCache on Clerk responses


### PR DESCRIPTION
## Description

Mutation requests (think: sign out) would fail as the API doesn't allow for `origin` and `authorization` to be set at the same time.

Fixes: SDK-1736

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
