### PR TITLE
fix(clerk-js): Better CAPTCHA widget console error

### DIFF
--- a/.changeset/sour-bulldogs-explode.md
+++ b/.changeset/sour-bulldogs-explode.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Improve the Smart CAPTCHA widget console error.

--- a/packages/clerk-js/src/utils/captcha/hcaptcha.ts
+++ b/packages/clerk-js/src/utils/captcha/hcaptcha.ts
@@ -56,7 +56,9 @@ export const getHCaptchaToken = async (captchaOptions: {
             visibleDiv.style.display = 'block';
             widgetDiv = visibleDiv;
           } else {
-            console.error('Captcha DOM element not found. Using invisible captcha widget.');
+            console.error(
+              'Cannot initialize Smart CAPTCHA widget because the `clerk-captcha` DOM element was not found; falling back to Invisible CAPTCHA widget. If you are using a custom flow, visit https://clerk.com/docs/custom-flows/bot-sign-up-protection for instructions',
+            );
             widgetDiv = createInvisibleDOMElement();
             isInvisibleWidget = true;
             hCaptchaSiteKey = invisibleSiteKey;

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -127,7 +127,9 @@ export const getTunstileToken = async (captchaOptions: {
             visibleDiv.style.display = 'block';
             widgetDiv = visibleDiv;
           } else {
-            console.error('Captcha DOM element not found. Using invisible captcha widget.');
+            console.error(
+              'Cannot initialize Smart CAPTCHA widget because the `clerk-captcha` DOM element was not found; falling back to Invisible CAPTCHA widget. If you are using a custom flow, visit https://clerk.com/docs/custom-flows/bot-sign-up-protection for instructions',
+            );
             widgetDiv = createInvisibleDOMElement();
             isInvisibleWidget = true;
             turnstileSiteKey = invisibleSiteKey;


### PR DESCRIPTION
This PR improves the error message thrown when falling back to invisible CAPTCHA, if the captcha DOM element is not found.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
