### PR TITLE
ci(repo): Run CI workflow on `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   merge_group:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - release/v4


### PR DESCRIPTION
## Description

Resolves SDK-1253

CI is failing ([example](https://github.com/clerk/javascript/actions/runs/9370908226/job/25799186362?pr=3494)) on some PRs from forked repositories due to repo secrets not being available. 

Refer to the documentation for [Using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow): "With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository."



## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
