### PR TITLE
fix(nextjs): Update imports to avoid Node.js build warnings on edge runtime

### DIFF
--- a/.changeset/yellow-carrots-provide.md
+++ b/.changeset/yellow-carrots-provide.md
@@ -2,4 +2,4 @@
 "@clerk/nextjs": patch
 ---
 
-Fixes Next.js build issue (https://github.com/clerk/javascript/issues/3660) where `AsyncLocalStorage` was being imported as Node.js module instead of using the global polyfill available for the edge runtime.
+Fixes Next.js build warnings (https://github.com/clerk/javascript/issues/3660) where `AsyncLocalStorage` and `MessageEvent` were being imported as Node.js modules on the edge runtime.

--- a/.changeset/yellow-carrots-provide.md
+++ b/.changeset/yellow-carrots-provide.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Fixes Next.js build issue (https://github.com/clerk/javascript/issues/3660) where `AsyncLocalStorage` was being imported as Node.js module instead of using the global polyfill available for the edge runtime.

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import type {
   AuthenticateRequestOptions,
   AuthObject,

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -7,7 +7,6 @@ import type {
 } from '@clerk/backend/internal';
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
-import { AsyncLocalStorage } from 'async_hooks';
 import type { NextMiddleware } from 'next/server';
 import { NextResponse } from 'next/server';
 

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -1,8 +1,8 @@
 import type { AuthenticateRequestOptions, ClerkRequest, RequestState } from '@clerk/backend/internal';
 import { constants } from '@clerk/backend/internal';
-import { logger } from '@clerk/shared';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
 import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
+import { logger } from '@clerk/shared/logger';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
 import AES from 'crypto-js/aes';
 import encUtf8 from 'crypto-js/enc-utf8';


### PR DESCRIPTION
## Description

Fixes https://github.com/clerk/javascript/issues/3660

- Uses `AsyncLocalStorage` available as a global polyfill for the edge runtime, instead of importing from Node.js: https://nextjs.org/docs/pages/api-reference/edge#nextjs-specific-polyfills
- Imports `logger` from nested import

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
