### PR TITLE
chore(astro): Update public env variables prefix

### DIFF
--- a/.changeset/fair-cows-taste.md
+++ b/.changeset/fair-cows-taste.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Update existing env variables that is still using `PUBLIC_ASTRO_APP` prefix to `PUBLIC_`.

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -80,11 +80,11 @@ npm run dev
 ### Set environment variables
 
 ```sh
-PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY=pk_(test|live)_xxxxxxx
+PUBLIC_CLERK_PUBLISHABLE_KEY=pk_(test|live)_xxxxxxx
 CLERK_SECRET_KEY=sk_(test|live)_xxxxxxx
 
-PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL=/sign-in # update this if sign in page exists on another path
-PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL=/sign-up # update this if sign up page exists on another path
+PUBLIC_CLERK_SIGN_IN_URL=/sign-in # update this if sign in page exists on another path
+PUBLIC_CLERK_SIGN_UP_URL=/sign-up # update this if sign up page exists on another path
 ```
 
 ### Update `env.d.ts`

--- a/packages/astro/src/internal/merge-env-vars-with-params.ts
+++ b/packages/astro/src/internal/merge-env-vars-with-params.ts
@@ -15,12 +15,12 @@ const mergeEnvVarsWithParams = (params?: AstroClerkIntegrationParams & { publish
   } = params || {};
 
   return {
-    signInUrl: paramSignIn || import.meta.env.PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL,
-    signUpUrl: paramSignUp || import.meta.env.PUBLIC_ASTRO_APP_CLERK_SIGN_UP_URL,
-    isSatellite: paramSatellite || import.meta.env.PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE,
-    proxyUrl: paramProxy || import.meta.env.PUBLIC_ASTRO_APP_CLERK_PROXY_URL,
-    domain: paramDomain || import.meta.env.PUBLIC_ASTRO_APP_CLERK_DOMAIN,
-    publishableKey: paramPublishableKey || import.meta.env.PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY || '',
+    signInUrl: paramSignIn || import.meta.env.PUBLIC_CLERK_SIGN_IN_URL,
+    signUpUrl: paramSignUp || import.meta.env.PUBLIC_CLERK_SIGN_UP_URL,
+    isSatellite: paramSatellite || import.meta.env.PUBLIC_CLERK_IS_SATELLITE,
+    proxyUrl: paramProxy || import.meta.env.PUBLIC_CLERK_PROXY_URL,
+    domain: paramDomain || import.meta.env.PUBLIC_CLERK_DOMAIN,
+    publishableKey: paramPublishableKey || import.meta.env.PUBLIC_CLERK_PUBLISHABLE_KEY || '',
     ...rest,
   };
 };

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -204,8 +204,8 @@ Missing domain and proxyUrl. A satellite application needs to specify a domain o
 1) With middleware
    e.g. export default clerkMiddleware({domain:'YOUR_DOMAIN',isSatellite:true});
 2) With environment variables e.g.
-   PUBLIC_ASTRO_APP_CLERK_DOMAIN='YOUR_DOMAIN'
-   PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE='true'
+   PUBLIC_CLERK_DOMAIN='YOUR_DOMAIN'
+   PUBLIC_CLERK_IS_SATELLITE='true'
    `;
 
 export const missingSignInUrlInDev = `
@@ -215,8 +215,8 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
 1) With middleware
    e.g. export default clerkMiddleware({signInUrl:'SOME_URL', isSatellite:true});
 2) With environment variables e.g.
-   PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL='SOME_URL'
-   PUBLIC_ASTRO_APP_CLERK_IS_SATELLITE='true'`;
+   PUBLIC_CLERK_SIGN_IN_URL='SOME_URL'
+   PUBLIC_CLERK_IS_SATELLITE='true'`;
 
 function decorateAstroLocal(req: Request, context: APIContext, requestState: RequestState) {
   const { reason, message, status, token } = requestState;

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     "CLERK_*",
     "GATSBY_CLERK_*",
     "NEXT_PUBLIC_CLERK_*",
-    "PUBLIC_ASTRO_APP_CLERK_*",
+    "PUBLIC_CLERK_*",
     "NODE_ENV",
     "NODE_VERSION",
     "NPM_VERSION",


### PR DESCRIPTION
## Description

This PR removes the `ASTRO_APP` prefix to some of the env variables. This was already tackled in https://github.com/clerk/javascript/pull/3669 but some of the files are still using the old prefix

## Checklist

- [ ] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
