### PR TITLE
feat(elements): Add signup identifier components

### DIFF
--- a/.changeset/plenty-glasses-notice.md
+++ b/.changeset/plenty-glasses-notice.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Adds signup identifier components for use in verification step

--- a/packages/elements/src/internals/machines/sign-up/index.ts
+++ b/packages/elements/src/internals/machines/sign-up/index.ts
@@ -3,6 +3,8 @@ export { SignUpRouterMachine, SignUpRouterMachineId } from './router.machine';
 export { SignUpStartMachine, SignUpStartMachineId } from './start.machine';
 export { SignUpVerificationMachine, SignUpVerificationMachineId } from './verification.machine';
 
+export { SignUpEmailAddressIdentifierSelector, SignUpPhoneNumberIdentifierSelector } from './router.selectors';
+
 export type { TSignUpContinueMachine } from './continue.machine';
 export type { TSignUpRouterMachine } from './router.machine';
 export type { TSignUpStartMachine } from './start.machine';

--- a/packages/elements/src/internals/machines/sign-up/router.selectors.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.selectors.ts
@@ -1,0 +1,9 @@
+import type { SignUpRouterSnapshot } from './router.types';
+
+export function SignUpEmailAddressIdentifierSelector(s: SignUpRouterSnapshot): string {
+  return s.context.clerk?.client.signUp.emailAddress || '';
+}
+
+export function SignUpPhoneNumberIdentifierSelector(s: SignUpRouterSnapshot): string {
+  return s.context.clerk?.client.signUp.phoneNumber || '';
+}

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -1,5 +1,5 @@
 import type { SignUpResource } from '@clerk/types';
-import type { ActorRefFrom, SnapshotFrom, StateMachine } from 'xstate';
+import type { ActorRefFrom, MachineSnapshot, StateMachine } from 'xstate';
 
 import type { TFormMachine } from '~/internals/machines/form';
 import type {
@@ -131,4 +131,12 @@ export type SignInRouterMachineActorRef = ActorRefFrom<TSignUpRouterParentMachin
 
 // ---------------------------------- Snapshot ---------------------------------- //
 
-export type SignUpRouterSnapshot = SnapshotFrom<TSignUpRouterParentMachine>;
+export type SignUpRouterSnapshot = MachineSnapshot<
+  SignUpRouterContext,
+  SignUpRouterEvents,
+  SignUpRouterChildren,
+  SignUpRouterStateValue,
+  SignUpRouterTags,
+  SignUpRouterOuptut,
+  any // TMeta - Introduced in XState 5.12.x
+>;

--- a/packages/elements/src/react/sign-up/identifiers.tsx
+++ b/packages/elements/src/react/sign-up/identifiers.tsx
@@ -1,0 +1,32 @@
+import {
+  SignUpEmailAddressIdentifierSelector,
+  SignUpPhoneNumberIdentifierSelector,
+} from '~/internals/machines/sign-up';
+
+import { SignUpRouterCtx } from './context';
+
+/**
+ * Render an email address identifier that has been provided by the user during a sign-up attempt. Renders a `string` (or empty string if it can't find an identifier).
+ *
+ * @example
+ * <SignUp.Strategy name="email_code">
+ *  <h1>Check your email</h1>
+ *  <p>We've sent a code to <SignUp.EmailAddressIdentifier />.</p>
+ * </SignUp.Strategy>
+ */
+export function SignUpEmailAddressIdentifier(): string {
+  return SignUpRouterCtx.useSelector(SignUpEmailAddressIdentifierSelector);
+}
+
+/**
+ * Render an phone number identifier that has been provided by the user during a sign-up attempt. Renders a `string` (or empty string if it can't find an identifier).
+ *
+ * @example
+ * <SignUp.Strategy name="phone_code">
+ *  <h1>Check your phone</h1>
+ *  <p>We've sent a code to <SignUp.PhoneNumberIdentifier />.</p>
+ * </SignUp.Strategy>
+ */
+export function SignUpPhoneNumberIdentifier(): string {
+  return SignUpRouterCtx.useSelector(SignUpPhoneNumberIdentifierSelector);
+}

--- a/packages/elements/src/react/sign-up/index.ts
+++ b/packages/elements/src/react/sign-up/index.ts
@@ -6,3 +6,8 @@ export { SignUpStep as Step } from './step';
 export { SignUpAction as Action } from './action';
 export { SignUpStrategy as Strategy } from './verifications';
 export { SignUpCaptcha as Captcha } from './captcha';
+
+export {
+  SignUpEmailAddressIdentifier as EmailAddressIdentifier,
+  SignUpPhoneNumberIdentifier as PhoneNumberIdentifier,
+} from './identifiers';

--- a/packages/ui/src/common/phone-number-field/index.tsx
+++ b/packages/ui/src/common/phone-number-field/index.tsx
@@ -75,6 +75,23 @@ export const PhoneNumberField = React.forwardRef(function PhoneNumberField(
   };
 
   React.useEffect(callOnChangeProp, [numberWithCode, onChange]);
+
+  // When the value is prefilled when returning to the start step from the verification step
+  // we need to parse the value and set the country and number
+  React.useEffect(() => {
+    const inputValue = inputRef.current?.value;
+    if (!inputValue) {
+      return;
+    }
+    if (inputValue.includes('+')) {
+      setNumberAndIso(inputValue);
+      setSelectedCountry(countryOptions.find(c => c.iso === iso) || countryOptions[0]);
+    } else {
+      setNumber(inputValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   React.useEffect(() => {
     if (isOpen) {
       commandInputRef.current?.focus();

--- a/packages/ui/src/common/phone-number-field/index.tsx
+++ b/packages/ui/src/common/phone-number-field/index.tsx
@@ -76,22 +76,6 @@ export const PhoneNumberField = React.forwardRef(function PhoneNumberField(
 
   React.useEffect(callOnChangeProp, [numberWithCode, onChange]);
 
-  // When the value is prefilled when returning to the start step from the verification step
-  // we need to parse the value and set the country and number
-  React.useEffect(() => {
-    const inputValue = inputRef.current?.value;
-    if (!inputValue) {
-      return;
-    }
-    if (inputValue.includes('+')) {
-      setNumberAndIso(inputValue);
-      setSelectedCountry(countryOptions.find(c => c.iso === iso) || countryOptions[0]);
-    } else {
-      setNumber(inputValue);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   React.useEffect(() => {
     if (isOpen) {
       commandInputRef.current?.focus();

--- a/packages/ui/src/components/sign-up/sign-up.tsx
+++ b/packages/ui/src/components/sign-up/sign-up.tsx
@@ -171,11 +171,7 @@ function SignUpComponentLoaded() {
                       <Card.Description>{t('signUp.phoneCode.subtitle')}</Card.Description>
                       <Card.Description>
                         <span className='flex items-center justify-center gap-2'>
-                          {/* TODO: elements work
-                                    1. https://linear.app/clerk/issue/SDK-1830/add-signup-elements-for-accessing-email-address-and-phone-number
-                                    2. https://linear.app/clerk/issue/SDK-1831/pre-populate-emailphone-number-fields-when-navigating-back-to-the
-                          */}
-                          +1 (424) 424-4242{' '}
+                          <SignUp.PhoneNumberIdentifier />
                           <SignUp.Action
                             navigate='start'
                             asChild
@@ -244,11 +240,7 @@ function SignUpComponentLoaded() {
                       <Card.Description>{t('signUp.emailCode.subtitle')}</Card.Description>
                       <Card.Description>
                         <span className='flex items-center justify-center gap-2'>
-                          {/* TODO: elements work
-                                    1. https://linear.app/clerk/issue/SDK-1830/add-signup-elements-for-accessing-email-address-and-phone-number
-                                    2. https://linear.app/clerk/issue/SDK-1831/pre-populate-emailphone-number-fields-when-navigating-back-to-the
-                          */}
-                          alex.carpenter@clerk.dev{' '}
+                          <SignUp.EmailAddressIdentifier />
                           <SignUp.Action
                             navigate='start'
                             asChild


### PR DESCRIPTION
## Description

During the sign up flow, when moving to the `phone_code` or `email_code` verification steps, we render the provided email address or phone number. This PR introduces both `<SignUp.EmailAddressIndentifier />` and `<SignUp.PhoneNumberIdentifier />` components.

https://linear.app/clerk/issue/SDK-1830/add-signup-elements-for-accessing-email-address-and-phone-number

https://github.com/clerk/javascript/assets/825855/2e3b6b4c-32fd-49b4-8731-0916668fdfa8

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
