### PR TITLE
fix(elements): Sign-Up `setActive` not firing

### DIFF
--- a/.changeset/ninety-geese-knock.md
+++ b/.changeset/ninety-geese-knock.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Fix `setActive` not firing upon a successful sign up.


### PR DESCRIPTION
## Description

Fixes Sign Up `setActive` not appropriately firing.

Ensures that ThirdParty machine doesn't try to initialized again after reset, if already running.

Fixes: SDK-1752

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
