### PR TITLE
chore(testing): Add experimental console warning on Cypress setup

### DIFF
--- a/.changeset/grumpy-plants-think.md
+++ b/.changeset/grumpy-plants-think.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Add experimental console warning on Cypress setup function

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -89,6 +89,8 @@ test("sign up", async ({ page }) => {
 
 ### Cypress
 
+⚠️ **Using Cypress to test Clerk is still in the experimental stage. Please be aware that there may be limitations and potential issues when using this approach.**
+
 Firstly, add your Clerk keys (`CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`) to your environment variables file (e.g. `.env.local` or `.env.`).
 You can find these keys in your Clerk Dashboard.
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -89,7 +89,7 @@ test("sign up", async ({ page }) => {
 
 ### Cypress
 
-⚠️ **Using Cypress to test Clerk is still in the experimental stage. Please be aware that there may be limitations and potential issues when using this approach.**
+⚠️ **Please note:** Support for Cypress is still experimental. Be aware that there are limitations and potential issues at this stage. Please open an issue with a minimal reproduction so that these issues can be fixed. Thanks!
 
 Firstly, add your Clerk keys (`CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`) to your environment variables file (e.g. `.env.local` or `.env.`).
 You can find these keys in your Clerk Dashboard.

--- a/packages/testing/src/cypress/setup.ts
+++ b/packages/testing/src/cypress/setup.ts
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 import type { ClerkSetupOptions } from '../common';
 import { fetchEnvVars } from '../common';
-import { experimentalConsoleWarning } from './utils';
 
 type ClerkSetupParams = {
   config: Cypress.PluginConfigOptions;
@@ -24,7 +23,10 @@ type ClerkSetupParams = {
  * @throws An error if the Cypress config object is not provided.
  */
 export const clerkSetup = async ({ config, options }: ClerkSetupParams) => {
-  experimentalConsoleWarning();
+  console.log(
+    '\x1b[33m%s\x1b[0m',
+    '@clerk/testing: Cypress is an experimental project and subject to change in the future.',
+  );
 
   if (!config) {
     throw new Error('The Cypress config object is required.');

--- a/packages/testing/src/cypress/setup.ts
+++ b/packages/testing/src/cypress/setup.ts
@@ -25,7 +25,7 @@ type ClerkSetupParams = {
 export const clerkSetup = async ({ config, options }: ClerkSetupParams) => {
   console.log(
     '\x1b[33m%s\x1b[0m',
-    '@clerk/testing: Cypress is an experimental project and subject to change in the future.',
+    '@clerk/testing: Support for Cypress is experimental and subject to change in the future.',
   );
 
   if (!config) {

--- a/packages/testing/src/cypress/setup.ts
+++ b/packages/testing/src/cypress/setup.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 import type { ClerkSetupOptions } from '../common';
 import { fetchEnvVars } from '../common';
+import { experimentalConsoleWarning } from './utils';
 
 type ClerkSetupParams = {
   config: Cypress.PluginConfigOptions;
@@ -23,6 +24,8 @@ type ClerkSetupParams = {
  * @throws An error if the Cypress config object is not provided.
  */
 export const clerkSetup = async ({ config, options }: ClerkSetupParams) => {
+  experimentalConsoleWarning();
+
   if (!config) {
     throw new Error('The Cypress config object is required.');
   }

--- a/packages/testing/src/cypress/utils.ts
+++ b/packages/testing/src/cypress/utils.ts
@@ -1,4 +1,0 @@
-export const experimentalConsoleWarning = () => {
-  const message = '@clerk/testing: Cypress is an experimental project and subject to change in the future.';
-  console.log('\x1b[33m%s\x1b[0m', message);
-};

--- a/packages/testing/src/cypress/utils.ts
+++ b/packages/testing/src/cypress/utils.ts
@@ -1,0 +1,4 @@
+export const experimentalConsoleWarning = () => {
+  const message = '@clerk/testing: Cypress is an experimental project and subject to change in the future.';
+  console.log('\x1b[33m%s\x1b[0m', message);
+};


### PR DESCRIPTION
## Description

This PR adds the following console message on the node process that runs the `clerkSetup` function from `@clerk/testing/cypress`:

```
@clerk/testing: Cypress is an experimental project and subject to change in the future.
```

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
