### PR TITLE
chore(dev-cli): Update to latest concurrently

### DIFF
--- a/.changeset/friendly-bottles-sin.md
+++ b/.changeset/friendly-bottles-sin.md
@@ -1,0 +1,5 @@
+---
+"@clerk/dev-cli": patch
+---
+
+Update dependencies (`concurrently@9.0.1`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16924,6 +16924,7 @@
     },
     "node_modules/concurrently": {
       "version": "8.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -16949,6 +16950,7 @@
     },
     "node_modules/concurrently/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -16962,6 +16964,7 @@
     },
     "node_modules/concurrently/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -16976,6 +16979,7 @@
     },
     "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16986,6 +16990,7 @@
     },
     "node_modules/concurrently/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -16996,24 +17001,20 @@
     },
     "node_modules/concurrently/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/concurrently/node_modules/rxjs": {
-      "version": "7.8.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/concurrently/node_modules/supports-color": {
       "version": "8.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -18091,14 +18092,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cypress/node_modules/rxjs": {
-      "version": "7.8.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/cypress/node_modules/signal-exit": {
       "version": "3.0.7",
       "dev": true,
@@ -18230,6 +18223,7 @@
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
@@ -33336,6 +33330,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "dev": true,
@@ -34309,7 +34311,8 @@
       }
     },
     "node_modules/spawn-command": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true
     },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
@@ -40910,7 +40913,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "concurrently": "^8.2.2",
+        "concurrently": "^9.0.1",
         "dotenv": "^16.4.5",
         "globby": "^14.0.2",
         "jscodeshift": "^0.16.1"
@@ -41158,6 +41161,44 @@
         "node": ">=18"
       }
     },
+    "packages/dev-cli/node_modules/concurrently": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.0.1.tgz",
+      "integrity": "sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "packages/dev-cli/node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "packages/dev-cli/node_modules/find-cache-dir": {
       "version": "2.1.0",
       "license": "MIT",
@@ -41196,6 +41237,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/dev-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/dev-cli/node_modules/jscodeshift": {

--- a/packages/dev-cli/package.json
+++ b/packages/dev-cli/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
-    "concurrently": "^8.2.2",
+    "concurrently": "^9.0.1",
     "dotenv": "^16.4.5",
     "globby": "^14.0.2",
     "jscodeshift": "^0.16.1"

--- a/packages/dev-cli/src/commands/watch.js
+++ b/packages/dev-cli/src/commands/watch.js
@@ -46,7 +46,6 @@ export async function watch({ js }) {
   };
 
   if (js) {
-    //@ts-expect-error The TypeScript types for the ESM version of concurrently are wrong. https://github.com/open-cli-tools/concurrently/issues/494
     const { result } = concurrently([clerkJsCommand], { prefixColors: 'auto' });
     return result;
   }
@@ -57,7 +56,6 @@ export async function watch({ js }) {
     commands.push(clerkJsCommand);
   }
 
-  //@ts-expect-error The TypeScript types for the ESM version of concurrently are wrong. https://github.com/open-cli-tools/concurrently/issues/494
   const { result } = concurrently(commands, { prefixColors: 'auto' });
   return result;
 }


### PR DESCRIPTION
## Description

This PR updates `concurrently` to the latest version which has improved TypeScript types, removing the need to use `ts-expect-error`.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
