### PR TITLE
fix(remix): Fix issue where request body has already been read

### DIFF
--- a/.changeset/bright-crabs-speak.md
+++ b/.changeset/bright-crabs-speak.md
@@ -1,0 +1,5 @@
+---
+"@clerk/remix": patch
+---
+
+Fixed a bug that was caused when the request body has already been read

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -125,10 +125,18 @@ export const wrapWithClerkState = (data: any) => {
  * @internal
  */
 export const patchRequest = (request: Request) => {
-  const clonedRequest = request.clone();
+  const clonedRequest = new Request(request.url, {
+    headers: request.headers,
+    method: request.method,
+    redirect: request.redirect,
+    cache: request.cache,
+    signal: request.signal,
+  });
+
   // If duplex is not set, set it to 'half' to avoid duplex issues with unidici
   if (clonedRequest.method !== 'GET' && clonedRequest.body !== null && !('duplex' in clonedRequest)) {
     (clonedRequest as unknown as { duplex: 'half' }).duplex = 'half';
   }
+
   return clonedRequest;
 };


### PR DESCRIPTION
## Description

This PR fixes a bug where the body has already been read and we try to clone the whole request and this results to an error.

<!-- Fixes #(issue number) -->

Fixes [#3769](https://github.com/clerk/javascript/issues/3759)

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
