### PR TITLE
feat(elements,ui): Return password validation error codes with relevant config entries

### DIFF
--- a/packages/elements/src/internals/machines/form/form.types.ts
+++ b/packages/elements/src/internals/machines/form/form.types.ts
@@ -1,12 +1,12 @@
 import type { ClerkElementsFieldError } from '~/internals/errors';
 import type { FieldStates } from '~/react/common/form/types';
 import type { PasswordConfig } from '~/react/hooks/use-password.hook';
-import type { ErrorMessagesKey } from '~/react/utils/generate-password-error-text';
+import type { ErrorCodeOrTuple } from '~/react/utils/generate-password-error-text';
 
 export type FormDefaultValues = Map<string, FieldDetails['value']>;
 
 interface FeedbackBase {
-  codes?: Array<ErrorMessagesKey>;
+  codes?: Array<ErrorCodeOrTuple>;
 }
 
 export interface FeedbackErrorType extends FeedbackBase {

--- a/packages/elements/src/react/common/form/index.tsx
+++ b/packages/elements/src/react/common/form/index.tsx
@@ -36,11 +36,10 @@ import {
   useFormSelector,
   useFormStore,
 } from '~/internals/machines/form/form.context';
-import type { PasswordConfig } from '~/react/hooks/use-password.hook';
 import { usePassword } from '~/react/hooks/use-password.hook';
 import { SignInRouterCtx } from '~/react/sign-in/context';
 import { useSignInPasskeyAutofill } from '~/react/sign-in/context/router.context';
-import type { ErrorMessagesKey } from '~/react/utils/generate-password-error-text';
+import type { ErrorCodeOrTuple } from '~/react/utils/generate-password-error-text';
 import { isReactFragment } from '~/react/utils/is-react-fragment';
 
 import type { OTPInputProps } from './otp';
@@ -234,7 +233,7 @@ const useInput = ({
         field: { name, feedback: { type: 'success', message: 'Your password meets all the necessary requirements.' } },
       });
     },
-    onValidationError: (error, keys, config) => {
+    onValidationError: (error, keys) => {
       if (error) {
         ref.send({
           type: 'FIELD.FEEDBACK.SET',
@@ -244,18 +243,17 @@ const useInput = ({
               type: 'error',
               message: new ClerkElementsFieldError('password-validation-error', error),
               codes: keys,
-              config,
             },
           },
         });
       }
     },
-    onValidationWarning: (warning, keys, config) =>
+    onValidationWarning: (warning, keys) =>
       ref.send({
         type: 'FIELD.FEEDBACK.SET',
-        field: { name, feedback: { type: 'warning', message: warning, codes: keys, config } },
+        field: { name, feedback: { type: 'warning', message: warning, codes: keys } },
       }),
-    onValidationInfo: (info, keys, config) => {
+    onValidationInfo: (info, keys) => {
       // TODO: If input is not focused, make this info an error
       ref.send({
         type: 'FIELD.FEEDBACK.SET',
@@ -265,7 +263,6 @@ const useInput = ({
             type: 'info',
             message: info,
             codes: keys,
-            config,
           },
         },
       });
@@ -523,8 +520,7 @@ type FieldStateRenderFn = {
   children: (state: {
     state: FieldStates;
     message: string | undefined;
-    codes: ErrorMessagesKey[] | undefined;
-    config?: PasswordConfig;
+    codes: ErrorCodeOrTuple[] | undefined;
   }) => React.ReactNode;
 };
 
@@ -565,9 +561,8 @@ function FieldState({ children }: FieldStateRenderFn) {
 
   const message = feedback?.message instanceof ClerkElementsFieldError ? feedback.message.message : feedback?.message;
   const codes = feedback?.codes;
-  const config = feedback && 'config' in feedback ? feedback?.config : undefined;
 
-  const fieldState = { state: enrichFieldState(validity, state), message, codes, config };
+  const fieldState = { state: enrichFieldState(validity, state), message, codes };
 
   return children(fieldState);
 }

--- a/packages/elements/src/react/hooks/use-password.hook.ts
+++ b/packages/elements/src/react/hooks/use-password.hook.ts
@@ -3,7 +3,7 @@ import { noop } from '@clerk/shared';
 import type { PasswordSettingsData, PasswordValidation } from '@clerk/types';
 import * as React from 'react';
 
-import type { ErrorMessagesKey } from '../utils/generate-password-error-text';
+import type { ErrorCodeOrTuple } from '../utils/generate-password-error-text';
 import { generatePasswordErrorText } from '../utils/generate-password-error-text';
 
 // This hook should mimic the already existing usePassword hook in the clerk-js package
@@ -12,10 +12,10 @@ import { generatePasswordErrorText } from '../utils/generate-password-error-text
 export type PasswordConfig = Omit<PasswordSettingsData, 'disable_hibp' | 'min_zxcvbn_strength' | 'show_zxcvbn'>;
 
 type UsePasswordCallbacks = {
-  onValidationError?: (error: string | undefined, keys: ErrorMessagesKey[], config: PasswordConfig) => void;
+  onValidationError?: (error: string | undefined, keys: ErrorCodeOrTuple[]) => void;
   onValidationSuccess?: () => void;
-  onValidationWarning?: (warning: string, keys: string[], config: PasswordConfig) => void;
-  onValidationInfo?: (info: string, keys: ErrorMessagesKey[], config: PasswordConfig) => void;
+  onValidationWarning?: (warning: string, keys: ErrorCodeOrTuple[]) => void;
+  onValidationInfo?: (info: string, keys: ErrorCodeOrTuple[]) => void;
   onValidationComplexity?: (b: boolean) => void;
 };
 
@@ -45,9 +45,9 @@ export const usePassword = (callbacks?: UsePasswordCallbacks) => {
           });
 
           if (res.complexity?.min_length) {
-            return onValidationInfo(message, keys, config);
+            return onValidationInfo(message, keys);
           }
-          return onValidationError(message, keys, config);
+          return onValidationError(message, keys);
         }
       }
 
@@ -57,7 +57,7 @@ export const usePassword = (callbacks?: UsePasswordCallbacks) => {
       if (res?.strength?.state === 'fail') {
         const keys = res.strength.keys;
         const error = keys.map(key => get(zxcvbnKeys, key)).join(' ');
-        return onValidationError(error, keys, config);
+        return onValidationError(error, keys);
       }
 
       /**
@@ -66,7 +66,7 @@ export const usePassword = (callbacks?: UsePasswordCallbacks) => {
       if (res?.strength?.state === 'pass') {
         const keys = res.strength.keys;
         const error = keys.map(key => get(zxcvbnKeys, key)).join(' ');
-        return onValidationWarning(error, keys, config);
+        return onValidationWarning(error, keys);
       }
 
       /**

--- a/packages/elements/src/react/utils/generate-password-error-text.ts
+++ b/packages/elements/src/react/utils/generate-password-error-text.ts
@@ -18,6 +18,7 @@ const errorMessages: Record<keyof Omit<ComplexityErrors, 'allowed_special_charac
 };
 
 export type ErrorMessagesKey = Autocomplete<keyof typeof errorMessages>;
+export type ErrorCodeOrTuple = ErrorMessagesKey | [ErrorMessagesKey, Record<string, string | number>];
 
 const createListFormat = (message: string[]) => {
   let messageWithPrefix: string;
@@ -36,8 +37,28 @@ type GeneratePasswordErrorTextProps = {
   failedValidations: ComplexityErrors | undefined;
 };
 
+/**
+ * This function builds a single entry in the error array returned from generatePasswordErrorText. It returns either a
+ * string or a tuple containing the error code and relevant entries from the instance's password complexity conrfig.
+ * @param key The string respresentation of a possible error during password validation
+ * @param config The instance's password complexity configuration
+ * @returns The error code or a tuple containing the error code and relevant entries from the config
+ */
+function buildErrorTuple(key: ErrorMessagesKey, config: ComplexityConfig): ErrorCodeOrTuple {
+  switch (key) {
+    case 'max_length':
+      return [key, { max_length: config.max_length }];
+    case 'min_length':
+      return [key, { min_length: config.min_length }];
+    case 'require_special_char':
+      return [key, { allowed_special_characters: config.allowed_special_characters }];
+    default:
+      return key;
+  }
+}
+
 export const generatePasswordErrorText = ({ config, failedValidations }: GeneratePasswordErrorTextProps) => {
-  const keys: ErrorMessagesKey[] = [];
+  const keys: ErrorCodeOrTuple[] = [];
 
   if (!failedValidations || Object.keys(failedValidations).length === 0) {
     return {
@@ -54,7 +75,8 @@ export const generatePasswordErrorText = ({ config, failedValidations }: Generat
     .filter(([, v]) => !!v)
     .map(([k]) => {
       const entry = k as keyof typeof errorMessages;
-      keys.push(entry);
+      const errorTuple = buildErrorTuple(entry, config);
+      keys.push(errorTuple);
       const errorKey = errorMessages[entry];
 
       if (Array.isArray(errorKey)) {

--- a/packages/ui/src/common/password-field.tsx
+++ b/packages/ui/src/common/password-field.tsx
@@ -69,7 +69,7 @@ export function PasswordField({
         </Common.FieldState>
         {props.validatePassword ? (
           <Common.FieldState>
-            {({ state, codes, config }) => {
+            {({ state, codes }) => {
               if (state === 'idle') {
                 return;
               }
@@ -88,7 +88,7 @@ export function PasswordField({
                   id={id}
                   intent={state}
                 >
-                  {translatePasswordError({ config, failedValidations: codes, locale, t })}
+                  {translatePasswordError({ failedValidations: codes, locale, t })}
                 </Field.Message>
               );
             }}

--- a/packages/ui/src/utils/makeLocalizable.ts
+++ b/packages/ui/src/utils/makeLocalizable.ts
@@ -77,7 +77,6 @@ type LocalizationKeyToValue<P extends DefaultLocalizationKey> = PathValue<typeof
 type LocalizationKeyToParams<P extends DefaultLocalizationKey> = GetICUArgs<LocalizationKeyToValue<P>>;
 
 const readObjectPath = <O extends Record<string, any>>(obj: O, path: string) => {
-  console.log({ path });
   const props = (path || '').split('.');
   let cur = obj;
   for (let i = 0; i < props.length; i++) {

--- a/packages/ui/src/utils/makeLocalizable.ts
+++ b/packages/ui/src/utils/makeLocalizable.ts
@@ -77,6 +77,7 @@ type LocalizationKeyToValue<P extends DefaultLocalizationKey> = PathValue<typeof
 type LocalizationKeyToParams<P extends DefaultLocalizationKey> = GetICUArgs<LocalizationKeyToValue<P>>;
 
 const readObjectPath = <O extends Record<string, any>>(obj: O, path: string) => {
+  console.log({ path });
   const props = (path || '').split('.');
   let cur = obj;
   for (let i = 0; i < props.length; i++) {
@@ -273,13 +274,11 @@ const errorMessages: Record<keyof Omit<ComplexityErrors, 'allowed_special_charac
 };
 
 export const translatePasswordError = ({
-  config,
   failedValidations,
   locale,
   t,
 }: {
-  config: UsePasswordComplexityConfig;
-  failedValidations: string[];
+  failedValidations: (string | [string, Record<string, string | number>])[];
   locale: string;
   t: ReturnType<typeof makeLocalizeable>['t'];
 }) => {
@@ -295,16 +294,22 @@ export const translatePasswordError = ({
     return failedValidations.map(v => t(v as any)).join(' ');
   }
 
-  // show min length error first by itself
-  const hasMinLengthError = failedValidations?.includes('min_length') || false;
+  // show min length error first by itself. Since the min_length error will always be a tuple, we check for both
+  // isArray and that the first element is min_length
+  const hasMinLengthError = failedValidations?.some(v => Array.isArray(v) && v[0] === 'min_length') || false;
 
   const messages = failedValidations
-    .filter(k => (hasMinLengthError ? k === 'min_length' : true))
+    .filter(k => (hasMinLengthError ? Array.isArray(k) && k[0] === 'min_length' : true))
     .map(k => {
-      const localizedKey = errorMessages[k as keyof typeof errorMessages];
-      if (Array.isArray(localizedKey)) {
+      const key = Array.isArray(k) ? k[0] : k;
+      const localizedKey = errorMessages[key as keyof typeof errorMessages];
+      if (Array.isArray(localizedKey) && Array.isArray(k)) {
         const [lk, attr] = localizedKey;
-        return t(lk as any, { [attr]: config[k as keyof UsePasswordComplexityConfig] });
+        // Because our translations use `{{ length }}` instead of `{{ min_length }}` and `{{ max_length}}`, we simply
+        // take the value of the first key. This is safe to do currently because the tuple object will only ever
+        // contain one key. In the future when we update our translated strings, this can be changed to simply pass
+        // through k[1] as the second argument to `t()`.
+        return t(lk as any, { [attr]: Object.values(k[1])[0] });
       }
       return t(localizedKey as any);
     });


### PR DESCRIPTION
## Description

This PR builds upon the work in #3812 to return password validation errors with their relevant config entries rather than asking the user to collate them themselves.

Errors are now returned as `(ErrorMessagesKey | [ErrorMessagesKey, Record<string, string | number>])[]`. This would allow users to localize error messages with something as simple as:

```tsx
{codes.map(c => Array.isArray(c) ? <p>{t(c[0], c[1])}</p> : <p>{t(c)}</p>)}
```

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
