### PR TITLE
chore(clerk-js): Add GoogleOneTap to bundlewatch

### DIFF
--- a/.changeset/gorgeous-crabs-judge.md
+++ b/.changeset/gorgeous-crabs-judge.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Change the webpackChunkName of GoogleOneTap from `"oneTap"` to `"onetap"` for consistency.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -12,6 +12,7 @@
     { "path": "./dist/signin*.js", "maxSize": "12KB" },
     { "path": "./dist/signup*.js", "maxSize": "10KB" },
     { "path": "./dist/userbutton*.js", "maxSize": "5KB" },
-    { "path": "./dist/userprofile*.js", "maxSize": "15KB" }
+    { "path": "./dist/userprofile*.js", "maxSize": "15KB" },
+    { "path": "./dist/onetap*.js", "maxSize": "1KB" }
   ]
 }

--- a/packages/clerk-js/src/ui/lazyModules/components.ts
+++ b/packages/clerk-js/src/ui/lazyModules/components.ts
@@ -12,7 +12,7 @@ const componentImportPaths = {
     import(/* webpackChunkName: "organizationswitcher" */ './../components/OrganizationSwitcher'),
   OrganizationList: () => import(/* webpackChunkName: "organizationlist" */ './../components/OrganizationList'),
   ImpersonationFab: () => import(/* webpackChunkName: "impersonationfab" */ './../components/ImpersonationFab'),
-  GoogleOneTap: () => import(/* webpackChunkName: "oneTap" */ './../components/GoogleOneTap'),
+  GoogleOneTap: () => import(/* webpackChunkName: "onetap" */ './../components/GoogleOneTap'),
 } as const;
 
 export const SignIn = lazy(() => componentImportPaths.SignIn().then(module => ({ default: module.SignIn })));


### PR DESCRIPTION
## Description

Monitor bundle size of google one tap.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
