### PR TITLE
chore(gatsby-plugin-clerk): Add transition period notice

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,7 @@
   "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["gatsby-plugin-clerk"],
+  "ignore": [],
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}.v{commit}"

--- a/.changeset/fluffy-wolves-itch.md
+++ b/.changeset/fluffy-wolves-itch.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-clerk": patch
+---
+
+Add notice of plans to EOL Gatsby SDK

--- a/packages/gatsby-plugin-clerk/README.md
+++ b/packages/gatsby-plugin-clerk/README.md
@@ -29,7 +29,7 @@
 ---
 
 > [!IMPORTANT]
-> Starting August 1, 2024, the Gatsby SDK is entering a one-month notice period. We are actively seeking a community maintainer to take over the project. For full details, please see our [changelog](https://clerk-git-rob-eco-93-changelog-entry-about-the-start-of-f25dc8.clerkstage.dev/changelog/2024-08-01-gatsby-eol).
+> Starting August 1, 2024, the Gatsby SDK is entering a one-month notice period. We are actively seeking a new community maintainer. For full details, please see our [changelog](https://clerk-git-rob-eco-93-changelog-entry-about-the-start-of-f25dc8.clerkstage.dev/changelog/2024-08-01-gatsby-eol).
 
 ## Overview
 

--- a/packages/gatsby-plugin-clerk/README.md
+++ b/packages/gatsby-plugin-clerk/README.md
@@ -29,7 +29,7 @@
 ---
 
 > [!IMPORTANT]
-> Starting August 1, 2024, the Gatsby SDK is entering a one-month notice period. We are actively seeking a new community maintainer. For full details, please see our [changelog](https://clerk-git-rob-eco-93-changelog-entry-about-the-start-of-f25dc8.clerkstage.dev/changelog/2024-08-01-gatsby-eol).
+> Starting August 1, 2024, the Gatsby SDK is entering a one-month notice period. We are actively seeking a new community maintainer. For full details, please see our [changelog](https://clerk.com/changelog/2024-08-01-gatsby-eol).
 
 ## Overview
 

--- a/packages/gatsby-plugin-clerk/README.md
+++ b/packages/gatsby-plugin-clerk/README.md
@@ -28,6 +28,9 @@
 
 ---
 
+> [!IMPORTANT]
+> Starting August 1, 2024, the Gatsby SDK is entering a one-month notice period. We are actively seeking a community maintainer to take over the project. For full details, please see our [changelog](https://clerk-git-rob-eco-93-changelog-entry-about-the-start-of-f25dc8.clerkstage.dev/changelog/2024-08-01-gatsby-eol).
+
 ## Overview
 
 Clerk is the easiest way to add authentication and user management to your Gatsby application. Add sign up, sign in, and profile management to your application in minutes.


### PR DESCRIPTION
## Description

This PR adds notice of plan to EOL Gatsby SDK

Fixes ECO-86 and ECO-92

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
