### PR TITLE
fix(elements): Preserve absolute URLs passed via `redirect_url`

### DIFF
--- a/.changeset/itchy-geckos-tell.md
+++ b/.changeset/itchy-geckos-tell.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Preserve absolute URLs passed via `redirect_url`

--- a/packages/elements/src/react/router/__tests__/router.test.ts
+++ b/packages/elements/src/react/router/__tests__/router.test.ts
@@ -101,6 +101,16 @@ describe('createClerkRouter', () => {
     expect(mockRouter.replace).toHaveBeenCalledWith('/app/dashboard?after_sign_in_url=foobar');
   });
 
+  it('pushes absolute URLs unmodified', () => {
+    const path = 'https://example.com';
+    const clerkRouter = createClerkRouter(mockRouter, '/app');
+
+    mockRouter.searchParams.mockImplementation(() => new URLSearchParams('after_sign_in_url=foobar&foo=bar'));
+    clerkRouter.push(path);
+
+    expect(mockRouter.push).toHaveBeenCalledWith('https://example.com');
+  });
+
   it('returns the correct pathname', () => {
     const clerkRouter = createClerkRouter(mockRouter, '/app');
 

--- a/packages/elements/src/react/router/router.ts
+++ b/packages/elements/src/react/router/router.ts
@@ -1,6 +1,7 @@
 import { withLeadingSlash, withoutTrailingSlash } from '@clerk/shared/url';
 
 import type { ROUTING } from '~/internals/constants';
+import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 
 export const PRESERVED_QUERYSTRING_PARAMS = ['after_sign_in_url', 'after_sign_up_url', 'redirect_url'];
 
@@ -87,6 +88,11 @@ export function createClerkRouter(router: ClerkHostRouter, basePath: string = '/
    * Certain query parameters need to be preserved when navigating internally. These query parameters are ultimately used by Clerk to dictate behavior, so we keep them around.
    */
   function makeDestinationUrlWithPreservedQueryParameters(path: string) {
+    // If the provided path is an absolute URL, return it unmodified.
+    if (isAbsoluteUrl(path)) {
+      return path;
+    }
+
     const destinationUrl = new URL(path, window.location.origin);
     const currentSearchParams = router.searchParams();
 

--- a/packages/elements/src/utils/is-absolute-url.ts
+++ b/packages/elements/src/utils/is-absolute-url.ts
@@ -1,0 +1,6 @@
+/* Code below is taken from https://github.com/vercel/next.js/blob/fe7ff3f468d7651a92865350bfd0f16ceba27db5/packages/next/src/shared/lib/utils.ts. LICENSE: MIT */
+
+// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
+// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/;
+export const isAbsoluteUrl = (url: string) => ABSOLUTE_URL_REGEX.test(url);


### PR DESCRIPTION
## Description

Adds support for navigating to absolute URLs via `context.router.push`. This allows `redirect_url` to be an absolute URL.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
