### PR TITLE
chore(clerk-js,types): Remove `__experimental_startPath` from `OrganizationProfileProps`

### DIFF
--- a/.changeset/khaki-experts-pretend.md
+++ b/.changeset/khaki-experts-pretend.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": minor
+"@clerk/types": minor
+---
+
+Removed `__experimental_startPath` from `OrganizationProfileProps` in `@clerk/clerk-js` and `@clerk/types`.

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -307,7 +307,7 @@ const Components = (props: ComponentsProps) => {
       onExternalNavigate={() => componentsControls.closeModal('organizationProfile')}
       startPath={buildVirtualRouterUrl({
         base: '/organizationProfile',
-        path: organizationProfileModal?.__experimental_startPath || urlStateParam?.path,
+        path: urlStateParam?.path,
       })}
       componentName={'OrganizationProfileModal'}
       modalContainerSx={{ alignItems: 'center' }}

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -88,7 +88,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       return openCreateOrganization({ afterCreateOrganizationUrl, skipInvitationScreen });
     };
 
-    const handleItemClick = (__experimental_startPath?: string) => {
+    const handleItemClick = () => {
       close();
       if (organizationProfileMode === 'navigation') {
         return navigateOrganizationProfile();
@@ -96,7 +96,6 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
 
       return openOrganizationProfile({
         ...organizationProfileProps,
-        ...(__experimental_startPath && { __experimental_startPath }),
         afterLeaveOrganizationUrl,
         //@ts-expect-error
         __unstable_manageBillingUrl,

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -842,11 +842,6 @@ export type OrganizationProfileProps = RoutingOptions & {
    * Provide custom pages and links to be rendered inside the OrganizationProfile.
    */
   customPages?: CustomPage[];
-  /**
-   * @experimental
-   * Specify on which page the organization profile modal will open.
-   **/
-  __experimental_startPath?: string;
 };
 
 export type OrganizationProfileModalProps = WithoutRouting<OrganizationProfileProps>;


### PR DESCRIPTION
…

## Description
Due to the decision not to ship support for custom items for OrganizationSwitcher, opening the OrganizationProfile in a specific page should not be supported.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
