### PR TITLE
fix(clerk-js): Passkeys should not be a candidate for the dynamic fie…

### DIFF
--- a/.changeset/heavy-wombats-sing.md
+++ b/.changeset/heavy-wombats-sing.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/types": patch
+---
+
+Allow users to display the email address field after selecting to input a phone number. Previously that was not possible when passkeys were enabled. (v4)

--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -45,7 +45,8 @@ const FirstFactorConfigs = Object.freeze({
 
 export type SignInStartIdentifier = 'email_address' | 'username' | 'phone_number' | 'email_address_username';
 export const groupIdentifiers = (attributes: Attribute[]): SignInStartIdentifier[] => {
-  let newAttributes: string[] = [...attributes];
+  // Always skip passkey, while passkey can be considered an identifier we want to exclude it in the UI we are delivering
+  let newAttributes: string[] = [...attributes.filter(a => a !== 'passkey')];
   //merge email_address and username attributes
   if (['email_address', 'username'].every(r => newAttributes.includes(r))) {
     newAttributes = newAttributes.filter(a => !['email_address', 'username'].includes(a));

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -11,7 +11,8 @@ export type Attribute =
   | 'password'
   | 'web3_wallet'
   | 'authenticator_app'
-  | 'backup_code';
+  | 'backup_code'
+  | 'passkey';
 
 export type VerificationStrategy = 'email_link' | 'email_code' | 'phone_code' | 'totp' | 'backup_code';
 


### PR DESCRIPTION
…ld (v4)

## Description
Passkeys should not be a candidate for the dynamic field.
Allow users to display the email address field after selecting to input a phone number. Previously that was not possible when passkeys were enabled.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
