### PR TITLE
fix(clerk-js): Open the upload organization logo dialog on placeholder click

### DIFF
--- a/.changeset/rotten-donkeys-sin.md
+++ b/.changeset/rotten-donkeys-sin.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix unresponsive behavior when clicking placeholder logo in the `<CreateOrganization />` component

--- a/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
@@ -72,7 +72,7 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
   const previewElement = objectUrl
     ? React.cloneElement(avatarPreview, { imageUrl: objectUrl })
     : avatarPreviewPlaceholder
-      ? React.cloneElement(avatarPreviewPlaceholder, { onClick: toggle })
+      ? React.cloneElement(avatarPreviewPlaceholder, { onClick: openDialog })
       : avatarPreview;
 
   return (


### PR DESCRIPTION
## Description

The current `toggle` function passed to the placeholder logo click handler is toggling visibility between the placeholder and uploaded image and I believe we should be opening the upload dialog here instead

https://github.com/user-attachments/assets/b6a6b12e-7e76-4ac4-949e-0e74c42341c2

## Checklist

- [ ] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
