### PR TITLE
fix(elements): Add check for `relatedTarget` to avoid validation running immediately after unsuccessful form submission

### DIFF
--- a/.changeset/plenty-snakes-repeat.md
+++ b/.changeset/plenty-snakes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fixes issue where an invalid password field was immediately being refocused after submission causing the validation to run and show the success state.

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -197,7 +197,6 @@ const useInput = ({
   type: inputType,
   onChange: onChangeProp,
   onBlur: onBlurProp,
-  onFocus: onFocusProp,
   ...passthroughProps
 }: FormInputProps) => {
   // Inputs can be used outside a <Field> wrapper if desired, so safely destructure here
@@ -295,16 +294,6 @@ const useInput = ({
     [onBlurProp, shouldValidatePassword, validatePassword],
   );
 
-  const onFocus = React.useCallback(
-    (event: React.FocusEvent<HTMLInputElement>) => {
-      onFocusProp?.(event);
-      if (shouldValidatePassword) {
-        validatePassword(event.target.value);
-      }
-    },
-    [onFocusProp, shouldValidatePassword, validatePassword],
-  );
-
   React.useEffect(() => {
     if (!name) {
       return;
@@ -363,7 +352,6 @@ const useInput = ({
       value: value ?? '',
       onChange,
       onBlur,
-      onFocus,
       'data-hidden': shouldBeHidden ? true : undefined,
       'data-has-value': hasValue ? true : undefined,
       'data-state': enrichFieldState(validity, fieldState),

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -197,6 +197,7 @@ const useInput = ({
   type: inputType,
   onChange: onChangeProp,
   onBlur: onBlurProp,
+  onFocus: onFocusProp,
   ...passthroughProps
 }: FormInputProps) => {
   // Inputs can be used outside a <Field> wrapper if desired, so safely destructure here
@@ -294,6 +295,20 @@ const useInput = ({
     [onBlurProp, shouldValidatePassword, validatePassword],
   );
 
+  const onFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      onFocusProp?.(event);
+      // Check for relatedTarget to avoid validating password when the input
+      // is programticallly focused after form submission. Avoids the issue
+      // where an error message would get removed and the success validation
+      // was shown immediately.
+      if (shouldValidatePassword && Boolean(event.relatedTarget)) {
+        validatePassword(event.target.value);
+      }
+    },
+    [onFocusProp, shouldValidatePassword, validatePassword],
+  );
+
   React.useEffect(() => {
     if (!name) {
       return;
@@ -352,6 +367,7 @@ const useInput = ({
       value: value ?? '',
       onChange,
       onBlur,
+      onFocus,
       'data-hidden': shouldBeHidden ? true : undefined,
       'data-has-value': hasValue ? true : undefined,
       'data-state': enrichFieldState(validity, fieldState),

--- a/packages/ui/src/common/password-field.tsx
+++ b/packages/ui/src/common/password-field.tsx
@@ -18,7 +18,6 @@ export function PasswordField({
   label?: React.ReactNode;
 } & Omit<React.ComponentProps<typeof Common.Input>, 'autoCapitalize' | 'autoComplete' | 'spellCheck' | 'type'>) {
   const [type, setType] = React.useState('password');
-  const [touched, setTouched] = React.useState(false);
 
   return (
     <Common.Field
@@ -39,7 +38,6 @@ export function PasswordField({
                 <Common.Input
                   type={type}
                   className={cx('pe-7', className)}
-                  onBlur={() => setTouched(true)}
                   {...props}
                   asChild
                 >
@@ -73,17 +71,6 @@ export function PasswordField({
             if (state === 'idle') {
               return;
             }
-
-            // Confirm success states immediately
-            if (state === 'success') {
-              return <Field.Message intent={state}>{message}</Field.Message>;
-            }
-
-            // Show errors and warnings only if the field has been interacted with
-            if (!touched) {
-              return;
-            }
-
             return <Field.Message intent={state}>{message}</Field.Message>;
           }}
         </Common.FieldState>

--- a/packages/ui/src/common/password-field.tsx
+++ b/packages/ui/src/common/password-field.tsx
@@ -18,6 +18,7 @@ export function PasswordField({
   label?: React.ReactNode;
 } & Omit<React.ComponentProps<typeof Common.Input>, 'autoCapitalize' | 'autoComplete' | 'spellCheck' | 'type'>) {
   const [type, setType] = React.useState('password');
+  const [touched, setTouched] = React.useState(false);
 
   return (
     <Common.Field
@@ -38,6 +39,7 @@ export function PasswordField({
                 <Common.Input
                   type={type}
                   className={cx('pe-7', className)}
+                  onBlur={() => setTouched(true)}
                   {...props}
                   asChild
                 >
@@ -71,6 +73,17 @@ export function PasswordField({
             if (state === 'idle') {
               return;
             }
+
+            // Confirm success states immediately
+            if (state === 'success') {
+              return <Field.Message intent={state}>{message}</Field.Message>;
+            }
+
+            // Show errors and warnings only if the field has been interacted with
+            if (!touched) {
+              return;
+            }
+
             return <Field.Message intent={state}>{message}</Field.Message>;
           }}
         </Common.FieldState>


### PR DESCRIPTION
## Description

Fixes issue where an invalid password field was immediately being refocused after submission causing the validation to run and show the success state.

BEFORE:

https://github.com/user-attachments/assets/b57e424d-69aa-42fc-aa37-88c40ae4a426

AFTER:

https://github.com/user-attachments/assets/e9f8b817-efc2-4c8e-86c1-2b2a2e62e29d


https://linear.app/clerk/issue/SDKI-154/validatepassword-usage-causing-inconsistent-errors-with-pwnd-message

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
