### PR TITLE
fix(astro): Remove duplicate auth headers values

### DIFF
--- a/.changeset/shy-ghosts-flash.md
+++ b/.changeset/shy-ghosts-flash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Remove duplicate headers set in Clerk middleware

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -104,11 +104,11 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
         handlerResult = handleControlFlowErrors(e, clerkRequest, requestState, context);
       }
 
-      if (isRedirect(handlerResult!)) {
-        return serverRedirectWithAuth(context, clerkRequest, handlerResult!, options);
+      if (isRedirect(handlerResult)) {
+        return serverRedirectWithAuth(context, clerkRequest, handlerResult, options);
       }
 
-      const response = await decorateRequest(context.locals, handlerResult!, requestState);
+      const response = decorateRequest(context.locals, handlerResult);
       if (requestState.headers) {
         requestState.headers.forEach((value, key) => {
           response.headers.append(key, value);
@@ -262,18 +262,7 @@ function findClosingHeadTagIndex(chunk: Uint8Array, endHeadTag: Uint8Array) {
   return chunk.findIndex((_, i) => endHeadTag.every((value, j) => value === chunk[i + j]));
 }
 
-async function decorateRequest(
-  locals: APIContext['locals'],
-  res: Response,
-  requestState: RequestState,
-): Promise<Response> {
-  const { reason, message, status, token } = requestState;
-
-  res.headers.set(constants.Headers.AuthToken, token || '');
-  res.headers.set(constants.Headers.AuthStatus, status);
-  res.headers.set(constants.Headers.AuthMessage, message || '');
-  res.headers.set(constants.Headers.AuthReason, reason || '');
-
+function decorateRequest(locals: APIContext['locals'], res: Response): Response {
   /**
    * Populate every page with the authObject. This allows for SSR to work properly
    * without sucrificing DX and having developers wrap each page with a Layout that would handle this.


### PR DESCRIPTION
## Description

This PR removes the redundant part where we set the `x-clerk-auth-*` headers twice, ensuring each header appears only once in the response. This also cleans up some types and unused non-null assertions.

<img width="456" alt="Screenshot 2024-08-13 at 2 51 21 PM" src="https://github.com/user-attachments/assets/291f9449-7e0b-4bdb-8ce0-1024277fdf91">


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
