### PR TITLE
fix(elements): Fix types for GlobalError/FieldError render fns

### DIFF
--- a/.changeset/quiet-games-brake.md
+++ b/.changeset/quiet-games-brake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Fix typing for GlobalError and FieldError render functions

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -20,7 +20,7 @@ import {
 } from '@radix-ui/react-form';
 import { Slot } from '@radix-ui/react-slot';
 import * as React from 'react';
-import type { SetRequired, Simplify } from 'type-fest';
+import type { SetRequired } from 'type-fest';
 import type { BaseActorRef } from 'xstate';
 
 import type { ClerkElementsError } from '~/internals/errors';
@@ -622,9 +622,8 @@ type FormErrorPropsAsChild = {
   code: string;
 };
 
-type FormErrorProps<T> = Simplify<
-  Omit<T, 'asChild' | 'children'> & (FormErrorPropsRenderFn | FormErrorPropsStd | FormErrorPropsAsChild)
->;
+type FormErrorProps<T> = Omit<T, 'asChild' | 'children'> &
+  (FormErrorPropsRenderFn | FormErrorPropsStd | FormErrorPropsAsChild);
 
 type FormGlobalErrorElement = React.ElementRef<'div'>;
 type FormGlobalErrorProps = FormErrorProps<React.ComponentPropsWithoutRef<'div'>>;


### PR DESCRIPTION
## Description

Fix types for GlobalError/FieldError render fns

Fixes SDK-1751

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
