### PR TITLE
fix(elements): Ensure missing passwordSettings don't throw

### DIFF
--- a/.changeset/strong-weeks-destroy.md
+++ b/.changeset/strong-weeks-destroy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Ensure missing passwordSettings don't throw an error

--- a/packages/elements/src/react/hooks/use-password.hook.ts
+++ b/packages/elements/src/react/hooks/use-password.hook.ts
@@ -20,7 +20,7 @@ type UsePasswordCallbacks = {
 export const usePassword = (callbacks?: UsePasswordCallbacks) => {
   const clerk = useClerk();
   const passwordSettings = clerk.__unstable__environment?.userSettings.passwordSettings as PasswordSettingsData;
-  const { disable_hibp, min_zxcvbn_strength, show_zxcvbn, ...config } = passwordSettings;
+  const { disable_hibp, min_zxcvbn_strength, show_zxcvbn, ...config } = passwordSettings || {};
 
   const {
     onValidationError = noop,


### PR DESCRIPTION
## Description

Password settings **could** be `undefined`, as such, we should handle that scenario.

<!-- Fixes #(issue number) -->

Fixes SDK-1801

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
