### PR TITLE
fix(testing): Use `@clerk/backend` package to fetch tokens

### DIFF
--- a/.changeset/honest-days-fetch.md
+++ b/.changeset/honest-days-fetch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/testing": patch
+---
+
+Use `@clerk/backend` package to fetch tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -51106,6 +51106,7 @@
       "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
+        "@clerk/backend": "1.3.0",
         "@clerk/shared": "2.3.2",
         "@clerk/types": "4.7.0",
         "dotenv": "16.4.5"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -62,6 +62,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@clerk/backend": "1.3.0",
     "@clerk/shared": "2.3.2",
     "@clerk/types": "4.7.0",
     "dotenv": "16.4.5"

--- a/packages/testing/src/common/constants.ts
+++ b/packages/testing/src/common/constants.ts
@@ -1,3 +1,1 @@
 export const TESTING_TOKEN_PARAM = '__clerk_testing_token';
-
-export const TESTING_TOKEN_API_URL = 'https://api.clerk.com/v1/testing_tokens';


### PR DESCRIPTION
## Description

Drops the custom fetch to BAPI, and replaces it with using the `@clerk/backend` package.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
