### PR TITLE
fix(repo): Actually run Next.js integration for v13 & v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
     strategy:
       matrix:
-        test-name: [ 'generic', 'nextjs', 'express', 'quickstart', 'ap-flows', 'elements' ]
+        test-name: ['generic', 'express', 'quickstart', 'ap-flows', 'elements']
         test-project: ['chrome']
         include:
           - test-name: 'nextjs'


### PR DESCRIPTION
## Description

The PR https://github.com/clerk/javascript/pull/3431 was in the correct state at some point but when it was merged the functionality of running the integration tests of Next.js both in Next 13 and 14 actually didn't work.

After reading https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-expanding-configurations I think what we had previously won't work.

Proof that Next 13 is used:
https://github.com/clerk/javascript/actions/runs/9379903450/job/25825965337?pr=3516#step:7:91

Proof that Next 14 is used:
https://github.com/clerk/javascript/actions/runs/9379903450/job/25825965564?pr=3516#step:7:89

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
