### PR TITLE
feat(express): Make handshake opt-in

### DIFF
--- a/.changeset/witty-knives-build.md
+++ b/.changeset/witty-knives-build.md
@@ -1,0 +1,5 @@
+---
+"@clerk/express": minor
+---
+
+Add opt-in option for handshake flow

--- a/package-lock.json
+++ b/package-lock.json
@@ -15398,6 +15398,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
       "dev": true,
@@ -21173,20 +21231,6 @@
       "version": "0.1.7",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/express/node_modules/statuses": {
       "version": "2.0.1",
@@ -32060,6 +32104,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "dev": true,
@@ -42352,13 +42412,226 @@
         "@types/express": "^4.17.21",
         "@types/node": "^18.19.33",
         "@types/supertest": "^6.0.2",
-        "express": "^4.19.2",
+        "express": "^4.21.0",
         "supertest": "^6.3.4",
         "tsup": "*",
         "typescript": "*"
       },
       "engines": {
         "node": ">=18.17.0"
+      }
+    },
+    "packages/express/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "packages/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/express/node_modules/express": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.10",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "packages/express/node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/express/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/express/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/express/node_modules/path-to-regexp": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "packages/express/node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "packages/express/node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/express/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/express/node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "packages/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "packages/express/node_modules/tslib": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -63,7 +63,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^18.19.33",
     "@types/supertest": "^6.0.2",
-    "express": "^4.19.2",
+    "express": "^4.21.0",
     "supertest": "^6.3.4",
     "tsup": "*",
     "typescript": "*"

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -19,13 +19,13 @@ describe('clerkMiddleware', () => {
     });
 
     it('throws error if secretKey is not passed as parameter', async () => {
-      const response = await runMiddleware(clerkMiddleware()).expect(500);
+      const response = await runMiddleware(clerkMiddleware({ enableHandshake: true })).expect(500);
 
       assertNoDebugHeaders(response);
     });
 
     it('works if secretKey is passed as parameter', async () => {
-      const options = { secretKey: 'sk_test_....' };
+      const options = { secretKey: 'sk_test_....', enableHandshake: true };
 
       const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
         200,
@@ -55,7 +55,7 @@ describe('clerkMiddleware', () => {
     });
 
     it('works if publishableKey is passed as parameter', async () => {
-      const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
+      const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
 
       const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
         200,
@@ -69,16 +69,14 @@ describe('clerkMiddleware', () => {
   it.todo('supports usage without invocation: app.use(clerkMiddleware)');
 
   it('supports usage without parameters: app.use(clerkMiddleware())', async () => {
-    const response = await runMiddleware(clerkMiddleware(), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
-      200,
-      'Hello world!',
-    );
+    await runMiddleware(clerkMiddleware(), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(200, 'Hello world!');
 
-    assertSignedOutDebugHeaders(response);
+    // TODO: Observability headers are not added by default
+    // assertSignedOutDebugHeaders(response);
   });
 
   it('supports usage with parameters: app.use(clerkMiddleware(options))', async () => {
-    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
+    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
 
     const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
       200,
@@ -94,10 +92,9 @@ describe('clerkMiddleware', () => {
       return next();
     };
 
-    const response = await runMiddleware(clerkMiddleware(handler), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
-      200,
-      'Hello world!',
-    );
+    const response = await runMiddleware(clerkMiddleware(handler, { enableHandshake: true }), {
+      Cookie: '__clerk_db_jwt=deadbeef;',
+    }).expect(200, 'Hello world!');
 
     expect(response.header).toHaveProperty('x-clerk-auth-custom', 'custom-value');
     assertSignedOutDebugHeaders(response);
@@ -108,7 +105,7 @@ describe('clerkMiddleware', () => {
       res.setHeader('x-clerk-auth-custom', 'custom-value');
       return next();
     };
-    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
+    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
 
     const response = await runMiddleware(clerkMiddleware(handler, options), {
       Cookie: '__clerk_db_jwt=deadbeef;',
@@ -144,7 +141,7 @@ describe('clerkMiddleware', () => {
   });
 
   it('supports handshake flow', async () => {
-    const response = await runMiddleware(clerkMiddleware(), {
+    const response = await runMiddleware(clerkMiddleware({ enableHandshake: true }), {
       Cookie: '__client_uat=1711618859;',
       'Sec-Fetch-Dest': 'document',
     }).expect(307);

--- a/packages/express/src/__tests__/helpers.ts
+++ b/packages/express/src/__tests__/helpers.ts
@@ -44,6 +44,7 @@ export function mockRequestWithAuth(auth: Partial<AuthObject> = {}): ExpressRequ
   } as unknown as ExpressRequestWithAuth;
 }
 
+// Applicable when opting-in to handshake flow
 export function assertSignedOutDebugHeaders(response: any) {
   expect(response.header).toHaveProperty('x-clerk-auth-status', 'signed-out');
   expect(response.header).toHaveProperty('x-clerk-auth-reason', 'session-token-and-uat-missing');

--- a/packages/express/src/clerkMiddleware.ts
+++ b/packages/express/src/clerkMiddleware.ts
@@ -23,6 +23,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
   const [handler, options] = parseHandlerAndOptions(args);
 
   const clerkClient = options.clerkClient || defaultClerkClient;
+  const enableHandshake = options.enableHandshake || false;
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const middleware: RequestHandler = async (request, response, next) => {
@@ -33,12 +34,14 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
         options,
       });
 
-      const err = setResponseHeaders(requestState, response);
-      if (err || response.writableEnded) {
-        if (err) {
-          next(err);
+      if (enableHandshake) {
+        const err = setResponseHeaders(requestState, response);
+        if (err || response.writableEnded) {
+          if (err) {
+            next(err);
+          }
+          return;
         }
-        return;
       }
 
       Object.assign(request, { auth: requestState.toAuth() });

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -7,6 +7,15 @@ export type ExpressRequestWithAuth = ExpressRequest & { auth: AuthObject };
 export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
   debug?: boolean;
   clerkClient?: ClerkClient;
+  /**
+   * Enables Clerk's handshake flow, which helps verify the session state
+   * when a session JWT has expired. It issues a 307 redirect to refresh
+   * the session JWT if the user is still logged in.
+   *
+   * This is useful for server-rendered fullstack applications to handle
+   * expired JWTs securely and maintain session continuity.
+   */
+  enableHandshake?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Description

Our SDK development guidelines suggests to [add handshake support](https://clerk.com/docs/references/sdk/fullstack#add-handshake-support) for Fullstack SDKs. This PR makes handshaking in our Express SDK opt-in since this is a [Backend-only SDK](https://clerk.com/docs/references/sdk/backend-only).

This should be a safe minor version bump since we didn't advertise and document our Express SDK yet.

_This is part of making our Express SDK ready. Tests to be added_

Resolves **ECO-195**

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
