### PR TITLE
fix(clerk-js): Update MFA second factor default UI logic

### DIFF
--- a/.changeset/three-feet-nail.md
+++ b/.changeset/three-feet-nail.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix issue where MFA two-factor UI was incorrectly rendering set default action in SMS code when TOTP strategy was defined.

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
@@ -150,10 +150,11 @@ const MfaPhoneCodeMenu = ({ phone, showTOTP }: MfaPhoneCodeMenuProps) => {
 
   const actions = (
     [
-      showTOTP
+      !showTOTP
         ? {
             label: localizationKeys('userProfile.start.mfaSection.phoneCode.actionLabel__setDefault'),
             onClick: () => phone.makeDefaultSecondFactor().catch(err => handleError(err, [], card.setError)),
+            isDisabled: phone.defaultSecondFactor,
           }
         : null,
       {


### PR DESCRIPTION
## Description

Currently, when you have both an TOTP + sms code two-step verification, we show the ability to set an SMS code as default but TOTP always takes precedence which makes for confusing behavior where users think they can set the SMS code as the default.

There is also a scenario where a user doesn't have a TOTP code setup, and two sms codes but they are not able to set the default SMS code due to TOTP code not available https://github.com/clerk/javascript/blob/22f19d3bfa987268610e93d2028815d12b374110/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx#L96

This PR updates the `MfaPhoneCodeMenu` logic to only allow setting sms code as default when there is no TOTP code set, and disables set default on sms codes when current sms code is already set as default.

https://github.com/user-attachments/assets/a370209b-eda4-4ba2-a322-ff8a27401605

fixes SDKI-615

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
