### PR TITLE
chore(repo): Notify clerk/dashboard for stable nextjs releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
             const preMode = require("fs").existsSync("./.changeset/pre.json");
             if (!preMode) {
               const clerkjsVersion = require('./packages/clerk-js/package.json').version;
+              const nextjsVersion = require('./packages/nextjs/package.json').version;
 
               github.rest.actions.createWorkflowDispatch({
                 owner: 'clerk',
@@ -85,6 +86,14 @@ jobs:
                 workflow_id: 'prepare-prod-clerkjs-proxy-pr.yml',
                 ref: 'main',
                 inputs: { version: clerkjsVersion }
+              })
+
+              github.rest.actions.createWorkflowDispatch({
+                owner: 'clerk',
+                repo: 'dashboard',
+                workflow_id: 'prepare-nextjs-sdk-update.yml',
+                ref: 'main',
+                inputs: { version: nextjsVersion }
               })
             } else{
               core.warning("Changeset in pre-mode should not prepare a ClerkJS production release")


### PR DESCRIPTION
## Description

Notify our own dashboard repo for a stable clerk/nextjs to ensure the dependency is always up to date.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
