### PR TITLE
fix(ui): Redirect landing page buttons to new UI

### DIFF
--- a/packages/ui/theme-builder/app/page.tsx
+++ b/packages/ui/theme-builder/app/page.tsx
@@ -1,29 +1,40 @@
-import { SignedIn, SignedOut, SignInButton, SignOutButton, SignUpButton } from '@clerk/nextjs';
+import { SignedIn, SignedOut, SignOutButton } from '@clerk/nextjs';
+import { cva } from 'cva';
+import Link from 'next/link';
 
-function Button({ children }: { children: React.ReactNode }) {
-  return (
-    <button className='relative isolate rounded border bg-white bg-gradient-to-b from-white to-neutral-50 px-2.5 py-1 text-sm font-medium'>
-      {children}
-    </button>
-  );
-}
+const button = cva({
+  base: [
+    'relative isolate',
+    'text-sm text-center font-medium',
+    'px-2.5 py-1',
+    'border bg-white bg-gradient-to-b from-white to-neutral-50',
+    'rounded',
+  ],
+});
 
 export default function Home() {
   return (
     <div className='relative'>
       <SignedIn>
         <SignOutButton>
-          <Button>Sign out</Button>
+          <button className={button()}>Sign out</button>
         </SignOutButton>
       </SignedIn>
       <SignedOut>
         <div className='flex flex-col gap-4'>
-          <SignInButton>
-            <Button>Sign in</Button>
-          </SignInButton>
-          <SignUpButton>
-            <Button>Sign up</Button>
-          </SignUpButton>
+          <Link
+            href='/sign-in'
+            className={button()}
+          >
+            Sign in
+          </Link>
+
+          <Link
+            href='/sign-up'
+            className={button()}
+          >
+            Sign up
+          </Link>
         </div>
       </SignedOut>
     </div>

--- a/packages/ui/theme-builder/package.json
+++ b/packages/ui/theme-builder/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-tooltip": "^1.1.1",
     "bezier-easing": "^2.1.0",
     "change-case": "^5.4.4",
-    "clsx": "^2.1.1",
+    "cva": "^1.0.0-beta.1",
     "colorjs.io": "^0.5.0",
     "next": "14.2.4",
     "react": "^18.3.1",


### PR DESCRIPTION
## Description

Clicking on these landing page buttons will open up the current UI rather than our rebuilt components; this PR amends that behaviour 

In the future, we'll seek to re-add these components, but it makes more sense to keep within our own flow for now

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
