### PR TITLE
chore(backend): Add webhook event types for roles and permissions

### DIFF
--- a/.changeset/mean-swans-relax.md
+++ b/.changeset/mean-swans-relax.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add webhook event types for roles and permissions

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -32,6 +32,8 @@ export const ObjectType = {
   Token: 'token',
   TotalCount: 'total_count',
   TestingToken: 'testing_token',
+  Role: 'role',
+  Permission: 'permission',
 } as const;
 
 export type ObjectType = (typeof ObjectType)[keyof typeof ObjectType];
@@ -376,4 +378,24 @@ export interface TestingTokenJSON {
   object: typeof ObjectType.TestingToken;
   token: string;
   expires_at: number;
+}
+
+export interface RoleJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.Role;
+  key: string;
+  name: string;
+  description: string;
+  permissions: PermissionJSON[];
+  is_creator_eligible: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface PermissionJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.Permission;
+  key: string;
+  name: string;
+  description: string;
+  created_at: number;
+  updated_at: number;
 }

--- a/packages/backend/src/api/resources/Webhooks.ts
+++ b/packages/backend/src/api/resources/Webhooks.ts
@@ -4,6 +4,8 @@ import type {
   OrganizationInvitationJSON,
   OrganizationJSON,
   OrganizationMembershipJSON,
+  PermissionJSON,
+  RoleJSON,
   SessionJSON,
   SMSMessageJSON,
   UserJSON,
@@ -38,6 +40,13 @@ export type OrganizationInvitationWebhookEvent = Webhook<
   OrganizationInvitationJSON
 >;
 
+export type RoleWebhookEvent = Webhook<'role.created' | 'role.updated' | 'role.deleted', RoleJSON>;
+
+export type PermissionWebhookEvent = Webhook<
+  'permission.created' | 'permission.updated' | 'permission.deleted',
+  PermissionJSON
+>;
+
 export type WebhookEvent =
   | UserWebhookEvent
   | SessionWebhookEvent
@@ -45,6 +54,8 @@ export type WebhookEvent =
   | SMSWebhookEvent
   | OrganizationWebhookEvent
   | OrganizationMembershipWebhookEvent
-  | OrganizationInvitationWebhookEvent;
+  | OrganizationInvitationWebhookEvent
+  | RoleWebhookEvent
+  | PermissionWebhookEvent;
 
 export type WebhookEventType = WebhookEvent['type'];


### PR DESCRIPTION
## Description

Resolves ORGS-165

Add webhook event types for roles and permissions. Those events were introduced a while ago and weren't included in the types here. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
