### PR TITLE
chore(clerk-react,nextjs,shared): Allow react and react-dom 19.0.0-beta

### DIFF
--- a/.changeset/hot-phones-serve.md
+++ b/.changeset/hot-phones-serve.md
@@ -1,0 +1,7 @@
+---
+"@clerk/nextjs": patch
+"@clerk/clerk-react": patch
+"@clerk/shared": patch
+---
+
+With the next major release, NextJS@15 will depend on `react` and `react-dom` v19, which is still in beta. We are updating our peer dependencies accordingly in order to accept `react` and `react-dom` @ `19.0.0-beta`

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -86,8 +86,8 @@
   },
   "peerDependencies": {
     "next": "^13.5.4 || ^14.0.3",
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=18 || >=19.0.0-beta",
+    "react-dom": ">=18 || >=19.0.0-beta"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -90,8 +90,8 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=18 || >=19.0.0-beta",
+    "react-dom": ">=18 || >=19.0.0-beta"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -104,8 +104,8 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=18 || >=19.0.0-beta",
+    "react-dom": ">=18 || >=19.0.0-beta"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
With the next major release, NextJS@15 will deped on react and react-dom v19 that is still in beta. We are updating our peer dependencies for the related packages, otherwise the package managers will fail to resolve the package versions when users try to install or update the Clerk packages.

 Due to the semver specification for prerelease tags (https://semver.org/#spec-item-11), we can't be very exact here. Adding `19.0.0-beta` to the list will also allow `19.0.0-canary` and `19.0.0-rc` releases as well, but this is not something we can or need to solve at the moment.

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
