### PR TITLE
fix(astro): Pre-bundle client dependency for exported control components

### DIFF
--- a/.changeset/thirty-hotels-buy.md
+++ b/.changeset/thirty-hotels-buy.md
@@ -2,4 +2,4 @@
 "@clerk/astro": patch
 ---
 
-Fixes an issue where control components in client-side rendered apps are empty.
+Fixes an issue where control components in client-side rendered apps are always hidden.

--- a/.changeset/thirty-hotels-buy.md
+++ b/.changeset/thirty-hotels-buy.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fixes an issue where control components in client-side rendered apps are empty.

--- a/packages/astro/src/integration/vite-plugin-astro-config.ts
+++ b/packages/astro/src/integration/vite-plugin-astro-config.ts
@@ -20,6 +20,13 @@ export function vitePluginAstroConfig(astroConfig: AstroConfig): VitePlugin {
         return resolvedVirtualModuleId;
       }
     },
+    config(config) {
+      // While Astro processes <script> tags by default, our control components
+      // which uses <script> tags and imports nanostores will not be processed by Astro.
+      // This ensures @clerk/astro/client is properly processed and bundled,
+      // resolving runtime import issues in these components.
+      config.optimizeDeps?.include?.push('@clerk/astro/client');
+    },
     load(id) {
       if (id === resolvedVirtualModuleId) {
         return `


### PR DESCRIPTION
## Description

This small PR pre-bundles `@clerk/astro/client` to ensure proper processing of  `<script>` tags and nanostore imports in our exported control components. This resolves runtime issues in development when these components are used in other projects.

Resolves ECO-188

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
