### PR TITLE
fix(elements): Sign-in/up root fallbacks not rendering properly

### DIFF
--- a/.changeset/friendly-dots-join.md
+++ b/.changeset/friendly-dots-join.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fix Sign In & Sign Up root fallbacks not rendering as expected

--- a/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
@@ -69,14 +69,6 @@ export default function SignUpPage() {
                 <Clerk.Icon />
                 Sign In with Google
               </Clerk.Connection>
-
-              <Clerk.Connection
-                name='metamask'
-                className='flex items-center justify-center gap-4 rounded bg-white px-4 py-3 text-sm text-[#161616] shadow-sm ring-1 ring-black/[0.06] transition-all hover:bg-opacity-80'
-              >
-                <Clerk.Icon />
-                Sign In with Metamask
-              </Clerk.Connection>
             </div>
 
             <Hr />
@@ -141,14 +133,6 @@ export default function SignUpPage() {
               >
                 <Clerk.Icon />
                 Sign In with Google
-              </Clerk.Connection>
-
-              <Clerk.Connection
-                name='metamask'
-                className='flex items-center justify-center gap-4 rounded bg-white px-4 py-3 text-sm text-[#161616] shadow-sm ring-1 ring-black/[0.06] transition-all hover:bg-opacity-80'
-              >
-                <Clerk.Icon />
-                Sign In with Metamask
               </Clerk.Connection>
             </div>
 

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -356,7 +356,8 @@ const useInput = ({
 const FORM_NAME = 'ClerkElementsForm';
 
 type FormElement = React.ElementRef<typeof RadixForm>;
-type FormProps = SetRequired<RadixFormProps, 'children'> & {
+type FormProps = Omit<RadixFormProps, 'children'> & {
+  children: React.ReactNode;
   flowActor?: BaseActorRef<{ type: 'SUBMIT' }>;
 };
 

--- a/packages/elements/src/react/sign-in/root.tsx
+++ b/packages/elements/src/react/sign-in/root.tsx
@@ -18,6 +18,9 @@ import { usePathnameWithoutCatchAll } from '../utils/path-inference/next';
 type SignInFlowProviderProps = {
   children: React.ReactNode;
   exampleMode?: boolean;
+  /**
+   * Fallback markup to render while Clerk is loading
+   */
   fallback?: React.ReactNode;
   isRootPath: boolean;
 };
@@ -71,11 +74,7 @@ function SignInFlowProvider({ children, exampleMode, fallback, isRootPath }: Sig
   );
 }
 
-export type SignInRootProps = SignInFlowProviderProps & {
-  /**
-   * Fallback markup to render while Clerk is loading
-   */
-  fallback?: React.ReactNode;
+export type SignInRootProps = Omit<SignInFlowProviderProps, 'isRootPath'> & {
   /**
    * The base path for your sign-in route.
    * Will be automatically inferred in Next.js.

--- a/packages/elements/src/react/sign-up/root.tsx
+++ b/packages/elements/src/react/sign-up/root.tsx
@@ -18,6 +18,9 @@ import { usePathnameWithoutCatchAll } from '../utils/path-inference/next';
 type SignUpFlowProviderProps = {
   children: React.ReactNode;
   exampleMode?: boolean;
+  /**
+   * Fallback markup to render while Clerk is loading
+   */
   fallback?: React.ReactNode;
   isRootPath: boolean;
 };
@@ -70,11 +73,7 @@ function SignUpFlowProvider({ children, exampleMode, fallback, isRootPath }: Sig
   );
 }
 
-export type SignUpRootProps = SignUpFlowProviderProps & {
-  /**
-   * Fallback markup to render while Clerk is loading
-   */
-  fallback?: React.ReactNode;
+export type SignUpRootProps = Omit<SignUpFlowProviderProps, 'isRootPath'> & {
   /**
    * The base path for your sign-up route.
    * Will be automatically inferred in Next.js.

--- a/packages/elements/src/react/sign-up/root.tsx
+++ b/packages/elements/src/react/sign-up/root.tsx
@@ -1,4 +1,4 @@
-import { ClerkLoaded, ClerkLoading, useClerk } from '@clerk/clerk-react';
+import { useClerk } from '@clerk/clerk-react';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
 import { useSelector } from '@xstate/react';
 import { useEffect } from 'react';
@@ -18,12 +18,14 @@ import { usePathnameWithoutCatchAll } from '../utils/path-inference/next';
 type SignUpFlowProviderProps = {
   children: React.ReactNode;
   exampleMode?: boolean;
+  fallback?: React.ReactNode;
+  isRootPath: boolean;
 };
 
 const actor = createActor(SignUpRouterMachine, { inspect });
 actor.start();
 
-function SignUpFlowProvider({ children, exampleMode }: SignUpFlowProviderProps) {
+function SignUpFlowProvider({ children, exampleMode, fallback, isRootPath }: SignUpFlowProviderProps) {
   const clerk = useClerk();
   const router = useClerkRouter();
   const formRef = useFormStore();
@@ -58,9 +60,14 @@ function SignUpFlowProvider({ children, exampleMode }: SignUpFlowProviderProps) 
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clerk, exampleMode, formRef?.id, !!router]);
+  }, [clerk, exampleMode, formRef?.id, !!router, clerk.loaded]);
 
-  return isReady ? <SignUpRouterCtx.Provider actorRef={actor}>{children}</SignUpRouterCtx.Provider> : null;
+  return (
+    <SignUpRouterCtx.Provider actorRef={actor}>
+      {isRootPath && !isReady && fallback ? <Form>{fallback}</Form> : null}
+      {clerk.loaded && isReady ? children : null}
+    </SignUpRouterCtx.Provider>
+  );
 }
 
 export type SignUpRootProps = SignUpFlowProviderProps & {
@@ -126,13 +133,12 @@ export function SignUpRoot({
       router={router}
     >
       <FormStoreProvider>
-        <SignUpFlowProvider exampleMode={exampleMode}>
-          {isRootPath ? (
-            <ClerkLoading>
-              <Form>{fallback}</Form>
-            </ClerkLoading>
-          ) : null}
-          <ClerkLoaded>{children}</ClerkLoaded>
+        <SignUpFlowProvider
+          exampleMode={exampleMode}
+          fallback={fallback}
+          isRootPath={isRootPath}
+        >
+          {children}
         </SignUpFlowProvider>
       </FormStoreProvider>
     </Router>


### PR DESCRIPTION
## Description

The sign in/up root fallbacks were still being held up by client-side requirements. This moves the logic such that this is no longer the case.

<!-- Fixes #(issue number) -->
Fixes SDK-1842

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
