### PR TITLE
fix(backend): Expose user saml_accounts property

### DIFF
--- a/.changeset/ten-onions-learn.md
+++ b/.changeset/ten-onions-learn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Consume and expose the 'saml_accounts' property of the user resource

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -1,5 +1,3 @@
-import type { SamlAccountJSON } from '@clerk/types';
-
 import type {
   InvitationStatus,
   OrganizationInvitationStatus,
@@ -23,6 +21,7 @@ export const ObjectType = {
   OrganizationMembership: 'organization_membership',
   PhoneNumber: 'phone_number',
   RedirectUrl: 'redirect_url',
+  SamlAccount: 'saml_account',
   Session: 'session',
   SignInAttempt: 'sign_in_attempt',
   SignInToken: 'sign_in_token',
@@ -101,6 +100,17 @@ export interface ExternalAccountJSON extends ClerkResourceJSON {
   username: string | null;
   public_metadata?: Record<string, unknown> | null;
   label: string | null;
+  verification: VerificationJSON | null;
+}
+
+export interface SamlAccountJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.SamlAccount;
+  provider: string;
+  provider_user_id: string | null;
+  active: boolean;
+  email_address: string;
+  first_name: string;
+  last_name: string;
   verification: VerificationJSON | null;
 }
 

--- a/packages/backend/src/api/resources/SamlAccount.ts
+++ b/packages/backend/src/api/resources/SamlAccount.ts
@@ -1,0 +1,28 @@
+import type { SamlAccountJSON } from './JSON';
+import { Verification } from './Verification';
+
+export class SamlAccount {
+  constructor(
+    readonly id: string,
+    readonly provider: string,
+    readonly providerUserId: string | null,
+    readonly active: boolean,
+    readonly emailAddress: string,
+    readonly firstName: string,
+    readonly lastName: string,
+    readonly verification: Verification | null,
+  ) {}
+
+  static fromJSON(data: SamlAccountJSON): SamlAccount {
+    return new SamlAccount(
+      data.id,
+      data.provider,
+      data.provider_user_id,
+      data.active,
+      data.email_address,
+      data.first_name,
+      data.last_name,
+      data.verification && Verification.fromJSON(data.verification),
+    );
+  }
+}

--- a/packages/backend/src/api/resources/User.ts
+++ b/packages/backend/src/api/resources/User.ts
@@ -1,7 +1,8 @@
 import { EmailAddress } from './EmailAddress';
 import { ExternalAccount } from './ExternalAccount';
-import type { ExternalAccountJSON, UserJSON } from './JSON';
+import type { ExternalAccountJSON, SamlAccountJSON, UserJSON } from './JSON';
 import { PhoneNumber } from './PhoneNumber';
+import { SamlAccount } from './SamlAccount';
 import { Web3Wallet } from './Web3Wallet';
 
 export class User {
@@ -31,6 +32,7 @@ export class User {
     readonly phoneNumbers: PhoneNumber[] = [],
     readonly web3Wallets: Web3Wallet[] = [],
     readonly externalAccounts: ExternalAccount[] = [],
+    readonly samlAccounts: SamlAccount[] = [],
     readonly lastActiveAt: number | null,
     readonly createOrganizationEnabled: boolean,
   ) {}
@@ -62,6 +64,7 @@ export class User {
       (data.phone_numbers || []).map(x => PhoneNumber.fromJSON(x)),
       (data.web3_wallets || []).map(x => Web3Wallet.fromJSON(x)),
       (data.external_accounts || []).map((x: ExternalAccountJSON) => ExternalAccount.fromJSON(x)),
+      (data.saml_accounts || []).map((x: SamlAccountJSON) => SamlAccount.fromJSON(x)),
       data.last_active_at,
       data.create_organization_enabled,
     );

--- a/packages/backend/src/fixtures/user.json
+++ b/packages/backend/src/fixtures/user.json
@@ -75,6 +75,24 @@
       "verification": null
     }
   ],
+  "saml_accounts": [
+    {
+      "object": "saml_account",
+      "id": "samlacc_microsoft",
+      "provider": "saml_microsoft",
+      "active": true,
+      "email_address": "john.doe@clerk.test",
+      "first_name": "John",
+      "last_name": "Doe",
+      "provider_user_id": null,
+      "verification": {
+        "status": "verified",
+        "strategy": "saml",
+        "attempts": null,
+        "expireAt": 1613831855
+      }
+    }
+  ],
   "public_metadata": {
     "zodiac_sign": "leo"
   },


### PR DESCRIPTION
## Description

We fix an omission on our end where we didn't expose the 'saml_accounts' user property and therefore customers were not able to use it via our SDK

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
