### PR TITLE
fix(clerk-js): Fallback to window location for modal sign in/up button flows

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -365,7 +365,7 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls.ensureMounted({ preloadHint: 'SignIn' }).then(controls =>
       controls.openModal('signIn', {
         ...props,
-        forceRedirectUrl: props.forceRedirectUrl || window.location.href,
+        fallbackRedirectUrl: props.fallbackRedirectUrl || window.location.href,
       }),
     );
   };
@@ -388,7 +388,7 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls.ensureMounted({ preloadHint: 'SignUp' }).then(controls =>
       controls.openModal('signUp', {
         ...props,
-        forcedRedirectUrl: props.forcedRedirectUrl || window.location.href,
+        fallbackRedirectUrl: props.fallbackRedirectUrl || window.location.href,
       }),
     );
   };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -362,9 +362,12 @@ export class Clerk implements ClerkInterface {
       }
       return;
     }
-    void this.#componentControls
-      .ensureMounted({ preloadHint: 'SignIn' })
-      .then(controls => controls.openModal('signIn', props || {}));
+    void this.#componentControls.ensureMounted({ preloadHint: 'SignIn' }).then(controls =>
+      controls.openModal('signIn', {
+        ...props,
+        forceRedirectUrl: props.forceRedirectUrl || window.location.href,
+      }),
+    );
   };
 
   public closeSignIn = (): void => {
@@ -382,9 +385,12 @@ export class Clerk implements ClerkInterface {
       }
       return;
     }
-    void this.#componentControls
-      .ensureMounted({ preloadHint: 'SignUp' })
-      .then(controls => controls.openModal('signUp', props || {}));
+    void this.#componentControls.ensureMounted({ preloadHint: 'SignUp' }).then(controls =>
+      controls.openModal('signUp', {
+        ...props,
+        forcedRedirectUrl: props.forcedRedirectUrl || window.location.href,
+      }),
+    );
   };
 
   public closeSignUp = (): void => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -362,12 +362,9 @@ export class Clerk implements ClerkInterface {
       }
       return;
     }
-    void this.#componentControls.ensureMounted({ preloadHint: 'SignIn' }).then(controls =>
-      controls.openModal('signIn', {
-        ...props,
-        fallbackRedirectUrl: props.fallbackRedirectUrl || window.location.href,
-      }),
-    );
+    void this.#componentControls
+      .ensureMounted({ preloadHint: 'SignIn' })
+      .then(controls => controls.openModal('signIn', props || {}));
   };
 
   public closeSignIn = (): void => {
@@ -385,12 +382,9 @@ export class Clerk implements ClerkInterface {
       }
       return;
     }
-    void this.#componentControls.ensureMounted({ preloadHint: 'SignUp' }).then(controls =>
-      controls.openModal('signUp', {
-        ...props,
-        fallbackRedirectUrl: props.fallbackRedirectUrl || window.location.href,
-      }),
-    );
+    void this.#componentControls
+      .ensureMounted({ preloadHint: 'SignUp' })
+      .then(controls => controls.openModal('signUp', props || {}));
   };
 
   public closeSignUp = (): void => {

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -98,6 +98,9 @@ export type SignUpForceRedirectUrl = {
   signUpForceRedirectUrl?: string | null;
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future release.
+ */
 export type SignUpFallbackRedirectUrl = {
   /**
    * Full URL or path to navigate after successful sign up.
@@ -107,6 +110,9 @@ export type SignUpFallbackRedirectUrl = {
   signUpFallbackRedirectUrl?: string | null;
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future release.
+ */
 export type SignInFallbackRedirectUrl = {
   /**
    * Full URL or path to navigate after successful sign in.


### PR DESCRIPTION
## Description

When `<SignInButton />` and `<SignUpButton />` are used in `modal` mode, fallback to current window location when no `fallbackRedirectUrl` prop is provided. This feels like the right behavior default for the usage of `modals` keeping the user on the page, the modal was initiated from.

fixes SDKI-616

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
