### PR TITLE
fix(nextjs): Move `server-only` resolution to runtime

### DIFF
--- a/.changeset/lucky-olives-explode.md
+++ b/.changeset/lucky-olives-explode.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Fixes regression on `@clerk/nextjs/server` (introduced on https://github.com/clerk/javascript/pull/3758) where `server-only` module was being resolved in runtimes without `react-server` available, such as `getAuth` on `getServerSideProps`.

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import type { AuthObject, RedirectFun } from '@clerk/backend/internal';
 import { constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
 import { notFound, redirect } from 'next/navigation';

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -16,6 +16,8 @@ import { buildRequestLike } from './utils';
 type Auth = AuthObject & { protect: AuthProtect; redirectToSignIn: RedirectFun<ReturnType<typeof redirect>> };
 
 export const auth = (): Auth => {
+  require('server-only');
+
   const request = buildRequestLike();
   const authObject = createGetAuth({
     debugLoggerName: 'auth()',

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -6,6 +6,8 @@ import { clerkClient } from '../../server/clerkClient';
 import { auth } from './auth';
 
 export async function currentUser(): Promise<User | null> {
+  require('server-only');
+
   const { userId } = auth();
   if (!userId) {
     return null;

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import type { User } from '@clerk/backend';
 
 import { clerkClient } from '../../server/clerkClient';


### PR DESCRIPTION
## Description

https://github.com/clerk/javascript/pull/3758 introduces an issue where `server-only` gets resolved when importing any module from `@clerk/nextjs/server`. An example of that is that the error gets thrown when using `getAuth` from `getServerSideProps`. 

This PRs moves the `server-only` resolution to runtime within `auth` and `currentUser`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
