### PR TITLE
chore(repo): Remove npm-cli-* dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,6 @@
         "jest-chrome": "^0.8.0",
         "jest-environment-jsdom": "^29.3.1",
         "lint-staged": "^14.0.1",
-        "npm-cli-adduser": "^1.1.4",
-        "npm-cli-login": "^1.0.0",
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.3",
         "publint": "^0.2.4",
@@ -12733,71 +12731,6 @@
         "join-component": "^1.1.0"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.73.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.73.0",
-        "@sentry/types": "7.73.0",
-        "@sentry/utils": "7.73.0",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.73.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.73.0",
-        "@sentry/utils": "7.73.0",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "7.73.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.73.0",
-        "@sentry/core": "7.73.0",
-        "@sentry/types": "7.73.0",
-        "@sentry/utils": "7.73.0",
-        "cookie": "^0.5.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.73.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.73.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.73.0",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "dev": true,
@@ -16298,16 +16231,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.0",
       "license": "MIT",
@@ -17393,11 +17316,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -18919,15 +18837,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -22530,11 +22439,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
@@ -26708,75 +26612,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "license": "MIT",
@@ -27032,47 +26867,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/serialize-error": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/global-agent/node_modules/type-fest": {
-      "version": "0.13.1",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/global-directory": {
@@ -27436,26 +27230,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/hard-rejection": {
@@ -27891,20 +27665,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/http-status-codes": {
@@ -31678,20 +31438,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "license": "MIT",
@@ -32776,11 +32522,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "license": "ISC",
@@ -32979,17 +32720,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -33958,77 +33688,12 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm-cli-adduser": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "commander": "^2.19.0"
-      },
-      "bin": {
-        "npm-cli-adduser": "index.js"
-      }
-    },
-    "node_modules/npm-cli-adduser/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-cli-login": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "npm-registry-client": "8.6.0",
-        "snyk": "^1.124.1"
-      },
-      "bin": {
-        "npm-cli-login": "bin/npm-cli-login.js"
-      }
-    },
     "node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm-package-arg": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^2.7.1",
-        "osenv": "^0.1.5",
-        "semver": "^5.6.0",
-        "validate-npm-package-name": "^3.0.0"
-      }
-    },
-    "node_modules/npm-package-arg/node_modules/builtins": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^1.0.3"
       }
     },
     "node_modules/npm-packlist": {
@@ -34046,43 +33711,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm-registry-client": {
-      "version": "8.6.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "concat-stream": "^1.5.2",
-        "graceful-fs": "^4.1.6",
-        "normalize-package-data": "~1.0.1 || ^2.0.0",
-        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-        "once": "^1.3.3",
-        "request": "^2.74.0",
-        "retry": "^0.10.0",
-        "safe-buffer": "^5.1.1",
-        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-        "slide": "^1.1.3",
-        "ssri": "^5.2.4"
-      },
-      "optionalDependencies": {
-        "npmlog": "2 || ^3.1.0 || ^4.0.0"
-      }
-    },
-    "node_modules/npm-registry-client/node_modules/retry": {
-      "version": "0.10.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm-registry-client/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/npm-run-all": {
@@ -34202,18 +33830,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "node_modules/npx-import": {
@@ -34344,15 +33960,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.5",
       "dev": true,
@@ -34454,14 +34061,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -34822,6 +34421,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -34838,6 +34438,7 @@
       "version": "0.1.5",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -38036,83 +37637,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "throttleit": "^1.0.0"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -38350,27 +37880,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/roarr/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/rollup": {
       "version": "4.18.0",
@@ -38680,11 +38189,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/semver-regex": {
       "version": "4.0.5",
@@ -39178,14 +38682,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/slugify": {
       "version": "1.6.6",
       "dev": true,
@@ -39358,22 +38854,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/snyk": {
-      "version": "1.1234.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sentry/node": "^7.36.0",
-        "global-agent": "^3.0.0"
-      },
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/socket.io": {
@@ -39763,14 +39243,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/stable": {

--- a/package.json
+++ b/package.json
@@ -86,8 +86,6 @@
     "jest-chrome": "^0.8.0",
     "jest-environment-jsdom": "^29.3.1",
     "lint-staged": "^14.0.1",
-    "npm-cli-adduser": "^1.1.4",
-    "npm-cli-login": "^1.0.0",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.3",
     "publint": "^0.2.4",


### PR DESCRIPTION
## Description

Follow up to https://github.com/clerk/javascript/pull/3620, which removes the now unneeded dependencies.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: cleanup
