### PR TITLE
feat(types): Add Hugging Face OAuth Provider constants

### DIFF
--- a/.changeset/selfish-dogs-taste.md
+++ b/.changeset/selfish-dogs-taste.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/types": patch
+---
+
+Introduce support for the Hugging Face OAuth Provider.

--- a/packages/clerk-js/src/ui/hooks/__tests__/useEnabledThirdPartyProviders.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/useEnabledThirdPartyProviders.test.tsx
@@ -41,6 +41,7 @@ describe('useEnabledThirdPartyProviders', () => {
       'oauth_gitlab',
       'oauth_google',
       'oauth_hubspot',
+      'oauth_huggingface',
       'oauth_instagram',
       'oauth_line',
       'oauth_linear',

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -36,6 +36,7 @@ export type SlackOauthProvider = 'slack';
 export type LinearOauthProvider = 'linear';
 export type XOauthProvider = 'x';
 export type EnstallOauthProvider = 'enstall';
+export type HuggingfaceOAuthProvider = 'huggingface';
 export type CustomOauthProvider = `custom_${string}`;
 
 export type OAuthProvider =
@@ -66,6 +67,7 @@ export type OAuthProvider =
   | LinearOauthProvider
   | XOauthProvider
   | EnstallOauthProvider
+  | HuggingfaceOAuthProvider
   | CustomOauthProvider;
 
 export const OAUTH_PROVIDERS: OAuthProviderData[] = [
@@ -230,6 +232,12 @@ export const OAUTH_PROVIDERS: OAuthProviderData[] = [
     strategy: 'oauth_enstall',
     name: 'Enstall',
     docsUrl: 'https://clerk.com/docs/authentication/social-connections/enstall',
+  },
+  {
+    provider: 'huggingface',
+    strategy: 'oauth_huggingface',
+    name: 'Hugging Face',
+    docsUrl: 'https://clerk.com/docs/authentication/social-connections/huggingface',
   },
 ];
 


### PR DESCRIPTION
Add constants for Hugging Face built in OAuth Provider. 

- [x] Add provider implementation - [PR](https://github.com/clerk/clerk_go/pull/7472).
- [x] Update `@clerk/types` with new constant - This PR
- [x] Add provider in the dashboard - [PR](https://github.com/clerk/dashboard/pull/3495)
- [x] Docs - [PR](https://github.com/clerk/clerk-docs/pull/1492)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
