### PR TITLE
feat(clerk-js,types): Add option to disable portaling within UserButton and OrgSwitcher components

### DIFF
--- a/.changeset/wise-birds-invent.md
+++ b/.changeset/wise-birds-invent.md
@@ -1,0 +1,8 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/types": patch
+---
+
+Add support for disabling portaling within both `<UserButton />` and `<OrganizationSwitcher />` components.
+
+Fixes issue where defaultOpen prop was not being forwarded within `<UserButton />`

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useId } from 'react';
 
-import { AcceptedInvitationsProvider, withCoreUserGuard } from '../../contexts';
+import { AcceptedInvitationsProvider, useOrganizationSwitcherContext, withCoreUserGuard } from '../../contexts';
 import { Flow } from '../../customizables';
 import { Popover, withCardStateProvider, withFloatingTree } from '../../elements';
 import { usePopover } from '../../hooks';
@@ -8,7 +8,9 @@ import { OrganizationSwitcherPopover } from './OrganizationSwitcherPopover';
 import { OrganizationSwitcherTrigger } from './OrganizationSwitcherTrigger';
 
 const _OrganizationSwitcher = withFloatingTree(() => {
+  const { defaultOpen, portal } = useOrganizationSwitcherContext();
   const { floating, reference, styles, toggle, isOpen, nodeId, context } = usePopover({
+    defaultOpen,
     placement: 'bottom-start',
     offset: 8,
   });
@@ -32,6 +34,7 @@ const _OrganizationSwitcher = withFloatingTree(() => {
           nodeId={nodeId}
           context={context}
           isOpen={isOpen}
+          portal={portal}
         >
           <OrganizationSwitcherPopover
             id={switcherButtonMenuId}

--- a/packages/clerk-js/src/ui/components/UserButton/UserButton.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButton.tsx
@@ -8,7 +8,7 @@ import { UserButtonPopover } from './UserButtonPopover';
 import { UserButtonTrigger } from './UserButtonTrigger';
 
 const _UserButton = withFloatingTree(() => {
-  const { defaultOpen } = useUserButtonContext();
+  const { defaultOpen, portal } = useUserButtonContext();
   const { floating, reference, styles, toggle, isOpen, nodeId, context } = usePopover({
     defaultOpen,
     placement: 'bottom-end',
@@ -33,6 +33,7 @@ const _UserButton = withFloatingTree(() => {
         nodeId={nodeId}
         context={context}
         isOpen={isOpen}
+        portal={portal}
       >
         <UserButtonPopover
           id={userButtonMenuId}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -895,6 +895,11 @@ export type UserButtonProps = UserButtonProfileMode & {
    */
   defaultOpen?: boolean;
   /**
+   * By default, the popover will be rendered outside of the app root and into the body.
+   * @default true
+   */
+  portal?: boolean;
+  /**
    * Full URL or path to navigate after sign out is complete
    * @deprecated Configure `afterSignOutUrl` as a global configuration, either in <ClerkProvider/> or in await Clerk.load()
    */
@@ -949,6 +954,11 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
      * Controls the default state of the OrganizationSwitcher
      */
     defaultOpen?: boolean;
+    /**
+     * By default, the popover will be rendered outside of the app root and into the body.
+     * @default true
+     */
+    portal?: boolean;
     /**
      * By default, users can switch between organization and their personal account.
      * This option controls whether OrganizationSwitcher will include the user's personal account


### PR DESCRIPTION
## Description

Allow disabling portal usage within both `<UserButton >` and `<OrganizationSwitcher />` components to allow folks to make use of these components within dialog or sheet contexts.


```
<UserButton portal={false} />
<OrganizationSwitcher portal={false} />
```

https://github.com/user-attachments/assets/5c281d86-4bd6-4dea-80c7-b9e9ad91c230


https://linear.app/clerk/issue/SDKI-518/expose-portal-prop-to-userbutton-and-organizationswitcher-components

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
