### PR TITLE
fix(nextjs): Make exported server action async

### DIFF
--- a/.changeset/smart-pants-rule.md
+++ b/.changeset/smart-pants-rule.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Makes the internally used `invalidateCacheAction()` server action an async function to comply with server actions constraints. More information: https://nextjs.org/docs/messages/invalid-use-server-value

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -57,7 +57,7 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
       return new Promise(res => {
         window.__clerk_internal_invalidateCachePromise = res;
         startTransition(() => {
-          //@ts-expect-error next exitsts on window
+          //@ts-expect-error next exists on window
           if (window.next?.version && typeof window.next.version === 'string' && window.next.version.startsWith('13')) {
             router.refresh();
           } else {

--- a/packages/nextjs/src/app-router/server-actions/invalidateCache.ts
+++ b/packages/nextjs/src/app-router/server-actions/invalidateCache.ts
@@ -2,6 +2,10 @@
 
 import { cookies } from 'next/headers';
 
+// This function needs to be async as we'd like to support next versions in the range of [14.1.2,14.2.0)
+// These versions required 'use server' files to export async methods only. This check was later relaxed
+// and the async is no longer required in newer next versions.
+// ref: https://github.com/vercel/next.js/pull/62821
 export async function invalidateCacheAction() {
   return cookies().delete(`__clerk_invalidate_cache_cookie_${Date.now()}`);
 }

--- a/packages/nextjs/src/app-router/server-actions/invalidateCache.ts
+++ b/packages/nextjs/src/app-router/server-actions/invalidateCache.ts
@@ -2,6 +2,6 @@
 
 import { cookies } from 'next/headers';
 
-export function invalidateCacheAction() {
+export async function invalidateCacheAction() {
   return cookies().delete(`__clerk_invalidate_cache_cookie_${Date.now()}`);
 }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fixes a reported issue where the following error was reported: https://nextjs.org/docs/messages/invalid-use-server-value

I'm not able to reproduce myself across a number of versions, but based on the documentation above, this function must be async, so I'm updating it.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
