### PR TITLE
fix(clerk-js): Set __session and __client_uat before invalidating cache

### DIFF
--- a/.changeset/poor-rockets-peel.md
+++ b/.changeset/poor-rockets-peel.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Set **session and **client_uat before invalidating cache during setActive flow

--- a/.changeset/poor-rockets-peel.md
+++ b/.changeset/poor-rockets-peel.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Set **session and **client_uat before invalidating cache during setActive flow
+Set `session` and `client_uat` before invalidating cache during `setActive()` flow

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -720,6 +720,10 @@ export class Clerk implements ClerkInterface {
       eventBus.dispatch(events.TokenUpdate, { token: null });
     }
 
+    if (session?.lastActiveToken) {
+      eventBus.dispatch(events.TokenUpdate, { token: session.lastActiveToken });
+    }
+
     await onBeforeSetActive();
 
     //1. setLastActiveSession to passed user session (add a param).
@@ -755,6 +759,7 @@ export class Clerk implements ClerkInterface {
     }
 
     this.#setAccessors(newSession);
+
     this.#emit();
     await onAfterSetActive();
     this.#resetComponentsState();


### PR DESCRIPTION
## Description

Fixes the following flow that mainly affected nextjs apps:

Setup:
- Dev instance
- Latest next, clerk/nextjs and clerk-js
- Multi-app-same-domain FF disabled
Steps:
- Go to app
- Enter email and hit continue (signIn.create):  client_uat is 0
- Enter password and hit continue (signIn.attemptFirstFactor) : client_uat > 0 (for accounts)
- Clerk-js invalidates cache : **client_uat is 0 because  clerk-js does not set it correctlly**

The main issue in the clerk-js codebase was that during sign-in/sign-up, we set the cookies **implicitly** when we update the current Client resource (Base -> updateClient -> Client.fromJson() -> new Session -> hydrate token cache).  However, the Clerk.client only gets updated AFTER the token cache is hydrated, so setting the client_uat token failed because when it runs, Clerk.client.activeSessions is still 0 (its still the previous value)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
