### PR TITLE
fix(clerk-js): Add explicit text color to phone number combobox select option

### DIFF
--- a/.changeset/wild-seals-beg.md
+++ b/.changeset/wild-seals-beg.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Add color to phone input select options to fix rendering within dark theme.

--- a/.changeset/wild-seals-beg.md
+++ b/.changeset/wild-seals-beg.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Add color to phone input select options to fix rendering within dark theme.
+Add color to phone input select options to fix rendering within dark and shadesOfPurple themes.

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -222,6 +222,7 @@ const CountryCodeListItem = memo((props: CountryCodeListItemProps) => {
           width: '100%',
           gap: theme.space.$2,
           padding: `${theme.space.$1x5} ${theme.space.$4}`,
+          color: theme.colors.$colorText,
         }),
         sx,
       ]}


### PR DESCRIPTION
## Description

Fixes issue where phone input combobox select options were not rendering correctly in dark theme due to no color being defined on select options.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-09-16 at 2 52 45 PM](https://github.com/user-attachments/assets/83381c3d-2a68-40c6-b122-38a2528f0083) | ![Screenshot 2024-09-16 at 2 52 21 PM](https://github.com/user-attachments/assets/1bb17851-6055-47a4-b5ef-3e998e1bc99d) |

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-09-16 at 3 01 23 PM](https://github.com/user-attachments/assets/711d2d7e-9c5b-435e-b001-3a1455aeef61) | ![Screenshot 2024-09-16 at 3 01 59 PM](https://github.com/user-attachments/assets/cc20097d-0095-49cf-b068-ddcb1fd0aa10) |

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-09-16 at 3 02 29 PM](https://github.com/user-attachments/assets/89fa9f41-cbd1-4c6b-811e-4c6ea8a96a4b) | ![Screenshot 2024-09-16 at 3 02 29 PM](https://github.com/user-attachments/assets/fe7eb65a-336c-4fa5-a332-248b93d46cd1) |  

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
