### PR TITLE
chore(astro): Remove dependency `@clerk/clerk-js`

### DIFF
--- a/.changeset/nine-shoes-hug.md
+++ b/.changeset/nine-shoes-hug.md
@@ -1,0 +1,7 @@
+---
+"@clerk/astro": patch
+---
+
+Remove dependency `@clerk/clerk-js`.
+
+Since clerk-js is being hotloaded it is unnecessary to keep the npm package as a dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51854,7 +51854,6 @@
       "license": "MIT",
       "dependencies": {
         "@clerk/backend": "1.6.3",
-        "@clerk/clerk-js": "5.14.1",
         "@clerk/shared": "2.5.1",
         "@clerk/types": "4.13.1",
         "nanoid": "5.0.7",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -80,7 +80,6 @@
   },
   "dependencies": {
     "@clerk/backend": "1.6.3",
-    "@clerk/clerk-js": "5.14.1",
     "@clerk/shared": "2.5.1",
     "@clerk/types": "4.13.1",
     "nanoid": "5.0.7",

--- a/packages/astro/src/internal/create-clerk-instance.ts
+++ b/packages/astro/src/internal/create-clerk-instance.ts
@@ -72,7 +72,7 @@ function updateClerkOptions(options: AstroClerkUpdateOptions) {
   if (!clerk) {
     throw new Error('Missing clerk instance');
   }
-  // TODO: Update Clerk type from @clerk/types to include this method
+  // `__unstable__updateProps` is not exposed as public API from `@clerk/types`
   void (clerk as any).__unstable__updateProps({
     options: { ...initOptions, ...options },
     appearance: { ...initOptions?.appearance, ...options.appearance },

--- a/packages/astro/src/internal/run-once.ts
+++ b/packages/astro/src/internal/run-once.ts
@@ -1,5 +1,3 @@
-import type { Clerk } from '@clerk/clerk-js';
-
 import { invokeClerkAstroJSFunctions } from './invoke-clerk-astro-js-functions';
 import { mountAllClerkAstroJSComponents } from './mount-clerk-astro-js-components';
 import type { CreateClerkInstanceInternalFn } from './types';
@@ -12,7 +10,7 @@ const runOnce = (onFirst: CreateClerkInstanceInternalFn) => {
   let hasRun = false;
   return (params: Parameters<CreateClerkInstanceInternalFn>[0]) => {
     if (hasRun) {
-      const clerkJSInstance = window.Clerk as Clerk;
+      const clerkJSInstance = window.Clerk;
       return new Promise(res => {
         if (!clerkJSInstance) {
           return res(false);

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -1,4 +1,4 @@
-import type { ClerkOptions, MultiDomainAndOrProxyPrimitives, Without } from '@clerk/types';
+import type { Clerk, ClerkOptions, ClientResource, MultiDomainAndOrProxyPrimitives, Without } from '@clerk/types';
 
 type AstroClerkUpdateOptions = Pick<ClerkOptions, 'appearance' | 'localization'>;
 
@@ -18,10 +18,23 @@ type AstroClerkIntegrationParams = Without<
 
 type AstroClerkCreateInstanceParams = AstroClerkIntegrationParams & { publishableKey: string };
 
+// Copied from `@clerk/clerk-react`
+export interface HeadlessBrowserClerk extends Clerk {
+  load: (opts?: Without<ClerkOptions, 'isSatellite'>) => Promise<void>;
+  updateClient: (client: ClientResource) => void;
+}
+
+// Copied from `@clerk/clerk-react`
+export interface BrowserClerk extends HeadlessBrowserClerk {
+  onComponentsReady: Promise<void>;
+  components: any;
+}
+
 declare global {
   interface Window {
     __astro_clerk_component_props: Map<string, Map<string, Record<string, unknown>>>;
     __astro_clerk_function_props: Map<string, Map<string, Record<string, unknown>>>;
+    Clerk: BrowserClerk;
   }
 }
 


### PR DESCRIPTION


## Description
Since clerk-js is being hotloaded it is unnecessary to keep the npm package as a dependency
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
