### PR TITLE
chore(localizations,types): Add translation keys for new organization name validation error

### DIFF
--- a/.changeset/clever-dots-return.md
+++ b/.changeset/clever-dots-return.md
@@ -2,4 +2,4 @@
 "@clerk/localizations": patch
 ---
 
-Addtranslation keys for organization name validation errors
+Add empty translation keys for organization name validation errors

--- a/.changeset/clever-dots-return.md
+++ b/.changeset/clever-dots-return.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Addtranslation keys for organization name validation errors

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -539,6 +539,7 @@ export const arSA: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'الأسم الأخير يجب الا يتجاوز 256 حرف',
     form_param_max_length_exceeded__name: 'الأسم يجب الا يتجاوز 256 حرف',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'كلمة المرور ليست قوية',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -540,6 +540,7 @@ export const bgBG: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Фамилията не трябва да надвишава 256 символа.',
     form_param_max_length_exceeded__name: 'Името не трябва да надвишава 256 символа.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Вашата парола не е достатъчно сигурна.',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -538,6 +538,7 @@ export const csCZ: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Vaše heslo není dostatečně silné.',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -539,6 +539,7 @@ export const daDK: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Efternavnet må ikke overstige 256 tegn.',
     form_param_max_length_exceeded__name: 'Navnet må ikke overstige 256 tegn.',
     form_param_nil: 'Dette felt kan ikke være tomt.',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Adgangskoden er forkert.',
     form_password_length_too_short: 'Adgangskoden er for kort.',
     form_password_not_strong_enough: 'Adgangskoden er ikke stærk nok.',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -546,6 +546,7 @@ export const deDE: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Der Nachname sollte nicht mehr als 256 Zeichen umfassen.',
     form_param_max_length_exceeded__name: 'Der Name sollte nicht länger als 256 Zeichen sein.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Passwort nicht stark genug',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -540,6 +540,7 @@ export const elGR: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Ο κωδικός πρόσβασής σας δεν είναι αρκετά ισχυρός.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -530,6 +530,7 @@ export const enUS: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Your password is not strong enough.',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -541,6 +541,7 @@ export const esES: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'El apellido no debe exceder los 256 caracteres.',
     form_param_max_length_exceeded__name: 'El nombre no debe exceder los 256 caracteres.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Tu contraseña no es lo suficientemente fuerte.',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -544,6 +544,7 @@ export const esMX: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'El apellido debe tener menos de 256 caracteres.',
     form_param_max_length_exceeded__name: 'El nombre debe tener menos de 256 caracteres.',
     form_param_nil: 'Campo vacío.',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Contraseña incorrecta.',
     form_password_length_too_short: 'La contraseña es muy corta.',
     form_password_not_strong_enough: 'La contraseña no es suficientemente segura.',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -541,6 +541,7 @@ export const fiFI: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Sukunimi saa olla enintään 256 merkkiä pitkä.',
     form_param_max_length_exceeded__name: 'Nimi saa olla enintään 256 merkkiä pitkä.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Salasana ei ole riittävän vahva.',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -543,6 +543,7 @@ export const frFR: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Le nom ne doit pas dépasser 256 caractères.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Mot de passe incorrect',
     form_password_length_too_short: 'Votre mot de passe est trop court.',
     form_password_not_strong_enough: "Votre mot de passe n'est pas assez fort.",

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -531,6 +531,7 @@ export const heIL: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'שם משפחה לא צריך לעלות על 256 תווים.',
     form_param_max_length_exceeded__name: 'שם לא צריך לעלות על 256 תווים.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'הסיסמה שלך אינה מספיק חזקה.',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -540,6 +540,7 @@ export const huHU: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'A vezetéknév nem lehet hosszabb, mint 256 karakter.',
     form_param_max_length_exceeded__name: 'A név nem lehet hosszabb mint 256 karakter.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'A jelszó nem elég erős',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -543,6 +543,7 @@ export const isIS: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Eftirnafn má ekki vera lengra en 256 stafir.',
     form_param_max_length_exceeded__name: 'Nafn má ekki vera lengra en 256 stafir.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Lykilorðið þitt er ekki nógu sterkt.',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -540,6 +540,7 @@ export const itIT: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Il cognome non deve superare i 256 caratteri.',
     form_param_max_length_exceeded__name: 'Il nome non deve superare i 256 caratteri.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'La tua password non è abbastanza forte.',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -540,6 +540,7 @@ export const jaJP: LocalizationResource = {
     form_param_max_length_exceeded__last_name: '姓は256文字を超えることはできません。',
     form_param_max_length_exceeded__name: '名前は256文字を超えることはできません。',
     form_param_nil: 'パラメータが存在しません。',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'パスワードが正しくありません。',
     form_password_length_too_short: 'パスワードの長さが短すぎます。',
     form_password_not_strong_enough: 'パスワードの強度が不十分です。',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -535,6 +535,7 @@ export const koKR: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: '비밀번호가 충분히 안전하지 않습니다.',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -541,6 +541,7 @@ export const mnMN: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Овог 256 тэмдэгтээс хэтрэхгүй байх ёстой.',
     form_param_max_length_exceeded__name: 'Нэр 256 тэмдэгтээс хэтрэхгүй байх ёстой.',
     form_param_nil: 'Параметр байхгүй байна.',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Нууц үг буруу байна.',
     form_password_length_too_short: 'Нууц үгийн урт хэт богино байна.',
     form_password_not_strong_enough: 'Таны нууц үг хангалттай хүчтэй биш байна.',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -540,6 +540,7 @@ export const nbNO: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Etternavn kan ikke være lengre enn 256 bokstaver.',
     form_param_max_length_exceeded__name: 'Navn kan ikke være lengre enn 256 bokstaver.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Passordet ditt er ikke sterkt nok.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -538,6 +538,7 @@ export const nlNL: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Your password is not strong enough.',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -538,6 +538,7 @@ export const plPL: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Your password is not strong enough.',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -541,6 +541,7 @@ export const ptBR: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'O sobrenome não deve exceder 256 caracteres.',
     form_param_max_length_exceeded__name: 'O nome não deve exceder 256 caracteres.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Senha incorreta.',
     form_password_length_too_short: 'Sua senha é muito curta. Por favor, tente novamente.',
     form_password_not_strong_enough: 'Sua senha não é forte o suficiente.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -538,6 +538,7 @@ export const ptPT: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'O apelido não deve exceder 256 caracteres.',
     form_param_max_length_exceeded__name: 'O nome não deve exceder 256 caracteres.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'A sua palavra-passe não é forte o suficiente.',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -542,6 +542,7 @@ export const roRO: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Numele de familie nu trebuie să depășească 256 de caractere.',
     form_param_max_length_exceeded__name: 'Numele nu trebuie să depășească 256 de caractere.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Parola dvs. nu este suficient de puternică.',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -542,6 +542,7 @@ export const ruRU: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Ваш пароль недостаточно надежный.',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -538,6 +538,7 @@ export const skSK: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Vaše heslo nie je dostatočne silné.',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -539,6 +539,7 @@ export const srRS: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Prezime ne sme premašiti 256 karaktera.',
     form_param_max_length_exceeded__name: 'Naziv ne sme premašiti 256 karaktera.',
     form_param_nil: 'Parametar ne može biti prazan.',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Lozinka je netačna.',
     form_password_length_too_short: 'Lozinka je prekratka.',
     form_password_not_strong_enough: 'Tvoja lozinka nije dovoljno jaka.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -539,6 +539,7 @@ export const svSE: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Efternamnet får inte överskrida 256 tecken.',
     form_param_max_length_exceeded__name: 'Namnet får inte överskrida 256 tecken.',
     form_param_nil: 'Parametern får inte vara tom.',
+    form_param_value_invalid: undefined,
     form_password_incorrect: 'Lösenordet är felaktigt.',
     form_password_length_too_short: 'Lösenordet är för kort.',
     form_password_not_strong_enough: 'Ditt lösenord är inte tillräckligt starkt.',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -536,6 +536,7 @@ export const thTH: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'นามสกุลไม่ควรเกิน 256 ตัวอักษร',
     form_param_max_length_exceeded__name: 'ชื่อไม่ควรเกิน 256 ตัวอักษร',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'รหัสผ่านของคุณไม่เพียงพอต่อความปลอดภัย',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -541,6 +541,7 @@ export const trTR: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Soyadınız 256 karakteri geçmemelidir.',
     form_param_max_length_exceeded__name: 'Adınız 256 karakteri geçmemelidir.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Şifreniz yeterince güçlü değil.',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -538,6 +538,7 @@ export const ukUA: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Ваш пароль недостатньо надійний.',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -538,6 +538,7 @@ export const viVN: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Mật khẩu của bạn không đủ mạnh.',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -527,6 +527,7 @@ export const zhCN: LocalizationResource = {
     form_param_max_length_exceeded__last_name: '姓氏长度不得超过256个字符。',
     form_param_max_length_exceeded__name: '姓名长度不得超过256个字符。',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: '您的密码强度不够。',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -534,6 +534,7 @@ export const zhTW: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
     form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: '您的密碼強度不夠。',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -816,6 +816,7 @@ type UnstableErrors = WithParamName<{
   form_identifier_exists__phone_number: LocalizationValue;
   form_password_not_strong_enough: LocalizationValue;
   form_password_size_in_bytes_exceeded: LocalizationValue;
+  form_param_value_invalid: LocalizationValue;
   passwordComplexity: {
     sentencePrefix: LocalizationValue;
     minimumLength: LocalizationValue;


### PR DESCRIPTION
## Description

This PR adds initial empty translation keys for new organization name validation errors. Just to make it easy to update later.

See **CORE-2276** and **DASH-387** for this one

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
