### PR TITLE
fix(elements): Pass sign up resource directly to child machine

### DIFF
--- a/.changeset/cyan-pets-relax.md
+++ b/.changeset/cyan-pets-relax.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fix call to `hasTags` on undefined `state`

--- a/.changeset/cyan-pets-relax.md
+++ b/.changeset/cyan-pets-relax.md
@@ -2,4 +2,4 @@
 "@clerk/elements": patch
 ---
 
-Fix call to `hasTags` on undefined `state`
+Handle call to `hasTags` on undefined `state`

--- a/.changeset/small-bears-yell.md
+++ b/.changeset/small-bears-yell.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Pass resource directly to machine over getSnapshot to avoid empty context

--- a/.changeset/three-houses-deny.md
+++ b/.changeset/three-houses-deny.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Update XState from 5.13.x to 5.15.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -49062,13 +49062,13 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@xstate/react": "^4.1.1",
         "client-only": "^0.0.1",
-        "xstate": "^5.13.0"
+        "xstate": "^5.15.0"
       },
       "devDependencies": {
         "@clerk/clerk-react": "5.2.8",
         "@clerk/eslint-config-custom": "*",
         "@clerk/shared": "2.3.3",
-        "@statelyai/inspect": "^0.3.1",
+        "@statelyai/inspect": "^0.4.0",
         "@types/node": "^18.19.33",
         "@types/react": "*",
         "@types/react-dom": "*",
@@ -49268,9 +49268,10 @@
       }
     },
     "packages/elements/node_modules/@statelyai/inspect": {
-      "version": "0.3.1",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@statelyai/inspect/-/inspect-0.4.0.tgz",
+      "integrity": "sha512-VxQldRlKYcu6rzLY83RSXVwMYexkH6hNx85B89YWYyXYWtNGaWHFCwV7a/Kz8FFPeUz8EKVAnyMOg2kNpn07wQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-safe-stringify": "^2.1.1",
         "isomorphic-ws": "^5.0.0",
@@ -49426,8 +49427,9 @@
       }
     },
     "packages/elements/node_modules/xstate": {
-      "version": "5.13.2",
-      "license": "MIT",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.15.0.tgz",
+      "integrity": "sha512-0DGArbj+ych7PcCqHzhEvXH1qVG41lhenwdbEPBRJyxQP9TLooUsR7oiR4YWYHblLOVWvz/esiw8HUtHXp/kZA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -75,13 +75,13 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@xstate/react": "^4.1.1",
     "client-only": "^0.0.1",
-    "xstate": "^5.13.0"
+    "xstate": "^5.15.0"
   },
   "devDependencies": {
     "@clerk/clerk-react": "5.2.8",
     "@clerk/eslint-config-custom": "*",
     "@clerk/shared": "2.3.3",
-    "@statelyai/inspect": "^0.3.1",
+    "@statelyai/inspect": "^0.4.0",
     "@types/node": "^18.19.33",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -359,9 +359,11 @@ export const SignUpRouterMachine = setup({
         id: 'verification',
         src: 'verificationMachine',
         input: ({ context, self }) => ({
+          attributes: context.clerk.__unstable__environment?.userSettings.attributes,
           basePath: context.router?.basePath,
           formRef: context.formRef,
           parent: self,
+          resource: context.clerk.client.signUp,
         }),
         onDone: {
           actions: 'raiseNext',

--- a/packages/elements/src/internals/machines/sign-up/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/verification.machine.ts
@@ -93,7 +93,7 @@ export const SignUpVerificationMachine = setup({
 
               // Short-circuit if the sign-up resource is already complete
               if (signInStatus === 'complete') {
-                return sendBack({ type: `EMAIL_LINK.VERIFIED`, resource });
+                return sendBack({ type: 'EMAIL_LINK.VERIFIED', resource });
               }
 
               switch (verificationStatus) {
@@ -105,13 +105,13 @@ export const SignUpVerificationMachine = setup({
                 }
                 case 'failed': {
                   sendBack({
-                    type: `EMAIL_LINK.FAILED`,
+                    type: 'EMAIL_LINK.FAILED',
                     error: new ClerkElementsError('email-link-verification-failed', 'Email verification failed'),
                     resource,
                   });
                   break;
                 }
-                case 'unverified':
+                // case 'unverified':
                 default:
                   return;
               }
@@ -170,12 +170,7 @@ export const SignUpVerificationMachine = setup({
     isStrategyEnabled: (
       { context },
       { attribute, strategy }: { attribute: Attribute; strategy: VerificationStrategy },
-    ) =>
-      Boolean(
-        context.parent
-          .getSnapshot()
-          .context.clerk.__unstable__environment?.userSettings.attributes[attribute].verifications.includes(strategy),
-      ),
+    ) => Boolean(context.attributes?.[attribute].verifications.includes(strategy)),
     shouldVerifyPhoneCode: shouldVerify('phone_number'),
     shouldVerifyEmailLink: shouldVerify('email_address', 'email_link'),
     shouldVerifyEmailCode: shouldVerify('email_address', 'email_code'),
@@ -186,13 +181,14 @@ export const SignUpVerificationMachine = setup({
   id: SignUpVerificationMachineId,
   initial: 'Init',
   context: ({ input }) => ({
+    attributes: input.attributes,
     basePath: input.basePath || SIGN_UP_DEFAULT_BASE_PATH,
     loadingStep: 'verifications',
     formRef: input.formRef,
     parent: input.parent,
     resendable: false,
     resendableAfter: RESENDABLE_COUNTDOWN_DEFAULT,
-    resource: input.parent.getSnapshot().context.clerk.client.signUp,
+    resource: input.resource,
   }),
   on: {
     NEXT: [

--- a/packages/elements/src/internals/machines/sign-up/verification.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/verification.types.ts
@@ -1,5 +1,5 @@
 import type { ClerkAPIResponseError } from '@clerk/shared/error';
-import type { SignUpResource } from '@clerk/types';
+import type { Attributes, SignUpResource } from '@clerk/types';
 import type { ActorRefFrom, DoneActorEvent, ErrorActorEvent } from 'xstate';
 
 import type { FormMachine } from '~/internals/machines/form';
@@ -63,9 +63,11 @@ export type SignUpVerificationEvents =
 // ---------------------------------- Input ---------------------------------- //
 
 export type SignUpVerificationInput = {
+  attributes: Attributes | undefined;
   basePath?: string;
   formRef: ActorRefFrom<typeof FormMachine>;
   parent: SignInRouterMachineActorRef;
+  resource: SignUpResource;
 };
 
 // ---------------------------------- Delays ---------------------------------- //
@@ -80,6 +82,7 @@ export type SignUpVerificationDelays = keyof typeof SignUpVerificationDelays;
 // ---------------------------------- Context ---------------------------------- //
 
 export interface SignUpVerificationContext {
+  attributes: Attributes | undefined;
   basePath: string;
   resource: SignUpResource;
   error?: Error | ClerkAPIResponseError;

--- a/packages/elements/src/react/hooks/use-active-tags.hook.ts
+++ b/packages/elements/src/react/hooks/use-active-tags.hook.ts
@@ -55,6 +55,10 @@ export function useActiveTags<TActor extends AnyActorRef, TTag extends TaggedAct
     (prev, next) => prev.tags === next.tags,
   );
 
+  if (!state) {
+    return false;
+  }
+
   if (typeof tags === 'string') {
     return state.hasTag(tags);
   }


### PR DESCRIPTION
## Description

- Handle call to `hasTags` on undefined `state`
- Pass Sign Up resource directly to machine over getSnapshot to avoid empty context
- Update XState from 5.13.x to 5.15.x

<!-- Fixes #(issue number) -->

Fixes SDK-1879

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
