### PR TITLE
fix(elements): Fix follow-on initialization discrepancies

### DIFF
--- a/.changeset/odd-coins-carry.md
+++ b/.changeset/odd-coins-carry.md
@@ -2,5 +2,6 @@
 '@clerk/elements': patch
 ---
 
+- Bump XState from version 5.12.0 to 5.13.0
 - We now maintain your current state while completing authentication redirecting rather than transitioning to a "Complete" step.
 - Fixes Sign In and Sign Up machines not appropriately attaching new form machines when returning to the Sign In or Sign Up pages.

--- a/.changeset/odd-coins-carry.md
+++ b/.changeset/odd-coins-carry.md
@@ -1,0 +1,6 @@
+---
+'@clerk/elements': patch
+---
+
+- We now maintain your current state while completing authentication redirecting rather than transitioning to a "Complete" step.
+- Fixes Sign In and Sign Up machines not appropriately attaching new form machines when returning to the Sign In or Sign Up pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38410,7 +38410,7 @@
         "@statelyai/inspect": "^0.3.0",
         "@xstate/react": "^4.1.1",
         "client-only": "^0.0.1",
-        "xstate": "^5.12.0"
+        "xstate": "^5.13.0"
       },
       "devDependencies": {
         "@clerk/clerk-react": "5.0.4",
@@ -38629,9 +38629,9 @@
       }
     },
     "packages/elements/node_modules/xstate": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.12.0.tgz",
-      "integrity": "sha512-4W/Hj553mwVnTLQ1itc3rni/cGtM5OkjyavTjaxCelc0ZZKE/ks6tYllc98KbekIoUrEPm4CJH/wTB5p5pPGEw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.13.0.tgz",
+      "integrity": "sha512-Z0om784N5u8sAzUvQJBa32jiTCIGGF/2ZsmKkerQEqeeUktAeOMK20FIHFUMywC4GcAkNksSvaeX7lwoRNXPEQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -74,7 +74,7 @@
     "@statelyai/inspect": "^0.3.0",
     "@xstate/react": "^4.1.1",
     "client-only": "^0.0.1",
-    "xstate": "^5.12.0"
+    "xstate": "^5.13.0"
   },
   "devDependencies": {
     "@clerk/clerk-react": "5.0.4",

--- a/packages/elements/src/internals/machines/sign-in/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.types.ts
@@ -10,6 +10,7 @@ import type {
   BaseRouterNextEvent,
   BaseRouterPrevEvent,
   BaseRouterRedirectEvent,
+  BaseRouterResetEvent,
   BaseRouterSetClerkEvent,
   BaseRouterStartEvent,
   BaseRouterTransferEvent,
@@ -54,6 +55,7 @@ export type SignInRouterForgotPasswordEvent = { type: 'NAVIGATE.FORGOT_PASSWORD'
 export type SignInRouterErrorEvent = BaseRouterErrorEvent;
 export type SignInRouterTransferEvent = BaseRouterTransferEvent;
 export type SignInRouterRedirectEvent = BaseRouterRedirectEvent;
+export type SignInRouterResetEvent = BaseRouterResetEvent;
 export type SignInRouterLoadingEvent = BaseRouterLoadingEvent<'start' | 'verifications' | 'reset-password'>;
 export type SignInRouterSetClerkEvent = BaseRouterSetClerkEvent;
 export type SignInRouterSubmitEvent = { type: 'SUBMIT' };
@@ -77,6 +79,7 @@ export type SignInRouterEvents =
   | SignInRouterErrorEvent
   | SignInRouterTransferEvent
   | SignInRouterRedirectEvent
+  | SignInRouterResetEvent
   | SignInVerificationFactorUpdateEvent
   | SignInRouterLoadingEvent
   | SignInRouterSetClerkEvent

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -59,7 +59,6 @@ export const SignUpRouterMachine = setup({
     },
     navigateExternal: ({ context }, { path }: { path: string }) => context.router?.push(path),
     raiseNext: raise({ type: 'NEXT' }),
-    // sds @ts-expect-error - This works; Unsure why typing doesn't
     setActive: (_, params?: { sessionId?: string; useLastActiveSession?: boolean }) =>
       enqueueActions(({ enqueue, check, context, event }) => {
         if (check('isExampleMode')) return;

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -10,6 +10,7 @@ import type {
   BaseRouterNextEvent,
   BaseRouterPrevEvent,
   BaseRouterRedirectEvent,
+  BaseRouterResetEvent,
   BaseRouterSetClerkEvent,
   BaseRouterStartEvent,
   BaseRouterTransferEvent,
@@ -46,6 +47,7 @@ export type SignUpRouterPrevEvent = BaseRouterPrevEvent;
 export type SignUpRouterErrorEvent = BaseRouterErrorEvent;
 export type SignUpRouterTransferEvent = BaseRouterTransferEvent;
 export type SignUpRouterRedirectEvent = BaseRouterRedirectEvent;
+export type SignUpRouterResetEvent = BaseRouterResetEvent;
 export type SignUpRouterLoadingEvent = BaseRouterLoadingEvent<'start' | 'verifications' | 'continue'>;
 export type SignUpRouterSetClerkEvent = BaseRouterSetClerkEvent;
 
@@ -64,6 +66,7 @@ export type SignUpRouterEvents =
   | SignUpRouterErrorEvent
   | SignUpRouterTransferEvent
   | SignUpRouterRedirectEvent
+  | SignUpRouterResetEvent
   | SignUpRouterLoadingEvent
   | SignUpRouterSetClerkEvent;
 

--- a/packages/elements/src/internals/machines/types/router.types.ts
+++ b/packages/elements/src/internals/machines/types/router.types.ts
@@ -17,6 +17,7 @@ export type BaseRouterLoadingStep = 'start' | 'verifications' | 'continue' | 're
 export type BaseRouterNextEvent<T extends ClerkResource> = { type: 'NEXT'; resource?: T };
 export type BaseRouterPrevEvent = { type: 'NAVIGATE.PREVIOUS' };
 export type BaseRouterStartEvent = { type: 'NAVIGATE.START' };
+export type BaseRouterResetEvent = { type: 'RESET' };
 export type BaseRouterErrorEvent = { type: 'ERROR'; error: Error };
 export type BaseRouterTransferEvent = { type: 'TRANSFER' };
 export type BaseRouterLoadingEvent<TSteps extends BaseRouterLoadingStep> = (

--- a/packages/elements/src/react/sign-in/root.tsx
+++ b/packages/elements/src/react/sign-in/root.tsx
@@ -44,7 +44,9 @@ function SignInFlowProvider({ children, exampleMode }: SignInFlowProviderProps) 
         actor.send(evt);
       }
     });
-  }, [clerk, exampleMode, formRef, router]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clerk, exampleMode, formRef?.id, !!router]);
 
   return <SignInRouterCtx.Provider actorRef={actor}>{children}</SignInRouterCtx.Provider>;
 }

--- a/packages/elements/src/react/sign-in/verifications.tsx
+++ b/packages/elements/src/react/sign-in/verifications.tsx
@@ -80,7 +80,7 @@ export function SignInStrategy({ children, name }: SignInStrategyProps) {
     }
 
     return () => {
-      if (factorCtx) {
+      if (factorCtx?.getSnapshot().status === 'active') {
         factorCtx.send({ type: 'STRATEGY.UNREGISTER', factor: name as unknown as SignInFactor });
       }
     };

--- a/packages/elements/src/react/sign-up/root.tsx
+++ b/packages/elements/src/react/sign-up/root.tsx
@@ -46,7 +46,8 @@ function SignUpFlowProvider({ children, exampleMode }: SignUpFlowProviderProps) 
         ref.send(evt);
       }
     });
-  }, [clerk, exampleMode, formRef, router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clerk, exampleMode, formRef?.id, !!router]);
 
   return isReady ? <SignUpRouterCtx.Provider actorRef={ref}>{children}</SignUpRouterCtx.Provider> : null;
 }


### PR DESCRIPTION
## Description

This is an addendum to the sign in/sign up updates seen in #3343.

This PR does the following:

- [x] Removes the need to transition to an alternate "Complete" state when using `.setActive`. The machine retains the current state throughout the `setActive` flow and resets after that's done.
- [x] Fixes the Sign In/Sign Up machine not appropriately attaching new form machines, thus breaking the flow.
- [x] Stops the `STRATEGY.UNREGISTER` event from being called on stopped machines.

Fixes SDK-1746

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
