### PR TITLE
feat(clerk-js,types): Supports default role on `OrganizationProfile` invitations

### DIFF
--- a/.changeset/large-chefs-move.md
+++ b/.changeset/large-chefs-move.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/types": patch
+---
+
+Supports default role on `OrganizationProfile` invitations. When inviting a member, the default role will be automatically selected, otherwise it falls back to the only available role.

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -11,6 +11,7 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
   domains!: {
     enabled: boolean;
     enrollmentModes: OrganizationEnrollmentMode[];
+    defaultRole: string | null;
   };
 
   public constructor(data: OrganizationSettingsJSON) {
@@ -26,6 +27,7 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
     this.domains = {
       enabled: domains?.enabled || false,
       enrollmentModes: domains?.enrollment_modes || [],
+      defaultRole: domains?.default_role || null,
     };
     return this;
   }

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -4,6 +4,7 @@ import type { ClerkAPIError } from '@clerk/types';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 
+import { useEnvironment } from '../../contexts';
 import { Flex } from '../../customizables';
 import { Form, FormButtonContainer, TagInput, useCardState } from '../../elements';
 import { useFetchRoles } from '../../hooks/useFetchRoles';
@@ -182,8 +183,20 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   );
 };
 
+/**
+ * Determines default role from the organization settings or fallsback to
+ * the only available role.
+ */
+const useDefaultRole = () => {
+  const { options } = useFetchRoles();
+  const { organizationSettings } = useEnvironment();
+
+  return organizationSettings.domains.default_role ?? options?.[0]?.value ?? undefined;
+};
+
 const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
   const { options, isLoading } = useFetchRoles();
+  const defaultRole = useDefaultRole();
 
   const { t } = useLocalizations();
 
@@ -195,6 +208,7 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
       >
         <RoleSelect
           {...field.props}
+          value={field.props.value ?? defaultRole}
           roles={options}
           isDisabled={isLoading}
           onChange={value => field.setValue(value)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -42,9 +42,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     label: localizationKeys('formFieldLabel__emailAddresses'),
   });
 
-  const defaultRole = useDefaultRole();
-
-  const roleField = useFormControl('role', defaultRole ?? '', {
+  const roleField = useFormControl('role', '', {
     label: localizationKeys('formFieldLabel__role'),
   });
 
@@ -190,6 +188,8 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
 
   const { t } = useLocalizations();
 
+  const defaultRole = useDefaultRole();
+
   return (
     <Form.ControlRow elementId={field.id}>
       <Flex
@@ -198,6 +198,7 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
       >
         <RoleSelect
           {...field.props}
+          value={field.props.value || (defaultRole ?? '')}
           roles={options}
           isDisabled={isLoading}
           onChange={value => field.setValue(value)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -42,7 +42,9 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     label: localizationKeys('formFieldLabel__emailAddresses'),
   });
 
-  const roleField = useFormControl('role', '', {
+  const defaultRole = useDefaultRole();
+
+  const roleField = useFormControl('role', defaultRole ?? '', {
     label: localizationKeys('formFieldLabel__role'),
   });
 
@@ -183,6 +185,31 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   );
 };
 
+const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
+  const { options, isLoading } = useFetchRoles();
+
+  const { t } = useLocalizations();
+
+  return (
+    <Form.ControlRow elementId={field.id}>
+      <Flex
+        direction='col'
+        gap={2}
+      >
+        <RoleSelect
+          {...field.props}
+          roles={options}
+          isDisabled={isLoading}
+          onChange={value => field.setValue(value)}
+          triggerSx={t => ({ minWidth: t.sizes.$40, justifyContent: 'space-between', display: 'flex' })}
+          optionListSx={t => ({ minWidth: t.sizes.$48 })}
+          prefixLocalizationKey={`${t(localizationKeys('formFieldLabel__role'))}:`}
+        />
+      </Flex>
+    </Form.ControlRow>
+  );
+};
+
 /**
  * Determines default role from the organization settings or fallback to
  * the only available role.
@@ -198,31 +225,4 @@ const useDefaultRole = () => {
   }
 
   return defaultRole;
-};
-
-const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
-  const { options, isLoading } = useFetchRoles();
-  const defaultRole = useDefaultRole();
-
-  const { t } = useLocalizations();
-
-  return (
-    <Form.ControlRow elementId={field.id}>
-      <Flex
-        direction='col'
-        gap={2}
-      >
-        <RoleSelect
-          {...field.props}
-          value={field.props.value || (defaultRole ?? '')}
-          roles={options}
-          isDisabled={isLoading}
-          onChange={value => field.setValue(value)}
-          triggerSx={t => ({ minWidth: t.sizes.$40, justifyContent: 'space-between', display: 'flex' })}
-          optionListSx={t => ({ minWidth: t.sizes.$48 })}
-          prefixLocalizationKey={`${t(localizationKeys('formFieldLabel__role'))}:`}
-        />
-      </Flex>
-    </Form.ControlRow>
-  );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -184,14 +184,20 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
 };
 
 /**
- * Determines default role from the organization settings or fallsback to
+ * Determines default role from the organization settings or fallback to
  * the only available role.
  */
 const useDefaultRole = () => {
   const { options } = useFetchRoles();
   const { organizationSettings } = useEnvironment();
 
-  return organizationSettings.domains.default_role ?? options?.[0]?.value ?? undefined;
+  let defaultRole = organizationSettings.domains.defaultRole;
+
+  if (!defaultRole && options?.length === 1) {
+    defaultRole = options[0].value;
+  }
+
+  return defaultRole;
 };
 
 const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
@@ -208,7 +214,7 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
       >
         <RoleSelect
           {...field.props}
-          value={field.props.value ?? defaultRole}
+          value={field.props.value || (defaultRole ?? '')}
           roles={options}
           isDisabled={isLoading}
           onChange={value => field.setValue(value)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -1,6 +1,7 @@
 import type { OrganizationInvitationResource } from '@clerk/types';
 import { describe } from '@jest/globals';
 import { waitFor } from '@testing-library/dom';
+import React from 'react';
 
 import { ClerkAPIResponseError } from '../../../../core/resources';
 import { render } from '../../../../testUtils';
@@ -43,9 +44,11 @@ describe('InviteMembersPage', () => {
 
   describe('with default role', () => {
     it("initializes with the organization's default role", async () => {
+      const defaultRole = 'mydefaultrole';
+
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withOrganizationDomains(undefined, 'admin');
+        f.withOrganizationDomains(undefined, defaultRole);
         f.withUser({
           email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
@@ -77,6 +80,17 @@ describe('InviteMembersPage', () => {
             createdAt: new Date(),
             updatedAt: new Date(),
           },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: defaultRole,
+            key: defaultRole,
+            name: defaultRole,
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
         ],
       });
 
@@ -88,13 +102,12 @@ describe('InviteMembersPage', () => {
         { wrapper },
       );
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
-      await userEvent.click(getByRole('button', { name: /admin/i }));
+      await userEvent.click(getByRole('button', { name: /mydefaultrole/i }));
     });
 
-    it('initializes with the only available role', async () => {
+    it("initializes if there's only one role available", async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withOrganizationDomains(undefined, undefined);
         f.withUser({
           email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
@@ -126,11 +139,59 @@ describe('InviteMembersPage', () => {
         { wrapper },
       );
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
-      await userEvent.click(getByRole('button', { name: /member/i }));
+      await waitFor(() => expect(getByRole('button', { name: /member/i })).toBeInTheDocument());
+    });
+
+    it("does not initialize if there's neither a default role nor a unique role", async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getRoles.mockResolvedValue({
+        total_count: 1,
+        data: [
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'member',
+            key: 'member',
+            name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
+      const { getByRole, userEvent, getByTestId } = render(
+        <Action.Root>
+          <InviteMembersScreen />
+        </Action.Root>,
+        { wrapper },
+      );
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await waitFor(() => expect(getByRole('button', { name: /select role/i })).toBeInTheDocument());
     });
   });
 
-  describe('Submitting', () => {
+  describe('when submitting', () => {
     it('keeps the Send button disabled until a role is selected and one or more email has been entered', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
@@ -149,6 +210,17 @@ describe('InviteMembersPage', () => {
             id: 'member',
             key: 'member',
             name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
             description: '',
             permissions: [],
             createdAt: new Date(),
@@ -197,6 +269,17 @@ describe('InviteMembersPage', () => {
             createdAt: new Date(),
             updatedAt: new Date(),
           },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
         ],
       });
 
@@ -238,6 +321,17 @@ describe('InviteMembersPage', () => {
             id: 'member',
             key: 'member',
             name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
             description: '',
             permissions: [],
             createdAt: new Date(),
@@ -348,6 +442,17 @@ describe('InviteMembersPage', () => {
             createdAt: new Date(),
             updatedAt: new Date(),
           },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
         ],
       });
 
@@ -407,6 +512,17 @@ describe('InviteMembersPage', () => {
             createdAt: new Date(),
             updatedAt: new Date(),
           },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
         ],
       });
 
@@ -457,6 +573,17 @@ describe('InviteMembersPage', () => {
             id: 'member',
             key: 'member',
             name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
             description: '',
             permissions: [],
             createdAt: new Date(),

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -41,6 +41,8 @@ describe('InviteMembersPage', () => {
     getByText('Enter or paste one or more email addresses, separated by spaces or commas.');
   });
 
+  it.todo("automatically selects the organization's default role");
+
   describe('Submitting', () => {
     it('keeps the Send button disabled until a role is selected and one or more email has been entered', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -41,7 +41,94 @@ describe('InviteMembersPage', () => {
     getByText('Enter or paste one or more email addresses, separated by spaces or commas.');
   });
 
-  it.todo("automatically selects the organization's default role");
+  describe('with default role', () => {
+    it("initializes with the organization's default role", async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationDomains(undefined, 'admin');
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getRoles.mockResolvedValue({
+        total_count: 2,
+        data: [
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'member',
+            key: 'member',
+            name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
+      const { getByRole, userEvent, getByTestId } = render(
+        <Action.Root>
+          <InviteMembersScreen />
+        </Action.Root>,
+        { wrapper },
+      );
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await userEvent.click(getByRole('button', { name: /admin/i }));
+    });
+
+    it('initializes with the only available role', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationDomains(undefined, undefined);
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getRoles.mockResolvedValue({
+        total_count: 1,
+        data: [
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'member',
+            key: 'member',
+            name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
+      const { getByRole, userEvent, getByTestId } = render(
+        <Action.Root>
+          <InviteMembersScreen />
+        </Action.Root>,
+        { wrapper },
+      );
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      await userEvent.click(getByRole('button', { name: /member/i }));
+    });
+  });
 
   describe('Submitting', () => {
     it('keeps the Send button disabled until a role is selected and one or more email has been entered', async () => {

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -296,9 +296,10 @@ const createOrganizationSettingsFixtureHelpers = (environment: EnvironmentJSON) 
     os.max_allowed_memberships = max;
   };
 
-  const withOrganizationDomains = (modes?: OrganizationEnrollmentMode[]) => {
+  const withOrganizationDomains = (modes?: OrganizationEnrollmentMode[], defaultRole?: string) => {
     os.domains.enabled = true;
     os.domains.enrollment_modes = modes || ['automatic_invitation', 'automatic_invitation', 'manual_invitation'];
+    os.domains.default_role = defaultRole ?? null;
   };
   return { withOrganizations, withMaxAllowedMemberships, withOrganizationDomains };
 };

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -13,6 +13,7 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
   domains: {
     enabled: boolean;
     enrollment_modes: OrganizationEnrollmentMode[];
+    default_role: string | null;
   };
 }
 
@@ -25,6 +26,6 @@ export interface OrganizationSettingsResource extends ClerkResource {
   domains: {
     enabled: boolean;
     enrollmentModes: OrganizationEnrollmentMode[];
-    default_role: string | null;
+    defaultRole: string | null;
   };
 }

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -25,5 +25,6 @@ export interface OrganizationSettingsResource extends ClerkResource {
   domains: {
     enabled: boolean;
     enrollmentModes: OrganizationEnrollmentMode[];
+    default_role: string | null;
   };
 }


### PR DESCRIPTION
## Description

Resolves ORGS-211

Prepares `OrganizationProfile` for the upcoming `default_role` changes. When inviting a member, the `default_role` will be automatically selected, otherwise it falls back to the only available role. 

Currently behind a feature flag in the Dashboard, we're now allowing updating `default_role` regardless of whether verified domains are enabled. 

---

https://github.com/user-attachments/assets/4750a26a-105c-4b10-9586-b2cb952bbe48



<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
