### PR TITLE
fix(elements): Fallback sign-in factors to empty array

### DIFF
--- a/.changeset/chilled-dots-talk.md
+++ b/.changeset/chilled-dots-talk.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Addresses the issue where sign-in factors were not properly falling back to empty arrays.

--- a/packages/elements/src/react/sign-in/choose-strategy.tsx
+++ b/packages/elements/src/react/sign-in/choose-strategy.tsx
@@ -106,7 +106,9 @@ export const SignInSupportedStrategy = React.forwardRef<SignInSupportedStrategyE
 
     const supportedFirstFactors = snapshot.context.clerk.client.signIn.supportedFirstFactors;
     const supportedSecondFactors = snapshot.context.clerk.client.signIn.supportedSecondFactors;
-    const factor = [...supportedFirstFactors, ...supportedSecondFactors].find(factor => name === factor.strategy);
+    const factor = [...(supportedFirstFactors ?? []), ...(supportedSecondFactors ?? [])].find(
+      factor => name === factor.strategy,
+    );
 
     const currentFactor = useSelector(
       (snapshot.children[SignInRouterSystemId.firstFactor] ||


### PR DESCRIPTION
## Description

Fixes scenario where sign-in factors get returned as empty values, therefore breaking iteration on `choose-strategy` component. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
