### PR TITLE
chore(types): Update `SAML_IDPS` constant for Microsoft Entra ID

### DIFF
--- a/.changeset/neat-vans-wonder.md
+++ b/.changeset/neat-vans-wonder.md
@@ -1,0 +1,5 @@
+---
+"@clerk/types": patch
+---
+
+Update `SAML_IDPS` constant to refer to Microsoft Entra ID instead of the deprecated Azure AD

--- a/packages/types/src/saml.ts
+++ b/packages/types/src/saml.ts
@@ -17,7 +17,7 @@ export const SAML_IDPS: SamlIdpMap = {
     logo: 'google',
   },
   saml_microsoft: {
-    name: 'Microsoft Azure AD',
+    name: 'Microsoft Entra ID (Formerly AD)',
     logo: 'azure',
   },
   saml_custom: {


### PR DESCRIPTION
## Description

Updates `SAML_IDPS` to mention Microsoft Entra ID instead of Azure AD.

Microsoft Entra ID is the new name for Azure AD. The names Azure Active Directory, Azure AD, and AAD are replaced with Microsoft Entra ID.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
