### PR TITLE
fix(clerk-js): Update the image alt attribute to fix accessibility issues reported by Lighthouse

### DIFF
--- a/.changeset/cool-pens-film.md
+++ b/.changeset/cool-pens-film.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Update the image alt attribute to fix accessibility issues reported by Lighthouse.

--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -38,7 +38,7 @@ export const Avatar = (props: AvatarProps) => {
       <Image
         elementDescriptor={[imageElementDescriptor, descriptors.avatarImage]}
         title={title}
-        alt={title}
+        alt={`${title}'s logo`}
         src={imageUrl || ''}
         sx={{ objectFit: 'cover', width: '100%', height: '100%' }}
         onError={() => setError(true)}


### PR DESCRIPTION
## Description

update the image alt attribute to fix the following issue reported in Lighthouse report
```
Image elements have [alt] attributes that are redundant text.
```
![image](https://github.com/user-attachments/assets/0763014d-b7ef-4c9e-b7a3-94d0c52f70b9)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: accessiblity
