### PR TITLE
fix(remix): Fix issues caused by modifying duplex on Request

### DIFF
--- a/.changeset/tall-hairs-dream.md
+++ b/.changeset/tall-hairs-dream.md
@@ -2,4 +2,4 @@
 "@clerk/remix": patch
 ---
 
-Fix issues with duplex on Request
+Fix issues caused by modifying duplex property on Request when it was already defined

--- a/.changeset/tall-hairs-dream.md
+++ b/.changeset/tall-hairs-dream.md
@@ -1,0 +1,5 @@
+---
+"@clerk/remix": patch
+---
+
+Fix issues with duplex on Request

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -126,7 +126,8 @@ export const wrapWithClerkState = (data: any) => {
  */
 export const patchRequest = (request: Request) => {
   const clonedRequest = request.clone();
-  if (clonedRequest.method !== 'GET' && clonedRequest.body !== null) {
+  // If duplex is not set, set it to 'half' to avoid duplex issues with unidici
+  if (clonedRequest.method !== 'GET' && clonedRequest.body !== null && !('duplex' in clonedRequest)) {
     (clonedRequest as unknown as { duplex: 'half' }).duplex = 'half';
   }
   return clonedRequest;


### PR DESCRIPTION
## Description

This PR fixes an issue that was introduced by https://github.com/clerk/javascript/pull/3495, where the `duplex` property was already defined and couldn't not be modified.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
