### PR TITLE
fix(astro): Remove extra character and improve Clerk nanostore

### DIFF
--- a/.changeset/friendly-waves-cheat.md
+++ b/.changeset/friendly-waves-cheat.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fixes a bug where subscribing to the `$clerkStore` nanostore would give incorrect values.

--- a/packages/astro/src/astro-components/control/SignedOut.astro
+++ b/packages/astro/src/astro-components/control/SignedOut.astro
@@ -20,4 +20,4 @@ const SignedOutComponent = isStaticOutput(isStatic) ? SignedOutCSR : SignedOutSS
 
 <SignedOutComponent class={className}>
   <slot />
-</SignedOutComponent>c
+</SignedOutComponent>

--- a/packages/astro/src/internal/create-clerk-instance.ts
+++ b/packages/astro/src/internal/create-clerk-instance.ts
@@ -1,6 +1,7 @@
 import { loadClerkJsScript, setClerkJsLoadingErrorPackageName } from '@clerk/shared/loadClerkJsScript';
 import type { ClerkOptions } from '@clerk/types';
 
+import { $clerkStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
 import type { AstroClerkCreateInstanceParams, AstroClerkUpdateOptions } from '../types';
 import { invokeClerkAstroJSFunctions } from './invoke-clerk-astro-js-functions';
@@ -53,6 +54,11 @@ async function createClerkInstanceInternal(options?: AstroClerkCreateInstancePar
     .load(initOptions)
     .then(() => {
       $csrState.setKey('isLoaded', true);
+      // Notify subscribers that $clerkStore has been loaded.
+      // We're doing this because nanostores uses `===` for equality
+      // and just by setting the value to `window.Clerk` again won't trigger an update.
+      // We notify only once as this store is for advanced users.
+      $clerkStore.notify();
 
       mountAllClerkAstroJSComponents();
       invokeClerkAstroJSFunctions();


### PR DESCRIPTION
## Description

This PR fixes an issue where `$clerkStore` never gets updated even after Clerk JS has been loaded.

See comment in [this PR](https://github.com/clerk/javascript/pull/3911/files#r1720870617) for more info.

```ts
import { $clerkStore } from '@clerk/astro/client'

$clerkStore.subscribe((clerk) => {
  console.log('clerk', clerk?.loaded) // loaded now gives correct values
})
```

<img width="300" alt="Screenshot 2024-08-22 at 10 26 49 AM" src="https://github.com/user-attachments/assets/427cb8b3-20f8-4a6e-b77c-7a04f9e33a08">

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
