### PR TITLE
fix(dev-cli): Fix monorepo root detection for installed package case

### DIFF
--- a/packages/dev-cli/src/utils/getClerkPackages.js
+++ b/packages/dev-cli/src/utils/getClerkPackages.js
@@ -1,14 +1,16 @@
 import { readFile } from 'node:fs/promises';
-import { dirname, join, posix, resolve } from 'node:path';
+import { dirname, posix } from 'node:path';
 
 import { globby } from 'globby';
+
+import { getMonorepoRoot } from './getMonorepoRoot.js';
 
 /**
  * Generates an object with keys of package names and values of absolute paths to the package folder.
  * @returns {Promise<Record<string, string>>}
  */
 export async function getClerkPackages() {
-  const monorepoRoot = resolve(join(import.meta.dirname, '..', '..', '..', '..'));
+  const monorepoRoot = await getMonorepoRoot();
   /** @type {Record<string, string>} */
   const packages = {};
   const clerkPackages = await globby([posix.join(monorepoRoot, 'packages', '*', 'package.json'), '!*node_modules*']);


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

Rely on the dev CLI configuration to get the `clerk/javascript` monorepo root, instead of assuming the dev-cli is being executed from within the monorepo.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
