### PR TITLE
feat(elements): Add active session selection [SDKI-290]

### DIFF
--- a/.changeset/fifty-terms-switch.md
+++ b/.changeset/fifty-terms-switch.md
@@ -1,0 +1,18 @@
+---
+"@clerk/elements": minor
+---
+
+
+Introduce multi-session choose account step and associated actions/components.
+
+Example:
+
+```tsx
+<SignIn.Step name='choose-session'>
+  <SignIn.SessionList asChild>
+    <SignIn.SessionListItem>
+      {({ session }) => <>{session.identifier} | <SignIn.Action setActiveSession>Switch...</SignIn.Action></>}
+    </SignIn.SessionListItem>
+  </SignIn.SessionList>
+</SignIn.Step>
+```

--- a/.changeset/fifty-terms-switch.md
+++ b/.changeset/fifty-terms-switch.md
@@ -9,7 +9,7 @@ Example:
 
 ```tsx
 <SignIn.Step name='choose-session'>
-  <SignIn.SessionList asChild>
+  <SignIn.SessionList>
     <SignIn.SessionListItem>
       {({ session }) => <>{session.identifier} | <SignIn.Action setActiveSession>Switch...</SignIn.Action></>}
     </SignIn.SessionListItem>

--- a/packages/elements/examples/nextjs/app/page.tsx
+++ b/packages/elements/examples/nextjs/app/page.tsx
@@ -84,6 +84,21 @@ export default function Home() {
           <p className='m-0 max-w-[30ch] text-sm opacity-50'>Modal Playground</p>
         </Link>
 
+        <SignedIn>
+          <Link
+            href='/sign-in/choose'
+            className='group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30'
+          >
+            <h2 className='mb-3 text-2xl font-semibold'>
+              Sessions{' '}
+              <span className='inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none'>
+                -&gt;
+              </span>
+            </h2>
+            <p className='m-0 max-w-[30ch] text-sm opacity-50'>Choose from Active Sessions via Multi-session support</p>
+          </Link>
+        </SignedIn>
+
         <a
           href='https://clerk.com/docs/custom-flows/overview#sign-in-flow'
           className='group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30'

--- a/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
@@ -247,7 +247,13 @@ export default function SignInPage() {
 
           <SignIn.SessionList asChild>
             <section>
-              <SignIn.SessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignIn.SessionListItem>
+              <SignIn.SessionListItem asChild>
+                {({ session }) => (
+                  <p>
+                    {session.identifier} | <SignIn.Action setActiveSession>Switch...</SignIn.Action>{' '}
+                  </p>
+                )}
+              </SignIn.SessionListItem>
             </section>
           </SignIn.SessionList>
         </SignIn.Step>

--- a/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
@@ -245,34 +245,10 @@ export default function SignInPage() {
         >
           <H3>CHOOSE SESSION:</H3>
 
-          <SignIn.SessionList
-            asChild
-            id='all-asChild'
-          >
+          <SignIn.SessionList asChild>
             <section>
               <SignIn.SessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignIn.SessionListItem>
             </section>
-          </SignIn.SessionList>
-
-          <SignIn.SessionList
-            asChild
-            id='default-with-root-asChild'
-          >
-            <section>
-              <SignIn.SessionListItem>{({ session }) => <>{session.id}</>}</SignIn.SessionListItem>
-            </section>
-          </SignIn.SessionList>
-
-          <SignIn.SessionList id='default'>
-            <SignIn.SessionListItem>{({ session }) => <>{session.id}</>}</SignIn.SessionListItem>
-          </SignIn.SessionList>
-
-          <SignIn.SessionList id='default-item-with-child'>
-            <SignIn.SessionListItem>{({ session }) => <strong>{session.id}</strong>}</SignIn.SessionListItem>
-          </SignIn.SessionList>
-
-          <SignIn.SessionList id='default-item-with-child'>
-            <SignIn.SessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignIn.SessionListItem>
           </SignIn.SessionList>
         </SignIn.Step>
         <SignIn.Step

--- a/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
@@ -240,6 +240,42 @@ export default function SignInPage() {
         </SignIn.Step>
 
         <SignIn.Step
+          name='choose-session'
+          className='flex w-96 flex-col items-center gap-6'
+        >
+          <H3>CHOOSE SESSION:</H3>
+
+          <SignIn.SessionList
+            asChild
+            id='all-asChild'
+          >
+            <section>
+              <SignIn.SessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignIn.SessionListItem>
+            </section>
+          </SignIn.SessionList>
+
+          <SignIn.SessionList
+            asChild
+            id='default-with-root-asChild'
+          >
+            <section>
+              <SignIn.SessionListItem>{({ session }) => <>{session.id}</>}</SignIn.SessionListItem>
+            </section>
+          </SignIn.SessionList>
+
+          <SignIn.SessionList id='default'>
+            <SignIn.SessionListItem>{({ session }) => <>{session.id}</>}</SignIn.SessionListItem>
+          </SignIn.SessionList>
+
+          <SignIn.SessionList id='default-item-with-child'>
+            <SignIn.SessionListItem>{({ session }) => <strong>{session.id}</strong>}</SignIn.SessionListItem>
+          </SignIn.SessionList>
+
+          <SignIn.SessionList id='default-item-with-child'>
+            <SignIn.SessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignIn.SessionListItem>
+          </SignIn.SessionList>
+        </SignIn.Step>
+        <SignIn.Step
           name='choose-strategy'
           className='flex w-96 flex-col items-center gap-6'
         >

--- a/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
@@ -187,6 +187,11 @@ export default function SignUpPage() {
             name='password'
           />
 
+          <CustomField
+            label='Phone Number'
+            name='phoneNumber'
+          />
+
           <CustomSubmit>Sign Up</CustomSubmit>
         </SignUp.Step>
 

--- a/packages/elements/src/internals/constants/index.ts
+++ b/packages/elements/src/internals/constants/index.ts
@@ -1,4 +1,5 @@
 export const SSO_CALLBACK_PATH_ROUTE = '/sso-callback';
+export const CHOOSE_SESSION_PATH_ROUTE = '/choose';
 export const MAGIC_LINK_VERIFY_PATH_ROUTE = '/verify';
 
 export const SIGN_IN_DEFAULT_BASE_PATH =

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -5,6 +5,7 @@ import type { NonReducibleUnknown } from 'xstate';
 import { and, assign, enqueueActions, fromPromise, log, not, or, raise, sendTo, setup } from 'xstate';
 
 import {
+  CHOOSE_SESSION_PATH_ROUTE,
   ERROR_CODES,
   ROUTING,
   SIGN_IN_DEFAULT_BASE_PATH,
@@ -22,6 +23,7 @@ import type {
   SignInRouterEvents,
   SignInRouterNextEvent,
   SignInRouterSchema,
+  SignInRouterSessionSetActiveEvent,
 } from './router.types';
 import { SignInStartMachine } from './start.machine';
 import { SignInFirstFactorMachine, SignInSecondFactorMachine } from './verification.machine';
@@ -78,11 +80,12 @@ export const SignInRouterMachine = setup({
         return;
       }
 
+      const id = (event as SignInRouterSessionSetActiveEvent)?.id;
       const lastActiveSessionId = context.clerk.client.lastActiveSessionId;
       const createdSessionId = ((event as SignInRouterNextEvent)?.resource || context.clerk.client.signIn)
         .createdSessionId;
 
-      const session = createdSessionId || lastActiveSessionId || null;
+      const session = id || createdSessionId || lastActiveSessionId || null;
 
       const beforeEmit = () =>
         context.router?.push(context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl());
@@ -119,7 +122,7 @@ export const SignInRouterMachine = setup({
         case ERROR_CODES.SAML_USER_ATTRIBUTE_MISSING:
         case ERROR_CODES.OAUTH_EMAIL_DOMAIN_RESERVED_BY_SAML:
         case ERROR_CODES.USER_LOCKED:
-          error = new ClerkElementsError(errorOrig.code, errorOrig.longMessage!);
+          error = new ClerkElementsError(errorOrig.code, errorOrig.longMessage || '');
           break;
         default:
           error = new ClerkElementsError(
@@ -163,6 +166,7 @@ export const SignInRouterMachine = setup({
     needsFirstFactor: and(['statusNeedsFirstFactor', isCurrentPath('/continue')]),
     needsSecondFactor: and(['statusNeedsSecondFactor', isCurrentPath('/continue')]),
     needsCallback: isCurrentPath(SSO_CALLBACK_PATH_ROUTE),
+    needsChooseSession: isCurrentPath(CHOOSE_SESSION_PATH_ROUTE),
     needsNewPassword: and(['statusNeedsNewPassword', isCurrentPath('/new-password')]),
 
     statusNeedsIdentifier: needsStatus('needs_identifier'),
@@ -277,6 +281,10 @@ export const SignInRouterMachine = setup({
         {
           guard: 'needsCallback',
           target: 'Callback',
+        },
+        {
+          guard: 'needsChooseSession',
+          target: 'ChooseSession',
         },
         {
           guard: 'isComplete',
@@ -575,6 +583,17 @@ export const SignInRouterMachine = setup({
             target: 'ResetPassword',
           },
         ],
+      },
+    },
+    ChooseSession: {
+      tags: ['step:choose-session'],
+      on: {
+        'SESSION.SET_ACTIVE': {
+          actions: {
+            type: 'setActive',
+            params: ({ event }) => ({ id: event.id }),
+          },
+        },
       },
     },
     Error: {

--- a/packages/elements/src/internals/machines/sign-in/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.types.ts
@@ -31,6 +31,7 @@ export const SignInRouterSteps = {
   error: 'step:error',
   forgotPassword: 'step:forgot-password',
   resetPassword: 'step:reset-password',
+  chooseSession: 'step:choose-session',
   chooseStrategy: 'step:choose-strategy',
 } as const;
 
@@ -70,6 +71,7 @@ export type SignInRouterPasskeyEvent = { type: 'AUTHENTICATE.PASSKEY' };
 export type SignInRouterPasskeyAutofillEvent = {
   type: 'AUTHENTICATE.PASSKEY.AUTOFILL';
 };
+export type SignInRouterSessionSetActiveEvent = { type: 'SESSION.SET_ACTIVE'; id: string };
 
 export interface SignInRouterInitEvent extends BaseRouterInput {
   type: 'INIT';
@@ -95,6 +97,7 @@ export type SignInRouterEvents =
   | SignInRouterResetStepEvent
   | SignInVerificationFactorUpdateEvent
   | SignInRouterLoadingEvent
+  | SignInRouterSessionSetActiveEvent
   | SignInRouterSetClerkEvent
   | SignInRouterSubmitEvent
   | SignInRouterPasskeyEvent

--- a/packages/elements/src/react/sign-in/action/action.tsx
+++ b/packages/elements/src/react/sign-in/action/action.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import type { FormSubmitProps } from '~/react/common';
 import { Submit } from '~/react/common';
 
-import type { SignInNavigateElementKey, SignInNavigateProps } from './navigate';
+import type { SignInNavigateProps } from './navigate';
 import { SignInNavigate } from './navigate';
 import type { SignInResendProps } from './resend';
 import { SignInResend } from './resend';
+import { SignInSetActiveSession } from './set-active-session';
 
 export type SignInActionProps = { asChild?: boolean } & FormSubmitProps &
   (
@@ -21,13 +22,7 @@ export type SignInActionProps = { asChild?: boolean } & FormSubmitProps &
     | ({ navigate?: never; resend: true; setActiveSession?: never; submit?: never } & SignInResendProps)
   );
 
-export type SignInActionCompProps = React.ForwardRefExoticComponent<
-  Exclude<SignInActionProps, 'navigate'> & {
-    to: SignInNavigateElementKey;
-  } & React.RefAttributes<HTMLButtonElement>
->;
-
-const SIGN_IN_ACTION_NAME = 'SignInAction';
+const DISPLAY_NAME = 'SignInAction';
 
 /**
  * Perform various actions during the sign-in process. This component is used to navigate between steps, submit the form, or resend a verification codes.
@@ -47,7 +42,7 @@ const SIGN_IN_ACTION_NAME = 'SignInAction';
  * <SignIn.Action resend>Resend</SignIn.Action>
  */
 export const SignInAction = React.forwardRef<React.ElementRef<'button'>, SignInActionProps>((props, forwardedRef) => {
-  const { submit, navigate, resend, ...rest } = props;
+  const { submit, navigate, resend, setActiveSession, ...rest } = props;
   let Comp: React.ForwardRefExoticComponent<any> | undefined;
 
   if (submit) {
@@ -56,6 +51,8 @@ export const SignInAction = React.forwardRef<React.ElementRef<'button'>, SignInA
     Comp = SignInNavigate;
   } else if (resend) {
     Comp = SignInResend;
+  } else if (setActiveSession) {
+    Comp = SignInSetActiveSession;
   }
 
   return Comp ? (
@@ -67,4 +64,4 @@ export const SignInAction = React.forwardRef<React.ElementRef<'button'>, SignInA
   ) : null;
 });
 
-SignInAction.displayName = SIGN_IN_ACTION_NAME;
+SignInAction.displayName = DISPLAY_NAME;

--- a/packages/elements/src/react/sign-in/action/action.tsx
+++ b/packages/elements/src/react/sign-in/action/action.tsx
@@ -13,10 +13,12 @@ export type SignInActionProps = { asChild?: boolean } & FormSubmitProps &
     | ({
         navigate: SignInNavigateProps['to'];
         resend?: never;
+        setActiveSession?: never;
         submit?: never;
       } & Omit<SignInNavigateProps, 'to'>)
-    | { navigate?: never; resend?: never; submit: true }
-    | ({ navigate?: never; resend: true; submit?: never } & SignInResendProps)
+    | { navigate?: never; resend?: never; setActiveSession?: never; submit: true }
+    | { navigate?: never; resend?: never; setActiveSession: true; submit?: never }
+    | ({ navigate?: never; resend: true; setActiveSession?: never; submit?: never } & SignInResendProps)
   );
 
 export type SignInActionCompProps = React.ForwardRefExoticComponent<

--- a/packages/elements/src/react/sign-in/action/navigate.tsx
+++ b/packages/elements/src/react/sign-in/action/navigate.tsx
@@ -5,10 +5,10 @@ import { SignInRouterCtx } from '~/react/sign-in/context';
 
 const SIGN_IN_NAVIGATE_NAME = 'SignInNavigate';
 const SignInNavigationEventMap = {
-  start: `NAVIGATE.START`,
-  previous: `NAVIGATE.PREVIOUS`,
-  'choose-strategy': `NAVIGATE.CHOOSE_STRATEGY`,
-  'forgot-password': `NAVIGATE.FORGOT_PASSWORD`,
+  start: 'NAVIGATE.START',
+  previous: 'NAVIGATE.PREVIOUS',
+  'choose-strategy': 'NAVIGATE.CHOOSE_STRATEGY',
+  'forgot-password': 'NAVIGATE.FORGOT_PASSWORD',
 } as const;
 
 export type SignInNavigateElementKey = keyof typeof SignInNavigationEventMap;

--- a/packages/elements/src/react/sign-in/action/set-active-session.tsx
+++ b/packages/elements/src/react/sign-in/action/set-active-session.tsx
@@ -1,0 +1,55 @@
+import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
+
+import type { SignInRouterSessionSetActiveEvent } from '~/internals/machines/sign-in';
+import { SignInRouterCtx } from '~/react/sign-in/context';
+
+const DISPLAY_NAME = 'SignInSetActiveSession';
+
+export type SignInSetActiveSessionElement = React.ElementRef<'button'>;
+export type SignInSetActiveSessionProps = {
+  asChild?: boolean;
+  children: React.ReactNode;
+};
+
+/**
+ * Sets the active session to the session with the provided ID.
+ *
+ * @param {boolean} [asChild] - When `true`, the component will render its child and passes all props to it.
+ *
+ * @example
+ * <SignInSetActiveSession setActiveSession>
+ *    t*****m@clerk.dev
+ * </SignInSetActiveSession>
+ */
+export const SignInSetActiveSession = React.forwardRef<SignInSetActiveSessionElement, SignInSetActiveSessionProps>(
+  ({ asChild, ...rest }, forwardedRef) => {
+    const actorRef = SignInRouterCtx.useActorRef();
+
+    const Comp = asChild ? Slot : 'button';
+    const defaultProps = asChild ? {} : { type: 'button' as const };
+
+    const sendEvent = React.useCallback(() => {
+      const event: SignInRouterSessionSetActiveEvent = { type: 'SESSION.SET_ACTIVE', id: 'abc123' };
+
+      if (actorRef.getSnapshot().can(event)) {
+        actorRef.send(event);
+      } else {
+        console.warn(
+          `Clerk: <SignIn.Action setActiveSession> is an invalid event. You can only choose an active session from <SignIn.Step name="choose-session">.`,
+        );
+      }
+    }, [actorRef]);
+
+    return (
+      <Comp
+        {...defaultProps}
+        {...rest}
+        onClick={sendEvent}
+        ref={forwardedRef}
+      />
+    );
+  },
+);
+
+SignInSetActiveSession.displayName = DISPLAY_NAME;

--- a/packages/elements/src/react/sign-in/action/set-active-session.tsx
+++ b/packages/elements/src/react/sign-in/action/set-active-session.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import type { SignInRouterSessionSetActiveEvent } from '~/internals/machines/sign-in';
 import { SignInRouterCtx } from '~/react/sign-in/context';
 
+import { useSignInActiveSessionContext } from '../choose-session/choose-session.hooks';
+
 const DISPLAY_NAME = 'SignInSetActiveSession';
 
 export type SignInSetActiveSessionElement = React.ElementRef<'button'>;
@@ -25,12 +27,13 @@ export type SignInSetActiveSessionProps = {
 export const SignInSetActiveSession = React.forwardRef<SignInSetActiveSessionElement, SignInSetActiveSessionProps>(
   ({ asChild, ...rest }, forwardedRef) => {
     const actorRef = SignInRouterCtx.useActorRef();
+    const session = useSignInActiveSessionContext();
 
     const Comp = asChild ? Slot : 'button';
     const defaultProps = asChild ? {} : { type: 'button' as const };
 
     const sendEvent = React.useCallback(() => {
-      const event: SignInRouterSessionSetActiveEvent = { type: 'SESSION.SET_ACTIVE', id: 'abc123' };
+      const event: SignInRouterSessionSetActiveEvent = { type: 'SESSION.SET_ACTIVE', id: session.id };
 
       if (actorRef.getSnapshot().can(event)) {
         actorRef.send(event);
@@ -39,7 +42,7 @@ export const SignInSetActiveSession = React.forwardRef<SignInSetActiveSessionEle
           `Clerk: <SignIn.Action setActiveSession> is an invalid event. You can only choose an active session from <SignIn.Step name="choose-session">.`,
         );
       }
-    }, [actorRef]);
+    }, [actorRef, session.id]);
 
     return (
       <Comp

--- a/packages/elements/src/react/sign-in/choose-session.tsx
+++ b/packages/elements/src/react/sign-in/choose-session.tsx
@@ -1,0 +1,102 @@
+import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
+
+import { useActiveTags } from '../hooks';
+import { createContextForDomValidation } from '../utils/create-context-for-dom-validation';
+import { isValidComponentType } from '../utils/is-valid-component-type';
+import { SignInRouterCtx } from './context';
+
+// ----------------------------------- TYPES ------------------------------------
+//
+export type SignInChooseSessionProps = React.HTMLAttributes<HTMLDivElement>;
+export type SignInSessionListProps = React.HTMLAttributes<HTMLUListElement> & { asChild?: boolean };
+export type SignInSessionListItemProps = Omit<React.HTMLAttributes<HTMLLIElement>, 'children'> & {
+  asChild?: boolean;
+  children: (session: any) => React.ReactNode;
+};
+
+// ---------------------------------- CONTEXT -----------------------------------
+
+export const SignInChooseSessionCtx = createContextForDomValidation('SignInChooseSessionCtx');
+const SignInActiveSessionContext = React.createContext<any>(null);
+
+// ----------------------------------- HOOKS ------------------------------------
+
+function useSignInActiveSessionContext() {
+  const ctx = React.useContext(SignInActiveSessionContext);
+
+  if (!ctx) {
+    throw new Error('SignInActiveSessionContext must be used within a SessionList/SignInSessionListItem');
+  }
+
+  return ctx;
+}
+
+function useSignInActiveSessionList() {
+  return SignInRouterCtx.useSelector(state =>
+    state.context.clerk.client.activeSessions.map(s => ({
+      id: s.id,
+      ...s.publicUserData,
+    })),
+  );
+}
+
+// --------------------------------- COMPONENTS ---------------------------------
+
+export function SignInChooseSession({ children, ...props }: SignInChooseSessionProps) {
+  const routerRef = SignInRouterCtx.useActorRef();
+  const activeState = useActiveTags(routerRef, 'step:choose-session');
+
+  return activeState ? (
+    <SignInChooseSessionCtx.Provider>
+      <div {...props}>{children}</div>
+    </SignInChooseSessionCtx.Provider>
+  ) : null;
+}
+
+export function SignInSessionList({ asChild, children, ...props }: SignInSessionListProps) {
+  const sessions = useSignInActiveSessionList();
+
+  if (!children || !sessions?.length) {
+    return null;
+  }
+
+  if (React.Children.count(children) > 1) {
+    return React.Children.only(null);
+  }
+
+  if (asChild && !isValidComponentType(children, SignInSessionListItem)) {
+    // TODO: Update error message
+    throw new Error('asChild cannot be used with SessionListItem as the direct child');
+  }
+
+  if (!React.isValidElement(children)) {
+    // TODO: Update error message
+    throw new Error('children must be a valid React element');
+  }
+
+  const newChildren = asChild ? (children.props.children as React.ReactNode) : children;
+  const childrenWithCtx = sessions.map(session => {
+    return (
+      <SignInActiveSessionContext.Provider
+        key={`SignInActiveSessionContext-${session.id}`}
+        value={session}
+      >
+        {newChildren}
+      </SignInActiveSessionContext.Provider>
+    );
+  });
+
+  if (asChild) {
+    return <Slot {...props}>{React.cloneElement(children, undefined, childrenWithCtx)}</Slot>;
+  }
+
+  return <ul {...props}>{childrenWithCtx}</ul>;
+}
+
+export function SignInSessionListItem({ asChild, children, ...props }: SignInSessionListItemProps) {
+  const session = useSignInActiveSessionContext();
+  const Comp = asChild ? Slot : 'li';
+
+  return <Comp {...props}>{children({ session })}</Comp>;
+}

--- a/packages/elements/src/react/sign-in/choose-session/__tests__/choose-session.test.tsx
+++ b/packages/elements/src/react/sign-in/choose-session/__tests__/choose-session.test.tsx
@@ -1,0 +1,136 @@
+import '@testing-library/jest-dom';
+
+import { render } from '@testing-library/react';
+
+import { SignInSessionList, SignInSessionListItem } from '../choose-session';
+import * as Hooks from '../choose-session.hooks';
+
+describe('SignInSessionList/SignInSessionListItem', () => {
+  beforeAll(() => {
+    jest.spyOn(Hooks, 'useSignInChooseSessionIsActive').mockImplementation(() => true);
+    jest.spyOn(Hooks, 'useSignInActiveSessionList').mockImplementation(() => [
+      {
+        id: 'abc123',
+        firstName: 'firstName',
+        lastName: 'lastName',
+        imageUrl: 'https://foo.bar/baz.jpg',
+        hasImage: true,
+        identifier: 'support@clerk.com',
+      },
+    ]);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render default ul/li elements', () => {
+    const { container } = render(
+      <SignInSessionList>
+        <SignInSessionListItem>{({ session }) => session.id}</SignInSessionListItem>
+      </SignInSessionList>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <ul>
+          <li>
+            abc123
+          </li>
+        </ul>
+      </div>
+    `);
+  });
+
+  it('should render default ul/li elements with children', () => {
+    const { container } = render(
+      <SignInSessionList>
+        <SignInSessionListItem>{({ session }) => <p>{session.id}</p>}</SignInSessionListItem>
+      </SignInSessionList>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <ul>
+          <li>
+            <p>
+              abc123
+            </p>
+          </li>
+        </ul>
+      </div>
+    `);
+  });
+
+  it('should render default ul with asChild children', () => {
+    const { container } = render(
+      <SignInSessionList>
+        <SignInSessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignInSessionListItem>
+      </SignInSessionList>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <ul>
+          <p>
+            abc123
+          </p>
+        </ul>
+      </div>
+    `);
+  });
+
+  it('should render asChold list with default li', () => {
+    const { container } = render(
+      <SignInSessionList asChild>
+        <section>
+          <SignInSessionListItem>{({ session }) => session.id}</SignInSessionListItem>
+        </section>
+      </SignInSessionList>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section>
+          <li>
+            abc123
+          </li>
+        </section>
+      </div>
+    `);
+  });
+
+  it('should render asChild list and items', () => {
+    const { container } = render(
+      <SignInSessionList asChild>
+        <section>
+          <SignInSessionListItem asChild>{({ session }) => <p>{session.id}</p>}</SignInSessionListItem>
+        </section>
+      </SignInSessionList>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section>
+          <p>
+            abc123
+          </p>
+        </section>
+      </div>
+    `);
+  });
+
+  it('should not allow asChild with a direct child of SessionListItem', () => {
+    const consoleErrorFn = jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+
+    expect(() =>
+      render(
+        <SignInSessionList asChild>
+          <SignInSessionListItem>{() => 'foo'}</SignInSessionListItem>
+        </SignInSessionList>,
+      ),
+    ).toThrow('asChild cannot be used with SessionListItem as the direct child');
+
+    consoleErrorFn.mockRestore();
+  });
+});

--- a/packages/elements/src/react/sign-in/choose-session/choose-session.hooks.ts
+++ b/packages/elements/src/react/sign-in/choose-session/choose-session.hooks.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { useActiveTags } from '../../hooks';
+import { SignInRouterCtx } from '../context';
+
+export const SignInActiveSessionContext = React.createContext<any>(null);
+
+export function useSignInActiveSessionContext() {
+  const ctx = React.useContext(SignInActiveSessionContext);
+
+  if (!ctx) {
+    throw new Error('SignInActiveSessionContext must be used within a SessionList/SignInSessionListItem');
+  }
+
+  return ctx;
+}
+
+export function useSignInChooseSessionIsActive() {
+  const routerRef = SignInRouterCtx.useActorRef();
+  return useActiveTags(routerRef, 'step:choose-session');
+}
+
+export function useSignInActiveSessionList() {
+  return SignInRouterCtx.useSelector(
+    state =>
+      state.context.clerk?.client?.activeSessions?.map(s => ({
+        id: s.id,
+        ...s.publicUserData,
+      })) || [],
+  );
+}

--- a/packages/elements/src/react/sign-in/choose-session/choose-session.tsx
+++ b/packages/elements/src/react/sign-in/choose-session/choose-session.tsx
@@ -1,13 +1,18 @@
 import { Slot } from '@radix-ui/react-slot';
 import * as React from 'react';
 
-import { useActiveTags } from '../hooks';
-import { createContextForDomValidation } from '../utils/create-context-for-dom-validation';
-import { isValidComponentType } from '../utils/is-valid-component-type';
-import { SignInRouterCtx } from './context';
+import { createContextForDomValidation } from '~/react/utils/create-context-for-dom-validation';
+import { isValidComponentType } from '~/react/utils/is-valid-component-type';
+
+import {
+  SignInActiveSessionContext,
+  useSignInActiveSessionContext,
+  useSignInActiveSessionList,
+  useSignInChooseSessionIsActive,
+} from './choose-session.hooks';
 
 // ----------------------------------- TYPES ------------------------------------
-//
+
 export type SignInChooseSessionProps = React.HTMLAttributes<HTMLDivElement>;
 export type SignInSessionListProps = React.HTMLAttributes<HTMLUListElement> & { asChild?: boolean };
 export type SignInSessionListItemProps = Omit<React.HTMLAttributes<HTMLLIElement>, 'children'> & {
@@ -18,34 +23,11 @@ export type SignInSessionListItemProps = Omit<React.HTMLAttributes<HTMLLIElement
 // ---------------------------------- CONTEXT -----------------------------------
 
 export const SignInChooseSessionCtx = createContextForDomValidation('SignInChooseSessionCtx');
-const SignInActiveSessionContext = React.createContext<any>(null);
-
-// ----------------------------------- HOOKS ------------------------------------
-
-function useSignInActiveSessionContext() {
-  const ctx = React.useContext(SignInActiveSessionContext);
-
-  if (!ctx) {
-    throw new Error('SignInActiveSessionContext must be used within a SessionList/SignInSessionListItem');
-  }
-
-  return ctx;
-}
-
-function useSignInActiveSessionList() {
-  return SignInRouterCtx.useSelector(state =>
-    state.context.clerk.client.activeSessions.map(s => ({
-      id: s.id,
-      ...s.publicUserData,
-    })),
-  );
-}
 
 // --------------------------------- COMPONENTS ---------------------------------
 
 export function SignInChooseSession({ children, ...props }: SignInChooseSessionProps) {
-  const routerRef = SignInRouterCtx.useActorRef();
-  const activeState = useActiveTags(routerRef, 'step:choose-session');
+  const activeState = useSignInChooseSessionIsActive();
 
   return activeState ? (
     <SignInChooseSessionCtx.Provider>
@@ -65,7 +47,7 @@ export function SignInSessionList({ asChild, children, ...props }: SignInSession
     return React.Children.only(null);
   }
 
-  if (asChild && !isValidComponentType(children, SignInSessionListItem)) {
+  if (asChild && isValidComponentType(children, SignInSessionListItem)) {
     // TODO: Update error message
     throw new Error('asChild cannot be used with SessionListItem as the direct child');
   }

--- a/packages/elements/src/react/sign-in/choose-session/choose-session.tsx
+++ b/packages/elements/src/react/sign-in/choose-session/choose-session.tsx
@@ -6,6 +6,7 @@ import { isValidComponentType } from '~/react/utils/is-valid-component-type';
 
 import {
   SignInActiveSessionContext,
+  type SignInActiveSessionListItem,
   useSignInActiveSessionContext,
   useSignInActiveSessionList,
   useSignInChooseSessionIsActive,
@@ -14,10 +15,13 @@ import {
 // ----------------------------------- TYPES ------------------------------------
 
 export type SignInChooseSessionProps = React.HTMLAttributes<HTMLDivElement>;
-export type SignInSessionListProps = React.HTMLAttributes<HTMLUListElement> & { asChild?: boolean };
+export type SignInSessionListProps = React.HTMLAttributes<HTMLUListElement> & {
+  asChild?: boolean;
+  includeCurrentSession?: true;
+};
 export type SignInSessionListItemProps = Omit<React.HTMLAttributes<HTMLLIElement>, 'children'> & {
   asChild?: boolean;
-  children: (session: any) => React.ReactNode;
+  children: ({ session }: { session: SignInActiveSessionListItem }) => React.ReactNode;
 };
 
 // ---------------------------------- CONTEXT -----------------------------------
@@ -36,8 +40,8 @@ export function SignInChooseSession({ children, ...props }: SignInChooseSessionP
   ) : null;
 }
 
-export function SignInSessionList({ asChild, children, ...props }: SignInSessionListProps) {
-  const sessions = useSignInActiveSessionList();
+export function SignInSessionList({ asChild, children, includeCurrentSession, ...props }: SignInSessionListProps) {
+  const sessions = useSignInActiveSessionList({ omitCurrent: !includeCurrentSession });
 
   if (!children || !sessions?.length) {
     return null;
@@ -76,9 +80,10 @@ export function SignInSessionList({ asChild, children, ...props }: SignInSession
   return <ul {...props}>{childrenWithCtx}</ul>;
 }
 
-export function SignInSessionListItem({ asChild, children, ...props }: SignInSessionListItemProps) {
+export function SignInSessionListItem(props: SignInSessionListItemProps) {
+  const { asChild = false, children, ...passthroughProps } = props;
   const session = useSignInActiveSessionContext();
   const Comp = asChild ? Slot : 'li';
 
-  return <Comp {...props}>{children({ session })}</Comp>;
+  return <Comp {...passthroughProps}>{children({ session })}</Comp>;
 }

--- a/packages/elements/src/react/sign-in/choose-session/index.tsx
+++ b/packages/elements/src/react/sign-in/choose-session/index.tsx
@@ -1,0 +1,2 @@
+export { SignInChooseSession, SignInSessionList, SignInSessionListItem } from './choose-session';
+export type { SignInSessionListProps, SignInChooseSessionProps, SignInSessionListItemProps } from './choose-session';

--- a/packages/elements/src/react/sign-in/index.ts
+++ b/packages/elements/src/react/sign-in/index.ts
@@ -6,6 +6,7 @@ export { SignInStep as Step } from './step';
 export { SignInAction as Action } from './action';
 export { SignInPasskey as Passkey } from './passkey';
 export { SignInSupportedStrategy as SupportedStrategy } from './choose-strategy';
+export { SignInSessionList as SessionList, SignInSessionListItem as SessionListItem } from './choose-session';
 
 export {
   SignInFirstFactor as FirstFactor,

--- a/packages/elements/src/react/sign-in/step.tsx
+++ b/packages/elements/src/react/sign-in/step.tsx
@@ -3,19 +3,17 @@ import { eventComponentMounted } from '@clerk/shared/telemetry';
 
 import { ClerkElementsRuntimeError } from '~/internals/errors';
 
-import type { SignInChooseStrategyProps } from './choose-strategy';
-import { SignInChooseStrategy, SignInForgotPassword } from './choose-strategy';
-import type { SignInResetPasswordProps } from './reset-password';
-import { SignInResetPassword } from './reset-password';
-import type { SignInStartProps } from './start';
-import { SignInStart } from './start';
-import type { SignInVerificationsProps } from './verifications';
-import { SignInVerifications } from './verifications';
+import { SignInChooseSession, type SignInChooseSessionProps } from './choose-session';
+import { SignInChooseStrategy, type SignInChooseStrategyProps, SignInForgotPassword } from './choose-strategy';
+import { SignInResetPassword, type SignInResetPasswordProps } from './reset-password';
+import { SignInStart, type SignInStartProps } from './start';
+import { SignInVerifications, type SignInVerificationsProps } from './verifications';
 
 export const SIGN_IN_STEPS = {
   start: 'start',
   verifications: 'verifications',
   'choose-strategy': 'choose-strategy',
+  'choose-session': 'choose-session',
   'forgot-password': 'forgot-password',
   'reset-password': 'reset-password',
 } as const;
@@ -27,7 +25,8 @@ export type SignInStepProps =
   | StepWithProps<'start', SignInStartProps>
   | StepWithProps<'verifications', SignInVerificationsProps>
   | StepWithProps<'choose-strategy' | 'forgot-password', SignInChooseStrategyProps>
-  | StepWithProps<'reset-password', SignInResetPasswordProps>;
+  | StepWithProps<'reset-password', SignInResetPasswordProps>
+  | StepWithProps<'choose-session', SignInChooseSessionProps>;
 
 /**
  * Render different steps of the sign-in flow. Initially the `'start'` step is rendered. Once a sign-in attempt has been created, `'verifications'` will be displayed. If during that verification step the user decides to choose a different method of signing in or verifying, the `'choose-strategy'` step will be displayed.
@@ -43,6 +42,7 @@ export type SignInStepProps =
  *  <SignIn.Step name='choose-strategy' />
  *  <SignIn.Step name='forgot-password' />
  *  <SignIn.Step name='reset-password' />
+ *  <SignIn.Step name='choose-session' />
  * </SignIn.Root>
  */
 export function SignInStep(props: SignInStepProps) {
@@ -51,9 +51,9 @@ export function SignInStep(props: SignInStepProps) {
   clerk.telemetry?.record(eventComponentMounted('Elements_SignInStep', { name: props.name }));
 
   switch (props.name) {
-    case SIGN_IN_STEPS['start']:
+    case SIGN_IN_STEPS.start:
       return <SignInStart {...props} />;
-    case SIGN_IN_STEPS['verifications']:
+    case SIGN_IN_STEPS.verifications:
       return <SignInVerifications {...props} />;
     case SIGN_IN_STEPS['choose-strategy']:
       return <SignInChooseStrategy {...props} />;
@@ -61,6 +61,8 @@ export function SignInStep(props: SignInStepProps) {
       return <SignInForgotPassword {...props} />;
     case SIGN_IN_STEPS['reset-password']:
       return <SignInResetPassword {...props} />;
+    case SIGN_IN_STEPS['choose-session']:
+      return <SignInChooseSession {...props} />;
     default:
       throw new ClerkElementsRuntimeError(`Invalid step name. Use: ${Object.keys(SIGN_IN_STEPS).join(',')}.`);
   }

--- a/packages/elements/src/react/utils/is-valid-component-type.ts
+++ b/packages/elements/src/react/utils/is-valid-component-type.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export function isValidComponentType(child: React.ReactNode, type: any): child is React.ReactElement {
+  return React.isValidElement(child) && child.type === type;
+}


### PR DESCRIPTION
## Description

Introduce multi-session choose account step and associated actions/components.

Example:

```tsx
<SignIn.Step name='choose-session'>
  <SignIn.SessionList>
    <SignIn.SessionListItem>
      {({ session }) => <>{session.identifier} | <SignIn.Action setActiveSession>Switch...</SignIn.Action></>}
    </SignIn.SessionListItem>
  </SignIn.SessionList>
</SignIn.Step>
```

By default, `SessionList` does not include the current session. Adding `includeCurrentSession` to `SignIn.SessionList` will include it.

<!-- Fixes #(issue number) -->

Fixes SDKI-290

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
