### PR TITLE
feat(ui): Add support icon variant support with `socialButtonsIconVariant` prop

### DIFF
--- a/packages/ui/src/common/connections.tsx
+++ b/packages/ui/src/common/connections.tsx
@@ -6,6 +6,7 @@ import { useAppearance } from '~/contexts';
 import { useEnabledConnections } from '~/hooks/use-enabled-connections';
 import { Button } from '~/primitives/button';
 import * as Icon from '~/primitives/icon';
+import { Image } from '~/primitives/image';
 
 /**
  * Calculates the number of columns given the total number of items and the maximum columns allowed per row.
@@ -54,16 +55,21 @@ function getColumnCount({ length, max }: Record<'length' | 'max', number>): numb
   return Math.ceil(length / numRows);
 }
 
+function iconImageUrl(id: string): string {
+  return `https://img.clerk.com/static/${id}.svg`;
+}
+
 export function Connections(
   props: { columns?: number } & Pick<React.ComponentProps<typeof Button>, 'disabled' | 'textVisuallyHidden'>,
 ) {
   const enabledConnections = useEnabledConnections();
   const { layout } = useAppearance().parsedAppearance;
+  const { socialButtonsVariant, socialButtonsIconVariant } = layout;
   const hasConnection = enabledConnections.length > 0;
   const textVisuallyHidden =
     typeof props?.textVisuallyHidden !== 'undefined'
       ? props.textVisuallyHidden
-      : enabledConnections.length > 2 || layout?.socialButtonsVariant === 'iconButton';
+      : enabledConnections.length > 2 || socialButtonsVariant === 'iconButton';
   const columns = getColumnCount({ length: enabledConnections.length, max: props?.columns || 6 });
 
   return hasConnection ? (
@@ -74,8 +80,6 @@ export function Connections(
       >
         {enabledConnections.map(c => {
           const connection = PROVIDERS.find(provider => provider.id === c.provider);
-          const iconKey = connection?.icon;
-          const IconComponent = iconKey ? Icon[iconKey] : null;
           return (
             <li
               key={c.provider}
@@ -92,7 +96,17 @@ export function Connections(
                         intent='connection'
                         busy={isConnectionLoading}
                         disabled={props?.disabled || isConnectionLoading}
-                        iconStart={IconComponent ? <IconComponent /> : null}
+                        iconStart={
+                          socialButtonsIconVariant === 'color' ? (
+                            <Image
+                              src={iconImageUrl(c.provider)}
+                              className='size-[1em]'
+                              alt=''
+                            />
+                          ) : connection?.icon ? (
+                            React.createElement(Icon[connection.icon])
+                          ) : null
+                        }
                         textVisuallyHidden={textVisuallyHidden}
                       >
                         {connection?.name || c.provider}

--- a/packages/ui/src/contexts/AppearanceContext.tsx
+++ b/packages/ui/src/contexts/AppearanceContext.tsx
@@ -34,7 +34,7 @@ export type ParsedElementsFragment = Partial<PartialTheme>;
  * the main type interacted with within components.
  */
 export type ParsedElements = Record<DescriptorIdentifier, ParsedDescriptor>;
-export type ParsedLayout = Required<Layout>;
+export type ParsedLayout = Required<Layout & { socialButtonsIconVariant: 'color' | 'monochrome' }>;
 
 type ElementsAppearanceConfig = string | (React.CSSProperties & { className?: string });
 
@@ -224,6 +224,7 @@ export const defaultAppearance: ParsedAppearance = {
     logoPlacement: 'inside',
     socialButtonsPlacement: 'top',
     socialButtonsVariant: 'auto',
+    socialButtonsIconVariant: 'color',
     logoImageUrl: '',
     logoLinkUrl: '',
     showOptionalFields: true,

--- a/packages/ui/theme-builder/app/theme-builder.tsx
+++ b/packages/ui/theme-builder/app/theme-builder.tsx
@@ -41,6 +41,7 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
   const [fontSize, setFontSize] = useState(fontSizeDefault);
   const [devMode, setDevMode] = useState('on');
   const [socialButtonsPlacement, setSocialButtonsPlacement] = useState('top');
+  const [socialButtonsIconVariant, setSocialButtonsIconVariant] = useState('color');
   const handleReset = () => {
     setLightAccent(lightAccentDefault);
     setLightGray(lightGrayDefault);
@@ -52,6 +53,8 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
     setSpacingUnit(spacingUnitDefault);
     setFontSize(fontSizeDefault);
     setDevMode('on');
+    setSocialButtonsPlacement('top');
+    setSocialButtonsIconVariant('color');
   };
   const lightResult = generateColors({
     appearance: 'light',
@@ -78,12 +81,14 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
     }
   }, [dir]);
   return (
-    <ClerkProvider key={devMode}>
+    <ClerkProvider key={`${devMode}-${socialButtonsIconVariant}`}>
       <AppearanceProvider
         appearance={{
           layout: {
             unsafe_disableDevelopmentModeWarnings: devMode === 'off',
             socialButtonsPlacement: socialButtonsPlacement as Layout['socialButtonsPlacement'],
+            // @ts-ignore: TODO fix
+            socialButtonsIconVariant: socialButtonsIconVariant,
           },
         }}
       >
@@ -191,6 +196,21 @@ export function ThemeBuilder({ children }: { children: React.ReactNode }) {
                 ]}
                 value={socialButtonsPlacement}
                 onValueChange={setSocialButtonsPlacement}
+              />
+              <ToggleGroup
+                label='Social button icon variant'
+                items={[
+                  {
+                    label: 'Color',
+                    value: 'color',
+                  },
+                  {
+                    label: 'Monochrome',
+                    value: 'monochrome',
+                  },
+                ]}
+                value={socialButtonsIconVariant}
+                onValueChange={setSocialButtonsIconVariant}
               />
               <ToggleGroup
                 label='Dev mode'


### PR DESCRIPTION
## Description

Introduces a new layout appearance prop `socialButtonsIconVariant` which has options for `color` or `monochrome` to render either the color version of the provider icon or a flat monochrome version.

One thing maybe to consider is the custom auth providers that we now support, those obviously won't have monochrome versions available. 

Color:

<img width="525" alt="Screenshot 2024-08-28 at 5 00 51 PM" src="https://github.com/user-attachments/assets/d7974bde-edec-4ce6-a992-94fa5d0ee88e">

Monochrome:

<img width="550" alt="Screenshot 2024-08-28 at 5 01 26 PM" src="https://github.com/user-attachments/assets/2df30895-c6b6-4cbe-92bc-1b09884a313c">


Closes SDKI-630

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
