### PR TITLE
feat(express): Make `requireAuth` middleware flexible

### DIFF
--- a/.changeset/popular-coats-turn.md
+++ b/.changeset/popular-coats-turn.md
@@ -1,5 +1,5 @@
 ---
-"@clerk/express": patch
+"@clerk/express": minor
 ---
 
 Make `requireAuth` middleware more flexible

--- a/.changeset/popular-coats-turn.md
+++ b/.changeset/popular-coats-turn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/express": patch
+---
+
+Make `requireAuth` middleware more flexible

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -84,12 +84,12 @@ app.use(clerkMiddleware(handler, options));
 
 ### `requireAuth`
 
-`requireAuth` is a middleware function that you can use to protect routes in your Express.js application. This function checks if the user is authenticated, and returns a 401 status code if they are not.
+`requireAuth` is a middleware function that you can use to protect routes in your Express.js application. This function checks if the user is authenticated, and passes an `UnauthorizedError` to the next middleware if they are not.
 
 `clerkMiddleware()` is required to be set in the middleware chain before this util is used.
 
 ```js
-import { clerkMiddleware, requireAuth } from '@clerk/express';
+import { clerkMiddleware, requireAuth, UnauthorizedError } from '@clerk/express';
 import express from 'express';
 
 const app = express();
@@ -102,6 +102,14 @@ app.use(clerkMiddleware());
 // Define a protected route
 app.get('/protected', requireAuth, (req, res) => {
   res.send('This is a protected route');
+});
+
+app.use((err, req, res, next) => {
+  if (err instanceof UnauthorizedError) {
+    res.status(401).send('Unauthorized');
+  } else {
+    next(err);
+  }
 });
 
 // Start the server and listen on the specified port

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -123,7 +123,7 @@ app.listen(port, () => {
 The `getAuth()` helper retrieves authentication state from the request object. See the [Next.js reference documentation](https://clerk.com/docs/references/nextjs/get-auth) for more information on how to use it.
 
 ```js
-import { clerkMiddleware, getAuth } from '@clerk/express';
+import { clerkMiddleware, getAuth, ForbiddenError } from '@clerk/express';
 import express from 'express';
 
 const app = express();
@@ -138,8 +138,8 @@ hasPermission = (request, response, next) => {
 
   // Handle if the user is not authorized
   if (!auth.has({ permission: 'org:admin:testpermission' })) {
-    response.status(403).send('Forbidden');
-    return;
+    // Catch this inside an error-handling middleware
+    return next(new ForbiddenError());
   }
 
   return next();

--- a/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`module exports should not change unless explicitly set 1`] = `
 [
+  "ForbiddenError",
   "UnauthorizedError",
   "clerkClient",
   "clerkMiddleware",

--- a/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`module exports should not change unless explicitly set 1`] = `
 [
+  "UnauthorizedError",
   "clerkClient",
   "clerkMiddleware",
   "createClerkClient",

--- a/packages/express/src/__tests__/requireAuth.test.ts
+++ b/packages/express/src/__tests__/requireAuth.test.ts
@@ -1,5 +1,17 @@
-import { requireAuth } from '../requireAuth';
+import type { NextFunction, Request as ExpressRequest, Response as ExpressResponse } from 'express';
+
+import { requireAuth, UnauthorizedError } from '../requireAuth';
 import { mockRequest, mockRequestWithAuth, mockResponse } from './helpers';
+
+// This middleware is used to handle the UnauthorizedError thrown by requireAuth
+// See https://expressjs.com/en/guide/error-handling.html for handling errors in Express
+const errorHandler = (err: Error, _req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+  if (err instanceof UnauthorizedError) {
+    return res.status(401).send('Unauthorized');
+  }
+
+  return next(err);
+};
 
 describe('requireAuth', () => {
   it('throws error if clerkMiddleware is not executed before this middleware', async () => {
@@ -8,24 +20,36 @@ describe('requireAuth', () => {
     );
   });
 
-  it('make application require auth - returns 401 Unauthorized for signed-out', async () => {
+  it('passes UnauthorizedError to next for unauthenticated requests', () => {
+    const request = mockRequestWithAuth();
     const response = mockResponse();
-    const nextFn = jest.fn();
+    const next = jest.fn();
 
-    requireAuth(mockRequestWithAuth(), response, nextFn);
+    requireAuth(request, response, next);
+
+    // Simulate how Express would call the error middleware
+    const error = next.mock.calls[0][0];
+    errorHandler(error, request, response, next);
 
     expect(response.status).toHaveBeenCalledWith(401);
-    expect(nextFn).not.toHaveBeenCalled();
+    expect(response.send).toHaveBeenCalledWith('Unauthorized');
   });
 
-  it('make application require auth - proceed with next middlewares for signed-in', async () => {
-    const response = mockResponse();
-    const nextFn = jest.fn();
+  it('allows access for authenticated requests', async () => {
     const request = mockRequestWithAuth({ userId: 'user_1234' });
+    const response = mockResponse();
+    const next = jest.fn();
 
-    requireAuth(request, response, nextFn);
+    requireAuth(request, response, next);
 
-    expect(response.status).not.toHaveBeenCalled();
-    expect(nextFn).toHaveBeenCalled();
+    // Simulate a protected route
+    const protectedRoute = (_req: ExpressRequest, res: ExpressResponse) => {
+      res.status(200).send('Welcome, user_1234');
+    };
+
+    protectedRoute(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.send).toHaveBeenCalledWith('Welcome, user_1234');
   });
 });

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -5,4 +5,4 @@ export { clerkClient } from './clerkClient';
 export type { ClerkMiddleware, ExpressRequestWithAuth } from './types';
 export { clerkMiddleware } from './clerkMiddleware';
 export { getAuth } from './getAuth';
-export { requireAuth, UnauthorizedError } from './requireAuth';
+export { requireAuth, ForbiddenError, UnauthorizedError } from './requireAuth';

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -5,4 +5,4 @@ export { clerkClient } from './clerkClient';
 export type { ClerkMiddleware, ExpressRequestWithAuth } from './types';
 export { clerkMiddleware } from './clerkMiddleware';
 export { getAuth } from './getAuth';
-export { requireAuth } from './requireAuth';
+export { requireAuth, UnauthorizedError } from './requireAuth';

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -85,11 +85,12 @@ export class ForbiddenError extends Error {
  *
  * @example
  * // Combining with permission check
+ * import { requireAuth, ForbiddenError } from '@clerk/express'
+ *
  * const hasPermission = (req, res, next) => {
  *    const auth = getAuth(req)
  *    if (!auth.has({ permission: 'permission' })) {
- *      res.status(403).send('Forbidden')
- *      return
+ *      return next(new ForbiddenError())
  *    }
  *    return next()
  * }

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -20,8 +20,11 @@ export class UnauthorizedError extends Error {
  * // Basic usage
  * import { requireAuth, UnauthorizedError } from '@clerk/express'
  *
- * router.get(requireAuth)
- * app.use((err, req, res, next) => {
+ * router.get('/path', requireAuth, getHandler)
+ * //or
+ * router.use(requireAuth)
+ *
+ * router.use((err, req, res, next) => {
  *   if (err instanceof UnauthorizedError) {
  *     res.status(401).send('Unauthorized')
  *   } else {

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -5,8 +5,6 @@ import { getAuth } from './getAuth';
 import { requestHasAuthObject } from './utils';
 
 /**
- * Represents an error for unauthenticated requests.
- *
  * This error is typically thrown by the `requireAuth` middleware when
  * a request is made to a protected route without proper authentication.
  *
@@ -27,6 +25,40 @@ export class UnauthorizedError extends Error {
   constructor() {
     super('Unauthorized');
     this.name = 'UnauthorizedError';
+  }
+}
+
+/**
+ * This error is typically used when a user is authenticated but lacks the necessary permissions
+ * to access a resource or perform an action.
+ *
+ * @class
+ * @extends Error
+ *
+ * @example
+ * // This error can be used in custom authorization middleware
+ * const checkPermission = (req, res, next) => {
+ *   const auth = getAuth(req)
+ *   if (!auth.has({ permission: 'permission' })) {
+ *     return next(new ForbiddenError());
+ *   }
+ *   next();
+ * };
+ *
+ * @example
+ * // This error is usually handled in an Express error handling middleware
+ * app.use((err, req, res, next) => {
+ *   if (err instanceof ForbiddenError) {
+ *     res.status(403).send('Forbidden');
+ *   } else {
+ *     next(err);
+ *   }
+ * });
+ */
+export class ForbiddenError extends Error {
+  constructor() {
+    super('Forbidden');
+    this.name = 'ForbiddenError';
   }
 }
 
@@ -53,10 +85,10 @@ export class UnauthorizedError extends Error {
  *
  * @example
  * // Combining with permission check
- * const hasPermission = (request, response, next) => {
- *    const auth = getAuth(request)
+ * const hasPermission = (req, res, next) => {
+ *    const auth = getAuth(req)
  *    if (!auth.has({ permission: 'permission' })) {
- *      response.status(403).send('Forbidden')
+ *      res.status(403).send('Forbidden')
  *      return
  *    }
  *    return next()

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -37,7 +37,7 @@ export class UnauthorizedError extends Error {
  * const hasPermission = (request, response, next) => {
  *    const auth = getAuth(request)
  *    if (!auth.has({ permission: 'permission' })) {
- *      response.status(403).json({ error: 'Forbidden' })
+ *      response.status(403).send('Forbidden')
  *      return
  *    }
  *    return next()

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -13,7 +13,8 @@ export class UnauthorizedError extends Error {
 
 /**
  * Middleware to require authentication for user requests.
- * Throws an UnauthorizedError for unauthenticated requests, which should be handled by an error middleware.
+ * Passes an UnauthorizedError to the next middleware for unauthenticated requests,
+ * which should be handled by an error middleware.
  *
  * @example
  * // Basic usage
@@ -41,7 +42,6 @@ export class UnauthorizedError extends Error {
  * router.get('/path', requireAuth, hasPermission, getHandler)
  *
  * @throws {Error} If `clerkMiddleware` is not set in the middleware chain before this util is used.
- * @throws {UnauthorizedError} If the request is not authenticated.
  */
 export const requireAuth: RequestHandler = (request, _response, next) => {
   if (!requestHasAuthObject(request)) {

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -4,6 +4,25 @@ import { middlewareRequired } from './errors';
 import { getAuth } from './getAuth';
 import { requestHasAuthObject } from './utils';
 
+/**
+ * Represents an error for unauthenticated requests.
+ *
+ * This error is typically thrown by the `requireAuth` middleware when
+ * a request is made to a protected route without proper authentication.
+ *
+ * @class
+ * @extends Error
+ *
+ * @example
+ * // This error is usually handled in an Express error handling middleware
+ * app.use((err, req, res, next) => {
+ *   if (err instanceof UnauthorizedError) {
+ *     res.status(401).send('Unauthorized');
+ *   } else {
+ *     next(err);
+ *   }
+ * });
+ */
 export class UnauthorizedError extends Error {
   constructor() {
     super('Unauthorized');


### PR DESCRIPTION
## Description

This pull request modifies the `requireAuth` middleware to return a custom `UnauthorizedError` via `next()` instead of throwing a 401 directly. The core change:

```ts
// Before
if (!getAuth(request).userId) {
  return response.status(401).send('Unauthorized');
}

// After
if (!getAuth(request).userId) {
  return next(new UnauthorizedError());
}
```

This aligns the `requireAuth` middleware with Express [error handling patterns](https://expressjs.com/en/guide/error-handling.html) and makes it customizable. Userland can now configure their own error handling middleware to process the `UnauthorizedError` as needed. Here's an example:

```ts
import { clerkMiddleware, requireAuth, UnauthorizedError } from '@clerk/express'

const app = express()
app.use(clerkMiddleware())

app.get('/protected', requireAuth, (req, res) => {
  res.send('This is a protected route')
})

app.use((err, req, res, next) => {
 if (err instanceof UnauthorizedError) {
   res.status(401).send('Unauthorized')
 } else {
   next(err)
 }
})
```

_This is part of making our Express SDK ready._

Resolves ECO-190

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
