### PR TITLE
fix(backend): Add missing hashers to PasswordHasher type

### DIFF
--- a/.changeset/pretty-elephants-kiss.md
+++ b/.changeset/pretty-elephants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Added missing phpass and bcrypt_sha256_django hashers to PasswordHasher type

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -48,10 +48,12 @@ type PasswordHasher =
   | 'argon2i'
   | 'argon2id'
   | 'bcrypt'
+  | 'bcrypt_sha256_django'
   | 'md5'
   | 'pbkdf2_sha256'
   | 'pbkdf2_sha256_django'
   | 'pbkdf2_sha1'
+  | 'phpass'
   | 'scrypt_firebase'
   | 'scrypt_werkzeug'
   | 'sha256';


### PR DESCRIPTION
## Description

Add the `phpass` and `bcrypt_sha256_django` hashers to the `PasswordHasher` type.


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
