### PR TITLE
fix(nextjs): Execute logger.commit() on every middleware invocation

### DIFF
--- a/.changeset/poor-cheetahs-rhyme.md
+++ b/.changeset/poor-cheetahs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Fix debug logs on `debug: true` parameter of `clerkMiddleware()`


### PR DESCRIPTION
## Description

We are using the `withLogger` wrapper to handle the logger.commit on every time the wrapped function is executed.

In `clerkMiddleware` we are wrapping the whole function with the `withLogger` instead of the returned nextMiddleware that is executed in every request causing the `logger.commit()` to be executed once during the initialization of the `clerkMiddleware()` (on 1st request). To make debug logs working for `clerkMiddleware` on every request we need to move the `withLogger` to wrap the returned middleware instead.

In `authMiddleware` we are wrapping the returned nextMiddleware which makes the debugging logs works without any change.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
