### PR TITLE
chore(repo): Update npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.14.0"
   },
-  "packageManager": "npm@8.5.0",
+  "packageManager": "npm@10.7.0",
   "engines": {
     "node": ">=18.17.0",
     "npm": ">=8.5.0"

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -24,6 +24,5 @@
     "eslint": "8.24.0",
     "eslint-config-next": "12.3.1",
     "typescript": "4.8.4"
-  },
-  "packageManager": "npm@8.5.0"
+  }
 }


### PR DESCRIPTION
## Description

The PR https://github.com/clerk/javascript/pull/3868 has the failed renovate update with this comment:

```shell
npm ERR! notsup Not compatible with your version of node/npm: astro@4.11.3
npm ERR! notsup Required: {"node":"^18.17.1 || ^20.3.0 || >=21.0.0","npm":">=9.6.5","pnpm":">=7.1.0"}
```

We're using an ancient `npm` version for our monorepo (8.5.0) so I'm updating it to 10.7.0 because in https://nodejs.org/en/about/previous-releases it shows that Node.js v18 ships with that version. We use v18 in our CI.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
