### PR TITLE
fix(clerk-js): Respect props passed to `buildSignInUrl` and `buildSignUpUrl`

### DIFF
--- a/.changeset/wet-peaches-grow.md
+++ b/.changeset/wet-peaches-grow.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+---
+
+Respect the `signInForceRedirectUrl`, `signInFallbackRedirectUrl`, `signUpForceRedirectUrl` and `signUpFallbackRedirectUrl` props passed to `SignInButton`, `SignUpButton` and the low-level `window.Clerk.buildSignInUrl` & `window.Clerk.buildSignUpUrl` methods. These props allow you to control the redirect behavior of the `SignIn` and `SignUp` components. For more information, refer to the [Custom Redirects](https://clerk.com/docs/guides/custom-redirects) guide.

--- a/packages/clerk-js/src/core/__tests__/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.redirects.test.ts
@@ -123,33 +123,33 @@ describe('Clerk singleton - Redirects', () => {
       });
 
       it('redirects to signInUrl for development instance', async () => {
-        await clerkForDevelopmentInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
+        await clerkForDevelopmentInstance.redirectToSignIn({ redirectUrl: '/example' });
         expect(mockNavigate).toHaveBeenCalledWith(
-          '/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F',
+          '/sign-in#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample',
           undefined,
         );
       });
 
       it('redirects to signInUrl for production instance', async () => {
-        await clerkForProductionInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
+        await clerkForProductionInstance.redirectToSignIn({ redirectUrl: '/example' });
         expect(mockNavigate).toHaveBeenCalledWith(
-          '/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F',
+          '/sign-in#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample',
           undefined,
         );
       });
 
       it('redirects to signUpUrl for development instance', async () => {
-        await clerkForDevelopmentInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
+        await clerkForDevelopmentInstance.redirectToSignUp({ redirectUrl: '/example' });
         expect(mockNavigate).toHaveBeenCalledWith(
-          '/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F',
+          '/sign-up#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample',
           undefined,
         );
       });
 
       it('redirects to signUpUrl for production instance', async () => {
-        await clerkForProductionInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
+        await clerkForProductionInstance.redirectToSignUp({ redirectUrl: '/example' });
         expect(mockNavigate).toHaveBeenCalledWith(
-          '/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F',
+          '/sign-up#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample',
           undefined,
         );
       });
@@ -220,31 +220,31 @@ describe('Clerk singleton - Redirects', () => {
       const host = 'http://another-test.host';
 
       it('redirects to signInUrl for development instance', async () => {
-        await clerkForDevelopmentInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
+        await clerkForDevelopmentInstance.redirectToSignIn({ redirectUrl: '/example' });
         expect(mockHref).toHaveBeenCalledTimes(1);
         expect(mockHref).toHaveBeenCalledWith(
-          `${host}/sign-in?__clerk_db_jwt=deadbeef#/?redirect_url=https%3A%2F%2Fwww.example.com%2F`,
+          `${host}/sign-in?__clerk_db_jwt=deadbeef#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample`,
         );
       });
 
       it('redirects to signInUrl for production instance', async () => {
-        await clerkForProductionInstance.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
+        await clerkForProductionInstance.redirectToSignIn({ redirectUrl: '/example' });
         expect(mockHref).toHaveBeenCalledTimes(1);
-        expect(mockHref).toHaveBeenCalledWith(`${host}/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F`);
+        expect(mockHref).toHaveBeenCalledWith(`${host}/sign-in#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample`);
       });
 
       it('redirects to signUpUrl for development instance', async () => {
-        await clerkForDevelopmentInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
+        await clerkForDevelopmentInstance.redirectToSignUp({ redirectUrl: '/example' });
         expect(mockHref).toHaveBeenCalledTimes(1);
         expect(mockHref).toHaveBeenCalledWith(
-          `${host}/sign-up?__clerk_db_jwt=deadbeef#/?redirect_url=https%3A%2F%2Fwww.example.com%2F`,
+          `${host}/sign-up?__clerk_db_jwt=deadbeef#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample`,
         );
       });
 
       it('redirects to signUpUrl for production instance', async () => {
-        await clerkForProductionInstance.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
+        await clerkForProductionInstance.redirectToSignUp({ redirectUrl: '/example' });
         expect(mockHref).toHaveBeenCalledTimes(1);
-        expect(mockHref).toHaveBeenCalledWith(`${host}/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F`);
+        expect(mockHref).toHaveBeenCalledWith(`${host}/sign-up#/?redirect_url=http%3A%2F%2Ftest.host%2Fexample`);
       });
 
       it('redirects to userProfileUrl', async () => {

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -91,8 +91,9 @@ export const useSignUpContext = (): SignUpContextType => {
   let signUpUrl = (ctx.routing === 'path' && ctx.path) || options.signUpUrl || displayConfig.signUpUrl;
   let signInUrl = ctx.signInUrl || options.signInUrl || displayConfig.signInUrl;
 
-  signUpUrl = redirectUrls.appendPreservedPropsToUrl(signUpUrl, queryParams);
-  signInUrl = redirectUrls.appendPreservedPropsToUrl(signInUrl, queryParams);
+  const preservedParams = redirectUrls.getPreservedSearchParams();
+  signInUrl = buildURL({ base: signInUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+  signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
 
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
@@ -161,8 +162,10 @@ export const useSignInContext = (): SignInContextType => {
   let signInUrl = (ctx.routing === 'path' && ctx.path) || options.signInUrl || displayConfig.signInUrl;
   let signUpUrl = ctx.signUpUrl || options.signUpUrl || displayConfig.signUpUrl;
 
-  signInUrl = redirectUrls.appendPreservedPropsToUrl(signInUrl, queryParams);
-  signUpUrl = redirectUrls.appendPreservedPropsToUrl(signUpUrl, queryParams);
+  const preservedParams = redirectUrls.getPreservedSearchParams();
+  signInUrl = buildURL({ base: signInUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+  signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
   return {

--- a/packages/clerk-js/src/ui/router/RouteContext.tsx
+++ b/packages/clerk-js/src/ui/router/RouteContext.tsx
@@ -1,4 +1,3 @@
-import type { ParsedQs } from 'qs';
 import React from 'react';
 
 export interface RouteContextValue {
@@ -15,7 +14,7 @@ export interface RouteContextValue {
   refresh: () => void;
   params: { [key: string]: string };
   queryString: string;
-  queryParams: ParsedQs;
+  queryParams: Record<string, string>;
   preservedParams?: string[];
   getMatchData: (path?: string, index?: boolean) => false | object;
   urlStateParam?: {

--- a/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
@@ -247,7 +247,7 @@ describe('redirectUrls', () => {
   });
 
   describe('search params', () => {
-    it('appends only the preserved props', () => {
+    it('flattens and returns all params', () => {
       const redirectUrls = new RedirectUrls(
         {
           signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
@@ -263,66 +263,33 @@ describe('redirectUrls', () => {
       );
 
       const params = redirectUrls.toSearchParams();
-      expect([...params.keys()].length).toBe(1);
+      expect([...params.keys()].length).toBe(3);
+      expect(params.get('sign_in_force_redirect_url')).toBe(
+        `${mockWindowLocation.href}props-sign-in-force-redirect-url`,
+      );
+      expect(params.get('sign_up_fallback_redirect_url')).toBe(
+        `${mockWindowLocation.href}search-param-sign-up-fallback-redirect-url`,
+      );
       expect(params.get('redirect_url')).toBe(`${mockWindowLocation.href}search-param-redirect-url`);
     });
   });
 
-  describe('append to url', () => {
-    it('does not append redirect urls from options to the url if the url is same origin', () => {
+  describe('preserved search params', () => {
+    it('does not return redirect urls if they are not in the preserved props array', () => {
       const redirectUrls = new RedirectUrls({
         signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
         signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
       });
 
-      const url = redirectUrls.appendPreservedPropsToUrl('https://www.clerk.com');
-      expect(url).toBe('https://www.clerk.com/');
-    });
-
-    it('appends redirect urls from options to the url if the url is cross origin', () => {
-      const redirectUrls = new RedirectUrls({}, {}, { redirect_url: '/search-param-redirect-url' });
-
-      const url = redirectUrls.appendPreservedPropsToUrl('https://www.example.com');
-      expect(url).toContain('search-param-redirect-url');
-    });
-
-    it('overrides the existing search params', () => {
-      const redirectUrls = new RedirectUrls(
-        {
-          signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
-          signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
-        },
-        {},
-        { redirect_url: '/search-param-redirect-url' },
-      );
-
-      const url = redirectUrls.appendPreservedPropsToUrl('https://www.example.com?redirect_url=existing');
-      expect(url).toBe(
-        'https://www.example.com/?redirect_url=existing#/?redirect_url=https%3A%2F%2Fwww.clerk.com%2Fsearch-param-redirect-url',
-      );
+      const params = redirectUrls.getPreservedSearchParams();
+      expect([...params.keys()].length).toBe(0);
     });
 
     it('appends redirect urls from props to the url even if the url is same origin', () => {
       const redirectUrls = new RedirectUrls({}, {}, { redirect_url: '/search-param-redirect-url' });
 
-      const url = redirectUrls.appendPreservedPropsToUrl('https://www.clerk.com');
-      expect(url).toContain('search-param-redirect-url');
-    });
-
-    it('does not append redirect urls from props to the url if the url is same origin if they match the options urls', () => {
-      const redirectUrls = new RedirectUrls(
-        {
-          signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
-          signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
-        },
-        {
-          signInFallbackRedirectUrl: 'sign-in-fallback-redirect-url',
-          signUpFallbackRedirectUrl: 'sign-up-fallback-redirect-url',
-        },
-      );
-
-      const url = redirectUrls.appendPreservedPropsToUrl('https://www.clerk.com');
-      expect(url).toBe('https://www.clerk.com/');
+      const params = redirectUrls.getPreservedSearchParams();
+      expect(params.get('redirect_url')).toContain('search-param-redirect-url');
     });
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -1,7 +1,6 @@
 import type { SignUpResource } from '@clerk/types';
 
 import {
-  appendAsQueryParams,
   buildURL,
   createAllowedRedirectOrigins,
   getETLDPlusOneFromFrontendApi,
@@ -257,6 +256,58 @@ describe('buildURL(options: URLParams, skipOrigin)', () => {
       ),
     ).toBe('http://test.host/foo?my-search=42#my-hash/qux?my-hash-search-1=42&my-hash-search-2=42');
   });
+
+  it('appends search params passed to hashSearchParams in the URL fragment', () => {
+    const base = 'https://clerk.com/';
+    const params = new URLSearchParams({ test1: '1', test2: '2' });
+    const url = buildURL({ base, hashSearchParams: params }, { stringify: true });
+    expect(url).toBe('https://clerk.com/#/?test1=1&test2=2');
+  });
+
+  it('does not append a URL fragment if nothing was passed', () => {
+    const base = 'https://clerk.com/';
+    const url = buildURL({ base }, { stringify: true });
+    expect(url).toBe('https://clerk.com/');
+  });
+
+  it('does not append a URL fragment if search params were passed but were empty', () => {
+    const base = 'https://clerk.com/';
+    const params = new URLSearchParams({});
+    const url = buildURL({ base, hashSearchParams: params }, { stringify: true });
+    expect(url).toBe('https://clerk.com/');
+  });
+
+  it('appends search params to the fragment if search params is a plain object', () => {
+    const base = 'https://clerk.com';
+    const params = { test1: '1', test2: '2' };
+    const url = buildURL({ base, hashSearchParams: params }, { stringify: true });
+    expect(url).toBe('https://clerk.com/#/?test1=1&test2=2');
+  });
+
+  it('appends search params to the fragment by merging all passed in params', () => {
+    const base = 'https://clerk.com';
+    const url = buildURL(
+      { base, hashSearchParams: [new URLSearchParams({ test1: '1', test2: '2' }), { test3: '3' }] },
+      { stringify: true },
+    );
+    expect(url).toBe('https://clerk.com/#/?test1=1&test2=2&test3=3');
+  });
+
+  it('overrides duplicate search params, giving priority to objects passed last', () => {
+    const base = 'https://clerk.com';
+    const url = buildURL(
+      { base, hashSearchParams: [new URLSearchParams({ test1: '1', test2: '2' }), { test2: '3' }] },
+      { stringify: true },
+    );
+    expect(url).toBe('https://clerk.com/#/?test1=1&test2=3');
+  });
+
+  it('snake_cases all params', () => {
+    const base = 'https://clerk.com';
+    const params = { redirectUrl: '1', test2: '2' };
+    const url = buildURL({ base, hashSearchParams: params }, { stringify: true });
+    expect(url).toBe('https://clerk.com/#/?redirect_url=1&test2=2');
+  });
 });
 
 describe('trimTrailingSlash(string)', () => {
@@ -274,57 +325,6 @@ describe('trimLeadingSlash(string)', () => {
     expect(trimLeadingSlash('/foo')).toBe('foo');
     expect(trimLeadingSlash('/foo/')).toBe('foo/');
     expect(trimLeadingSlash('//foo//bar///')).toBe('foo//bar///');
-  });
-});
-
-describe('appendQueryParams(base,url)', () => {
-  it('returns the same url if no params provided', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base);
-    expect(res).toBe('https://dashboard.clerk.com/');
-  });
-
-  it('handles plain strings', () => {
-    const base = 'https://dashboard.clerk.com';
-    const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, { redirect_url: url });
-    expect(res).toBe(
-      'https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F',
-    );
-  });
-
-  it('handles multiple params', () => {
-    const base = 'https://dashboard.clerk.com';
-    const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, { redirect_url: url, after_sign_in_url: url });
-    expect(res).toBe(
-      'https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F&after_sign_in_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F',
-    );
-  });
-
-  it('skips falsy values', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirect_url: undefined });
-    expect(res).toBe('https://dashboard.clerk.com/');
-  });
-
-  it('converts relative to absolute urls', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirect_url: 'http://localhost/test' });
-    expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
-  });
-
-  it('converts keys from camel to snake case', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirectUrl: 'http://localhost/test' });
-    expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
-  });
-
-  it('keeps origin before appending if base and url have different origin', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const url = new URL('https://www.google.com/something').href;
-    const res = appendAsQueryParams(base, { redirect_url: url });
-    expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fwww.google.com%2Fsomething');
   });
 });
 

--- a/packages/clerk-js/src/utils/querystring.ts
+++ b/packages/clerk-js/src/utils/querystring.ts
@@ -3,7 +3,7 @@ import qs from 'qs';
 export const getQueryParams = (queryString: string) => {
   return qs.parse(queryString || '', {
     ignoreQueryPrefix: true,
-  });
+  }) as Record<string, string>;
 };
 
 export const stringifyQueryParams = (params: Record<string, unknown> | Array<unknown>) => {

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -47,6 +47,7 @@ interface BuildURLParams extends Partial<URL> {
   base?: string;
   hashPath?: string;
   hashSearch?: string;
+  hashSearchParams?: URLSearchParams | Record<string, string> | Array<URLSearchParams | Record<string, string>>;
 }
 
 interface BuildURLOptions<T> {
@@ -77,7 +78,7 @@ export function buildURL<B extends boolean>(
 ): B extends true ? string : URL;
 
 export function buildURL(params: BuildURLParams, options: BuildURLOptions<boolean> = {}): URL | string {
-  const { base, hashPath, hashSearch, searchParams, ...rest } = params;
+  const { base, hashPath, hashSearch, searchParams, hashSearchParams, ...rest } = params;
 
   let fallbackBase = '';
   // This check is necessary for React native environments where window is undefined.
@@ -94,7 +95,9 @@ export function buildURL(params: BuildURLParams, options: BuildURLOptions<boolea
   // Properly copy URLSearchParams
   if (searchParams instanceof URLSearchParams) {
     searchParams.forEach((value, key) => {
-      url.searchParams.set(key, value);
+      if (value !== null && value !== undefined) {
+        url.searchParams.set(camelToSnake(key), value);
+      }
     });
   }
 
@@ -103,24 +106,44 @@ export function buildURL(params: BuildURLParams, options: BuildURLOptions<boolea
   // Treat that hash part of the main URL as if it's another URL with a pathname and a search.
   // Another nested hash inside the top level hash (e.g. #my-hash#my-second-hash) is currently
   // not supported as there is no use case for it yet.
-  if (hashPath || hashSearch) {
+  if (hashPath || hashSearch || hashSearchParams) {
     // Parse the hash to a URL object
     const dummyUrlForHash = new URL(DUMMY_URL_BASE + url.hash.substring(1));
 
     // Join the current hash path and with the provided one
     dummyUrlForHash.pathname = joinPaths(dummyUrlForHash.pathname, hashPath || '');
 
-    // Merge search params
-    const hashSearchParams = getQueryParams(hashSearch || '');
-    for (const [key, val] of Object.entries(hashSearchParams)) {
+    // Merge search params from hashSearch string
+    const searchParamsFromHashSearchString = getQueryParams(hashSearch || '');
+    for (const [key, val] of Object.entries(searchParamsFromHashSearchString)) {
       dummyUrlForHash.searchParams.append(key, val as string);
     }
 
-    // Keep just the pathname and the search
+    // Merge search params from the hashSearchParams object
+    if (hashSearchParams) {
+      const paramsArr = Array.isArray(hashSearchParams) ? hashSearchParams : [hashSearchParams];
+      for (const _params of paramsArr) {
+        if (!(_params instanceof URLSearchParams) && typeof _params !== 'object') {
+          continue;
+        }
+        const params = new URLSearchParams(_params);
+        params.forEach((value, key) => {
+          if (value !== null && value !== undefined) {
+            dummyUrlForHash.searchParams.set(camelToSnake(key), value);
+          }
+        });
+      }
+    }
+
+    // Keep just the pathname and the  search
     const newHash = dummyUrlForHash.href.replace(DUMMY_URL_BASE, '');
 
-    // Assign them to the hash of the main url
-    url.hash = newHash;
+    // if the hash is `/`, it means that nothing new was added to the hash
+    // so we can skip assigning it to the hash of the main url
+    if (newHash !== '/') {
+      // Assign them to the hash of the main url
+      url.hash = newHash;
+    }
   }
 
   const { stringify, skipOrigin } = options;
@@ -178,25 +201,6 @@ export const trimLeadingSlash = (path: string): string => {
 export const stripSameOrigin = (url: URL, baseUrl: URL): string => {
   const sameOrigin = baseUrl.origin === url.origin;
   return sameOrigin ? stripOrigin(url) : `${url}`;
-};
-
-export const appendAsQueryParams = (
-  baseUrl: string | URL,
-  values: Record<string, string | null | undefined> = {},
-): string => {
-  const base = toURL(baseUrl);
-  const params = new URLSearchParams();
-  for (const [key, val] of Object.entries(values)) {
-    if (!val) {
-      continue;
-    }
-    params.append(camelToSnake(key), val);
-  }
-
-  // The following line will prepend the hash with a `/`.
-  // This is required for ClerkJS Components Hash router to work as expected
-  // as it treats the hash as sub-path with its nested querystring parameters.
-  return `${base}${params.toString() ? '#/?' + params.toString() : ''}`;
 };
 
 export const hasExternalAccountSignUpError = (signUp: SignUpResource): boolean => {

--- a/packages/react/src/components/SignInButton.tsx
+++ b/packages/react/src/components/SignInButton.tsx
@@ -25,7 +25,7 @@ export const SignInButton = withClerk(({ clerk, children, ...props }: WithClerkP
   };
 
   const wrappedChildClickHandler: React.MouseEventHandler = async e => {
-    await safeExecute(child.props.onClick)(e);
+    await safeExecute((child as any).props.onClick)(e);
     return clickHandler();
   };
 

--- a/packages/react/src/components/SignInButton.tsx
+++ b/packages/react/src/components/SignInButton.tsx
@@ -7,12 +7,17 @@ import { withClerk } from './withClerk';
 export const SignInButton = withClerk(({ clerk, children, ...props }: WithClerkProp<SignInButtonProps>) => {
   const { signUpFallbackRedirectUrl, forceRedirectUrl, fallbackRedirectUrl, signUpForceRedirectUrl, mode, ...rest } =
     props;
-
   children = normalizeWithDefaultValue(children, 'Sign in');
   const child = assertSingleChild(children)('SignInButton');
 
   const clickHandler = () => {
-    const opts = { signUpFallbackRedirectUrl, forceRedirectUrl, fallbackRedirectUrl, signUpForceRedirectUrl };
+    const opts = {
+      signUpFallbackRedirectUrl,
+      signUpForceRedirectUrl,
+      signInForceRedirectUrl: forceRedirectUrl,
+      signInFallbackRedirectUrl: fallbackRedirectUrl,
+    };
+
     if (mode === 'modal') {
       return clerk.openSignIn(opts);
     }
@@ -20,7 +25,7 @@ export const SignInButton = withClerk(({ clerk, children, ...props }: WithClerkP
   };
 
   const wrappedChildClickHandler: React.MouseEventHandler = async e => {
-    await safeExecute((child as any).props.onClick)(e);
+    await safeExecute(child.props.onClick)(e);
     return clickHandler();
   };
 

--- a/packages/react/src/components/SignUpButton.tsx
+++ b/packages/react/src/components/SignUpButton.tsx
@@ -20,8 +20,8 @@ export const SignUpButton = withClerk(({ clerk, children, ...props }: WithClerkP
 
   const clickHandler = () => {
     const opts = {
-      fallbackRedirectUrl,
-      forceRedirectUrl,
+      signUpFallbackRedirectUrl: fallbackRedirectUrl,
+      signUpForceRedirectUrl: forceRedirectUrl,
       signInFallbackRedirectUrl,
       signInForceRedirectUrl,
       unsafeMetadata,
@@ -35,7 +35,7 @@ export const SignUpButton = withClerk(({ clerk, children, ...props }: WithClerkP
   };
 
   const wrappedChildClickHandler: React.MouseEventHandler = async e => {
-    await safeExecute((child as any).props.onClick)(e);
+    await safeExecute(child.props.onClick)(e);
     return clickHandler();
   };
 

--- a/packages/react/src/components/SignUpButton.tsx
+++ b/packages/react/src/components/SignUpButton.tsx
@@ -35,7 +35,7 @@ export const SignUpButton = withClerk(({ clerk, children, ...props }: WithClerkP
   };
 
   const wrappedChildClickHandler: React.MouseEventHandler = async e => {
-    await safeExecute(child.props.onClick)(e);
+    await safeExecute((child as any).props.onClick)(e);
     return clickHandler();
   };
 

--- a/packages/react/src/components/__tests__/SignInButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignInButton.test.tsx
@@ -52,28 +52,17 @@ describe('<SignInButton/>', () => {
     const btn = screen.getByText('Sign in');
     await userEvent.click(btn);
 
-    expect(mockRedirectToSignIn).toHaveBeenCalledWith({ forceRedirectUrl: url });
+    expect(mockRedirectToSignIn).toHaveBeenCalledWith({ signInForceRedirectUrl: url });
   });
 
-  it('handles forceRedirectUrl prop', async () => {
-    render(<SignInButton forceRedirectUrl={url} />);
+  it('handles fallbackRedirectUrl prop', async () => {
+    render(<SignInButton fallbackRedirectUrl={url} />);
 
     const btn = screen.getByText('Sign in');
     await userEvent.click(btn);
 
     expect(mockRedirectToSignIn).toHaveBeenCalledWith({
-      forceRedirectUrl: url,
-    });
-  });
-
-  it('handles signUpForceRedirectUrl prop', async () => {
-    render(<SignInButton signUpForceRedirectUrl={url} />);
-
-    const btn = screen.getByText('Sign in');
-    await userEvent.click(btn);
-
-    expect(mockRedirectToSignIn).toHaveBeenCalledWith({
-      signUpForceRedirectUrl: url,
+      signInFallbackRedirectUrl: url,
     });
   });
 

--- a/packages/react/src/components/__tests__/SignUpButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignUpButton.test.tsx
@@ -53,28 +53,17 @@ describe('<SignUpButton/>', () => {
     const btn = screen.getByText('Sign up');
     userEvent.click(btn);
     await waitFor(() => {
-      expect(mockRedirectToSignUp).toHaveBeenCalledWith({ forceRedirectUrl: url });
+      expect(mockRedirectToSignUp).toHaveBeenCalledWith({ signUpForceRedirectUrl: url });
     });
   });
 
-  it('handles forceRedirectUrl prop', async () => {
-    render(<SignUpButton forceRedirectUrl={url} />);
+  it('handles fallbackRedirectUrl prop', async () => {
+    render(<SignUpButton fallbackRedirectUrl={url} />);
     const btn = screen.getByText('Sign up');
     userEvent.click(btn);
     await waitFor(() => {
       expect(mockRedirectToSignUp).toHaveBeenCalledWith({
-        forceRedirectUrl: url,
-      });
-    });
-  });
-
-  it('handles forceRedirectUrl prop', async () => {
-    render(<SignUpButton forceRedirectUrl={url} />);
-    const btn = screen.getByText('Sign up');
-    userEvent.click(btn);
-    await waitFor(() => {
-      expect(mockRedirectToSignUp).toHaveBeenCalledWith({
-        forceRedirectUrl: url,
+        signUpFallbackRedirectUrl: url,
       });
     });
   });


### PR DESCRIPTION
## Description
This PR updates the buildSignInUrl and buildSignUpUrl methods to correctly propagate the redirect props via URL search params. This allows the SignInButton and SignUpButton components to be configurable via their props as well.

Additionally,  this PR: 
- simplifies the RedirectUrl class by dropping the concern of appending params to the URL. This is now handled by the low-level buildUrl util 
- it fixes an issues when serializing initial values in the buildSignInUrl and buildSignUpUrl helpers. Search params need to be snake_cased in order to be respected
- buildUrl now accepts a new hashSearchParams prop and it snake_cases all search params by default 


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
