### PR TITLE
chore(clerk-expo): Support `EXPO_PUBLIC_` prefixes for env variables

### DIFF
--- a/.changeset/giant-poems-drum.md
+++ b/.changeset/giant-poems-drum.md
@@ -1,0 +1,10 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Support `EXPO_PUBLIC_` prefixes for env variables.
+```dotenv
+## .env
+
+EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=xxxxxxxx
+```

--- a/packages/expo/src/ClerkProvider.tsx
+++ b/packages/expo/src/ClerkProvider.tsx
@@ -15,7 +15,8 @@ export type ClerkProviderProps = ClerkReactProviderProps & {
 
 export function ClerkProvider(props: ClerkProviderProps): JSX.Element {
   const { children, tokenCache = MemoryTokenCache, publishableKey, ...rest } = props;
-  const key = publishableKey || process.env.CLERK_PUBLISHABLE_KEY || '';
+  const key =
+    publishableKey || process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY || process.env.CLERK_PUBLISHABLE_KEY || '';
 
   return (
     <ClerkReactProvider


### PR DESCRIPTION
## Description

The `EXPO_PUBLIC_` prefix is available since SDK 49. More details [here](https://docs.expo.dev/guides/environment-variables/)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
