### PR TITLE
fix(elements): Update `FieldError`/`GlobalError` types to allow render function children while using the `asChild` prop

### DIFF
--- a/.changeset/sharp-apples-think.md
+++ b/.changeset/sharp-apples-think.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Update FieldError/GlobalError types to allow render function children while using the asChild prop

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -605,9 +605,9 @@ const FIELD_ERROR_NAME = 'ClerkElementsFieldError';
 
 type FormErrorRenderProps = Pick<ClerkElementsError, 'code' | 'message'>;
 
-type FormErrorPropsRenderFn = {
-  asChild?: never;
-  children?: (error: FormErrorRenderProps) => React.ReactNode;
+type FormErrorPropsAsChild = {
+  asChild?: true | never;
+  children?: React.ReactElement | ((error: FormErrorRenderProps) => React.ReactNode);
   code?: string;
 };
 
@@ -617,14 +617,7 @@ type FormErrorPropsStd = {
   code: string;
 };
 
-type FormErrorPropsAsChild = {
-  asChild?: true;
-  children: React.ReactElement;
-  code: string;
-};
-
-type FormErrorProps<T> = Omit<T, 'asChild' | 'children'> &
-  (FormErrorPropsRenderFn | FormErrorPropsStd | FormErrorPropsAsChild);
+type FormErrorProps<T> = Omit<T, 'asChild' | 'children'> & (FormErrorPropsStd | FormErrorPropsAsChild);
 
 type FormGlobalErrorElement = React.ElementRef<'div'>;
 type FormGlobalErrorProps = FormErrorProps<React.ComponentPropsWithoutRef<'div'>>;


### PR DESCRIPTION
## Description

Updates `FieldError`/`GlobalError` types to allow render function children while using the `asChild` prop

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Fixes SDK-1767

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
