### PR TITLE
fix(clerk-js): UP/OP footer padding on small screens

### DIFF
--- a/.changeset/nasty-walls-double.md
+++ b/.changeset/nasty-walls-double.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix UserProfile and OrganizationProfile wrong padding on footer for small screens when Development notice is enabled

--- a/packages/clerk-js/src/ui/elements/Card/CardFooter.tsx
+++ b/packages/clerk-js/src/ui/elements/Card/CardFooter.tsx
@@ -37,7 +37,7 @@ export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>((pro
   });
 
   const profileCardFooterStyles = (t: InternalTheme) => ({
-    padding: `${t.space.$4} ${t.space.$6} ${t.space.$2}`,
+    padding: `${t.space.$4} ${t.space.$8}`,
   });
 
   return (
@@ -59,7 +59,7 @@ export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>((pro
             marginTop: 0,
           },
         }),
-        isProfileFooter ? profileCardFooterStyles : footerStyles,
+        !isProfileFooter && footerStyles,
         sx,
       ]}
       {...rest}
@@ -72,6 +72,7 @@ export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>((pro
         devModeNoticeSx={t => ({
           padding: t.space.$none,
         })}
+        outerSx={isProfileFooter ? profileCardFooterStyles : undefined}
         withDevOverlay
       />
     </Flex>


### PR DESCRIPTION
## Description

This PR fixes wrong padding on the footer of UP and OP components when development notice was enabled and it was viewed in small screens

# Before
![CleanShot 2024-09-19 at 13 37 05@2x](https://github.com/user-attachments/assets/02247807-ee4f-43e1-b232-b0b94dc4770b)


# After
![CleanShot 2024-09-19 at 13 36 34@2x](https://github.com/user-attachments/assets/c6017f4b-5cfd-4fb8-8a1e-b4a8cbd2cd27)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
