### PR TITLE
fix(backend): Add missing `deleteSelfEnabled` property in `UpdateUserParams`

### DIFF
--- a/.changeset/quiet-ravens-sneeze.md
+++ b/.changeset/quiet-ravens-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Add missing `deleteSelfEnabled` property in `UpdateUserParams`.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -95,6 +95,7 @@ type UpdateUserParams = {
   backupCodes?: string[];
   externalId?: string;
   createdAt?: Date;
+  deleteSelfEnabled?: boolean;
   createOrganizationEnabled?: boolean;
   createOrganizationsLimit?: number;
 } & UserMetadataParams &


### PR DESCRIPTION
## Description

`deleteSelfEnabled` was missing from the `UpdateUserParams` type

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
