### PR TITLE
fix(elements): Update supported factors based on status

### DIFF
--- a/.changeset/funny-berries-jam.md
+++ b/.changeset/funny-berries-jam.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Ensure correct supported strategies are rendered based on first or second factor needs.

--- a/packages/elements/src/react/sign-in/choose-strategy.tsx
+++ b/packages/elements/src/react/sign-in/choose-strategy.tsx
@@ -108,8 +108,11 @@ export const SignInSupportedStrategy = React.forwardRef<SignInSupportedStrategyE
     const routerRef = SignInRouterCtx.useActorRef();
     const snapshot = routerRef.getSnapshot();
 
-    const supportedFirstFactors = snapshot.context.clerk.client.signIn.supportedFirstFactors || [];
-    const supportedSecondFactors = snapshot.context.clerk.client.signIn.supportedSecondFactors || [];
+    const status = snapshot.context.clerk.client.signIn.status;
+    const supportedFirstFactors =
+      status === 'needs_first_factor' ? snapshot.context.clerk.client.signIn.supportedFirstFactors || [] : [];
+    const supportedSecondFactors =
+      status === 'needs_second_factor' ? snapshot.context.clerk.client.signIn.supportedSecondFactors || [] : [];
     const factor = [...supportedFirstFactors, ...supportedSecondFactors].find(factor => name === factor.strategy);
 
     const currentFactor = useSelector(

--- a/packages/ui/src/components/sign-in/first-factor-connections.tsx
+++ b/packages/ui/src/components/sign-in/first-factor-connections.tsx
@@ -1,0 +1,27 @@
+import { useSignIn } from '@clerk/clerk-react';
+
+import { Connections } from '~/common/connections';
+import { useLocalizations } from '~/hooks/use-localizations';
+import { Separator } from '~/primitives/separator';
+
+export function FirstFactorConnections({
+  isGlobalLoading,
+  hasConnection,
+}: {
+  isGlobalLoading: boolean;
+  hasConnection: boolean;
+}) {
+  const { t } = useLocalizations();
+  const { signIn } = useSignIn();
+  const isFirstFactor = signIn?.status === 'needs_first_factor';
+
+  if (isFirstFactor) {
+    return (
+      <>
+        <Connections disabled={isGlobalLoading} />
+        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
+      </>
+    );
+  }
+  return null;
+}

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -1,4 +1,3 @@
-import { useSignIn } from '@clerk/clerk-react';
 import * as Common from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 import * as React from 'react';
@@ -29,6 +28,8 @@ import * as Icon from '~/primitives/icon';
 import { LinkButton } from '~/primitives/link';
 import { Separator } from '~/primitives/separator';
 import { formatSafeIdentifier } from '~/utils/format-safe-identifier';
+
+import { FirstFactorConnections } from './first-factor-connections';
 
 /**
  * Implementation Details:
@@ -107,26 +108,6 @@ function SignInGetHelp() {
       <Card.Footer branded={branded} />
     </Card.Root>
   );
-}
-
-function FirstFactorConnections({
-  isGlobalLoading,
-  hasConnection,
-}: {
-  isGlobalLoading: boolean;
-  hasConnection: boolean;
-}) {
-  const { t } = useLocalizations();
-  const { signIn } = useSignIn();
-  if (signIn?.status === 'needs_first_factor') {
-    return (
-      <>
-        <Connections disabled={isGlobalLoading} />
-        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
-      </>
-    );
-  }
-  return null;
 }
 
 export function SignInComponentLoaded() {

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -887,9 +887,10 @@ export function SignInComponentLoaded() {
                       }}
                     </Common.GlobalError>
                     <div className='flex flex-col gap-6'>
-                      <Connections disabled={isGlobalLoading} />
-
-                      {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
+                      <SignIn.FirstFactor>
+                        <Connections disabled={isGlobalLoading} />
+                        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
+                      </SignIn.FirstFactor>
 
                       <div className='flex flex-col gap-3'>
                         <div className='flex flex-col gap-2'>

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -887,10 +887,9 @@ export function SignInComponentLoaded() {
                       }}
                     </Common.GlobalError>
                     <div className='flex flex-col gap-6'>
-                      <SignIn.FirstFactor>
-                        <Connections disabled={isGlobalLoading} />
-                        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
-                      </SignIn.FirstFactor>
+                      <Connections disabled={isGlobalLoading} />
+
+                      {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
 
                       <div className='flex flex-col gap-3'>
                         <div className='flex flex-col gap-2'>

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -1,3 +1,4 @@
+import { useSignIn } from '@clerk/clerk-react';
 import * as Common from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 import * as React from 'react';
@@ -106,6 +107,26 @@ function SignInGetHelp() {
       <Card.Footer branded={branded} />
     </Card.Root>
   );
+}
+
+function FirstFactorConnections({
+  isGlobalLoading,
+  hasConnection,
+}: {
+  isGlobalLoading: boolean;
+  hasConnection: boolean;
+}) {
+  const { t } = useLocalizations();
+  const { signIn } = useSignIn();
+  if (signIn?.status === 'needs_first_factor') {
+    return (
+      <>
+        <Connections disabled={isGlobalLoading} />
+        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
+      </>
+    );
+  }
+  return null;
 }
 
 export function SignInComponentLoaded() {
@@ -887,10 +908,10 @@ export function SignInComponentLoaded() {
                       }}
                     </Common.GlobalError>
                     <div className='flex flex-col gap-6'>
-                      <Connections disabled={isGlobalLoading} />
-
-                      {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
-
+                      <FirstFactorConnections
+                        isGlobalLoading={isGlobalLoading}
+                        hasConnection={hasConnection}
+                      />
                       <div className='flex flex-col gap-3'>
                         <div className='flex flex-col gap-2'>
                           <SignIn.SupportedStrategy


### PR DESCRIPTION
## Description

Ensure correct supported strategies are rendered based on first or second factor needs.

https://linear.app/clerk/issue/SDKI-294/choose-strategy-step-returning-incorrect-supportedstrategy-for-second

BEFORE:
<img width="570" alt="Screenshot 2024-07-30 at 4 02 37 PM" src="https://github.com/user-attachments/assets/9ffa28b4-64a9-4776-858b-17e68aa19932">

AFTER:
<img width="511" alt="Screenshot 2024-07-30 at 4 02 17 PM" src="https://github.com/user-attachments/assets/59836111-fb2d-47e9-9b87-035bac7d17b3">

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
