### PR TITLE
fix(astro): Prevent circular JSON error with complex Astro configs

### DIFF
--- a/.changeset/smart-mice-worry.md
+++ b/.changeset/smart-mice-worry.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fixes an issue where complex Astro configs caused circular reference JSON errors

--- a/packages/astro/src/integration/vite-plugin-astro-config.ts
+++ b/packages/astro/src/integration/vite-plugin-astro-config.ts
@@ -30,10 +30,10 @@ export function vitePluginAstroConfig(astroConfig: AstroConfig): VitePlugin {
     load(id) {
       if (id === resolvedVirtualModuleId) {
         return `
-          export const astroConfig = ${JSON.stringify(astroConfig)};
+          const configOutput = '${astroConfig.output}';
 
           export function isStaticOutput(forceStatic) {
-            if (astroConfig.output === 'hybrid' && forceStatic === undefined) {
+            if (configOutput === 'hybrid' && forceStatic === undefined) {
               // Default page is prerendered in hybrid mode
               return true;
             }
@@ -42,7 +42,7 @@ export function vitePluginAstroConfig(astroConfig: AstroConfig): VitePlugin {
               return forceStatic;
             }
 
-            return astroConfig.output === 'static';
+            return configOutput === 'static';
           }
         `;
       }


### PR DESCRIPTION
## Description

Previously, the integration was [stringifying the entire Astro config](https://github.com/clerk/javascript/blob/d8954948d08e3d8090b2be41b4670d76341c6dfd/packages/astro/src/integration/vite-plugin-astro-config.ts#L33), which causes a a "Converting circular structure to JSON" error when the Clerk integration was last in the integrations config. This PR fix removes the full config stringification and instead only uses the `output` property from the Astro config, as that's the only part needed.

Resolves SDK-1930
Fixes https://github.com/clerk/javascript/issues/4142

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
