### PR TITLE
chore(nextjs): Add tests covering the new middleware matcher

### DIFF
--- a/packages/nextjs/src/utils/__tests__/matcher.test.ts
+++ b/packages/nextjs/src/utils/__tests__/matcher.test.ts
@@ -1,0 +1,87 @@
+import { pathToRegexp } from 'path-to-regexp';
+
+const createMatcher = (config: { matcher: string[] }) => (path: string) => {
+  return config.matcher.some(matcher => {
+    return pathToRegexp(matcher).test(path);
+  });
+};
+
+describe('nextjs matcher', () => {
+  /**
+   * 🚨🚨🚨🚨
+   * This is the matcher we document for clerkMiddleware + authMiddleware.
+   * Any change made to the matcher here needs to be reflected in the documentation, the dashboard
+   * and vice versa.
+   * 🚨🚨🚨🚨
+   */
+  const config = {
+    matcher: [
+      // Skip Next.js internals and all static files, unless found in search params
+      '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+      // Always run for API routes
+      '/(api|trpc)(.*)',
+    ],
+  };
+
+  const match = createMatcher(config);
+
+  it.each([
+    // Skip nextjs internals
+    '/_next', //
+    '/_next/',
+    '/_next/static/',
+    '/_next/static',
+    '/_next/images',
+    '/favicon.ico',
+    // Skip android manifest file
+    '/site.webmanifest',
+    // Skip normal files
+    '/file.js',
+    '/img.jpeg',
+    '/img.jpg',
+    '/img.png',
+    '/img.jpg?param=1',
+    // We can't cover this case without extremely complex regex
+    // '/img.jpg?param=img.jpg',
+  ])('skips the middleware for "%s"', async path => {
+    expect(match(path)).toBe(false);
+  });
+
+  it.each([
+    // Always protect /api and /trpc
+    '/api/', //
+    '/api',
+    '/api/endpoint',
+    '/api/endpoint.json',
+    '/trpc',
+    '/trpc/',
+    '/trpc/endpoint',
+    '/trpc/endpoint.json',
+    '/trpc/endpoint.action',
+    // Paths with file extensions are not files without `.`
+    '/somethingjpg',
+    // Always protect jsons
+    '/file.json',
+    '/file.json/',
+    '/a/b.json',
+    // Sanity checks for paths
+    '/',
+    '/path',
+    '/path/',
+    '/nested/path',
+    '/nested/path/multiple/levels',
+    // Paths with slugs containing `.` are not files
+    '/slug-123',
+    '/sl.ug-123',
+    '/sl.ug',
+    '/clerk.com',
+    // Paths containing search params are not files, even if they contain a file extension
+    '/download?filename=1.jpg',
+    '/download/?filename=1.jpg',
+    '/download?test=1&filename=1.jpg',
+    '/download?filename=1.jpg&test=1',
+    '/download?filename=1.png&test=1',
+  ])('triggers the middleware for "%s"', path => {
+    expect(match(path)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

The matcher we currently document breaks Clerk for the following scenario. 
- Have an app using the currently documented matcher
- Have a URL structure similar to `/articles/:article-slug`. `:article-slug` would be something like `${article_title}_${article_id}` , eg: `/article/hello-team-support_123a` - pretty common stuff so far.

If an article contains a `.` in its name, eg `/article/i-use-clerk.com-and-why-you-should-too_123`, then `auth()` and related helpers will fail because the matcher will not match the request URL and the middleware will be skipped.

This bug recently hit a few customers. This PR updates the matcher with a simplified version that no longer handles files as an edge case. We want to update our own dashboard first to further test the new matcher, before we reach out to the customers with the updated version.

The new matcher works for all cases tested in this PR. In comparison, the old matcher we used (shown below) failed for at least the following cases:

```
    ✕ triggers the middleware for "/sl.ug-123" (1 ms)
    ✕ triggers the middleware for "/sl.ug"
    ✕ triggers the middleware for "/download?filename=1.jpg"
    ✕ triggers the middleware for "/download/?filename=1.jpg" (1 ms)
    ✕ triggers the middleware for "/download?test=1&filename=1.jpg"
    ✕ triggers the middleware for "/download?filename=1.jpg&test=1"
    ✕ triggers the middleware for "/download?filename=1.png&test=1"
    ✕ triggers the middleware for "/file.json" (1 ms)
    ✕ triggers the middleware for "/file.json/"
    ✕ triggers the middleware for "/a/b.json"
```

Important: any change here needs to be reflected in the docs + the dashboard quickstart page. 

For reference, the old matcher was:

```
export const config = {
  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
};
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
