### PR TITLE
fix(ui): Format safe identifier phone number during sign in verification step

### DIFF
--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -10,7 +10,6 @@ import { EmailOrUsernameOrPhoneNumberField } from '~/common/email-or-username-or
 import { OTPField } from '~/common/otp-field';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
-import { parsePhoneString } from '~/common/phone-number-field/utils';
 import { PhoneNumberOrUsernameField } from '~/common/phone-number-or-username-field';
 import { UsernameField } from '~/common/username-field';
 import { useAttributes } from '~/hooks/use-attributes';
@@ -25,7 +24,7 @@ import * as Icon from '~/primitives/icon';
 import { LinkButton } from '~/primitives/link-button';
 import { SecondaryButton } from '~/primitives/secondary-button';
 import { Seperator } from '~/primitives/seperator';
-import { isPhoneNumber } from '~/utils/is-phone-number';
+import { formatSafeIdentifier } from '~/utils/format-safe-identifier';
 
 export function SignInComponent() {
   return (
@@ -208,10 +207,7 @@ export function SignInComponentLoaded() {
                         <span className='flex items-center justify-center gap-2'>
                           <SignIn.SafeIdentifier
                             transform={val => {
-                              if (!isPhoneNumber(val)) {
-                                return parsePhoneString(val).formattedNumberWithCode;
-                              }
-                              return val;
+                              return formatSafeIdentifier(val) || val;
                             }}
                           />
                           <SignIn.Action

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -10,6 +10,7 @@ import { EmailOrUsernameOrPhoneNumberField } from '~/common/email-or-username-or
 import { OTPField } from '~/common/otp-field';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
+import { parsePhoneString } from '~/common/phone-number-field/utils';
 import { PhoneNumberOrUsernameField } from '~/common/phone-number-or-username-field';
 import { UsernameField } from '~/common/username-field';
 import { useAttributes } from '~/hooks/use-attributes';
@@ -24,6 +25,7 @@ import * as Icon from '~/primitives/icon';
 import { LinkButton } from '~/primitives/link-button';
 import { SecondaryButton } from '~/primitives/secondary-button';
 import { Seperator } from '~/primitives/seperator';
+import { isPhoneNumber } from '~/utils/is-phone-number';
 
 export function SignInComponent() {
   return (
@@ -204,7 +206,14 @@ export function SignInComponentLoaded() {
                       <Card.Description>{t('signIn.password.subtitle')}</Card.Description>
                       <Card.Description>
                         <span className='flex items-center justify-center gap-2'>
-                          <SignIn.SafeIdentifier />
+                          <SignIn.SafeIdentifier
+                            transform={val => {
+                              if (!isPhoneNumber(val)) {
+                                return parsePhoneString(val).formattedNumberWithCode;
+                              }
+                              return val;
+                            }}
+                          />
                           <SignIn.Action
                             navigate='start'
                             asChild

--- a/packages/ui/src/utils/format-safe-identifier.ts
+++ b/packages/ui/src/utils/format-safe-identifier.ts
@@ -1,0 +1,15 @@
+import { stringToFormattedPhoneString } from '~/common/phone-number-field/utils';
+
+export const isMaskedIdentifier = (str: string | undefined | null) => str && str.includes('**');
+
+/**
+ * Formats a string that can contain an email, a username or a phone number.
+ * Depending on the scenario, the string might be obfuscated (parts of the identifier replaced with "*")
+ * Refer to the tests for examples.
+ */
+export const formatSafeIdentifier = (str: string | undefined | null) => {
+  if (!str || str.includes('@') || isMaskedIdentifier(str) || str.match(/[a-zA-Z]/)) {
+    return str;
+  }
+  return stringToFormattedPhoneString(str);
+};

--- a/packages/ui/src/utils/is-phone-number.ts
+++ b/packages/ui/src/utils/is-phone-number.ts
@@ -1,5 +1,0 @@
-const phoneRegex = /^(\+\d{1,3}[-\s]?)?\(?[0-9]{3}\)?[-\s]?[0-9]{3}[-\s]?[0-9]{4}$/;
-
-export function isPhoneNumber(str: string) {
-  return phoneRegex.test(str);
-}

--- a/packages/ui/src/utils/is-phone-number.ts
+++ b/packages/ui/src/utils/is-phone-number.ts
@@ -1,0 +1,5 @@
+const phoneRegex = /^(\+\d{1,3}[-\s]?)?\(?[0-9]{3}\)?[-\s]?[0-9]{3}[-\s]?[0-9]{4}$/;
+
+export function isPhoneNumber(str: string) {
+  return phoneRegex.test(str);
+}


### PR DESCRIPTION
## Description

Add formatSafeIdentifier util to format phone number during sign in verification step

BEFORE:
<img width="518" alt="Screenshot 2024-07-17 at 5 29 29 PM" src="https://github.com/user-attachments/assets/b3fc87e5-2ef0-48da-b00c-068135483a75">

AFTER:
<img width="512" alt="Screenshot 2024-07-17 at 5 29 13 PM" src="https://github.com/user-attachments/assets/e3ad60ba-1cfc-4215-bbbc-8f2462fa9fac">

https://linear.app/clerk/issue/SDKI-121/signin-verifications-phone-number-should-be-formatted-according-to

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
