### PR TITLE
chore(nextjs): Fix server actions detection

### DIFF
--- a/.changeset/selfish-trainers-shop.md
+++ b/.changeset/selfish-trainers-shop.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Fix server actions detection

--- a/packages/nextjs/src/server/nextFetcher.ts
+++ b/packages/nextjs/src/server/nextFetcher.ts
@@ -12,6 +12,10 @@ type NextFetcher = Fetcher & {
  * Full type can be found https://github.com/vercel/next.js/blob/6185444e0a944a82e7719ac37dad8becfed86acd/packages/next/src/client/components/static-generation-async-storage.external.ts#L4
  */
 interface StaticGenerationAsyncStorage {
+  /**
+   * Available for >=next@13.5.4
+   * A string with a suffix of `/page` or `/route` dictating usage from a page.tsx or a route.tsx file
+   */
   readonly pagePath?: string;
 }
 


### PR DESCRIPTION
## Description

`isServerActionRequest` was still depending on the `next-url` header which no longer is available (removed at `14.0.4` for server actions and in `14.2.3` when requesting RSCs ([Related PR](https://github.com/clerk/javascript/pull/3529))

This PR fixes the issue and prepares the ground for future work that would require these utilities to work properly.

`pagePath` from __nextGetStaticStore is available since `next@13.5.4` until `next@14.2.5` which is the latest stable release

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
