### PR TITLE
feat(dev-cli): Improve warnings for invalid configurations

### DIFF
--- a/.changeset/clean-flies-own.md
+++ b/.changeset/clean-flies-own.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Print error when the `root` property of the configuration file is `null`

--- a/.changeset/plenty-drinks-drive.md
+++ b/.changeset/plenty-drinks-drive.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Warn when `publishableKey` or `secretKey` are invalid

--- a/.changeset/red-bobcats-change.md
+++ b/.changeset/red-bobcats-change.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Warn if configuration file already exists when running `clerk-dev init`

--- a/packages/dev-cli/src/cli.js
+++ b/packages/dev-cli/src/cli.js
@@ -66,5 +66,8 @@ export default function cli() {
       await watch({ js });
     });
 
-  program.parseAsync();
+  program.parseAsync().catch(err => {
+    console.error(err.message);
+    process.exit(1);
+  });
 }

--- a/packages/dev-cli/src/commands/init.js
+++ b/packages/dev-cli/src/commands/init.js
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
@@ -9,6 +10,12 @@ import { getCLIRoot } from '../utils/getMonorepoRoot.js';
  * Performs one-time machine-level configuration tasks such as creating a blank config file.
  */
 export async function init() {
+  // If the config file already exists, print a warning and exit.
+  if (existsSync(CONFIG_FILE)) {
+    console.warn('Configuration file already exists. Run `clerk-dev config` to open it.');
+    return;
+  }
+
   const cliRoot = getCLIRoot();
 
   /** @type import('../utils/getConfiguration.js').Configuration */

--- a/packages/dev-cli/src/commands/setup.js
+++ b/packages/dev-cli/src/commands/setup.js
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { parse } from 'dotenv';
 
 import { applyCodemod } from '../codemods/index.js';
+import { INVALID_INSTANCE_KEYS_ERROR } from '../utils/errors.js';
 import { getClerkPackages } from '../utils/getClerkPackages.js';
 import { getConfiguration } from '../utils/getConfiguration.js';
 import { getDependencies } from '../utils/getDependencies.js';
@@ -64,7 +65,11 @@ async function detectFramework() {
  */
 async function getInstanceConfiguration(configuration) {
   const { activeInstance, instances } = configuration;
-  return instances[activeInstance];
+  const activeInstanceConfig = instances[activeInstance];
+  if (!activeInstanceConfig.publishableKey.startsWith('pk_') || !activeInstanceConfig.secretKey.startsWith('sk_')) {
+    throw new Error(INVALID_INSTANCE_KEYS_ERROR);
+  }
+  return activeInstanceConfig;
 }
 
 /**

--- a/packages/dev-cli/src/commands/watch.js
+++ b/packages/dev-cli/src/commands/watch.js
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 
 import concurrently from 'concurrently';
 
+import { NULL_ROOT_ERROR } from '../utils/errors.js';
 import { getClerkPackages } from '../utils/getClerkPackages.js';
 import { getDependencies } from '../utils/getDependencies.js';
 import { getMonorepoRoot } from '../utils/getMonorepoRoot.js';
@@ -24,6 +25,9 @@ export async function watch({ js }) {
   const args = ['watch', 'build', ...filterArgs];
 
   const cwd = await getMonorepoRoot();
+  if (!cwd) {
+    throw new Error(NULL_ROOT_ERROR);
+  }
 
   /** @type {import('concurrently').ConcurrentlyCommandInput} */
   const clerkJsCommand = {

--- a/packages/dev-cli/src/utils/errors.js
+++ b/packages/dev-cli/src/utils/errors.js
@@ -1,0 +1,2 @@
+export const NULL_ROOT_ERROR =
+  'The `root` property of your configuration file is null. Run `clerk-dev set-root` in your local checkout of clerk/javascript to set it.';

--- a/packages/dev-cli/src/utils/errors.js
+++ b/packages/dev-cli/src/utils/errors.js
@@ -1,2 +1,5 @@
 export const NULL_ROOT_ERROR =
   'The `root` property of your configuration file is null. Run `clerk-dev set-root` in your local checkout of clerk/javascript to set it.';
+
+export const INVALID_INSTANCE_KEYS_ERROR =
+  'The publishableKey and secretKey fields of your config are invalid. publishableKey should start with `pk_` and secretKey should start with `sk_`.';

--- a/packages/dev-cli/src/utils/getClerkPackages.js
+++ b/packages/dev-cli/src/utils/getClerkPackages.js
@@ -3,6 +3,7 @@ import { dirname, posix } from 'node:path';
 
 import { globby } from 'globby';
 
+import { NULL_ROOT_ERROR } from './errors.js';
 import { getMonorepoRoot } from './getMonorepoRoot.js';
 
 /**
@@ -11,6 +12,9 @@ import { getMonorepoRoot } from './getMonorepoRoot.js';
  */
 export async function getClerkPackages() {
   const monorepoRoot = await getMonorepoRoot();
+  if (!monorepoRoot) {
+    throw new Error(NULL_ROOT_ERROR);
+  }
   /** @type {Record<string, string>} */
   const packages = {};
   const clerkPackages = await globby([posix.join(monorepoRoot, 'packages', '*', 'package.json'), '!*node_modules*']);

--- a/packages/dev-cli/src/utils/getMonorepoRoot.js
+++ b/packages/dev-cli/src/utils/getMonorepoRoot.js
@@ -7,15 +7,10 @@ export function getCLIRoot() {
 }
 
 /**
- * Gets the `root` property of the clerk-dev configuration file, falling back to the folder containing the source
- * for the running instance of clerk-dev.
- * @returns {Promise<string>}
+ * Gets the `root` property of the clerk-dev configuration file.
+ * @returns {Promise<string | null>}
  */
 export async function getMonorepoRoot() {
   const config = await getConfiguration();
-  if (config.root) {
-    return config.root;
-  }
-
-  return getCLIRoot();
+  return config.root;
 }


### PR DESCRIPTION
## Description

This PR adds more error messages to `clerk-dev` to notify the user of invalid configurations. It now warns in the following instances:

- Running `clerk-dev init` with an existing configuration file
- Running `clerk-dev setup` or `clerk-dev watch` with a `null` `root` configuration
- Running `clerk-dev setup` with an invalid `publishableKey` or `secretKey`

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
