### PR TITLE
fix(testing): Improve error when clerkSetup does not run before tests

### DIFF
--- a/.changeset/clean-beds-count.md
+++ b/.changeset/clean-beds-count.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Improve the error message when `setupClerkTestingToken` cannot find the FAPI URL

--- a/packages/testing/src/common/errors.ts
+++ b/packages/testing/src/common/errors.ts
@@ -1,0 +1,3 @@
+export const ERROR_MISSING_FRONTEND_API_URL =
+  'The Clerk Frontend API URL is required to bypass bot protection. ' +
+  'Make sure the clerkSetup function is called during your global setup before setupClerkTestingToken is called.';

--- a/packages/testing/src/common/index.ts
+++ b/packages/testing/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './types';
 export * from './setup';
+export * from './errors';

--- a/packages/testing/src/cypress/setupClerkTestingToken.ts
+++ b/packages/testing/src/cypress/setupClerkTestingToken.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 import type { SetupClerkTestingTokenOptions } from '../common';
-import { TESTING_TOKEN_PARAM } from '../common';
+import { ERROR_MISSING_FRONTEND_API_URL, TESTING_TOKEN_PARAM } from '../common';
 
 type SetupClerkTestingTokenParams = {
   options?: SetupClerkTestingTokenOptions;
@@ -24,7 +24,7 @@ type SetupClerkTestingTokenParams = {
 export const setupClerkTestingToken = (params?: SetupClerkTestingTokenParams) => {
   const fapiUrl = params?.options?.frontendApiUrl || Cypress.env('CLERK_FAPI');
   if (!fapiUrl) {
-    throw new Error('The Frontend API URL is required to bypass bot protection.');
+    throw new Error(ERROR_MISSING_FRONTEND_API_URL);
   }
   const apiUrl = `https://${fapiUrl}/v1/**`;
 

--- a/packages/testing/src/playwright/setupClerkTestingToken.ts
+++ b/packages/testing/src/playwright/setupClerkTestingToken.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 import type { SetupClerkTestingTokenOptions } from '../common';
-import { TESTING_TOKEN_PARAM } from '../common';
+import { ERROR_MISSING_FRONTEND_API_URL, TESTING_TOKEN_PARAM } from '../common';
 
 type SetupClerkTestingTokenParams = {
   page: Page;
@@ -27,7 +27,7 @@ type SetupClerkTestingTokenParams = {
 export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestingTokenParams) => {
   const fapiUrl = options?.frontendApiUrl || process.env.CLERK_FAPI;
   if (!fapiUrl) {
-    throw new Error('The Frontend API URL is required to bypass bot protection.');
+    throw new Error(ERROR_MISSING_FRONTEND_API_URL);
   }
   const apiUrl = `https://${fapiUrl}/v1/**/*`;
 


### PR DESCRIPTION
## Description

When `setupClerkTestingToken` cannot find the FAPI URL, it means that the `clerkSetup` function has not initialized properly on the global setup step.

This PR improves the error message thrown to say the following:
`The Clerk Frontend API URL is required to bypass bot protection. Make sure the clerkSetup function is called during your global setup before setupClerkTestingToken is called.`

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
