### PR TITLE
fix(ui): Ensure PhoneNumberField label and input are connected

### DIFF
--- a/packages/ui/src/common/phone-number-field/index.tsx
+++ b/packages/ui/src/common/phone-number-field/index.tsx
@@ -40,6 +40,7 @@ export const PhoneNumberField = React.forwardRef(function PhoneNumberField(
   const { translateError } = useLocalizations();
   const [isOpen, setOpen] = React.useState(false);
   const [selectedCountry, setSelectedCountry] = React.useState(countryOptions[0]);
+  const id = React.useId();
   const containerRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const commandListRef = React.useRef<HTMLDivElement>(null);
@@ -95,7 +96,7 @@ export const PhoneNumberField = React.forwardRef(function PhoneNumberField(
     >
       <Field.Root>
         <Common.Label asChild>
-          <Field.Label>
+          <Field.Label htmlFor={id}>
             {label}{' '}
             {alternativeFieldTrigger ? (
               <Field.LabelEnd>{alternativeFieldTrigger}</Field.LabelEnd>
@@ -200,6 +201,7 @@ export const PhoneNumberField = React.forwardRef(function PhoneNumberField(
                 <input
                   ref={mergeRefs([forwardedRef, inputRef])}
                   type='tel'
+                  id={id}
                   maxLength={25}
                   value={formattedNumber}
                   onPaste={handlePaste}

--- a/packages/ui/src/primitives/field.tsx
+++ b/packages/ui/src/primitives/field.tsx
@@ -31,7 +31,7 @@ export const Label = React.forwardRef(function Label(
     children,
     visuallyHidden,
     ...props
-  }: React.HTMLAttributes<HTMLLabelElement> & { visuallyHidden?: boolean },
+  }: React.HTMLAttributes<HTMLLabelElement> & { htmlFor?: string; visuallyHidden?: boolean },
   forwardedRef: React.ForwardedRef<HTMLLabelElement>,
 ) {
   return (


### PR DESCRIPTION
## Description

Since we're using a custom input for the phone number ui rendering, we were missing the proper label for attribute that mapped to the input id. This implements a custom mapping to ensure they are connected properly.

https://linear.app/clerk/issue/SDKI-491/fix-phone-number-field-label-input-mapping

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
