### PR TITLE
fix(dev-cli): Call mkdir before attempting to write the config file

### DIFF
--- a/.changeset/heavy-pillows-sparkle.md
+++ b/.changeset/heavy-pillows-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Fix a bug where `clerk-dev init` would error if the config directory did not already exist.

--- a/packages/dev-cli/src/commands/init.js
+++ b/packages/dev-cli/src/commands/init.js
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
-import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 import { CONFIG_FILE } from '../utils/getConfiguration.js';
 import { getCLIRoot } from '../utils/getMonorepoRoot.js';
@@ -25,6 +25,8 @@ export async function init() {
       },
     },
   };
+
+  await mkdir(dirname(CONFIG_FILE), { recursive: true });
 
   await writeFile(CONFIG_FILE, JSON.stringify(configuration, null, 2), 'utf-8');
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensure the directory where we write the config file exists.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
