### PR TITLE
fix(dev-cli): Use configured monorepo root when calculating Clerk packages

### DIFF
--- a/.changeset/wicked-pianos-argue.md
+++ b/.changeset/wicked-pianos-argue.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Use configured monorepo root when calculating Clerk packages

--- a/packages/dev-cli/src/utils/getClerkPackages.js
+++ b/packages/dev-cli/src/utils/getClerkPackages.js
@@ -1,14 +1,16 @@
 import { readFile } from 'node:fs/promises';
-import { dirname, join, posix, resolve } from 'node:path';
+import { dirname, posix } from 'node:path';
 
 import { globby } from 'globby';
+
+import { getMonorepoRoot } from './getMonorepoRoot.js';
 
 /**
  * Generates an object with keys of package names and values of absolute paths to the package folder.
  * @returns {Promise<Record<string, string>>}
  */
 export async function getClerkPackages() {
-  const monorepoRoot = resolve(join(import.meta.dirname, '..', '..', '..', '..'));
+  const monorepoRoot = await getMonorepoRoot();
   /** @type {Record<string, string>} */
   const packages = {};
   const clerkPackages = await globby([posix.join(monorepoRoot, 'packages', '*', 'package.json'), '!*node_modules*']);


### PR DESCRIPTION
## Description

This PR updates the `getClerkPackages` function of `clerk-dev` to use the configured monorepo root. In a previous iteration of `clerk-dev` it was expected that the CLI would be installed from the local checkout of `javascript`. We switched instead to installing it via `npm`, but the logic for `getClerkPackages` was not updated.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
