### PR TITLE
fix(astro): Accessing import.meta at build causes app to break

### DIFF
--- a/.changeset/thirty-icons-laugh.md
+++ b/.changeset/thirty-icons-laugh.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Bug fix: Removed import.meta from integration to avoid breaking app during build.

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -25,16 +25,6 @@ function createIntegration<P extends { mode: 'hotload' | 'bundled' }>({ mode }: 
     const clerkJSVariant = (params as any)?.clerkJSVariant as string | undefined;
     const clerkJSVersion = (params as any)?.clerkJSVersion as string | undefined;
 
-    const internalParams: ClerkOptions = {
-      ...params,
-      sdkMetadata: {
-        version: packageVersion,
-        name: packageName,
-        // eslint-disable-next-line turbo/no-undeclared-env-vars
-        environment: import.meta.env.MODE,
-      },
-    };
-
     return {
       name: '@clerk/astro/integration',
       hooks: {
@@ -50,6 +40,15 @@ function createIntegration<P extends { mode: 'hotload' | 'bundled' }>({ mode }: 
           if (typeof clerkJSVariant !== 'undefined' && clerkJSVariant !== 'headless' && clerkJSVariant !== '') {
             logger.error('Invalid value for clerkJSVariant. Acceptable values are `"headless"`, `""`, and `undefined`');
           }
+
+          const internalParams: ClerkOptions = {
+            ...params,
+            sdkMetadata: {
+              version: packageVersion,
+              name: packageName,
+              environment: command === 'dev' ? 'development' : 'production',
+            },
+          };
 
           const defaultBundledImportPath = `${packageName}/internal/bundled`;
 


### PR DESCRIPTION
## Description

Pretty much what the title says
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
