### PR TITLE
chore(astro): Add `@clerk/astro` to Astro integrations page

### DIFF
--- a/.changeset/heavy-planes-smash.md
+++ b/.changeset/heavy-planes-smash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Add `@clerk/astro` to Astro integrations page

--- a/.changeset/heavy-planes-smash.md
+++ b/.changeset/heavy-planes-smash.md
@@ -2,4 +2,4 @@
 "@clerk/astro": patch
 ---
 
-Add `@clerk/astro` to Astro integrations page
+Add `@clerk/astro` to Astro integrations list page

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -21,6 +21,7 @@
     "clerk",
     "typescript",
     "passwordless",
+    "astro-component",
     "withastro"
   ],
   "sideEffects": false,

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -20,7 +20,8 @@
     "astro-integration",
     "clerk",
     "typescript",
-    "passwordless"
+    "passwordless",
+    "withastro"
   ],
   "sideEffects": false,
   "bugs": {


### PR DESCRIPTION
## Description

This small PR allows our Clerk SDK to show up in the [Astro integrations list page](https://astro.build/integrations). More info on how they pull up repositories from NPM [here](https://docs.astro.build/en/reference/publish-to-npm/#packagejson-data).

<img width="1107" alt="Screenshot 2024-09-19 at 7 43 10 AM" src="https://github.com/user-attachments/assets/3293a382-eeca-4e9a-b5b6-d2e5615264f8">


## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
