### PR TITLE
feat(elements): Add support for `signOutOfOtherSessions` checkbox

### DIFF
--- a/.changeset/clean-cups-knock.md
+++ b/.changeset/clean-cups-knock.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Add support for checkbox input usage and `signOutOfOtherSessions` functionality

--- a/packages/elements/src/internals/machines/form/form.context.ts
+++ b/packages/elements/src/internals/machines/form/form.context.ts
@@ -20,8 +20,23 @@ export const globalErrorsSelector = (state: SnapshotState) => state.context.erro
 /**
  * Selects if a specific field has a value
  */
-export const fieldValueSelector = (name: string | undefined) => (state: SnapshotState) =>
-  name ? state.context.fields.get(name)?.value : '';
+export const fieldValueSelector = (name: string | undefined) => (state: SnapshotState) => {
+  if (!name) {
+    return '';
+  }
+
+  const field = state.context.fields.get(name);
+
+  if (!field) {
+    return '';
+  }
+
+  if ('value' in field) {
+    return field.value ?? '';
+  }
+
+  return '';
+};
 
 /**
  * Selects if a specific field has a value

--- a/packages/elements/src/internals/machines/form/form.machine.ts
+++ b/packages/elements/src/internals/machines/form/form.machine.ts
@@ -19,7 +19,9 @@ export interface FormMachineContext extends MachineContext {
   defaultCheckeds: FormDefaultCheckeds;
   errors: ClerkElementsError[];
   fields: FormFields;
-  ptional?: Set<string>;
+  hidden?: Set<string>;
+  missing?: Set<string>;
+  optional?: Set<string>;
   progressive: boolean;
   required?: Set<string>;
 }

--- a/packages/elements/src/internals/machines/form/form.types.ts
+++ b/packages/elements/src/internals/machines/form/form.types.ts
@@ -2,8 +2,8 @@ import type { ClerkElementsFieldError } from '~/internals/errors';
 import type { FieldStates } from '~/react/common/form/types';
 import type { ErrorMessagesKey } from '~/react/utils/generate-password-error-text';
 
-export type FormDefaultValues = Map<string, FieldDetails['value']>;
-export type FormDefaultCheckeds = Map<string, FieldDetails['checked']>;
+export type FormDefaultValues = Map<string, FieldDetailsWithValue['value']>;
+export type FormDefaultCheckeds = Map<string, FieldDetailsWithChecked['checked']>;
 
 interface FeedbackBase {
   codes?: Array<ErrorMessagesKey>;
@@ -19,11 +19,32 @@ export interface FeedbackOtherType extends FeedbackBase {
   message: string;
 }
 
-export type FieldDetails = {
+interface FieldDetailsBase {
   name?: string;
-  value?: string | readonly string[] | number;
-  checked?: boolean;
   feedback?: FeedbackErrorType | FeedbackOtherType;
-};
+}
+
+export interface FieldDetailsWithValue extends FieldDetailsBase {
+  type:
+    | 'text'
+    | 'email'
+    | 'password'
+    | 'tel'
+    | 'number'
+    | 'date'
+    | 'time'
+    | 'datetime-local'
+    | 'month'
+    | 'week'
+    | 'otp';
+  value?: string | readonly string[] | number;
+}
+
+export interface FieldDetailsWithChecked extends FieldDetailsBase {
+  type: 'checkbox';
+  checked?: boolean;
+}
+
+export type FieldDetails = FieldDetailsWithValue | FieldDetailsWithChecked;
 
 export type FormFields = Map<string, FieldDetails>;

--- a/packages/elements/src/internals/machines/form/form.types.ts
+++ b/packages/elements/src/internals/machines/form/form.types.ts
@@ -3,6 +3,7 @@ import type { FieldStates } from '~/react/common/form/types';
 import type { ErrorMessagesKey } from '~/react/utils/generate-password-error-text';
 
 export type FormDefaultValues = Map<string, FieldDetails['value']>;
+export type FormDefaultCheckeds = Map<string, FieldDetails['checked']>;
 
 interface FeedbackBase {
   codes?: Array<ErrorMessagesKey>;
@@ -21,6 +22,7 @@ export interface FeedbackOtherType extends FeedbackBase {
 export type FieldDetails = {
   name?: string;
   value?: string | readonly string[] | number;
+  checked?: boolean;
   feedback?: FeedbackErrorType | FeedbackOtherType;
 };
 

--- a/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
@@ -18,9 +18,7 @@ export const SignInResetPasswordMachine = setup({
     attempt: fromPromise<SignInResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const password = (fields.get('password')?.value as string) || '';
-        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.value
-          ? (Boolean(fields.get('signOutOfOtherSessions')?.value) as boolean)
-          : false;
+        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.checked;
         return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password, signOutOfOtherSessions });
       },
     ),

--- a/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
@@ -18,7 +18,10 @@ export const SignInResetPasswordMachine = setup({
     attempt: fromPromise<SignInResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const password = (fields.get('password')?.value as string) || '';
-        return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password });
+        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.value
+          ? (Boolean(fields.get('signOutOfOtherSessions')?.value) as boolean)
+          : false;
+        return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password, signOutOfOtherSessions });
       },
     ),
   },

--- a/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
@@ -2,7 +2,7 @@ import type { SignInResource } from '@clerk/types';
 import type { DoneActorEvent } from 'xstate';
 import { fromPromise, sendTo, setup } from 'xstate';
 
-import type { FormFields } from '~/internals/machines/form';
+import type { FieldDetailsWithChecked, FieldDetailsWithValue, FormFields } from '~/internals/machines/form';
 import { sendToLoading } from '~/internals/machines/shared';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
@@ -17,8 +17,9 @@ export const SignInResetPasswordMachine = setup({
   actors: {
     attempt: fromPromise<SignInResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
-        const password = (fields.get('password')?.value as string) || '';
-        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.checked || false;
+        const password = ((fields.get('password') as FieldDetailsWithValue)?.value as string) || '';
+        const signOutOfOtherSessions =
+          (fields.get('signOutOfOtherSessions') as FieldDetailsWithChecked)?.checked || false;
         return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password, signOutOfOtherSessions });
       },
     ),

--- a/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
@@ -18,7 +18,7 @@ export const SignInResetPasswordMachine = setup({
     attempt: fromPromise<SignInResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const password = (fields.get('password')?.value as string) || '';
-        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.checked;
+        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.checked || false;
         return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password, signOutOfOtherSessions });
       },
     ),

--- a/packages/elements/src/internals/machines/sign-in/start.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/start.machine.ts
@@ -2,7 +2,7 @@ import type { SignInResource } from '@clerk/types';
 import { fromPromise, not, sendTo, setup } from 'xstate';
 
 import { SIGN_IN_DEFAULT_BASE_PATH } from '~/internals/constants';
-import type { FormFields } from '~/internals/machines/form';
+import type { FieldDetailsWithValue, FormFields } from '~/internals/machines/form';
 import { sendToLoading } from '~/internals/machines/shared';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
@@ -27,8 +27,8 @@ export const SignInStartMachine = setup({
       ({ input: { fields, parent } }) => {
         const clerk = parent.getSnapshot().context.clerk;
 
-        const password = fields.get('password');
-        const identifier = fields.get('identifier');
+        const password = fields.get('password') as FieldDetailsWithValue;
+        const identifier = fields.get('identifier') as FieldDetailsWithValue;
 
         const passwordParams = password?.value
           ? {

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -388,8 +388,8 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
       let attemptParams: AttemptFirstFactorParams;
 
       const strategy = currentFactor.strategy;
-      const code = fields.get('code')?.value as string | undefined;
-      const password = fields.get('password')?.value as string | undefined;
+      const code = (fields.get('code') as FieldDetailsWithValue)?.value as string | undefined;
+      const password = (fields.get('password') as FieldDetailsWithValue)?.value as string | undefined;
 
       switch (strategy) {
         case 'passkey': {

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -18,7 +18,7 @@ import { assign, fromPromise, log, sendTo, setup } from 'xstate';
 
 import { RESENDABLE_COUNTDOWN_DEFAULT } from '~/internals/constants';
 import { ClerkElementsRuntimeError } from '~/internals/errors';
-import type { FormFields } from '~/internals/machines/form';
+import type { FieldDetailsWithValue, FormFields } from '~/internals/machines/form';
 import type { SignInStrategyName, WithParams } from '~/internals/machines/shared';
 import { sendToLoading } from '~/internals/machines/shared';
 import { determineStartingSignInFactor, determineStartingSignInSecondFactor } from '~/internals/machines/sign-in/utils';
@@ -366,7 +366,7 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
       );
     }),
     prepare: fromPromise(async ({ input }) => {
-      const { params, parent, resendable } = input as PrepareFirstFactorInput;
+      const { params, parent, resendable } = input;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send
@@ -429,7 +429,7 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
           break;
         }
         case 'web3_metamask_signature': {
-          const signature = fields.get('signature')?.value as string | undefined;
+          const signature = (fields.get('signature') as FieldDetailsWithValue)?.value as string | undefined;
           assertIsDefined(signature, 'Web3 Metamask signature');
 
           attemptParams = {
@@ -479,7 +479,7 @@ export const SignInSecondFactorMachine = SignInVerificationMachine.provide({
     attempt: fromPromise(async ({ input }) => {
       const { fields, parent, currentFactor } = input as AttemptSecondFactorInput;
 
-      const code = fields.get('code')?.value as string;
+      const code = (fields.get('code') as FieldDetailsWithValue)?.value as string;
 
       assertIsDefined(currentFactor, 'Current factor');
       assertIsDefined(code, 'Code');

--- a/packages/elements/src/internals/machines/sign-up/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/verification.machine.ts
@@ -21,6 +21,7 @@ import type { WithParams } from '~/internals/machines/shared';
 import { sendToLoading } from '~/internals/machines/shared';
 import { assertActorEventError } from '~/internals/machines/utils/assert';
 
+import type { FieldDetailsWithValue } from '../form';
 import type { SignInRouterMachineActorRef } from './router.types';
 import {
   type SignUpVerificationContext,
@@ -442,7 +443,9 @@ export const SignUpVerificationMachine = setup({
               parent: context.parent,
               params: {
                 strategy: 'email_code',
-                code: (context.formRef.getSnapshot().context.fields.get('code')?.value as string) || '',
+                code:
+                  ((context.formRef.getSnapshot().context.fields.get('code') as FieldDetailsWithValue)
+                    ?.value as string) || '',
               },
             }),
             onDone: {
@@ -541,7 +544,9 @@ export const SignUpVerificationMachine = setup({
               parent: context.parent,
               params: {
                 strategy: 'phone_code',
-                code: (context.formRef.getSnapshot().context.fields.get('code')?.value as string) || '',
+                code:
+                  ((context.formRef.getSnapshot().context.fields.get('code') as FieldDetailsWithValue)
+                    ?.value as string) || '',
               },
             }),
             onDone: {

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -193,9 +193,11 @@ const useField = ({ name }: Partial<Pick<FieldDetails, 'name'>>) => {
 
 const useInput = ({
   name: inputName,
+  defaultValue,
   value: providedValue,
-  type: inputType,
   defaultChecked,
+  checked: providedChecked,
+  type: inputType,
   onChange: onChangeProp,
   onBlur: onBlurProp,
   onFocus: onFocusProp,
@@ -265,9 +267,10 @@ const useInput = ({
     if (!name) {
       return;
     }
-
-    ref.send({ type: 'FIELD.ADD', field: { name, checked: defaultChecked, value: providedValue } });
-
+    ref.send({
+      type: 'FIELD.ADD',
+      field: { name, checked: defaultChecked || providedChecked, value: defaultValue || providedValue },
+    });
     return () => ref.send({ type: 'FIELD.REMOVE', field: { name } });
   }, [ref]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -314,7 +317,11 @@ const useInput = ({
     if (providedValue !== undefined) {
       ref.send({ type: 'FIELD.UPDATE', field: { name, value: providedValue } });
     }
-  }, [name, ref, providedValue]);
+
+    if (providedChecked !== undefined) {
+      ref.send({ type: 'FIELD.UPDATE', field: { name, checked: providedChecked } });
+    }
+  }, [name, ref, providedValue, providedChecked]);
 
   // TODO: Implement clerk-js utils
   const shouldBeHidden = false;
@@ -365,7 +372,6 @@ const useInput = ({
       onChange,
       onBlur,
       onFocus,
-      defaultChecked,
       'data-hidden': shouldBeHidden ? true : undefined,
       'data-has-value': hasValue ? true : undefined,
       'data-state': enrichFieldState(validity, fieldState),

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -195,6 +195,7 @@ const useInput = ({
   name: inputName,
   value: providedValue,
   type: inputType,
+  defaultChecked,
   onChange: onChangeProp,
   onBlur: onBlurProp,
   onFocus: onFocusProp,
@@ -265,21 +266,10 @@ const useInput = ({
       return;
     }
 
-    ref.send({ type: 'FIELD.ADD', field: { name, value: providedValue } });
+    ref.send({ type: 'FIELD.ADD', field: { name, checked: defaultChecked, value: providedValue } });
 
     return () => ref.send({ type: 'FIELD.REMOVE', field: { name } });
   }, [ref]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const getInputValue = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (inputType === 'checkbox') {
-        return event.target.checked.toString();
-      }
-
-      return event.target.value;
-    },
-    [inputType],
-  );
 
   // Register the onChange handler for field updates to persist to the machine context
   const onChange = React.useCallback(
@@ -288,12 +278,12 @@ const useInput = ({
       if (!name) {
         return;
       }
-      ref.send({ type: 'FIELD.UPDATE', field: { name, value: getInputValue(event) } });
+      ref.send({ type: 'FIELD.UPDATE', field: { name, checked: event.target.checked, value: event.target.value } });
       if (shouldValidatePassword) {
         validatePassword(event.target.value);
       }
     },
-    [ref, name, onChangeProp, shouldValidatePassword, validatePassword, getInputValue],
+    [ref, name, onChangeProp, shouldValidatePassword, validatePassword],
   );
 
   const onBlur = React.useCallback(
@@ -375,6 +365,7 @@ const useInput = ({
       onChange,
       onBlur,
       onFocus,
+      defaultChecked,
       'data-hidden': shouldBeHidden ? true : undefined,
       'data-has-value': hasValue ? true : undefined,
       'data-state': enrichFieldState(validity, fieldState),

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -27,7 +27,7 @@ import type { BaseActorRef } from 'xstate';
 
 import type { ClerkElementsError } from '~/internals/errors';
 import { ClerkElementsFieldError, ClerkElementsRuntimeError } from '~/internals/errors';
-import type { FieldDetails } from '~/internals/machines/form';
+import type { FieldDetails, FieldDetailsWithValue } from '~/internals/machines/form';
 import {
   fieldFeedbackSelector,
   fieldHasValueSelector,
@@ -267,10 +267,17 @@ const useInput = ({
     if (!name) {
       return;
     }
-    ref.send({
-      type: 'FIELD.ADD',
-      field: { name, checked: defaultChecked || providedChecked, value: defaultValue || providedValue },
-    });
+    if (type === 'checkbox') {
+      ref.send({
+        type: 'FIELD.ADD',
+        field: { name, type: 'checkbox', checked: defaultChecked || providedChecked },
+      });
+    } else {
+      ref.send({
+        type: 'FIELD.ADD',
+        field: { name, type: inputType as FieldDetailsWithValue['type'], value: defaultValue || providedValue },
+      });
+    }
     return () => ref.send({ type: 'FIELD.REMOVE', field: { name } });
   }, [ref]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -270,6 +270,17 @@ const useInput = ({
     return () => ref.send({ type: 'FIELD.REMOVE', field: { name } });
   }, [ref]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const getInputValue = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputType === 'checkbox') {
+        return event.target.checked.toString();
+      }
+
+      return event.target.value;
+    },
+    [inputType],
+  );
+
   // Register the onChange handler for field updates to persist to the machine context
   const onChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -277,12 +288,12 @@ const useInput = ({
       if (!name) {
         return;
       }
-      ref.send({ type: 'FIELD.UPDATE', field: { name, value: event.target.value } });
+      ref.send({ type: 'FIELD.UPDATE', field: { name, value: getInputValue(event) } });
       if (shouldValidatePassword) {
         validatePassword(event.target.value);
       }
     },
-    [ref, name, onChangeProp, shouldValidatePassword, validatePassword],
+    [ref, name, onChangeProp, shouldValidatePassword, validatePassword, getInputValue],
   );
 
   const onBlur = React.useCallback(


### PR DESCRIPTION
## Description

Add support for checkbox input usage and `signOutOfOtherSessions` functionality in sign in password reset flow

Usage:

```tsx
<Common.Field name="signOutOfOtherSessions">
  <Common.Input type="checkbox" />
  <Common.Label>Sign out of all other devices</Common.Label>
</Common.Field>
```

https://linear.app/clerk/issue/SDKI-146/signin-reset-password-sign-out-of-all-other-devices-checkbox

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
