### PR TITLE
chore(astro): Allow child elements in unstyled Astro components

### DIFF
--- a/.changeset/rare-onions-rest.md
+++ b/.changeset/rare-onions-rest.md
@@ -1,0 +1,17 @@
+---
+"@clerk/astro": patch
+---
+
+Allow child elements in unstyled Astro components.
+
+Usage:
+
+```astro
+---
+import { SignInButton } from '@clerk/components/astro'
+---
+
+<SignInButton>
+  <button>Sign in with Clerk</button>
+</SignInButton>
+```

--- a/.changeset/rare-onions-rest.md
+++ b/.changeset/rare-onions-rest.md
@@ -11,7 +11,7 @@ Usage:
 import { SignInButton } from '@clerk/components/astro'
 ---
 
-<SignInButton>
+<SignInButton asChild>
   <button>Sign in with Clerk</button>
 </SignInButton>
 ```

--- a/integration/templates/astro-node/src/pages/buttons.astro
+++ b/integration/templates/astro-node/src/pages/buttons.astro
@@ -6,10 +6,13 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout title="Welcome to Astro.">
   <SignInButton
+    asChild
     mode="modal"
     fallbackRedirectUrl="/user"
   >
-    Sign in
+    <button>
+      Sign in
+    </button>
   </SignInButton>
 
   <SignUpButton

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -1,7 +1,13 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignInProps } from "@clerk/types";
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & { as: Tag; mode?: 'redirect' | 'modal' }>
+import type { SignInProps } from '@clerk/types'
+import { addUnstyledAttributeToFirstTag } from './utils'
+
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & {
+  as: Tag;
+  asChild?: boolean;
+  mode?: 'redirect' | 'modal';
+}>
 
 import { generateSafeId } from '@clerk/astro/internal';
 
@@ -9,6 +15,7 @@ const safeId = generateSafeId();
 
 const {
   as: Tag = 'button',
+  asChild,
   forceRedirectUrl,
   fallbackRedirectUrl,
   signUpFallbackRedirectUrl,
@@ -23,11 +30,24 @@ const signInOptions = {
   signUpFallbackRedirectUrl,
   signUpForceRedirectUrl,
 };
+
+let htmlElement = ''
+
+if (asChild) {
+  htmlElement = await Astro.slots.render('default')
+  htmlElement = addUnstyledAttributeToFirstTag(htmlElement, safeId)
+}
 ---
 
-<Tag {...elementProps} data-clerk-unstyled-id={safeId}>
-  <slot>Sign in</slot>
-</Tag >
+{
+  asChild ? (
+    <Fragment set:html={htmlElement} />
+  ) : (
+    <Tag {...elementProps} data-clerk-unstyled-id={safeId}>
+      <slot>Sign in</slot>
+    </Tag >
+  )
+}
 
 <script is:inline define:vars={{ signInOptions, mode, safeId }}>
   const btn = document.querySelector(`[data-clerk-unstyled-id="${safeId}"]`);

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -4,6 +4,7 @@ import type { SignInProps } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & {
+  /** @deprecated Use the default slot instead of the 'as' prop */
   as: Tag;
   asChild?: boolean;
   mode?: 'redirect' | 'modal';

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -1,21 +1,10 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignInProps } from '@clerk/types'
+import type { ButtonProps } from '../../types';
 import { addUnstyledAttributeToFirstTag } from './utils'
 
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & {
-  /**
-   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
-   * Use the default slot with the 'asChild' prop instead.
-   * @example
-   * <SignInButton asChild>
-   *   <button>Sign in</button>
-   * </SignInButton>
-   */
-  as: Tag;
-  asChild?: boolean;
-  mode?: 'redirect' | 'modal';
-}>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & ButtonProps<Tag>>
 
 import { generateSafeId } from '@clerk/astro/internal';
 

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -4,7 +4,14 @@ import type { SignInProps } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & {
-  /** @deprecated Use the default slot instead of the 'as' prop */
+  /**
+   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
+   * Use the default slot with the 'asChild' prop instead.
+   * @example
+   * <SignInButton asChild>
+   *   <button>Sign in</button>
+   * </SignInButton>
+   */
   as: Tag;
   asChild?: boolean;
   mode?: 'redirect' | 'modal';

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -2,13 +2,17 @@
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignInProps } from '@clerk/types'
 import type { ButtonProps } from '../../types';
-import { addUnstyledAttributeToFirstTag } from './utils'
+import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignInProps & ButtonProps<Tag>>
 
 import { generateSafeId } from '@clerk/astro/internal';
 
 const safeId = generateSafeId();
+
+if ('as' in Astro.props) {
+  logAsPropUsageDeprecation()
+}
 
 const {
   as: Tag = 'button',

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -1,20 +1,10 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignOutOptions } from '@clerk/types'
+import type { SignOutOptions, Without } from '@clerk/types'
+import type { ButtonProps } from '../../types';
 import { addUnstyledAttributeToFirstTag } from './utils'
 
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & {
-  /**
-   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
-   * Use the default slot with the 'asChild' prop instead.
-   * @example
-   * <SignInButton asChild>
-   *   <button>Sign in</button>
-   * </SignInButton>
-   */
-  as: Tag;
-  asChild?: boolean;
-}>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & Without<ButtonProps<Tag>, 'mode'>>
 
 import { generateSafeId } from '@clerk/astro/internal'
 

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -2,13 +2,17 @@
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignOutOptions, Without } from '@clerk/types'
 import type { ButtonProps } from '../../types';
-import { addUnstyledAttributeToFirstTag } from './utils'
+import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & Without<ButtonProps<Tag>, 'mode'>>
 
 import { generateSafeId } from '@clerk/astro/internal'
 
 const safeId = generateSafeId();
+
+if ('as' in Astro.props) {
+  logAsPropUsageDeprecation()
+}
 
 const {
   as: Tag = 'button',

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -4,7 +4,14 @@ import type { SignOutOptions } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & {
-  /** @deprecated Use the default slot instead of the 'as' prop */
+  /**
+   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
+   * Use the default slot with the 'asChild' prop instead.
+   * @example
+   * <SignInButton asChild>
+   *   <button>Sign in</button>
+   * </SignInButton>
+   */
   as: Tag;
   asChild?: boolean;
 }>

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -1,23 +1,42 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignOutOptions } from '@clerk/types';
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<{ as: Tag; } & SignOutOptions>
+import type { SignOutOptions } from '@clerk/types'
+import { addUnstyledAttributeToFirstTag } from './utils'
 
-import { generateSafeId } from '@clerk/astro/internal';
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & {
+  as: Tag;
+  asChild?: boolean;
+}>
+
+import { generateSafeId } from '@clerk/astro/internal'
 
 const safeId = generateSafeId();
 
 const {
   as: Tag = 'button',
+  asChild,
   redirectUrl = '/',
   sessionId,
   ...elementProps
 } = Astro.props
+
+let htmlElement = ''
+
+if (asChild) {
+  htmlElement = await Astro.slots.render('default')
+  htmlElement = addUnstyledAttributeToFirstTag(htmlElement, safeId)
+}
 ---
 
-<Tag {...elementProps} data-clerk-unstyled-id={safeId}>
-  <slot>Sign out</slot>
-</Tag >
+{
+  asChild ? (
+    <Fragment set:html={htmlElement} />
+  ) : (
+    <Tag {...elementProps} data-clerk-unstyled-id={safeId}>
+      <slot>Sign out</slot>
+    </Tag >
+  )
+}
 
 <script is:inline define:vars={{ redirectUrl, sessionId, safeId }}>
   const btn = document.querySelector(`[data-clerk-unstyled-id="${safeId}"]`);

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -4,6 +4,7 @@ import type { SignOutOptions } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & {
+  /** @deprecated Use the default slot instead of the 'as' prop */
   as: Tag;
   asChild?: boolean;
 }>

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -1,7 +1,13 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignUpProps } from "@clerk/types";
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & { as: Tag; mode?: 'redirect' | 'modal' }>
+import type { SignUpProps } from '@clerk/types'
+import { addUnstyledAttributeToFirstTag } from './utils'
+
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & {
+  as: Tag;
+  asChild?: boolean;
+  mode?: 'redirect' | 'modal'
+}>
 
 import { generateSafeId } from '@clerk/astro/internal';
 
@@ -9,6 +15,7 @@ const safeId = generateSafeId();
 
 const {
   as: Tag = 'button',
+  asChild,
   fallbackRedirectUrl,
   forceRedirectUrl,
   signInFallbackRedirectUrl,
@@ -25,11 +32,24 @@ const signUpOptions = {
   signInForceRedirectUrl,
   unsafeMetadata,
 }
+
+let htmlElement = ''
+
+if (asChild) {
+  htmlElement = await Astro.slots.render('default')
+  htmlElement = addUnstyledAttributeToFirstTag(htmlElement, safeId)
+}
 ---
 
-<Tag {...elementProps} data-clerk-unstyled-id={safeId}>
-  <slot>Sign up</slot>
-</Tag >
+{
+  asChild ? (
+    <Fragment set:html={htmlElement} />
+  ) : (
+    <Tag {...elementProps} data-clerk-unstyled-id={safeId}>
+      <slot>Sign up</slot>
+    </Tag >
+  )
+}
 
 <script is:inline define:vars={{ signUpOptions, mode, safeId }}>
   const btn = document.querySelector(`[data-clerk-unstyled-id="${safeId}"]`);

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -1,21 +1,10 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignUpProps } from '@clerk/types'
+import type { ButtonProps } from '../../types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & {
-  /**
-   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
-   * Use the default slot with the 'asChild' prop instead.
-   * @example
-   * <SignInButton asChild>
-   *   <button>Sign in</button>
-   * </SignInButton>
-   */
-  as: Tag;
-  asChild?: boolean;
-  mode?: 'redirect' | 'modal'
-}>
+type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & ButtonProps<Tag>>
 
 import { generateSafeId } from '@clerk/astro/internal';
 

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -2,13 +2,17 @@
 import type { HTMLTag, Polymorphic } from 'astro/types'
 import type { SignUpProps } from '@clerk/types'
 import type { ButtonProps } from '../../types'
-import { addUnstyledAttributeToFirstTag } from './utils'
+import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & ButtonProps<Tag>>
 
 import { generateSafeId } from '@clerk/astro/internal';
 
 const safeId = generateSafeId();
+
+if ('as' in Astro.props) {
+  logAsPropUsageDeprecation()
+}
 
 const {
   as: Tag = 'button',

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -4,7 +4,14 @@ import type { SignUpProps } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & {
-  /** @deprecated Use the default slot instead of the 'as' prop */
+  /**
+   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
+   * Use the default slot with the 'asChild' prop instead.
+   * @example
+   * <SignInButton asChild>
+   *   <button>Sign in</button>
+   * </SignInButton>
+   */
   as: Tag;
   asChild?: boolean;
   mode?: 'redirect' | 'modal'

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -4,6 +4,7 @@ import type { SignUpProps } from '@clerk/types'
 import { addUnstyledAttributeToFirstTag } from './utils'
 
 type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignUpProps & {
+  /** @deprecated Use the default slot instead of the 'as' prop */
   as: Tag;
   asChild?: boolean;
   mode?: 'redirect' | 'modal'

--- a/packages/astro/src/astro-components/unstyled/utils.ts
+++ b/packages/astro/src/astro-components/unstyled/utils.ts
@@ -5,3 +5,17 @@
 export function addUnstyledAttributeToFirstTag(html: string, attributeValue: string): string {
   return html.replace(/(<[^>]+)>/, `$1 data-clerk-unstyled-id="${attributeValue}">`);
 }
+
+/**
+ * Logs a deprecation warning when the 'as' prop is used.
+ */
+export function logAsPropUsageDeprecation() {
+  if (import.meta.env.PROD) {
+    return;
+  }
+
+  console.warn(
+    `[@clerk/astro] The 'as' prop is deprecated and will be removed in a future version. ` +
+      `Use the default slot with the 'asChild' prop instead. `,
+  );
+}

--- a/packages/astro/src/astro-components/unstyled/utils.ts
+++ b/packages/astro/src/astro-components/unstyled/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * This function is used when an element is passed as a default slot and we need
+ * to add an attribute to it so that we can reference it in a click listener.
+ */
+export function addUnstyledAttributeToFirstTag(html: string, attributeValue: string): string {
+  return html.replace(/(<[^>]+)>/, `$1 data-clerk-unstyled-id="${attributeValue}">`);
+}

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -70,3 +70,17 @@ type ProtectProps =
     };
 
 export type { AstroClerkUpdateOptions, AstroClerkIntegrationParams, AstroClerkCreateInstanceParams, ProtectProps };
+
+export type ButtonProps<Tag> = {
+  /**
+   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
+   * Use the default slot with the 'asChild' prop instead.
+   * @example
+   * <SignInButton asChild>
+   *   <button>Sign in</button>
+   * </SignInButton>
+   */
+  as: Tag;
+  asChild?: boolean;
+  mode?: 'redirect' | 'modal';
+};


### PR DESCRIPTION
## Description

This PR adds the option to use custom elements/components inside our unstyled components, similar to the [React counterpart](https://clerk.com/docs/components/unstyled/sign-in-button#custom-usage), and adds a deprecation notice for the `as` prop.

With this change, we can now do:

```astro
---
import { SignInButton } from '@clerk/components/astro'
---
<SignInButton asChild>
  <button>Sign in with Clerk</button>
</SignInButton>
```

The new `asChild` prop determines if we should render the default slot as an element or just a string. We need this prop because Astro doesn't have a way to determine if a slot contains an element/component or a string.

Previously, we used the `as` prop to render a different element:

```astro
---
import { SignInButton } from '@clerk/components/astro'
---
<SignInButton as="button">
  Sign in with Clerk
</SignInButton>
```

The problem with the old approach was that we couldn't use an existing component or inherit styles. This PR offers better flexibility.

Resolves ECO-187

## Checklist

- [ ] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
