### PR TITLE
fix(nextjs): Handle `__nextGetStaticStore` returning `undefined`

### DIFF
--- a/.changeset/twelve-books-glow.md
+++ b/.changeset/twelve-books-glow.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Bug fix: Handle `nextGetStore.getStore()` returning `undefined`. Previously a TypeError would occur, when `pagePath` was accessed.

--- a/packages/nextjs/src/server/nextFetcher.ts
+++ b/packages/nextjs/src/server/nextFetcher.ts
@@ -5,7 +5,7 @@ type Fetcher = typeof globalThis.fetch;
  */
 type NextFetcher = Fetcher & {
   readonly __nextPatched: true;
-  readonly __nextGetStaticStore: () => { getStore: () => StaticGenerationAsyncStorage };
+  readonly __nextGetStaticStore: () => { getStore: () => StaticGenerationAsyncStorage | undefined };
 };
 
 /**

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -134,7 +134,7 @@ const isAppRouterInternalNavigation = (req: Request) =>
 
 const isPagePathAvailable = () => {
   const __fetch = globalThis.fetch;
-  return Boolean(isNextFetcher(__fetch) ? __fetch.__nextGetStaticStore().getStore().pagePath : false);
+  return Boolean(isNextFetcher(__fetch) ? __fetch.__nextGetStaticStore().getStore()?.pagePath : false);
 };
 
 const isPagesRouterInternalNavigation = (req: Request) => !!req.headers.get(nextConstants.Headers.NextjsData);


### PR DESCRIPTION
## Description
Bug fix: Handle `nextGetStore.getStore()` returning `undefined`. Previously a TypeError would occur, when `pagePath` was accessed.

Fixes: #3772
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
