### PR TITLE
fix: handle ppr error message refactor

### DIFF
--- a/.changeset/small-cycles-hug.md
+++ b/.changeset/small-cycles-hug.md
@@ -1,0 +1,9 @@
+---
+'@clerk/nextjs': patch
+---
+
+Updated the check ran against the error caught by `buildRequestLike()` to re-throw Static Bailout errors thrown by React in the context of PPR (Partial Pre-Rendering), as these errors shouldn't be caught. This change was required as we have been checking the error message itself, but stopped working after the message was changed in a Next.js update a few months ago.
+
+- Breaking PR: https://github.com/vercel/next.js/commit/3008af6b0e7b2c8aadd986bdcbce5bad6c39ccc8#diff-20c354509ae1e93e143d91b67b75e3df592c38b7d1ec6ccf7c4a2f72b32ab17d
+- Why PPR errors shouldn't be caught: https://nextjs.org/docs/messages/ppr-caught-error
+- Previous fix: https://github.com/clerk/javascript/pull/2518

--- a/packages/nextjs/src/app-router/server/utils.ts
+++ b/packages/nextjs/src/app-router/server/utils.ts
@@ -1,5 +1,22 @@
 import { NextRequest } from 'next/server';
 
+const isPrerenderingBailout = (e: unknown) => {
+  if (!(e instanceof Error) || !('message' in e)) return false;
+
+  const { message } = e;
+
+  const lowerCaseInput = message.toLowerCase();
+  const dynamicServerUsage = lowerCaseInput.includes('dynamic server usage');
+  const bailOutPrerendering = lowerCaseInput.includes('this page needs to bail out of prerendering');
+
+  // note: new error message syntax introduced in next@14.1.1-canary.21
+  // but we still want to support older versions.
+  // https://github.com/vercel/next.js/pull/61332 (dynamic-rendering.ts:153)
+  const routeRegex = /Route .*? needs to bail out of prerendering at this point because it used .*?./;
+
+  return routeRegex.test(message) || dynamicServerUsage || bailOutPrerendering;
+};
+
 export const buildRequestLike = () => {
   try {
     // Dynamically import next/headers, otherwise Next12 apps will break
@@ -8,15 +25,9 @@ export const buildRequestLike = () => {
     const { headers } = require('next/headers');
     return new NextRequest('https://placeholder.com', { headers: headers() });
   } catch (e: any) {
-    if (
-      e &&
-      'message' in e &&
-      typeof e.message === 'string' &&
-      (e.message.toLowerCase().includes('Dynamic server usage'.toLowerCase()) ||
-        e.message.toLowerCase().includes('This page needs to bail out of prerendering'.toLowerCase()))
-    ) {
-      throw e;
-    }
+    // rethrow the error when react throws a prerendering bailout
+    // https://nextjs.org/docs/messages/ppr-caught-error
+    if (e && isPrerenderingBailout(e)) throw e;
 
     throw new Error(
       `Clerk: auth() and currentUser() are only supported in App Router (/app directory).\nIf you're using /pages, try getAuth() instead.\nOriginal error: ${e}`,


### PR DESCRIPTION
## Description

in a [pull request introduced last january](https://github.com/vercel/next.js/commit/3008af6b0e7b2c8aadd986bdcbce5bad6c39ccc8#diff-20c354509ae1e93e143d91b67b75e3df592c38b7d1ec6ccf7c4a2f72b32ab17d) in next.js (`dynamic-rendering.ts:153`), the message passed in `React.unstable_postpone` thrown for PPR bailout was changed, meaning the check implemented by #2518 was not enough anymore, and the bailout was not being rethrown anymore, breaking next.js builds using ppr, and probably other issues. 

i've updated it to match the latest version, but kept the old check for the sake of not causing a breaking change.

to test:
- run a next.js build on an app that uses ppr with the latest version of @clerk/nextjs ([should fail](https://gist.github.com/ceIia/dacd8c2fe3f0363278bc4dff5f4a4004))
- run another build with this pr (shouldn't fail anymore)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
