### PR TITLE
fix(elements): Form machine error typing

### DIFF
--- a/.changeset/proud-coats-look.md
+++ b/.changeset/proud-coats-look.md
@@ -1,0 +1,6 @@
+---
+"@clerk/elements": patch
+"@clerk/shared": patch
+---
+
+Fixes issue where errors were incorrectly being returned as an `any` type.

--- a/packages/elements/src/internals/errors/index.ts
+++ b/packages/elements/src/internals/errors/index.ts
@@ -1,3 +1,4 @@
+import type { MetamaskError } from '@clerk/shared';
 import type { ClerkAPIError } from '@clerk/types';
 
 export abstract class ClerkElementsErrorBase extends Error {
@@ -21,8 +22,12 @@ export abstract class ClerkElementsErrorBase extends Error {
 }
 
 export class ClerkElementsError extends ClerkElementsErrorBase {
-  static fromAPIError(error: ClerkAPIError) {
-    return new ClerkElementsError(error.code, error.longMessage || error.message);
+  static fromAPIError(error: ClerkAPIError | MetamaskError) {
+    return new ClerkElementsError(
+      error.code.toString(),
+      // @ts-expect-error - Expected that longMessage isn't a property of MetamaskError
+      error.longMessage || error.message,
+    );
   }
 
   constructor(code: string, message: string) {

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -31,7 +31,7 @@ export interface MetamaskError extends Error {
   data?: unknown;
 }
 
-export function isKnownError(error: any) {
+export function isKnownError(error: any): error is ClerkAPIResponseError | ClerkRuntimeError | MetamaskError {
   return isClerkAPIResponseError(error) || isMetamaskError(error) || isClerkRuntimeError(error);
 }
 


### PR DESCRIPTION
## Description

Started getting a type error where `errors` was returning as any vs the correct error type.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
