### PR TITLE
fix(elements): Prevent flash of "hidden" OTP input

### DIFF
--- a/.changeset/slow-dingos-hammer.md
+++ b/.changeset/slow-dingos-hammer.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fixes a bug that briefly showed the underlying primitive input for OTPs when auto-filled in MacOS

--- a/packages/elements/src/react/common/form/otp.tsx
+++ b/packages/elements/src/react/common/form/otp.tsx
@@ -259,14 +259,14 @@ const wrapperStyle = {
 const inputStyle = {
   display: 'block',
   background: 'transparent',
-  opacity: 1,
+  opacity: 0,
   outline: 'transparent solid 0px',
   appearance: 'none',
   color: 'transparent',
   position: 'absolute',
   inset: 0,
   caretColor: 'transparent',
-  border: '0 px solid transparent',
+  border: '0px solid transparent',
   // width is handled inline
   height: '100%',
   letterSpacing: '-1rem',


### PR DESCRIPTION
## Description

Recently noticed a "yellow" flash during MacOS "autofill"

https://github.com/user-attachments/assets/fe9f0dc1-3cc0-40b4-927c-bad2208f1c81

After some debugging, I was able to determine this was the underlying input that powers the OTP; extending the "transparent" styles to include `opacity: 0;`

Appreciate there may be some context missing here though, given the value was previously `opacity: 1;`

**After**


https://github.com/user-attachments/assets/50f6f12c-c02a-4fd1-898f-87806e81c25f



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
