### PR TITLE
fix(elements): only validate `onFocus` or `onBlur` when value has changed

### DIFF
--- a/.changeset/strong-beers-compete.md
+++ b/.changeset/strong-beers-compete.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fix issue where password field validation was incorrectly showing successful field state due to input being refocused on invalid form submission

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -94,6 +94,16 @@ const enrichFieldState = (validity: ValidityState | undefined, fieldState: Field
  * Hooks
  * -----------------------------------------------------------------------------------------------*/
 
+function usePrevious<T>(value: T): T | undefined {
+  const ref = React.useRef<T>();
+
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
 const useGlobalErrors = () => {
   const errors = useFormSelector(globalErrorsSelector);
 
@@ -251,6 +261,7 @@ const useInput = ({
     },
   });
   const value = useFormSelector(fieldValueSelector(name));
+  const prevValue = usePrevious(value);
   const hasValue = Boolean(value);
   const type = inputType ?? determineInputTypeFromName(rawName);
   let shouldValidatePassword = false;
@@ -288,21 +299,21 @@ const useInput = ({
   const onBlur = React.useCallback(
     (event: React.FocusEvent<HTMLInputElement>) => {
       onBlurProp?.(event);
-      if (shouldValidatePassword) {
+      if (shouldValidatePassword && event.target.value !== prevValue) {
         validatePassword(event.target.value);
       }
     },
-    [onBlurProp, shouldValidatePassword, validatePassword],
+    [onBlurProp, shouldValidatePassword, validatePassword, prevValue],
   );
 
   const onFocus = React.useCallback(
     (event: React.FocusEvent<HTMLInputElement>) => {
       onFocusProp?.(event);
-      if (shouldValidatePassword) {
+      if (shouldValidatePassword && event.target.value !== prevValue) {
         validatePassword(event.target.value);
       }
     },
-    [onFocusProp, shouldValidatePassword, validatePassword],
+    [onFocusProp, shouldValidatePassword, validatePassword, prevValue],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## Description

Fix issue where a password field containing an error was refocused on submission causing the validation to run updating to successful field state. This PR updates the logic to make sure the value has changed before running the check again to ensure the error message is rendered.

BEFORE:

https://github.com/user-attachments/assets/f01c5d1d-9af6-4485-b628-616e396448df

AFTER:

https://github.com/user-attachments/assets/cd52913f-1998-48eb-b76c-507325ca6759

https://linear.app/clerk/issue/SDKI-171/passwordfield-error-message-is-being-wiped-on-submission-due-to

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
