### PR TITLE
feat(clerk-js): Add title attribute to organization preview

### DIFF
--- a/.changeset/warm-shoes-dance.md
+++ b/.changeset/warm-shoes-dance.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+feat: add title attribute to organization preview so truncated org names are able to be previewed without requiring a user to switch to a different org

--- a/.changeset/warm-shoes-dance.md
+++ b/.changeset/warm-shoes-dance.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-feat: add title attribute to organization preview so truncated org names are able to be previewed without requiring a user to switch to a different org
+Add the `title` attribute to `<OrganizationPreview>` component so that truncated organization names can be previewed e.g. through hovering

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -89,6 +89,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
           as='span'
           truncate
           sx={mainIdentifierSx}
+          title={organization.name}
         >
           {organization.name} {badge}
         </Text>


### PR DESCRIPTION
Adds a `title` attribute to the span rendered for organization previews so that users can hover and see the full organization name without having to switch.

<img width="2156" alt="Screenshot 2024-06-05 at 3 08 49 PM" src="https://github.com/clerk/javascript/assets/69559/e26ab232-e037-4268-ba47-f42242a7974d">
