### PR TITLE
fix(chrome-extension): Appropriately handle fulfilled, but null, cookie promises

### DIFF
--- a/.changeset/ninety-toes-fix.md
+++ b/.changeset/ninety-toes-fix.md
@@ -1,0 +1,5 @@
+---
+"@clerk/chrome-extension": patch
+---
+
+Appropriately handle fulfilled, but null, cookie promises

--- a/packages/chrome-extension/src/utils/cookies.ts
+++ b/packages/chrome-extension/src/utils/cookies.ts
@@ -25,7 +25,7 @@ export async function getClientCookie({ urls, name }: GetClientCookieParams) {
   const cookieResults = await Promise.allSettled(cookiePromises);
 
   for (const cookie of cookieResults) {
-    if (cookie.status === 'fulfilled') {
+    if (cookie.status === 'fulfilled' && cookie.value) {
       return cookie.value;
     }
   }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Depending on certain setups, we were receiving fulfulled, but null, promises. This updates that check.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
