### PR TITLE
refactor(react): Update SignInButton props to only accept `fallbackRedirectUrl` or `forceRedirectUrl` prop not both

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -86,11 +86,23 @@ type ButtonProps = {
   children?: React.ReactNode;
 };
 
+// https://github.com/sindresorhus/type-fest/blob/main/source/require-one-or-none.d.ts
+type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> = {
+  [Key in KeysType]: Required<Pick<ObjectType, Key>> & Partial<Record<Exclude<KeysType, Key>, never>>;
+}[KeysType] &
+  Omit<ObjectType, KeysType>;
+
+type RequireNone<KeysType extends PropertyKey> = Partial<Record<KeysType, never>>;
+
+type RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> = (
+  | RequireExactlyOne<ObjectType, KeysType>
+  | RequireNone<KeysType>
+) &
+  Omit<ObjectType, KeysType>;
+
 export type SignInButtonProps = ButtonProps &
-  Pick<
-    SignInProps,
-    'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signUpForceRedirectUrl' | 'signUpFallbackRedirectUrl'
-  >;
+  RequireOneOrNone<SignInProps, 'fallbackRedirectUrl' | 'forceRedirectUrl'> &
+  RequireOneOrNone<SignInProps, 'signUpForceRedirectUrl' | 'signUpFallbackRedirectUrl'>;
 
 export type SignUpButtonProps = {
   unsafeMetadata?: SignUpUnsafeMetadata;


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
