### PR TITLE
feat(elements): Allow for Passkey events in verifications

### DIFF
--- a/.changeset/silent-students-vanish.md
+++ b/.changeset/silent-students-vanish.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Allow for passkey triggers in the verification steps

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -395,6 +395,9 @@ export const SignInRouterMachine = setup({
         },
       },
       on: {
+        'AUTHENTICATE.PASSKEY': {
+          actions: sendTo('firstFactor', ({ event }) => event),
+        },
         'RESET.STEP': {
           target: 'FirstFactor',
           reenter: true,

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -14,7 +14,7 @@ import type {
   Web3Attempt,
 } from '@clerk/types';
 import type { DoneActorEvent } from 'xstate';
-import { assign, fromPromise, log, sendTo, setup } from 'xstate';
+import { assign, fromPromise, log, not, sendTo, setup } from 'xstate';
 
 import {
   MAGIC_LINK_VERIFY_PATH_ROUTE,
@@ -80,6 +80,18 @@ const SignInVerificationMachine = setup({
     attempt: fromPromise<SignInResource, AttemptFirstFactorInput | AttemptSecondFactorInput>(() =>
       Promise.reject(new ClerkElementsRuntimeError('Actor `attempt` must be overridden')),
     ),
+    attemptPasskey: fromPromise<
+      SignInResource,
+      { parent: SignInRouterMachineActorRef; flow: 'autofill' | 'discoverable' | undefined }
+    >(({ input: { parent, flow } }) => {
+      return parent.getSnapshot().context.clerk.client.signIn.authenticateWithPasskey({
+        flow,
+      });
+    }),
+    // attemptPasskey: fromPromise<
+    //   SignInResource,
+    //   { parent: SignInRouterMachineActorRef; flow: 'autofill' | 'discoverable' | undefined }
+    // >(() => Promise.reject(new ClerkElementsRuntimeError('Actor `attemptPasskey` must be overridden'))),
   },
   actions: {
     resendableTick: assign(({ context }) => ({
@@ -261,6 +273,11 @@ const SignInVerificationMachine = setup({
       tags: ['state:pending'],
       description: 'Waiting for user input',
       on: {
+        'AUTHENTICATE.PASSKEY': {
+          guard: not('isExampleMode'),
+          target: 'AttemptingPasskey',
+          reenter: true,
+        },
         'NAVIGATE.CHOOSE_STRATEGY': 'ChooseStrategy',
         'NAVIGATE.FORGOT_PASSWORD': 'ChooseStrategy',
         RETRY: 'Preparing',
@@ -355,6 +372,25 @@ const SignInVerificationMachine = setup({
         },
       },
     },
+    AttemptingPasskey: {
+      tags: ['state:attempting', 'state:loading'],
+      entry: 'sendToLoading',
+      invoke: {
+        id: 'attemptPasskey',
+        src: 'attemptPasskey',
+        input: ({ context }) => ({
+          parent: context.parent,
+          flow: 'discoverable',
+        }),
+        onDone: {
+          actions: ['sendToNext', 'sendToLoading'],
+        },
+        onError: {
+          actions: ['setFormErrors', 'sendToLoading'],
+          target: 'Pending',
+        },
+      },
+    },
     Hist: {
       type: 'history',
     },
@@ -375,7 +411,7 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
       );
     }),
     prepare: fromPromise(async ({ input }) => {
-      const { params, parent, resendable } = input as PrepareFirstFactorInput;
+      const { params, parent, resendable } = input;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -59,7 +59,7 @@ export type AttemptSecondFactorInput = {
   currentFactor: SignInSecondFactor | null;
 };
 
-const isNonPreperableStrategy = (strategy?: SignInFirstFactor['strategy'] | SignInSecondFactor['strategy']) => {
+const isNonPreparableStrategy = (strategy?: SignInFirstFactor['strategy'] | SignInSecondFactor['strategy']) => {
   if (!strategy) {
     return false;
   }
@@ -183,7 +183,7 @@ const SignInVerificationMachine = setup({
   },
   guards: {
     isResendable: ({ context }) => context.resendable || context.resendableAfter === 0,
-    isNeverResendable: ({ context }) => isNonPreperableStrategy(context.currentFactor?.strategy),
+    isNeverResendable: ({ context }) => isNonPreparableStrategy(context.currentFactor?.strategy),
   },
   delays: SignInVerificationDelays,
   types: {} as SignInVerificationSchema,
@@ -407,14 +407,14 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
       );
     }),
     prepare: fromPromise(async ({ input }) => {
-      const { params, parent, resendable } = input;
+      const { params, parent, resendable } = input as PrepareFirstFactorInput;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send
       const currentVerificationExpiration = clerk.client.signIn.firstFactorVerification.expireAt;
       const needsPrepare = resendable || !currentVerificationExpiration || currentVerificationExpiration < new Date();
 
-      if (isNonPreperableStrategy(params?.strategy) || !needsPrepare) {
+      if (isNonPreparableStrategy(params?.strategy) || !needsPrepare) {
         return Promise.resolve(clerk.client.signIn);
       }
 
@@ -510,7 +510,7 @@ export const SignInSecondFactorMachine = SignInVerificationMachine.provide({
       ),
     ),
     prepare: fromPromise(async ({ input }) => {
-      const { params, parent, resendable } = input;
+      const { params, parent, resendable } = input as PrepareSecondFactorInput;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -88,10 +88,6 @@ const SignInVerificationMachine = setup({
         flow,
       });
     }),
-    // attemptPasskey: fromPromise<
-    //   SignInResource,
-    //   { parent: SignInRouterMachineActorRef; flow: 'autofill' | 'discoverable' | undefined }
-    // >(() => Promise.reject(new ClerkElementsRuntimeError('Actor `attemptPasskey` must be overridden'))),
   },
   actions: {
     resendableTick: assign(({ context }) => ({


### PR DESCRIPTION
## Description

Enables `AUTHENTICATE.PASSKEY` to be called from within the First Factor verification step.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Fixes SDKI-640

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
