### PR TITLE
fix(clerk-js): ImpersonationFab needs a router to navigate on sign out

### DIFF
--- a/.changeset/strong-mugs-dress.md
+++ b/.changeset/strong-mugs-dress.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Bug Fix: Navigation during signing out requires a router which was missing from the ImpersonationFab

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -120,12 +120,14 @@ export const LazyImpersonationFabProvider = (
 ) => {
   return (
     <Suspense>
-      <AppearanceProvider
-        globalAppearance={props.globalAppearance}
-        appearanceKey={'impersonationFab'}
-      >
-        {props.children}
-      </AppearanceProvider>
+      <VirtualRouter startPath=''>
+        <AppearanceProvider
+          globalAppearance={props.globalAppearance}
+          appearanceKey={'impersonationFab'}
+        >
+          {props.children}
+        </AppearanceProvider>
+      </VirtualRouter>
     </Suspense>
   );
 };


### PR DESCRIPTION
## Description
Fixes this error while impersonating a user
![image](https://github.com/user-attachments/assets/4f1f4c5b-d419-434b-a7d9-d6c94e9b4d28)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
