### PR TITLE
feat(clerk-js,backend,types): Implement "disable additional identifiers" for SAML connection

### DIFF
--- a/.changeset/fresh-forks-talk.md
+++ b/.changeset/fresh-forks-talk.md
@@ -1,0 +1,7 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/backend": patch
+"@clerk/types": patch
+---
+
+Conditionally renders identification sections on `UserProfile` based on the SAML connection configuration for disabling additional identifiers.

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -114,6 +114,7 @@ export interface SamlAccountJSON extends ClerkResourceJSON {
   first_name: string;
   last_name: string;
   verification: VerificationJSON | null;
+  saml_connection: SamlAccountConnectionJSON | null;
 }
 
 export interface IdentificationLinkJSON extends ClerkResourceJSON {
@@ -396,6 +397,20 @@ export interface PermissionJSON extends ClerkResourceJSON {
   key: string;
   name: string;
   description: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface SamlAccountConnectionJSON extends ClerkResourceJSON {
+  id: string;
+  name: string;
+  domain: string;
+  active: boolean;
+  provider: string;
+  sync_user_attributes: boolean;
+  allow_subdomains: boolean;
+  allow_idp_initiated: boolean;
+  disable_additional_identifications: boolean;
   created_at: number;
   updated_at: number;
 }

--- a/packages/backend/src/api/resources/SamlAccount.ts
+++ b/packages/backend/src/api/resources/SamlAccount.ts
@@ -1,4 +1,5 @@
 import type { SamlAccountJSON } from './JSON';
+import { SamlAccountConnection } from './SamlConnection';
 import { Verification } from './Verification';
 
 export class SamlAccount {
@@ -11,6 +12,7 @@ export class SamlAccount {
     readonly firstName: string,
     readonly lastName: string,
     readonly verification: Verification | null,
+    readonly samlConnection: SamlAccountConnection | null,
   ) {}
 
   static fromJSON(data: SamlAccountJSON): SamlAccount {
@@ -23,6 +25,7 @@ export class SamlAccount {
       data.first_name,
       data.last_name,
       data.verification && Verification.fromJSON(data.verification),
+      data.saml_connection && SamlAccountConnection.fromJSON(data.saml_connection),
     );
   }
 }

--- a/packages/backend/src/api/resources/SamlConnection.ts
+++ b/packages/backend/src/api/resources/SamlConnection.ts
@@ -1,4 +1,4 @@
-import type { AttributeMappingJSON, SamlConnectionJSON } from './JSON';
+import type { AttributeMappingJSON, SamlAccountConnectionJSON, SamlConnectionJSON } from './JSON';
 
 export class SamlConnection {
   constructor(
@@ -45,6 +45,35 @@ export class SamlConnection {
       data.created_at,
       data.updated_at,
       data.attribute_mapping && AttributeMapping.fromJSON(data.attribute_mapping),
+    );
+  }
+}
+
+export class SamlAccountConnection {
+  constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly domain: string,
+    readonly active: boolean,
+    readonly provider: string,
+    readonly syncUserAttributes: boolean,
+    readonly allowSubdomains: boolean,
+    readonly allowIdpInitiated: boolean,
+    readonly createdAt: number,
+    readonly updatedAt: number,
+  ) {}
+  static fromJSON(data: SamlAccountConnectionJSON): SamlAccountConnection {
+    return new SamlAccountConnection(
+      data.id,
+      data.name,
+      data.domain,
+      data.active,
+      data.provider,
+      data.sync_user_attributes,
+      data.allow_subdomains,
+      data.allow_idp_initiated,
+      data.created_at,
+      data.updated_at,
     );
   }
 }

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.browser.js", "maxSize": "64.1kB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "65kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "43kB" },
     { "path": "./dist/ui-common*.js", "maxSize": "86KB" },
     { "path": "./dist/vendors*.js", "maxSize": "70KB" },

--- a/packages/clerk-js/src/core/resources/SamlAccount.ts
+++ b/packages/clerk-js/src/core/resources/SamlAccount.ts
@@ -1,5 +1,13 @@
-import type { SamlAccountJSON, SamlAccountResource, SamlIdpSlug, VerificationResource } from '@clerk/types';
+import type {
+  SamlAccountConnectionJSON,
+  SamlAccountConnectionResource,
+  SamlAccountJSON,
+  SamlAccountResource,
+  SamlIdpSlug,
+  VerificationResource,
+} from '@clerk/types';
 
+import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './Base';
 import { Verification } from './Verification';
 
@@ -12,6 +20,7 @@ export class SamlAccount extends BaseResource implements SamlAccountResource {
   firstName = '';
   lastName = '';
   verification: VerificationResource | null = null;
+  samlConnection: SamlAccountConnectionResource | null = null;
 
   public constructor(data: Partial<SamlAccountJSON>, pathRoot: string);
   public constructor(data: SamlAccountJSON, pathRoot: string) {
@@ -35,6 +44,46 @@ export class SamlAccount extends BaseResource implements SamlAccountResource {
 
     if (data.verification) {
       this.verification = new Verification(data.verification);
+    }
+
+    if (data.saml_connection) {
+      this.samlConnection = new SamlAccountConnection(data.saml_connection);
+    }
+
+    return this;
+  }
+}
+
+export class SamlAccountConnection extends BaseResource implements SamlAccountConnectionResource {
+  id!: string;
+  name!: string;
+  domain!: string;
+  active!: boolean;
+  provider!: string;
+  syncUserAttributes!: boolean;
+  allowSubdomains!: boolean;
+  allowIdpInitiated!: boolean;
+  disableAdditionalIdentifications!: boolean;
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  constructor(data: SamlAccountConnectionJSON | null) {
+    super();
+    this.fromJSON(data);
+  }
+  protected fromJSON(data: SamlAccountConnectionJSON | null): this {
+    if (data) {
+      this.id = data.id;
+      this.name = data.name;
+      this.domain = data.domain;
+      this.active = data.active;
+      this.provider = data.provider;
+      this.syncUserAttributes = data.sync_user_attributes;
+      this.allowSubdomains = data.allow_subdomains;
+      this.allowIdpInitiated = data.allow_idp_initiated;
+      this.disableAdditionalIdentifications = data.disable_additional_identifications;
+      this.createdAt = unixEpochToDate(data.created_at);
+      this.updatedAt = unixEpochToDate(data.updated_at);
     }
 
     return this;

--- a/packages/clerk-js/src/ui/components/UserProfile/AccountPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AccountPage.tsx
@@ -15,12 +15,19 @@ export const AccountPage = withCardStateProvider(() => {
   const { attributes, saml, social } = useEnvironment().userSettings;
   const card = useCardState();
   const { user } = useUser();
+
   const showUsername = attributes.username.enabled;
   const showEmail = attributes.email_address.enabled;
   const showPhone = attributes.phone_number.enabled;
   const showConnectedAccounts = social && Object.values(social).filter(p => p.enabled).length > 0;
   const showSamlAccounts = saml && saml.enabled && user && user.samlAccounts.length > 0;
   const showWeb3 = attributes.web3_wallet.enabled;
+
+  const shouldAllowIdentificationCreation =
+    !showSamlAccounts ||
+    !user?.samlAccounts?.some(
+      samlAccount => samlAccount.active && samlAccount.samlConnection?.disableAdditionalIdentifications,
+    );
 
   return (
     <Col
@@ -43,11 +50,11 @@ export const AccountPage = withCardStateProvider(() => {
 
         <UserProfileSection />
         {showUsername && <UsernameSection />}
-        {showEmail && <EmailsSection />}
-        {showPhone && <PhoneSection />}
-        {showConnectedAccounts && <ConnectedAccountsSection />}
+        {showEmail && <EmailsSection shouldAllowCreation={shouldAllowIdentificationCreation} />}
+        {showPhone && <PhoneSection shouldAllowCreation={shouldAllowIdentificationCreation} />}
+        {showConnectedAccounts && <ConnectedAccountsSection shouldAllowCreation={shouldAllowIdentificationCreation} />}
         {showSamlAccounts && <EnterpriseAccountsSection />}
-        {showWeb3 && <Web3Section />}
+        {showWeb3 && <Web3Section shouldAllowCreation={shouldAllowIdentificationCreation} />}
       </Col>
     </Col>
   );

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -46,41 +46,43 @@ const errorCodesForReconnect = [
   'external_account_email_address_verification_required',
 ];
 
-export const ConnectedAccountsSection = withCardStateProvider(() => {
-  const { user } = useUser();
-  const card = useCardState();
+export const ConnectedAccountsSection = withCardStateProvider(
+  ({ shouldAllowCreation = true }: { shouldAllowCreation?: boolean }) => {
+    const { user } = useUser();
+    const card = useCardState();
+    const hasExternalAccounts = Boolean(user?.externalAccounts?.length);
 
-  if (!user) {
-    return null;
-  }
+    if (!user || (!shouldAllowCreation && !hasExternalAccounts)) {
+      return null;
+    }
 
-  const accounts = [
-    ...user.verifiedExternalAccounts,
-    ...user.unverifiedExternalAccounts.filter(a => a.verification?.error),
-  ];
+    const accounts = [
+      ...user.verifiedExternalAccounts,
+      ...user.unverifiedExternalAccounts.filter(a => a.verification?.error),
+    ];
 
-  return (
-    <ProfileSection.Root
-      title={localizationKeys('userProfile.start.connectedAccountsSection.title')}
-      centered={false}
-      id='connectedAccounts'
-    >
-      <Card.Alert>{card.error}</Card.Alert>
-      <Action.Root>
-        <ProfileSection.ItemList id='connectedAccounts'>
-          {accounts.map(account => (
-            <ConnectedAccount
-              key={account.id}
-              account={account}
-            />
-          ))}
-        </ProfileSection.ItemList>
-
-        <AddConnectedAccount />
-      </Action.Root>
-    </ProfileSection.Root>
-  );
-});
+    return (
+      <ProfileSection.Root
+        title={localizationKeys('userProfile.start.connectedAccountsSection.title')}
+        centered={false}
+        id='connectedAccounts'
+      >
+        <Card.Alert>{card.error}</Card.Alert>
+        <Action.Root>
+          <ProfileSection.ItemList id='connectedAccounts'>
+            {accounts.map(account => (
+              <ConnectedAccount
+                key={account.id}
+                account={account}
+              />
+            ))}
+          </ProfileSection.ItemList>
+          {shouldAllowCreation && <AddConnectedAccount />}
+        </Action.Root>
+      </ProfileSection.Root>
+    );
+  },
+);
 
 const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => {
   const { additionalOAuthScopes, componentName, mode } = useUserProfileContext();

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailsSection.tsx
@@ -35,7 +35,7 @@ const EmailScreen = (props: EmailScreenProps) => {
   );
 };
 
-export const EmailsSection = () => {
+export const EmailsSection = ({ shouldAllowCreation = true }) => {
   const { user } = useUser();
 
   return (
@@ -79,19 +79,21 @@ export const EmailsSection = () => {
               </Action.Open>
             </Action.Root>
           ))}
-
-          <Action.Trigger value='add'>
-            <ProfileSection.ArrowButton
-              id='emailAddresses'
-              localizationKey={localizationKeys('userProfile.start.emailAddressesSection.primaryButton')}
-            />
-          </Action.Trigger>
-
-          <Action.Open value='add'>
-            <Action.Card>
-              <EmailScreen />
-            </Action.Card>
-          </Action.Open>
+          {shouldAllowCreation && (
+            <>
+              <Action.Trigger value='add'>
+                <ProfileSection.ArrowButton
+                  id='emailAddresses'
+                  localizationKey={localizationKeys('userProfile.start.emailAddressesSection.primaryButton')}
+                />
+              </Action.Trigger>
+              <Action.Open value='add'>
+                <Action.Card>
+                  <EmailScreen />
+                </Action.Card>
+              </Action.Open>
+            </>
+          )}
         </ProfileSection.ItemList>
       </Action.Root>
     </ProfileSection.Root>

--- a/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
@@ -35,8 +35,13 @@ const PhoneScreen = (props: PhoneScreenProps) => {
   );
 };
 
-export const PhoneSection = () => {
+export const PhoneSection = ({ shouldAllowCreation = true }: { shouldAllowCreation?: boolean }) => {
   const { user } = useUser();
+  const hasPhoneNumbers = Boolean(user?.phoneNumbers?.length);
+
+  if (!shouldAllowCreation && !hasPhoneNumbers) {
+    return null;
+  }
 
   return (
     <ProfileSection.Root
@@ -84,19 +89,21 @@ export const PhoneSection = () => {
               </Action.Open>
             </Action.Root>
           ))}
-
-          <Action.Trigger value='add'>
-            <ProfileSection.ArrowButton
-              id='phoneNumbers'
-              localizationKey={localizationKeys('userProfile.start.phoneNumbersSection.primaryButton')}
-            />
-          </Action.Trigger>
-
-          <Action.Open value='add'>
-            <Action.Card>
-              <PhoneScreen />
-            </Action.Card>
-          </Action.Open>
+          {shouldAllowCreation && (
+            <>
+              <Action.Trigger value='add'>
+                <ProfileSection.ArrowButton
+                  id='phoneNumbers'
+                  localizationKey={localizationKeys('userProfile.start.phoneNumbersSection.primaryButton')}
+                />
+              </Action.Trigger>
+              <Action.Open value='add'>
+                <Action.Card>
+                  <PhoneScreen />
+                </Action.Card>
+              </Action.Open>
+            </>
+          )}
         </ProfileSection.ItemList>
       </Action.Root>
     </ProfileSection.Root>

--- a/packages/clerk-js/src/ui/components/UserProfile/Web3Section.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/Web3Section.tsx
@@ -28,75 +28,82 @@ const shortenWeb3Address = (address: string) => {
   return address.slice(0, 6) + '...' + address.slice(-4);
 };
 
-export const Web3Section = withCardStateProvider(() => {
-  const { user } = useUser();
-  const card = useCardState();
-  const { strategyToDisplayData } = useEnabledThirdPartyProviders();
+export const Web3Section = withCardStateProvider(
+  ({ shouldAllowCreation = true }: { shouldAllowCreation?: boolean }) => {
+    const { user } = useUser();
+    const card = useCardState();
+    const { strategyToDisplayData } = useEnabledThirdPartyProviders();
+    const hasWeb3Wallets = Boolean(user?.web3Wallets?.length);
 
-  return (
-    <ProfileSection.Root
-      title={localizationKeys('userProfile.start.web3WalletsSection.title')}
-      id='web3Wallets'
-    >
-      <Card.Alert>{card.error}</Card.Alert>
-      <Action.Root>
-        <ProfileSection.ItemList id='web3Wallets'>
-          {user?.web3Wallets.map(wallet => {
-            const strategy = wallet.verification.strategy as keyof typeof strategyToDisplayData;
+    if (!shouldAllowCreation && !hasWeb3Wallets) {
+      return null;
+    }
 
-            return (
-              strategyToDisplayData[strategy] && (
-                <Action.Root key={wallet.id}>
-                  <Action.Closed value=''>
-                    <ProfileSection.Item
-                      key={wallet.id}
-                      id='web3Wallets'
-                      align='start'
-                    >
-                      <Flex sx={t => ({ alignItems: 'center', gap: t.space.$2, width: '100%' })}>
-                        {strategyToDisplayData[strategy].iconUrl && (
-                          <Image
-                            src={strategyToDisplayData[strategy].iconUrl}
-                            alt={strategyToDisplayData[strategy].name}
-                            sx={theme => ({ width: theme.sizes.$4 })}
-                          />
-                        )}
-                        <Box sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
-                          <Flex
-                            gap={2}
-                            justify='start'
-                          >
-                            <Text>
-                              {strategyToDisplayData[strategy].name} ({shortenWeb3Address(wallet.web3Wallet)})
-                            </Text>
-                            {user?.primaryWeb3WalletId === wallet.id && (
-                              <Badge localizationKey={localizationKeys('badge__primary')} />
-                            )}
-                            {wallet.verification.status !== 'verified' && (
-                              <Badge localizationKey={localizationKeys('badge__unverified')} />
-                            )}
-                          </Flex>
-                        </Box>
-                      </Flex>
-                      <Web3WalletMenu />
-                    </ProfileSection.Item>
-                  </Action.Closed>
+    return (
+      <ProfileSection.Root
+        title={localizationKeys('userProfile.start.web3WalletsSection.title')}
+        id='web3Wallets'
+      >
+        <Card.Alert>{card.error}</Card.Alert>
+        <Action.Root>
+          <ProfileSection.ItemList id='web3Wallets'>
+            {user?.web3Wallets.map(wallet => {
+              const strategy = wallet.verification.strategy as keyof typeof strategyToDisplayData;
 
-                  <Action.Open value='remove'>
-                    <Action.Card variant='destructive'>
-                      <RemoveWeb3WalletScreen walletId={wallet.id} />
-                    </Action.Card>
-                  </Action.Open>
-                </Action.Root>
-              )
-            );
-          })}
-        </ProfileSection.ItemList>
-        <AddWeb3WalletActionMenu />
-      </Action.Root>
-    </ProfileSection.Root>
-  );
-});
+              return (
+                strategyToDisplayData[strategy] && (
+                  <Action.Root key={wallet.id}>
+                    <Action.Closed value=''>
+                      <ProfileSection.Item
+                        key={wallet.id}
+                        id='web3Wallets'
+                        align='start'
+                      >
+                        <Flex sx={t => ({ alignItems: 'center', gap: t.space.$2, width: '100%' })}>
+                          {strategyToDisplayData[strategy].iconUrl && (
+                            <Image
+                              src={strategyToDisplayData[strategy].iconUrl}
+                              alt={strategyToDisplayData[strategy].name}
+                              sx={theme => ({ width: theme.sizes.$4 })}
+                            />
+                          )}
+                          <Box sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
+                            <Flex
+                              gap={2}
+                              justify='start'
+                            >
+                              <Text>
+                                {strategyToDisplayData[strategy].name} ({shortenWeb3Address(wallet.web3Wallet)})
+                              </Text>
+                              {user?.primaryWeb3WalletId === wallet.id && (
+                                <Badge localizationKey={localizationKeys('badge__primary')} />
+                              )}
+                              {wallet.verification.status !== 'verified' && (
+                                <Badge localizationKey={localizationKeys('badge__unverified')} />
+                              )}
+                            </Flex>
+                          </Box>
+                        </Flex>
+                        <Web3WalletMenu />
+                      </ProfileSection.Item>
+                    </Action.Closed>
+
+                    <Action.Open value='remove'>
+                      <Action.Card variant='destructive'>
+                        <RemoveWeb3WalletScreen walletId={wallet.id} />
+                      </Action.Card>
+                    </Action.Open>
+                  </Action.Root>
+                )
+              );
+            })}
+          </ProfileSection.ItemList>
+          {shouldAllowCreation && <AddWeb3WalletActionMenu />}
+        </Action.Root>
+      </ProfileSection.Root>
+    );
+  },
+);
 
 const Web3WalletMenu = () => {
   const { open } = useActionContext();

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/AccountPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/AccountPage.test.tsx
@@ -1,3 +1,4 @@
+import type { SamlAccountJSON } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 
 import { render, screen, waitFor } from '../../../../testUtils';
@@ -109,6 +110,91 @@ describe('AccountPage', () => {
       render(<AccountPage />, { wrapper });
       screen.getByText(/Enterprise Accounts/i);
       screen.getByText(/Okta Workforce/i);
+    });
+
+    describe('with `disable_additional_identifications`', () => {
+      const emailAddress = 'george@jungle.com';
+      const phoneNumber = '+301234567890';
+      const firstName = 'George';
+      const lastName = 'Clerk';
+
+      const samlAccount: SamlAccountJSON = {
+        id: 'samlacc_foo',
+        provider: 'saml_okta',
+        email_address: emailAddress,
+        first_name: firstName,
+        last_name: lastName,
+        saml_connection: {
+          id: 'samlc_foo',
+          active: true,
+          disable_additional_identifications: true,
+          allow_idp_initiated: true,
+          allow_subdomains: true,
+          domain: 'foo.com',
+          name: 'Foo',
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+          object: 'saml_connection',
+          provider: 'saml_okta',
+          sync_user_attributes: true,
+        },
+        active: true,
+        object: 'saml_account',
+        provider_user_id: '',
+      };
+
+      it('shows only the enterprise accounts of the user', async () => {
+        const { wrapper } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPhoneNumber();
+          f.withSocialProvider({ provider: 'google' });
+          f.withSaml();
+          f.withUser({
+            email_addresses: [emailAddress],
+            saml_accounts: [samlAccount],
+            first_name: firstName,
+            last_name: lastName,
+          });
+        });
+
+        render(<AccountPage />, { wrapper });
+
+        expect(screen.queryByText(/Add email address/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Phone numbers/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Connected Accounts/i)).not.toBeInTheDocument();
+        screen.getByText(/Enterprise Accounts/i);
+        screen.getByText(/Okta Workforce/i);
+      });
+
+      it('shows the enterprise accounts of the user, and the other sections, but hides the add button', async () => {
+        const { wrapper } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPhoneNumber();
+          f.withSocialProvider({ provider: 'google' });
+          f.withSaml();
+          f.withUser({
+            email_addresses: [emailAddress],
+            phone_numbers: [phoneNumber],
+            external_accounts: [{ provider: 'google', email_address: 'test@clerk.com' }],
+            saml_accounts: [samlAccount],
+            first_name: firstName,
+            last_name: lastName,
+          });
+        });
+
+        render(<AccountPage />, { wrapper });
+
+        screen.getByText(/Email addresses/i);
+        screen.getByText(/Phone numbers/i);
+        screen.getByText(/Connected Accounts/i);
+        screen.getByText(/Enterprise Accounts/i);
+        screen.getByText(/Okta Workforce/i);
+
+        // Add buttons should be hidden
+        expect(screen.queryByText(/Add email address/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Add phone number/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Connect account/i)).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,3 +59,4 @@ export * from './customPages';
 export * from './pagination';
 export * from './passkey';
 export * from './customMenuItems';
+export * from './samlConnection';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -199,6 +199,7 @@ export interface SamlAccountJSON extends ClerkResourceJSON {
   first_name: string;
   last_name: string;
   verification?: VerificationJSON;
+  saml_connection?: SamlAccountConnectionJSON;
 }
 
 export interface UserJSON extends ClerkResourceJSON {
@@ -511,4 +512,18 @@ export interface PublicKeyCredentialRequestOptionsJSON {
   rpId: string;
   timeout: number;
   userVerification: 'discouraged' | 'preferred' | 'required';
+}
+
+export interface SamlAccountConnectionJSON extends ClerkResourceJSON {
+  id: string;
+  name: string;
+  domain: string;
+  active: boolean;
+  provider: string;
+  sync_user_attributes: boolean;
+  allow_subdomains: boolean;
+  allow_idp_initiated: boolean;
+  disable_additional_identifications: boolean;
+  created_at: number;
+  updated_at: number;
 }

--- a/packages/types/src/samlAccount.ts
+++ b/packages/types/src/samlAccount.ts
@@ -1,5 +1,6 @@
 import type { ClerkResource } from './resource';
 import type { SamlIdpSlug } from './saml';
+import type { SamlAccountConnectionResource } from './samlConnection';
 import type { VerificationResource } from './verification';
 
 export interface SamlAccountResource extends ClerkResource {
@@ -10,4 +11,5 @@ export interface SamlAccountResource extends ClerkResource {
   firstName: string;
   lastName: string;
   verification: VerificationResource | null;
+  samlConnection: SamlAccountConnectionResource | null;
 }

--- a/packages/types/src/samlConnection.ts
+++ b/packages/types/src/samlConnection.ts
@@ -1,0 +1,15 @@
+import type { ClerkResource } from './resource';
+
+export interface SamlAccountConnectionResource extends ClerkResource {
+  id: string;
+  name: string;
+  domain: string;
+  active: boolean;
+  provider: string;
+  syncUserAttributes: boolean;
+  allowSubdomains: boolean;
+  allowIdpInitiated: boolean;
+  disableAdditionalIdentifications: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Description
This pull request introduces a new feature for SAML connections. On the dashboard, users will be able to turn on/off a new flag called `disable_additional_identifications`. This is responsible for blocking the users to add any new identification other than their saml account. This pull request adds the new `saml_connection` field on the `saml_accounts`, and perform a logical check on the `<UserProfile />` to conditional render the other sections (and add buttons).

## Checklist
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
