### PR TITLE
refactor(elements): Bring sign-up loading in-line with sign-in

### DIFF
--- a/.changeset/forty-kings-roll.md
+++ b/.changeset/forty-kings-roll.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Refactors sign-up loading logic to be in-line with sign-in

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -284,7 +284,7 @@ export const SignUpRouterMachine = setup({
       ],
     },
     Start: {
-      tags: 'route:start',
+      tags: ['step:start'],
       exit: 'clearFormErrors',
       invoke: {
         id: 'start',
@@ -322,7 +322,7 @@ export const SignUpRouterMachine = setup({
       },
     },
     Continue: {
-      tags: 'route:continue',
+      tags: ['step:continue'],
       invoke: {
         id: 'continue',
         src: 'continueMachine',
@@ -354,7 +354,7 @@ export const SignUpRouterMachine = setup({
       },
     },
     Verification: {
-      tags: 'route:verification',
+      tags: ['step:verification'],
       invoke: {
         id: 'verification',
         src: 'verificationMachine',
@@ -406,7 +406,7 @@ export const SignUpRouterMachine = setup({
       },
     },
     Callback: {
-      tags: 'route:callback',
+      tags: ['step:callback'],
       entry: sendTo(ThirdPartyMachineId, { type: 'CALLBACK' }),
       on: {
         NEXT: [
@@ -437,7 +437,7 @@ export const SignUpRouterMachine = setup({
       },
     },
     Error: {
-      tags: 'route:error',
+      tags: ['step:error'],
       on: {
         NEXT: {
           target: 'Start',

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -20,16 +20,16 @@ import type {
 
 // ---------------------------------- Tags ---------------------------------- //
 
-export const SignUpRouterRoutes = {
-  start: 'route:start',
-  continue: 'route:continue',
-  verification: 'route:verification',
-  callback: 'route:callback',
-  error: 'route:error',
+export const SignUpRouterSteps = {
+  start: 'step:start',
+  continue: 'step:continue',
+  verification: 'step:verification',
+  callback: 'step:callback',
+  error: 'step:error',
 } as const;
 
-export type SignUpRouterRoutes = keyof typeof SignUpRouterRoutes;
-export type SignUpRouterTags = (typeof SignUpRouterRoutes)[keyof typeof SignUpRouterRoutes];
+export type SignUpRouterSteps = keyof typeof SignUpRouterSteps;
+export type SignUpRouterTags = (typeof SignUpRouterSteps)[keyof typeof SignUpRouterSteps];
 
 // ---------------------------------- Children ---------------------------------- //
 

--- a/packages/elements/src/react/sign-up/continue.tsx
+++ b/packages/elements/src/react/sign-up/continue.tsx
@@ -11,7 +11,7 @@ export const SignUpContinueCtx = createContextFromActorRef<TSignUpContinueMachin
 
 export function SignUpContinue(props: SignUpContinueProps) {
   const routerRef = SignUpRouterCtx.useActorRef();
-  const activeState = useActiveTags(routerRef, 'route:continue');
+  const activeState = useActiveTags(routerRef, 'step:continue');
 
   return activeState ? <SignUpContinueInner {...props} /> : null;
 }

--- a/packages/elements/src/react/sign-up/start.tsx
+++ b/packages/elements/src/react/sign-up/start.tsx
@@ -11,7 +11,7 @@ export const SignUpStartCtx = createContextFromActorRef<TSignUpStartMachine>('Si
 
 export function SignUpStart(props: SignUpStartProps) {
   const routerRef = SignUpRouterCtx.useActorRef();
-  const activeState = useActiveTags(routerRef, 'route:start');
+  const activeState = useActiveTags(routerRef, 'step:start');
 
   return activeState ? <SignUpStartInner {...props} /> : null;
 }

--- a/packages/elements/src/react/sign-up/verifications.tsx
+++ b/packages/elements/src/react/sign-up/verifications.tsx
@@ -31,7 +31,7 @@ export const SignUpVerificationCtx = createContextFromActorRef<TSignUpVerificati
  */
 export function SignUpVerifications(props: SignUpVerificationsProps) {
   const ref = SignUpRouterCtx.useActorRef();
-  const activeState = useActiveTags(ref, 'route:verification');
+  const activeState = useActiveTags(ref, 'step:verification');
 
   return activeState ? <SignUpVerifyInner {...props} /> : null;
 }


### PR DESCRIPTION
## Description

This is a fast-follow to #3648, to bring sign-in and sign-up loading in-line with one another.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
