### PR TITLE
chore(tanstack-start): Throw more useful error when clerkHandler is not configured

### DIFF
--- a/.changeset/rotten-mangos-hear.md
+++ b/.changeset/rotten-mangos-hear.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-start": minor
+---
+
+Throw an error when `clerkHandler()` is not configured in the SSR entrypoint

--- a/.changeset/rotten-mangos-hear.md
+++ b/.changeset/rotten-mangos-hear.md
@@ -2,4 +2,4 @@
 "@clerk/tanstack-start": minor
 ---
 
-Throw an error when `clerkHandler()` is not configured in the SSR entrypoint
+Throw a more useful error when `clerkHandler()` is not configured in the SSR entrypoint

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -119,7 +119,9 @@ function RootComponent() {
 function RootDocument({ children }: { children: React.ReactNode }) { ... }
 ```
 
-Also you will need to make on more modification to `app/ssr.tsx`:
+### Setup `clerkHandler` in the SSR entrypoint
+
+You will also need to make on more modification to you SSR entrypoint (default: `app/ssr.tsx`):
 
 - Wrap the `createStartHandler` with `createClerkHandler`
 

--- a/packages/tanstack-start/src/client/ClerkProvider.tsx
+++ b/packages/tanstack-start/src/client/ClerkProvider.tsx
@@ -3,17 +3,18 @@ import { useRouteContext } from '@tanstack/react-router';
 import { Asset } from '@tanstack/start';
 import { useEffect } from 'react';
 
-import { isClient } from '../utils';
+import { errorThrower, isClient } from '../utils';
+import { clerkHandlerNotConfigured } from '../utils/errors';
 import { ClerkOptionsProvider } from './OptionsContext';
 import type { TanstackStartClerkProviderProps } from './types';
 import { useAwaitableNavigate } from './useAwaitableNavigate';
+
+export * from '@clerk/clerk-react';
 
 const SDK_METADATA = {
   name: PACKAGE_NAME,
   version: PACKAGE_VERSION,
 };
-
-export * from '@clerk/clerk-react';
 
 const awaitableNavigateRef: { current: ReturnType<typeof useAwaitableNavigate> | undefined } = { current: undefined };
 
@@ -26,6 +27,10 @@ export function ClerkProvider({ children, ...providerProps }: TanstackStartClerk
   useEffect(() => {
     awaitableNavigateRef.current = awaitableNavigate;
   }, [awaitableNavigate]);
+
+  if (!routerContext?.clerkInitialState?.__internal_clerk_state) {
+    errorThrower.throw(clerkHandlerNotConfigured);
+  }
 
   const clerkInitState = isClient() ? (window as any).__clerk_init_state : routerContext?.clerkInitialState;
 

--- a/packages/tanstack-start/src/utils/errors.ts
+++ b/packages/tanstack-start/src/utils/errors.ts
@@ -20,7 +20,7 @@ export const noFetchFnCtxPassedInGetAuth = createErrorMessage(`
 export const clerkHandlerNotConfigured = createErrorMessage(`
     It looks like you're trying to use Clerk without configuring the Clerk handler.
 
-    To fix this, make sure you have the \`clerkHandler\` configure in you SSR entry file (example: app/ssr.tsx).
+    To fix this, make sure you have the \`clerkHandler()\` configure in you SSR entry file (example: app/ssr.tsx).
 
-    For more info, check out the docs: https://github.com/clerk/javascript/tree/main/packages/tanstack-start#usage,
+    For more info, check out the docs: https://github.com/clerk/javascript/tree/main/packages/tanstack-start#setup-clerkhandler-in-the-ssr-entrypoint,
     `);

--- a/packages/tanstack-start/src/utils/errors.ts
+++ b/packages/tanstack-start/src/utils/errors.ts
@@ -16,3 +16,11 @@ export const noFetchFnCtxPassedInGetAuth = createErrorMessage(`
     ...
   });
   `);
+
+export const clerkHandlerNotConfigured = createErrorMessage(`
+    It looks like you're trying to use Clerk without configuring the Clerk handler.
+
+    To fix this, make sure you have the \`clerkHandler\` configure in you SSR entry file (example: app/ssr.tsx).
+
+    For more info, check out the docs: https://github.com/clerk/javascript/tree/main/packages/tanstack-start#usage,
+    `);


### PR DESCRIPTION
## Description

Right now when the `clerkHandler` is not configured in the SSR entrypoint `app/ssr.tsx` an error is thrown that in can't access the `__internal_clerk_state` which is not helpful on what is wrong, after this PR we throw a more useful error to  guide the user on how to setup the `clerkHandler()`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
