### PR TITLE
fix(repo): Bump Node to latest version

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -4,9 +4,7 @@ inputs:
   node-version:
     description: 'The node version to use'
     required: false
-    # This is pinned to `18.20.2` because `18.20.3` bumps npm from `10.5.0` to `10.7.0`, which causes our verdaccio setup to fail (see SDK-1793).
-    # TODO: Update workflows/ci.yml when this isn't pinned anymore.
-    default: '18.20.2'
+    default: '18'
   playwright-enabled:
     description: 'Enable Playwright?'
     required: false

--- a/.github/actions/verdaccio/action.yml
+++ b/.github/actions/verdaccio/action.yml
@@ -33,8 +33,7 @@ runs:
       run: |
         nohup ./node_modules/.bin/verdaccio --config ./verdaccio.publish.yaml & echo "VERDACCIO_PID=$!" >> $GITHUB_ENV
         sleep 5
-        ./node_modules/.bin/npm-cli-adduser -u ${{ inputs.auth-user }} -p ${{ inputs.auth-password }} -e ${{ inputs.auth-email }} -r ${{ inputs.registry }}
-        ./node_modules/.bin/npm-cli-login -u ${{ inputs.auth-user }} -p ${{ inputs.auth-password }} -e ${{ inputs.auth-email }} -r ${{ inputs.registry }}
+        npm config set $(echo ${{ inputs.registry }} | sed -E 's/https?://')/:_authToken secretToken
 
     - name: Publish to Verdaccio
       shell: bash
@@ -48,5 +47,4 @@ runs:
       shell: bash
       run: |
         nohup ./node_modules/.bin/verdaccio --config ./verdaccio.install.yaml & sleep 5
-        ./node_modules/.bin/npm-cli-adduser -u ${{ inputs.auth-user }} -p ${{ inputs.auth-password }} -e ${{ inputs.auth-email }} -r ${{ inputs.registry }}
-        ./node_modules/.bin/npm-cli-login -u ${{ inputs.auth-user }} -p ${{ inputs.auth-password }} -e ${{ inputs.auth-email }} -r ${{ inputs.registry }}
+        npm config set $(echo ${{ inputs.registry }} | sed -E 's/https?://')/:_authToken secretToken

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     timeout-minutes: ${{ vars.TIMEOUT_MINUTES_NORMAL && fromJSON(vars.TIMEOUT_MINUTES_NORMAL) || 10 }}
 
     env:
-      # TODO: Update once actions/init/action.yml isn't pinned to 18.20.2
-      NODE_VERSION: 18.20.2
       TURBO_SUMMARIZE: false
 
     steps:
@@ -34,7 +32,6 @@ jobs:
         id: config
         uses: ./.github/actions/init
         with:
-          node-version: ${{ env.NODE_VERSION }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-summarize: ${{ env.TURBO_SUMMARIZE }}
           turbo-team: ${{ vars.TURBO_TEAM }}
@@ -115,8 +112,7 @@ jobs:
         uses: ./.github/actions/init
         with:
           # Ensures that all builds are cached appropriately with a consistent run name `Unit Tests (18)`.
-          # TODO: Update once actions/init/action.yml isn't pinned to 18.20.2
-          node-version: ${{ matrix.node-version == '18' && '18.20.2' || matrix.node-version }}
+          node-version: ${{ matrix.node-version }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-summarize: ${{ env.TURBO_SUMMARIZE }}
           turbo-team: ${{ vars.TURBO_TEAM }}
@@ -125,8 +121,7 @@ jobs:
       - name: Run tests
         run: npx turbo test $TURBO_ARGS
         env:
-          # TODO: Update once actions/init/action.yml isn't pinned to 18.20.2
-          NODE_VERSION: ${{ matrix.node-version == '18' && '18.20.2' || matrix.node-version }}
+          NODE_VERSION: ${{ matrix.node-version }}
 
       - name: Upload Turbo Summary
         uses: actions/upload-artifact@v4
@@ -142,10 +137,6 @@ jobs:
     needs: formatting-linting
     runs-on: ${{ vars.RUNNER_MEDIUM || 'ubuntu-latest-m' }}
     timeout-minutes: ${{ vars.TIMEOUT_MINUTES_LONG && fromJSON(vars.TIMEOUT_MINUTES_LONG) || 15 }}
-
-    env:
-      # TODO: Update once actions/init/action.yml isn't pinned to 18.20.2
-      NODE_VERSION: 18.20.2
 
     strategy:
       matrix:
@@ -184,7 +175,6 @@ jobs:
         id: config
         uses: ./.github/actions/init
         with:
-          node-version: ${{ env.NODE_VERSION }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates our Verdaccio process to unblock the upgrade to Node v18.20.3, which includes npm v10.7.0.

In modern versions of npm, you need to have an `authToken` in your `.npmrc` to be able to run `npm publish`. We achieved this previously with the use of the packages `npm-cli-adduser` and `npm-cli-login`. These packages were last updated six years ago. npm v10.7.0 included a rework of the CLI output, which breaks those packages since they relied on a specific output structure. We can achieve the same end result as those packages by simply adding an `_authToken` entry to `.npmrc` manually. Our Verdaccio configuration doesn't rely on the `_authToken` being any specific value due to the use of `$all`, which [allows all users, both anonymous and logged in, to publish packages](https://verdaccio.org/docs/authentication#understanding-groups).

As part of this PR, I've removed all the `TODO` comments and temporary version pins. We now default to the latest version of Node v18, which is 18.20.3 as of writing.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: repo hygiene
