### PR TITLE
fix(shared): Allow routers to access private members

### DIFF
--- a/.changeset/green-hairs-drive.md
+++ b/.changeset/green-hairs-drive.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix issue where class-based routers were unable to access their private members during the `pathname` and `searchParams` methods.

--- a/packages/shared/src/router/router.ts
+++ b/packages/shared/src/router/router.ts
@@ -135,6 +135,14 @@ export function createClerkRouter(router: ClerkHostRouter, basePath: string = '/
     return router.shallowPush(destinationUrl);
   }
 
+  function pathname() {
+    return router.pathname();
+  }
+
+  function searchParams() {
+    return router.searchParams();
+  }
+
   return {
     child,
     match,
@@ -143,8 +151,8 @@ export function createClerkRouter(router: ClerkHostRouter, basePath: string = '/
     push,
     replace,
     shallowPush,
-    pathname: router.pathname,
-    searchParams: router.searchParams,
+    pathname,
+    searchParams,
     basePath: normalizedBasePath,
   };
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with `createClerkRouter` where class-based routers were unable to access private members in the `pathname` and `searchParams` methods due to losing the scope of `this`.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
