### PR TITLE
chore(repo): Correct changeset

### DIFF
--- a/.changeset/metal-mirrors-attack.md
+++ b/.changeset/metal-mirrors-attack.md
@@ -1,2 +1,5 @@
 ---
+"gatsby-plugin-clerk": patch
 ---
+
+Clerk plans to transition `gatsby-plugin-clerk` into an End-of-life (EOL) state. Notice added to the README.


### PR DESCRIPTION
In https://github.com/clerk/javascript/pull/3877 the changeset was left blank. In order to publish it, it needs to be filled out. This is relevant since the proposed release in https://github.com/clerk/javascript/pull/3873 (a major release) is incorrect.