### PR TITLE
fix(clerk-js): Only render active sessions in devices section

### DIFF
--- a/.changeset/perfect-penguins-swim.md
+++ b/.changeset/perfect-penguins-swim.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Only render active sessions in the active devices section. Fixes the bug where a device with no information would render upon revoking.

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -28,12 +28,17 @@ export const ActiveDevicesSection = () => {
         {isLoading ? (
           <FullHeightLoader />
         ) : (
-          sessions?.sort(currentSessionFirst(session!.id)).map(sa => (
-            <DeviceItem
-              key={sa.id}
-              session={sa}
-            />
-          ))
+          sessions?.sort(currentSessionFirst(session!.id)).map(sa => {
+            if (sa.status !== 'active') {
+              return null;
+            }
+            return (
+              <DeviceItem
+                key={sa.id}
+                session={sa}
+              />
+            );
+          })
         )}
       </ProfileSection.ItemList>
     </ProfileSection.Root>

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -78,10 +78,10 @@ export const useFetch = <K, T>(
 
   useEffect(() => {
     const fetcherMissing = !fetcherRef.current;
-    const isCacheStale = Date.now() - (getCache()?.cachedAt || 0) < staleTime;
+    const isCacheStale = Date.now() - (getCache()?.cachedAt || 0) >= staleTime;
     const isRequestOnGoing = getCache()?.isValidating;
 
-    if (fetcherMissing || isCacheStale || isRequestOnGoing) {
+    if (fetcherMissing || !isCacheStale || isRequestOnGoing) {
       return;
     }
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fixes this view when revoking:
<img width="847" alt="Screenshot 2024-06-03 at 11 48 06" src="https://github.com/clerk/javascript/assets/73396808/ab357d39-642b-4c7b-bcca-5497481d740d">

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
