### PR TITLE
fix(repo): Set @clerk/types as normal dep

### DIFF
--- a/.changeset/proud-fans-report.md
+++ b/.changeset/proud-fans-report.md
@@ -1,0 +1,13 @@
+---
+'@clerk/localizations': patch
+'@clerk/elements': patch
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+'@clerk/express': patch
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/remix': patch
+'@clerk/clerk-expo': patch
+---
+
+Set `@clerk/types` as a dependency for packages that had it as a dev dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38751,13 +38751,13 @@
       "license": "MIT",
       "dependencies": {
         "@clerk/shared": "2.2.1",
+        "@clerk/types": "4.5.1",
         "cookie": "0.5.0",
         "snakecase-keys": "5.4.4",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@cloudflare/workers-types": "^3.18.0",
         "@types/chai": "^4.3.3",
         "@types/cookie": "^0.5.1",
@@ -39437,6 +39437,7 @@
       "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
+        "@clerk/types": "^4.5.1",
         "@radix-ui/react-form": "^0.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@xstate/react": "^4.1.1",
@@ -39447,7 +39448,6 @@
         "@clerk/clerk-react": "5.2.2",
         "@clerk/eslint-config-custom": "*",
         "@clerk/shared": "2.2.1",
-        "@clerk/types": "^4.5.1",
         "@statelyai/inspect": "^0.3.1",
         "@types/node": "^18.17.0",
         "@types/react": "*",
@@ -39858,13 +39858,13 @@
         "@clerk/clerk-js": "5.5.3",
         "@clerk/clerk-react": "5.2.2",
         "@clerk/shared": "2.2.1",
+        "@clerk/types": "4.5.1",
         "base-64": "^1.0.0",
         "react-native-url-polyfill": "2.0.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "^4.5.1",
         "@types/base-64": "^1.0.2",
         "@types/node": "^20.11.24",
         "@types/react": "*",
@@ -39943,11 +39943,11 @@
       "dependencies": {
         "@clerk/backend": "^1.2.1",
         "@clerk/shared": "^2.2.1",
+        "@clerk/types": "4.5.1",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@types/express": "^4.17",
         "@types/node": "^18.17.0",
         "@types/supertest": "^6.0.2",
@@ -39995,12 +39995,12 @@
         "@clerk/backend": "1.2.1",
         "@clerk/clerk-react": "5.2.2",
         "@clerk/clerk-sdk-node": "5.0.9",
+        "@clerk/types": "4.5.1",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@types/cookie": "^0.5.0",
         "@types/node": "^18.17.0",
         "gatsby": "^5.0.0",
@@ -40021,9 +40021,11 @@
       "name": "@clerk/localizations",
       "version": "2.4.3",
       "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "4.5.1"
+      },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "tsup": "*",
         "typescript": "*"
       },
@@ -40039,13 +40041,13 @@
         "@clerk/backend": "1.2.1",
         "@clerk/clerk-react": "5.2.2",
         "@clerk/shared": "2.2.1",
+        "@clerk/types": "4.5.1",
         "crypto-js": "4.2.0",
         "path-to-regexp": "6.2.1",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@types/crypto-js": "4.2.2",
         "@types/node": "^18.17.0",
         "@types/react": "*",
@@ -40177,12 +40179,12 @@
         "@clerk/backend": "1.2.1",
         "@clerk/clerk-react": "5.2.2",
         "@clerk/shared": "2.2.1",
+        "@clerk/types": "4.5.1",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@remix-run/react": "^2.0.0",
         "@remix-run/server-runtime": "^2.0.0",
         "@types/cookie": "^0.5.0",
@@ -40212,11 +40214,11 @@
       "dependencies": {
         "@clerk/backend": "1.2.1",
         "@clerk/shared": "2.2.1",
+        "@clerk/types": "4.5.1",
         "tslib": "2.4.1"
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@types/express": "4.17.14",
         "@types/node": "^18.17.0",
         "nock": "^13.0.7",
@@ -40239,6 +40241,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@clerk/types": "4.5.1",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.1",
         "std-env": "^3.7.0",
@@ -40246,7 +40249,6 @@
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
-        "@clerk/types": "4.5.1",
         "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
         "@types/node": "^18.17.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -96,13 +96,13 @@
   },
   "dependencies": {
     "@clerk/shared": "2.2.1",
+    "@clerk/types": "4.5.1",
     "cookie": "0.5.0",
     "snakecase-keys": "5.4.4",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@cloudflare/workers-types": "^3.18.0",
     "@types/chai": "^4.3.3",
     "@types/cookie": "^0.5.1",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -70,6 +70,7 @@
     "test:cache:clear": "jest --clearCache --useStderr"
   },
   "dependencies": {
+    "@clerk/types": "^4.5.1",
     "@radix-ui/react-form": "^0.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@xstate/react": "^4.1.1",
@@ -80,7 +81,6 @@
     "@clerk/clerk-react": "5.2.2",
     "@clerk/eslint-config-custom": "*",
     "@clerk/shared": "2.2.1",
-    "@clerk/types": "^4.5.1",
     "@statelyai/inspect": "^0.3.1",
     "@types/node": "^18.17.0",
     "@types/react": "*",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -42,13 +42,13 @@
     "@clerk/clerk-js": "5.5.3",
     "@clerk/clerk-react": "5.2.2",
     "@clerk/shared": "2.2.1",
+    "@clerk/types": "4.5.1",
     "base-64": "^1.0.0",
     "react-native-url-polyfill": "2.0.0",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "^4.5.1",
     "@types/base-64": "^1.0.2",
     "@types/node": "^20.11.24",
     "@types/react": "*",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -55,11 +55,11 @@
   "dependencies": {
     "@clerk/backend": "^1.2.1",
     "@clerk/shared": "^2.2.1",
+    "@clerk/types": "4.5.1",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@types/express": "^4.17",
     "@types/node": "^18.17.0",
     "@types/supertest": "^6.0.2",

--- a/packages/gatsby-plugin-clerk/package.json
+++ b/packages/gatsby-plugin-clerk/package.json
@@ -47,12 +47,12 @@
     "@clerk/backend": "1.2.1",
     "@clerk/clerk-react": "5.2.2",
     "@clerk/clerk-sdk-node": "5.0.9",
+    "@clerk/types": "4.5.1",
     "cookie": "0.5.0",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@types/cookie": "^0.5.0",
     "@types/node": "^18.17.0",
     "gatsby": "^5.0.0",

--- a/packages/localizations/package.json
+++ b/packages/localizations/package.json
@@ -95,9 +95,11 @@
     "generate": "tsc src/utils/generate.ts && node src/utils/generate.js && prettier --write src/*.ts",
     "lint": "eslint src/"
   },
+  "dependencies": {
+    "@clerk/types": "4.5.1"
+  },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "tsup": "*",
     "typescript": "*"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -70,13 +70,13 @@
     "@clerk/backend": "1.2.1",
     "@clerk/clerk-react": "5.2.2",
     "@clerk/shared": "2.2.1",
+    "@clerk/types": "4.5.1",
     "crypto-js": "4.2.0",
     "path-to-regexp": "6.2.1",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@types/crypto-js": "4.2.2",
     "@types/node": "^18.17.0",
     "@types/react": "*",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -76,12 +76,12 @@
     "@clerk/backend": "1.2.1",
     "@clerk/clerk-react": "5.2.2",
     "@clerk/shared": "2.2.1",
+    "@clerk/types": "4.5.1",
     "cookie": "0.5.0",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@remix-run/react": "^2.0.0",
     "@remix-run/server-runtime": "^2.0.0",
     "@types/cookie": "^0.5.0",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -55,11 +55,11 @@
   "dependencies": {
     "@clerk/backend": "1.2.1",
     "@clerk/shared": "2.2.1",
+    "@clerk/types": "4.5.1",
     "tslib": "2.4.1"
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@types/express": "4.17.14",
     "@types/node": "^18.17.0",
     "nock": "^13.0.7",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -88,6 +88,7 @@
     "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html"
   },
   "dependencies": {
+    "@clerk/types": "4.5.1",
     "glob-to-regexp": "0.4.1",
     "js-cookie": "3.0.1",
     "std-env": "^3.7.0",
@@ -95,7 +96,6 @@
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
-    "@clerk/types": "4.5.1",
     "@types/glob-to-regexp": "0.4.1",
     "@types/js-cookie": "3.0.2",
     "@types/node": "^18.17.0",


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
When installing a Clerk package that has @clerk/types as a dev dep, the types packages is usually not installed (depending on the package manager/ or the user's setup). I think this should be a normal dependency similar to how "@clerk/shared" is used across the monorepo.

Seems to fix the issue I noticed: 
With `latest`: 
![image](https://github.com/clerk/javascript/assets/73396808/1d962098-3685-4fbc-90a5-98249588910d)

WIth snapshot of this PR:
![image](https://github.com/clerk/javascript/assets/73396808/9e7f2eba-bacc-4fbc-bd8f-59766372b950)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
