### PR TITLE
fix(elements): Reverts addition of `relatedTarget` check within `onFocus` input handler

### DIFF
--- a/.changeset/cold-lobsters-drive.md
+++ b/.changeset/cold-lobsters-drive.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Reverts [addition of relatedTarget check](https://github.com/clerk/javascript/pull/3762) in onFocus event handler which prevented fieldstate info from render on focus.

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -298,11 +298,7 @@ const useInput = ({
   const onFocus = React.useCallback(
     (event: React.FocusEvent<HTMLInputElement>) => {
       onFocusProp?.(event);
-      // Check for relatedTarget to avoid validating password when the input
-      // is programticallly focused after form submission. Avoids the issue
-      // where an error message would get removed and the success validation
-      // was shown immediately.
-      if (shouldValidatePassword && Boolean(event.relatedTarget)) {
+      if (shouldValidatePassword) {
         validatePassword(event.target.value);
       }
     },


### PR DESCRIPTION
## Description

Reverting the changes in https://github.com/clerk/javascript/pull/3762 to fix failing E2E tests.

<img width="1392" alt="Screenshot 2024-07-19 at 1 49 42 PM" src="https://github.com/user-attachments/assets/a48499a9-0ac7-4a69-99de-d4fcdf97f23b">


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
