### PR TITLE
feat(testing): Introduce Cypress Custom commands for sign-in and sign-out

### DIFF
--- a/.changeset/cyan-gorillas-live.md
+++ b/.changeset/cyan-gorillas-live.md
@@ -1,0 +1,5 @@
+---
+"@clerk/testing": minor
+---
+
+Introduce Cypress Custom commands for sign-in and sign-out.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -128,6 +128,102 @@ it("sign up", () => {
 });
 ```
 
+## Cypress Custom commands
+
+This package also provides custom commands to sign-in/sign-out with Clerk in your Cypress tests without having to interact with the UI.
+To use these commands, you must import them in your `cypress/support/commands.ts` file.
+
+```ts
+// cypress/support/commands.ts
+/// <reference types="cypress" />
+import { addClerkCommands } from '@clerk/testing/cypress';
+addClerkCommands({ Cypress, cy });
+
+export {};
+```
+
+### `cy.clerkSignIn`
+
+The `cy.clerkSignIn` command is used to sign in a user using Clerk. This custom command supports only the following first factor strategies:
+
+- Password
+- Phone code
+- Email code
+
+**Note:** Multi-factor authentication is not supported.
+
+This helper internally uses the `setupClerkTestingToken`, so you don't need to call it separately.
+
+**Prerequisites**
+
+- You must call `cy.visit` before calling this command.
+- Navigate to a non-protected page that loads Clerk before using this command.
+
+**Parameters**
+
+- `signInParams`: The sign-in object.
+  - `strategy`: The sign-in strategy. Supported strategies are `'password'`, `'phone_code'`, and `'email_code'`.
+  - `identifier`: The user's identifier. This could be a username, a phone number, or an email.
+  - `password`: The user's password. This is required only if the strategy is `'password'`.
+
+**Strategy Specifics**
+
+- **Password:** The command will sign in the user using the provided password and identifier.
+- **Phone Code:** You must have a user with a test phone number as an identifier (e.g., `+15555550100`).
+- **Email Code:** You must have a user with a test email as an identifier (e.g., `your_email+clerk_test@example.com`).
+
+**Example**
+
+```ts
+it('sign in', () => {
+  cy.visit(`/`);
+  cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
+  cy.visit('/protected');
+});
+```
+
+### `cy.clerkSignOut`
+
+The `cy.clerkSignOut` command is used to sign out the current user using Clerk.
+
+**Prerequisites**
+
+- You must call `cy.visit` before calling this command.
+- Navigate to a page that loads Clerk before using this command.
+
+**Parameters**
+
+- `signOutOptions`: A `SignOutOptions` object.
+
+**Example**
+
+```ts
+it('sign out', () => {
+  cy.visit(`/`);
+  cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
+  cy.visit('/protected');
+  cy.clerkSignOut();
+});
+```
+
+### `cy.clerkLoaded`
+
+The `cy.clerkLoaded` command asserts that Clerk has been loaded.
+
+**Prerequisites**
+
+- You must call `cy.visit` before calling this command.
+- Navigate to a page that loads Clerk before using this command.
+
+**Example**
+
+```ts
+it('check Clerk loaded', () => {
+  cy.visit(`/`);
+  cy.clerkLoaded();
+});
+```
+
 ## Support
 
 You can get in touch with us in any of the following ways:

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -130,7 +130,7 @@ it("sign up", () => {
 
 ## Cypress Custom commands
 
-This package also provides custom commands to sign-in/sign-out with Clerk in your Cypress tests without having to interact with the UI.
+This package also provides custom commands to sign in/sign out with Clerk in your Cypress tests without having to interact with the UI.
 To use these commands, you must import them in your `cypress/support/commands.ts` file.
 
 ```ts

--- a/packages/testing/src/cypress/custom-commands.ts
+++ b/packages/testing/src/cypress/custom-commands.ts
@@ -43,7 +43,6 @@ declare global {
        * @param signInParams.password - The user's password. Required only if the strategy is 'password'.
        *
        * @example
-       * ```ts
        *  it("sign in", () => {
        *     cy.visit(`/`);
        *     cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
@@ -58,7 +57,6 @@ declare global {
        * @param signOutOptions - A SignOutOptions object.
        *
        * @example
-       * ```ts
        *  it("sign out", () => {
        *     cy.visit(`/`);
        *     cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });

--- a/packages/testing/src/cypress/custom-commands.ts
+++ b/packages/testing/src/cypress/custom-commands.ts
@@ -1,0 +1,201 @@
+/// <reference types="cypress" />
+import type {
+  Clerk,
+  EmailCodeFactor,
+  PhoneCodeFactor,
+  SignInFirstFactor,
+  SignInResource,
+  SignOutOptions,
+} from '@clerk/types';
+
+import { setupClerkTestingToken } from './setupClerkTestingToken';
+
+const CLERK_TEST_CODE = '424242';
+
+type CypressClerkSignInParams =
+  | {
+      strategy: 'password';
+      password: string;
+      identifier: string;
+    }
+  | {
+      strategy: 'phone_code' | 'email_code';
+      identifier: string;
+    };
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Signs in a user using Clerk. This custom command supports only password, phone_code and email_code first factor strategies.
+       * Multi-factor is not supported.
+       * This helper is using the `setupClerkTestingToken` internally.
+       * It is required to call `cy.visit` before calling this command, and navigate to a not protected page that loads Clerk.
+       *
+       * If the strategy is password, the command will sign in the user using the provided password and identifier.
+       * If the strategy is phone_code, you are required to have a user with a test phone number as an identifier (e.g. +15555550100).
+       * If the strategy is email_code, you are required to have a user with a test email as an identifier (e.g. your_email+clerk_test@example.com).
+       *
+       * @param signInParams - The sign in parameters.
+       * @param signInParams.strategy - The sign in strategy. Supported strategies are 'password', 'phone_code' and 'email_code'.
+       * @param signInParams.identifier - The user's identifier. Could be a username, a phone number or an email.
+       * @param signInParams.password - The user's password. Required only if the strategy is 'password'.
+       *
+       * @example
+       * ```ts
+       *  it("sign in", () => {
+       *     cy.visit(`/`);
+       *     cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
+       *     cy.visit('/protected');
+       *  });
+       */
+      clerkSignIn(signInParams: CypressClerkSignInParams): Chainable<void>;
+
+      /**
+       * Signs out the current user using Clerk.
+       * It is required to call `cy.visit` before calling this command, and navigate to a page that loads Clerk.
+       * @param signOutOptions - A SignOutOptions object.
+       *
+       * @example
+       * ```ts
+       *  it("sign out", () => {
+       *     cy.visit(`/`);
+       *     cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
+       *     cy.visit('/protected');
+       *     cy.clerkSignOut();
+       *  });
+       */
+      clerkSignOut(signOutOptions?: SignOutOptions): Chainable<void>;
+
+      /**
+       * Asserts that Clerk has been loaded.
+       * It is required to call `cy.visit` before calling this command, and navigate to a page that loads Clerk.
+       */
+      clerkLoaded(): Chainable<void>;
+    }
+  }
+  interface Window {
+    Clerk: Clerk;
+  }
+}
+
+type AddClerkCommandsParams = {
+  Cypress: typeof Cypress;
+  cy: Cypress.Chainable;
+};
+
+export const addClerkCommands = ({ Cypress, cy }: AddClerkCommandsParams) => {
+  Cypress.Commands.add(`clerkSignIn`, signInParams => {
+    setupClerkTestingToken();
+    cy.log(`Signing in.`);
+
+    cy.window()
+      .should(window => {
+        expect(window).to.not.have.property(`Clerk`, undefined);
+        expect(window.Clerk.loaded).to.eq(true);
+      })
+      .then(async window => {
+        if (!window.Clerk.client) {
+          return;
+        }
+        const signIn = window.Clerk.client.signIn;
+        try {
+          if (signInParams.strategy === 'password') {
+            const res = await signIn.create(signInParams);
+            await window.Clerk.setActive({
+              session: res.createdSessionId,
+            });
+          } else {
+            assertIdentifierRequirement(signInParams.identifier, signInParams.strategy);
+            await signInWithCode(signIn, window.Clerk.setActive, signInParams.identifier, signInParams.strategy);
+          }
+        } catch (err: any) {
+          cy.log(`Clerk: Failed to sign in: ${err?.message}`);
+          throw new Error(`Clerk: Failed to sign in: ${err?.message}`);
+        }
+
+        cy.log(`Finished signing in.`);
+      });
+  });
+
+  Cypress.Commands.add(`clerkSignOut`, signOutOptions => {
+    cy.log(`Signing out.`);
+
+    cy.window()
+      .should(window => {
+        expect(window).to.not.have.property(`Clerk`, undefined);
+        expect(window.Clerk.loaded).to.eq(true);
+      })
+      .then(async window => {
+        await window.Clerk.signOut(signOutOptions);
+
+        cy.log(`Finished signing out.`);
+      });
+  });
+
+  Cypress.Commands.add(`clerkLoaded`, () => {
+    cy.window().should(window => {
+      expect(window).to.not.have.property(`Clerk`, undefined);
+      expect(window.Clerk.loaded).to.eq(true);
+    });
+  });
+};
+
+const isPhoneCodeFactor = (factor: SignInFirstFactor): factor is PhoneCodeFactor => {
+  return factor.strategy === 'phone_code';
+};
+
+const isEmailCodeFactor = (factor: SignInFirstFactor): factor is EmailCodeFactor => {
+  return factor.strategy === 'email_code';
+};
+
+const signInWithCode = async (
+  signIn: SignInResource,
+  setActive: any,
+  identifier: string,
+  strategy: 'phone_code' | 'email_code',
+) => {
+  const { supportedFirstFactors } = await signIn.create({
+    identifier,
+  });
+  const codeFactorFn = strategy === 'phone_code' ? isPhoneCodeFactor : isEmailCodeFactor;
+  const codeFactor = supportedFirstFactors?.find(codeFactorFn);
+  if (codeFactor) {
+    const prepareParams =
+      strategy === 'phone_code'
+        ? { strategy, phoneNumberId: (codeFactor as PhoneCodeFactor).phoneNumberId }
+        : { strategy, emailAddressId: (codeFactor as EmailCodeFactor).emailAddressId };
+
+    await signIn.prepareFirstFactor(prepareParams);
+    const signInAttempt = await signIn.attemptFirstFactor({
+      strategy,
+      code: CLERK_TEST_CODE,
+    });
+
+    if (signInAttempt.status === 'complete') {
+      await setActive({ session: signInAttempt.createdSessionId });
+    } else {
+      throw new Error(`Failed to signing in. Status is ${signInAttempt.status}`);
+    }
+  } else {
+    throw new Error(`${strategy} is not enabled.`);
+  }
+};
+
+const assertIdentifierRequirement = (identifier: string, strategy: string) => {
+  if (strategy === 'phone_code' && !identifier.includes('+155555501')) {
+    throw new Error(
+      `Clerk: Phone number should be a test phone number.\n
+       Example: +15555550100.\n
+       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#phone-numbers`,
+    );
+  }
+  if (strategy === 'email_code' && !identifier.includes('+clerk_test')) {
+    throw new Error(
+      `Clerk: Email should be a test email.\n
+       Any email with the +clerk_test subaddress is a test email address.\n
+       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#email-addresses`,
+    );
+  }
+};

--- a/packages/testing/src/cypress/custom-commands.ts
+++ b/packages/testing/src/cypress/custom-commands.ts
@@ -176,7 +176,7 @@ const signInWithCode = async (
     if (signInAttempt.status === 'complete') {
       await setActive({ session: signInAttempt.createdSessionId });
     } else {
-      throw new Error(`Failed to signing in. Status is ${signInAttempt.status}`);
+      throw new Error(`Failed to sign in. Status is ${signInAttempt.status}`);
     }
   } else {
     throw new Error(`${strategy} is not enabled.`);

--- a/packages/testing/src/cypress/index.ts
+++ b/packages/testing/src/cypress/index.ts
@@ -1,2 +1,3 @@
 export { clerkSetup } from './setup';
 export { setupClerkTestingToken } from './setupClerkTestingToken';
+export { addClerkCommands } from './custom-commands';


### PR DESCRIPTION
## Description

This PR adds Custom commands on the Cypress integration to better sign-in and sign-out.

### Add the custom commands

To use these commands, you must import them in your `cypress/support/commands.ts` file.

```ts
// cypress/support/commands.ts
/// <reference types="cypress" />
import { addClerkCommands } from '@clerk/testing/cypress';
addClerkCommands({ Cypress, cy });

export {};
```

### `cy.clerkSignIn`

The `cy.clerkSignIn` command is used to sign in a user using Clerk. This custom command supports only the following first factor strategies:

- Password
- Phone code
- Email code

**Note:** Multi-factor authentication is not supported.

This helper internally uses the `setupClerkTestingToken`, so you don't need to call it separately.

**Prerequisites**

- You must call `cy.visit` before calling this command.
- Navigate to a non-protected page that loads Clerk before using this command.

**Parameters**

- `signInParams`: The sign-in object.
  - `strategy`: The sign-in strategy. Supported strategies are `'password'`, `'phone_code'`, and `'email_code'`.
  - `identifier`: The user's identifier. This could be a username, a phone number, or an email.
  - `password`: The user's password. This is required only if the strategy is `'password'`.

**Strategy Specifics**

- **Password:** The command will sign in the user using the provided password and identifier.
- **Phone Code:** You must have a user with a test phone number as an identifier (e.g., `+15555550100`).
- **Email Code:** You must have a user with a test email as an identifier (e.g., `your_email+clerk_test@example.com`).

**Example**

```ts
it('sign in', () => {
  cy.visit(`/`);
  cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
  cy.visit('/protected');
});
```

### `cy.clerkSignOut`

The `cy.clerkSignOut` command is used to sign out the current user using Clerk.

**Prerequisites**

- You must call `cy.visit` before calling this command.
- Navigate to a page that loads Clerk before using this command.

**Parameters**

- `signOutOptions`: A `SignOutOptions` object.

**Example**

```ts
it('sign out', () => {
  cy.visit(`/`);
  cy.clerkSignIn({ strategy: 'phone_code', identifier: '+15555550100' });
  cy.visit('/protected');
  cy.clerkSignOut();
});
```

### `cy.clerkLoaded`

The `cy.clerkLoaded` command asserts that Clerk has been loaded.

**Prerequisites**

- You must call `cy.visit` before calling this command.
- Navigate to a page that loads Clerk before using this command.

**Example**

```ts
it('check Clerk loaded', () => {
  cy.visit(`/`);
  cy.clerkLoaded();
});
```

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
