### PR TITLE
chore(clerk-js): Remove sessionId parameter from all verify session methods

### DIFF
--- a/.changeset/calm-rabbits-talk.md
+++ b/.changeset/calm-rabbits-talk.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Remove sessionId parameter from all **experimental** verify session methods.

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -257,7 +257,7 @@ export class User extends BaseResource implements UserResource {
     const json = (
       await BaseResource._fetch({
         method: 'POST',
-        path: `/me/sessions/${User.clerk.session?.id}/verify`,
+        path: `/me/sessions/verify`,
         body: {
           level,
           maxAge,
@@ -289,7 +289,7 @@ export class User extends BaseResource implements UserResource {
     const json = (
       await BaseResource._fetch({
         method: 'POST',
-        path: `/me/sessions/${User.clerk.session?.id}/verify/prepare_first_factor`,
+        path: `/me/sessions/verify/prepare_first_factor`,
         body: {
           ...config,
           strategy: factor.strategy,
@@ -306,7 +306,7 @@ export class User extends BaseResource implements UserResource {
     const json = (
       await BaseResource._fetch({
         method: 'POST',
-        path: `/me/sessions/${User.clerk.session?.id}/verify/attempt_first_factor`,
+        path: `/me/sessions/verify/attempt_first_factor`,
         body: { ...attemptFactor, strategy: attemptFactor.strategy } as any,
       })
     )?.response as unknown as __experimental_SessionVerificationJSON;
@@ -320,7 +320,7 @@ export class User extends BaseResource implements UserResource {
     const json = (
       await BaseResource._fetch({
         method: 'POST',
-        path: `/me/sessions/${User.clerk.session?.id}/verify/prepare_second_factor`,
+        path: `/me/sessions/verify/prepare_second_factor`,
         body: params as any,
       })
     )?.response as unknown as __experimental_SessionVerificationJSON;
@@ -334,7 +334,7 @@ export class User extends BaseResource implements UserResource {
     const json = (
       await BaseResource._fetch({
         method: 'POST',
-        path: `/me/sessions/${User.clerk.session?.id}/verify/attempt_second_factor`,
+        path: `/me/sessions/verify/attempt_second_factor`,
         body: params as any,
       })
     )?.response as unknown as __experimental_SessionVerificationJSON;


### PR DESCRIPTION
## Description

Dropping the unnecessary  sessionId parameter from the path. Verifying a session should only be applied to the current active session of a user and can be implicitly defined.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
