### PR TITLE
fix(clerk-js): Improve logging for CAPTCHA script loading errors

### DIFF
--- a/.changeset/fast-timers-matter.md
+++ b/.changeset/fast-timers-matter.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Improve logging for CAPTCHA script loading errors

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -82,7 +82,6 @@ export class SignUp extends BaseResource implements SignUpResource {
         paramsWithCaptcha.captchaToken = captchaToken;
         paramsWithCaptcha.captchaWidgetType = captchaWidgetTypeUsed;
       } catch (e) {
-        console.error('Clerk CAPTCHA Error: ', e.captchaError || e.message || e);
         if (e.captchaError) {
           paramsWithCaptcha.captchaError = e.captchaError;
         } else {

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -82,6 +82,7 @@ export class SignUp extends BaseResource implements SignUpResource {
         paramsWithCaptcha.captchaToken = captchaToken;
         paramsWithCaptcha.captchaWidgetType = captchaWidgetTypeUsed;
       } catch (e) {
+        console.error('Clerk CAPTCHA Error: ', e.captchaError || e.message || e);
         if (e.captchaError) {
           paramsWithCaptcha.captchaError = e.captchaError;
         } else {

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -1,8 +1,6 @@
 import { loadScript } from '@clerk/shared/loadScript';
 import type { CaptchaWidgetType } from '@clerk/types';
 
-import { clerkFailedToLoadThirdPartyScript } from '../core/errors';
-
 interface RenderOptions {
   /**
    * Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation.
@@ -76,9 +74,12 @@ export async function loadCaptcha(url: string) {
   if (!window.turnstile) {
     try {
       await loadScript(url, { defer: true });
-    } catch (_) {
+    } catch {
       // Rethrow with specific message
-      clerkFailedToLoadThirdPartyScript('Cloudflare Turnstile');
+      console.error('Clerk: Failed to load the CAPTCHA script from the URL: ', url);
+      throw {
+        captchaError: 'captcha_script_failed_to_load',
+      };
     }
   }
   return window.turnstile;
@@ -112,7 +113,7 @@ export const getCaptchaToken = async (captchaOptions: {
     return div;
   };
 
-  const captcha = await loadCaptcha(scriptUrl);
+  const captcha: Turnstile = await loadCaptcha(scriptUrl);
   let retries = 0;
   const errorCodes: (string | number)[] = [];
 


### PR DESCRIPTION
## Description

This PR adds a `console.error` on every CAPTCHA error.

Also, when script loading fails, we log it in the FAPI, meaning that the `/sign_ups` API call will be executed and will include the following value:
```
captchaError: 'captcha_script_failed_to_load'
```

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
