### PR TITLE
fix(backend): Replace `session-token-outdated` error with more specific errors

### DIFF
--- a/.changeset/ninety-comics-scream.md
+++ b/.changeset/ninety-comics-scream.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Improve debugging error reasons.

--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -13,6 +13,7 @@ export const TokenVerificationErrorReason = {
   TokenInvalidAuthorizedParties: 'token-invalid-authorized-parties',
   TokenInvalidSignature: 'token-invalid-signature',
   TokenNotActiveYet: 'token-not-active-yet',
+  TokenIatInTheFuture: 'token-iat-in-the-future',
   TokenVerificationFailed: 'token-verification-failed',
   InvalidSecretKey: 'secret-key-invalid',
   LocalJWKMissing: 'jwk-local-missing',

--- a/packages/backend/src/jwt/assertions.ts
+++ b/packages/backend/src/jwt/assertions.ts
@@ -162,7 +162,7 @@ export const assertIssuedAtClaim = (iat: number | undefined, clockSkewInMs: numb
   const postIssued = issuedAtDate.getTime() > currentDate.getTime() + clockSkewInMs;
   if (postIssued) {
     throw new TokenVerificationError({
-      reason: TokenVerificationErrorReason.TokenNotActiveYet,
+      reason: TokenVerificationErrorReason.TokenIatInTheFuture,
       message: `JWT issued at date claim (iat) is in the future. Issued at date: ${issuedAtDate.toUTCString()}; Current date: ${currentDate.toUTCString()};`,
     });
   }

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -238,7 +238,7 @@ export default (QUnit: QUnit) => {
 
       const requestState = await authenticateRequest(mockRequestWithHeaderAuth(), mockOptions());
 
-      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenOutdated });
+      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenExpired });
       assert.strictEqual(requestState.toAuth(), null);
     });
 
@@ -487,7 +487,7 @@ export default (QUnit: QUnit) => {
         mockOptions(),
       );
 
-      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenOutdated });
+      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenIATBeforeClientUAT });
       assert.equal(requestState.message, '');
       assert.strictEqual(requestState.toAuth(), null);
     });
@@ -554,7 +554,7 @@ export default (QUnit: QUnit) => {
         mockOptions(),
       );
 
-      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenOutdated });
+      assertHandshake(assert, requestState, { reason: AuthErrorReason.SessionTokenExpired });
       assert.true(/^JWT is expired/.test(requestState.message || ''));
       assert.strictEqual(requestState.toAuth(), null);
     });

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -64,7 +64,10 @@ export const AuthErrorReason = {
   SatelliteCookieNeedsSyncing: 'satellite-needs-syncing',
   SessionTokenAndUATMissing: 'session-token-and-uat-missing',
   SessionTokenMissing: 'session-token-missing',
-  SessionTokenOutdated: 'session-token-outdated',
+  SessionTokenExpired: 'session-token-expired',
+  SessionTokenIATBeforeClientUAT: 'session-token-iat-before-client-uat',
+  SessionTokenNotActiveYet: 'session-token-not-active-yet',
+  SessionTokenIatInTheFuture: 'session-token-iat-in-the-future',
   SessionTokenWithoutClientUAT: 'session-token-but-no-client-uat',
   UnexpectedError: 'unexpected-error',
 } as const;


### PR DESCRIPTION
## Description

This PR replaces the `'session-token-outdated'` auth error reason with the following 4 more specific ones:

1. `'session-token-expired'`: Session token has expired.
2. `'session-token-iat-before-client-uat'`: Session token was issued before the timestamp depicted in `__client_uat`
3. `'session-token-not-active-yet'`: Current time was before session token's nbf claim (possible clock skew)
4. `'session-token-iat-in-the-future'`:  Session token was issued in the future (possible clock skew)

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
