### PR TITLE
fix(astro): Use batched stores to avoid race conditions in auth store

### DIFF
--- a/.changeset/pretty-peas-search.md
+++ b/.changeset/pretty-peas-search.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fix incorrect authentication state when subscribing to client stores.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39015,20 +39015,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/nanostores": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.10.3.tgz",
-      "integrity": "sha512-Nii8O1XqmawqSCf9o2aWqVxhKRN01+iue9/VEd1TiJCr9VT5XxgPFbF1Edl1XN6pwJcZRsl8Ki+z01yb/T/C2g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "dev": true,
@@ -51857,7 +51843,7 @@
         "@clerk/shared": "2.5.2",
         "@clerk/types": "4.14.0",
         "nanoid": "5.0.7",
-        "nanostores": "0.10.3",
+        "nanostores": "0.11.2",
         "path-to-regexp": "6.2.2"
       },
       "devDependencies": {
@@ -51969,6 +51955,20 @@
       },
       "engines": {
         "node": "^18 || >=20"
+      }
+    },
+    "packages/astro/node_modules/nanostores": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.11.0.tgz",
+      "integrity": "sha512-fT2u3vmWmUt93G9dmUgpnbs3AAYJb6lzu7KrJ1FdC/rjFopGiboS3bfKYv6NNkuY6g6eiRakTR48wKSL/F5C+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "packages/backend": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -83,7 +83,7 @@
     "@clerk/shared": "2.5.2",
     "@clerk/types": "4.14.0",
     "nanoid": "5.0.7",
-    "nanostores": "0.10.3",
+    "nanostores": "0.11.2",
     "path-to-regexp": "6.2.2"
   },
   "devDependencies": {

--- a/packages/astro/src/stores/external.ts
+++ b/packages/astro/src/stores/external.ts
@@ -1,6 +1,6 @@
 import { deriveState } from '@clerk/shared/deriveState';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
-import { computed, onMount, type Store } from 'nanostores';
+import { batched, computed, onMount, type Store } from 'nanostores';
 
 import { $clerk, $csrState, $initialState } from './internal';
 
@@ -13,7 +13,7 @@ import { $clerk, $csrState, $initialState } from './internal';
  *
  * $authStore.subscribe((auth) => console.log(auth.userId))
  */
-export const $authStore = computed([$csrState, $initialState], (state, initialState) => {
+export const $authStore = batched([$csrState, $initialState], (state, initialState) => {
   return deriveState(
     state.isLoaded,
     {

--- a/packages/astro/src/stores/internal.ts
+++ b/packages/astro/src/stores/internal.ts
@@ -16,10 +16,10 @@ export const $csrState = map<{
   organization: OrganizationResource | undefined | null;
 }>({
   isLoaded: false,
-  client: null,
-  user: null,
-  session: null,
-  organization: null,
+  client: undefined,
+  user: undefined,
+  session: undefined,
+  organization: undefined,
 });
 
 export const $initialState = map<InitialState>();


### PR DESCRIPTION
## Description

This PR fixes an issue where the `$authStore` nanostore goes back to its initial values (`null/undefined`) after clerk-js has been loaded. See what's happening in the screen recording below:

https://github.com/user-attachments/assets/66a73350-34eb-4d76-9b0a-db91683b0df4

This is happening because `computed` stores react each time any of their dependencies get updated. In our case, the `$csrStore` and `$initialState` stores. It resets back to `undefined` even though we have an initial value because of how the [`derivedStore`](https://github.com/clerk/javascript/blob/main/packages/shared/src/deriveState.ts) function works:

1. We set the `$initialState` coming from SSR, we have an `$authStore` value [available](https://github.com/clerk/javascript/blob/ed7baa0488df0ee4c48add2aac934ffb47e4a6d2/packages/shared/src/deriveState.ts#L13).
2. Next, after clerk-js has been loaded, we set the `isLoaded` property of `$csrStore` to `true`, and `derivedState` will recalculate and [give us the client state and not SSR state](https://github.com/clerk/javascript/blob/ed7baa0488df0ee4c48add2aac934ffb47e4a6d2/packages/shared/src/deriveState.ts#L15), which at this time is still undefined since [it didn't reach the listener for resources yet](https://github.com/clerk/javascript/blob/ed7baa0488df0ee4c48add2aac934ffb47e4a6d2/packages/astro/src/internal/create-clerk-instance.ts#L55). This is where we get `undefined` values again.
3. Next, we are setting each key of the resources (client, user, org, session), and each action will trigger the computed `$authStore` again, giving us different values.

This is where the `batched` store comes in. This store will wait until the end of a tick to update itself. This is what we want for `derivedState` to give a correct output in SSR and CSR:

https://github.com/user-attachments/assets/a89dc4fb-6e99-488c-96b8-da5501e95354

All other stores should work properly as they depend on the `$authStore`.

Fixes ECO-162

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
