### PR TITLE
fix(backend): Do not cache 307 redirects

### DIFF
--- a/.changeset/spotty-students-judge.md
+++ b/.changeset/spotty-students-judge.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Fix Chrome caching 307 redirects when a handshake is triggered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,10 +543,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -1328,10 +1330,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2565,14 +2569,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.6",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -11243,18 +11249,20 @@
       }
     },
     "node_modules/@tanstack/start-vite-plugin": {
-      "version": "1.57.6",
+      "version": "1.57.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/start-vite-plugin/-/start-vite-plugin-1.57.14.tgz",
+      "integrity": "sha512-TmuAuD5IkUUz7vX9DcPCYNIgs2WXiMyLacN0uyzYa7mlOfp/vKwSIfMGvkZsyr6jhqzWHeB00EPql60HfjIqaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
         "@babel/plugin-syntax-jsx": "^7.24.7",
-        "@babel/plugin-syntax-typescript": "^7.24.7",
+        "@babel/plugin-syntax-typescript": "^7.25.4",
         "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.3",
-        "@babel/types": "^7.25.2",
+        "@babel/traverse": "^7.25.6",
+        "@babel/types": "^7.25.6",
         "@types/babel__core": "^7.20.5",
         "@types/babel__generator": "^7.6.8",
         "@types/babel__template": "^7.4.4",

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -55,6 +55,7 @@ const Headers = {
   ContentType: 'content-type',
   SecFetchDest: 'sec-fetch-dest',
   Location: 'location',
+  CacheControl: 'cache-control',
 } as const;
 
 const ContentTypes = {

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -62,6 +62,7 @@ function assertHandshake(
     signInUrl?: string;
   },
 ) {
+  assert.true(!!requestState.headers.get('cache-control'));
   assert.propContains(requestState, {
     proxyUrl: '',
     status: AuthStatus.Handshake,

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -121,7 +121,7 @@ export async function authenticateRequest(
       newUrl.searchParams.delete(constants.QueryParameters.Handshake);
       newUrl.searchParams.delete(constants.QueryParameters.HandshakeHelp);
       headers.append(constants.Headers.Location, newUrl.toString());
-      headers.append(constants.Headers.CacheControl, 'no-store');
+      headers.set(constants.Headers.CacheControl, 'no-store');
     }
 
     if (sessionToken === '') {
@@ -179,7 +179,7 @@ ${error.getFullMessage()}`,
       // Chrome aggressively caches inactive tabs. If we don't set the header here,
       // all 307 redirects will be cached and the handshake will end up in an infinite loop.
       if (handshakeHeaders.get(constants.Headers.Location)) {
-        handshakeHeaders.append(constants.Headers.CacheControl, 'no-store');
+        handshakeHeaders.set(constants.Headers.CacheControl, 'no-store');
       }
 
       // Introduce the mechanism to protect for infinite handshake redirect loops

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -96,7 +96,7 @@ export async function authenticateRequest(
       url.searchParams.append(constants.QueryParameters.DevBrowser, authenticateContext.devBrowserToken);
     }
 
-    return new Headers({ location: url.href });
+    return new Headers({ [constants.Headers.Location]: url.href });
   }
 
   async function resolveHandshake() {
@@ -120,7 +120,8 @@ export async function authenticateRequest(
       const newUrl = new URL(authenticateContext.clerkUrl);
       newUrl.searchParams.delete(constants.QueryParameters.Handshake);
       newUrl.searchParams.delete(constants.QueryParameters.HandshakeHelp);
-      headers.append('Location', newUrl.toString());
+      headers.append(constants.Headers.Location, newUrl.toString());
+      headers.append(constants.Headers.CacheControl, 'no-store');
     }
 
     if (sessionToken === '') {
@@ -174,6 +175,13 @@ ${error.getFullMessage()}`,
       // Right now the only usage of passing in different headers is for multi-domain sync, which redirects somewhere else.
       // In the future if we want to decorate the handshake redirect with additional headers per call we need to tweak this logic.
       const handshakeHeaders = headers ?? buildRedirectToHandshake();
+
+      // Chrome aggressively caches inactive tabs. If we don't set the header here,
+      // all 307 redirects will be cached and the handshake will end up in an infinite loop.
+      if (handshakeHeaders.get(constants.Headers.Location)) {
+        handshakeHeaders.append(constants.Headers.CacheControl, 'no-store');
+      }
+
       // Introduce the mechanism to protect for infinite handshake redirect loops
       // using a cookie and returning true if it's infinite redirect loop or false if we can
       // proceed with triggering handshake.
@@ -294,7 +302,7 @@ ${error.getFullMessage()}`,
         authenticateContext.clerkUrl.toString(),
       );
 
-      const headers = new Headers({ location: redirectURL.toString() });
+      const headers = new Headers({ [constants.Headers.Location]: redirectURL.toString() });
       return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.SatelliteCookieNeedsSyncing, '', headers);
     }
 
@@ -314,7 +322,7 @@ ${error.getFullMessage()}`,
       }
       redirectBackToSatelliteUrl.searchParams.append(constants.QueryParameters.ClerkSynced, 'true');
 
-      const headers = new Headers({ location: redirectBackToSatelliteUrl.toString() });
+      const headers = new Headers({ [constants.Headers.Location]: redirectBackToSatelliteUrl.toString() });
       return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.PrimaryRespondsToSyncing, '', headers);
     }
     /**

--- a/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
@@ -19,6 +19,7 @@ exports[`constants from environment variables 1`] = `
     "AuthStatus": "x-clerk-auth-status",
     "AuthToken": "x-clerk-auth-token",
     "Authorization": "authorization",
+    "CacheControl": "cache-control",
     "ClerkRedirectTo": "x-clerk-redirect-to",
     "ClerkRequestData": "x-clerk-request-data",
     "ClerkUrl": "x-clerk-clerk-url",


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

Chrome aggressively caches inactive tabs. If we don't set the header here, all 307 redirects will be cached and the handshake will end up in an infinite loop.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
