### PR TITLE
fix(backend,shared,clerk-js): Improve cookie suffixes

### DIFF
--- a/packages/backend/src/tokens/__tests__/authenticateContext.test.ts
+++ b/packages/backend/src/tokens/__tests__/authenticateContext.test.ts
@@ -2,6 +2,7 @@ import type QUnit from 'qunit';
 import sinon from 'sinon';
 
 import { createCookieHeader, createJwt, mockJwtPayload, pkLive, pkTest } from '../../fixtures';
+import { getCookieSuffix } from '../../util/shared';
 import { createAuthenticateContext } from '../authenticateContext';
 import { createClerkRequest } from '../clerkRequest';
 
@@ -30,7 +31,7 @@ export default (QUnit: QUnit) => {
     });
     module('suffixedCookies', () => {
       module('use un-suffixed cookies', () => {
-        test('request with un-suffixed cookies', assert => {
+        test('request with un-suffixed cookies', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: clientUat,
@@ -38,7 +39,7 @@ export default (QUnit: QUnit) => {
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
 
@@ -47,19 +48,19 @@ export default (QUnit: QUnit) => {
           assert.equal(context.clientUat, clientUat);
         });
 
-        test('request with suffixed and valid newer un-suffixed cookies - case of ClerkJS downgrade', assert => {
+        test('request with suffixed and valid newer un-suffixed cookies - case of ClerkJS downgrade', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: clientUat,
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedClientUat,
+              __client_uat_MqCvchyS: suffixedClientUat,
               __session: newSession,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
+              __session_MqCvchyS: suffixedSession,
               __clerk_db_jwt: '__clerk_db_jwt',
-              __clerk_db_jwt_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '__clerk_db_jwt-suffixed',
+              __clerk_db_jwt_MqCvchyS: '__clerk_db_jwt-suffixed',
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
 
@@ -69,17 +70,17 @@ export default (QUnit: QUnit) => {
           assert.equal(context.devBrowserToken, '__clerk_db_jwt');
         });
 
-        test('request with suffixed client_uat as signed-out and un-suffixed client_uat as signed-in - case of ClerkJS downgrade', assert => {
+        test('request with suffixed client_uat as signed-out and un-suffixed client_uat as signed-in - case of ClerkJS downgrade', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: clientUat,
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '0',
+              __client_uat_vWCgMp3A: '0',
               __session: session,
               __clerk_db_jwt: '__clerk_db_jwt',
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkTest,
           });
 
@@ -88,17 +89,17 @@ export default (QUnit: QUnit) => {
           assert.equal(context.clientUat, clientUat);
         });
 
-        test('prod: request with suffixed session and signed-out suffixed client_uat', assert => {
+        test('prod: request with suffixed session and signed-out suffixed client_uat', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: '0',
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '0',
+              __client_uat_MqCvchyS: '0',
               __session: session,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
+              __session_MqCvchyS: suffixedSession,
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
 
@@ -109,17 +110,17 @@ export default (QUnit: QUnit) => {
       });
 
       module('use suffixed cookies', () => {
-        test('prod: request with valid suffixed and un-suffixed cookies', assert => {
+        test('prod: request with valid suffixed and un-suffixed cookies', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: clientUat,
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedClientUat,
+              __client_uat_MqCvchyS: suffixedClientUat,
               __session: session,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
+              __session_MqCvchyS: suffixedSession,
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
           assert.true(context.suffixedCookies);
@@ -127,17 +128,17 @@ export default (QUnit: QUnit) => {
           assert.equal(context.clientUat, suffixedClientUat);
         });
 
-        test('prod: request with invalid issuer un-suffixed and valid suffixed cookies - case of multiple apps on same eTLD+1 domain', assert => {
+        test('prod: request with invalid issuer un-suffixed and valid suffixed cookies - case of multiple apps on same eTLD+1 domain', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: clientUat,
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedClientUat,
+              __client_uat_MqCvchyS: suffixedClientUat,
               __session: sessionWithInvalidIssuer,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
+              __session_MqCvchyS: suffixedSession,
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
           assert.true(context.suffixedCookies);
@@ -145,27 +146,27 @@ export default (QUnit: QUnit) => {
           assert.equal(context.clientUat, suffixedClientUat);
         });
 
-        test('dev: request with invalid issuer un-suffixed and valid multiple suffixed cookies - case of multiple apps on localhost', assert => {
+        test('dev: request with invalid issuer un-suffixed and valid multiple suffixed cookies - case of multiple apps on localhost', async assert => {
           const blahSession = createJwt({ payload: { iss: 'http://blah' } });
           const fooSession = createJwt({ payload: { iss: 'http://foo' } });
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: '0',
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '0',
-              __client_uat_Y2xlcmsuYmxhaC5wdW1hLTc1LmxjbC5kZXYk: '1717490193',
-              __client_uat_Y2xlcmsuZm9vLnB1bWEtNzUubGNsLmRldiQ: '1717490194',
+              __client_uat_vWCgMp3A: '0',
+              __client_uat_8HKF1r6W: '1717490193',
+              __client_uat_Rmi8c5i8: '1717490194',
               __session: session,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
-              __session_Y2xlcmsuYmxhaC5wdW1hLTc1LmxjbC5kZXYk: blahSession,
-              __session_Y2xlcmsuZm9vLnB1bWEtNzUubGNsLmRldiQ: fooSession,
+              __session_vWCgMp3A: suffixedSession,
+              __session_8HKF1r6W: blahSession,
+              __session_Rmi8c5i8: fooSession,
               __clerk_db_jwt: '__clerk_db_jwt',
-              __clerk_db_jwt_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '__clerk_db_jwt-suffixed',
-              __clerk_db_jwt_Y2xlcmsuYmxhaC5wdW1hLTc1LmxjbC5kZXYk: '__clerk_db_jwt-suffixed-blah',
-              __clerk_db_jwt_Y2xlcmsuZm9vLnB1bWEtNzUubGNsLmRldiQ: '__clerk_db_jwt-suffixed-foo',
+              __clerk_db_jwt_vWCgMp3A: '__clerk_db_jwt-suffixed',
+              __clerk_db_jwt_8HKF1r6W: '__clerk_db_jwt-suffixed-blah',
+              __clerk_db_jwt_Rmi8c5i8: '__clerk_db_jwt-suffixed-foo',
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkTest,
           });
 
@@ -175,19 +176,19 @@ export default (QUnit: QUnit) => {
           assert.equal(context.devBrowserToken, '__clerk_db_jwt-suffixed');
         });
 
-        test('dev: request with suffixed session and signed-out suffixed client_uat', assert => {
+        test('dev: request with suffixed session and signed-out suffixed client_uat', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: '0',
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '0',
+              __client_uat_vWCgMp3A: '0',
               __session: session,
-              __session_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: suffixedSession,
+              __session_vWCgMp3A: suffixedSession,
               __clerk_db_jwt: '__clerk_db_jwt',
-              __clerk_db_jwt_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '__clerk_db_jwt-suffixed',
+              __clerk_db_jwt_vWCgMp3A: '__clerk_db_jwt-suffixed',
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkTest,
           });
 
@@ -197,16 +198,16 @@ export default (QUnit: QUnit) => {
           assert.equal(context.devBrowserToken, '__clerk_db_jwt-suffixed');
         });
 
-        test('prod: request without suffixed session and signed-out suffixed client_uat', assert => {
+        test('prod: request without suffixed session and signed-out suffixed client_uat', async assert => {
           const headers = new Headers({
             cookie: createCookieHeader({
               __client_uat: '0',
-              __client_uat_Y2xlcmsuaW5zcGlyZWQucHVtYS03NC5sY2wuZGV2JA: '0',
+              __client_uat_MqCvchyS: '0',
               __session: session,
             }),
           });
           const clerkRequest = createClerkRequest(new Request('http://example.com', { headers }));
-          const context = createAuthenticateContext(clerkRequest, {
+          const context = await createAuthenticateContext(clerkRequest, {
             publishableKey: pkLive,
           });
 
@@ -215,6 +216,25 @@ export default (QUnit: QUnit) => {
           assert.equal(context.clientUat, '0');
         });
       });
+    });
+  });
+
+  // Added these tests to verify that the generated sha-1 is the same as the one used in cookie assignment
+  // Tests copied from packages/shared/src/__tests__/keys.test.ts
+  module('getCookieSuffix(publishableKey)', () => {
+    test('given `pk_live_Y2xlcmsuY2xlcmsuZGV2JA` pk, returns `1Z8AzTQD` cookie suffix', async assert => {
+      assert.equal(await getCookieSuffix('pk_live_Y2xlcmsuY2xlcmsuZGV2JA'), '1Z8AzTQD');
+    });
+
+    test('given `pk_test_Y2xlcmsuY2xlcmsuZGV2JA` pk, returns `QvfNY2dr` cookie suffix', async assert => {
+      assert.equal(await getCookieSuffix('pk_test_Y2xlcmsuY2xlcmsuZGV2JA'), 'QvfNY2dr');
+    });
+
+    test('omits special characters from the cookie suffix', async assert => {
+      const pk = 'pk_test_ZW5vdWdoLWFscGFjYS04Mi5jbGVyay5hY2NvdW50cy5sY2xjbGVyay5jb20k';
+      assert.equal(await getCookieSuffix(pk), 'jtYvyt_H');
+      const pk2 = 'pk_test_eHh4eHh4LXhhYWFhYS1hYS5jbGVyay5hY2NvdW50cy5sY2xjbGVyay5jb20k';
+      assert.equal(await getCookieSuffix(pk2), 'tZJdb-5s');
     });
   });
 };

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -62,7 +62,7 @@ export async function authenticateRequest(
   request: Request,
   options: AuthenticateRequestOptions,
 ): Promise<RequestState> {
-  const authenticateContext = createAuthenticateContext(createClerkRequest(request), options);
+  const authenticateContext = await createAuthenticateContext(createClerkRequest(request), options);
   assertValidSecretKey(authenticateContext.secretKey);
 
   if (authenticateContext.isSatellite) {

--- a/packages/backend/src/util/optionsAssertions.ts
+++ b/packages/backend/src/util/optionsAssertions.ts
@@ -1,4 +1,4 @@
-import { parsePublishableKey } from '@clerk/shared/keys';
+import { parsePublishableKey } from './shared';
 
 export function assertValidSecretKey(val: unknown): asserts val is string {
   if (!val || typeof val !== 'string') {

--- a/packages/backend/src/util/shared.ts
+++ b/packages/backend/src/util/shared.ts
@@ -5,6 +5,7 @@ export {
   isProductionFromSecretKey,
   parsePublishableKey,
   getCookieSuffix,
+  getSuffixedCookieName,
 } from '@clerk/shared/keys';
 export { deprecated, deprecatedProperty } from '@clerk/shared/deprecated';
 

--- a/packages/clerk-js/src/core/auth/cookies/clientUat.ts
+++ b/packages/clerk-js/src/core/auth/cookies/clientUat.ts
@@ -19,9 +19,9 @@ export type ClientUatCookieHandler = {
  * The cookie is used as hint from the Clerk Backend packages to identify
  * if the user is authenticated or not.
  */
-export const createClientUatCookie = (publishableKey: string): ClientUatCookieHandler => {
+export const createClientUatCookie = (cookieSuffix: string): ClientUatCookieHandler => {
   const clientUatCookie = createCookieHandler(CLIENT_UAT_COOKIE_NAME);
-  const suffixedClientUatCookie = createCookieHandler(getSuffixedCookieName(CLIENT_UAT_COOKIE_NAME, publishableKey));
+  const suffixedClientUatCookie = createCookieHandler(getSuffixedCookieName(CLIENT_UAT_COOKIE_NAME, cookieSuffix));
 
   const get = (): number => {
     const value = suffixedClientUatCookie.get() || clientUatCookie.get();

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -17,9 +17,9 @@ export type DevBrowserCookieHandler = {
  * The cookie is used to authenticate FAPI requests and pass
  * authentication from AP to the app.
  */
-export const createDevBrowserCookie = (publishableKey: string): DevBrowserCookieHandler => {
+export const createDevBrowserCookie = (cookieSuffix: string): DevBrowserCookieHandler => {
   const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_KEY);
-  const suffixedDevBrowserCookie = createCookieHandler(getSuffixedCookieName(DEV_BROWSER_JWT_KEY, publishableKey));
+  const suffixedDevBrowserCookie = createCookieHandler(getSuffixedCookieName(DEV_BROWSER_JWT_KEY, cookieSuffix));
 
   const get = () => suffixedDevBrowserCookie.get() || devBrowserCookie.get();
 

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -16,9 +16,9 @@ export type SessionCookieHandler = {
  * The cookie is used by the Clerk backend SDKs to identify
  * the authenticated user.
  */
-export const createSessionCookie = (publishableKey: string): SessionCookieHandler => {
+export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler => {
   const sessionCookie = createCookieHandler(SESSION_COOKIE_NAME);
-  const suffixedSessionCookie = createCookieHandler(getSuffixedCookieName(SESSION_COOKIE_NAME, publishableKey));
+  const suffixedSessionCookie = createCookieHandler(getSuffixedCookieName(SESSION_COOKIE_NAME, cookieSuffix));
 
   const remove = () => {
     suffixedSessionCookie.remove();

--- a/packages/clerk-js/src/core/auth/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/devBrowser.ts
@@ -21,12 +21,12 @@ export interface DevBrowser {
 
 export type CreateDevBrowserOptions = {
   frontendApi: string;
-  publishableKey: string;
+  cookieSuffix: string;
   fapiClient: FapiClient;
 };
 
-export function createDevBrowser({ publishableKey, frontendApi, fapiClient }: CreateDevBrowserOptions): DevBrowser {
-  const devBrowserCookie = createDevBrowserCookie(publishableKey);
+export function createDevBrowser({ cookieSuffix, frontendApi, fapiClient }: CreateDevBrowserOptions): DevBrowser {
+  const devBrowserCookie = createDevBrowserCookie(cookieSuffix);
 
   function getDevBrowserJWT() {
     return devBrowserCookie.get();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -159,7 +159,7 @@ export class Clerk implements ClerkInterface {
   #publishableKey: string = '';
   #domain: DomainOrProxyUrl['domain'];
   #proxyUrl: DomainOrProxyUrl['proxyUrl'];
-  #authService: AuthCookieService | null = null;
+  #authService?: AuthCookieService;
   #broadcastChannel: LocalStorageBroadcastChannel<ClerkCoreBroadcastChannelEvent> | null = null;
   #componentControls?: ReturnType<MountComponentRenderer> | null;
   //@ts-expect-error with being undefined even though it's not possible - related to issue with ts and error thrower
@@ -1504,7 +1504,7 @@ export class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    this.#authService = new AuthCookieService(this, this.#fapiClient);
+    this.#authService = await AuthCookieService.create(this, this.#fapiClient);
 
     /**
      * 1. Multi-domain SSO handling

--- a/packages/shared/jest.setup.ts
+++ b/packages/shared/jest.setup.ts
@@ -1,3 +1,7 @@
+import { webcrypto } from 'node:crypto';
+
+import { TextDecoder, TextEncoder } from 'util';
+
 const navigatorMock = {};
 
 Object.defineProperty(navigatorMock, 'userAgent', {
@@ -32,3 +36,10 @@ Object.defineProperty(global.window, 'navigator', {
   value: navigatorMock,
   writable: true,
 });
+
+// polyfill TextDecoder, TextEncoder for jsdom >= 16
+Object.assign(global, { TextDecoder, TextEncoder });
+
+// polyfill using webcrypto.subtle to fix issue with missing crypto.subtle
+// @ts-ignore
+globalThis.crypto.subtle = webcrypto.subtle;

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -1,6 +1,7 @@
 import {
   buildPublishableKey,
   createDevOrStagingUrlCache,
+  getCookieSuffix,
   isDevelopmentFromPublishableKey,
   isDevelopmentFromSecretKey,
   isProductionFromPublishableKey,
@@ -162,5 +163,24 @@ describe('isProductionFromSecretKey(key)', () => {
   test.each(cases)('given %p as a secret key string, returns %p', (secretKeyStr, expected) => {
     const result = isProductionFromSecretKey(secretKeyStr);
     expect(result).toEqual(expected);
+  });
+});
+
+describe('getCookieSuffix(publishableKey)', () => {
+  const cases: Array<[string, string]> = [
+    ['pk_live_Y2xlcmsuY2xlcmsuZGV2JA', '1Z8AzTQD'],
+    ['pk_test_Y2xlcmsuY2xlcmsuZGV2JA', 'QvfNY2dr'],
+  ];
+
+  test.each(cases)('given %p pk, returns %p cookie suffix', async (pk, expected) => {
+    expect(await getCookieSuffix(pk)).toEqual(expected);
+  });
+
+  test('omits special characters from the cookie suffix', async () => {
+    const pk = 'pk_test_ZW5vdWdoLWFscGFjYS04Mi5jbGVyay5hY2NvdW50cy5sY2xjbGVyay5jb20k';
+    expect(await getCookieSuffix(pk)).toEqual('jtYvyt_H');
+
+    const pk2 = 'pk_test_eHh4eHh4LXhhYWFhYS1hYS5jbGVyay5hY2NvdW50cy5sY2xjbGVyay5jb20k';
+    expect(await getCookieSuffix(pk2)).toEqual('tZJdb-5s');
   });
 });

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -110,10 +110,14 @@ export function isProductionFromSecretKey(apiKey: string): boolean {
   return apiKey.startsWith('live_') || apiKey.startsWith('sk_live_');
 }
 
-export const getCookieSuffix = (publishableKey: string): string => {
-  return publishableKey.split('_').pop() || '';
-};
+export async function getCookieSuffix(publishableKey: string): Promise<string> {
+  const data = new TextEncoder().encode(publishableKey);
+  const digest = await globalThis.crypto.subtle.digest('sha-1', data);
+  const stringDigest = String.fromCharCode(...new Uint8Array(digest));
+  // Base 64 Encoding with URL and Filename Safe Alphabet: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+  return isomorphicBtoa(stringDigest).replace(/\+/gi, '-').replace(/\//gi, '_').substring(0, 8);
+}
 
-export const getSuffixedCookieName = (cookieName: string, publishableKey: string): string => {
-  return `${cookieName}_${getCookieSuffix(publishableKey)}`;
+export const getSuffixedCookieName = (cookieName: string, cookieSuffix: string): string => {
+  return `${cookieName}_${cookieSuffix}`;
 };


### PR DESCRIPTION
## Description

Improve the cookie suffixes from the publishableKey to a fixed length 8 char string (hashed substring of publishableKey) to reduce the cookie size.
This change will also reduce the handshake payload by ~ 120 bytes.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
