### PR TITLE
fix(repo): Adjust flaky sign up test

### DIFF
--- a/integration/tests/sign-up-flow.test.ts
+++ b/integration/tests/sign-up-flow.test.ts
@@ -54,7 +54,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('sign up f
     });
 
     // Check if password error is visible
-    await expect(u.page.getByText(/your password must contain \d+ or more characters/i)).toBeVisible();
+    await expect(u.page.getByText(/your password must contain \d+ or more characters/i).first()).toBeVisible();
 
     // Check if user is signed out
     await u.po.expect.toBeSignedOut();


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
One of our sign up tests has been flaking recently due to the fact that the test has been locating multiple elements with the password error message. This is a result of our our form field feedback is rendered, where one is an "info" and one is an "error". It's valid for both of these to be rendered, one visible and one hidden. This can be recreated on the Clerk Dashboard sign up form. Entering a password < 8 characters will render both info and feedback elements with the same message.

I'm not exactly sure why both are only rendered sometimes during this test, but we should be able to safely grab the first rendered element and assert on its visibility.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
