### PR TITLE
fix(shared): Add missing entries to "files" array in package.json

### DIFF
--- a/.changeset/shaggy-lobsters-film.md
+++ b/.changeset/shaggy-lobsters-film.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Set correct "files" property in package.json

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,7 @@
   },
   "main": "./dist/index.js",
   "files": [
+    "authorization",
     "dist",
     "browser",
     "callWithRetry",
@@ -73,7 +74,9 @@
     "scripts",
     "telemetry",
     "logger",
-    "webauthn"
+    "webauthn",
+    "router",
+    "pathToRegexp"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/shared/subpaths.mjs
+++ b/packages/shared/subpaths.mjs
@@ -1,5 +1,5 @@
 // This file is a helper for the "subpath-workaround.mjs" script
-// We have to polyfill our "exports" subpaths :cry:
+// When adding an entry to "subpathNames" also add it to "files" in package.json
 
 export const subpathNames = [
   'authorization',

--- a/scripts/subpath-workaround.mjs
+++ b/scripts/subpath-workaround.mjs
@@ -30,6 +30,11 @@ async function run() {
     ...subpathHelperFile.ignoredFolders,
     'dist',
   ];
+
+  if (pkgFile.files.length !== allFilesNames.length) {
+    throw new Error('The package.json "files" array length does not match the subpaths.mjs');
+  }
+
   const hasAllSubpathsInFiles = pkgFile.files.every(name => allFilesNames.includes(name));
 
   if (!hasAllSubpathsInFiles) {


### PR DESCRIPTION
## Description

The last couple of PRs merged did miss adding the new subpaths to the `files` array in package.json. The script that should have checked it miss it, it'll catch it now.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
