### PR TITLE
fix(elements): Fix `SignIn.SafeIdentifier` potentially outputting an incorrect value

### DIFF
--- a/.changeset/two-apricots-serve.md
+++ b/.changeset/two-apricots-serve.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Fix `SignIn.SafeIdentifier` potentially outputting an incorrect identifier when using similar multi-session sign in strategies.

--- a/packages/elements/src/internals/machines/sign-in/__tests__/router.selectors.test.ts
+++ b/packages/elements/src/internals/machines/sign-in/__tests__/router.selectors.test.ts
@@ -1,0 +1,150 @@
+import type { PartialDeep } from 'type-fest';
+
+import { SignInSafeIdentifierSelectorForStrategy } from '../router.selectors';
+import type { SignInRouterSnapshot } from '../router.types';
+
+describe('SignInSafeIdentifierSelectorForStrategy', () => {
+  it('should output support@clerk.dev (firstFactor - safeIdentifier)', () => {
+    const identifier = 'support@clerk.dev';
+    const snapshot: PartialDeep<SignInRouterSnapshot> = {
+      status: 'active',
+      context: {
+        clerk: {
+          client: {
+            signIn: {
+              status: 'needs_first_factor',
+              supportedFirstFactors: [
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: 's******@c****.com',
+                  emailAddressId: 'idn_foo',
+                },
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: identifier,
+                  emailAddressId: 'idn_bar',
+                  primary: true,
+                },
+              ],
+              supportedSecondFactors: null,
+              identifier,
+            },
+          },
+        },
+      },
+    };
+
+    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
+    expect(result).toEqual(identifier);
+  });
+
+  it('should output support@clerk.dev (identifier)', () => {
+    const identifier = 'support@clerk.dev';
+    const snapshot: PartialDeep<SignInRouterSnapshot> = {
+      status: 'active',
+      context: {
+        clerk: {
+          client: {
+            signIn: {
+              status: 'needs_first_factor',
+              supportedFirstFactors: [
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: 's******@c****.com',
+                  emailAddressId: 'idn_foo',
+                },
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: 's******@c****.com',
+                  emailAddressId: 'idn_bar',
+                  primary: true,
+                },
+              ],
+              supportedSecondFactors: null,
+              identifier,
+            },
+          },
+        },
+      },
+    };
+
+    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
+    expect(result).toEqual(identifier);
+  });
+
+  it('should output support@clerk.dev (identfier - default)', () => {
+    const identifier = 'support@clerk.dev';
+    const snapshot: PartialDeep<SignInRouterSnapshot> = {
+      status: 'active',
+      context: {
+        clerk: {
+          client: {
+            signIn: {
+              status: 'needs_first_factor',
+              supportedFirstFactors: [],
+              supportedSecondFactors: null,
+              identifier,
+            },
+          },
+        },
+      },
+    };
+
+    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
+    expect(result).toEqual(identifier);
+  });
+
+  it('should output s******@c****.com (initial factor)', () => {
+    const snapshot: PartialDeep<SignInRouterSnapshot> = {
+      status: 'active',
+      context: {
+        clerk: {
+          client: {
+            signIn: {
+              status: 'needs_first_factor',
+              supportedFirstFactors: [
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: 's******@c****.com',
+                  emailAddressId: 'idn_foo',
+                },
+                {
+                  strategy: 'email_code',
+                  safeIdentifier: 's*****2@c****.com',
+                  emailAddressId: 'idn_bar',
+                  primary: true,
+                },
+              ],
+              supportedSecondFactors: null,
+              identifier: undefined,
+            },
+          },
+        },
+      },
+    };
+
+    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
+    expect(result).toEqual('s******@c****.com');
+  });
+
+  it('should output an empty string', () => {
+    const snapshot: PartialDeep<SignInRouterSnapshot> = {
+      status: 'active',
+      context: {
+        clerk: {
+          client: {
+            signIn: {
+              status: 'needs_first_factor',
+              supportedFirstFactors: [],
+              supportedSecondFactors: null,
+              identifier: undefined,
+            },
+          },
+        },
+      },
+    };
+
+    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
+    expect(result).toEqual('');
+  });
+});

--- a/packages/elements/src/internals/machines/sign-in/__tests__/router.selectors.test.ts
+++ b/packages/elements/src/internals/machines/sign-in/__tests__/router.selectors.test.ts
@@ -1,150 +1,104 @@
-import type { PartialDeep } from 'type-fest';
+import type { SignInFirstFactor } from '@clerk/types';
 
 import { SignInSafeIdentifierSelectorForStrategy } from '../router.selectors';
 import type { SignInRouterSnapshot } from '../router.types';
 
+const IDENTIFIER = 'support@clerk.dev';
+
+function createSnapshot(
+  supportedFirstFactors: Partial<SignInFirstFactor>[] = [],
+  identifier?: string,
+): SignInRouterSnapshot {
+  return {
+    context: {
+      clerk: {
+        client: {
+          signIn: {
+            status: 'needs_first_factor',
+            supportedFirstFactors: supportedFirstFactors.map(f => ({
+              strategy: 'email_code',
+              emailAddressId: 'idn_foo',
+              ...f,
+            })),
+            supportedSecondFactors: null,
+            identifier: identifier,
+          },
+        },
+      },
+    },
+  } as unknown as SignInRouterSnapshot;
+}
+
 describe('SignInSafeIdentifierSelectorForStrategy', () => {
-  it('should output support@clerk.dev (firstFactor - safeIdentifier)', () => {
-    const identifier = 'support@clerk.dev';
-    const snapshot: PartialDeep<SignInRouterSnapshot> = {
-      status: 'active',
-      context: {
-        clerk: {
-          client: {
-            signIn: {
-              status: 'needs_first_factor',
-              supportedFirstFactors: [
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: 's******@c****.com',
-                  emailAddressId: 'idn_foo',
-                },
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: identifier,
-                  emailAddressId: 'idn_bar',
-                  primary: true,
-                },
-              ],
-              supportedSecondFactors: null,
-              identifier,
-            },
+  describe('Match: Identifier', () => {
+    it('should output support@clerk.dev (matchingFactorForIdentifier.safeIdentifier)', () => {
+      const snapshot = createSnapshot(
+        [
+          {
+            safeIdentifier: 's******@c****.com',
           },
-        },
-      },
-    };
+          {
+            safeIdentifier: IDENTIFIER,
+            primary: true,
+          },
+        ],
+        IDENTIFIER,
+      );
 
-    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
-    expect(result).toEqual(identifier);
+      const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot);
+      expect(result).toEqual(IDENTIFIER);
+    });
   });
 
-  it('should output support@clerk.dev (identifier)', () => {
-    const identifier = 'support@clerk.dev';
-    const snapshot: PartialDeep<SignInRouterSnapshot> = {
-      status: 'active',
-      context: {
-        clerk: {
-          client: {
-            signIn: {
-              status: 'needs_first_factor',
-              supportedFirstFactors: [
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: 's******@c****.com',
-                  emailAddressId: 'idn_foo',
-                },
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: 's******@c****.com',
-                  emailAddressId: 'idn_bar',
-                  primary: true,
-                },
-              ],
-              supportedSecondFactors: null,
-              identifier,
-            },
+  describe('Match: Strategy', () => {
+    it('should output support@clerk.dev (matchingFactorForStrategy.safeIdentifier)', () => {
+      const snapshot = createSnapshot(
+        [
+          {
+            safeIdentifier: 's******@c****.com',
           },
-        },
-      },
-    };
+          {
+            safeIdentifier: IDENTIFIER,
+            primary: true,
+          },
+        ],
+        IDENTIFIER,
+      );
 
-    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
-    expect(result).toEqual(identifier);
+      const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot);
+      expect(result).toEqual(IDENTIFIER);
+    });
+
+    it('should output s*****1@c****.com (matchingFactorForStrategy.safeIdentifier)', () => {
+      const snapshot = createSnapshot(
+        [
+          {
+            safeIdentifier: 's*****1@c****.com',
+          },
+          {
+            safeIdentifier: 's*****2@c****.com',
+            primary: true,
+          },
+        ],
+        IDENTIFIER,
+      );
+
+      const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot);
+      expect(result).toEqual('s*****1@c****.com');
+    });
   });
 
-  it('should output support@clerk.dev (identfier - default)', () => {
-    const identifier = 'support@clerk.dev';
-    const snapshot: PartialDeep<SignInRouterSnapshot> = {
-      status: 'active',
-      context: {
-        clerk: {
-          client: {
-            signIn: {
-              status: 'needs_first_factor',
-              supportedFirstFactors: [],
-              supportedSecondFactors: null,
-              identifier,
-            },
-          },
-        },
-      },
-    };
+  describe('Match: Default', () => {
+    it('should output support@clerk.dev (signIn.identifier)', () => {
+      const snapshot = createSnapshot([], IDENTIFIER);
+      const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot);
+      expect(result).toEqual(IDENTIFIER);
+    });
 
-    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
-    expect(result).toEqual(identifier);
-  });
-
-  it('should output s******@c****.com (initial factor)', () => {
-    const snapshot: PartialDeep<SignInRouterSnapshot> = {
-      status: 'active',
-      context: {
-        clerk: {
-          client: {
-            signIn: {
-              status: 'needs_first_factor',
-              supportedFirstFactors: [
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: 's******@c****.com',
-                  emailAddressId: 'idn_foo',
-                },
-                {
-                  strategy: 'email_code',
-                  safeIdentifier: 's*****2@c****.com',
-                  emailAddressId: 'idn_bar',
-                  primary: true,
-                },
-              ],
-              supportedSecondFactors: null,
-              identifier: undefined,
-            },
-          },
-        },
-      },
-    };
-
-    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
-    expect(result).toEqual('s******@c****.com');
-  });
-
-  it('should output an empty string', () => {
-    const snapshot: PartialDeep<SignInRouterSnapshot> = {
-      status: 'active',
-      context: {
-        clerk: {
-          client: {
-            signIn: {
-              status: 'needs_first_factor',
-              supportedFirstFactors: [],
-              supportedSecondFactors: null,
-              identifier: undefined,
-            },
-          },
-        },
-      },
-    };
-
-    const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot as any);
-    expect(result).toEqual('');
+    it('should output an empty string', () => {
+      const snapshot = createSnapshot([], undefined);
+      const result = SignInSafeIdentifierSelectorForStrategy('email_code')(snapshot);
+      expect(result).toEqual('');
+    });
   });
 });

--- a/packages/elements/src/internals/machines/sign-in/router.selectors.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.selectors.ts
@@ -8,18 +8,24 @@ export function SignInSafeIdentifierSelectorForStrategy(
 ): (s: SignInRouterSnapshot) => string {
   return (s: SignInRouterSnapshot) => {
     const signIn = s.context.clerk?.client.signIn;
-    const identifier = signIn.identifier || '';
 
     if (strategy) {
-      const matchingFactor = [...(signIn.supportedFirstFactors ?? []), ...(signIn.supportedSecondFactors ?? [])].find(
-        f => f.strategy === strategy,
-      );
+      const matchingFactors = [
+        ...(signIn.supportedFirstFactors ?? []),
+        ...(signIn.supportedSecondFactors ?? []),
+      ].filter(f => f.strategy === strategy);
+
+      const matchingFactor =
+        signIn.identifier && matchingFactors.length > 0
+          ? matchingFactors.find(f => 'safeIdentifier' in f && f.safeIdentifier === signIn.identifier)
+          : matchingFactors[0];
+
       if (matchingFactor && 'safeIdentifier' in matchingFactor) {
         return matchingFactor.safeIdentifier;
       }
     }
 
-    return identifier;
+    return signIn.identifier || '';
   };
 }
 

--- a/packages/elements/src/internals/machines/sign-in/router.selectors.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.selectors.ts
@@ -3,32 +3,6 @@ import { formatSalutation } from '~/internals/machines/utils/formatters';
 
 import type { SignInRouterSnapshot } from './router.types';
 
-// export function SignInSafeIdentifierSelectorForStrategy(
-//   strategy: SignInStrategyName | undefined,
-// ): (s: SignInRouterSnapshot) => string {
-//   return (s: SignInRouterSnapshot) => {
-//     const signIn = s.context.clerk?.client.signIn;
-
-//     if (strategy) {
-//       const matchingFactors = [
-//         ...(signIn.supportedFirstFactors ?? []),
-//         ...(signIn.supportedSecondFactors ?? []),
-//       ].filter(f => f.strategy === strategy);
-
-//       const matchingFactor =
-//         signIn.identifier && matchingFactors.length > 0
-//           ? matchingFactors.find(f => 'safeIdentifier' in f && f.safeIdentifier === signIn.identifier)
-//           : matchingFactors[0];
-
-//       if (matchingFactor && 'safeIdentifier' in matchingFactor) {
-//         return matchingFactor.safeIdentifier;
-//       }
-//     }
-
-//     return signIn.identifier || '';
-//   };
-// }
-
 export function SignInSafeIdentifierSelectorForStrategy(
   strategy: SignInStrategyName | undefined,
 ): (s: SignInRouterSnapshot) => string {

--- a/packages/elements/src/internals/machines/sign-in/router.selectors.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.selectors.ts
@@ -3,6 +3,32 @@ import { formatSalutation } from '~/internals/machines/utils/formatters';
 
 import type { SignInRouterSnapshot } from './router.types';
 
+// export function SignInSafeIdentifierSelectorForStrategy(
+//   strategy: SignInStrategyName | undefined,
+// ): (s: SignInRouterSnapshot) => string {
+//   return (s: SignInRouterSnapshot) => {
+//     const signIn = s.context.clerk?.client.signIn;
+
+//     if (strategy) {
+//       const matchingFactors = [
+//         ...(signIn.supportedFirstFactors ?? []),
+//         ...(signIn.supportedSecondFactors ?? []),
+//       ].filter(f => f.strategy === strategy);
+
+//       const matchingFactor =
+//         signIn.identifier && matchingFactors.length > 0
+//           ? matchingFactors.find(f => 'safeIdentifier' in f && f.safeIdentifier === signIn.identifier)
+//           : matchingFactors[0];
+
+//       if (matchingFactor && 'safeIdentifier' in matchingFactor) {
+//         return matchingFactor.safeIdentifier;
+//       }
+//     }
+
+//     return signIn.identifier || '';
+//   };
+// }
+
 export function SignInSafeIdentifierSelectorForStrategy(
   strategy: SignInStrategyName | undefined,
 ): (s: SignInRouterSnapshot) => string {
@@ -15,13 +41,19 @@ export function SignInSafeIdentifierSelectorForStrategy(
         ...(signIn.supportedSecondFactors ?? []),
       ].filter(f => f.strategy === strategy);
 
-      const matchingFactor =
+      const matchingFactorForIdentifier =
         signIn.identifier && matchingFactors.length > 0
           ? matchingFactors.find(f => 'safeIdentifier' in f && f.safeIdentifier === signIn.identifier)
-          : matchingFactors[0];
+          : null;
 
-      if (matchingFactor && 'safeIdentifier' in matchingFactor) {
-        return matchingFactor.safeIdentifier;
+      const matchingFactorForStrategy = matchingFactors[0];
+
+      if (matchingFactorForIdentifier && 'safeIdentifier' in matchingFactorForIdentifier) {
+        return matchingFactorForIdentifier.safeIdentifier;
+      }
+
+      if (matchingFactorForStrategy && 'safeIdentifier' in matchingFactorForStrategy) {
+        return matchingFactorForStrategy.safeIdentifier;
       }
     }
 


### PR DESCRIPTION
## Description

Fix `SignIn.SafeIdentifier` potentially outputting an incorrect identifier when using similar multi-session sign in strategies.

<!-- Fixes #(issue number) -->

Fixes: SDKI-609

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
