### PR TITLE
feat(ui): Remove need to manually pass globalAppearance

### DIFF
--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -8,7 +8,7 @@ import { SignInGetHelp } from '~/components/sign-in/steps/get-help';
 import { SignInResetPassword } from '~/components/sign-in/steps/reset-password';
 import { SignInStart } from '~/components/sign-in/steps/start';
 import { SignInVerifications } from '~/components/sign-in/steps/verifications';
-import { type Appearance, AppearanceProvider, useAppearance } from '~/contexts';
+import { type Appearance, AppearanceProvider } from '~/contexts';
 
 import { SignInChooseSession } from './steps/choose-session';
 
@@ -25,13 +25,9 @@ import { SignInChooseSession } from './steps/choose-session';
  */
 export function SignIn({ appearance }: { appearance?: Appearance }) {
   const [showHelp, setShowHelp] = React.useState(false);
-  const { appearance: globalAppearance } = useAppearance();
 
   return (
-    <AppearanceProvider
-      globalAppearance={globalAppearance}
-      appearance={appearance}
-    >
+    <AppearanceProvider appearance={appearance}>
       <GetHelpContext.Provider value={{ showHelp, setShowHelp }}>
         <SignInRoot>
           {showHelp ? (


### PR DESCRIPTION
## Description

This PR removes the need to manually call `useAppearance` and pass the resulting `appearance` to nested `AppearanceProvider` contexts by calling `usePartialAppearance` within the provider itself. This allows us to arbitrarily nest `AppearanceProvider`s without losing values. It also adjusts the `parseAppearance` call to use `parsedAppearance` instead, similarly to support arbitrary nesting levels.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
