### PR TITLE
fix(clerk-js,types): Enable the ability to disable preparation on startEmailLinkFlow

### DIFF
--- a/.changeset/moody-items-sit.md
+++ b/.changeset/moody-items-sit.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Enable the ability to disable preparation of startEmailLinkFlow

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -50,14 +50,21 @@ export class EmailAddress extends BaseResource implements EmailAddressResource {
   createEmailLinkFlow = (): CreateEmailLinkFlowReturn<StartEmailLinkFlowParams, EmailAddressResource> => {
     const { run, stop } = Poller();
 
-    const startEmailLinkFlow = async ({ redirectUrl }: StartEmailLinkFlowParams): Promise<EmailAddressResource> => {
+    const startEmailLinkFlow = async ({
+      prepare = true,
+      redirectUrl,
+    }: StartEmailLinkFlowParams): Promise<EmailAddressResource> => {
       if (!this.id) {
         clerkVerifyEmailAddressCalledBeforeCreate('SignUp');
       }
-      await this.prepareVerification({
-        strategy: 'email_link',
-        redirectUrl: redirectUrl,
-      });
+
+      if (prepare) {
+        await this.prepareVerification({
+          strategy: 'email_link',
+          redirectUrl: redirectUrl,
+        });
+      }
+
       return new Promise((resolve, reject) => {
         void run(() => {
           return this.reload()

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -152,16 +152,21 @@ export class SignIn extends BaseResource implements SignInResource {
 
     const startEmailLinkFlow = async ({
       emailAddressId,
+      prepare = true,
       redirectUrl,
     }: SignInStartEmailLinkFlowParams): Promise<SignInResource> => {
       if (!this.id) {
         clerkVerifyEmailAddressCalledBeforeCreate('SignIn');
       }
-      await this.prepareFirstFactor({
-        strategy: 'email_link',
-        emailAddressId: emailAddressId,
-        redirectUrl: redirectUrl,
-      });
+
+      if (prepare) {
+        await this.prepareFirstFactor({
+          strategy: 'email_link',
+          emailAddressId: emailAddressId,
+          redirectUrl: redirectUrl,
+        });
+      }
+
       return new Promise((resolve, reject) => {
         void run(() => {
           return this.reload()

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -122,14 +122,20 @@ export class SignUp extends BaseResource implements SignUpResource {
   createEmailLinkFlow = (): CreateEmailLinkFlowReturn<StartEmailLinkFlowParams, SignUpResource> => {
     const { run, stop } = Poller();
 
-    const startEmailLinkFlow = async ({ redirectUrl }: StartEmailLinkFlowParams): Promise<SignUpResource> => {
+    const startEmailLinkFlow = async ({
+      prepare = true,
+      redirectUrl,
+    }: StartEmailLinkFlowParams): Promise<SignUpResource> => {
       if (!this.id) {
         clerkVerifyEmailAddressCalledBeforeCreate('SignUp');
       }
-      await this.prepareEmailAddressVerification({
-        strategy: 'email_link',
-        redirectUrl,
-      });
+
+      if (prepare) {
+        await this.prepareEmailAddressVerification({
+          strategy: 'email_link',
+          redirectUrl,
+        });
+      }
 
       return new Promise((resolve, reject) => {
         void run(() => {

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -123,7 +123,6 @@ export function _SignInFactorOne(): JSX.Element {
   }
 
   switch (currentFactor?.strategy) {
-    // @ts-ignore
     case 'passkey':
       return (
         <SignInFactorOnePasskey

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
@@ -35,6 +35,7 @@ export const SignInFactorOneEmailLinkCard = (props: SignInFactorOneEmailLinkCard
 
   React.useEffect(() => {
     void startEmailLinkVerification();
+    props.onFactorPrepare();
   }, []);
 
   const restartVerification = () => {
@@ -45,6 +46,7 @@ export const SignInFactorOneEmailLinkCard = (props: SignInFactorOneEmailLinkCard
   const startEmailLinkVerification = () => {
     startEmailLinkFlow({
       emailAddressId: props.factor.emailAddressId,
+      prepare: !props.factorAlreadyPrepared,
       redirectUrl: buildEmailLinkRedirectUrl(signInContext, signInUrl),
     })
       .then(res => handleVerificationResult(res))

--- a/packages/nextjs/src/client-boundary/hooks/useEnforceCatchAllRoute.tsx
+++ b/packages/nextjs/src/client-boundary/hooks/useEnforceCatchAllRoute.tsx
@@ -64,27 +64,27 @@ To resolve this, ensure that the middleware does not protect the catch-all route
         error();
       }
     } else {
-      const check = async () => {
-        // make sure to run this as soon as possible
-        // but don't run again when strict mode is enabled
-        ref.current++;
-        if (ref.current > 1) {
-          return;
-        }
-        let res;
-        try {
-          const url = `${window.location.origin}${
-            window.location.pathname
-          }/${component}_clerk_catchall_check_${Date.now()}`;
-          res = await fetch(url, { signal: ac.signal });
-        } catch (e) {
-          // no op
-        }
-        if (res?.status === 404) {
-          error();
-        }
-      };
-      void check();
+      // const check = async () => {
+      //   // make sure to run this as soon as possible
+      //   // but don't run again when strict mode is enabled
+      //   ref.current++;
+      //   if (ref.current > 1) {
+      //     return;
+      //   }
+      //   let res;
+      //   try {
+      //     const url = `${window.location.origin}${
+      //       window.location.pathname
+      //     }/${component}_clerk_catchall_check_${Date.now()}`;
+      //     res = await fetch(url, { signal: ac.signal });
+      //   } catch (e) {
+      //     // no op
+      //   }
+      //   if (res?.status === 404) {
+      //     error();
+      //   }
+      // };
+      // void check();
     }
 
     return () => {

--- a/packages/types/src/verification.ts
+++ b/packages/types/src/verification.ts
@@ -33,6 +33,7 @@ export interface SignatureVerificationAttemptParam {
 export type VerificationAttemptParams = CodeVerificationAttemptParam | SignatureVerificationAttemptParam;
 
 export interface StartEmailLinkFlowParams {
+  prepare?: boolean;
   redirectUrl: string;
 }
 


### PR DESCRIPTION
## Description

TODO

<!-- Fixes #(issue number) -->

Fixes SDK-1799

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
