### PR TITLE
feat(express): Support Express v5

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -68,6 +68,9 @@
     "tsup": "*",
     "typescript": "*"
   },
+  "peerDependencies": {
+    "express": "^4.17.0 || ^5.0.0"
+  },
   "engines": {
     "node": ">=18.17.0"
   },


### PR DESCRIPTION
## Description

This PR sets a minimum Express 4 version and support for Express 5.

For Express `^4.17.0` - we went with this version as it's a more stable version, to avoid issues with earlier 4.x.x releases. We didn't want to start all the way back at 4.0.0 and risk running into old bugs or outdated features. 

Here's the total downloads of `4.17.x`:

<img width="589" alt="Screenshot 2024-09-20 at 8 56 36 AM" src="https://github.com/user-attachments/assets/2e9ad43c-5ee0-4e77-a70b-2e223e7c1578">

For v5, there is not really a big breaking change and it aims to support backward compatibility with Express 4. Here's a [small breaking note](https://github.com/expressjs/express/blob/5.x/History.md#500--2024-09-10) that should not affect our SDK. Full changelog can be found [here](https://github.com/expressjs/express/releases/tag/v5.0.0) if interested.

Note that Express v5 is still tagged as `next` and not `latest` even though it's stable. But we want to add support to it now as we don't want to release another major change in the future.

I tested v5 locally with our current CI test and it passed.

_This is part of making our Express SDK ready._

Resolves ECO-192

## Checklist

- [x] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
