### PR TITLE
fix(clerk-js): Update existing `SignUp` object on `SignUpContinue` OAuth

### DIFF
--- a/.changeset/loud-tables-rush.md
+++ b/.changeset/loud-tables-rush.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+---
+
+A bug was fixed to not override the existing sign-up state on the OAuth callback.
+
+When continuing a sign-up flow with social connections, `@clerk/clerk-js` was creating a new `SignUpResource` object, instead of patching the existing one.
+
+This was affecting Web3 sign-up flows, since the wallet ID was being overridden on the browser redirect.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -175,6 +175,7 @@ function _SignUpContinue() {
                 <SignUpSocialButtons
                   enableOAuthProviders={showOauthProviders}
                   enableWeb3Providers={showWeb3Providers}
+                  continueSignUp
                 />
               )}
               <SignUpForm


### PR DESCRIPTION
## Description

Resolves SDK-1689 - fixes Web3 sign-up flow with social connections.

The SDK was creating a new `SignUp` object on OAuth callback when continuing a signup flow, overriding properties such as `web3_wallet`. 

Instead of creating a new `SignUp` object, it should update the existing one. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
