### PR TITLE
fix(tanstack-start): Fix hard reload flicker

### DIFF
--- a/.changeset/stale-feet-tease.md
+++ b/.changeset/stale-feet-tease.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-start": patch
+---
+
+Fix to prevent hard reload for internal navigation

--- a/packages/tanstack-start/src/client/useAwaitableNavigate.ts
+++ b/packages/tanstack-start/src/client/useAwaitableNavigate.ts
@@ -1,6 +1,6 @@
 import type { NavigateOptions } from '@tanstack/react-router';
 import { useLocation, useNavigate } from '@tanstack/react-router';
-import React from 'react';
+import React, { useTransition } from 'react';
 
 type Resolve = (value?: unknown) => void;
 
@@ -12,20 +12,18 @@ export const useAwaitableNavigate = () => {
     resolveFunctionsRef.current.forEach(resolve => resolve());
     resolveFunctionsRef.current.splice(0, resolveFunctionsRef.current.length);
   };
+  const [_, startTransition] = useTransition();
 
   React.useEffect(() => {
     resolveAll();
   }, [location]);
 
-  return ({ to, replace }: NavigateOptions) => {
+  return (options: NavigateOptions) => {
     return new Promise(res => {
-      resolveFunctionsRef.current.push(res);
-      res(
-        navigate({
-          to,
-          replace,
-        }),
-      );
+      startTransition(() => {
+        resolveFunctionsRef.current.push(res);
+        res(navigate(options));
+      });
     });
   };
 };


### PR DESCRIPTION
## Description

This PR fixes hard reload navigation issue happening when navigating to component internal routes

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
