### PR TITLE
chore(clerk-js,localizations): Add signup start action link translations

### DIFF
--- a/.changeset/six-toys-clap.md
+++ b/.changeset/six-toys-clap.md
@@ -1,0 +1,6 @@
+---
+"@clerk/localizations": patch
+"@clerk/clerk-js": patch
+---
+
+Add `signUp.start.actionLink__use_email` and `signUp.start.actionLink__use_phone` localization keys.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -76,7 +76,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
               isRequired={fields.emailAddress!.required}
               isOptional={!fields.emailAddress!.required}
               isDisabled={fields.emailAddress!.disabled}
-              actionLabel={canToggleEmailPhone ? 'Use phone instead' : undefined}
+              actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
               onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
             />
           </Form.ControlRow>
@@ -87,7 +87,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
               {...formState.phoneNumber.props}
               isRequired={fields.phoneNumber!.required}
               isOptional={!fields.phoneNumber!.required}
-              actionLabel={canToggleEmailPhone ? 'Use email instead' : undefined}
+              actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
               onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
             />
           </Form.ControlRow>

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -454,6 +454,8 @@ export const arSA: LocalizationResource = {
     },
     start: {
       actionLink: 'تسجيل الدخول',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'لديك حساب بالفعل؟',
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'أنشاء حساب جديد',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -457,6 +457,8 @@ export const bgBG: LocalizationResource = {
     },
     start: {
       actionLink: 'Влезте',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Вече имате акаунт?',
       subtitle: 'Добре дошли! Моля, попълнете данните, за да започнете.',
       title: 'Създайте своя акаунт',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -454,6 +454,8 @@ export const csCZ: LocalizationResource = {
     },
     start: {
       actionLink: 'Přihlásit se',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Máte účet?',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Vytvořte si účet',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -455,6 +455,8 @@ export const daDK: LocalizationResource = {
     },
     start: {
       actionLink: 'Log ind',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Har du en konto?',
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Opret din konto',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -463,6 +463,8 @@ export const deDE: LocalizationResource = {
     },
     start: {
       actionLink: 'Einloggen',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Haben Sie ein Konto?',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Erstelle deinen Account',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -457,6 +457,8 @@ export const elGR: LocalizationResource = {
     },
     start: {
       actionLink: 'Σύνδεση',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Έχετε ήδη λογαριασμό;',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Δημιουργήστε τον λογαριασμό σας',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -446,8 +446,8 @@ export const enUS: LocalizationResource = {
     },
     start: {
       actionLink: 'Sign in',
-      actionLink__use_phone: 'Use phone instead',
       actionLink__use_email: 'Use email instead',
+      actionLink__use_phone: 'Use phone instead',
       actionText: 'Already have an account?',
       subtitle: 'Welcome! Please fill in the details to get started.',
       title: 'Create your account',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -446,6 +446,8 @@ export const enUS: LocalizationResource = {
     },
     start: {
       actionLink: 'Sign in',
+      actionLink__use_phone: 'Use phone instead',
+      actionLink__use_email: 'Use email instead',
       actionText: 'Already have an account?',
       subtitle: 'Welcome! Please fill in the details to get started.',
       title: 'Create your account',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -457,6 +457,8 @@ export const esES: LocalizationResource = {
     },
     start: {
       actionLink: 'Entrar',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: '¿Tienes una cuenta?',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Crea tu cuenta',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -461,6 +461,8 @@ export const esMX: LocalizationResource = {
     },
     start: {
       actionLink: 'Acceder',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: '¿Tienes una cuenta?',
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Crea tu cuenta',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -1,3 +1,15 @@
+/*
+ * =====================================================================================
+ * DISCLAIMER:
+ * =====================================================================================
+ * This localization file is a community contribution and is not officially maintained
+ * by Clerk. It has been provided by the community and may not be fully aligned
+ * with the current or future states of the main application. Clerk does not guarantee
+ * the accuracy, completeness, or timeliness of the translations in this file.
+ * Use of this file is at your own risk and discretion.
+ * =====================================================================================
+ */
+
 import type { LocalizationResource } from '@clerk/types';
 
 export const fiFI: LocalizationResource = {
@@ -297,6 +309,10 @@ export const fiFI: LocalizationResource = {
       title: 'Tarkista sähköpostisi',
     },
     emailLink: {
+      clientMismatch: {
+        subtitle: 'Jatkaaksesi avaa vahvistuslinkki laitteella ja selaimella, josta aloitit kirjautumisen',
+        title: 'Vahvistuslinkki on virheellinen tälle laitteelle',
+      },
       expired: {
         subtitle: 'Palaa alkuperäiseen välilehteen jatkaaksesi.',
         title: 'Tämä vahvistuslinkki on vanhentunut',
@@ -325,10 +341,6 @@ export const fiFI: LocalizationResource = {
         subtitle: 'Palaa alkuperäiseen välilehteen jatkaaksesi',
         subtitleNewTab: 'Palaa uuteen välilehteen jatkaaksesi',
         titleNewTab: 'Kirjautunut toiseen välilehteen',
-      },
-      clientMismatch: {
-        subtitle: 'Jatkaaksesi avaa vahvistuslinkki laitteella ja selaimella, josta aloitit kirjautumisen',
-        title: 'Vahvistuslinkki on virheellinen tälle laitteelle',
       },
     },
     forgotPassword: {
@@ -416,6 +428,10 @@ export const fiFI: LocalizationResource = {
       title: 'Tarkista sähköpostisi',
     },
     emailLink: {
+      clientMismatch: {
+        subtitle: 'Jatkaaksesi avaa vahvistuslinkki laitteella ja selaimella, josta aloitit rekisteröitymisen',
+        title: 'Vahvistuslinkki on virheellinen tälle laitteelle',
+      },
       formSubtitle: 'Käytä sähköpostiisi lähetettyä vahvistuslinkkiä',
       formTitle: 'Vahvistuslinkki',
       loading: {
@@ -432,10 +448,6 @@ export const fiFI: LocalizationResource = {
         subtitleNewTab: 'Palaa uuteen välilehteen jatkaaksesi',
         title: 'Rekisteröitynyt toiseen välilehteen',
       },
-      clientMismatch: {
-        subtitle: 'Jatkaaksesi avaa vahvistuslinkki laitteella ja selaimella, josta aloitit rekisteröitymisen',
-        title: 'Vahvistuslinkki on virheellinen tälle laitteelle',
-      },
     },
     phoneCode: {
       formSubtitle: 'Syötä puhelimeesi lähetetty koodi',
@@ -446,6 +458,8 @@ export const fiFI: LocalizationResource = {
     },
     start: {
       actionLink: 'Kirjaudu sisään',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Onko sinulla jo tili?',
       subtitle: 'Tervetuloa! Luo tili jatkaaksesi.',
       title: 'Luo tili',
@@ -720,6 +734,7 @@ export const fiFI: LocalizationResource = {
         actionLabel__reauthorize: 'Valtuuta nyt',
         destructiveActionTitle: 'Poista',
         primaryButton: 'Yhdistä tili',
+        subtitle__disconnected: undefined,
         subtitle__reauthorize:
           'Tarvittavat käyttöoikeudet on päivitetty, ja saatat kokea rajoitettua toiminnallisuutta. Valtuuta tämä sovellus välttääksesi mahdolliset ongelmat.',
         title: 'Yhdistetyt tilit',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -457,6 +457,8 @@ export const frFR: LocalizationResource = {
     },
     start: {
       actionLink: "S'identifier",
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Vous avez déjà un compte ?',
       subtitle: 'pour continuer à {{applicationName}}',
       title: 'Créez votre compte',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -452,6 +452,8 @@ export const heIL: LocalizationResource = {
     },
     start: {
       actionLink: 'התחבר',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'יש לך חשבון?',
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'צור את החשבון שלך',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -457,6 +457,8 @@ export const huHU: LocalizationResource = {
     },
     start: {
       actionLink: 'Bejelentkezés',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Van már fiókod?',
       subtitle: 'Üdv! Kérlek add meg az adatokat, hogy elkezdhesd.',
       title: 'Fiók létrehozása',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -457,6 +457,8 @@ export const itIT: LocalizationResource = {
     },
     start: {
       actionLink: 'Accedi',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Hai giá un account?',
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Crea il tuo account',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -457,6 +457,8 @@ export const jaJP: LocalizationResource = {
     },
     start: {
       actionLink: 'サインイン',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'アカウントをお持ちですか？',
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'アカウントを作成',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -452,6 +452,8 @@ export const koKR: LocalizationResource = {
     },
     start: {
       actionLink: '로그인하기',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: '계정이 있으신가요?',
       subtitle: '환영합니다! 아래 정보를 입력해주세요.',
       title: '계정 만들기',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -458,6 +458,8 @@ export const mnMN: LocalizationResource = {
     },
     start: {
       actionLink: 'Нэвтрэх',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Бүртгэлтэй юу?',
       subtitle: 'Тавтай морил! Эхлэхийн тулд дэлгэрэнгүй мэдээллийг бөглөнө үү.',
       title: 'Бүртгэл үүсгэх',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -457,6 +457,8 @@ export const nbNO: LocalizationResource = {
     },
     start: {
       actionLink: 'Logg inn',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Har du allerede en konto?',
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Opprett kontoen din',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -455,6 +455,8 @@ export const nlNL: LocalizationResource = {
     },
     start: {
       actionLink: 'Inloggen',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Heb je al een account?',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Maak je account aan',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -455,6 +455,8 @@ export const plPL: LocalizationResource = {
     },
     start: {
       actionLink: 'Zaloguj się',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Masz już konto?',
       subtitle: 'aby kontynuować w {{applicationName}}',
       title: 'Utwórz swoje konto',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -458,6 +458,8 @@ export const ptBR: LocalizationResource = {
     },
     start: {
       actionLink: 'Entrar',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Possui uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar sua conta',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -455,6 +455,8 @@ export const ptPT: LocalizationResource = {
     },
     start: {
       actionLink: 'Entrar',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Já tem uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar a sua conta',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -459,6 +459,8 @@ export const roRO: LocalizationResource = {
     },
     start: {
       actionLink: 'Conectați-vă',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Aveți un cont?',
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Creați-vă un cont',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -459,6 +459,8 @@ export const ruRU: LocalizationResource = {
     },
     start: {
       actionLink: 'Войти',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Уже есть аккаунт?',
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Создайте Ваш аккаунт',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -455,6 +455,8 @@ export const skSK: LocalizationResource = {
     },
     start: {
       actionLink: 'Prihlásiť sa',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Máte účet?',
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Vytvorte si účet',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -456,6 +456,8 @@ export const srRS: LocalizationResource = {
     },
     start: {
       actionLink: 'Prijavi se',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Već imaš nalog?',
       subtitle: 'Dobrodošao! Molimo popuni detalje da započneš.',
       title: 'Kreiraj svoj nalog',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -456,6 +456,8 @@ export const svSE: LocalizationResource = {
     },
     start: {
       actionLink: 'Logga in',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Har du redan ett konto?',
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Skapa ditt konto',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -453,6 +453,8 @@ export const thTH: LocalizationResource = {
     },
     start: {
       actionLink: 'เข้าสู่ระบบ',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'มีบัญชีอยู่แล้วใช่หรือไม่?',
       subtitle: 'ยินดีต้อนรับ! กรุณากรอกข้อมูลเพื่อเริ่มต้น',
       title: 'สร้างบัญชีของคุณ',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -455,6 +455,8 @@ export const trTR: LocalizationResource = {
     },
     start: {
       actionLink: 'Giriş yap',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Hesabınız var mı?',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Hesap oluştur',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -455,6 +455,8 @@ export const ukUA: LocalizationResource = {
     },
     start: {
       actionLink: 'Увійти',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Уже є акаунт?',
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Створіть Ваш акаунт',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -455,6 +455,8 @@ export const viVN: LocalizationResource = {
     },
     start: {
       actionLink: 'Đăng nhập',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: 'Đã có tài khoản?',
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Tạo tài khoản của bạn',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -446,6 +446,8 @@ export const zhCN: LocalizationResource = {
     },
     start: {
       actionLink: '登录',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: '已经有账户了？',
       subtitle: '继续使用 {{applicationName}}',
       title: '创建您的账户',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -452,6 +452,8 @@ export const zhTW: LocalizationResource = {
     },
     start: {
       actionLink: '登錄',
+      actionLink__use_email: undefined,
+      actionLink__use_phone: undefined,
       actionText: '已經有帳戶了？',
       subtitle: '繼續使用 {{applicationName}}',
       title: '創建您的帳戶',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -99,6 +99,8 @@ type _LocalizationResource = {
       subtitle: LocalizationValue;
       actionText: LocalizationValue;
       actionLink: LocalizationValue;
+      actionLink__use_phone: LocalizationValue;
+      actionLink__use_email: LocalizationValue;
     };
     emailLink: {
       title: LocalizationValue;


### PR DESCRIPTION
## Description

Adds two new localization keys for signup start form.

- Add `Use email instead` - `signUp.start.actionLink__use_email`
- Add `Use phone instead` - `signUp.start.actionLink__use_phone`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
