### PR TITLE
Revert "fix(chrome-extension): Remove Origin from API mutation request headers"

### DIFF
--- a/.changeset/modern-steaks-think.md
+++ b/.changeset/modern-steaks-think.md
@@ -1,5 +1,0 @@
----
-'@clerk/chrome-extension': patch
----
-
-Remove `Origin` from API mutation request headers via `onInstalled` listener.

--- a/.changeset/modern-steaks-think.md
+++ b/.changeset/modern-steaks-think.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': patch
+---
+
+Remove `Origin` from API mutation request headers via `onInstalled` listener.

--- a/.changeset/rotten-mice-juggle.md
+++ b/.changeset/rotten-mice-juggle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': patch
+---
+
+Revert: Remove `Origin` from API mutation request headers via `onInstalled` listener.

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -1,36 +1,9 @@
-// Override Clerk React error thrower to show that errors come from @clerk/chrome-extension
-import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';
-import type { DeclarativeNetRequest } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
-
-setErrorThrowerOptions({ packageName: PACKAGE_NAME });
-
-browser.runtime.onInstalled.addListener(() => {
-  const rules: DeclarativeNetRequest.Rule[] = [
-    {
-      id: 654321,
-      action: {
-        type: 'modifyHeaders',
-        requestHeaders: [{ header: 'Origin', operation: 'remove' }],
-      },
-      condition: {
-        initiatorDomains: [browser.runtime.id],
-        isUrlFilterCaseSensitive: true,
-        regexFilter: '.+_is_native=1.*',
-        requestMethods: ['post', 'put', 'delete'],
-        resourceTypes: ['xmlhttprequest'],
-      },
-    },
-  ];
-
-  void browser.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: rules.map(r => r.id),
-    addRules: rules,
-  });
-});
-
 export * from '@clerk/clerk-react';
 export type { StorageCache } from './utils/storage';
 
 // The order matters since we want override @clerk/clerk-react ClerkProvider
 export { ClerkProvider } from './ClerkProvider';
+
+// Override Clerk React error thrower to show that errors come from @clerk/chrome-extension
+import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';
+setErrorThrowerOptions({ packageName: PACKAGE_NAME });


### PR DESCRIPTION
The previous PR wasn't supposed to be merged.

Reverts clerk/javascript#3363