### PR TITLE
feat(clerk-react): Add 'nonce' prop to ClerkProvider

### DIFF
--- a/.changeset/few-guests-collect.md
+++ b/.changeset/few-guests-collect.md
@@ -1,7 +1,8 @@
 ---
-"@clerk/nextjs": patch
-"@clerk/clerk-react": patch
-"@clerk/shared": patch
+"@clerk/nextjs": minor
+"@clerk/shared": minor
+"@clerk/clerk-react": minor
+"@clerk/clerk-js": minor
 ---
 
-Add a nonce prop to `ClerkProvider` that can be used to thread the nonce value through to the clerk-js script load to support apps using a strict-dynamic content security policy. For NextJs applications, the nonce will be automatically pulled from the CSP header and threaded through without needing any props so long as the provider is server-rendered.
+Add a `nonce` to clerk-js' script loading options. Also adds a `nonce` prop to `ClerkProvider`. This can be used to thread a nonce value through to the clerk-js script load to support apps using a `strict-dynamic` content security policy. For next.js applications, the nonce will be automatically pulled from the CSP header and threaded through without needing any props so long as the provider is server-rendered.

--- a/.changeset/few-guests-collect.md
+++ b/.changeset/few-guests-collect.md
@@ -1,0 +1,7 @@
+---
+"@clerk/nextjs": patch
+"@clerk/clerk-react": patch
+"@clerk/shared": patch
+---
+
+Add a nonce prop to `ClerkProvider` that can be used to thread the nonce value through to the clerk-js script load to support apps using a strict-dynamic content security policy. For NextJs applications, the nonce will be automatically pulled from the CSP header and threaded through without needing any props so long as the provider is server-rendered.

--- a/.changeset/fuzzy-elephants-warn.md
+++ b/.changeset/fuzzy-elephants-warn.md
@@ -1,8 +1,0 @@
----
-"@clerk/nextjs": minor
-"@clerk/shared": minor
-"@clerk/clerk-react": minor
-"@clerk/clerk-js": minor
----
-
-Adds the ability to pass a nonce to clerk-js' script loading and a 'nonce' property to ClerkProvider

--- a/.changeset/fuzzy-elephants-warn.md
+++ b/.changeset/fuzzy-elephants-warn.md
@@ -1,0 +1,8 @@
+---
+"@clerk/nextjs": minor
+"@clerk/shared": minor
+"@clerk/clerk-react": minor
+"@clerk/clerk-js": minor
+---
+
+Adds the ability to pass a nonce to clerk-js' script loading and a 'nonce' property to ClerkProvider

--- a/integration/templates/next-app-router/src/app/csp/page.tsx
+++ b/integration/templates/next-app-router/src/app/csp/page.tsx
@@ -1,0 +1,13 @@
+import { headers } from 'next/headers';
+import { ClerkLoaded } from '@clerk/nextjs';
+
+export default function CSPPage() {
+  return (
+    <div>
+      CSP: <pre>{headers().get('Content-Security-Policy')}</pre>
+      <ClerkLoaded>
+        <p>clerk loaded</p>
+      </ClerkLoaded>
+    </div>
+  );
+}

--- a/integration/templates/next-app-router/src/middleware.ts
+++ b/integration/templates/next-app-router/src/middleware.ts
@@ -1,10 +1,23 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 
+const csp = `default-src 'self';
+  script-src 'self' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-deadbeef';
+  img-src 'self' https://img.clerk.com;
+  worker-src 'self' blob:;
+  style-src 'self' 'unsafe-inline';
+  frame-src 'self' https://challenges.cloudflare.com;
+`;
+
 const isProtectedRoute = createRouteMatcher(['/protected(.*)', '/user(.*)', '/switcher(.*)']);
+const isCSPRoute = createRouteMatcher(['/csp']);
 
 export default clerkMiddleware((auth, req) => {
   if (isProtectedRoute(req)) {
     auth().protect();
+  }
+
+  if (isCSPRoute(req)) {
+    req.headers.set('Content-Security-Policy', csp.replace(/\n/g, ''));
   }
 });
 

--- a/integration/tests/content-security-policy.test.ts
+++ b/integration/tests/content-security-policy.test.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+
+import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+
+testAgainstRunningApps({ withPattern: ['next.appRouter.withEmailCodes'] })(
+  'Content Security Policy @nextjs',
+  ({ app }) => {
+    test.describe.configure({ mode: 'serial' });
+
+    test('Clerk loads when nonce is specified', async ({ page }) => {
+      const u = createTestUtils({ app, page });
+      await u.page.goToRelative('/csp');
+      await u.page.getByText('clerk loaded').waitFor({ state: 'visible' });
+    });
+  },
+);

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -1,18 +1,22 @@
 import type { InitialState, Without } from '@clerk/types';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import type { NextClerkProviderProps } from '../../types';
 import { mergeNextClerkPropsWithEnv } from '../../utils/mergeNextClerkPropsWithEnv';
 import { ClientClerkProvider } from '../client/ClerkProvider';
 import { initialState } from './auth';
+import { getScriptNonceFromHeader } from './utils';
 
 export function ClerkProvider(props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>) {
   const { children, ...rest } = props;
   const state = initialState()?.__clerk_ssr_state as InitialState;
+  const cspHeader = headers().get('Content-Security-Policy');
 
   return (
     <ClientClerkProvider
       {...mergeNextClerkPropsWithEnv(rest)}
+      nonce={getScriptNonceFromHeader(cspHeader || '')}
       initialState={state}
     >
       {children}

--- a/packages/nextjs/src/app-router/server/utils.ts
+++ b/packages/nextjs/src/app-router/server/utils.ts
@@ -77,7 +77,7 @@ export function getScriptNonceFromHeader(cspHeaderValue: string): string | undef
   // extra layer.
   if (/[&><\u2028\u2029]/g.test(nonce)) {
     throw new Error(
-      'Nonce value from Content-Security-Policy contained HTML escape characters.\nLearn more: https://nextjs.org/docs/messages/nonce-contained-invalid-characters',
+      'Nonce value from Content-Security-Policy contained invalid HTML escape characters, which is disallowed for security reasons. Make sure that your nonce value does not contain the following characters: `<`, `>`, `&`',
     );
   }
 

--- a/packages/nextjs/src/app-router/server/utils.ts
+++ b/packages/nextjs/src/app-router/server/utils.ts
@@ -38,3 +38,48 @@ export const buildRequestLike = () => {
     );
   }
 };
+
+// Original source: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
+export function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
+  const directives = cspHeaderValue
+    // Directives are split by ';'.
+    .split(';')
+    .map(directive => directive.trim());
+
+  // First try to find the directive for the 'script-src', otherwise try to
+  // fallback to the 'default-src'.
+  const directive =
+    directives.find(dir => dir.startsWith('script-src')) || directives.find(dir => dir.startsWith('default-src'));
+
+  // If no directive could be found, then we're done.
+  if (!directive) {
+    return;
+  }
+
+  // Extract the nonce from the directive
+  const nonce = directive
+    .split(' ')
+    // Remove the 'strict-src'/'default-src' string, this can't be the nonce.
+    .slice(1)
+    .map(source => source.trim())
+    // Find the first source with the 'nonce-' prefix.
+    .find(source => source.startsWith("'nonce-") && source.length > 8 && source.endsWith("'"))
+    // Grab the nonce by trimming the 'nonce-' prefix.
+    ?.slice(7, -1);
+
+  // If we could't find the nonce, then we're done.
+  if (!nonce) {
+    return;
+  }
+
+  // Don't accept the nonce value if it contains HTML escape characters.
+  // Technically, the spec requires a base64'd value, but this is just an
+  // extra layer.
+  if (/[&><\u2028\u2029]/g.test(nonce)) {
+    throw new Error(
+      'Nonce value from Content-Security-Policy contained HTML escape characters.\nLearn more: https://nextjs.org/docs/messages/nonce-contained-invalid-characters',
+    );
+  }
+
+  return nonce;
+}

--- a/packages/nextjs/src/utils/clerk-js-script.tsx
+++ b/packages/nextjs/src/utils/clerk-js-script.tsx
@@ -10,7 +10,7 @@ type ClerkJSScriptProps = {
 };
 
 function ClerkJSScript(props: ClerkJSScriptProps) {
-  const { publishableKey, clerkJSUrl, clerkJSVersion, clerkJSVariant } = useClerkNextOptions();
+  const { publishableKey, clerkJSUrl, clerkJSVersion, clerkJSVariant, nonce } = useClerkNextOptions();
   const { domain, proxyUrl } = useClerk();
   const options = {
     domain,
@@ -19,6 +19,7 @@ function ClerkJSScript(props: ClerkJSScriptProps) {
     clerkJSUrl,
     clerkJSVersion,
     clerkJSVariant,
+    nonce,
   };
   const scriptUrl = clerkJsScriptUrl(options);
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -424,6 +424,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
             publishableKey: this.#publishableKey,
             proxyUrl: this.proxyUrl,
             domain: this.domain,
+            nonce: this.options.nonce,
           });
         }
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -31,6 +31,7 @@ export type IsomorphicClerkOptions = Without<ClerkOptions, 'isSatellite'> & {
   clerkJSVersion?: string;
   sdkMetadata?: SDKMetadata;
   publishableKey: string;
+  nonce?: string;
 } & MultiDomainAndOrProxy;
 
 export type ClerkProviderProps = IsomorphicClerkOptions & {

--- a/packages/react/src/utils/loadClerkJsScript.ts
+++ b/packages/react/src/utils/loadClerkJsScript.ts
@@ -13,10 +13,11 @@ const FAILED_TO_LOAD_ERROR = 'Clerk: Failed to load Clerk';
 type LoadClerkJsScriptOptions = Omit<IsomorphicClerkOptions, 'proxyUrl' | 'domain'> & {
   proxyUrl?: string;
   domain?: string;
+  nonce?: string;
 };
 
 const loadClerkJsScript = (opts: LoadClerkJsScriptOptions) => {
-  const { publishableKey } = opts;
+  const { publishableKey, nonce } = opts;
 
   if (!publishableKey) {
     errorThrower.throwMissingPublishableKeyError();
@@ -39,6 +40,7 @@ const loadClerkJsScript = (opts: LoadClerkJsScriptOptions) => {
   return loadScript(clerkJsScriptUrl(opts), {
     async: true,
     crossOrigin: 'anonymous',
+    nonce,
     beforeLoad: applyClerkJsScriptAttributes(opts),
   }).catch(() => {
     throw new Error(FAILED_TO_LOAD_ERROR);
@@ -79,6 +81,10 @@ const buildClerkJsScriptAttributes = (options: LoadClerkJsScriptOptions) => {
 
   if (options.domain) {
     obj['data-clerk-domain'] = options.domain;
+  }
+
+  if (options.nonce) {
+    obj.nonce = options.nonce;
   }
 
   return obj;

--- a/packages/shared/src/loadScript.ts
+++ b/packages/shared/src/loadScript.ts
@@ -5,11 +5,12 @@ type LoadScriptOptions = {
   async?: boolean;
   defer?: boolean;
   crossOrigin?: 'anonymous' | 'use-credentials';
+  nonce?: string;
   beforeLoad?: (script: HTMLScriptElement) => void;
 };
 
 export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTMLScriptElement> {
-  const { async, defer, beforeLoad, crossOrigin } = opts || {};
+  const { async, defer, beforeLoad, crossOrigin, nonce } = opts || {};
   return new Promise((resolve, reject) => {
     if (!src) {
       reject(NO_SRC_ERROR);
@@ -36,6 +37,7 @@ export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTM
     });
 
     script.src = src;
+    script.nonce = nonce;
     beforeLoad?.(script);
     document.body.appendChild(script);
   });


### PR DESCRIPTION
## Description

When using a [strict-dynamic](https://content-security-policy.com/strict-dynamic/) content security policy, Clerk currently will not work, as we do not pass a nonce to the hotloaded clerk-js script. This PR adds a `nonce` prop to `ClerkProvider` that can be used to thread the nonce value through to the clerk-js script load. It also includes an extra feature for next.js where the nonce will be automatically pulled from the CSP header and threaded through without needing any props so long as the provider is server-rendered.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
