### PR TITLE
feat(dev-cli): Remove macOS-specific Terminal functionality

### DIFF
--- a/.changeset/old-points-raise.md
+++ b/.changeset/old-points-raise.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Remove macOS-specific Terminal functionality

--- a/package-lock.json
+++ b/package-lock.json
@@ -22530,8 +22530,8 @@
     },
     "node_modules/concurrently": {
       "version": "8.2.2",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "date-fns": "^2.30.0",
@@ -22556,7 +22556,6 @@
     },
     "node_modules/concurrently/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -22570,7 +22569,6 @@
     },
     "node_modules/concurrently/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -22585,7 +22583,6 @@
     },
     "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -22596,7 +22593,6 @@
     },
     "node_modules/concurrently/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -22607,12 +22603,10 @@
     },
     "node_modules/concurrently/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22620,7 +22614,6 @@
     },
     "node_modules/concurrently/node_modules/rxjs": {
       "version": "7.8.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -22628,7 +22621,6 @@
     },
     "node_modules/concurrently/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -24100,7 +24092,6 @@
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
@@ -44301,7 +44292,6 @@
     },
     "node_modules/shell-quote": {
       "version": "1.8.1",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -44880,8 +44870,7 @@
       }
     },
     "node_modules/spawn-command": {
-      "version": "0.0.2",
-      "dev": true
+      "version": "0.0.2"
     },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
@@ -46630,7 +46619,6 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -51402,6 +51390,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
+        "concurrently": "^8.2.2",
         "dotenv": "^16.4.5",
         "globby": "^14.0.2",
         "jscodeshift": "^0.16.1"

--- a/packages/dev-cli/README.md
+++ b/packages/dev-cli/README.md
@@ -74,14 +74,7 @@ clerk-dev watch
 
 This will run the `build` task for any `@clerk/*` packages in the `package.json` of the current working directory, including any of their dependencies.
 
-> [!NOTE]
-> On macOS, this command will automatically spawn a new Terminal.app window running the dev task for `clerk-js`. On other operating systems, you will need to run the following command in a new terminal:
->
-> ```sh
-> clerk-dev watch --js
-> ```
-
-If you do not want to spawn the watcher for `@clerk/clerk-js`, you can instead pass `--no-js`.
+If you do not want to start the watcher for `@clerk/clerk-js`, you can instead pass `--no-js`.
 
 ```sh
 clerk-dev watch --no-js

--- a/packages/dev-cli/package.json
+++ b/packages/dev-cli/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
+    "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
     "globby": "^14.0.2",
     "jscodeshift": "^0.16.1"


### PR DESCRIPTION
## Description

This PR removes the macOS-specific functionality that was used to spawn a new Terminal window containing the builder for `clerk-js` in favor of simply using `concurrently` to run everything in the same terminal instance. To make it easier to distinguish the output, we use concurrently's `prefixColors` feature which prepends `[packages]` for the build process of dependencies and `[clerk-js]` for the `clerk-js` build.

![Screen Shot 2024-07-31 at 16 36 36 PM](https://github.com/user-attachments/assets/422acd69-fd3d-4a2b-aad8-5b62f15b6861)


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
