### PR TITLE
chore(shared): Exports `match` utility from the `path-to-regexp` lib

### DIFF
--- a/.changeset/big-elephants-add.md
+++ b/.changeset/big-elephants-add.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Expose match from `path-to-regexp`.

--- a/.changeset/big-elephants-add.md
+++ b/.changeset/big-elephants-add.md
@@ -2,4 +2,4 @@
 "@clerk/shared": patch
 ---
 
-Expose match from `path-to-regexp`.
+Exports `match` utility from the `path-to-regexp` lib.

--- a/packages/shared/src/compiled/path-to-regexp/index.d.ts
+++ b/packages/shared/src/compiled/path-to-regexp/index.d.ts
@@ -1,0 +1,102 @@
+interface ParseOptions {
+  /**
+   * Set the default delimiter for repeat parameters. (default: `'/'`)
+   */
+  delimiter?: string;
+  /**
+   * List of characters to automatically consider prefixes when parsing.
+   */
+  prefixes?: string;
+}
+interface RegexpToFunctionOptions {
+  /**
+   * Function for decoding strings for params.
+   */
+  decode?: (value: string, token: Key) => string;
+}
+/**
+ * A match result contains data about the path match.
+ */
+interface MatchResult<P extends object = object> {
+  path: string;
+  index: number;
+  params: P;
+}
+/**
+ * A match is either `false` (no match) or a match result.
+ */
+type Match<P extends object = object> = false | MatchResult<P>;
+/**
+ * The match function takes a string and returns whether it matched the path.
+ */
+type MatchFunction<P extends object = object> = (path: string) => Match<P>;
+/**
+ * Create path match function from `path-to-regexp` spec.
+ */
+declare function match<P extends object = object>(
+  str: Path,
+  options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions,
+): MatchFunction<P>;
+/**
+ * Metadata about a key.
+ */
+interface Key {
+  name: string | number;
+  prefix: string;
+  suffix: string;
+  pattern: string;
+  modifier: string;
+}
+interface TokensToRegexpOptions {
+  /**
+   * When `true` the regexp will be case sensitive. (default: `false`)
+   */
+  sensitive?: boolean;
+  /**
+   * When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)
+   */
+  strict?: boolean;
+  /**
+   * When `true` the regexp will match to the end of the string. (default: `true`)
+   */
+  end?: boolean;
+  /**
+   * When `true` the regexp will match from the beginning of the string. (default: `true`)
+   */
+  start?: boolean;
+  /**
+   * Sets the final character for non-ending optimistic matches. (default: `/`)
+   */
+  delimiter?: string;
+  /**
+   * List of characters that can also be "end" characters.
+   */
+  endsWith?: string;
+  /**
+   * Encode path tokens for use in the `RegExp`.
+   */
+  encode?: (value: string) => string;
+}
+/**
+ * Supported `path-to-regexp` input types.
+ */
+type Path = string | RegExp | Array<string | RegExp>;
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array can be passed in for the keys, which will hold the
+ * placeholder key descriptions. For example, using `/user/:id`, `keys` will
+ * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+ */
+declare function pathToRegexp(path: Path, keys?: Key[], options?: TokensToRegexpOptions & ParseOptions): RegExp;
+
+export {
+  type Match,
+  type MatchFunction,
+  type ParseOptions,
+  type Path,
+  type RegexpToFunctionOptions,
+  type TokensToRegexpOptions,
+  match,
+  pathToRegexp,
+};

--- a/packages/shared/src/compiled/path-to-regexp/index.js
+++ b/packages/shared/src/compiled/path-to-regexp/index.js
@@ -1,238 +1,258 @@
 /* eslint-disable no-redeclare */
 
 function _(r) {
-  for (var n = [], e = 0; e < r.length; ) {
-    var t = r[e];
-    if (t === '*' || t === '+' || t === '?') {
-      n.push({ type: 'MODIFIER', index: e, value: r[e++] });
-      continue;
+  for (var n = [], e = 0; e < r.length;) {
+    var a = r[e];
+    if (a === "*" || a === "+" || a === "?") {
+      n.push({
+        type: "MODIFIER",
+        index: e,
+        value: r[e++]
+      });
+      continue
     }
-    if (t === '\\') {
-      n.push({ type: 'ESCAPED_CHAR', index: e++, value: r[e++] });
-      continue;
+    if (a === "\\") {
+      n.push({
+        type: "ESCAPED_CHAR",
+        index: e++,
+        value: r[e++]
+      });
+      continue
     }
-    if (t === '{') {
-      n.push({ type: 'OPEN', index: e, value: r[e++] });
-      continue;
+    if (a === "{") {
+      n.push({
+        type: "OPEN",
+        index: e,
+        value: r[e++]
+      });
+      continue
     }
-    if (t === '}') {
-      n.push({ type: 'CLOSE', index: e, value: r[e++] });
-      continue;
+    if (a === "}") {
+      n.push({
+        type: "CLOSE",
+        index: e,
+        value: r[e++]
+      });
+      continue
     }
-    if (t === ':') {
-      for (var u = '', a = e + 1; a < r.length; ) {
-        var f = r.charCodeAt(a);
-        if ((f >= 48 && f <= 57) || (f >= 65 && f <= 90) || (f >= 97 && f <= 122) || f === 95) {
-          u += r[a++];
-          continue;
+    if (a === ":") {
+      for (var u = "", t = e + 1; t < r.length;) {
+        var c = r.charCodeAt(t);
+        if (c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || c === 95) {
+          u += r[t++];
+          continue
         }
-        break;
+        break
       }
-      if (!u) {
-        throw new TypeError('Missing parameter name at '.concat(e));
-      }
-      n.push({ type: 'NAME', index: e, value: u }), (e = a);
-      continue;
+      if (!u) throw new TypeError("Missing parameter name at ".concat(e));
+      n.push({
+        type: "NAME",
+        index: e,
+        value: u
+      }), e = t;
+      continue
     }
-    if (t === '(') {
-      var l = 1,
-        d = '',
-        a = e + 1;
-      if (r[a] === '?') {
-        throw new TypeError('Pattern cannot start with "?" at '.concat(a));
-      }
-      for (; a < r.length; ) {
-        if (r[a] === '\\') {
-          d += r[a++] + r[a++];
-          continue;
+    if (a === "(") {
+      var o = 1,
+        h = "",
+        t = e + 1;
+      if (r[t] === "?") throw new TypeError('Pattern cannot start with "?" at '.concat(t));
+      for (; t < r.length;) {
+        if (r[t] === "\\") {
+          h += r[t++] + r[t++];
+          continue
         }
-        if (r[a] === ')') {
-          if ((l--, l === 0)) {
-            a++;
-            break;
+        if (r[t] === ")") {
+          if (o--, o === 0) {
+            t++;
+            break
           }
-        } else if (r[a] === '(' && (l++, r[a + 1] !== '?')) {
-          throw new TypeError('Capturing groups are not allowed at '.concat(a));
-        }
-        d += r[a++];
+        } else if (r[t] === "(" && (o++, r[t + 1] !== "?")) throw new TypeError("Capturing groups are not allowed at ".concat(t));
+        h += r[t++]
       }
-      if (l) {
-        throw new TypeError('Unbalanced pattern at '.concat(e));
-      }
-      if (!d) {
-        throw new TypeError('Missing pattern at '.concat(e));
-      }
-      n.push({ type: 'PATTERN', index: e, value: d }), (e = a);
-      continue;
+      if (o) throw new TypeError("Unbalanced pattern at ".concat(e));
+      if (!h) throw new TypeError("Missing pattern at ".concat(e));
+      n.push({
+        type: "PATTERN",
+        index: e,
+        value: h
+      }), e = t;
+      continue
     }
-    n.push({ type: 'CHAR', index: e, value: r[e++] });
+    n.push({
+      type: "CHAR",
+      index: e,
+      value: r[e++]
+    })
   }
-  return n.push({ type: 'END', index: e, value: '' }), n;
+  return n.push({
+    type: "END",
+    index: e,
+    value: ""
+  }), n
 }
-function D(r, n) {
-  n === void 0 && (n = {});
-  for (
-    var e = _(r),
-      t = n.prefixes,
-      u = t === void 0 ? './' : t,
-      a = '[^'.concat(y(n.delimiter || '/#?'), ']+?'),
-      f = [],
-      l = 0,
-      d = 0,
-      p = '',
-      c = function (v) {
-        if (d < e.length && e[d].type === v) {
-          return e[d++].value;
-        }
-      },
-      w = function (v) {
-        var g = c(v);
-        if (g !== void 0) {
-          return g;
-        }
-        var h = e[d],
-          b = h.type,
-          N = h.index;
-        throw new TypeError('Unexpected '.concat(b, ' at ').concat(N, ', expected ').concat(v));
-      },
-      A = function () {
-        for (var v = '', g; (g = c('CHAR') || c('ESCAPED_CHAR')); ) {
-          v += g;
-        }
-        return v;
-      };
-    d < e.length;
 
-  ) {
-    var s = c('CHAR'),
-      C = c('NAME'),
-      E = c('PATTERN');
-    if (C || E) {
-      var x = s || '';
-      u.indexOf(x) === -1 && ((p += x), (x = '')),
-        p && (f.push(p), (p = '')),
-        f.push({ name: C || l++, prefix: x, suffix: '', pattern: E || a, modifier: c('MODIFIER') || '' });
-      continue;
+function F(r, n) {
+  n === void 0 && (n = {});
+  for (var e = _(r), a = n.prefixes, u = a === void 0 ? "./" : a, t = n.delimiter, c = t === void 0 ? "/#?" : t, o = [], h = 0, m = 0, d = "", f = function(l) {
+    if (m < e.length && e[m].type === l) return e[m++].value
+  }, w = function(l) {
+    var v = f(l);
+    if (v !== void 0) return v;
+    var E = e[m],
+      P = E.type,
+      S = E.index;
+    throw new TypeError("Unexpected ".concat(P, " at ").concat(S, ", expected ").concat(l))
+  }, p = function() {
+    for (var l = "", v; v = f("CHAR") || f("ESCAPED_CHAR");) l += v;
+    return l
+  }, O = function(l) {
+    for (var v = 0, E = c; v < E.length; v++) {
+      var P = E[v];
+      if (l.indexOf(P) > -1) return !0
     }
-    var o = s || c('ESCAPED_CHAR');
-    if (o) {
-      p += o;
-      continue;
+    return !1
+  }, A = function(l) {
+    var v = o[o.length - 1],
+      E = l || (v && typeof v == "string" ? v : "");
+    if (v && !E) throw new TypeError('Must have text between two parameters, missing text after "'.concat(v.name, '"'));
+    return !E || O(E) ? "[^".concat(s(c), "]+?") : "(?:(?!".concat(s(E), ")[^").concat(s(c), "])+?")
+  }; m < e.length;) {
+    var T = f("CHAR"),
+      x = f("NAME"),
+      C = f("PATTERN");
+    if (x || C) {
+      var g = T || "";
+      u.indexOf(g) === -1 && (d += g, g = ""), d && (o.push(d), d = ""), o.push({
+        name: x || h++,
+        prefix: g,
+        suffix: "",
+        pattern: C || A(g),
+        modifier: f("MODIFIER") || ""
+      });
+      continue
     }
-    p && (f.push(p), (p = ''));
-    var R = c('OPEN');
+    var i = T || f("ESCAPED_CHAR");
+    if (i) {
+      d += i;
+      continue
+    }
+    d && (o.push(d), d = "");
+    var R = f("OPEN");
     if (R) {
-      var x = A(),
-        T = c('NAME') || '',
-        i = c('PATTERN') || '',
-        m = A();
-      w('CLOSE'),
-        f.push({
-          name: T || (i ? l++ : ''),
-          pattern: T && !i ? a : i,
-          prefix: x,
-          suffix: m,
-          modifier: c('MODIFIER') || '',
-        });
-      continue;
+      var g = p(),
+        y = f("NAME") || "",
+        N = f("PATTERN") || "",
+        b = p();
+      w("CLOSE"), o.push({
+        name: y || (N ? h++ : ""),
+        pattern: y && !N ? A(g) : N,
+        prefix: g,
+        suffix: b,
+        modifier: f("MODIFIER") || ""
+      });
+      continue
     }
-    w('END');
+    w("END")
   }
-  return f;
+  return o
 }
-function y(r) {
-  return r.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+
+function H(r, n) {
+  var e = [],
+    a = M(r, e, n);
+  return I(a, e, n)
 }
-function O(r) {
-  return r && r.sensitive ? '' : 'i';
-}
-function M(r, n) {
-  if (!n) {
-    return r;
-  }
-  for (var e = /\((?:\?<(.*?)>)?(?!\?)/g, t = 0, u = e.exec(r.source); u; ) {
-    n.push({ name: u[1] || t++, prefix: '', suffix: '', modifier: '', pattern: '' }), (u = e.exec(r.source));
-  }
-  return r;
-}
-function S(r, n, e) {
-  var t = r.map(function (u) {
-    return P(u, n, e).source;
-  });
-  return new RegExp('(?:'.concat(t.join('|'), ')'), O(e));
-}
-function F(r, n, e) {
-  return H(D(r, e), n, e);
-}
-function H(r, n, e) {
+
+function I(r, n, e) {
   e === void 0 && (e = {});
-  for (
-    var t = e.strict,
-      u = t === void 0 ? !1 : t,
-      a = e.start,
-      f = a === void 0 ? !0 : a,
-      l = e.end,
-      d = l === void 0 ? !0 : l,
-      p = e.encode,
-      c =
-        p === void 0
-          ? function (N) {
-              return N;
-            }
-          : p,
-      w = e.delimiter,
-      A = w === void 0 ? '/#?' : w,
-      s = e.endsWith,
-      C = s === void 0 ? '' : s,
-      E = '['.concat(y(C), ']|$'),
-      x = '['.concat(y(A), ']'),
-      o = f ? '^' : '',
-      R = 0,
-      T = r;
-    R < T.length;
-    R++
-  ) {
-    var i = T[R];
-    if (typeof i == 'string') {
-      o += y(c(i));
-    } else {
-      var m = y(c(i.prefix)),
-        v = y(c(i.suffix));
-      if (i.pattern) {
-        if ((n && n.push(i), m || v)) {
-          if (i.modifier === '+' || i.modifier === '*') {
-            var g = i.modifier === '*' ? '?' : '';
-            o += '(?:'
-              .concat(m, '((?:')
-              .concat(i.pattern, ')(?:')
-              .concat(v)
-              .concat(m, '(?:')
-              .concat(i.pattern, '))*)')
-              .concat(v, ')')
-              .concat(g);
-          } else {
-            o += '(?:'.concat(m, '(').concat(i.pattern, ')').concat(v, ')').concat(i.modifier);
-          }
-        } else {
-          i.modifier === '+' || i.modifier === '*'
-            ? (o += '((?:'.concat(i.pattern, ')').concat(i.modifier, ')'))
-            : (o += '('.concat(i.pattern, ')').concat(i.modifier));
-        }
-      } else {
-        o += '(?:'.concat(m).concat(v, ')').concat(i.modifier);
-      }
+  var a = e.decode,
+    u = a === void 0 ? function(t) {
+      return t
+    } : a;
+  return function(t) {
+    var c = r.exec(t);
+    if (!c) return !1;
+    for (var o = c[0], h = c.index, m = Object.create(null), d = function(w) {
+      if (c[w] === void 0) return "continue";
+      var p = n[w - 1];
+      p.modifier === "*" || p.modifier === "+" ? m[p.name] = c[w].split(p.prefix + p.suffix).map(function(O) {
+        return u(O, p)
+      }) : m[p.name] = u(c[w], p)
+    }, f = 1; f < c.length; f++) d(f);
+    return {
+      path: o,
+      index: h,
+      params: m
     }
   }
-  if (d) {
-    u || (o += ''.concat(x, '?')), (o += e.endsWith ? '(?='.concat(E, ')') : '$');
-  } else {
-    var h = r[r.length - 1],
-      b = typeof h == 'string' ? x.indexOf(h[h.length - 1]) > -1 : h === void 0;
-    u || (o += '(?:'.concat(x, '(?=').concat(E, '))?')), b || (o += '(?='.concat(x, '|').concat(E, ')'));
+}
+
+function s(r) {
+  return r.replace(/([.+*?=^!:${}()[\]|/\\])/g, "\\$1")
+}
+
+function D(r) {
+  return r && r.sensitive ? "" : "i"
+}
+
+function $(r, n) {
+  if (!n) return r;
+  for (var e = /\((?:\?<(.*?)>)?(?!\?)/g, a = 0, u = e.exec(r.source); u;) n.push({
+    name: u[1] || a++,
+    prefix: "",
+    suffix: "",
+    modifier: "",
+    pattern: ""
+  }), u = e.exec(r.source);
+  return r
+}
+
+function W(r, n, e) {
+  var a = r.map(function(u) {
+    return M(u, n, e).source
+  });
+  return new RegExp("(?:".concat(a.join("|"), ")"), D(e))
+}
+
+function L(r, n, e) {
+  return U(F(r, e), n, e)
+}
+
+function U(r, n, e) {
+  e === void 0 && (e = {});
+  for (var a = e.strict, u = a === void 0 ? !1 : a, t = e.start, c = t === void 0 ? !0 : t, o = e.end, h = o === void 0 ? !0 : o, m = e.encode, d = m === void 0 ? function(v) {
+    return v
+  } : m, f = e.delimiter, w = f === void 0 ? "/#?" : f, p = e.endsWith, O = p === void 0 ? "" : p, A = "[".concat(s(O), "]|$"), T = "[".concat(s(w), "]"), x = c ? "^" : "", C = 0, g = r; C < g.length; C++) {
+    var i = g[C];
+    if (typeof i == "string") x += s(d(i));
+    else {
+      var R = s(d(i.prefix)),
+        y = s(d(i.suffix));
+      if (i.pattern)
+        if (n && n.push(i), R || y)
+          if (i.modifier === "+" || i.modifier === "*") {
+            var N = i.modifier === "*" ? "?" : "";
+            x += "(?:".concat(R, "((?:").concat(i.pattern, ")(?:").concat(y).concat(R, "(?:").concat(i.pattern, "))*)").concat(y, ")").concat(N)
+          } else x += "(?:".concat(R, "(").concat(i.pattern, ")").concat(y, ")").concat(i.modifier);
+        else {
+          if (i.modifier === "+" || i.modifier === "*") throw new TypeError('Can not repeat "'.concat(i.name, '" without a prefix and suffix'));
+          x += "(".concat(i.pattern, ")").concat(i.modifier)
+        } else x += "(?:".concat(R).concat(y, ")").concat(i.modifier)
+    }
   }
-  return new RegExp(o, O(e));
+  if (h) u || (x += "".concat(T, "?")), x += e.endsWith ? "(?=".concat(A, ")") : "$";
+  else {
+    var b = r[r.length - 1],
+      l = typeof b == "string" ? T.indexOf(b[b.length - 1]) > -1 : b === void 0;
+    u || (x += "(?:".concat(T, "(?=").concat(A, "))?")), l || (x += "(?=".concat(T, "|").concat(A, ")"))
+  }
+  return new RegExp(x, D(e))
 }
-function P(r, n, e) {
-  return r instanceof RegExp ? M(r, n) : Array.isArray(r) ? S(r, n, e) : F(r, n, e);
+
+function M(r, n, e) {
+  return r instanceof RegExp ? $(r, n) : Array.isArray(r) ? W(r, n, e) : L(r, n, e)
 }
-export { P as pathToRegexp };
+export {
+  H as match, M as pathToRegexp
+};

--- a/packages/shared/src/compiled/path-to-regexp/index.js
+++ b/packages/shared/src/compiled/path-to-regexp/index.js
@@ -55,12 +55,12 @@ function _(r) {
     }
     if (a === '(') {
       var o = 1,
-        h = '',
+        m = '',
         t = e + 1;
       if (r[t] === '?') throw new TypeError('Pattern cannot start with "?" at '.concat(t));
       for (; t < r.length; ) {
         if (r[t] === '\\') {
-          h += r[t++] + r[t++];
+          m += r[t++] + r[t++];
           continue;
         }
         if (r[t] === ')') {
@@ -70,14 +70,14 @@ function _(r) {
           }
         } else if (r[t] === '(' && (o++, r[t + 1] !== '?'))
           throw new TypeError('Capturing groups are not allowed at '.concat(t));
-        h += r[t++];
+        m += r[t++];
       }
       if (o) throw new TypeError('Unbalanced pattern at '.concat(e));
-      if (!h) throw new TypeError('Missing pattern at '.concat(e));
+      if (!m) throw new TypeError('Missing pattern at '.concat(e));
       n.push({
         type: 'PATTERN',
         index: e,
-        value: h,
+        value: m,
       }),
         (e = t);
       continue;
@@ -107,28 +107,28 @@ function F(r, n) {
       t = n.delimiter,
       c = t === void 0 ? '/#?' : t,
       o = [],
-      h = 0,
       m = 0,
-      d = '',
+      h = 0,
+      p = '',
       f = function (l) {
-        if (m < e.length && e[m].type === l) return e[m++].value;
+        if (h < e.length && e[h].type === l) return e[h++].value;
       },
       w = function (l) {
         var v = f(l);
         if (v !== void 0) return v;
-        var E = e[m],
-          P = E.type,
+        var E = e[h],
+          N = E.type,
           S = E.index;
-        throw new TypeError('Unexpected '.concat(P, ' at ').concat(S, ', expected ').concat(l));
+        throw new TypeError('Unexpected '.concat(N, ' at ').concat(S, ', expected ').concat(l));
       },
-      p = function () {
+      d = function () {
         for (var l = '', v; (v = f('CHAR') || f('ESCAPED_CHAR')); ) l += v;
         return l;
       },
-      O = function (l) {
+      M = function (l) {
         for (var v = 0, E = c; v < E.length; v++) {
-          var P = E[v];
-          if (l.indexOf(P) > -1) return !0;
+          var N = E[v];
+          if (l.indexOf(N) > -1) return !0;
         }
         return !1;
       },
@@ -137,9 +137,9 @@ function F(r, n) {
           E = l || (v && typeof v == 'string' ? v : '');
         if (v && !E)
           throw new TypeError('Must have text between two parameters, missing text after "'.concat(v.name, '"'));
-        return !E || O(E) ? '[^'.concat(s(c), ']+?') : '(?:(?!'.concat(s(E), ')[^').concat(s(c), '])+?');
+        return !E || M(E) ? '[^'.concat(s(c), ']+?') : '(?:(?!'.concat(s(E), ')[^').concat(s(c), '])+?');
       };
-    m < e.length;
+    h < e.length;
 
   ) {
     var T = f('CHAR'),
@@ -147,10 +147,10 @@ function F(r, n) {
       C = f('PATTERN');
     if (x || C) {
       var g = T || '';
-      u.indexOf(g) === -1 && ((d += g), (g = '')),
-        d && (o.push(d), (d = '')),
+      u.indexOf(g) === -1 && ((p += g), (g = '')),
+        p && (o.push(p), (p = '')),
         o.push({
-          name: x || h++,
+          name: x || m++,
           prefix: g,
           suffix: '',
           pattern: C || A(g),
@@ -160,20 +160,20 @@ function F(r, n) {
     }
     var i = T || f('ESCAPED_CHAR');
     if (i) {
-      d += i;
+      p += i;
       continue;
     }
-    d && (o.push(d), (d = ''));
+    p && (o.push(p), (p = ''));
     var R = f('OPEN');
     if (R) {
-      var g = p(),
+      var g = d(),
         y = f('NAME') || '',
-        N = f('PATTERN') || '',
-        b = p();
+        O = f('PATTERN') || '',
+        b = d();
       w('CLOSE'),
         o.push({
-          name: y || (N ? h++ : ''),
-          pattern: y && !N ? A(g) : N,
+          name: y || (O ? m++ : ''),
+          pattern: y && !O ? A(g) : O,
           prefix: g,
           suffix: b,
           modifier: f('MODIFIER') || '',
@@ -187,7 +187,7 @@ function F(r, n) {
 
 function H(r, n) {
   var e = [],
-    a = M(r, e, n);
+    a = P(r, e, n);
   return I(a, e, n);
 }
 
@@ -205,26 +205,26 @@ function I(r, n, e) {
     if (!c) return !1;
     for (
       var o = c[0],
-        h = c.index,
-        m = Object.create(null),
-        d = function (w) {
+        m = c.index,
+        h = Object.create(null),
+        p = function (w) {
           if (c[w] === void 0) return 'continue';
-          var p = n[w - 1];
-          p.modifier === '*' || p.modifier === '+'
-            ? (m[p.name] = c[w].split(p.prefix + p.suffix).map(function (O) {
-                return u(O, p);
+          var d = n[w - 1];
+          d.modifier === '*' || d.modifier === '+'
+            ? (h[d.name] = c[w].split(d.prefix + d.suffix).map(function (M) {
+                return u(M, d);
               }))
-            : (m[p.name] = u(c[w], p));
+            : (h[d.name] = u(c[w], d));
         },
         f = 1;
       f < c.length;
       f++
     )
-      d(f);
+      p(f);
     return {
       path: o,
-      index: h,
-      params: m,
+      index: m,
+      params: h,
     };
   };
 }
@@ -253,7 +253,7 @@ function $(r, n) {
 
 function W(r, n, e) {
   var a = r.map(function (u) {
-    return M(u, n, e).source;
+    return P(u, n, e).source;
   });
   return new RegExp('(?:'.concat(a.join('|'), ')'), D(e));
 }
@@ -270,19 +270,19 @@ function U(r, n, e) {
       t = e.start,
       c = t === void 0 ? !0 : t,
       o = e.end,
-      h = o === void 0 ? !0 : o,
-      m = e.encode,
-      d =
-        m === void 0
+      m = o === void 0 ? !0 : o,
+      h = e.encode,
+      p =
+        h === void 0
           ? function (v) {
               return v;
             }
-          : m,
+          : h,
       f = e.delimiter,
       w = f === void 0 ? '/#?' : f,
-      p = e.endsWith,
-      O = p === void 0 ? '' : p,
-      A = '['.concat(s(O), ']|$'),
+      d = e.endsWith,
+      M = d === void 0 ? '' : d,
+      A = '['.concat(s(M), ']|$'),
       T = '['.concat(s(w), ']'),
       x = c ? '^' : '',
       C = 0,
@@ -291,14 +291,14 @@ function U(r, n, e) {
     C++
   ) {
     var i = g[C];
-    if (typeof i == 'string') x += s(d(i));
+    if (typeof i == 'string') x += s(p(i));
     else {
-      var R = s(d(i.prefix)),
-        y = s(d(i.suffix));
+      var R = s(p(i.prefix)),
+        y = s(p(i.suffix));
       if (i.pattern)
         if ((n && n.push(i), R || y))
           if (i.modifier === '+' || i.modifier === '*') {
-            var N = i.modifier === '*' ? '?' : '';
+            var O = i.modifier === '*' ? '?' : '';
             x += '(?:'
               .concat(R, '((?:')
               .concat(i.pattern, ')(?:')
@@ -306,7 +306,7 @@ function U(r, n, e) {
               .concat(R, '(?:')
               .concat(i.pattern, '))*)')
               .concat(y, ')')
-              .concat(N);
+              .concat(O);
           } else x += '(?:'.concat(R, '(').concat(i.pattern, ')').concat(y, ')').concat(i.modifier);
         else {
           if (i.modifier === '+' || i.modifier === '*')
@@ -316,7 +316,7 @@ function U(r, n, e) {
       else x += '(?:'.concat(R).concat(y, ')').concat(i.modifier);
     }
   }
-  if (h) u || (x += ''.concat(T, '?')), (x += e.endsWith ? '(?='.concat(A, ')') : '$');
+  if (m) u || (x += ''.concat(T, '?')), (x += e.endsWith ? '(?='.concat(A, ')') : '$');
   else {
     var b = r[r.length - 1],
       l = typeof b == 'string' ? T.indexOf(b[b.length - 1]) > -1 : b === void 0;
@@ -325,7 +325,7 @@ function U(r, n, e) {
   return new RegExp(x, D(e));
 }
 
-function M(r, n, e) {
+function P(r, n, e) {
   return r instanceof RegExp ? $(r, n) : Array.isArray(r) ? W(r, n, e) : L(r, n, e);
 }
-export { H as match, M as pathToRegexp };
+export { H as match, P as pathToRegexp };

--- a/packages/shared/src/compiled/path-to-regexp/index.js
+++ b/packages/shared/src/compiled/path-to-regexp/index.js
@@ -1,258 +1,331 @@
-/* eslint-disable no-redeclare */
+/* eslint-disable no-redeclare, curly */
 
 function _(r) {
-  for (var n = [], e = 0; e < r.length;) {
+  for (var n = [], e = 0; e < r.length; ) {
     var a = r[e];
-    if (a === "*" || a === "+" || a === "?") {
+    if (a === '*' || a === '+' || a === '?') {
       n.push({
-        type: "MODIFIER",
+        type: 'MODIFIER',
         index: e,
-        value: r[e++]
+        value: r[e++],
       });
-      continue
+      continue;
     }
-    if (a === "\\") {
+    if (a === '\\') {
       n.push({
-        type: "ESCAPED_CHAR",
+        type: 'ESCAPED_CHAR',
         index: e++,
-        value: r[e++]
+        value: r[e++],
       });
-      continue
+      continue;
     }
-    if (a === "{") {
+    if (a === '{') {
       n.push({
-        type: "OPEN",
+        type: 'OPEN',
         index: e,
-        value: r[e++]
+        value: r[e++],
       });
-      continue
+      continue;
     }
-    if (a === "}") {
+    if (a === '}') {
       n.push({
-        type: "CLOSE",
+        type: 'CLOSE',
         index: e,
-        value: r[e++]
+        value: r[e++],
       });
-      continue
+      continue;
     }
-    if (a === ":") {
-      for (var u = "", t = e + 1; t < r.length;) {
+    if (a === ':') {
+      for (var u = '', t = e + 1; t < r.length; ) {
         var c = r.charCodeAt(t);
-        if (c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || c === 95) {
+        if ((c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 95) {
           u += r[t++];
-          continue
+          continue;
         }
-        break
+        break;
       }
-      if (!u) throw new TypeError("Missing parameter name at ".concat(e));
+      if (!u) throw new TypeError('Missing parameter name at '.concat(e));
       n.push({
-        type: "NAME",
+        type: 'NAME',
         index: e,
-        value: u
-      }), e = t;
-      continue
+        value: u,
+      }),
+        (e = t);
+      continue;
     }
-    if (a === "(") {
+    if (a === '(') {
       var o = 1,
-        h = "",
+        h = '',
         t = e + 1;
-      if (r[t] === "?") throw new TypeError('Pattern cannot start with "?" at '.concat(t));
-      for (; t < r.length;) {
-        if (r[t] === "\\") {
+      if (r[t] === '?') throw new TypeError('Pattern cannot start with "?" at '.concat(t));
+      for (; t < r.length; ) {
+        if (r[t] === '\\') {
           h += r[t++] + r[t++];
-          continue
+          continue;
         }
-        if (r[t] === ")") {
-          if (o--, o === 0) {
+        if (r[t] === ')') {
+          if ((o--, o === 0)) {
             t++;
-            break
+            break;
           }
-        } else if (r[t] === "(" && (o++, r[t + 1] !== "?")) throw new TypeError("Capturing groups are not allowed at ".concat(t));
-        h += r[t++]
+        } else if (r[t] === '(' && (o++, r[t + 1] !== '?'))
+          throw new TypeError('Capturing groups are not allowed at '.concat(t));
+        h += r[t++];
       }
-      if (o) throw new TypeError("Unbalanced pattern at ".concat(e));
-      if (!h) throw new TypeError("Missing pattern at ".concat(e));
+      if (o) throw new TypeError('Unbalanced pattern at '.concat(e));
+      if (!h) throw new TypeError('Missing pattern at '.concat(e));
       n.push({
-        type: "PATTERN",
+        type: 'PATTERN',
         index: e,
-        value: h
-      }), e = t;
-      continue
+        value: h,
+      }),
+        (e = t);
+      continue;
     }
     n.push({
-      type: "CHAR",
+      type: 'CHAR',
       index: e,
-      value: r[e++]
-    })
+      value: r[e++],
+    });
   }
-  return n.push({
-    type: "END",
-    index: e,
-    value: ""
-  }), n
+  return (
+    n.push({
+      type: 'END',
+      index: e,
+      value: '',
+    }),
+    n
+  );
 }
 
 function F(r, n) {
   n === void 0 && (n = {});
-  for (var e = _(r), a = n.prefixes, u = a === void 0 ? "./" : a, t = n.delimiter, c = t === void 0 ? "/#?" : t, o = [], h = 0, m = 0, d = "", f = function(l) {
-    if (m < e.length && e[m].type === l) return e[m++].value
-  }, w = function(l) {
-    var v = f(l);
-    if (v !== void 0) return v;
-    var E = e[m],
-      P = E.type,
-      S = E.index;
-    throw new TypeError("Unexpected ".concat(P, " at ").concat(S, ", expected ").concat(l))
-  }, p = function() {
-    for (var l = "", v; v = f("CHAR") || f("ESCAPED_CHAR");) l += v;
-    return l
-  }, O = function(l) {
-    for (var v = 0, E = c; v < E.length; v++) {
-      var P = E[v];
-      if (l.indexOf(P) > -1) return !0
-    }
-    return !1
-  }, A = function(l) {
-    var v = o[o.length - 1],
-      E = l || (v && typeof v == "string" ? v : "");
-    if (v && !E) throw new TypeError('Must have text between two parameters, missing text after "'.concat(v.name, '"'));
-    return !E || O(E) ? "[^".concat(s(c), "]+?") : "(?:(?!".concat(s(E), ")[^").concat(s(c), "])+?")
-  }; m < e.length;) {
-    var T = f("CHAR"),
-      x = f("NAME"),
-      C = f("PATTERN");
+  for (
+    var e = _(r),
+      a = n.prefixes,
+      u = a === void 0 ? './' : a,
+      t = n.delimiter,
+      c = t === void 0 ? '/#?' : t,
+      o = [],
+      h = 0,
+      m = 0,
+      d = '',
+      f = function (l) {
+        if (m < e.length && e[m].type === l) return e[m++].value;
+      },
+      w = function (l) {
+        var v = f(l);
+        if (v !== void 0) return v;
+        var E = e[m],
+          P = E.type,
+          S = E.index;
+        throw new TypeError('Unexpected '.concat(P, ' at ').concat(S, ', expected ').concat(l));
+      },
+      p = function () {
+        for (var l = '', v; (v = f('CHAR') || f('ESCAPED_CHAR')); ) l += v;
+        return l;
+      },
+      O = function (l) {
+        for (var v = 0, E = c; v < E.length; v++) {
+          var P = E[v];
+          if (l.indexOf(P) > -1) return !0;
+        }
+        return !1;
+      },
+      A = function (l) {
+        var v = o[o.length - 1],
+          E = l || (v && typeof v == 'string' ? v : '');
+        if (v && !E)
+          throw new TypeError('Must have text between two parameters, missing text after "'.concat(v.name, '"'));
+        return !E || O(E) ? '[^'.concat(s(c), ']+?') : '(?:(?!'.concat(s(E), ')[^').concat(s(c), '])+?');
+      };
+    m < e.length;
+
+  ) {
+    var T = f('CHAR'),
+      x = f('NAME'),
+      C = f('PATTERN');
     if (x || C) {
-      var g = T || "";
-      u.indexOf(g) === -1 && (d += g, g = ""), d && (o.push(d), d = ""), o.push({
-        name: x || h++,
-        prefix: g,
-        suffix: "",
-        pattern: C || A(g),
-        modifier: f("MODIFIER") || ""
-      });
-      continue
+      var g = T || '';
+      u.indexOf(g) === -1 && ((d += g), (g = '')),
+        d && (o.push(d), (d = '')),
+        o.push({
+          name: x || h++,
+          prefix: g,
+          suffix: '',
+          pattern: C || A(g),
+          modifier: f('MODIFIER') || '',
+        });
+      continue;
     }
-    var i = T || f("ESCAPED_CHAR");
+    var i = T || f('ESCAPED_CHAR');
     if (i) {
       d += i;
-      continue
+      continue;
     }
-    d && (o.push(d), d = "");
-    var R = f("OPEN");
+    d && (o.push(d), (d = ''));
+    var R = f('OPEN');
     if (R) {
       var g = p(),
-        y = f("NAME") || "",
-        N = f("PATTERN") || "",
+        y = f('NAME') || '',
+        N = f('PATTERN') || '',
         b = p();
-      w("CLOSE"), o.push({
-        name: y || (N ? h++ : ""),
-        pattern: y && !N ? A(g) : N,
-        prefix: g,
-        suffix: b,
-        modifier: f("MODIFIER") || ""
-      });
-      continue
+      w('CLOSE'),
+        o.push({
+          name: y || (N ? h++ : ''),
+          pattern: y && !N ? A(g) : N,
+          prefix: g,
+          suffix: b,
+          modifier: f('MODIFIER') || '',
+        });
+      continue;
     }
-    w("END")
+    w('END');
   }
-  return o
+  return o;
 }
 
 function H(r, n) {
   var e = [],
     a = M(r, e, n);
-  return I(a, e, n)
+  return I(a, e, n);
 }
 
 function I(r, n, e) {
   e === void 0 && (e = {});
   var a = e.decode,
-    u = a === void 0 ? function(t) {
-      return t
-    } : a;
-  return function(t) {
+    u =
+      a === void 0
+        ? function (t) {
+            return t;
+          }
+        : a;
+  return function (t) {
     var c = r.exec(t);
     if (!c) return !1;
-    for (var o = c[0], h = c.index, m = Object.create(null), d = function(w) {
-      if (c[w] === void 0) return "continue";
-      var p = n[w - 1];
-      p.modifier === "*" || p.modifier === "+" ? m[p.name] = c[w].split(p.prefix + p.suffix).map(function(O) {
-        return u(O, p)
-      }) : m[p.name] = u(c[w], p)
-    }, f = 1; f < c.length; f++) d(f);
+    for (
+      var o = c[0],
+        h = c.index,
+        m = Object.create(null),
+        d = function (w) {
+          if (c[w] === void 0) return 'continue';
+          var p = n[w - 1];
+          p.modifier === '*' || p.modifier === '+'
+            ? (m[p.name] = c[w].split(p.prefix + p.suffix).map(function (O) {
+                return u(O, p);
+              }))
+            : (m[p.name] = u(c[w], p));
+        },
+        f = 1;
+      f < c.length;
+      f++
+    )
+      d(f);
     return {
       path: o,
       index: h,
-      params: m
-    }
-  }
+      params: m,
+    };
+  };
 }
 
 function s(r) {
-  return r.replace(/([.+*?=^!:${}()[\]|/\\])/g, "\\$1")
+  return r.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
 }
 
 function D(r) {
-  return r && r.sensitive ? "" : "i"
+  return r && r.sensitive ? '' : 'i';
 }
 
 function $(r, n) {
   if (!n) return r;
-  for (var e = /\((?:\?<(.*?)>)?(?!\?)/g, a = 0, u = e.exec(r.source); u;) n.push({
-    name: u[1] || a++,
-    prefix: "",
-    suffix: "",
-    modifier: "",
-    pattern: ""
-  }), u = e.exec(r.source);
-  return r
+  for (var e = /\((?:\?<(.*?)>)?(?!\?)/g, a = 0, u = e.exec(r.source); u; )
+    n.push({
+      name: u[1] || a++,
+      prefix: '',
+      suffix: '',
+      modifier: '',
+      pattern: '',
+    }),
+      (u = e.exec(r.source));
+  return r;
 }
 
 function W(r, n, e) {
-  var a = r.map(function(u) {
-    return M(u, n, e).source
+  var a = r.map(function (u) {
+    return M(u, n, e).source;
   });
-  return new RegExp("(?:".concat(a.join("|"), ")"), D(e))
+  return new RegExp('(?:'.concat(a.join('|'), ')'), D(e));
 }
 
 function L(r, n, e) {
-  return U(F(r, e), n, e)
+  return U(F(r, e), n, e);
 }
 
 function U(r, n, e) {
   e === void 0 && (e = {});
-  for (var a = e.strict, u = a === void 0 ? !1 : a, t = e.start, c = t === void 0 ? !0 : t, o = e.end, h = o === void 0 ? !0 : o, m = e.encode, d = m === void 0 ? function(v) {
-    return v
-  } : m, f = e.delimiter, w = f === void 0 ? "/#?" : f, p = e.endsWith, O = p === void 0 ? "" : p, A = "[".concat(s(O), "]|$"), T = "[".concat(s(w), "]"), x = c ? "^" : "", C = 0, g = r; C < g.length; C++) {
+  for (
+    var a = e.strict,
+      u = a === void 0 ? !1 : a,
+      t = e.start,
+      c = t === void 0 ? !0 : t,
+      o = e.end,
+      h = o === void 0 ? !0 : o,
+      m = e.encode,
+      d =
+        m === void 0
+          ? function (v) {
+              return v;
+            }
+          : m,
+      f = e.delimiter,
+      w = f === void 0 ? '/#?' : f,
+      p = e.endsWith,
+      O = p === void 0 ? '' : p,
+      A = '['.concat(s(O), ']|$'),
+      T = '['.concat(s(w), ']'),
+      x = c ? '^' : '',
+      C = 0,
+      g = r;
+    C < g.length;
+    C++
+  ) {
     var i = g[C];
-    if (typeof i == "string") x += s(d(i));
+    if (typeof i == 'string') x += s(d(i));
     else {
       var R = s(d(i.prefix)),
         y = s(d(i.suffix));
       if (i.pattern)
-        if (n && n.push(i), R || y)
-          if (i.modifier === "+" || i.modifier === "*") {
-            var N = i.modifier === "*" ? "?" : "";
-            x += "(?:".concat(R, "((?:").concat(i.pattern, ")(?:").concat(y).concat(R, "(?:").concat(i.pattern, "))*)").concat(y, ")").concat(N)
-          } else x += "(?:".concat(R, "(").concat(i.pattern, ")").concat(y, ")").concat(i.modifier);
+        if ((n && n.push(i), R || y))
+          if (i.modifier === '+' || i.modifier === '*') {
+            var N = i.modifier === '*' ? '?' : '';
+            x += '(?:'
+              .concat(R, '((?:')
+              .concat(i.pattern, ')(?:')
+              .concat(y)
+              .concat(R, '(?:')
+              .concat(i.pattern, '))*)')
+              .concat(y, ')')
+              .concat(N);
+          } else x += '(?:'.concat(R, '(').concat(i.pattern, ')').concat(y, ')').concat(i.modifier);
         else {
-          if (i.modifier === "+" || i.modifier === "*") throw new TypeError('Can not repeat "'.concat(i.name, '" without a prefix and suffix'));
-          x += "(".concat(i.pattern, ")").concat(i.modifier)
-        } else x += "(?:".concat(R).concat(y, ")").concat(i.modifier)
+          if (i.modifier === '+' || i.modifier === '*')
+            throw new TypeError('Can not repeat "'.concat(i.name, '" without a prefix and suffix'));
+          x += '('.concat(i.pattern, ')').concat(i.modifier);
+        }
+      else x += '(?:'.concat(R).concat(y, ')').concat(i.modifier);
     }
   }
-  if (h) u || (x += "".concat(T, "?")), x += e.endsWith ? "(?=".concat(A, ")") : "$";
+  if (h) u || (x += ''.concat(T, '?')), (x += e.endsWith ? '(?='.concat(A, ')') : '$');
   else {
     var b = r[r.length - 1],
-      l = typeof b == "string" ? T.indexOf(b[b.length - 1]) > -1 : b === void 0;
-    u || (x += "(?:".concat(T, "(?=").concat(A, "))?")), l || (x += "(?=".concat(T, "|").concat(A, ")"))
+      l = typeof b == 'string' ? T.indexOf(b[b.length - 1]) > -1 : b === void 0;
+    u || (x += '(?:'.concat(T, '(?=').concat(A, '))?')), l || (x += '(?='.concat(T, '|').concat(A, ')'));
   }
-  return new RegExp(x, D(e))
+  return new RegExp(x, D(e));
 }
 
 function M(r, n, e) {
-  return r instanceof RegExp ? $(r, n) : Array.isArray(r) ? W(r, n, e) : L(r, n, e)
+  return r instanceof RegExp ? $(r, n) : Array.isArray(r) ? W(r, n, e) : L(r, n, e);
 }
-export {
-  H as match, M as pathToRegexp
-};
+export { H as match, M as pathToRegexp };

--- a/packages/shared/src/pathToRegexp.ts
+++ b/packages/shared/src/pathToRegexp.ts
@@ -1,9 +1,17 @@
+import type {
+  Match,
+  MatchFunction,
+  ParseOptions,
+  Path,
+  RegexpToFunctionOptions,
+  TokensToRegexpOptions,
+} from './compiled/path-to-regexp';
 import { match as matchBase, pathToRegexp as pathToRegexpBase } from './compiled/path-to-regexp';
 
 export const pathToRegexp = (path: string) => {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return pathToRegexpBase(path) as RegExp;
+    return pathToRegexpBase(path);
   } catch (e: any) {
     throw new Error(
       `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
@@ -17,7 +25,7 @@ export function match<P extends object = object>(
 ): MatchFunction<P> {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return matchBase(str, options) as MatchFunction<P>;
+    return matchBase(str, options);
   } catch (e: any) {
     throw new Error(
       `Invalid path and options: Consult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
@@ -25,86 +33,4 @@ export function match<P extends object = object>(
   }
 }
 
-/**
- * A match is either `false` (no match) or a match result.
- */
-export type Match<P extends object = object> = false | MatchResult<P>;
-
-/**
- * The match function takes a string and returns whether it matched the path.
- */
-export type MatchFunction<P extends object = object> = (path: string) => Match<P>;
-
-/**
- * Supported `path-to-regexp` input types.
- */
-export type Path = string | RegExp | Array<string | RegExp>;
-
-/**
- * A match result contains data about the path match.
- */
-export interface MatchResult<P extends object = object> {
-  path: string;
-  index: number;
-  params: P;
-}
-
-export interface ParseOptions {
-  /**
-   * Set the default delimiter for repeat parameters. (default: `'/'`)
-   */
-  delimiter?: string;
-  /**
-   * List of characters to automatically consider prefixes when parsing.
-   */
-  prefixes?: string;
-}
-
-export interface TokensToRegexpOptions {
-  /**
-   * When `true` the regexp will be case sensitive. (default: `false`)
-   */
-  sensitive?: boolean;
-  /**
-   * When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)
-   */
-  strict?: boolean;
-  /**
-   * When `true` the regexp will match to the end of the string. (default: `true`)
-   */
-  end?: boolean;
-  /**
-   * When `true` the regexp will match from the beginning of the string. (default: `true`)
-   */
-  start?: boolean;
-  /**
-   * Sets the final character for non-ending optimistic matches. (default: `/`)
-   */
-  delimiter?: string;
-  /**
-   * List of characters that can also be "end" characters.
-   */
-  endsWith?: string;
-  /**
-   * Encode path tokens for use in the `RegExp`.
-   */
-  encode?: (value: string) => string;
-}
-
-export interface RegexpToFunctionOptions {
-  /**
-   * Function for decoding strings for params.
-   */
-  decode?: (value: string, token: Key) => string;
-}
-
-/**
- * Metadata about a key.
- */
-export interface Key {
-  name: string | number;
-  prefix: string;
-  suffix: string;
-  pattern: string;
-  modifier: string;
-}
+export { type Match, type MatchFunction };

--- a/packages/shared/src/pathToRegexp.ts
+++ b/packages/shared/src/pathToRegexp.ts
@@ -11,7 +11,7 @@ import { match as matchBase, pathToRegexp as pathToRegexpBase } from './compiled
 export const pathToRegexp = (path: string) => {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return pathToRegexpBase(path);
+    return pathToRegexpBase(path) as RegExp;
   } catch (e: any) {
     throw new Error(
       `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
@@ -25,7 +25,7 @@ export function match<P extends object = object>(
 ): MatchFunction<P> {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return matchBase(str, options);
+    return matchBase(str, options) as MatchFunction<P>;
   } catch (e: any) {
     throw new Error(
       `Invalid path and options: Consult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,

--- a/packages/shared/src/pathToRegexp.ts
+++ b/packages/shared/src/pathToRegexp.ts
@@ -11,7 +11,7 @@ import { match as matchBase, pathToRegexp as pathToRegexpBase } from './compiled
 export const pathToRegexp = (path: string) => {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return pathToRegexpBase(path) as RegExp;
+    return pathToRegexpBase(path);
   } catch (e: any) {
     throw new Error(
       `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
@@ -25,7 +25,7 @@ export function match<P extends object = object>(
 ): MatchFunction<P> {
   try {
     // @ts-ignore no types exists for the pre-compiled package
-    return matchBase(str, options) as MatchFunction<P>;
+    return matchBase(str, options);
   } catch (e: any) {
     throw new Error(
       `Invalid path and options: Consult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,

--- a/packages/shared/src/pathToRegexp.ts
+++ b/packages/shared/src/pathToRegexp.ts
@@ -1,4 +1,4 @@
-import { pathToRegexp as pathToRegexpBase } from './compiled/path-to-regexp';
+import { match as matchBase, pathToRegexp as pathToRegexpBase } from './compiled/path-to-regexp';
 
 export const pathToRegexp = (path: string) => {
   try {
@@ -6,7 +6,105 @@ export const pathToRegexp = (path: string) => {
     return pathToRegexpBase(path) as RegExp;
   } catch (e: any) {
     throw new Error(
-      `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp\n${e.message}`,
+      `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
     );
   }
 };
+
+export function match<P extends object = object>(
+  str: Path,
+  options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions,
+): MatchFunction<P> {
+  try {
+    // @ts-ignore no types exists for the pre-compiled package
+    return matchBase(str, options) as MatchFunction<P>;
+  } catch (e: any) {
+    throw new Error(
+      `Invalid path and options: Consult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp/tree/6.x\n${e.message}`,
+    );
+  }
+}
+
+/**
+ * A match is either `false` (no match) or a match result.
+ */
+export type Match<P extends object = object> = false | MatchResult<P>;
+
+/**
+ * The match function takes a string and returns whether it matched the path.
+ */
+export type MatchFunction<P extends object = object> = (path: string) => Match<P>;
+
+/**
+ * Supported `path-to-regexp` input types.
+ */
+export type Path = string | RegExp | Array<string | RegExp>;
+
+/**
+ * A match result contains data about the path match.
+ */
+export interface MatchResult<P extends object = object> {
+  path: string;
+  index: number;
+  params: P;
+}
+
+export interface ParseOptions {
+  /**
+   * Set the default delimiter for repeat parameters. (default: `'/'`)
+   */
+  delimiter?: string;
+  /**
+   * List of characters to automatically consider prefixes when parsing.
+   */
+  prefixes?: string;
+}
+
+export interface TokensToRegexpOptions {
+  /**
+   * When `true` the regexp will be case sensitive. (default: `false`)
+   */
+  sensitive?: boolean;
+  /**
+   * When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)
+   */
+  strict?: boolean;
+  /**
+   * When `true` the regexp will match to the end of the string. (default: `true`)
+   */
+  end?: boolean;
+  /**
+   * When `true` the regexp will match from the beginning of the string. (default: `true`)
+   */
+  start?: boolean;
+  /**
+   * Sets the final character for non-ending optimistic matches. (default: `/`)
+   */
+  delimiter?: string;
+  /**
+   * List of characters that can also be "end" characters.
+   */
+  endsWith?: string;
+  /**
+   * Encode path tokens for use in the `RegExp`.
+   */
+  encode?: (value: string) => string;
+}
+
+export interface RegexpToFunctionOptions {
+  /**
+   * Function for decoding strings for params.
+   */
+  decode?: (value: string, token: Key) => string;
+}
+
+/**
+ * Metadata about a key.
+ */
+export interface Key {
+  name: string | number;
+  prefix: string;
+  suffix: string;
+  pattern: string;
+  modifier: string;
+}


### PR DESCRIPTION
## Description

### What changed?

This surfaces a new path-to-regexp function, [match](https://github.com/pillarjs/path-to-regexp/tree/6.x?tab=readme-ov-file#match), that upcoming functionality depends on.

### How did you generate the minified js?

Thanks to @nikosdouvlis for giving me the run-down. The procedure goes:

To create the new minified code (high-level)
- Create a minimal typescript project with an index.ts that imports the functionality that you need
- Use tsup to bundle it into a minified file
- Beautify the minified file (e.g. add newlines)

More details for internal folks here: https://clerkinc.slack.com/archives/C07LN8YS9HB/p1726666913614259?thread_ts=1726240424.533199&cid=C07LN8YS9HB

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
