### PR TITLE
feature(ui): Implement `socialButtonsPlacement` layout logic

### DIFF
--- a/packages/ui/src/components/sign-in/steps/choose-strategy.tsx
+++ b/packages/ui/src/components/sign-in/steps/choose-strategy.tsx
@@ -6,6 +6,7 @@ import { Connections } from '~/common/connections';
 import { GlobalError } from '~/common/global-error';
 import { useGetHelp } from '~/components/sign-in/hooks/use-get-help';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
+import { useAppearance } from '~/contexts';
 import { useCard } from '~/hooks/use-card';
 import { useDevModeWarning } from '~/hooks/use-dev-mode-warning';
 import { useEnabledConnections } from '~/hooks/use-enabled-connections';
@@ -14,29 +15,16 @@ import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
 import * as Icon from '~/primitives/icon';
 import { LinkButton } from '~/primitives/link';
-import { Separator } from '~/primitives/separator';
 
 /* Internal
   ============================================ */
 
-function FirstFactorConnections({
-  isGlobalLoading,
-  hasConnection,
-}: {
-  isGlobalLoading: boolean;
-  hasConnection: boolean;
-}) {
-  const { t } = useLocalizations();
+function FirstFactorConnections({ isGlobalLoading }: { isGlobalLoading: boolean }) {
   const { signIn } = useSignIn();
   const isFirstFactor = signIn?.status === 'needs_first_factor';
 
   if (isFirstFactor) {
-    return (
-      <>
-        <Connections disabled={isGlobalLoading} />
-        {hasConnection ? <Separator>{t('dividerText')}</Separator> : null}
-      </>
-    );
+    return <Connections disabled={isGlobalLoading} />;
   }
   return null;
 }
@@ -69,118 +57,113 @@ export function SignInChooseStrategy() {
                 <GlobalError />
 
                 <Card.Body>
-                  <div className='flex flex-col gap-6'>
-                    <FirstFactorConnections
-                      isGlobalLoading={isGlobalLoading}
-                      hasConnection={hasConnection}
-                    />
-                    <div className='flex flex-col gap-3'>
-                      <div className='flex flex-col gap-2'>
-                        <SignIn.SupportedStrategy
-                          name='email_link'
-                          asChild
-                        >
-                          <Button
-                            intent='secondary'
-                            iconStart={<Icon.LinkSm />}
-                          >
-                            <SignIn.SafeIdentifier
-                              transform={(identifier: string) =>
-                                t('signIn.alternativeMethods.blockButton__emailLink', {
-                                  identifier,
-                                })
-                              }
-                            />
-                          </Button>
-                        </SignIn.SupportedStrategy>
-
-                        <SignIn.SupportedStrategy
-                          name='email_code'
-                          asChild
-                        >
-                          <Button
-                            intent='secondary'
-                            iconStart={<Icon.EnvelopeSm />}
-                          >
-                            <SignIn.SafeIdentifier
-                              transform={(identifier: string) =>
-                                t('signIn.alternativeMethods.blockButton__emailCode', {
-                                  identifier,
-                                })
-                              }
-                            />
-                          </Button>
-                        </SignIn.SupportedStrategy>
-
-                        <SignIn.SupportedStrategy
-                          name='phone_code'
-                          asChild
-                        >
-                          <Button
-                            intent='secondary'
-                            iconStart={<Icon.SMSSm />}
-                          >
-                            <SignIn.SafeIdentifier
-                              transform={(identifier: string) =>
-                                t('signIn.alternativeMethods.blockButton__phoneCode', {
-                                  identifier,
-                                })
-                              }
-                            />
-                          </Button>
-                        </SignIn.SupportedStrategy>
-
-                        <SignIn.SupportedStrategy
-                          name='passkey'
-                          asChild
-                        >
-                          <Button
-                            intent='secondary'
-                            iconStart={<Icon.FingerprintSm />}
-                          >
-                            {t('signIn.alternativeMethods.blockButton__passkey')}
-                          </Button>
-                        </SignIn.SupportedStrategy>
-
-                        <SignIn.SupportedStrategy
-                          name='password'
-                          asChild
-                        >
-                          <Button
-                            intent='secondary'
-                            iconStart={<Icon.LockSm />}
-                          >
-                            {t('signIn.alternativeMethods.blockButton__password')}
-                          </Button>
-                        </SignIn.SupportedStrategy>
-
-                        {
-                          // `SupportedStrategy`s that are only intended for use
-                          // within `choose-strategy`, not the `forgot-password`
-                          // `Step
-                        }
-                        <SignIn.SupportedStrategy
-                          name='totp'
-                          asChild
-                        >
-                          <Button intent='secondary'>{t('signIn.alternativeMethods.blockButton__totp')}</Button>
-                        </SignIn.SupportedStrategy>
-
-                        <SignIn.SupportedStrategy
-                          name='backup_code'
-                          asChild
-                        >
-                          <Button intent='secondary'>{t('signIn.alternativeMethods.blockButton__backupCode')}</Button>
-                        </SignIn.SupportedStrategy>
-                      </div>
-
-                      <SignIn.Action
-                        navigate='previous'
+                  <div className='flex flex-col gap-3'>
+                    <div className='flex flex-col gap-2'>
+                      <FirstFactorConnections isGlobalLoading={isGlobalLoading} />
+                      <SignIn.SupportedStrategy
+                        name='email_link'
                         asChild
                       >
-                        <LinkButton>{t('backButton')}</LinkButton>
-                      </SignIn.Action>
+                        <Button
+                          intent='secondary'
+                          iconStart={<Icon.LinkSm />}
+                        >
+                          <SignIn.SafeIdentifier
+                            transform={(identifier: string) =>
+                              t('signIn.alternativeMethods.blockButton__emailLink', {
+                                identifier,
+                              })
+                            }
+                          />
+                        </Button>
+                      </SignIn.SupportedStrategy>
+
+                      <SignIn.SupportedStrategy
+                        name='email_code'
+                        asChild
+                      >
+                        <Button
+                          intent='secondary'
+                          iconStart={<Icon.EnvelopeSm />}
+                        >
+                          <SignIn.SafeIdentifier
+                            transform={(identifier: string) =>
+                              t('signIn.alternativeMethods.blockButton__emailCode', {
+                                identifier,
+                              })
+                            }
+                          />
+                        </Button>
+                      </SignIn.SupportedStrategy>
+
+                      <SignIn.SupportedStrategy
+                        name='phone_code'
+                        asChild
+                      >
+                        <Button
+                          intent='secondary'
+                          iconStart={<Icon.SMSSm />}
+                        >
+                          <SignIn.SafeIdentifier
+                            transform={(identifier: string) =>
+                              t('signIn.alternativeMethods.blockButton__phoneCode', {
+                                identifier,
+                              })
+                            }
+                          />
+                        </Button>
+                      </SignIn.SupportedStrategy>
+
+                      <SignIn.SupportedStrategy
+                        name='passkey'
+                        asChild
+                      >
+                        <Button
+                          intent='secondary'
+                          iconStart={<Icon.FingerprintSm />}
+                        >
+                          {t('signIn.alternativeMethods.blockButton__passkey')}
+                        </Button>
+                      </SignIn.SupportedStrategy>
+
+                      <SignIn.SupportedStrategy
+                        name='password'
+                        asChild
+                      >
+                        <Button
+                          intent='secondary'
+                          iconStart={<Icon.LockSm />}
+                        >
+                          {t('signIn.alternativeMethods.blockButton__password')}
+                        </Button>
+                      </SignIn.SupportedStrategy>
+
+                      {
+                        // `SupportedStrategy`s that are only intended for use
+                        // within `choose-strategy`, not the `forgot-password`
+                        // `Step
+                      }
+                      <SignIn.SupportedStrategy
+                        name='totp'
+                        asChild
+                      >
+                        <Button intent='secondary'>{t('signIn.alternativeMethods.blockButton__totp')}</Button>
+                      </SignIn.SupportedStrategy>
+
+                      <SignIn.SupportedStrategy
+                        name='backup_code'
+                        asChild
+                      >
+                        <Button intent='secondary'>{t('signIn.alternativeMethods.blockButton__backupCode')}</Button>
+                      </SignIn.SupportedStrategy>
                     </div>
+
+                    <SignIn.Action
+                      navigate='previous'
+                      asChild
+                    >
+                      <LinkButton>{t('backButton')}</LinkButton>
+                    </SignIn.Action>
                   </div>
                 </Card.Body>
               </Card.Content>

--- a/packages/ui/src/components/sign-in/steps/start.tsx
+++ b/packages/ui/src/components/sign-in/steps/start.tsx
@@ -42,7 +42,7 @@ export function SignInStart() {
   return (
     <Common.Loading scope='global'>
       {isGlobalLoading => {
-        const conntections = [
+        const connectionsWithSeperator = [
           <Connections disabled={isGlobalLoading} />,
           hasConnection && hasIdentifier ? <Separator>{t('dividerText')}</Separator> : null,
         ];
@@ -59,7 +59,7 @@ export function SignInStart() {
                 <GlobalError />
 
                 <Card.Body>
-                  {layout.socialButtonsPlacement === 'top' ? conntections : null}
+                  {layout.socialButtonsPlacement === 'top' ? connectionsWithSeperator : null}
 
                   {hasIdentifier ? (
                     <div className='flex flex-col gap-4'>
@@ -126,7 +126,7 @@ export function SignInStart() {
                       ) : null}
                     </div>
                   ) : null}
-                  {layout.socialButtonsPlacement === 'bottom' ? conntections.reverse() : null}
+                  {layout.socialButtonsPlacement === 'bottom' ? connectionsWithSeperator.reverse() : null}
                 </Card.Body>
                 <Card.Actions>
                   <Common.Loading scope='submit'>

--- a/packages/ui/src/components/sign-in/steps/start.tsx
+++ b/packages/ui/src/components/sign-in/steps/start.tsx
@@ -11,6 +11,7 @@ import { PhoneNumberField } from '~/common/phone-number-field';
 import { PhoneNumberOrUsernameField } from '~/common/phone-number-or-username-field';
 import { UsernameField } from '~/common/username-field';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
+import { useAppearance } from '~/contexts';
 import { useAttributes } from '~/hooks/use-attributes';
 import { useCard } from '~/hooks/use-card';
 import { useDevModeWarning } from '~/hooks/use-dev-mode-warning';
@@ -35,11 +36,16 @@ export function SignInStart() {
   const hasConnection = enabledConnections.length > 0;
   const hasIdentifier = emailAddressEnabled || usernameEnabled || phoneNumberEnabled;
   const isDev = useDevModeWarning();
+  const { layout } = useAppearance().parsedAppearance;
   const { logoProps, footerProps } = useCard();
 
   return (
     <Common.Loading scope='global'>
       {isGlobalLoading => {
+        const conntections = [
+          <Connections disabled={isGlobalLoading} />,
+          hasConnection && hasIdentifier ? <Separator>{t('dividerText')}</Separator> : null,
+        ];
         return (
           <SignIn.Step name='start'>
             <Card.Root banner={isDev ? LOCALIZATION_NEEDED.developmentMode : null}>
@@ -53,9 +59,7 @@ export function SignInStart() {
                 <GlobalError />
 
                 <Card.Body>
-                  <Connections disabled={isGlobalLoading} />
-
-                  {hasConnection && hasIdentifier ? <Separator>{t('dividerText')}</Separator> : null}
+                  {layout.socialButtonsPlacement === 'top' ? conntections : null}
 
                   {hasIdentifier ? (
                     <div className='flex flex-col gap-4'>
@@ -122,6 +126,7 @@ export function SignInStart() {
                       ) : null}
                     </div>
                   ) : null}
+                  {layout.socialButtonsPlacement === 'bottom' ? conntections.reverse() : null}
                 </Card.Body>
                 <Card.Actions>
                   <Common.Loading scope='submit'>

--- a/packages/ui/src/components/sign-up/steps/start.tsx
+++ b/packages/ui/src/components/sign-up/steps/start.tsx
@@ -12,6 +12,7 @@ import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
 import { UsernameField } from '~/common/username-field';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
+import { useAppearance } from '~/contexts';
 import { useAttributes } from '~/hooks/use-attributes';
 import { useCard } from '~/hooks/use-card';
 import { useDevModeWarning } from '~/hooks/use-dev-mode-warning';
@@ -40,11 +41,16 @@ export function SignUpStart() {
   const hasConnection = enabledConnections.length > 0;
   const hasIdentifier = emailAddressEnabled || usernameEnabled || phoneNumberEnabled;
   const isDev = useDevModeWarning();
+  const { layout } = useAppearance().parsedAppearance;
   const { logoProps, footerProps } = useCard();
 
   return (
     <Common.Loading scope='global'>
       {isGlobalLoading => {
+        const connectionsWithSeperator = [
+          <Connections disabled={isGlobalLoading} />,
+          hasConnection && hasIdentifier ? <Separator>{t('dividerText')}</Separator> : null,
+        ];
         return (
           <SignUp.Step name='start'>
             <Card.Root banner={isDev ? LOCALIZATION_NEEDED.developmentMode : null}>
@@ -62,9 +68,7 @@ export function SignUpStart() {
                 <GlobalError />
 
                 <Card.Body>
-                  <Connections disabled={isGlobalLoading} />
-
-                  {hasConnection && hasIdentifier ? <Separator>{t('dividerText')}</Separator> : null}
+                  {layout.socialButtonsPlacement === 'top' ? connectionsWithSeperator : null}
 
                   {hasIdentifier ? (
                     <div className='flex flex-col gap-4'>
@@ -117,6 +121,8 @@ export function SignUpStart() {
                       ) : null}
                     </div>
                   ) : null}
+
+                  {layout.socialButtonsPlacement === 'bottom' ? connectionsWithSeperator.reverse() : null}
 
                   {userSettings.signUp.captcha_enabled ? <SignUp.Captcha className='empty:hidden' /> : null}
                 </Card.Body>

--- a/packages/ui/theme-builder/app/components/logo.tsx
+++ b/packages/ui/theme-builder/app/components/logo.tsx
@@ -1,4 +1,4 @@
-import { SVGAttributes } from 'react';
+import type { SVGAttributes } from 'react';
 
 export const Logo = (props: SVGAttributes<SVGElement>) => (
   <svg

--- a/packages/ui/theme-builder/app/page.tsx
+++ b/packages/ui/theme-builder/app/page.tsx
@@ -2,7 +2,10 @@ import { SignedIn, SignedOut, SignInButton, SignUpButton, UserButton } from '@cl
 
 function Button({ children }: { children: React.ReactNode }) {
   return (
-    <button className='relative isolate rounded border bg-white bg-gradient-to-b from-white to-neutral-50 px-2.5 py-1 text-sm font-medium'>
+    <button
+      className='relative isolate rounded border bg-white bg-gradient-to-b from-white to-neutral-50 px-2.5 py-1 text-sm font-medium'
+      type='button'
+    >
       {children}
     </button>
   );

--- a/packages/ui/theme-builder/app/theme-builder.tsx
+++ b/packages/ui/theme-builder/app/theme-builder.tsx
@@ -39,6 +39,7 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
   const [spacingUnit, setSpacingUnit] = useState(spacingUnitDefault);
   const [fontSize, setFontSize] = useState(fontSizeDefault);
   const [devMode, setDevMode] = useState('on');
+  const [socialButtonsPlacement, setSocialButtonsPlacement] = useState('top');
   const handleReset = () => {
     setLightAccent(lightAccentDefault);
     setLightGray(lightGrayDefault);
@@ -77,7 +78,14 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
   }, [dir]);
   return (
     <ClerkProvider key={devMode}>
-      <AppearanceProvider appearance={{ layout: { unsafe_disableDevelopmentModeWarnings: devMode === 'off' } }}>
+      <AppearanceProvider
+        appearance={{
+          layout: {
+            unsafe_disableDevelopmentModeWarnings: devMode === 'off',
+            socialButtonsPlacement: socialButtonsPlacement as 'top' | 'bottom' | undefined,
+          },
+        }}
+      >
         <style
           dangerouslySetInnerHTML={{
             __html: css,
@@ -167,6 +175,21 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
                 ]}
                 value={dir}
                 onValueChange={setDir}
+              />
+              <ToggleGroup
+                label='Social button placement'
+                items={[
+                  {
+                    label: 'Top',
+                    value: 'top',
+                  },
+                  {
+                    label: 'Bottom',
+                    value: 'bottom',
+                  },
+                ]}
+                value={socialButtonsPlacement}
+                onValueChange={setSocialButtonsPlacement}
               />
               <ToggleGroup
                 label='Dev mode'

--- a/packages/ui/theme-builder/app/theme-builder.tsx
+++ b/packages/ui/theme-builder/app/theme-builder.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { ClerkProvider } from '@clerk/nextjs';
+import type { Layout } from '@clerk/types';
 import { AppearanceProvider } from '@clerk/ui/contexts';
 import { cx } from 'cva';
 import { usePathname, useRouter } from 'next/navigation';
@@ -82,7 +83,7 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
         appearance={{
           layout: {
             unsafe_disableDevelopmentModeWarnings: devMode === 'off',
-            socialButtonsPlacement: socialButtonsPlacement as 'top' | 'bottom' | undefined,
+            socialButtonsPlacement: socialButtonsPlacement as Layout['socialButtonsPlacement'],
           },
         }}
       >

--- a/packages/ui/theme-builder/app/theme-builder.tsx
+++ b/packages/ui/theme-builder/app/theme-builder.tsx
@@ -3,13 +3,13 @@ import { ClerkProvider } from '@clerk/nextjs';
 import { AppearanceProvider } from '@clerk/ui/contexts';
 import { cx } from 'cva';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ColorPicker } from './color-picker';
+import { Logo } from './components/logo';
 import { generateColors, getPreviewStyles } from './generate-colors';
 import { ThemeDialog } from './theme-dialog';
 import { ToggleGroup } from './toggle-group';
-import { Logo } from './components/logo';
 
 const lightAccentDefault = '#6C47FF';
 const lightGrayDefault = '#2f3037';
@@ -26,6 +26,7 @@ const fontSizeDefault = '0.8125rem';
 export function ThemeBuilder({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
+  const previewRef = useRef<HTMLDivElement>(null);
   const [dir, setDir] = useState('ltr');
   const [appearance, setAppearance] = useState('light');
   const [lightAccent, setLightAccent] = useState(lightAccentDefault);
@@ -70,7 +71,9 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
     fontSize,
   });
   useEffect(() => {
-    document.documentElement.dir = dir;
+    if (previewRef.current) {
+      previewRef.current.dir = dir;
+    }
   }, [dir]);
   return (
     <ClerkProvider key={devMode}>
@@ -80,7 +83,7 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
             __html: css,
           }}
         />
-        <div className='z-1 pointer-events-none fixed inset-x-0 top-0 z-50 h-[calc(theme(size.1)-theme(ringWidth.1))] bg-neutral-100'></div>
+        <div className='z-1 pointer-events-none fixed inset-x-0 top-0 z-50 h-[calc(theme(size.1)-theme(ringWidth.1))] bg-neutral-100' />
         <div
           className={cx(
             'm-1 mb-0 grid h-[calc(100dvh-theme(size.1))] grid-cols-[min-content,minmax(0,1fr)] grid-rows-[min-content,minmax(0,1fr)] overflow-hidden rounded-t-xl bg-white ring-1 ring-neutral-900/[0.075]',
@@ -291,6 +294,7 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
           </aside>
 
           <figure
+            ref={previewRef}
             className={cx('relative isolate grid items-center overflow-y-auto p-8', {
               'bg-white': appearance === 'light',
               'dark bg-neutral-950': appearance === 'dark',


### PR DESCRIPTION
## Description

Implements `socialButtonsPlacement` logic.

Example:

```tsx
<SignIn
  appearance={{
    layout: {
      socialButtonsPlacement: 'bottom',
    },
  }}
/>
```

| Top | Bottom |
|--------|--------|
| <img width="1392" alt="Screenshot 2024-08-20 at 4 09 33 PM" src="https://github.com/user-attachments/assets/7c20ba2d-a592-472d-8228-cffabc22ec4c"> | <img width="1392" alt="Screenshot 2024-08-20 at 4 08 12 PM" src="https://github.com/user-attachments/assets/3391e411-990f-41be-8f87-fb53ab1106cc"> | 

Closes SDKI-559

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
