### PR TITLE
feat(astro): Change prefix for public env variables to `PUBLIC_`.

### DIFF
--- a/.changeset/soft-dragons-thank.md
+++ b/.changeset/soft-dragons-thank.md
@@ -1,0 +1,6 @@
+---
+"@clerk/astro": patch
+---
+
+Change prefix for public env variables to `PUBLIC_`. The previous prefix was `PUBLIC_ASTRO_APP_`.
+- After this change the publishable key from should be set as `PUBLIC_CLERK_PUBLISHABLE_KEY=xxxxx`

--- a/integration/presets/astro.ts
+++ b/integration/presets/astro.ts
@@ -8,7 +8,7 @@ const clerkLocalizationLocal = `file:${process.cwd()}/packages/localizations`;
 const astroNode = applicationConfig()
   .setName('astro-node')
   .useTemplate(templates['astro-node'])
-  .setEnvFormatter('public', key => `PUBLIC_ASTRO_APP_${key}`)
+  .setEnvFormatter('public', key => `PUBLIC_${key}`)
   .addScript('setup', 'npm i')
   .addScript('dev', 'npm run dev')
   .addScript('build', 'npm run build')

--- a/packages/astro/src/env.d.ts
+++ b/packages/astro/src/env.d.ts
@@ -1,21 +1,21 @@
 /// <reference types="astro/client" />
 
 interface InternalEnv {
-  readonly PUBLIC_ASTRO_APP_CLERK_FRONTEND_API?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_JS_URL?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_JS_VARIANT?: 'headless' | '';
-  readonly PUBLIC_ASTRO_APP_CLERK_JS_VERSION?: string;
+  readonly PUBLIC_CLERK_FRONTEND_API?: string;
+  readonly PUBLIC_CLERK_PUBLISHABLE_KEY?: string;
+  readonly PUBLIC_CLERK_JS_URL?: string;
+  readonly PUBLIC_CLERK_JS_VARIANT?: 'headless' | '';
+  readonly PUBLIC_CLERK_JS_VERSION?: string;
   readonly CLERK_API_KEY?: string;
   readonly CLERK_API_URL?: string;
   readonly CLERK_API_VERSION?: string;
   readonly CLERK_JWT_KEY?: string;
   readonly CLERK_SECRET_KEY?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_DOMAIN?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_PROXY_URL?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL?: string;
+  readonly PUBLIC_CLERK_DOMAIN?: string;
+  readonly PUBLIC_CLERK_IS_SATELLITE?: string;
+  readonly PUBLIC_CLERK_PROXY_URL?: string;
+  readonly PUBLIC_CLERK_SIGN_IN_URL?: string;
+  readonly PUBLIC_CLERK_SIGN_UP_URL?: string;
 }
 
 interface ImportMeta {

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -3,7 +3,7 @@ import type { AstroIntegration } from 'astro';
 import { name as packageName } from '../../package.json';
 import type { AstroClerkIntegrationParams } from '../types';
 
-const buildEnvVarFromOption = (valueToBeStored: unknown, envName: string) => {
+const buildEnvVarFromOption = (valueToBeStored: unknown, envName: keyof InternalEnv) => {
   return valueToBeStored ? { [`import.meta.env.${envName}`]: JSON.stringify(valueToBeStored) } : {};
 };
 
@@ -52,16 +52,16 @@ function createIntegration<P extends { mode: 'hotload' | 'bundled' }>({ mode }: 
                 /**
                  * Convert the integration params to environment variable in order for be readable from the server
                  */
-                ...buildEnvVarFromOption(signInUrl, 'PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL'),
-                ...buildEnvVarFromOption(signUpUrl, 'PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL'),
-                ...buildEnvVarFromOption(isSatellite, 'PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE'),
-                ...buildEnvVarFromOption(proxyUrl, 'PUBLIC_ASTRO_APP_CLERK_PROXY_URL'),
-                ...buildEnvVarFromOption(domain, 'PUBLIC_ASTRO_APP_CLERK_DOMAIN'),
-                ...buildEnvVarFromOption(domain, 'PUBLIC_ASTRO_APP_CLERK_DOMAIN'),
-                ...buildEnvVarFromOption(domain, 'PUBLIC_ASTRO_APP_CLERK_DOMAIN'),
-                ...buildEnvVarFromOption(clerkJSUrl, 'PUBLIC_ASTRO_APP_CLERK_JS_URL'),
-                ...buildEnvVarFromOption(clerkJSVariant, 'PUBLIC_ASTRO_APP_CLERK_JS_VARIANT'),
-                ...buildEnvVarFromOption(clerkJSVersion, 'PUBLIC_ASTRO_APP_CLERK_JS_VERSION'),
+                ...buildEnvVarFromOption(signInUrl, 'PUBLIC_CLERK_SIGN_IN_URL'),
+                ...buildEnvVarFromOption(signUpUrl, 'PUBLIC_CLERK_SIGN_UP_URL'),
+                ...buildEnvVarFromOption(isSatellite, 'PUBLIC_CLERK_IS_SATELLITE'),
+                ...buildEnvVarFromOption(proxyUrl, 'PUBLIC_CLERK_PROXY_URL'),
+                ...buildEnvVarFromOption(domain, 'PUBLIC_CLERK_DOMAIN'),
+                ...buildEnvVarFromOption(domain, 'PUBLIC_CLERK_DOMAIN'),
+                ...buildEnvVarFromOption(domain, 'PUBLIC_CLERK_DOMAIN'),
+                ...buildEnvVarFromOption(clerkJSUrl, 'PUBLIC_CLERK_JS_URL'),
+                ...buildEnvVarFromOption(clerkJSVariant, 'PUBLIC_CLERK_JS_VARIANT'),
+                ...buildEnvVarFromOption(clerkJSVersion, 'PUBLIC_CLERK_JS_VERSION'),
                 __HOTLOAD__: mode === 'hotload',
               },
 

--- a/packages/astro/src/server/get-safe-env.ts
+++ b/packages/astro/src/server/get-safe-env.ts
@@ -21,16 +21,16 @@ function getContextEnvVar(envVarName: keyof InternalEnv, contextOrLocals: Contex
  */
 function getSafeEnv(context: ContextOrLocals) {
   return {
-    domain: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_DOMAIN', context),
-    isSatellite: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE', context) === 'true',
-    proxyUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_PROXY_URL', context),
-    pk: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY', context),
+    domain: getContextEnvVar('PUBLIC_CLERK_DOMAIN', context),
+    isSatellite: getContextEnvVar('PUBLIC_CLERK_IS_SATELLITE', context) === 'true',
+    proxyUrl: getContextEnvVar('PUBLIC_CLERK_PROXY_URL', context),
+    pk: getContextEnvVar('PUBLIC_CLERK_PUBLISHABLE_KEY', context),
     sk: getContextEnvVar('CLERK_SECRET_KEY', context),
-    signInUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL', context),
-    signUpUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL', context),
-    clerkJsUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_JS_URL', context),
-    clerkJsVariant: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_JS_VARIANT', context) as 'headless' | '' | undefined,
-    clerkJsVersion: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_JS_VERSION', context),
+    signInUrl: getContextEnvVar('PUBLIC_CLERK_SIGN_IN_URL', context),
+    signUpUrl: getContextEnvVar('PUBLIC_CLERK_SIGN_UP_URL', context),
+    clerkJsUrl: getContextEnvVar('PUBLIC_CLERK_JS_URL', context),
+    clerkJsVariant: getContextEnvVar('PUBLIC_CLERK_JS_VARIANT', context) as 'headless' | '' | undefined,
+    clerkJsVersion: getContextEnvVar('PUBLIC_CLERK_JS_VERSION', context),
     apiVersion: getContextEnvVar('CLERK_API_VERSION', context),
     apiUrl: getContextEnvVar('CLERK_API_URL', context),
   };
@@ -45,11 +45,11 @@ function getSafeEnv(context: ContextOrLocals) {
  */
 function getClientSafeEnv(context: ContextOrLocals) {
   return {
-    domain: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_DOMAIN', context),
-    isSatellite: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE', context) === 'true',
-    proxyUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_PROXY_URL', context),
-    signInUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL', context),
-    signUpUrl: getContextEnvVar('PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL', context),
+    domain: getContextEnvVar('PUBLIC_CLERK_DOMAIN', context),
+    isSatellite: getContextEnvVar('PUBLIC_CLERK_IS_SATELLITE', context) === 'true',
+    proxyUrl: getContextEnvVar('PUBLIC_CLERK_PROXY_URL', context),
+    signInUrl: getContextEnvVar('PUBLIC_CLERK_SIGN_IN_URL', context),
+    signUpUrl: getContextEnvVar('PUBLIC_CLERK_SIGN_UP_URL', context),
   };
 }
 


### PR DESCRIPTION
## Description

This replaces the previous prefix `PUBLIC_ASTRO_APP`, and aligns it with the [standard from Astro](https://docs.astro.build/en/guides/environment-variables/#setting-environment-variables)

Given the fact that the astro sdk is in v0, we are not considering this change as breaking.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
