### PR TITLE
[Core 1 Backport] Fix cookies on Cypress + Improve script loading failure logging

### DIFF
--- a/.changeset/fast-timers-matter.md
+++ b/.changeset/fast-timers-matter.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Improve logging for CAPTCHA script loading errors

--- a/.changeset/rotten-rats-carry.md
+++ b/.changeset/rotten-rats-carry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix Cypress setting cookies as third-party

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -1,8 +1,6 @@
 import { loadScript } from '@clerk/shared/loadScript';
 import type { CaptchaWidgetType } from '@clerk/types';
 
-import { clerkFailedToLoadThirdPartyScript } from '../core/errors';
-
 interface RenderOptions {
   /**
    * Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation.
@@ -76,9 +74,12 @@ export async function loadCaptcha(url: string) {
   if (!window.turnstile) {
     try {
       await loadScript(url, { defer: true });
-    } catch (_) {
+    } catch {
       // Rethrow with specific message
-      clerkFailedToLoadThirdPartyScript('Cloudflare Turnstile');
+      console.error('Clerk: Failed to load the CAPTCHA script from the URL: ', url);
+      throw {
+        captchaError: 'captcha_script_failed_to_load',
+      };
     }
   }
   return window.turnstile;
@@ -112,7 +113,7 @@ export const getCaptchaToken = async (captchaOptions: {
     return div;
   };
 
-  const captcha = await loadCaptcha(scriptUrl);
+  const captcha: Turnstile = await loadCaptcha(scriptUrl);
   let retries = 0;
   const errorCodes: (string | number)[] = [];
 

--- a/packages/clerk-js/src/utils/runtime.ts
+++ b/packages/clerk-js/src/utils/runtime.ts
@@ -10,8 +10,14 @@ export function usesHttps() {
   return inBrowser() && window.location.protocol === 'https:';
 }
 
+function isCypress() {
+  return typeof window !== 'undefined' && typeof (window as any).Cypress !== 'undefined';
+}
+
 export function inIframe() {
-  return inBrowser() && window.self !== window.top;
+  // checks if the current window is an iframe
+  // excludes the case where the current window runs in a Cypress test
+  return inBrowser() && window.self !== window.top && !isCypress();
 }
 
 export function inCrossOriginIframe() {


### PR DESCRIPTION
This PR backports 2 fixes from Core 2:

- Set Clerk cookies as first-party cookies when in a Cypress environment (#3245)
- Send captcha error to FAPI when captcha script loading fails (#3374)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
