### PR TITLE
feat(nextjs,backend,types): adds accountless signup to nextjs app router (opt in only for now)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,10 @@
         "import": "./dist/runtime/node/crypto.mjs"
       },
       "default": "./dist/runtime/browser/crypto.mjs"
+    },
+    "#ephemeral": {
+      "node": "./dist/runtime/node/ephemeral.js",
+      "default": "./dist/runtime/browser/ephemeral.js"
     }
   },
   "exports": {

--- a/packages/backend/src/__tests__/exports.test.ts
+++ b/packages/backend/src/__tests__/exports.test.ts
@@ -38,6 +38,7 @@ export default (QUnit: QUnit) => {
         'createRedirect',
         'debugRequestState',
         'decorateObjectWithResources',
+        'fetchEphemeralAccount',
         'makeAuthObjectSerializable',
         'signedInAuthObject',
         'signedOutAuthObject',

--- a/packages/backend/src/__tests__/exports.test.ts
+++ b/packages/backend/src/__tests__/exports.test.ts
@@ -38,6 +38,7 @@ export default (QUnit: QUnit) => {
         'createRedirect',
         'debugRequestState',
         'decorateObjectWithResources',
+        'EPHEMERAL_MODE_AVAILABLE',
         'fetchEphemeralAccount',
         'makeAuthObjectSerializable',
         'signedInAuthObject',

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -2,7 +2,7 @@ import { ClerkAPIResponseError, parseError } from '@clerk/shared/error';
 import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 import snakecaseKeys from 'snakecase-keys';
 
-import { API_URL, API_VERSION, constants, USER_AGENT } from '../constants';
+import { API_URL, API_VERSION, constants, EPHEMERAL_MODE_AVAILABLE, USER_AGENT } from '../constants';
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
 import runtime from '../runtime';
@@ -57,7 +57,7 @@ type BuildRequestOptions = {
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
     // TODO: Remove this once we have a better way to handle ephemeral keys
-    if (!options.secretKey && !!process && process.env.NODE_ENV === 'development') {
+    if (!options.secretKey && EPHEMERAL_MODE_AVAILABLE) {
       const ephemeralAccount = await runtime.fetchEphemeralAccount();
       if (ephemeralAccount) {
         options.secretKey = ephemeralAccount.secretKey;

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -56,6 +56,14 @@ type BuildRequestOptions = {
 };
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
+    // TODO: Remove this once we have a better way to handle ephemeral keys
+    if (!options.secretKey && !!process && process.env.NODE_ENV === 'development') {
+      const ephemeralAccount = await runtime.fetchEphemeralAccount();
+      if (ephemeralAccount) {
+        options.secretKey = ephemeralAccount.secretKey;
+      }
+    }
+
     const { secretKey, apiUrl = API_URL, apiVersion = API_VERSION, userAgent = USER_AGENT } = options;
     const { path, method, queryParams, headerParams, bodyParams, formData } = requestOptions;
 

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -5,6 +5,9 @@ export const USER_AGENT = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
 export const MAX_CACHE_LAST_UPDATED_AT_SECONDS = 5 * 60;
 export const JWKS_CACHE_TTL_MS = 1000 * 60 * 60;
 
+export const EPHEMERAL_MODE_AVAILABLE =
+  process.env.NODE_ENV === 'development' && process.env.CLERK_FEATURE_FLAG_EPHEMERAL_ACCOUNTS === 'true';
+
 const Attributes = {
   AuthToken: '__clerkAuthToken',
   AuthSignature: '__clerkAuthSignature',

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -20,6 +20,9 @@ const Cookies = {
   ClientUat: '__client_uat',
   Handshake: '__clerk_handshake',
   DevBrowser: '__clerk_db_jwt',
+  EphemeralExpiresAt: '__clerk_ephemeral_expires_at',
+  EphemeralPublishableKey: '__clerk_ephemeral_publishable_key',
+  EphemeralSecretKey: '__clerk_ephemeral_secret_key',
   RedirectCount: '__clerk_redirect_count',
 } as const;
 
@@ -28,6 +31,9 @@ const QueryParameters = {
   ClerkRedirectUrl: '__clerk_redirect_url',
   // use the reference to Cookies to indicate that it's the same value
   DevBrowser: Cookies.DevBrowser,
+  EphemeralExpiresAt: '__clerk_ephemeral_expires_at',
+  EphemeralPublishableKey: '__clerk_ephemeral_publishable_key',
+  EphemeralSecretKey: '__clerk_ephemeral_secret_key',
   Handshake: Cookies.Handshake,
   HandshakeHelp: '__clerk_help',
   LegacyDevBrowser: '__dev_session',

--- a/packages/backend/src/internal.ts
+++ b/packages/backend/src/internal.ts
@@ -1,16 +1,16 @@
-export { constants } from './constants';
+export { EPHEMERAL_MODE_AVAILABLE, constants } from './constants';
 export { createRedirect } from './createRedirect';
 export type { RedirectFun } from './createRedirect';
 
-export type { CreateAuthenticateRequestOptions } from './tokens/factory';
 export { createAuthenticateRequest } from './tokens/factory';
+export type { CreateAuthenticateRequestOptions } from './tokens/factory';
 
 export { debugRequestState } from './tokens/request';
 
 export type { AuthenticateRequestOptions } from './tokens/types';
 
-export type { SignedInAuthObjectOptions, SignedInAuthObject, SignedOutAuthObject } from './tokens/authObjects';
-export { makeAuthObjectSerializable, signedOutAuthObject, signedInAuthObject } from './tokens/authObjects';
+export { makeAuthObjectSerializable, signedInAuthObject, signedOutAuthObject } from './tokens/authObjects';
+export type { SignedInAuthObject, SignedInAuthObjectOptions, SignedOutAuthObject } from './tokens/authObjects';
 
 export { AuthStatus } from './tokens/authStatus';
 export type { RequestState, SignedInState, SignedOutState } from './tokens/authStatus';

--- a/packages/backend/src/internal.ts
+++ b/packages/backend/src/internal.ts
@@ -16,6 +16,7 @@ export { AuthStatus } from './tokens/authStatus';
 export type { RequestState, SignedInState, SignedOutState } from './tokens/authStatus';
 
 export { decorateObjectWithResources, stripPrivateDataFromObject } from './util/decorateObjectWithResources';
+export { fetchEphemeralAccount } from './util/fetchEphemeralAccount';
 
 export { createClerkRequest } from './tokens/clerkRequest';
 export type { ClerkRequest } from './tokens/clerkRequest';

--- a/packages/backend/src/runtime.ts
+++ b/packages/backend/src/runtime.ts
@@ -14,10 +14,13 @@
 
 // @ts-ignore - These are package subpaths
 import { webcrypto as crypto } from '#crypto';
+// @ts-ignore - These are package subpaths
+import { fetchEphemeralAccount } from '#ephemeral';
 
 type Runtime = {
   crypto: Crypto;
   fetch: typeof globalThis.fetch;
+  fetchEphemeralAccount: typeof fetchEphemeralAccount;
   AbortController: typeof globalThis.AbortController;
   Blob: typeof globalThis.Blob;
   FormData: typeof globalThis.FormData;
@@ -38,6 +41,7 @@ const globalFetch = fetch.bind(globalThis);
 const runtime: Runtime = {
   crypto,
   fetch: globalFetch,
+  fetchEphemeralAccount: fetchEphemeralAccount,
   AbortController: globalThis.AbortController,
   Blob: globalThis.Blob,
   FormData: globalThis.FormData,

--- a/packages/backend/src/runtime/browser/ephemeral.js
+++ b/packages/backend/src/runtime/browser/ephemeral.js
@@ -1,0 +1,5 @@
+async function fetchEphemeralAccount() {
+  return null;
+}
+
+export { fetchEphemeralAccount };

--- a/packages/backend/src/runtime/node/ephemeral.js
+++ b/packages/backend/src/runtime/node/ephemeral.js
@@ -1,0 +1,154 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { isPublishableKey } = require('@clerk/shared');
+
+async function createEphemeralAccount() {
+  const body = await postJSON('https://api.clerkstage.dev/v1/public/demo_instance');
+
+  const account = {
+    publishableKey: body.frontend_api_key,
+    secretKey: body.backend_api_key,
+    expiresAt: daysFromNow(1),
+  };
+
+  write(account);
+
+  return account;
+}
+
+async function fetchEphemeralAccount() {
+  const account = read();
+
+  if (account) {
+    const verified = await verifyEphemeralAccount(account);
+
+    if (verified) {
+      return account;
+    }
+  }
+
+  return await createEphemeralAccount();
+}
+
+async function verifyEphemeralAccount(account) {
+  // TODO: API not implemented yet.
+  //
+  // try {
+  //   await postJSON('https://api.clerkstage.dev/v1/ephemeral-account/verify', {
+  //     publishable_key: account.publishableKey,
+  //     secret_key: account.secretKey,
+  //   })
+  //
+  //   return true
+  //
+  // } catch (err) {
+  //   if (err instanceof ClientError) {
+  //     return false;
+  //   }
+  //
+  //   throw err;
+  // }
+
+  if (!isPublishableKey(account.publishableKey)) {
+    return false;
+  }
+
+  // NOTE: Simulate failed verification after 15 minutes
+  if (account.expiresAt < daysFromNow(1) - 60 * 15) {
+    return false;
+  }
+
+  return true;
+}
+
+const PATH = path.join(process.cwd(), 'node_modules', '.cache', 'clerkjs', 'ephemeral.json');
+
+function read() {
+  try {
+    if (fs.existsSync(PATH)) {
+      const config = JSON.parse(fs.readFileSync(PATH, { encoding: 'utf-8' }));
+
+      if (config.expiresAt < now()) {
+        return null;
+      }
+
+      return config;
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function write(obj) {
+  fs.mkdirSync(path.dirname(PATH), { recursive: true });
+
+  const content = JSON.stringify(obj);
+
+  fs.writeFileSync(PATH, content, {
+    encoding: 'utf8',
+    mode: '0777',
+    flag: 'w',
+  });
+}
+
+function postJSON(url, body) {
+  return apiResult(
+    fetch(url, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }),
+  );
+}
+
+async function apiResult(whenResponse) {
+  const response = await whenResponse;
+
+  if (response.status === 204) {
+    return null;
+  } else if (response.ok) {
+    const body = await response.json();
+    return body;
+  } else if (response.status >= 400 && response.status < 500) {
+    const body = await response.json();
+    const error = new ClientError(response.statusText, response.status, body);
+    throw error;
+  } else {
+    const error = new ServerError(response.statusText, response.status);
+    throw error;
+  }
+}
+
+class ClientError extends Error {
+  constructor(message, status, body) {
+    super(message);
+    this.status = status;
+    this.name = 'ClientError';
+    this.body = body;
+  }
+}
+
+class ServerError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+    this.name = 'ServerError';
+  }
+}
+
+function now() {
+  return daysFromNow(0);
+}
+
+function daysFromNow(days) {
+  return Math.floor(Date.now() / 1000) + 60 * 60 * 24 * days;
+}
+
+module.exports.fetchEphemeralAccount = fetchEphemeralAccount;

--- a/packages/backend/src/util/fetchEphemeralAccount.ts
+++ b/packages/backend/src/util/fetchEphemeralAccount.ts
@@ -1,0 +1,7 @@
+import type { EphemeralAccount } from '@clerk/types';
+
+import runtime from '../runtime';
+
+export function fetchEphemeralAccount(): Promise<EphemeralAccount> {
+  return runtime.fetchEphemeralAccount();
+}

--- a/packages/backend/tsup.config.test.ts
+++ b/packages/backend/tsup.config.test.ts
@@ -16,7 +16,7 @@ export default defineConfig(overrideOptions => {
       PACKAGE_VERSION: `"0.0.0-test"`,
       __DEV__: `${isWatch}`,
     },
-    external: ['#crypto'],
+    external: ['#crypto', '#ephemeral'],
     clean: true,
     minify: false,
     tsconfig: 'tsconfig.test.json',

--- a/packages/backend/tsup.config.ts
+++ b/packages/backend/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(overrideOptions => {
       PACKAGE_VERSION: `"${version}"`,
       __DEV__: `${isWatch}`,
     },
-    external: ['#crypto'],
+    external: ['#crypto', '#ephemeral'],
     bundle: true,
     clean: true,
     minify: false,

--- a/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
@@ -7,6 +7,9 @@ exports[`constants from environment variables 1`] = `
   "Cookies": {
     "ClientUat": "__client_uat",
     "DevBrowser": "__clerk_db_jwt",
+    "EphemeralExpiresAt": "__clerk_ephemeral_expires_at",
+    "EphemeralPublishableKey": "__clerk_ephemeral_publishable_key",
+    "EphemeralSecretKey": "__clerk_ephemeral_secret_key",
     "Handshake": "__clerk_handshake",
     "RedirectCount": "__clerk_redirect_count",
     "Refresh": "__refresh",

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -1,5 +1,7 @@
+import { constants, fetchEphemeralAccount } from '@clerk/backend/internal';
 import type { InitialState, Without } from '@clerk/types';
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 import React from 'react';
 
 import type { NextClerkProviderProps } from '../../types';
@@ -8,14 +10,43 @@ import { ClientClerkProvider } from '../client/ClerkProvider';
 import { initialState } from './auth';
 import { getScriptNonceFromHeader } from './utils';
 
-export function ClerkProvider(props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>) {
+export async function ClerkProvider(
+  props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>,
+) {
   const { children, ...rest } = props;
   const state = initialState()?.__clerk_ssr_state as InitialState;
   const cspHeader = headers().get('Content-Security-Policy');
 
+  const providerProps = { ...mergeNextClerkPropsWithEnv(rest) };
+
+  if (!providerProps.publishableKey) {
+    const ephemeralAccount = await fetchEphemeralAccount();
+    const cookieExpiresAt = cookies().get(constants.QueryParameters.EphemeralExpiresAt)?.value;
+    const cookiePublishableKey = cookies().get(constants.QueryParameters.EphemeralPublishableKey)?.value;
+    const cookieSecretKey = cookies().get(constants.QueryParameters.EphemeralSecretKey)?.value;
+
+    const stale =
+      cookieExpiresAt !== String(ephemeralAccount.expiresAt) ||
+      cookiePublishableKey !== ephemeralAccount.publishableKey ||
+      cookieSecretKey !== ephemeralAccount.secretKey;
+
+    if (stale) {
+      const params = new URLSearchParams({
+        [constants.QueryParameters.EphemeralExpiresAt]: String(ephemeralAccount.expiresAt),
+        [constants.QueryParameters.EphemeralPublishableKey]: ephemeralAccount.publishableKey,
+        [constants.QueryParameters.EphemeralSecretKey]: ephemeralAccount.secretKey,
+      });
+
+      redirect(`?${params}`);
+    }
+
+    providerProps.ephemeral = true;
+    providerProps.publishableKey = ephemeralAccount.publishableKey;
+  }
+
   return (
     <ClientClerkProvider
-      {...mergeNextClerkPropsWithEnv(rest)}
+      {...providerProps}
       nonce={getScriptNonceFromHeader(cspHeader || '')}
       initialState={state}
     >

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -1,6 +1,6 @@
 import type { AuthObject } from '@clerk/backend';
 import type { RedirectFun } from '@clerk/backend/internal';
-import { constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
+import { constants, createClerkRequest, createRedirect, EPHEMERAL_MODE_AVAILABLE } from '@clerk/backend/internal';
 import { isClerkKeyError } from '@clerk/shared';
 import { notFound, redirect } from 'next/navigation';
 
@@ -53,7 +53,7 @@ const baseAuth = (): Auth => {
 export const auth = (): Auth | Record<string, any> => {
   require('server-only');
 
-  if (process.env.NODE_ENV !== 'development') {
+  if (!EPHEMERAL_MODE_AVAILABLE) {
     return baseAuth();
   }
 

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -2,7 +2,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { AuthObject, ClerkClient } from '@clerk/backend';
 import type { AuthenticateRequestOptions, ClerkRequest, RedirectFun, RequestState } from '@clerk/backend/internal';
-import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
+import {
+  AuthStatus,
+  constants,
+  createClerkRequest,
+  createRedirect,
+  EPHEMERAL_MODE_AVAILABLE,
+} from '@clerk/backend/internal';
 import { isClerkKeyError } from '@clerk/shared';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { NextMiddleware, NextRequest } from 'next/server';
@@ -87,7 +93,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   const [request, event] = parseRequestAndEvent(args);
   const [handler, params] = parseHandlerAndOptions(args);
 
-  const ephemeralMode = process.env.NODE_ENV === 'development';
+  const ephemeralMode = EPHEMERAL_MODE_AVAILABLE;
   let ephemeral: Ephemeral | undefined;
 
   return clerkMiddlewareRequestDataStorage.run(clerkMiddlewareRequestDataStore, () => {
@@ -127,6 +133,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
       if (options.debug) {
         logger.enable();
       }
+
       const clerkRequest = createClerkRequest(request);
       logger.debug('options', options);
       logger.debug('url', () => clerkRequest.toJSON());

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -39,6 +39,16 @@ export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError 
   return 'clerkError' in err;
 }
 
+// TODO: Find a better way to error when missing keys
+export function isClerkKeyError(err: any) {
+  const message = String(err);
+  return (
+    message.includes('Missing publishableKey') ||
+    message.includes('Missing secretKey') ||
+    message.includes("Clerk can't detect usage of clerkMiddleware()")
+  );
+}
+
 /**
  * Checks if the provided error object is an instance of ClerkRuntimeError.
  *

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -4,3 +4,9 @@ export type PublishableKey = {
   frontendApi: string;
   instanceType: InstanceType;
 };
+
+export type EphemeralAccount = {
+  publishableKey: string;
+  secretKey: string;
+  expiresAt: number;
+};


### PR DESCRIPTION
## Description

Before, users needed to sign up to Clerk to copy and paste environment keys before they got started building. This is a bit of friction when you're trying to focus on learning a new framework or building your business logic.

This feature attempts to eliminate this requirement when ran in development mode.

It does this by first trying to load ephemeral keys from a local cache. If these keys do not exist, it fetches them from Clerk's API and stores them locally before using them for any future Clerk requests.

To enable this, the environment variable `CLERK_FEATURE_FLAG_EPHEMERAL_ACCOUNTS` must be set to true.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
