### PR TITLE
fix(localizations): review ko-KR (user profile - navbar)

### DIFF
--- a/.changeset/shy-phones-leave.md
+++ b/.changeset/shy-phones-leave.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Updates on ko-KR localization

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -653,10 +653,10 @@ export const koKR: LocalizationResource = {
     },
     mobileButton__menu: '메뉴',
     navbar: {
-      account: 'Profile',
+      account: '프로필',
       description: '계정 정보를 관리하세요.',
-      security: 'Security',
-      title: '게정',
+      security: '보안',
+      title: '계정',
     },
     passkeyScreen: {
       removeResource: {


### PR DESCRIPTION
## Description
Fixing typo and translating to Korean in the navbar of user profile in ko-KR localization

### Fixing typo
title: 게정 → 계정
### Translating
account: Profile → 프로필     (same as headerTitle__account: '프로필')
security: Security → 보안     (same as headerTitle__security: '보안')

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Fixing typo and translating to Korean in the navbar of user profile in ko-KR localization
