### PR TITLE
fix(backend): Add missing url property to Invitation object

### DIFF
--- a/.changeset/good-snakes-confess.md
+++ b/.changeset/good-snakes-confess.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add url property to the Invitation object

--- a/packages/backend/src/api/resources/Invitation.ts
+++ b/packages/backend/src/api/resources/Invitation.ts
@@ -9,6 +9,7 @@ export class Invitation {
     readonly createdAt: number,
     readonly updatedAt: number,
     readonly status: InvitationStatus,
+    readonly url?: string,
     readonly revoked?: boolean,
   ) {}
 
@@ -20,6 +21,7 @@ export class Invitation {
       data.created_at,
       data.updated_at,
       data.status,
+      data.url,
       data.revoked,
     );
   }


### PR DESCRIPTION
## Description

Adds the `url` property to the Invitation object for the Backend SDK

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
