### PR TITLE
feat(ui): Extract some logic into reusable hooks

### DIFF
--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -1,8 +1,7 @@
 import { useClerk } from '@clerk/clerk-react';
 import * as Common from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
-import { enUS } from '@clerk/localizations';
-import type { ClerkOptions, EnvironmentResource } from '@clerk/types';
+import type { EnvironmentResource } from '@clerk/types';
 
 import { Connections } from '~/common/connections';
 import { EmailField } from '~/common/email-field';
@@ -14,6 +13,9 @@ import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
 import { PhoneNumberOrUsernameField } from '~/common/phone-number-or-username-field';
 import { UsernameField } from '~/common/username-field';
+import { useAttributes } from '~/hooks/use-attributes';
+import { useDisplayConfig } from '~/hooks/use-display-config';
+import { useLocalizations } from '~/hooks/use-localizations';
 import { Alert } from '~/primitives/alert';
 import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
@@ -22,7 +24,6 @@ import { LinkButton } from '~/primitives/link-button';
 import { SecondaryButton } from '~/primitives/secondary-button';
 import { Seperator } from '~/primitives/seperator';
 import { getEnabledSocialConnectionsFromEnvironment } from '~/utils/getEnabledSocialConnectionsFromEnvironment';
-import { makeLocalizeable } from '~/utils/makeLocalizable';
 
 export function SignInComponent() {
   return (
@@ -34,19 +35,16 @@ export function SignInComponent() {
 
 export function SignInComponentLoaded() {
   const clerk = useClerk();
-  // TODO: Replace `any` with proper types
-  const { t, translateError } = makeLocalizeable(((clerk as any)?.options as ClerkOptions)?.localization || enUS);
   const enabledConnections = getEnabledSocialConnectionsFromEnvironment(
     (clerk as any)?.__unstable__environment as EnvironmentResource,
   );
   const locationBasedCountryIso = (clerk as any)?.__internal_country;
-  const attributes = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.userSettings.attributes;
-  const displayConfig = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.displayConfig;
-  const { enabled: usernameEnabled } = attributes['username'];
-  const { enabled: phoneNumberEnabled } = attributes['phone_number'];
-  const { enabled: emailAddressEnabled } = attributes['email_address'];
-  const { enabled: passkeyEnabled } = attributes['passkey'];
-  const { applicationName, logoImageUrl, homeUrl } = displayConfig;
+  const { t, translateError } = useLocalizations();
+  const { enabled: usernameEnabled } = useAttributes('username');
+  const { enabled: phoneNumberEnabled } = useAttributes('phone_number');
+  const { enabled: emailAddressEnabled } = useAttributes('email_address');
+  const { enabled: passkeyEnabled } = useAttributes('passkey');
+  const { applicationName, logoImageUrl, homeUrl } = useDisplayConfig();
 
   const hasConnection = enabledConnections.length > 0;
   const hasIdentifier = emailAddressEnabled || usernameEnabled || phoneNumberEnabled;

--- a/packages/ui/src/components/sign-up/sign-up.tsx
+++ b/packages/ui/src/components/sign-up/sign-up.tsx
@@ -1,8 +1,7 @@
 import { useClerk } from '@clerk/clerk-react';
 import * as Common from '@clerk/elements/common';
 import * as SignUp from '@clerk/elements/sign-up';
-import { enUS } from '@clerk/localizations';
-import type { ClerkOptions, EnvironmentResource } from '@clerk/types';
+import type { EnvironmentResource } from '@clerk/types';
 
 import { Connections } from '~/common/connections';
 import { EmailField } from '~/common/email-field';
@@ -12,6 +11,9 @@ import { OTPField } from '~/common/otp-field';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
 import { UsernameField } from '~/common/username-field';
+import { useAttributes } from '~/hooks/use-attributes';
+import { useDisplayConfig } from '~/hooks/use-display-config';
+import { useLocalizations } from '~/hooks/use-localizations';
 import { Alert } from '~/primitives/alert';
 import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
@@ -19,7 +21,6 @@ import * as Icon from '~/primitives/icon';
 import { LinkButton } from '~/primitives/link-button';
 import { Seperator } from '~/primitives/seperator';
 import { getEnabledSocialConnectionsFromEnvironment } from '~/utils/getEnabledSocialConnectionsFromEnvironment';
-import { makeLocalizeable } from '~/utils/makeLocalizable';
 
 export function SignUpComponent() {
   return (
@@ -32,20 +33,18 @@ export function SignUpComponent() {
 function SignUpComponentLoaded() {
   const clerk = useClerk();
   // TODO: Replace `any` with proper types
-  const { t, translateError } = makeLocalizeable(((clerk as any)?.options as ClerkOptions)?.localization || enUS);
   const enabledConnections = getEnabledSocialConnectionsFromEnvironment(
     (clerk as any)?.__unstable__environment as EnvironmentResource,
   );
   const locationBasedCountryIso = (clerk as any)?.__internal_country;
-  const attributes = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.userSettings.attributes;
-  const displayConfig = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.displayConfig;
-  const { enabled: firstNameEnabled, required: firstNameRequired } = attributes['first_name'];
-  const { enabled: lastNameEnabled, required: lastNameRequired } = attributes['last_name'];
-  const { enabled: usernameEnabled, required: usernameRequired } = attributes['username'];
-  const { enabled: phoneNumberEnabled, required: phoneNumberRequired } = attributes['phone_number'];
-  const { enabled: emailAddressEnabled, required: emailAddressRequired } = attributes['email_address'];
-  const { enabled: passwordEnabled, required: passwordRequired } = attributes['password'];
-  const { applicationName, homeUrl, logoImageUrl } = displayConfig;
+  const { t, translateError } = useLocalizations();
+  const { enabled: firstNameEnabled, required: firstNameRequired } = useAttributes('first_name');
+  const { enabled: lastNameEnabled, required: lastNameRequired } = useAttributes('last_name');
+  const { enabled: usernameEnabled, required: usernameRequired } = useAttributes('username');
+  const { enabled: phoneNumberEnabled, required: phoneNumberRequired } = useAttributes('phone_number');
+  const { enabled: emailAddressEnabled, required: emailAddressRequired } = useAttributes('email_address');
+  const { enabled: passwordEnabled, required: passwordRequired } = useAttributes('password');
+  const { applicationName, homeUrl, logoImageUrl } = useDisplayConfig();
 
   const hasConnection = enabledConnections.length > 0;
   const hasIdentifier = emailAddressEnabled || usernameEnabled || phoneNumberEnabled;

--- a/packages/ui/src/hooks/use-attributes.ts
+++ b/packages/ui/src/hooks/use-attributes.ts
@@ -1,8 +1,9 @@
 import { useClerk } from '@clerk/clerk-react';
-import type { Attribute, EnvironmentResource } from '@clerk/types';
+import type { Attribute, AttributeData, EnvironmentResource } from '@clerk/types';
 
-export function useAttributes(attribute?: Attribute) {
+export function useAttributes(attribute: Attribute): AttributeData {
   const clerk = useClerk();
-  const attributes = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.userSettings.attributes;
-  return attribute ? attributes[attribute] : attributes;
+  const userSettingsAttributes = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.userSettings
+    .attributes;
+  return userSettingsAttributes[attribute];
 }

--- a/packages/ui/src/hooks/use-attributes.ts
+++ b/packages/ui/src/hooks/use-attributes.ts
@@ -1,0 +1,8 @@
+import { useClerk } from '@clerk/clerk-react';
+import type { Attribute, EnvironmentResource } from '@clerk/types';
+
+export function useAttributes(attribute?: Attribute) {
+  const clerk = useClerk();
+  const attributes = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.userSettings.attributes;
+  return attribute ? attributes[attribute] : attributes;
+}

--- a/packages/ui/src/hooks/use-display-config.ts
+++ b/packages/ui/src/hooks/use-display-config.ts
@@ -1,0 +1,8 @@
+import { useClerk } from '@clerk/clerk-react';
+import type { EnvironmentResource } from '@clerk/types';
+
+export function useDisplayConfig() {
+  const clerk = useClerk();
+  const displayConfig = ((clerk as any)?.__unstable__environment as EnvironmentResource)?.displayConfig;
+  return displayConfig;
+}

--- a/packages/ui/src/hooks/use-localizations.ts
+++ b/packages/ui/src/hooks/use-localizations.ts
@@ -1,0 +1,11 @@
+import { useClerk } from '@clerk/clerk-react';
+import { enUS } from '@clerk/localizations';
+import type { ClerkOptions } from '@clerk/types';
+
+import { makeLocalizeable } from '~/utils/makeLocalizable';
+
+export function useLocalizations() {
+  const clerk = useClerk();
+  const { t, translateError } = makeLocalizeable(((clerk as any)?.options as ClerkOptions)?.localization || enUS);
+  return { t, translateError };
+}


### PR DESCRIPTION
## Description

Introduce three new hooks based on current usage across `<SignIn />` `<SignUp />` components:

- `useLocalization` - access both `t` and `translateError` functions throughout components
- `useAttributes` - access field attributes such as `enabled` or `required`
- `useDisplayConfig` - access display config settings such as `applicationName`, `homeUrl`, `logoImageUrl`

Currently I am just updating the usage within the sign-in/up flows. Likely in a follow up PR we may refactor the common components to access this data internally using these hooks vs needs to pass them in as props within the sign-in/up components.


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
