### PR TITLE
fix(clerk-js): Ensure getToken() reads correct organization ID

### DIFF
--- a/.changeset/bright-falcons-move.md
+++ b/.changeset/bright-falcons-move.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix bug where session.getToken() was reading a stale organization ID.


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fixes a bug where `getToken()` would read stale organization data from `clerk.organization`. This is problematic because in the `setActive()` flow we call `getToken()` before `clerk.organization` is updated, and so we were reading a stale org ID when attempting to fetch a token for a new session.

For impersonation specifically, this was problematic as the impersonator's session would be in memory while `setActive()` was being called with the impersonated session.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
