### PR TITLE
refactor(elements): `FieldError` to enable `asChild` usage

### DIFF
--- a/.changeset/fast-singers-dress.md
+++ b/.changeset/fast-singers-dress.md
@@ -2,4 +2,4 @@
 '@clerk/elements': patch
 ---
 
-Update `<FieldError />` to render as a `div` vs `span` to avoid issues with invalid markup when using the render function.
+Update `<FieldError />` to enable `asChild` prop for custom markup in render function usage.

--- a/.changeset/fast-singers-dress.md
+++ b/.changeset/fast-singers-dress.md
@@ -2,4 +2,4 @@
 '@clerk/elements': patch
 ---
 
-Refactor `FieldError` to make use of `asChild` prop when using as render function
+Update `<FieldError />` to render as a `div` vs `span` to avoid issues with invalid markup when using the render function.

--- a/.changeset/fast-singers-dress.md
+++ b/.changeset/fast-singers-dress.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Refactor `FieldError` to make use of `asChild` prop when using as render function

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -717,7 +717,9 @@ const FieldError = React.forwardRef<FormFieldErrorElement, FormFieldErrorProps>(
       return null;
     }
 
-    const child = typeof children === 'function' ? children(error) : children;
+    const isRenderFunction = typeof children === 'function';
+
+    const child = isRenderFunction ? children(error) : children;
     // const forceMatch = code ? error.code === code : undefined; // TODO: Re-add when Radix Form is updated
 
     return (
@@ -726,6 +728,7 @@ const FieldError = React.forwardRef<FormFieldErrorElement, FormFieldErrorProps>(
         // forceMatch={forceMatch}
         {...rest}
         ref={forwardedRef}
+        asChild={isRenderFunction}
       >
         {child || error.message}
       </RadixFormMessage>

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -717,9 +717,7 @@ const FieldError = React.forwardRef<FormFieldErrorElement, FormFieldErrorProps>(
       return null;
     }
 
-    const isRenderFunction = typeof children === 'function';
-
-    const child = isRenderFunction ? children(error) : children;
+    const child = typeof children === 'function' ? children(error) : children;
     // const forceMatch = code ? error.code === code : undefined; // TODO: Re-add when Radix Form is updated
 
     return (
@@ -728,9 +726,9 @@ const FieldError = React.forwardRef<FormFieldErrorElement, FormFieldErrorProps>(
         // forceMatch={forceMatch}
         {...rest}
         ref={forwardedRef}
-        asChild={isRenderFunction}
+        asChild
       >
-        {child || error.message}
+        <div>{child || error.message}</div>
       </RadixFormMessage>
     );
   },

--- a/packages/elements/src/react/utils/is-react-fragment.ts
+++ b/packages/elements/src/react/utils/is-react-fragment.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export function isReactFragment(node: React.ReactNode) {
+  return React.isValidElement(node) && node.type === React.Fragment;
+}


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Update `<FieldError />` composable similar to how `<GlobalError />` currently works.

```tsx
// Input
<Clerk.FieldError className='text-red-400' />

// Output
<span id="radix-:ru:">Error message</span>
```

```tsx
// Input
<Clerk.FieldError className='text-red-400'>
  {({ message }) => {
    return <span>{message}</span>;
  }}
</Clerk.FieldError>

// Output
<span id="radix-:ru:"><span>Error message</span></span>
```

```tsx
// Input
<Clerk.FieldError className='text-red-400' asChild>
  {({ message }) => {
    return <p>{message}</p>;
  }}
</Clerk.FieldError>

// Output
<p id="radix-:ru:">Error message</p>
```

Fixes issue with invalid markup when using the render function and providing a `p` or `div` tag as the child element.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
