### PR TITLE
chore(backend): Introduce `include_members_count` parameter to `getOrganization`

### DIFF
--- a/.changeset/light-geckos-allow.md
+++ b/.changeset/light-geckos-allow.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Introduce `includeMembersCount` parameter to `getOrganization`, allowing to retrieve an organization with `membersCount`.

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -34,7 +34,9 @@ type CreateParams = {
   maxAllowedMemberships?: number;
 } & MetadataParams;
 
-type GetOrganizationParams = { organizationId: string } | { slug: string };
+type GetOrganizationParams = ({ organizationId: string } | { slug: string }) & {
+  includeMembersCount?: boolean;
+};
 
 type UpdateParams = {
   name?: string;
@@ -115,12 +117,16 @@ export class OrganizationAPI extends AbstractAPI {
   }
 
   public async getOrganization(params: GetOrganizationParams) {
+    const { includeMembersCount } = params;
     const organizationIdOrSlug = 'organizationId' in params ? params.organizationId : params.slug;
     this.requireId(organizationIdOrSlug);
 
     return this.request<Organization>({
       method: 'GET',
       path: joinPaths(basePath, organizationIdOrSlug),
+      queryParams: {
+        includeMembersCount,
+      },
     });
   }
 


### PR DESCRIPTION
## Description

Part of ORGS-197

`include_members_count` query param for `/organizations/{organizationID}` recently got supported on BAPI, therefore forwarding this param here as well. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
