### PR TITLE
fix(clerk-js): Fix undefined properties error in `ConnectedAccountsMenu.tsx`

### DIFF
--- a/.changeset/famous-eggs-cough.md
+++ b/.changeset/famous-eggs-cough.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+---
+
+- Fixes an issue in Connected Accounts menu that was related to Custom OAuth Providers:
+- Resolves undefined properties error that occurred when a Custom OAuth Provider was `enabled` but `authenticatable` was set to `false`.

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -51,7 +51,15 @@ export const useEnabledThirdPartyProviders = () => {
     s => !oauthStrategies.includes(s) && s.startsWith('oauth_custom_'),
   );
 
-  customSocialProviderStrategies.forEach(s => {
+  // Get all custom OAuth providers
+  const allCustomOAuthProviders = Object.keys(social).filter(s => s.startsWith('oauth_custom_')) as OAuthStrategy[];
+
+  // Get all active custom social providers
+  const activeCustomSocialStrategies = socialProviderStrategies.filter(
+    s => !oauthStrategies.includes(s) || s.startsWith('oauth_custom_'),
+  );
+
+  allCustomOAuthProviders.forEach(s => {
     const providerName = s.replace('oauth_', '') as OAuthProvider;
     providerToDisplayData[providerName] = {
       strategy: s,
@@ -60,7 +68,7 @@ export const useEnabledThirdPartyProviders = () => {
     };
   });
 
-  customAuthenticatableSocialStrategies.forEach(s => {
+  activeCustomSocialStrategies.forEach(s => {
     const providerId = s.replace('oauth_', '') as OAuthProvider;
     strategyToDisplayData[s] = {
       id: providerId,


### PR DESCRIPTION
## Description

In this pr we are fixing undefined properties error in `ConnectedAccountsMenu.tsx` when Custom OAuth Provider is `active` and `authenticatable` is `false`

The error was:
<img width="892" alt="Screenshot 2024-08-24 at 12 24 41 AM" src="https://github.com/user-attachments/assets/0c1896cf-40e4-49c1-bf08-b07b27488a38">

The bug was that we populated the `strategyToDisplayData` with `authenticatable` instead of `active` Custom OAuth Providers. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
