### PR TITLE
fix(clerk-js): Add missing x padding to ClerkAndPagesTag

### DIFF
--- a/.changeset/purple-chicken-flash.md
+++ b/.changeset/purple-chicken-flash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix missing horizonatal padding when page urls are used within `<UserButton />`.

--- a/packages/clerk-js/src/ui/elements/PopoverCard.tsx
+++ b/packages/clerk-js/src/ui/elements/PopoverCard.tsx
@@ -92,7 +92,7 @@ const PopoverCardFooter = (props: PropsOfComponent<typeof Flex>) => {
 
       <Card.ClerkAndPagesTag
         outerSx={t => ({
-          padding: `${t.space.$4} ${t.space.$none}`,
+          padding: `${t.space.$4} ${t.space.$8}`,
         })}
         withFooterPages={!!shouldShowTagOrLinks}
         devModeNoticeSx={t => ({


### PR DESCRIPTION
## Description

Fixes issue where no horizontal padding was used within `<UserButton />` and page urls were present.

BEFORE:

<img width="412" alt="Screenshot 2024-08-05 at 12 59 44 PM" src="https://github.com/user-attachments/assets/91da9fb1-cc67-426d-87fa-8e460e546076">

<img width="430" alt="Screenshot 2024-08-05 at 1 00 01 PM" src="https://github.com/user-attachments/assets/74846111-25bc-4235-9447-a811754319d8">


AFTER:

<img width="436" alt="Screenshot 2024-08-05 at 1 00 35 PM" src="https://github.com/user-attachments/assets/897d3688-dfb4-4e2d-8854-530a4e67c77a">


<img width="458" alt="Screenshot 2024-08-05 at 1 00 20 PM" src="https://github.com/user-attachments/assets/d158c402-59fe-4872-bc3f-928ee3bb1792">



<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
