### PR TITLE
fix(clerk-js): Correctly use allowlist for protocol extensions in all codepaths

### DIFF
--- a/.changeset/polite-poems-cross.md
+++ b/.changeset/polite-poems-cross.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Correctly use updated protocol verification in all code paths

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -60,6 +60,7 @@ import type {
 
 import type { MountComponentRenderer } from '../ui/Components';
 import {
+  ALLOWED_PROTOCOLS,
   buildURL,
   completeSignUpFlow,
   createAllowedRedirectOrigins,
@@ -782,8 +783,10 @@ export class Clerk implements ClerkInterface {
 
     let toURL = new URL(to, window.location.href);
 
-    if (toURL.protocol !== 'http:' && toURL.protocol !== 'https:') {
-      console.warn('Clerk: Not a valid protocol. Redirecting to /');
+    if (!ALLOWED_PROTOCOLS.includes(toURL.protocol)) {
+      console.warn(
+        `Clerk: "${toURL.protocol}" is not a valid protocol. Redirecting to "/" instead. If you think this is a mistake, please open an issue.`,
+      );
       toURL = new URL('/', window.location.href);
     }
 

--- a/packages/clerk-js/src/utils/windowNavigate.ts
+++ b/packages/clerk-js/src/utils/windowNavigate.ts
@@ -1,6 +1,6 @@
 export const CLERK_BEFORE_UNLOAD_EVENT = 'clerk:beforeunload';
 
-const ALLOWED_PROTOCOLS = [
+export const ALLOWED_PROTOCOLS = [
   'http:',
   'https:',
   // Refers to https://wails.io/


### PR DESCRIPTION
## Description

Follow up to https://github.com/clerk/javascript/pull/3584 and https://github.com/clerk/javascript/pull/3564 - we were missing the allowlist in the second place where this check lives.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
