### PR TITLE
fix(dev-cli): Correctly return package version

### DIFF
--- a/.changeset/smart-llamas-ring.md
+++ b/.changeset/smart-llamas-ring.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Correctly return package version

--- a/packages/dev-cli/src/cli.js
+++ b/packages/dev-cli/src/cli.js
@@ -6,11 +6,12 @@ import { setInstance } from './commands/set-instance.js';
 import { setRoot } from './commands/set-root.js';
 import { setup } from './commands/setup.js';
 import { watch } from './commands/watch.js';
+import { getPackageVersion } from './utils/getPackageVersion.js';
 
 export default function cli() {
   const program = new Command();
 
-  program.name('clerk-dev').description('CLI to make developing Clerk packages easier').version('0.0.0');
+  program.name('clerk-dev').description('CLI to make developing Clerk packages easier').version(getPackageVersion());
 
   program
     .command('init')

--- a/packages/dev-cli/src/utils/getPackageVersion.js
+++ b/packages/dev-cli/src/utils/getPackageVersion.js
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module';
+
+/**
+ * Get the version of the dev-cli as specified in the `package.json` file.
+ * @returns {string}
+ */
+export function getPackageVersion() {
+  // Currently we use createRequire which allows us to import JSON files without logging a warning to the console about
+  // the experimental nature of JSON file imports.
+  const pkgJson = createRequire(import.meta.url)('../../package.json');
+  return pkgJson.version;
+}


### PR DESCRIPTION
## Description

This PR fixes the hardcoded version string in `clerk-dev` to correctly report the currently executing version number.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
