### PR TITLE
fix(astro): Middleware return type

### DIFF
--- a/.changeset/ninety-squids-appear.md
+++ b/.changeset/ninety-squids-appear.md
@@ -2,4 +2,4 @@
 "@clerk/astro": patch
 ---
 
-Fix middleware return type.
+Allow the handler of `clerkMiddleware` to return undefined. When undefined is returned, `clerkMiddleware` implicitly calls `await next()`.

--- a/.changeset/ninety-squids-appear.md
+++ b/.changeset/ninety-squids-appear.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fix middleware return type.

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -40,7 +40,7 @@ type ClerkAstroMiddlewareHandler = (
   auth: () => ClerkMiddlewareAuthObject,
   context: AstroMiddlewareContextParam,
   next: AstroMiddlewareNextParam,
-) => AstroMiddlewareReturn;
+) => AstroMiddlewareReturn | undefined;
 
 type ClerkAstroMiddlewareOptions = AuthenticateRequestOptions;
 


### PR DESCRIPTION
## Description

The middleware contains logic to check for a passed handler. When no handler is provided, it automatically executes the [next function](https://github.com/clerk/javascript/blob/195fd46bd5cff3b54161ede02848d1c08e695116/packages/astro/src/server/clerk-middleware.ts#L108).  However, the return type doesn't handle this scenario and still expects us to call the `next` function. It should be optional.

<img width="596" alt="Screenshot 2024-07-23 at 3 27 01 PM" src="https://github.com/user-attachments/assets/200ad0a7-acb7-4120-8e07-18ba27d9d7cb">

This small PR addresses the issue.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
