### PR TITLE
fix(astro): Protect component prop types

### DIFF
--- a/.changeset/friendly-bags-whisper.md
+++ b/.changeset/friendly-bags-whisper.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fixed a bug where the `<Protect />` component would not validate any properties passed

--- a/packages/astro/src/astro-components/control/Protect.astro
+++ b/packages/astro/src/astro-components/control/Protect.astro
@@ -1,6 +1,31 @@
 ---
-import { ProtectComponentDefaultProps } from "../../types";
-type Props = ProtectComponentDefaultProps
+import type {
+  CheckAuthorizationWithCustomPermissions,
+  OrganizationCustomPermissionKey,
+  OrganizationCustomRoleKey,
+} from '@clerk/types';
+
+type Props =
+  | {
+      condition?: never;
+      role: OrganizationCustomRoleKey;
+      permission?: never;
+    }
+  | {
+      condition?: never;
+      role?: never;
+      permission: OrganizationCustomPermissionKey;
+    }
+  | {
+      condition: (has: CheckAuthorizationWithCustomPermissions) => boolean;
+      role?: never;
+      permission?: never;
+    }
+  | {
+      condition?: never;
+      role?: never;
+      permission?: never;
+    };
 
 const { has, userId } = Astro.locals.auth();
 const isUnauthorized =

--- a/packages/astro/src/react/controlComponents.tsx
+++ b/packages/astro/src/react/controlComponents.tsx
@@ -1,10 +1,14 @@
-import type { CheckAuthorizationWithCustomPermissions, HandleOAuthCallbackParams } from '@clerk/types';
+import type {
+  CheckAuthorizationWithCustomPermissions,
+  HandleOAuthCallbackParams,
+  OrganizationCustomPermissionKey,
+  OrganizationCustomRoleKey,
+} from '@clerk/types';
 import { computed } from 'nanostores';
 import type { PropsWithChildren } from 'react';
 import React, { useEffect, useState } from 'react';
 
 import { $csrState } from '../stores/internal';
-import type { ProtectComponentDefaultProps } from '../types';
 import { useAuth } from './hooks';
 import type { WithClerkProp } from './utils';
 import { withClerk } from './utils';
@@ -70,7 +74,28 @@ export const ClerkLoading = ({ children }: React.PropsWithChildren): JSX.Element
 };
 
 export type ProtectProps = React.PropsWithChildren<
-  ProtectComponentDefaultProps & {
+  (
+    | {
+        condition?: never;
+        role: OrganizationCustomRoleKey;
+        permission?: never;
+      }
+    | {
+        condition?: never;
+        role?: never;
+        permission: OrganizationCustomPermissionKey;
+      }
+    | {
+        condition: (has: CheckAuthorizationWithCustomPermissions) => boolean;
+        role?: never;
+        permission?: never;
+      }
+    | {
+        condition?: never;
+        role?: never;
+        permission?: never;
+      }
+  ) & {
     fallback?: React.ReactNode;
   }
 >;

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -1,11 +1,4 @@
-import type {
-  CheckAuthorizationWithCustomPermissions,
-  ClerkOptions,
-  MultiDomainAndOrProxyPrimitives,
-  OrganizationCustomPermissionKey,
-  OrganizationCustomRoleKey,
-  Without,
-} from '@clerk/types';
+import type { ClerkOptions, MultiDomainAndOrProxyPrimitives, Without } from '@clerk/types';
 
 type AstroClerkUpdateOptions = Pick<ClerkOptions, 'appearance' | 'localization'>;
 
@@ -32,31 +25,4 @@ declare global {
   }
 }
 
-type ProtectComponentDefaultProps =
-  | {
-      condition?: never;
-      role: OrganizationCustomRoleKey;
-      permission?: never;
-    }
-  | {
-      condition?: never;
-      role?: never;
-      permission: OrganizationCustomPermissionKey;
-    }
-  | {
-      condition: (has: CheckAuthorizationWithCustomPermissions) => boolean;
-      role?: never;
-      permission?: never;
-    }
-  | {
-      condition?: never;
-      role?: never;
-      permission?: never;
-    };
-
-export type {
-  AstroClerkUpdateOptions,
-  AstroClerkIntegrationParams,
-  AstroClerkCreateInstanceParams,
-  ProtectComponentDefaultProps,
-};
+export type { AstroClerkUpdateOptions, AstroClerkIntegrationParams, AstroClerkCreateInstanceParams };


### PR DESCRIPTION
## Description

This PR addresses an issue where the `<Protect />` component was accepting any prop without TypeScript raising errors. All the Astro components does not have a build step, and directly copied to `components/*`, so relative paths will not be resolvable.

<img width="614" alt="Screenshot 2024-07-30 at 3 29 41 PM" src="https://github.com/user-attachments/assets/828183c4-d36a-4db9-a15b-15d9279c43ca">

<img width="504" alt="Screenshot 2024-07-30 at 4 34 14 PM" src="https://github.com/user-attachments/assets/a7d9b758-b1d4-4d0e-abf5-65f0a5a882ff">

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
