### PR TITLE
chore(repo): Remove commitlint as part of pre-commit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
         if: ${{ !(github.event_name == 'merge_group') }}
         run: if [ "${{ github.event.pull_request.user.login }}" = "clerk-cookie" ]; then echo 'Skipping' && exit 0; else npx changeset status --since=origin/main; fi
 
+      - name: Lint Pull Request Title
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
+
       - name: Lint GitHub Actions Workflows
         run: npx eslint .github
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
         if: ${{ !(github.event_name == 'merge_group') }}
         run: if [ "${{ github.event.pull_request.user.login }}" = "clerk-cookie" ]; then echo 'Skipping' && exit 0; else npx changeset status --since=origin/main; fi
 
-      - name: Lint Pull Request Title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
-
       - name: Lint GitHub Actions Workflows
         run: npx eslint .github
         shell: bash

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -1,3 +1,7 @@
+# As squash merging is enforced in this repository, we enforce conventional commits
+# in the PR title, which is used as the commit message on merge, to ensure that the
+# commit messages that make it into the main branch follow a standard format.
+# This step is done in a separate workflow file so that we can trigger on the `edited` pull_request event type.
 name: PR Title Lint
 
 on:

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -1,0 +1,20 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  pr-title-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Lint Pull Request Title
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx commitlint --edit $1


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Remove commitlint running as part of pre-commit checks. Instead, run it on the PR title. Due to squash merging, this will ensure that commits to `main` have formatted messages, but commits to branches unchecked. ⏩

fixes SDK-1753

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
