### PR TITLE
feat(clerk-js): Add ability to set active organization by slug

### DIFF
--- a/.changeset/wicked-seahorses-juggle.md
+++ b/.changeset/wicked-seahorses-juggle.md
@@ -1,5 +1,6 @@
 ---
 "@clerk/clerk-js": patch
+"@clerk/types": patch
 ---
 
 Introduce ability to set an active organization by slug

--- a/.changeset/wicked-seahorses-juggle.md
+++ b/.changeset/wicked-seahorses-juggle.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Introduce ability to set an active organization by slug

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -712,7 +712,7 @@ export class Clerk implements ClerkInterface {
     if (newSession && shouldSwitchOrganization) {
       const organizationIdOrSlug = typeof organization === 'string' ? organization : organization?.id;
 
-      if (isOrganizationId(organizationIdOrSlug!)) {
+      if (isOrganizationId(organizationIdOrSlug)) {
         newSession.lastActiveOrganizationId = organizationIdOrSlug || null;
       } else {
         const matchingOrganization = newSession.user.organizationMemberships.find(

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -75,6 +75,7 @@ import {
   inBrowser,
   isDevAccountPortalOrigin,
   isError,
+  isOrganizationId,
   isRedirectForFAPIInitiatedFlow,
   noOrganizationExists,
   noUserExists,
@@ -707,9 +708,18 @@ export class Clerk implements ClerkInterface {
     // However, if the `organization` parameter is not given (i.e. `undefined`), we want
     // to keep the organization id that the session had.
     const shouldSwitchOrganization = organization !== undefined;
+
     if (newSession && shouldSwitchOrganization) {
-      const organizationId = typeof organization === 'string' ? organization : organization?.id;
-      newSession.lastActiveOrganizationId = organizationId || null;
+      const organizationIdOrSlug = typeof organization === 'string' ? organization : organization?.id;
+
+      if (isOrganizationId(organizationIdOrSlug!)) {
+        newSession.lastActiveOrganizationId = organizationIdOrSlug || null;
+      } else {
+        const matchingOrganization = newSession.user.organizationMemberships.find(
+          mem => mem.organization.slug === organizationIdOrSlug,
+        );
+        newSession.lastActiveOrganizationId = matchingOrganization?.organization.id || null;
+      }
     }
 
     // If this.session exists, then signOut was triggered by the current tab

--- a/packages/clerk-js/src/utils/__tests__/organization.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/organization.test.ts
@@ -1,0 +1,15 @@
+import { isOrganizationId } from '../organization';
+
+describe('isOrganizationId(string)', () => {
+  it('should return true for strings starting with `org_`', () => {
+    expect(isOrganizationId('org_123')).toBe(true);
+    expect(isOrganizationId('org_abc')).toBe(true);
+  });
+
+  it('should return false for strings not starting with `org_`', () => {
+    expect(isOrganizationId('user_123')).toBe(false);
+    expect(isOrganizationId('123org_')).toBe(false);
+    expect(isOrganizationId('ORG_123')).toBe(false);
+    expect(isOrganizationId('')).toBe(false);
+  });
+});

--- a/packages/clerk-js/src/utils/__tests__/organization.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/organization.test.ts
@@ -10,6 +10,11 @@ describe('isOrganizationId(string)', () => {
     expect(isOrganizationId('user_123')).toBe(false);
     expect(isOrganizationId('123org_')).toBe(false);
     expect(isOrganizationId('ORG_123')).toBe(false);
+  });
+
+  it('should handle falsy values', () => {
+    expect(isOrganizationId(undefined)).toBe(false);
+    expect(isOrganizationId(null)).toBe(false);
     expect(isOrganizationId('')).toBe(false);
   });
 });

--- a/packages/clerk-js/src/utils/index.ts
+++ b/packages/clerk-js/src/utils/index.ts
@@ -25,3 +25,4 @@ export * from './queryStateParams';
 export * from './normalizeRoutingOptions';
 export * from './image';
 export * from './completeSignUpFlow';
+export * from './organization';

--- a/packages/clerk-js/src/utils/organization.ts
+++ b/packages/clerk-js/src/utils/organization.ts
@@ -1,8 +1,8 @@
 /**
  * Checks and assumes a string is an organization ID if it starts with 'org_', specifically for
- disambiguating with slugs. `_` is a disallowed character in slug names, so slugs cannot 
+ disambiguating with slugs. `_` is a disallowed character in slug names, so slugs cannot
  start with `org_`.
  */
-export function isOrganizationId(id: string) {
-  return id.startsWith('org_');
+export function isOrganizationId(id: string | null | undefined): boolean {
+  return typeof id === 'string' && id.startsWith('org_');
 }

--- a/packages/clerk-js/src/utils/organization.ts
+++ b/packages/clerk-js/src/utils/organization.ts
@@ -1,7 +1,7 @@
 /**
  * Checks and assumes a string is an organization ID if it starts with 'org_', specifically for
- disambiguating with slugs. `_` is a disallowed character in slug names, so slugs cannot
- start with `org_`.
+ * disambiguating with slugs. `_` is a disallowed character in slug names, so slugs cannot
+ * start with `org_`.
  */
 export function isOrganizationId(id: string | null | undefined): boolean {
   return typeof id === 'string' && id.startsWith('org_');

--- a/packages/clerk-js/src/utils/organization.ts
+++ b/packages/clerk-js/src/utils/organization.ts
@@ -1,0 +1,6 @@
+/**
+ * Checks and assumes a string is an organization ID if it starts with 'org_'.
+ */
+export function isOrganizationId(id: string) {
+  return id.startsWith('org_');
+}

--- a/packages/clerk-js/src/utils/organization.ts
+++ b/packages/clerk-js/src/utils/organization.ts
@@ -1,5 +1,7 @@
 /**
- * Checks and assumes a string is an organization ID if it starts with 'org_'.
+ * Checks and assumes a string is an organization ID if it starts with 'org_', specifically for
+ disambiguating with slugs. `_` is a disallowed character in slug names, so slugs cannot 
+ start with `org_`.
  */
 export function isOrganizationId(id: string) {
   return id.startsWith('org_');

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -681,7 +681,7 @@ export type SetActiveParams = {
   session?: ActiveSessionResource | string | null;
 
   /**
-   * The organization resource or organization id (string version) to be set as active in the current session.
+   * The organization resource or organization ID/slug (string version) to be set as active in the current session.
    * If `null`, the currently active organization is removed as active.
    */
   organization?: OrganizationResource | string | null;


### PR DESCRIPTION
## Description

This PR introduces ability to set an active organization by slug and updates existing org tests to use a proper Org ID format (`org_*`).

```ts
setActive({ organization: 'some-cool-slug' })
```

Fixes ORGS-17

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
