### PR TITLE
feat(tanstack-start): Export @clerk/backend from server subpath

### DIFF
--- a/.changeset/poor-months-share.md
+++ b/.changeset/poor-months-share.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-start": minor
+---
+
+Introducing `clerkClient` from `@clerk/tanstack-start/server` for accessing the `@clerk/backend` client

--- a/.changeset/poor-months-share.md
+++ b/.changeset/poor-months-share.md
@@ -2,4 +2,4 @@
 "@clerk/tanstack-start": minor
 ---
 
-Introducing `clerkClient` from `@clerk/tanstack-start/server` for accessing the `@clerk/backend` client
+Introducing `clerkClient()` from `@clerk/tanstack-start/server` for accessing the `@clerk/backend` client

--- a/packages/tanstack-start/src/server/clerkClient.ts
+++ b/packages/tanstack-start/src/server/clerkClient.ts
@@ -1,0 +1,34 @@
+import { createClerkClient } from '@clerk/backend';
+
+import {
+  API_URL,
+  API_VERSION,
+  DOMAIN,
+  IS_SATELLITE,
+  PROXY_URL,
+  PUBLISHABLE_KEY,
+  SDK_METADATA,
+  SECRET_KEY,
+  TELEMETRY_DEBUG,
+  TELEMETRY_DISABLED,
+} from './constants';
+
+const clerkClient: typeof createClerkClient = options =>
+  createClerkClient({
+    secretKey: SECRET_KEY,
+    publishableKey: PUBLISHABLE_KEY,
+    apiUrl: API_URL,
+    apiVersion: API_VERSION,
+    userAgent: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
+    proxyUrl: PROXY_URL,
+    domain: DOMAIN,
+    isSatellite: IS_SATELLITE,
+    sdkMetadata: SDK_METADATA,
+    telemetry: {
+      disabled: TELEMETRY_DISABLED,
+      debug: TELEMETRY_DEBUG,
+    },
+    ...options,
+  });
+
+export { clerkClient };

--- a/packages/tanstack-start/src/server/constants.ts
+++ b/packages/tanstack-start/src/server/constants.ts
@@ -1,0 +1,25 @@
+import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey';
+
+import { getEnvVariable, getPublicEnvVariables } from '../utils/env';
+
+export const CLERK_JS_VERSION = getPublicEnvVariables().clerkJsVersion || '';
+export const CLERK_JS_URL = getPublicEnvVariables().clerkJsUrl || '';
+export const API_VERSION = getEnvVariable('CLERK_API_VERSION') || 'v1';
+export const SECRET_KEY = getEnvVariable('CLERK_SECRET_KEY') || '';
+export const PUBLISHABLE_KEY = getPublicEnvVariables().publishableKey || '';
+export const ENCRYPTION_KEY = getEnvVariable('CLERK_ENCRYPTION_KEY') || '';
+export const API_URL = getEnvVariable('CLERK_API_URL') || apiUrlFromPublishableKey(PUBLISHABLE_KEY);
+export const DOMAIN = getPublicEnvVariables().domain || '';
+export const PROXY_URL = getPublicEnvVariables().proxyUrl || '';
+export const CLERK_JWT_KEY = getEnvVariable('CLERK_JWT_KEY') || '';
+export const IS_SATELLITE = getPublicEnvVariables().isSatellite || false;
+export const SIGN_IN_URL = getPublicEnvVariables().signInUrl || '';
+export const SIGN_UP_URL = getPublicEnvVariables().signUpUrl || '';
+export const SDK_METADATA = {
+  name: PACKAGE_NAME,
+  version: PACKAGE_VERSION,
+  environment: getEnvVariable('NODE_ENV'),
+};
+
+export const TELEMETRY_DISABLED = getPublicEnvVariables().telemetryDisabled;
+export const TELEMETRY_DEBUG = getPublicEnvVariables().telemetryDebug;

--- a/packages/tanstack-start/src/server/index.ts
+++ b/packages/tanstack-start/src/server/index.ts
@@ -1,6 +1,7 @@
 export * from './middlewareHandler';
 
 export * from './getAuth';
+export { clerkClient } from './clerkClient';
 
 /**
  * Re-export resource types from @clerk/backend

--- a/packages/tanstack-start/src/server/loadOptions.ts
+++ b/packages/tanstack-start/src/server/loadOptions.ts
@@ -3,30 +3,34 @@ import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
 import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
-import { isTruthy } from '@clerk/shared/underscore';
 
 import { errorThrower } from '../utils';
 import { getEnvVariable, getPublicEnvVariables } from '../utils/env';
+import {
+  CLERK_JWT_KEY,
+  DOMAIN,
+  IS_SATELLITE,
+  PROXY_URL,
+  PUBLISHABLE_KEY,
+  SECRET_KEY,
+  SIGN_IN_URL,
+  SIGN_UP_URL,
+} from './constants';
 import type { LoaderOptions } from './types';
 import { patchRequest } from './utils';
 
 export const loadOptions = (request: Request, overrides: LoaderOptions = {}) => {
   const clerkRequest = createClerkRequest(patchRequest(request));
 
-  const secretKey = overrides.secretKey || overrides.secretKey || getEnvVariable('CLERK_SECRET_KEY');
-  const publishableKey = overrides.publishableKey || getPublicEnvVariables().publishableKey;
-  const jwtKey = overrides.jwtKey || getEnvVariable('CLERK_JWT_KEY');
+  const secretKey = overrides.secretKey || SECRET_KEY;
+  const publishableKey = overrides.publishableKey || PUBLISHABLE_KEY;
+  const jwtKey = overrides.jwtKey || CLERK_JWT_KEY;
   const apiUrl = getEnvVariable('CLERK_API_URL') || apiUrlFromPublishableKey(publishableKey);
-  const domain = handleValueOrFn(overrides.domain, new URL(request.url)) || getPublicEnvVariables().domain;
-  const isSatellite =
-    handleValueOrFn(overrides.isSatellite, new URL(request.url)) || isTruthy(getPublicEnvVariables().isSatellite);
-  const relativeOrAbsoluteProxyUrl = handleValueOrFn(
-    overrides?.proxyUrl,
-    clerkRequest.clerkUrl,
-    getPublicEnvVariables().proxyUrl,
-  );
-  const signInUrl = overrides.signInUrl || getPublicEnvVariables().signInUrl;
-  const signUpUrl = overrides.signUpUrl || getPublicEnvVariables().signUpUrl;
+  const domain = handleValueOrFn(overrides.domain, new URL(request.url)) || DOMAIN;
+  const isSatellite = handleValueOrFn(overrides.isSatellite, new URL(request.url)) || IS_SATELLITE;
+  const relativeOrAbsoluteProxyUrl = handleValueOrFn(overrides?.proxyUrl, clerkRequest.clerkUrl, PROXY_URL);
+  const signInUrl = overrides.signInUrl || SIGN_IN_URL;
+  const signUpUrl = overrides.signUpUrl || SIGN_UP_URL;
   const afterSignInUrl = overrides.afterSignInUrl || getPublicEnvVariables().afterSignInUrl;
   const afterSignUpUrl = overrides.afterSignUpUrl || getPublicEnvVariables().afterSignUpUrl;
 

--- a/packages/tanstack-start/src/utils/env.ts
+++ b/packages/tanstack-start/src/utils/env.ts
@@ -42,7 +42,8 @@ export const getPublicEnvVariables = () => {
     clerkJsVersion: getEnvVariable('VITE_CLERK_JS_VERSION') || getEnvVariable('CLERK_JS_VERSION'),
     telemetryDisabled:
       isTruthy(getEnvVariable('VITE_CLERK_TELEMETRY_DISABLED')) || isTruthy(getEnvVariable('CLERK_TELEMETRY_DISABLED')),
-    telemetryDebug: getEnvVariable('VITE_CLERK_TELEMETRY_DEBUG') || getEnvVariable('CLERK_TELEMETRY_DEBUG'),
+    telemetryDebug:
+      isTruthy(getEnvVariable('VITE_CLERK_TELEMETRY_DEBUG')) || isTruthy(getEnvVariable('CLERK_TELEMETRY_DEBUG')),
     afterSignInUrl: getEnvVariable('VITE_CLERK_AFTER_SIGN_IN_URL') || getEnvVariable('CLERK_AFTER_SIGN_IN_URL'),
     afterSignUpUrl: getEnvVariable('VITE_CLERK_AFTER_SIGN_UP_URL') || getEnvVariable('CLERK_AFTER_SIGN_UP_URL'),
   };


### PR DESCRIPTION
## Description

This PR re-exports types from `@clerk/backend` from the `@clerk/tanstack-start/server` subpath and also introduces 
`clerkClient` which gives access to backend client but with using the environment variables by default.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
