### PR TITLE
feat(nextjs): Allows access to `request` object to dynamically define `clerkMiddleware` options

### DIFF
--- a/.changeset/ten-months-kick.md
+++ b/.changeset/ten-months-kick.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": minor
+---
+
+Allows access to request object to dynamically define `clerkMiddleware` options

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -226,6 +226,22 @@ describe('clerkMiddleware(params)', () => {
     expect(decryptedData).toEqual(options);
   });
 
+  it('allows to access the request object to dynamically define options', async () => {
+    const resp = await clerkMiddleware(
+      () => {
+        return NextResponse.next();
+      },
+      req => {
+        console.log({ req });
+
+        return {
+          domain: req.nextUrl.host,
+        };
+      },
+    )(mockRequest({ url: '/sign-in' }), {} as NextFetchEvent);
+    expect(resp?.status).toEqual(200);
+  });
+
   describe('auth().redirectToSignIn()', () => {
     it('redirects to sign-in url when redirectToSignIn is called and the request is a page request', async () => {
       const req = mockRequest({

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -4,7 +4,7 @@ import { constants } from '@clerk/backend/internal';
 import { deprecated } from '@clerk/shared/deprecated';
 
 import { buildRequestLike, isPrerenderingBailout } from '../app-router/server/utils';
-import { clerkMiddlewareRequestDataStore } from './clerkMiddleware';
+import { clerkMiddlewareRequestDataStorage } from './clerkMiddleware';
 import {
   API_URL,
   API_VERSION,
@@ -62,7 +62,7 @@ const clerkClientForRequest = () => {
   }
 
   // Fallbacks between options from middleware runtime and `NextRequest` from application server
-  const options = clerkMiddlewareRequestDataStore.getStore() ?? requestData;
+  const options = clerkMiddlewareRequestDataStorage.getStore()?.get('requestData') ?? requestData;
   if (options?.secretKey || options?.publishableKey) {
     return createClerkClientWithOptions(options);
   }

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -61,8 +61,14 @@ const clerkClientForRequest = () => {
     }
   }
 
+  console.log('🍋 inside clerkClient', {
+    store: clerkMiddlewareRequestDataStore,
+    data: clerkMiddlewareRequestDataStore?.getStore(),
+  });
+
   // Fallbacks between options from middleware runtime and `NextRequest` from application server
   const options = clerkMiddlewareRequestDataStore.getStore() ?? requestData;
+
   if (options?.secretKey || options?.publishableKey) {
     return createClerkClientWithOptions(options);
   }

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -61,14 +61,8 @@ const clerkClientForRequest = () => {
     }
   }
 
-  console.log('🍋 inside clerkClient', {
-    store: clerkMiddlewareRequestDataStore,
-    data: clerkMiddlewareRequestDataStore?.getStore(),
-  });
-
   // Fallbacks between options from middleware runtime and `NextRequest` from application server
   const options = clerkMiddlewareRequestDataStore.getStore() ?? requestData;
-
   if (options?.secretKey || options?.publishableKey) {
     return createClerkClientWithOptions(options);
   }

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -79,9 +79,6 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   const [request, event] = parseRequestAndEvent(args);
   const [handler, params] = parseHandlerAndOptions(args);
 
-  // Starts the store with an empty context and transitions once request data is available
-  clerkMiddlewareRequestDataStore.enterWith({});
-
   const nextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
     // Handles the case where `options` is a callback function to dynamically access `NextRequest`
     const resolvedParams = typeof params === 'function' ? params(request) : params;
@@ -103,7 +100,15 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
       ...resolvedParams,
     };
 
+    console.log({
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      enterWith: clerkMiddlewareRequestDataStore.enterWith,
+      isDefined: !!clerkMiddlewareRequestDataStore.enterWith,
+    });
+
     clerkMiddlewareRequestDataStore.enterWith(options);
+
+    console.log('passed enterWith 🍋');
 
     clerkClient().telemetry.record(
       eventMethodCalled('clerkMiddleware', {

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -75,24 +75,34 @@ export const clerkMiddlewareRequestDataStore = new AsyncLocalStorage<Partial<Aut
 
 export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   const [request, event] = parseRequestAndEvent(args);
-  const [handler, params] = parseHandlerAndOptions(args, request);
+  const [handler, params] = parseHandlerAndOptions(args);
 
-  const publishableKey = assertKey(params.publishableKey || PUBLISHABLE_KEY, () =>
-    errorThrower.throwMissingPublishableKeyError(),
-  );
-  const secretKey = assertKey(params.secretKey || SECRET_KEY, () => errorThrower.throwMissingSecretKeyError());
-  const signInUrl = params.signInUrl || SIGN_IN_URL;
-  const signUpUrl = params.signUpUrl || SIGN_UP_URL;
+  // Starts the store with an empty context and transitions once request data is available
+  clerkMiddlewareRequestDataStore.enterWith({});
 
-  const options = {
-    ...params,
-    publishableKey,
-    secretKey,
-    signInUrl,
-    signUpUrl,
-  };
+  const nextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
+    // Handles the case where `options` is a callback function to dynamically access `Request`
+    const resolvedParams = typeof params === 'function' ? params(request) : params;
 
-  return clerkMiddlewareRequestDataStore.run(options, () => {
+    const publishableKey = assertKey(resolvedParams.publishableKey || PUBLISHABLE_KEY, () =>
+      errorThrower.throwMissingPublishableKeyError(),
+    );
+    const secretKey = assertKey(resolvedParams.secretKey || SECRET_KEY, () =>
+      errorThrower.throwMissingSecretKeyError(),
+    );
+    const signInUrl = resolvedParams.signInUrl || SIGN_IN_URL;
+    const signUpUrl = resolvedParams.signUpUrl || SIGN_UP_URL;
+
+    const options = {
+      publishableKey,
+      secretKey,
+      signInUrl,
+      signUpUrl,
+      ...resolvedParams,
+    };
+
+    clerkMiddlewareRequestDataStore.enterWith(options);
+
     clerkClient().telemetry.record(
       eventMethodCalled('clerkMiddleware', {
         handler: Boolean(handler),
@@ -101,81 +111,79 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
       }),
     );
 
-    const nextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
-      if (params.debug) {
-        logger.enable();
-      }
-      const clerkRequest = createClerkRequest(request);
-      logger.debug('options', options);
-      logger.debug('url', () => clerkRequest.toJSON());
+    if (resolvedParams.debug) {
+      logger.enable();
+    }
+    const clerkRequest = createClerkRequest(request);
+    logger.debug('options', options);
+    logger.debug('url', () => clerkRequest.toJSON());
 
-      const requestState = await clerkClient().authenticateRequest(
-        clerkRequest,
-        createAuthenticateRequestOptions(clerkRequest, options),
-      );
+    const requestState = await clerkClient().authenticateRequest(
+      clerkRequest,
+      createAuthenticateRequestOptions(clerkRequest, options),
+    );
 
-      logger.debug('requestState', () => ({
-        status: requestState.status,
-        headers: JSON.stringify(Object.fromEntries(requestState.headers)),
-        reason: requestState.reason,
-      }));
+    logger.debug('requestState', () => ({
+      status: requestState.status,
+      headers: JSON.stringify(Object.fromEntries(requestState.headers)),
+      reason: requestState.reason,
+    }));
 
-      const locationHeader = requestState.headers.get(constants.Headers.Location);
-      if (locationHeader) {
-        return new Response(null, { status: 307, headers: requestState.headers });
-      } else if (requestState.status === AuthStatus.Handshake) {
-        throw new Error('Clerk: handshake status without redirect');
-      }
-
-      const authObject = requestState.toAuth();
-      logger.debug('auth', () => ({ auth: authObject, debug: authObject.debug() }));
-
-      const redirectToSignIn = createMiddlewareRedirectToSignIn(clerkRequest);
-      const protect = createMiddlewareProtect(clerkRequest, authObject, redirectToSignIn);
-      const authObjWithMethods: ClerkMiddlewareAuthObject = Object.assign(authObject, { protect, redirectToSignIn });
-
-      let handlerResult: Response = NextResponse.next();
-      try {
-        const userHandlerResult = await clerkMiddlewareRequestDataStore.run(options, async () =>
-          handler?.(() => authObjWithMethods, request, event),
-        );
-        handlerResult = userHandlerResult || handlerResult;
-      } catch (e: any) {
-        handlerResult = handleControlFlowErrors(e, clerkRequest, requestState);
-      }
-
-      // TODO @nikos: we need to make this more generic
-      // and move the logic in clerk/backend
-      if (requestState.headers) {
-        requestState.headers.forEach((value, key) => {
-          handlerResult.headers.append(key, value);
-        });
-      }
-
-      if (isRedirect(handlerResult)) {
-        logger.debug('handlerResult is redirect');
-        return serverRedirectWithAuth(clerkRequest, handlerResult, options);
-      }
-
-      if (options.debug) {
-        setRequestHeadersOnNextResponse(handlerResult, clerkRequest, { [constants.Headers.EnableDebug]: 'true' });
-      }
-
-      decorateRequest(clerkRequest, handlerResult, requestState, params);
-
-      return handlerResult;
-    });
-
-    // If we have a request and event, we're being called as a middleware directly
-    // eg, export default clerkMiddleware;
-    if (request && event) {
-      return nextMiddleware(request, event);
+    const locationHeader = requestState.headers.get(constants.Headers.Location);
+    if (locationHeader) {
+      return new Response(null, { status: 307, headers: requestState.headers });
+    } else if (requestState.status === AuthStatus.Handshake) {
+      throw new Error('Clerk: handshake status without redirect');
     }
 
-    // Otherwise, return a middleware that can be called with a request and event
-    // eg, export default clerkMiddleware(auth => { ... });
-    return nextMiddleware;
+    const authObject = requestState.toAuth();
+    logger.debug('auth', () => ({ auth: authObject, debug: authObject.debug() }));
+
+    const redirectToSignIn = createMiddlewareRedirectToSignIn(clerkRequest);
+    const protect = createMiddlewareProtect(clerkRequest, authObject, redirectToSignIn);
+    const authObjWithMethods: ClerkMiddlewareAuthObject = Object.assign(authObject, { protect, redirectToSignIn });
+
+    let handlerResult: Response = NextResponse.next();
+    try {
+      const userHandlerResult = await clerkMiddlewareRequestDataStore.run(options, async () =>
+        handler?.(() => authObjWithMethods, request, event),
+      );
+      handlerResult = userHandlerResult || handlerResult;
+    } catch (e: any) {
+      handlerResult = handleControlFlowErrors(e, clerkRequest, requestState);
+    }
+
+    // TODO @nikos: we need to make this more generic
+    // and move the logic in clerk/backend
+    if (requestState.headers) {
+      requestState.headers.forEach((value, key) => {
+        handlerResult.headers.append(key, value);
+      });
+    }
+
+    if (isRedirect(handlerResult)) {
+      logger.debug('handlerResult is redirect');
+      return serverRedirectWithAuth(clerkRequest, handlerResult, options);
+    }
+
+    if (options.debug) {
+      setRequestHeadersOnNextResponse(handlerResult, clerkRequest, { [constants.Headers.EnableDebug]: 'true' });
+    }
+
+    decorateRequest(clerkRequest, handlerResult, requestState, resolvedParams);
+
+    return handlerResult;
   });
+
+  // If we have a request and event, we're being called as a middleware directly
+  // eg, export default clerkMiddleware;
+  if (request && event) {
+    return nextMiddleware(request, event);
+  }
+
+  // Otherwise, return a middleware that can be called with a request and event
+  // eg, export default clerkMiddleware(auth => { ... });
+  return nextMiddleware;
 };
 
 const parseRequestAndEvent = (args: unknown[]) => {
@@ -185,20 +193,11 @@ const parseRequestAndEvent = (args: unknown[]) => {
   ];
 };
 
-const parseHandlerAndOptions = (args: unknown[], request: NextRequest | undefined) => {
-  let options = (args.length === 2 ? args[1] : typeof args[0] === 'function' ? {} : args[0]) || {};
-  const handler = typeof args[0] === 'function' ? args[0] : undefined;
-
-  const hasHandlerAndOptions = args.length === 2;
-  if (hasHandlerAndOptions) {
-    /**
-     * Provides the `request` object if options is being called as a callback
-     * @example `clerkMiddleware((auth) => { ... }, (req) => ({ domain: req.nextUrl.host }))`
-     */
-    options = typeof args[1] === 'function' ? args[1](request) : args[1];
-  }
-
-  return [handler, options] as [ClerkMiddlewareHandler | undefined, ClerkMiddlewareOptions];
+const parseHandlerAndOptions = (args: unknown[]) => {
+  return [
+    typeof args[0] === 'function' ? args[0] : undefined,
+    (args.length === 2 ? args[1] : typeof args[0] === 'function' ? {} : args[0]) || {},
+  ] as [ClerkMiddlewareHandler | undefined, ClerkMiddlewareOptions | ((req?: NextRequest) => ClerkMiddlewareOptions)];
 };
 
 type AuthenticateRequest = Pick<ClerkClient, 'authenticateRequest'>['authenticateRequest'];

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -44,6 +44,8 @@ type ClerkMiddlewareHandler = (
 
 export type ClerkMiddlewareOptions = AuthenticateRequestOptions & { debug?: boolean };
 
+type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions;
+
 /**
  * Middleware for Next.js that handles authentication and authorization with Clerk.
  * For more details, please refer to the docs: https://clerk.com/docs/references/nextjs/clerk-middleware
@@ -58,7 +60,7 @@ interface ClerkMiddleware {
    * @example
    * export default clerkMiddleware((auth, request, event) => { ... }, (req) => options);
    */
-  (handler: ClerkMiddlewareHandler, options?: (req: NextRequest) => ClerkMiddlewareOptions): NextMiddleware;
+  (handler: ClerkMiddlewareHandler, options?: ClerkMiddlewareOptionsCallback): NextMiddleware;
   /**
    * @example
    * export default clerkMiddleware(options);
@@ -81,7 +83,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   clerkMiddlewareRequestDataStore.enterWith({});
 
   const nextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
-    // Handles the case where `options` is a callback function to dynamically access `Request`
+    // Handles the case where `options` is a callback function to dynamically access `NextRequest`
     const resolvedParams = typeof params === 'function' ? params(request) : params;
 
     const publishableKey = assertKey(resolvedParams.publishableKey || PUBLISHABLE_KEY, () =>
@@ -197,7 +199,7 @@ const parseHandlerAndOptions = (args: unknown[]) => {
   return [
     typeof args[0] === 'function' ? args[0] : undefined,
     (args.length === 2 ? args[1] : typeof args[0] === 'function' ? {} : args[0]) || {},
-  ] as [ClerkMiddlewareHandler | undefined, ClerkMiddlewareOptions | ((req?: NextRequest) => ClerkMiddlewareOptions)];
+  ] as [ClerkMiddlewareHandler | undefined, ClerkMiddlewareOptions | ClerkMiddlewareOptionsCallback];
 };
 
 type AuthenticateRequest = Pick<ClerkClient, 'authenticateRequest'>['authenticateRequest'];


### PR DESCRIPTION
## Description

Resolves SDK-1932 

Allows to dynamically access the Next.js `request` object when providing options to `clerkMiddleware`: 

```ts
export default clerkMiddleware((auth) => {
  return NextResponse.next();
}, (req) => {
 return ({
    domain: req.nextUrl.host,
  })
});
```

Another example of a use case where Clerk keys could be fetched based on tenant: 

```ts
export default clerkMiddleware((auth, req) => {
  return NextResponse.next();
}, (req) => {
  const tenant = getTenant(req)
  const { publishableKey, secretKey } = getClerkKeys(tenant)

  return {
    publishableKey,
    secretKey,
  }
})
```

---

This is another improvement for the ["Next.js dynamic keys" feature](https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys). So far we propagate `secretKey` and `publishableKey` from the middleware to the application server allowing those keys to be provided statically during runtime, but we don't support dynamically resolving per request as in the example above.  

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
