### PR TITLE
feat(ui): Implement resendable ui

### DIFF
--- a/packages/ui/src/components/sign-up/sign-up.tsx
+++ b/packages/ui/src/components/sign-up/sign-up.tsx
@@ -173,18 +173,21 @@ function SignUpComponentLoaded() {
                       <OTPField
                         disabled={isGlobalLoading}
                         // TODO:
-                        // 1. Replace `button` with `SignIn.Action` when `exampleMode` is removed
-                        // 2. Replace `button` with consolidated styles (tackled later)
+                        // 1. Replace `button` with consolidated styles (tackled later)
                         resend={
-                          <>
-                            Didn&apos;t recieve a code?{' '}
-                            <button
-                              type='button'
-                              className='text-accent-9 focus-visible:ring-default -mx-0.5 rounded-sm px-0.5 font-medium outline-none hover:underline focus-visible:ring-2'
-                            >
-                              Resend
-                            </button>
-                          </>
+                          <SignUp.Action
+                            asChild
+                            resend
+                            // eslint-disable-next-line react/no-unstable-nested-components
+                            fallback={({ resendableAfter }) => (
+                              <p className='text-gray-9 border border-transparent px-2.5 py-1.5 text-base font-medium'>
+                                Didn&apos;t recieve a code? Resend (
+                                <span className='tabular-nums'>{resendableAfter}</span>)
+                              </p>
+                            )}
+                          >
+                            <TextButton>Didn&apos;t recieve a code? Resend</TextButton>
+                          </SignUp.Action>
                         }
                       />
                       <Common.Loading scope='step:verifications'>
@@ -217,18 +220,21 @@ function SignUpComponentLoaded() {
                       <OTPField
                         disabled={isGlobalLoading}
                         // TODO:
-                        // 1. Replace `button` with `SignIn.Action` when `exampleMode` is removed
-                        // 2. Replace `button` with consolidated styles (tackled later)
+                        // 1. Replace `button` with consolidated styles (tackled later)
                         resend={
-                          <>
-                            Didn&apos;t recieve a code?{' '}
-                            <button
-                              type='button'
-                              className='text-accent-9 focus-visible:ring-default -mx-0.5 rounded-sm px-0.5 font-medium outline-none hover:underline focus-visible:ring-2'
-                            >
-                              Resend
-                            </button>
-                          </>
+                          <SignUp.Action
+                            asChild
+                            resend
+                            // eslint-disable-next-line react/no-unstable-nested-components
+                            fallback={({ resendableAfter }) => (
+                              <p className='text-gray-9 border border-transparent px-2.5 py-1.5 text-base font-medium'>
+                                Didn&apos;t recieve a code? Resend (
+                                <span className='tabular-nums'>{resendableAfter}</span>)
+                              </p>
+                            )}
+                          >
+                            <TextButton>Didn&apos;t recieve a code? Resend</TextButton>
+                          </SignUp.Action>
                         }
                       />
                       <Common.Loading scope='step:verifications'>


### PR DESCRIPTION
## Description


https://linear.app/clerk/issue/SDKI-43/implement-resendable-and-resendablefallback-primitives

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
