### PR TITLE
chore(repo): Make Gatsby changeset empty

### DIFF
--- a/.changeset/fluffy-wolves-itch.md
+++ b/.changeset/fluffy-wolves-itch.md
@@ -1,5 +1,2 @@
 ---
-"gatsby-plugin-clerk": patch
 ---
-
-Add notice of plans to EOL Gatsby SDK


### PR DESCRIPTION
Together with https://github.com/clerk/javascript/pull/3883 this should ensure that in https://github.com/clerk/javascript/pull/3873 we don't release a new major of `gatsby-plugin-clerk` but only push a path release on the old v4 release branch.