### PR TITLE
fix(clerk-js): Application logo rendering size

### DIFF
--- a/.changeset/fair-squids-deny.md
+++ b/.changeset/fair-squids-deny.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fixes an issue where the application logo would render smaller then intended

--- a/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
+++ b/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
@@ -61,7 +61,7 @@ export const ApplicationLogo = (props: ApplicationLogoProps) => {
       {...props}
       sx={[
         theme => ({
-          height: getContainerHeightForImageRatio(imageRef, theme.sizes.$4),
+          height: getContainerHeightForImageRatio(imageRef, theme.sizes.$6),
           justifyContent: 'center',
         }),
         props.sx,


### PR DESCRIPTION
## Description

Fixes issue where application logos were rendering smaller then intended. Reverts the changes to application logo from https://github.com/clerk/javascript/pull/2716

Fixes SDKI-576

Square logo:

<img width="584" alt="Screenshot 2024-08-14 at 3 53 42 PM" src="https://github.com/user-attachments/assets/f496e2e0-338b-4907-bbae-7872104df2b4">

Horizontal logo:

<img width="845" alt="Screenshot 2024-08-14 at 3 54 36 PM" src="https://github.com/user-attachments/assets/5de319e6-0b21-4197-8188-0359c0fd06dd">

Vertical logo:

<img width="605" alt="Screenshot 2024-08-14 at 3 55 27 PM" src="https://github.com/user-attachments/assets/df68d947-8a5c-4f20-87b4-074694dcc540">

Clerk logo before and after:

| Before | After |
|--------|--------|
| <img width="637" alt="Screenshot 2024-08-14 at 3 58 19 PM" src="https://github.com/user-attachments/assets/8e9f1c70-8e4e-4cb8-b6df-466ede0d5bb7"> | <img width="637" alt="Screenshot 2024-08-14 at 3 58 28 PM" src="https://github.com/user-attachments/assets/da3bee67-b15b-4e1e-bd73-1faa02ff3e11"> | 


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
