### PR TITLE
fix(clerk-js): Remove session cookie when signing out and `onBeforeSetActive`

### DIFF
--- a/.changeset/fluffy-turtles-applaud.md
+++ b/.changeset/fluffy-turtles-applaud.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix to update auth state after signing out

--- a/.changeset/fluffy-turtles-applaud.md
+++ b/.changeset/fluffy-turtles-applaud.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/nextjs': patch
+'@clerk/clerk-js': patch
 ---
 
-Fix to update auth state after signing out
+Remove cookie when signing out before running `onBeforeSetActive` to resolve issues where we do navigations in `onBeforeSetActive`.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -728,6 +728,7 @@ export class Clerk implements ClerkInterface {
     const shouldSignOutSession = this.session && newSession === null;
     if (shouldSignOutSession) {
       this.#broadcastSignOutEvent();
+      removeSessionCookie();
     }
 
     await onBeforeSetActive();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -742,13 +742,9 @@ export class Clerk implements ClerkInterface {
       newSession = this.#getSessionFromClient(newSession?.id);
     }
 
-    // Sync __session and __client_uat to cookies using events.TokenUpdate dispatched event
-    // only for newSession is null since the getToken will not be executed. Since getToken
-    // triggers internally a events.TokenUpdate there is no need to trigger it when the newSession exists.
-    const token = await newSession?.getToken();
-    if (!token) {
-      eventBus.dispatch(events.TokenUpdate, { token: null });
-    }
+    // getToken syncs __session and __client_uat to cookies using events.TokenUpdate dispatched event.
+    await newSession?.getToken();
+
     //2. If there's a beforeEmit, typically we're navigating.  Emit the session as
     //   undefined, then wait for beforeEmit to complete before emitting the new session.
     //   When undefined, neither SignedIn nor SignedOut renders, which avoids flickers or

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -728,7 +728,7 @@ export class Clerk implements ClerkInterface {
     const shouldSignOutSession = this.session && newSession === null;
     if (shouldSignOutSession) {
       this.#broadcastSignOutEvent();
-      removeSessionCookie();
+      eventBus.dispatch(events.TokenUpdate, { token: null });
     }
 
     await onBeforeSetActive();

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -55,6 +55,7 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
         window.__clerk_internal_invalidateCachePromise = res;
         startTransition(() => {
           router.refresh();
+          router.push(window.location.href);
         });
       });
     };

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -55,7 +55,6 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
         window.__clerk_internal_invalidateCachePromise = res;
         startTransition(() => {
           router.refresh();
-          router.push(window.location.href);
         });
       });
     };


### PR DESCRIPTION
## Description

**Problem:**

Right now when signing out on Next.js with app router, there is a chance that you will get an error as we are clearing the app router cache before removing the session cookie.

**Solution:**

The solution is to move the removal of the session cookie before clearing the app router cache.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
