### PR TITLE
fix(clerk-js): Add descriptor for formatted dates in tables

### DIFF
--- a/.changeset/warm-candles-thank.md
+++ b/.changeset/warm-candles-thank.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add descriptor for formatted dates in tables. Those elements can be identified by the `cl-formattedDate__tableCell` css class.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -2,7 +2,7 @@ import { useOrganization, useUser } from '@clerk/shared/react';
 import type { OrganizationMembershipResource } from '@clerk/types';
 
 import { Protect } from '../../common/Gate';
-import { Badge, localizationKeys, Td, Text } from '../../customizables';
+import { Badge, Box, descriptors, localizationKeys, Td, Text } from '../../customizables';
 import { ThreeDotsMenu, useCardState, UserPreview } from '../../elements';
 import { useFetchRoles, useLocalizeCustomRoles } from '../../hooks/useFetchRoles';
 import { handleError } from '../../utils';
@@ -91,7 +91,15 @@ const MemberRow = (props: {
           badge={isCurrentUser && <Badge localizationKey={localizationKeys('badge__you')} />}
         />
       </Td>
-      <Td>{membership.createdAt.toLocaleDateString()}</Td>
+      <Td>
+        <Box
+          as='span'
+          elementDescriptor={descriptors.formattedDate}
+          elementId={descriptors.formattedDate.setId('tableCell')}
+        >
+          {membership.createdAt.toLocaleDateString()}
+        </Box>
+      </Td>
       <Td>
         <Protect
           permission={'org:sys_memberships:manage'}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -1,7 +1,7 @@
 import { useOrganization } from '@clerk/shared/react';
 import type { OrganizationInvitationResource } from '@clerk/types';
 
-import { localizationKeys, Td, Text } from '../../customizables';
+import { Box, descriptors, localizationKeys, Td, Text } from '../../customizables';
 import { ThreeDotsMenu, useCardState, UserPreview } from '../../elements';
 import { useFetchRoles, useLocalizeCustomRoles } from '../../hooks/useFetchRoles';
 import { handleError } from '../../utils';
@@ -79,7 +79,15 @@ const InvitationRow = (props: {
           user={{ primaryEmailAddress: { emailAddress: invitation.emailAddress } } as any}
         />
       </Td>
-      <Td>{invitation.createdAt.toLocaleDateString()}</Td>
+      <Td>
+        <Box
+          as='span'
+          elementDescriptor={descriptors.formattedDate}
+          elementId={descriptors.formattedDate.setId('tableCell')}
+        >
+          {invitation.createdAt.toLocaleDateString()}
+        </Box>
+      </Td>
       <Td>
         <Text
           colorScheme='secondary'

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
@@ -1,7 +1,7 @@
 import { useOrganization } from '@clerk/shared/react';
 import type { OrganizationMembershipRequestResource } from '@clerk/types';
 
-import { Button, Flex, localizationKeys, Td } from '../../customizables';
+import { Box, Button, descriptors, Flex, localizationKeys, Td } from '../../customizables';
 import { useCardState, UserPreview, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
 import { DataTable, RowContainer } from './MemberListTable';
@@ -84,7 +84,15 @@ const RequestRow = withCardStateProvider(
             user={{ primaryEmailAddress: { emailAddress: request.publicUserData.identifier } } as any}
           />
         </Td>
-        <Td>{request.createdAt.toLocaleDateString()}</Td>
+        <Td>
+          <Box
+            as='span'
+            elementDescriptor={descriptors.formattedDate}
+            elementId={descriptors.formattedDate.setId('tableCell')}
+          >
+            {request.createdAt.toLocaleDateString()}
+          </Box>
+        </Td>
 
         <Td>
           <AcceptRejectRequestButtons {...{ onAccept, onReject }} />

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -228,6 +228,8 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'formattedPhoneNumberFlag',
   'formattedPhoneNumberText',
 
+  'formattedDate',
+
   'scrollBox',
 
   'navbar',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -353,6 +353,8 @@ export type ElementsConfig = {
   formattedPhoneNumberFlag: WithOptions;
   formattedPhoneNumberText: WithOptions;
 
+  formattedDate: WithOptions<'tableCell'>;
+
   scrollBox: WithOptions;
 
   navbar: WithOptions;


### PR DESCRIPTION
## Description

This PR adds a descriptor for the formatted dates and a descriptor id that indicates the usage within a table

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
