### PR TITLE
fix(clerk-js): Ensure we do not access `addEventListener` and `dispatchEvent` in non-browser environments

### DIFF
--- a/.changeset/modern-foxes-run.md
+++ b/.changeset/modern-foxes-run.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Ensure we don't access `window.addEventListener()` and `window.dispatchEvent` in non-browser environments.

--- a/packages/clerk-js/src/utils/injectedWeb3Providers.ts
+++ b/packages/clerk-js/src/utils/injectedWeb3Providers.ts
@@ -35,13 +35,18 @@ export class InjectedWeb3Providers {
     coinbase: 'Coinbase Wallet',
     metamask: 'MetaMask',
   } as const;
+  #hasSetupEventListeners = false;
 
   constructor() {
     if (typeof window === 'undefined') {
       return;
     }
-    window.addEventListener('eip6963:announceProvider', this.#onAnnouncement as EventListener);
-    window.dispatchEvent(new Event('eip6963:requestProvider'));
+
+    if (!this.#hasSetupEventListeners) {
+      window.addEventListener('eip6963:announceProvider', this.#onAnnouncement as EventListener);
+      window.dispatchEvent(new Event('eip6963:requestProvider'));
+      this.#hasSetupEventListeners = true;
+    }
   }
 
   get = (provider: InjectedWeb3Provider) => {

--- a/packages/clerk-js/src/utils/injectedWeb3Providers.ts
+++ b/packages/clerk-js/src/utils/injectedWeb3Providers.ts
@@ -29,7 +29,7 @@ interface EIP6963ProviderDetail {
 type EIP6963AnnounceProviderEvent = CustomEvent;
 type InjectedWeb3Provider = MetamaskWeb3Provider | CoinbaseWeb3Provider;
 
-class InjectedWeb3Providers {
+export class InjectedWeb3Providers {
   #providers: EIP6963ProviderDetail[] = [];
   #providerIdMap: Record<InjectedWeb3Provider, string> = {
     coinbase: 'Coinbase Wallet',
@@ -55,5 +55,3 @@ class InjectedWeb3Providers {
     this.#providers.push(event.detail);
   };
 }
-
-export const injectedWeb3Providers = new InjectedWeb3Providers();

--- a/packages/clerk-js/src/utils/injectedWeb3Providers.ts
+++ b/packages/clerk-js/src/utils/injectedWeb3Providers.ts
@@ -29,24 +29,27 @@ interface EIP6963ProviderDetail {
 type EIP6963AnnounceProviderEvent = CustomEvent;
 type InjectedWeb3Provider = MetamaskWeb3Provider | CoinbaseWeb3Provider;
 
-export class InjectedWeb3Providers {
+class InjectedWeb3Providers {
   #providers: EIP6963ProviderDetail[] = [];
   #providerIdMap: Record<InjectedWeb3Provider, string> = {
     coinbase: 'Coinbase Wallet',
     metamask: 'MetaMask',
   } as const;
-  #hasSetupEventListeners = false;
+  static #instance: InjectedWeb3Providers | null = null;
 
-  constructor() {
+  private constructor() {
     if (typeof window === 'undefined') {
       return;
     }
+    window.addEventListener('eip6963:announceProvider', this.#onAnnouncement as EventListener);
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+  }
 
-    if (!this.#hasSetupEventListeners) {
-      window.addEventListener('eip6963:announceProvider', this.#onAnnouncement as EventListener);
-      window.dispatchEvent(new Event('eip6963:requestProvider'));
-      this.#hasSetupEventListeners = true;
+  public static getInstance(): InjectedWeb3Providers {
+    if (!InjectedWeb3Providers.#instance) {
+      InjectedWeb3Providers.#instance = new InjectedWeb3Providers();
     }
+    return InjectedWeb3Providers.#instance;
   }
 
   get = (provider: InjectedWeb3Provider) => {
@@ -60,3 +63,5 @@ export class InjectedWeb3Providers {
     this.#providers.push(event.detail);
   };
 }
+
+export const getInjectedWeb3Providers = () => InjectedWeb3Providers.getInstance();

--- a/packages/clerk-js/src/utils/web3.ts
+++ b/packages/clerk-js/src/utils/web3.ts
@@ -1,7 +1,7 @@
 import type { Web3Provider } from '@clerk/types';
 
 import { toHex } from './hex';
-import { injectedWeb3Providers } from './injectedWeb3Providers';
+import { InjectedWeb3Providers } from './injectedWeb3Providers';
 
 type GetWeb3IdentifierParams = {
   provider: Web3Provider;
@@ -80,5 +80,7 @@ async function getEthereumProvider(provider: Web3Provider) {
     const sdk = new CoinbaseWalletSDK({});
     return sdk.makeWeb3Provider({ options: 'all' });
   }
+
+  const injectedWeb3Providers = new InjectedWeb3Providers();
   return injectedWeb3Providers.get(provider);
 }

--- a/packages/clerk-js/src/utils/web3.ts
+++ b/packages/clerk-js/src/utils/web3.ts
@@ -1,7 +1,7 @@
 import type { Web3Provider } from '@clerk/types';
 
 import { toHex } from './hex';
-import { InjectedWeb3Providers } from './injectedWeb3Providers';
+import { getInjectedWeb3Providers } from './injectedWeb3Providers';
 
 type GetWeb3IdentifierParams = {
   provider: Web3Provider;
@@ -81,6 +81,6 @@ async function getEthereumProvider(provider: Web3Provider) {
     return sdk.makeWeb3Provider({ options: 'all' });
   }
 
-  const injectedWeb3Providers = new InjectedWeb3Providers();
+  const injectedWeb3Providers = getInjectedWeb3Providers();
   return injectedWeb3Providers.get(provider);
 }


### PR DESCRIPTION
## Description

This PR makes sure to **NOT** call browser specific methods (`addEventListener`, `dispatchEvent`) implemented in [4059](https://github.com/clerk/javascript/pull/4059) in non-browser environments. Even though we are trying to block calls by [checking `window` object](https://github.com/clerk/javascript/blob/c63a5adf0ba4b99252146f168318f51b709bb5dd/packages/clerk-js/src/utils/injectedWeb3Providers.ts#L40), it'll still pass because React Native does have some polyfills to the `window` object.

Fixes SDK-1922

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
