### PR TITLE
fix(clerk-js): UserButton sign out of all accounts visibility

### DIFF
--- a/.changeset/violet-kangaroos-lay.md
+++ b/.changeset/violet-kangaroos-lay.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Only render the Sign out of all accounts action within `<UserButton />` when there are multiple sessions.

--- a/packages/clerk-js/src/ui/components/UserButton/UserButtonPopover.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButtonPopover.tsx
@@ -66,7 +66,9 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
           )}
         </PopoverCard.Content>
         <PopoverCard.Footer elementDescriptor={descriptors.userButtonPopoverFooter}>
-          {!authConfig.singleSessionMode && <SignOutAllActions handleSignOutAllClicked={handleSignOutAllClicked} />}
+          {!authConfig.singleSessionMode && otherSessions.length > 0 && (
+            <SignOutAllActions handleSignOutAllClicked={handleSignOutAllClicked} />
+          )}
         </PopoverCard.Footer>
       </PopoverCard.Root>
     </RootBox>


### PR DESCRIPTION
## Description

Only render the `Sign out of all accounts` button if the user has more than one other session open.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-09-20 at 11 58 48 AM](https://github.com/user-attachments/assets/02c3e069-fede-4f3d-bd94-224e68822aeb) | ![Screenshot 2024-09-20 at 11 58 14 AM](https://github.com/user-attachments/assets/200abb4f-4a58-47d3-ad48-dccc1ef356b1) | 

Multiple sessions still visible:

![Screenshot 2024-09-20 at 12 02 01 PM](https://github.com/user-attachments/assets/4264e58e-dee4-4640-b9b0-bd1a70ebe9ba)


Fixes SDKI-670

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
