### PR TITLE
fix(elements): Use window.location to navigate for absolute URLs

### DIFF
--- a/.changeset/breezy-bears-smell.md
+++ b/.changeset/breezy-bears-smell.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Use window.location to navigate for absolute URLs

--- a/packages/elements/src/react/router/next.ts
+++ b/packages/elements/src/react/router/next.ts
@@ -1,6 +1,7 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { NEXT_WINDOW_HISTORY_SUPPORT_VERSION } from '~/internals/constants';
+import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 
 import type { ClerkHostRouter } from './router';
 
@@ -21,7 +22,13 @@ export const useNextRouter = (): ClerkHostRouter => {
   return {
     mode: 'path',
     name: 'NextRouter',
-    push: (path: string) => router.push(path),
+    push: (path: string) => {
+      if (isAbsoluteUrl(path)) {
+        window.location.href = path;
+      } else {
+        router.push(path);
+      }
+    },
     replace: (path: string) =>
       canUseWindowHistoryAPIs ? window.history.replaceState(null, '', path) : router.replace(path),
     shallowPush(path: string) {

--- a/packages/elements/src/react/router/virtual.ts
+++ b/packages/elements/src/react/router/virtual.ts
@@ -2,6 +2,8 @@
 
 import { useSyncExternalStore } from 'react';
 
+import { isAbsoluteUrl } from '~/utils/is-absolute-url';
+
 import type { ClerkHostRouter } from './router';
 
 const DUMMY_ORIGIN = 'https://clerk.dummy';
@@ -21,11 +23,15 @@ class VirtualRouter implements ClerkHostRouter {
   }
 
   push(path: string) {
-    const newUrl = new URL(this.#url.toString());
-    newUrl.pathname = path;
+    if (typeof window !== 'undefined' && isAbsoluteUrl(path)) {
+      window.location.href = path;
+    } else {
+      const newUrl = new URL(this.#url.toString());
+      newUrl.pathname = path;
 
-    this.#url = newUrl;
-    this.emit();
+      this.#url = newUrl;
+      this.emit();
+    }
   }
 
   replace(path: string) {

--- a/packages/elements/src/utils/is-absolute-url.ts
+++ b/packages/elements/src/utils/is-absolute-url.ts
@@ -1,0 +1,4 @@
+// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
+// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/;
+export const isAbsoluteUrl = (url: string) => ABSOLUTE_URL_REGEX.test(url);


### PR DESCRIPTION
## Description

Adds support for navigating to absolute URLs via `context.router.push`. This allows `redirect_url` to be an absolute URL.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
