### PR TITLE
chore(nextjs): Introduce build-time error for server-only helpers on client-side

### DIFF
--- a/.changeset/perfect-chairs-work.md
+++ b/.changeset/perfect-chairs-work.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Return build-time error if `auth` and `currentUser` server-side helpers are imported into Client Components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41884,6 +41884,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "license": "ISC"
@@ -49890,6 +49895,7 @@
         "@clerk/types": "4.8.0",
         "crypto-js": "4.2.0",
         "path-to-regexp": "6.2.2",
+        "server-only": "0.0.1",
         "tslib": "2.4.1"
       },
       "devDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -73,6 +73,7 @@
     "@clerk/types": "4.8.0",
     "crypto-js": "4.2.0",
     "path-to-regexp": "6.2.2",
+    "server-only": "0.0.1",
     "tslib": "2.4.1"
   },
   "devDependencies": {

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { AuthObject, RedirectFun } from '@clerk/backend/internal';
 import { constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
 import { notFound, redirect } from 'next/navigation';

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { User } from '@clerk/backend';
 
 import { clerkClient } from '../../server/clerkClient';

--- a/packages/nextjs/src/server/__tests__/exports.test.ts
+++ b/packages/nextjs/src/server/__tests__/exports.test.ts
@@ -1,3 +1,5 @@
+jest.mock('server-only', () => null);
+
 import * as publicExports from '../index';
 
 describe('/server public exports', () => {


### PR DESCRIPTION
## Description

Resolves https://github.com/clerk/javascript/issues/3660

Uses the `server-only` package to throw a build-time error if Clerk server-side helpers get accidentally imported on the client side. 

![CleanShot 2024-07-18 at 09 57 12@2x](https://github.com/user-attachments/assets/0ffc3f02-f5b8-4a69-bae4-9e8644a8eca3)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
