### PR TITLE
feat(elements): Add support for redirect_url URL parameter

### DIFF
--- a/.changeset/hungry-pianos-punch.md
+++ b/.changeset/hungry-pianos-punch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Add support for redirect_url URL parameter

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -84,7 +84,8 @@ export const SignInRouterMachine = setup({
 
       const session = createdSessionId || lastActiveSessionId || null;
 
-      const beforeEmit = () => context.router?.push(context.clerk.buildAfterSignInUrl());
+      const beforeEmit = () =>
+        context.router?.push(context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl());
       void context.clerk.setActive({ session, beforeEmit });
 
       enqueue.raise({ type: 'RESET' }, { delay: 2000 }); // Reset machine after 2s delay.
@@ -186,7 +187,8 @@ export const SignInRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signInUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignInUrl(),
+          redirectUrlComplete:
+            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
         },
       })),
     },
@@ -201,7 +203,8 @@ export const SignInRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signInUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignInUrl(),
+          redirectUrlComplete:
+            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
         },
       })),
     },
@@ -284,7 +287,9 @@ export const SignInRouterMachine = setup({
             log('Already logged in'),
             {
               type: 'navigateExternal',
-              params: ({ context }) => ({ path: context.clerk.buildAfterSignInUrl() }),
+              params: ({ context }) => ({
+                path: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+              }),
             },
           ],
         },

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -78,7 +78,8 @@ export const SignUpRouterMachine = setup({
         (params?.useLastActiveSession && context.clerk.client.lastActiveSessionId) ||
         ((event as SignUpRouterNextEvent)?.resource || context.clerk.client.signUp).createdSessionId;
 
-      const beforeEmit = () => context.router?.push(context.clerk.buildAfterSignUpUrl());
+      const beforeEmit = () =>
+        context.router?.push(context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl());
       void context.clerk.setActive({ session, beforeEmit });
     },
     delayedReset: raise({ type: 'RESET' }, { delay: 3000 }), // Reset machine after 3s delay.
@@ -187,7 +188,8 @@ export const SignUpRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignUpUrl(),
+          redirectUrlComplete:
+            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
         },
       })),
     },
@@ -202,7 +204,8 @@ export const SignUpRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignUpUrl(),
+          redirectUrlComplete:
+            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
         },
       })),
     },
@@ -273,7 +276,9 @@ export const SignUpRouterMachine = setup({
             log('Already logged in'),
             {
               type: 'navigateExternal',
-              params: ({ context }) => ({ path: context.clerk.buildAfterSignUpUrl() }),
+              params: ({ context }) => ({
+                path: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+              }),
             },
           ],
         },


### PR DESCRIPTION
## Description

This PR adds support for `?redirect_url` in Elements to both sign in and sign up.

### Testing Instructions

- [ ] While running theme builder, navigate to `http://localhost:3000/sign-in?redirect_url=/404`
- [ ] Sign in
- [ ] Confirm that you're navigated to `http://localhost:3000/404?redirect_url=%2F404`
- [ ] Repeat steps for Sign Up

### Notes

It really feels like this behavior should be delegated to `clerk-js`, possibly in the form of updating `buildAfterSignInUrl` to take in parameters such as `redirect_url`. Currently `buildAfterSignInUrl` only captures parameters when Clerk is initialized, not at the time of authentication.

Fixes SDKI-295

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
