### PR TITLE
fix(nextjs): Redirect URL fixes

### DIFF
--- a/.changeset/small-frogs-march.md
+++ b/.changeset/small-frogs-march.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': minor
+---
+
+Utilize an awaitable replace function internally to avoid race conditions when using `router.replace`.

--- a/.changeset/small-frogs-march.md
+++ b/.changeset/small-frogs-march.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/nextjs': minor
+'@clerk/nextjs': patch
 ---
 
 Utilize an awaitable replace function internally to avoid race conditions when using `router.replace`.

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -8,7 +8,7 @@ import { ClerkNextOptionsProvider } from '../../client-boundary/NextOptionsConte
 import type { NextClerkProviderProps } from '../../types';
 import { ClerkJSScript } from '../../utils/clerk-js-script';
 import { mergeNextClerkPropsWithEnv } from '../../utils/mergeNextClerkPropsWithEnv';
-import { useAwaitableNavigate } from './useAwaitableNavigate';
+import { useAwaitablePush } from './useAwaitablePush';
 import { useAwaitableReplace } from './useAwaitableReplace';
 
 declare global {
@@ -22,7 +22,7 @@ declare global {
 export const ClientClerkProvider = (props: NextClerkProviderProps) => {
   const { __unstable_invokeMiddlewareOnAuthStateChange = true, children } = props;
   const router = useRouter();
-  const navigate = useAwaitableNavigate();
+  const push = useAwaitablePush();
   const replace = useAwaitableReplace();
   const [isPending, startTransition] = useTransition();
 
@@ -70,7 +70,7 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
 
   const mergedProps = mergeNextClerkPropsWithEnv({
     ...props,
-    routerPush: navigate,
+    routerPush: push,
     routerReplace: replace,
   });
 

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -9,6 +9,7 @@ import type { NextClerkProviderProps } from '../../types';
 import { ClerkJSScript } from '../../utils/clerk-js-script';
 import { mergeNextClerkPropsWithEnv } from '../../utils/mergeNextClerkPropsWithEnv';
 import { useAwaitableNavigate } from './useAwaitableNavigate';
+import { useAwaitableReplace } from './useAwaitableReplace';
 
 declare global {
   export interface Window {
@@ -22,6 +23,7 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
   const { __unstable_invokeMiddlewareOnAuthStateChange = true, children } = props;
   const router = useRouter();
   const navigate = useAwaitableNavigate();
+  const replace = useAwaitableReplace();
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
@@ -69,7 +71,7 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
   const mergedProps = mergeNextClerkPropsWithEnv({
     ...props,
     routerPush: navigate,
-    routerReplace: to => router.replace(to),
+    routerReplace: replace,
   });
 
   return (

--- a/packages/nextjs/src/app-router/client/useAwaitablePush.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitablePush.ts
@@ -17,7 +17,7 @@ declare global {
  * This is accomplished by wrapping the call to `router.push` in `startTransition()`, which should rely on React to coordinate the pending state. We key off of
  * `isPending` to flush the stored promises and ensure the navigates "resolve".
  */
-export const useAwaitableNavigate = () => {
+export const useAwaitablePush = () => {
   const router = useRouter();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();

--- a/packages/nextjs/src/app-router/client/useAwaitablePush.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitablePush.ts
@@ -1,16 +1,8 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 
-import type { NextClerkProviderProps } from '../../types';
-
-declare global {
-  interface Window {
-    __clerk_internal_navPromisesBuffer: Array<() => void> | undefined;
-    __clerk_internal_navFun: NonNullable<NextClerkProviderProps['routerPush']>;
-  }
-}
+import { useInternalNavFun } from './useInternalNavFun';
 
 /**
  * Creates an "awaitable" navigation function that will do its best effort to wait for Next.js to finish its route transition.
@@ -19,60 +11,9 @@ declare global {
  */
 export const useAwaitablePush = () => {
   const router = useRouter();
-  const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
 
-  if (typeof window !== 'undefined') {
-    window.__clerk_internal_navFun = (to, opts) => {
-      return new Promise<void>(res => {
-        if (!window.__clerk_internal_navPromisesBuffer) {
-          // We need to use window to store the reference to the buffer,
-          // as ClerkProvider might be unmounted and remounted during navigations
-          // If we use a ref, it will be reset when ClerkProvider is unmounted
-          window.__clerk_internal_navPromisesBuffer = [];
-        }
-        window.__clerk_internal_navPromisesBuffer.push(res);
-        startTransition(() => {
-          // If the navigation is internal, we should use the history API to navigate
-          // as this is the way to perform a shallow navigation in Next.js App Router
-          // without unmounting/remounting the page or fetching data from the server.
-          if (opts?.__internal_metadata?.navigationType === 'internal') {
-            // In 14.1.0, useSearchParams becomes reactive to shallow updates,
-            // but only if passing `null` as the history state.
-            // Older versions need to maintain the history state for push to work,
-            // without affecting how the Next router works.
-            const state = ((window as any).next?.version ?? '') < '14.1.0' ? history.state : null;
-            window.history.pushState(state, '', to);
-          } else {
-            // If the navigation is external (usually when navigating away from the component but still within the app),
-            // we should use the Next.js router to navigate as it will handle updating the URL and also
-            // fetching the new page if necessary.
-            router.push(to);
-          }
-        });
-      });
-    };
-  }
-
-  const flushPromises = () => {
-    window.__clerk_internal_navPromisesBuffer?.forEach(resolve => resolve());
-    window.__clerk_internal_navPromisesBuffer = [];
-  };
-
-  // Flush any pending promises on mount/unmount
-  useEffect(() => {
-    flushPromises();
-    return flushPromises;
-  }, []);
-
-  // Handle flushing the promise buffer when a navigation happens
-  useEffect(() => {
-    if (!isPending) {
-      flushPromises();
-    }
-  }, [pathname, isPending]);
-
-  return useCallback((to: string) => {
-    return window.__clerk_internal_navFun(to);
-  }, []);
+  return useInternalNavFun({
+    windowNav: window?.history.pushState.bind(window.history),
+    routerNav: router.push.bind(router),
+  });
 };

--- a/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
@@ -1,16 +1,8 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 
-import type { NextClerkProviderProps } from '../../types';
-
-declare global {
-  interface Window {
-    __clerk_internal_navPromisesBuffer: Array<() => void> | undefined;
-    __clerk_internal_navFun: NonNullable<NextClerkProviderProps['routerReplace']>;
-  }
-}
+import { useInternalNavFun } from './useInternalNavFun';
 
 /**
  * Creates an "awaitable" navigation function that will do its best effort to wait for Next.js to finish its route transition.
@@ -19,60 +11,9 @@ declare global {
  */
 export const useAwaitableReplace = () => {
   const router = useRouter();
-  const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
 
-  if (typeof window !== 'undefined') {
-    window.__clerk_internal_navFun = (to, opts) => {
-      return new Promise<void>(res => {
-        if (!window.__clerk_internal_navPromisesBuffer) {
-          // We need to use window to store the reference to the buffer,
-          // as ClerkProvider might be unmounted and remounted during navigations
-          // If we use a ref, it will be reset when ClerkProvider is unmounted
-          window.__clerk_internal_navPromisesBuffer = [];
-        }
-        window.__clerk_internal_navPromisesBuffer.push(res);
-        startTransition(() => {
-          // If the navigation is internal, we should use the history API to navigate
-          // as this is the way to perform a shallow navigation in Next.js App Router
-          // without unmounting/remounting the page or fetching data from the server.
-          if (opts?.__internal_metadata?.navigationType === 'internal') {
-            // In 14.1.0, useSearchParams becomes reactive to shallow updates,
-            // but only if passing `null` as the history state.
-            // Older versions need to maintain the history state for push to work,
-            // without affecting how the Next router works.
-            const state = ((window as any).next?.version ?? '') < '14.1.0' ? history.state : null;
-            window.history.replaceState(state, '', to);
-          } else {
-            // If the navigation is external (usually when navigating away from the component but still within the app),
-            // we should use the Next.js router to navigate as it will handle updating the URL and also
-            // fetching the new page if necessary.
-            router.replace(to);
-          }
-        });
-      });
-    };
-  }
-
-  const flushPromises = () => {
-    window.__clerk_internal_navPromisesBuffer?.forEach(resolve => resolve());
-    window.__clerk_internal_navPromisesBuffer = [];
-  };
-
-  // Flush any pending promises on mount/unmount
-  useEffect(() => {
-    flushPromises();
-    return flushPromises;
-  }, []);
-
-  // Handle flushing the promise buffer when a navigation happens
-  useEffect(() => {
-    if (!isPending) {
-      flushPromises();
-    }
-  }, [pathname, isPending]);
-
-  return useCallback((to: string) => {
-    return window.__clerk_internal_navFun(to);
-  }, []);
+  return useInternalNavFun({
+    windowNav: window?.history.replaceState.bind(window.history),
+    routerNav: router.replace.bind(router),
+  });
 };

--- a/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
@@ -8,7 +8,7 @@ import type { NextClerkProviderProps } from '../../types';
 declare global {
   interface Window {
     __clerk_internal_navPromisesBuffer: Array<() => void> | undefined;
-    __clerk_internal_navFun: NonNullable<NextClerkProviderProps['routerPush']>;
+    __clerk_internal_navFun: NonNullable<NextClerkProviderProps['routerReplace']>;
   }
 }
 

--- a/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
+++ b/packages/nextjs/src/app-router/client/useAwaitableReplace.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useTransition } from 'react';
+
+import type { NextClerkProviderProps } from '../../types';
+
+declare global {
+  interface Window {
+    __clerk_internal_navPromisesBuffer: Array<() => void> | undefined;
+    __clerk_internal_navFun: NonNullable<NextClerkProviderProps['routerPush']>;
+  }
+}
+
+/**
+ * Creates an "awaitable" navigation function that will do its best effort to wait for Next.js to finish its route transition.
+ * This is accomplished by wrapping the call to `router.replace` in `startTransition()`, which should rely on React to coordinate the pending state. We key off of
+ * `isPending` to flush the stored promises and ensure the navigates "resolve".
+ */
+export const useAwaitableReplace = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  if (typeof window !== 'undefined') {
+    window.__clerk_internal_navFun = (to, opts) => {
+      return new Promise<void>(res => {
+        if (!window.__clerk_internal_navPromisesBuffer) {
+          // We need to use window to store the reference to the buffer,
+          // as ClerkProvider might be unmounted and remounted during navigations
+          // If we use a ref, it will be reset when ClerkProvider is unmounted
+          window.__clerk_internal_navPromisesBuffer = [];
+        }
+        window.__clerk_internal_navPromisesBuffer.push(res);
+        startTransition(() => {
+          // If the navigation is internal, we should use the history API to navigate
+          // as this is the way to perform a shallow navigation in Next.js App Router
+          // without unmounting/remounting the page or fetching data from the server.
+          if (opts?.__internal_metadata?.navigationType === 'internal') {
+            // In 14.1.0, useSearchParams becomes reactive to shallow updates,
+            // but only if passing `null` as the history state.
+            // Older versions need to maintain the history state for push to work,
+            // without affecting how the Next router works.
+            const state = ((window as any).next?.version ?? '') < '14.1.0' ? history.state : null;
+            window.history.replaceState(state, '', to);
+          } else {
+            // If the navigation is external (usually when navigating away from the component but still within the app),
+            // we should use the Next.js router to navigate as it will handle updating the URL and also
+            // fetching the new page if necessary.
+            router.replace(to);
+          }
+        });
+      });
+    };
+  }
+
+  const flushPromises = () => {
+    window.__clerk_internal_navPromisesBuffer?.forEach(resolve => resolve());
+    window.__clerk_internal_navPromisesBuffer = [];
+  };
+
+  // Flush any pending promises on mount/unmount
+  useEffect(() => {
+    flushPromises();
+    return flushPromises;
+  }, []);
+
+  // Handle flushing the promise buffer when a navigation happens
+  useEffect(() => {
+    if (!isPending) {
+      flushPromises();
+    }
+  }, [pathname, isPending]);
+
+  return useCallback((to: string) => {
+    return window.__clerk_internal_navFun(to);
+  }, []);
+};

--- a/packages/nextjs/src/app-router/client/useInternalNavFun.ts
+++ b/packages/nextjs/src/app-router/client/useInternalNavFun.ts
@@ -1,0 +1,77 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useTransition } from 'react';
+
+import type { NextClerkProviderProps } from '../../types';
+
+declare global {
+  interface Window {
+    __clerk_internal_navFun: NonNullable<
+      NextClerkProviderProps['routerPush'] | NextClerkProviderProps['routerReplace']
+    >;
+    __clerk_internal_navPromisesBuffer: Array<() => void> | undefined;
+  }
+}
+
+export const useInternalNavFun = (props: {
+  windowNav: typeof window.history.pushState | typeof window.history.replaceState;
+  routerNav: AppRouterInstance['push'] | AppRouterInstance['replace'];
+}) => {
+  const { windowNav, routerNav } = props;
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  if (typeof window !== 'undefined') {
+    window.__clerk_internal_navFun = (to, opts) => {
+      return new Promise<void>(res => {
+        if (!window.__clerk_internal_navPromisesBuffer) {
+          // We need to use window to store the reference to the buffer,
+          // as ClerkProvider might be unmounted and remounted during navigations
+          // If we use a ref, it will be reset when ClerkProvider is unmounted
+          window.__clerk_internal_navPromisesBuffer = [];
+        }
+        window.__clerk_internal_navPromisesBuffer.push(res);
+        startTransition(() => {
+          // If the navigation is internal, we should use the history API to navigate
+          // as this is the way to perform a shallow navigation in Next.js App Router
+          // without unmounting/remounting the page or fetching data from the server.
+          if (opts?.__internal_metadata?.navigationType === 'internal') {
+            // In 14.1.0, useSearchParams becomes reactive to shallow updates,
+            // but only if passing `null` as the history state.
+            // Older versions need to maintain the history state for push/replace to work,
+            // without affecting how the Next router works.
+            const state = ((window as any).next?.version ?? '') < '14.1.0' ? history.state : null;
+            windowNav(state, '', to);
+          } else {
+            // If the navigation is external (usually when navigating away from the component but still within the app),
+            // we should use the Next.js router to navigate as it will handle updating the URL and also
+            // fetching the new page if necessary.
+            routerNav(to);
+          }
+        });
+      });
+    };
+  }
+
+  const flushPromises = () => {
+    window.__clerk_internal_navPromisesBuffer?.forEach(resolve => resolve());
+    window.__clerk_internal_navPromisesBuffer = [];
+  };
+
+  // Flush any pending promises on mount/unmount
+  useEffect(() => {
+    flushPromises();
+    return flushPromises;
+  }, []);
+
+  // Handle flushing the promise buffer when a navigation happens
+  useEffect(() => {
+    if (!isPending) {
+      flushPromises();
+    }
+  }, [pathname, isPending]);
+
+  return useCallback((to: string) => {
+    return window.__clerk_internal_navFun(to);
+  }, []);
+};


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Create an `awaitableReplace` function, similar to the `awaitableNavigate` that we utilize for app router. This is essential in order to immediately be able to set state and render components, when we convert a hash based path to a path based one, inside `PathRouter.tsx`.

<!-- Fixes #(issue number) -->
Fixes #3403 

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
