### PR TITLE
chore(repo): Remove changeset check for renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Require Changeset
         if: ${{ !(github.event_name == 'merge_group') }}
-        run: if [ "${{ github.event.pull_request.user.login }}" = "clerk-cookie" ]; then echo 'Skipping' && exit 0; else npx changeset status --since=origin/main; fi
+        run: if [[ "${{ github.event.pull_request.user.login }}" = "clerk-cookie" || "${{ github.event.pull_request.user.login }}" = "renovate[bot]" ]]; then echo 'Skipping' && exit 0; else npx changeset status --since=origin/main; fi
 
       - name: Lint GitHub Actions Workflows
         run: npx eslint .github


### PR DESCRIPTION
## Description

According to https://unix.stackexchange.com/a/560315 you can use an OR in bash like that 😅 
This PR skips the required changeset check for Renovate PRs.

Got the login ID through checking with GitHub's API:

```json
  "url": "https://api.github.com/repos/clerk/javascript/pulls/3493",
  "id": 1898965849,
  "title": "fix(shared): Update minor & patch dependencies",
  "user": {
    "login": "renovate[bot]",
    "id": 29139614,
    "type": "Bot",
    "site_admin": false
  },
```

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
