### PR TITLE
feat(backend): Add `awscognito` to `PasswordHasher` type

### DIFF
--- a/.changeset/young-spies-provide.md
+++ b/.changeset/young-spies-provide.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Adds `awscognito` to backend `PasswordHasher` type

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -47,6 +47,7 @@ type UserMetadataParams = {
 type PasswordHasher =
   | 'argon2i'
   | 'argon2id'
+  | 'awscognito'
   | 'bcrypt'
   | 'bcrypt_sha256_django'
   | 'md5'


### PR DESCRIPTION
## Description

This adds `awscognito` to our `PasswordHasher` type.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
