### PR TITLE
fix(clerk-expo): Ensure correct mobile detection for native requests

### DIFF
--- a/.changeset/moody-donuts-explode.md
+++ b/.changeset/moody-donuts-explode.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-expo": patch
+---
+
+Fixes an issue where iOS session activities were incorrectly classified as non-mobile

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -43,13 +43,13 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
         // https://reactnative.dev/docs/0.61/network#known-issues-with-fetch-and-cookie-based-authentication
         requestInit.credentials = 'omit';
 
+        // Instructs the backend to parse the api token from the Authorization header.
         requestInit.url?.searchParams.append('_is_native', '1');
 
         const jwt = await getToken(KEY);
         (requestInit.headers as Headers).set('authorization', jwt || '');
 
-        // Adding 'x-mobile' header for native mobile requests.
-        // This signals the backend that the request is from a mobile device.
+        // Instructs the backend that the request is from a mobile device.
         // Some iOS devices have an empty user-agent, so we can't rely on that.
         if (isNative()) {
           (requestInit.headers as Headers).set('x-mobile', '1');

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -4,6 +4,7 @@ import type { BrowserClerk, HeadlessBrowserClerk } from '@clerk/clerk-react';
 
 import { MemoryTokenCache } from '../../cache/MemoryTokenCache';
 import { errorThrower } from '../../errorThrower';
+import { isNative } from '../../utils';
 import type { BuildClerkOptions } from './types';
 
 const KEY = '__clerk_client_jwt';
@@ -46,6 +47,13 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
 
         const jwt = await getToken(KEY);
         (requestInit.headers as Headers).set('authorization', jwt || '');
+
+        // Adding 'x-mobile' header for native mobile requests.
+        // This signals the backend that the request is from a mobile device.
+        // Some iOS devices have an empty user-agent, so we can't rely on that.
+        if (isNative()) {
+          (requestInit.headers as Headers).set('x-mobile', '1');
+        }
       });
 
       // @ts-expect-error - This is an internal API


### PR DESCRIPTION
## Description

This PR addresses an issue where the `isMobile` value of a [`SessionActivity`](https://clerk.com/docs/references/javascript/session-with-activities#session-activity) is incorrectly set to `false` for iOS devices. The problem is caused by some iOS devices sending an empty `user-agent` header:

Here's an example of an expo login request in iOS (notice there's no `user-agent` header and `isMobile` is false):

<img width="723" alt="Screenshot 2024-09-10 at 7 49 14 AM" src="https://github.com/user-attachments/assets/ffc5b41a-49a0-4c1c-9bf7-d1ed08f58e78">

<img width="526" alt="Screenshot 2024-09-10 at 8 47 05 AM" src="https://github.com/user-attachments/assets/adc0b066-3439-4676-beda-b5b6e57b732a">


The backend relies on either the `x-mobile` or `user-agent` headers to determine if a request is from a mobile device. This update adds the `x-mobile` header for all native requests, ensuring that the backend correctly records session activities as mobile, regardless of the `user-agent` value.

Here's a [`SessionActivity`](https://clerk.com/docs/references/javascript/session-with-activities#session-activity) record after signing in with a `x-mobile` header (notice `isMobile` is `true`):

<img width="523" alt="Screenshot 2024-09-10 at 8 06 16 AM" src="https://github.com/user-attachments/assets/3fade236-f961-4eaf-a4eb-49a60b58a122">


Resolves ECO-189

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
