### PR TITLE
feat(astro): Add opt-out support for SDK telemetry

### DIFF
--- a/.changeset/four-pots-type.md
+++ b/.changeset/four-pots-type.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Introduce option to opt-out of telemetry data collection

--- a/packages/astro/src/env.d.ts
+++ b/packages/astro/src/env.d.ts
@@ -16,6 +16,8 @@ interface InternalEnv {
   readonly PUBLIC_CLERK_PROXY_URL?: string;
   readonly PUBLIC_CLERK_SIGN_IN_URL?: string;
   readonly PUBLIC_CLERK_SIGN_UP_URL?: string;
+  readonly PUBLIC_CLERK_TELEMETRY_DISABLED?: string;
+  readonly PUBLIC_CLERK_TELEMETRY_DEBUG?: string;
 }
 
 interface ImportMeta {

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -50,12 +50,12 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
 
           const buildImportPath = `${packageName}/internal`;
 
-          // Set params as envs do backend code has access to them
+          // Set params as envs so backend code has access to them
           updateConfig({
             vite: {
               define: {
                 /**
-                 * Convert the integration params to environment variable in order for be readable from the server
+                 * Convert the integration params to environment variable in order for it to be readable from the server
                  */
                 ...buildEnvVarFromOption(signInUrl, 'PUBLIC_CLERK_SIGN_IN_URL'),
                 ...buildEnvVarFromOption(signUpUrl, 'PUBLIC_CLERK_SIGN_UP_URL'),

--- a/packages/astro/src/internal/merge-env-vars-with-params.ts
+++ b/packages/astro/src/internal/merge-env-vars-with-params.ts
@@ -1,3 +1,5 @@
+import { isTruthy } from '@clerk/shared/underscore';
+
 import type { AstroClerkIntegrationParams } from '../types';
 
 /**
@@ -11,6 +13,7 @@ const mergeEnvVarsWithParams = (params?: AstroClerkIntegrationParams & { publish
     proxyUrl: paramProxy,
     domain: paramDomain,
     publishableKey: paramPublishableKey,
+    telemetry: paramTelemetry,
     ...rest
   } = params || {};
 
@@ -21,6 +24,10 @@ const mergeEnvVarsWithParams = (params?: AstroClerkIntegrationParams & { publish
     proxyUrl: paramProxy || import.meta.env.PUBLIC_CLERK_PROXY_URL,
     domain: paramDomain || import.meta.env.PUBLIC_CLERK_DOMAIN,
     publishableKey: paramPublishableKey || import.meta.env.PUBLIC_CLERK_PUBLISHABLE_KEY || '',
+    telemetry: paramTelemetry || {
+      disabled: isTruthy(import.meta.env.PUBLIC_CLERK_TELEMETRY_DISABLED),
+      debug: isTruthy(import.meta.env.PUBLIC_CLERK_TELEMETRY_DEBUG),
+    },
     ...rest,
   };
 };

--- a/packages/astro/src/server/clerk-client.ts
+++ b/packages/astro/src/server/clerk-client.ts
@@ -21,6 +21,10 @@ const createClerkClientWithOptions: CreateClerkClientWithOptions = (context, opt
       // eslint-disable-next-line turbo/no-undeclared-env-vars
       environment: import.meta.env.MODE,
     },
+    telemetry: {
+      disabled: getSafeEnv(context).telemetryDisabled,
+      debug: getSafeEnv(context).telemetryDebug,
+    },
     ...options,
   });
 

--- a/packages/astro/src/server/get-safe-env.ts
+++ b/packages/astro/src/server/get-safe-env.ts
@@ -1,10 +1,11 @@
+import { isTruthy } from '@clerk/shared/underscore';
 import type { APIContext } from 'astro';
 
 type ContextOrLocals = APIContext | APIContext['locals'];
 
 /**
  * @internal
- * Isomorphic handler for reading environemnt variables defined from Vite or are injected in the request context (CF Pages)
+ * Isomorphic handler for reading environment variables defined from Vite or are injected in the request context (CF Pages)
  */
 function getContextEnvVar(envVarName: keyof InternalEnv, contextOrLocals: ContextOrLocals): string | undefined {
   const locals = 'locals' in contextOrLocals ? contextOrLocals.locals : contextOrLocals;
@@ -33,6 +34,8 @@ function getSafeEnv(context: ContextOrLocals) {
     clerkJsVersion: getContextEnvVar('PUBLIC_CLERK_JS_VERSION', context),
     apiVersion: getContextEnvVar('CLERK_API_VERSION', context),
     apiUrl: getContextEnvVar('CLERK_API_URL', context),
+    telemetryDisabled: isTruthy(getContextEnvVar('PUBLIC_CLERK_TELEMETRY_DISABLED', context)),
+    telemetryDebug: isTruthy(getContextEnvVar('PUBLIC_CLERK_TELEMETRY_DEBUG', context)),
   };
 }
 

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -13,7 +13,6 @@ type AstroClerkIntegrationParams = Without<
   ClerkOptions,
   | 'isSatellite'
   | 'sdkMetadata'
-  | 'telemetry'
   | 'standardBrowser'
   | 'selectInitialSession'
   | 'routerReplace'


### PR DESCRIPTION
## Description

Adds opt-out support to the TelemetryCollector by passing an option to the integration or with environment variables similar to [existing frameworks](https://clerk.com/docs/telemetry).

Fixes ECO-65

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
