### PR TITLE
feat(elements): Add support for signOutOfOtherSessions checkbox

### DIFF
--- a/.changeset/tasty-brooms-check.md
+++ b/.changeset/tasty-brooms-check.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Add support for checkbox input usage and `signOutOfOtherSessions` functionality

--- a/packages/elements/src/internals/machines/form/form.machine.ts
+++ b/packages/elements/src/internals/machines/form/form.machine.ts
@@ -19,7 +19,7 @@ export interface FormMachineContext extends MachineContext {
 }
 
 export type FormMachineEvents =
-  | { type: 'FIELD.ADD'; field: Pick<FieldDetails, 'name' | 'value'> }
+  | { type: 'FIELD.ADD'; field: Pick<FieldDetails, 'name' | 'type' | 'value' | 'checked'> }
   | { type: 'FIELD.REMOVE'; field: Pick<FieldDetails, 'name'> }
   | {
       type: 'MARK_AS_PROGRESSIVE';
@@ -35,7 +35,7 @@ export type FormMachineEvents =
   | { type: 'UNMARK_AS_PROGRESSIVE' }
   | {
       type: 'FIELD.UPDATE';
-      field: Pick<FieldDetails, 'name' | 'value'>;
+      field: Pick<FieldDetails, 'name' | 'value' | 'checked'>;
     }
   | { type: 'ERRORS.SET'; error: any }
   | { type: 'ERRORS.CLEAR' }
@@ -160,6 +160,8 @@ export const FormMachine = setup({
           if (context.fields.has(event.field.name)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             context.fields.get(event.field.name)!.value = event.field.value;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            context.fields.get(event.field.name)!.checked = event.field.checked;
           }
 
           return context.fields;

--- a/packages/elements/src/internals/machines/form/form.types.ts
+++ b/packages/elements/src/internals/machines/form/form.types.ts
@@ -20,7 +20,9 @@ export interface FeedbackOtherType extends FeedbackBase {
 
 export type FieldDetails = {
   name?: string;
+  type: React.HTMLInputTypeAttribute;
   value?: string | readonly string[] | number;
+  checked?: boolean;
   feedback?: FeedbackErrorType | FeedbackOtherType;
 };
 

--- a/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/reset-password.machine.ts
@@ -18,7 +18,8 @@ export const SignInResetPasswordMachine = setup({
     attempt: fromPromise<SignInResource, { parent: SignInRouterMachineActorRef; fields: FormFields }>(
       ({ input: { fields, parent } }) => {
         const password = (fields.get('password')?.value as string) || '';
-        return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password });
+        const signOutOfOtherSessions = fields.get('signOutOfOtherSessions')?.checked || false;
+        return parent.getSnapshot().context.clerk.client.signIn.resetPassword({ password, signOutOfOtherSessions });
       },
     ),
   },

--- a/packages/elements/src/internals/machines/sign-up/utils/__tests__/fields-to-params.test.ts
+++ b/packages/elements/src/internals/machines/sign-up/utils/__tests__/fields-to-params.test.ts
@@ -3,9 +3,9 @@ import { fieldsToSignUpParams } from '../fields-to-params';
 describe('fieldsToSignUpParams', () => {
   it('converts form fields to sign up params', () => {
     const fields = new Map([
-      ['firstName', { value: 'John' }],
-      ['emailAddress', { value: 'john@example.com' }],
-      ['password', { value: 'password123' }],
+      ['firstName', { type: 'text', value: 'John' }],
+      ['emailAddress', { type: 'text', value: 'john@example.com' }],
+      ['password', { type: 'text', value: 'password123' }],
     ]);
 
     const params = fieldsToSignUpParams(fields);
@@ -19,9 +19,9 @@ describe('fieldsToSignUpParams', () => {
 
   it('ignores undefined values', () => {
     const fields = new Map([
-      ['firstName', { value: 'John' }],
-      ['emailAddress', { value: undefined }],
-      ['password', { value: 'password123' }],
+      ['firstName', { type: 'text', value: 'John' }],
+      ['emailAddress', { type: 'text', value: undefined }],
+      ['password', { type: 'text', value: 'password123' }],
     ]);
 
     const params = fieldsToSignUpParams(fields);
@@ -34,9 +34,9 @@ describe('fieldsToSignUpParams', () => {
 
   it('ignores non-sign-up keys', () => {
     const fields = new Map([
-      ['firstName', { value: 'John' }],
-      ['foo', { value: 'bar' }],
-      ['bar', { value: 'foo' }],
+      ['firstName', { type: 'text', value: 'John' }],
+      ['foo', { type: 'text', value: 'bar' }],
+      ['bar', { type: 'text', value: 'foo' }],
     ]);
 
     const params = fieldsToSignUpParams(fields);


### PR DESCRIPTION
## Description

Add support for checkbox input usage and `signOutOfOtherSessions` functionality in sign in password reset flow

Usage:

```tsx
<Common.Field name="signOutOfOtherSessions">
  <Common.Input type="checkbox" />
  <Common.Label>Sign out of all other devices</Common.Label>
</Common.Field>
```

https://linear.app/clerk/issue/SDKI-146/signin-reset-password-sign-out-of-all-other-devices-checkbox

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
