### PR TITLE
feat(clerk-js,ui,types): Hide sign up url from `<SignIn />` component when Invite-Only is turned on

### DIFF
--- a/.changeset/gold-lamps-appear.md
+++ b/.changeset/gold-lamps-appear.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": minor
+"@clerk/types": minor
+---
+
+Hide sign up url from `<SignIn />` component when the Invite-Only mode is turned on.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -410,13 +410,15 @@ export function _SignInStart(): JSX.Element {
           </Col>
         </Card.Content>
         <Card.Footer>
-          <Card.Action elementId='signIn'>
-            <Card.ActionText localizationKey={localizationKeys('signIn.start.actionText')} />
-            <Card.ActionLink
-              localizationKey={localizationKeys('signIn.start.actionLink')}
-              to={clerk.buildUrlWithAuth(signUpUrl)}
-            />
-          </Card.Action>
+          {!userSettings.signUp.invite_only_enabled && (
+            <Card.Action elementId='signIn'>
+              <Card.ActionText localizationKey={localizationKeys('signIn.start.actionText')} />
+              <Card.ActionLink
+                localizationKey={localizationKeys('signIn.start.actionLink')}
+                to={clerk.buildUrlWithAuth(signUpUrl)}
+              />
+            </Card.Action>
+          )}
         </Card.Footer>
       </Card.Root>
     </Flow.Part>

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -111,6 +111,29 @@ describe('SignInStart', () => {
     });
   });
 
+  describe('Invite only', () => {
+    it('"Don\'t have an account?" text should be hidden', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withInviteOnlyEnabled();
+      });
+      render(<SignInStart />, { wrapper });
+      expect(screen.queryByText(/Don’t have an account?/i)).not.toBeInTheDocument();
+    });
+
+    it('"Don\'t have an account?" text should be visible', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      render(<SignInStart />, { wrapper });
+
+      const signUpLink = screen.getByText('Don’t have an account?').nextElementSibling;
+      expect(signUpLink?.textContent).toBe('Sign up');
+      expect(signUpLink?.tagName.toUpperCase()).toBe('A');
+      expect(signUpLink?.getAttribute('href')).toMatch(fixtures.environment.displayConfig.signUpUrl);
+    });
+  });
+
   describe('Social OAuth', () => {
     it.each(OAUTH_PROVIDERS)('shows the "Continue with $name" social OAuth button', async ({ provider, name }) => {
       const { wrapper } = await createFixtures(f => {

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -476,6 +476,10 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     };
   };
 
+  const withInviteOnlyEnabled = () => {
+    us.sign_up.invite_only_enabled = true;
+  };
+
   // TODO: Add the rest, consult pkg/generate/auth_config.go
 
   return {
@@ -493,5 +497,6 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     withAuthenticatorApp,
     withPasskey,
     withPasskeySettings,
+    withInviteOnlyEnabled,
   };
 };

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -51,6 +51,7 @@ export type SignUpData = {
   allowlist_only: boolean;
   progressive: boolean;
   captcha_enabled: boolean;
+  invite_only_enabled: boolean;
 };
 
 export type PasswordSettingsData = {

--- a/packages/ui/src/components/sign-in/steps/start.tsx
+++ b/packages/ui/src/components/sign-in/steps/start.tsx
@@ -17,6 +17,7 @@ import { useCard } from '~/hooks/use-card';
 import { useDevModeWarning } from '~/hooks/use-dev-mode-warning';
 import { useDisplayConfig } from '~/hooks/use-display-config';
 import { useEnabledConnections } from '~/hooks/use-enabled-connections';
+import { useEnvironment } from '~/hooks/use-environment';
 import { useLocalizations } from '~/hooks/use-localizations';
 import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
@@ -27,6 +28,7 @@ import { Separator } from '~/primitives/separator';
 export function SignInStart() {
   const enabledConnections = useEnabledConnections();
   const { t } = useLocalizations();
+  const { userSettings } = useEnvironment();
   const { enabled: usernameEnabled } = useAttributes('username');
   const { enabled: phoneNumberEnabled } = useAttributes('phone_number');
   const { enabled: emailAddressEnabled } = useAttributes('email_address');
@@ -184,12 +186,14 @@ export function SignInStart() {
               </Card.Content>
 
               <Card.Footer {...footerProps}>
-                <Card.FooterAction>
-                  <Card.FooterActionText>
-                    {t('signIn.start.actionText')}{' '}
-                    <Card.FooterActionLink href='/sign-up'> {t('signIn.start.actionLink')}</Card.FooterActionLink>
-                  </Card.FooterActionText>
-                </Card.FooterAction>
+                {!userSettings.signUp.invite_only_enabled ? (
+                  <Card.FooterAction>
+                    <Card.FooterActionText>
+                      {t('signIn.start.actionText')}{' '}
+                      <Card.FooterActionLink href='/sign-up'> {t('signIn.start.actionLink')}</Card.FooterActionLink>
+                    </Card.FooterActionText>
+                  </Card.FooterAction>
+                ) : null}
               </Card.Footer>
             </Card.Root>
           </SignIn.Step>


### PR DESCRIPTION
## Description

Hide sign up url from `<SignIn />` component when the Invite-Only mode is turned on.

In a following pr we're going to introduce e2e tests

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

![Screenshot 2024-09-10 at 3 12 58 PM](https://github.com/user-attachments/assets/1003a246-0a1f-4e19-a4ac-4193f5bb078f)

![Screenshot 2024-09-10 at 3 08 23 PM](https://github.com/user-attachments/assets/6f5afc65-19f1-4406-a808-58b80b45c5dd)

