### PR TITLE
Replaced "Delete account" with spanish translation "Eliminar cuenta"

### DIFF
--- a/.changeset/famous-tools-thank.md
+++ b/.changeset/famous-tools-thank.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Replaced "Delete account" with spanish translation "Eliminar cuenta"

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -593,7 +593,7 @@ export const esMX: LocalizationResource = {
       title: 'Agregar cuenta conectada',
     },
     deletePage: {
-      actionDescription: 'Escribe "Delete account" a continuación para continuar',
+      actionDescription: 'Escribe "Eliminar cuenta" a continuación para continuar',
       confirm: 'Eliminar cuenta',
       messageLine1: '¿Estas seguro que quieres eliminar tu cuenta?',
       messageLine2: 'Esta acción es permanente e irreversible.',


### PR DESCRIPTION
## Description
Spanish localization issue, currently, if you write 'Delete account' in the text field, it will not work because it expects 'Eliminar cuenta'. This disrupts the user experience. 

![image](https://github.com/user-attachments/assets/ce6f0fc1-b222-4c11-8a08-264b87ed23e7)


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
