### PR TITLE
fix(clerk-js): Handle gracefully Coinbase Wallet initial configuration

### DIFF
--- a/.changeset/gold-vans-swim.md
+++ b/.changeset/gold-vans-swim.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Handle gracefully Coinbase Wallet initial configuration

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -207,7 +207,24 @@ export class SignUp extends BaseResource implements SignUpResource {
       clerkVerifyWeb3WalletCalledBeforeCreate('SignUp');
     }
 
-    const signature = await generateSignature({ identifier, nonce, provider });
+    let signature: string;
+    try {
+      signature = await generateSignature({ identifier, nonce, provider });
+    } catch (err) {
+      // There is a chance that as a first time visitor when you try to setup and use the
+      // Coinbase Wallet from scratch in order to authenticate, the initial generate
+      // signature request to be rejected. For this reason we retry the request once more
+      // in order for the flow to be able to be completed successfully.
+      //
+      // error code 4001 means the user rejected the request
+      // Reference: https://docs.cdp.coinbase.com/wallet-sdk/docs/errors
+      if (provider === 'coinbase_wallet' && err.code === 4001) {
+        signature = await generateSignature({ identifier, nonce, provider });
+      } else {
+        throw err;
+      }
+    }
+
     return this.attemptWeb3WalletVerification({ signature, strategy });
   };
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

There is a chance that as a first time visitor when you try to setup and use the Coinbase Wallet from scratch in order to authenticate, the initial generate signature request to be rejected. For this reason we retry the request once more in order for the flow to be able to be completed successfully.

### Before
https://github.com/user-attachments/assets/26ec0c8b-055b-4df3-a71b-482ed02b4b34

### After
https://github.com/user-attachments/assets/0cdc578f-c810-46b8-ac6e-92511bcc5c8f


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
