### PR TITLE
feat(tailwindcss-transformer): Add support for empty class names

### DIFF
--- a/.changeset/strong-emus-sleep.md
+++ b/.changeset/strong-emus-sleep.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tailwindcss-transformer": patch
+---
+
+Add support for empty class names and cl-test prefixed classes

--- a/packages/tailwindcss-transformer/src/__tests__/__snapshots__/transform-classname-cl-test.test.ts.snap
+++ b/packages/tailwindcss-transformer/src/__tests__/__snapshots__/transform-classname-cl-test.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty className 1`] = `
+"const Button: React.FC<ButtonProps> = ({ children, className }) => {
+    return <button className='cl-test-123'>{children}</button>
+  }"
+`;

--- a/packages/tailwindcss-transformer/src/__tests__/__snapshots__/transform-classname-empty.test.ts.snap
+++ b/packages/tailwindcss-transformer/src/__tests__/__snapshots__/transform-classname-empty.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty className 1`] = `
+"const Button: React.FC<ButtonProps> = ({ children, className }) => {
+    return <button className=''>{children}</button>
+  }"
+`;

--- a/packages/tailwindcss-transformer/src/__tests__/transform-classname-cl-test.test.ts
+++ b/packages/tailwindcss-transformer/src/__tests__/transform-classname-cl-test.test.ts
@@ -1,0 +1,13 @@
+import { transform } from '../index';
+
+test('empty className', () => {
+  const result = transform(
+    `const Button: React.FC<ButtonProps> = ({ children, className }) => {
+    return <button className='cl-test-123'>{children}</button>
+  }`,
+    {
+      styleCache: new Map(),
+    },
+  );
+  expect(result).toMatchSnapshot();
+});

--- a/packages/tailwindcss-transformer/src/__tests__/transform-classname-empty.test.ts
+++ b/packages/tailwindcss-transformer/src/__tests__/transform-classname-empty.test.ts
@@ -1,0 +1,13 @@
+import { transform } from '../index';
+
+test('empty className', () => {
+  const result = transform(
+    `const Button: React.FC<ButtonProps> = ({ children, className }) => {
+    return <button className=''>{children}</button>
+  }`,
+    {
+      styleCache: new Map(),
+    },
+  );
+  expect(result).toMatchSnapshot();
+});

--- a/packages/tailwindcss-transformer/src/index.ts
+++ b/packages/tailwindcss-transformer/src/index.ts
@@ -15,6 +15,7 @@ import { replaceVariableScope } from './replace-variable-scope';
 type StyleCache = Map<string, string>;
 
 const clRegex = /^cl-[a-z0-9]{8}$/;
+const clTestRegex = /^cl-test/;
 
 function isBinaryExpression(node: recast.types.namedTypes.BinaryExpression) {
   return recast.types.namedTypes.BinaryExpression.check(node);
@@ -45,6 +46,9 @@ function visitNode(node: recast.types.ASTNode, ctx: { styleCache: StyleCache }, 
       if (clRegex.test(path.node.value)) {
         return false;
       }
+      if (clTestRegex.test(path.node.value)) {
+        return false;
+      }
       if (isBinaryExpression(path.parentPath.node)) {
         return false;
       }
@@ -52,6 +56,9 @@ function visitNode(node: recast.types.ASTNode, ctx: { styleCache: StyleCache }, 
         return false;
       }
       if (path.parentPath.node.type === 'ObjectProperty' && path.parentPath.node.key === path.node) {
+        return false;
+      }
+      if (path.node.value === '') {
         return false;
       }
       const cn = generateHashedClassName(path.node.value);


### PR DESCRIPTION
## Description

This PR adds support for empty class names and `cl-test` prefixed class names to our Tailwind transformer. This allows us to use code like `className: ''` without causing a build error. Additionally, it allows for classes such as `cl-test-one` to remain unchanged, and prevents them from throwing errors. This is useful when writing unit tests within source files since it alleviates the need to use actual Tailwind classes.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
