### PR TITLE
fix(backend): Missing `deleteSelfEnabled` from User

### DIFF
--- a/.changeset/angry-phones-nail.md
+++ b/.changeset/angry-phones-nail.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Bug fix: Introducing missing `deleteSelfEnabled` from User.

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -312,6 +312,7 @@ export interface UserJSON extends ClerkResourceJSON {
   last_active_at: number | null;
   create_organization_enabled: boolean;
   create_organizations_limit: number | null;
+  delete_self_enabled: boolean;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/User.ts
+++ b/packages/backend/src/api/resources/User.ts
@@ -37,6 +37,7 @@ export class User {
     readonly lastActiveAt: number | null,
     readonly createOrganizationEnabled: boolean,
     readonly createOrganizationsLimit: number | null = null,
+    readonly deleteSelfEnabled: boolean,
   ) {}
 
   static fromJSON(data: UserJSON): User {
@@ -71,6 +72,7 @@ export class User {
       data.last_active_at,
       data.create_organization_enabled,
       data.create_organizations_limit,
+      data.delete_self_enabled,
     );
   }
 


### PR DESCRIPTION
## Description

Bug fix: Introducing missing `deleteSelfEnabled` from User.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
