### PR TITLE
fix(clerk-js): Navigate to `/choose` when signing out during multi session

### DIFF
--- a/.changeset/three-nails-fetch.md
+++ b/.changeset/three-nails-fetch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Navigate to `/choose` when signing out during multi session.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -969,7 +969,16 @@ export class Clerk implements ClerkInterface {
 
   public buildAfterMultiSessionSingleSignOutUrl(): string {
     if (!this.#options.afterMultiSessionSingleSignOutUrl) {
-      return this.environment ? `${this.environment.displayConfig.signInUrl}/choose` : this.buildAfterSignOutUrl();
+      return this.buildUrlWithAuth(
+        buildURL(
+          {
+            base: this.#options.signInUrl
+              ? `${this.#options.signInUrl}/choose`
+              : this.environment?.displayConfig.afterSignOutOneUrl,
+          },
+          { stringify: true },
+        ),
+      );
     }
 
     return this.buildUrlWithAuth(this.#options.afterMultiSessionSingleSignOutUrl);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -969,7 +969,7 @@ export class Clerk implements ClerkInterface {
 
   public buildAfterMultiSessionSingleSignOutUrl(): string {
     if (!this.#options.afterMultiSessionSingleSignOutUrl) {
-      return this.buildAfterSignOutUrl();
+      return this.environment ? `${this.environment.displayConfig.signInUrl}/choose` : this.buildAfterSignOutUrl();
     }
 
     return this.buildUrlWithAuth(this.#options.afterMultiSessionSingleSignOutUrl);

--- a/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
@@ -147,7 +147,7 @@ describe('UserButton', () => {
       await userEvent.click(getByText('Sign out'));
       await waitFor(() => {
         expect(fixtures.clerk.signOut).toHaveBeenCalledWith(expect.any(Function), { sessionId: '0' });
-        expect(fixtures.clerk.redirectWithAuth).toHaveBeenCalledWith('https://dashboard.clerk.com/sign-in/choose');
+        expect(fixtures.clerk.redirectWithAuth).toHaveBeenCalledWith('https://accounts.clerk.com/sign-in/choose');
       });
     });
 

--- a/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
@@ -1,6 +1,6 @@
 import { describe } from '@jest/globals';
 
-import { render } from '../../../../testUtils';
+import { render, waitFor } from '../../../../testUtils';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { UserButton } from '../UserButton';
 
@@ -139,11 +139,30 @@ describe('UserButton', () => {
 
     it('signs out of the currently active session when clicking "Sign out"', async () => {
       const { wrapper, fixtures } = await createFixtures(initConfig);
-      fixtures.clerk.signOut.mockReturnValueOnce(Promise.resolve());
+      fixtures.clerk.signOut.mockImplementationOnce(callback => {
+        return Promise.resolve(callback());
+      });
       const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
       await userEvent.click(getByRole('button', { name: 'Open user button' }));
       await userEvent.click(getByText('Sign out'));
-      expect(fixtures.clerk.signOut).toHaveBeenCalledWith(expect.any(Function), { sessionId: '0' });
+      await waitFor(() => {
+        expect(fixtures.clerk.signOut).toHaveBeenCalledWith(expect.any(Function), { sessionId: '0' });
+        expect(fixtures.clerk.redirectWithAuth).toHaveBeenCalledWith('https://dashboard.clerk.com/sign-in/choose');
+      });
+    });
+
+    it('signs out of all currently active session when clicking "Sign out of all accounts"', async () => {
+      const { wrapper, fixtures } = await createFixtures(initConfig);
+      fixtures.clerk.signOut.mockImplementationOnce(callback => {
+        return Promise.resolve(callback());
+      });
+      const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
+      await userEvent.click(getByRole('button', { name: 'Open user button' }));
+      await userEvent.click(getByText('Sign out of all accounts'));
+      await waitFor(() => {
+        expect(fixtures.clerk.signOut).toHaveBeenCalledWith(expect.any(Function));
+        expect(fixtures.router.navigate).toHaveBeenCalledWith('/');
+      });
     });
   });
 

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -27,11 +27,8 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
     if (otherSessions.length === 0) {
       return signOut(opts.navigateAfterSignOut);
     }
-    return signOut(opts.navigateAfterMultiSessionSingleSignOut, { sessionId: session.id }).finally(
-      () =>
-        void navigate(`${opts.signInUrl}/choose`).finally(() => {
-          card.setIdle();
-        }),
+    return signOut(opts.navigateAfterMultiSessionSingleSignOut, { sessionId: session.id }).finally(() =>
+      card.setIdle(),
     );
   };
 

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -27,8 +27,11 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
     if (otherSessions.length === 0) {
       return signOut(opts.navigateAfterSignOut);
     }
-    return signOut(opts.navigateAfterMultiSessionSingleSignOut, { sessionId: session.id }).finally(() =>
-      card.setIdle(),
+    return signOut(opts.navigateAfterMultiSessionSingleSignOut, { sessionId: session.id }).finally(
+      () =>
+        void navigate(`${opts.signInUrl}/choose`).finally(() => {
+          card.setIdle();
+        }),
     );
   };
 

--- a/packages/clerk-js/src/ui/utils/test/mockHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/mockHelpers.ts
@@ -65,6 +65,7 @@ export const mockClerkMethods = (clerk: LoadedClerk): DeepJestMocked<LoadedClerk
   });
   mockProp(clerk, 'navigate');
   mockProp(clerk, 'setActive');
+  mockProp(clerk, 'redirectWithAuth');
   mockProp(clerk, '__internal_navigateWithError');
   return clerk as any as DeepJestMocked<LoadedClerk>;
 };


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/66e41cbd-2059-4808-9ae8-5dc3ccc58796

Fixes SDKI-671

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
