### PR TITLE
feat(backend): Add param in User.update()

### DIFF
--- a/.changeset/three-ghosts-develop.md
+++ b/.changeset/three-ghosts-develop.md
@@ -1,0 +1,17 @@
+---
+'@clerk/backend': minor
+---
+
+Add `createOrganizationsLimit` param in `@clerk/backend` method `User.updateUser()`
+Example:
+
+```typescript
+    import { createClerkClient }  from '@clerk/backend';
+
+    const clerkClient = createClerkClient({...});
+    // Update user with createOrganizationsLimit equals 10
+    await clerkClient.users.updateUser('user_...', { createOrganizationsLimit: 10 })
+
+    // Remove createOrganizationsLimit
+    await clerkClient.users.updateUser('user_...', { createOrganizationsLimit: 0 })
+```

--- a/.changeset/three-ghosts-develop.md
+++ b/.changeset/three-ghosts-develop.md
@@ -1,5 +1,7 @@
 ---
-'@clerk/backend': minor
+"@clerk/backend": minor
+"@clerk/clerk-js": minor
+"@clerk/types": minor
 ---
 
 Add `createOrganizationsLimit` param in `@clerk/backend` method `User.updateUser()`

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -95,6 +95,7 @@ type UpdateUserParams = {
   externalId?: string;
   createdAt?: Date;
   createOrganizationEnabled?: boolean;
+  createOrganizationsLimit?: number;
 } & UserMetadataParams &
   (UserPasswordHashingParams | object);
 

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -310,6 +310,7 @@ export interface UserJSON extends ClerkResourceJSON {
   updated_at: number;
   last_active_at: number | null;
   create_organization_enabled: boolean;
+  create_organizations_limit: number | null;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/User.ts
+++ b/packages/backend/src/api/resources/User.ts
@@ -36,6 +36,7 @@ export class User {
     readonly samlAccounts: SamlAccount[] = [],
     readonly lastActiveAt: number | null,
     readonly createOrganizationEnabled: boolean,
+    readonly createOrganizationsLimit: number | null = null,
   ) {}
 
   static fromJSON(data: UserJSON): User {
@@ -69,6 +70,7 @@ export class User {
       (data.saml_accounts || []).map((x: SamlAccountJSON) => SamlAccount.fromJSON(x)),
       data.last_active_at,
       data.create_organization_enabled,
+      data.create_organizations_limit,
     );
   }
 

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -84,6 +84,7 @@ export class User extends BaseResource implements UserResource {
   publicMetadata: UserPublicMetadata = {};
   unsafeMetadata: UserUnsafeMetadata = {};
   createOrganizationEnabled = false;
+  createOrganizationsLimit: number | null = null;
   deleteSelfEnabled = false;
   lastSignInAt: Date | null = null;
   updatedAt: Date | null = null;
@@ -348,6 +349,7 @@ export class User extends BaseResource implements UserResource {
     this.twoFactorEnabled = data.two_factor_enabled;
 
     this.createOrganizationEnabled = data.create_organization_enabled;
+    this.createOrganizationsLimit = data.create_organizations_limit;
     this.deleteSelfEnabled = data.delete_self_enabled;
 
     if (data.last_sign_in_at) {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -208,6 +208,7 @@ export interface UserJSON extends ClerkResourceJSON {
   unsafe_metadata: UserUnsafeMetadata;
   last_sign_in_at: number | null;
   create_organization_enabled: boolean;
+  create_organizations_limit: number | null;
   delete_self_enabled: boolean;
   updated_at: number;
   created_at: number;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -80,6 +80,7 @@ export interface UserResource extends ClerkResource {
   unsafeMetadata: UserUnsafeMetadata;
   lastSignInAt: Date | null;
   createOrganizationEnabled: boolean;
+  createOrganizationsLimit: number | null;
   deleteSelfEnabled: boolean;
   updatedAt: Date | null;
   createdAt: Date | null;


### PR DESCRIPTION
## Description
This PR adds a new field for the `user.update()` called `createOrganizationsLimit` which can be either number or null. This field is used to control how many orgs an user can create.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
