### PR TITLE
fix(astro): Set default element for Polymorphic components

### DIFF
--- a/.changeset/mighty-roses-give.md
+++ b/.changeset/mighty-roses-give.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fixes an issue where not setting an element in an unstyled component causes a TypeScript error.

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignInProps } from "@clerk/types";
-type Props<Tag extends HTMLTag = HTMLTag> = Polymorphic<SignInProps & { as: Tag; mode?: 'redirect' | 'modal' }>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & { as: Tag; mode?: 'redirect' | 'modal' }>
 
 import { generateSafeId } from '@clerk/astro/internal';
 

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignOutOptions } from '@clerk/types';
-type Props<Tag extends HTMLTag = HTMLTag> = Polymorphic<{ as: Tag; } & SignOutOptions>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<{ as: Tag; } & SignOutOptions>
 
 import { generateSafeId } from '@clerk/astro/internal';
 

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignUpProps } from "@clerk/types";
-type Props<Tag extends HTMLTag = HTMLTag> = Polymorphic<SignUpProps & { as: Tag; mode?: 'redirect' | 'modal' }>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & { as: Tag; mode?: 'redirect' | 'modal' }>
 
 import { generateSafeId } from '@clerk/astro/internal';
 


### PR DESCRIPTION
## Description

This PR sets a default element type to the [Polymorphic](https://docs.astro.build/en/guides/typescript/#polymorphic-type) unstyled Astro components and addresses prop spreading to resolve TS union errors and simplify type evaluation:

<img width="820" alt="Screenshot 2024-08-29 at 3 54 49 PM" src="https://github.com/user-attachments/assets/a4b22653-1996-46f5-aeb8-c28675b3a247">

With a default element:

<img width="817" alt="Screenshot 2024-08-29 at 3 55 47 PM" src="https://github.com/user-attachments/assets/213e5ce1-4f2d-4161-bef9-cb86f7c5e8d9">

Fixes ECO-172

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
