### PR TITLE
feat(ui): Add bundlewatch config

### DIFF
--- a/packages/ui/bundlewatch.config.json
+++ b/packages/ui/bundlewatch.config.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    { "path": "./dist/components/sign-in.js", "maxSize": "40kB" },
+    { "path": "./dist/components/sign-up.js", "maxSize": "40kB" }
+  ]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "dev:theme-builder": "concurrently \"npm run dev\" \"cd theme-builder && npm run dev\""
+    "dev:theme-builder": "concurrently \"npm run dev\" \"cd theme-builder && npm run dev\"",
+    "bundlewatch": "npx bundlewatch --config bundlewatch.config.json"
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.2.4",


### PR DESCRIPTION
## Description

Adds bundlewatch config to ui directory and set arbitrary limits for both the sign-in and sign-up components. Limits are definitely open for discussion.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
