### PR TITLE
fix(clerk-js): Fix space encoding for query params

### DIFF
--- a/.changeset/tame-dots-trade.md
+++ b/.changeset/tame-dots-trade.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix space encoding for query params

--- a/packages/clerk-js/src/utils/__tests__/querystring.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/querystring.test.ts
@@ -22,6 +22,14 @@ describe('getQueryParams(string)', () => {
     const res = getQueryParams('?foo=42&foo=43&bar=1');
     expect(res).toEqual({ foo: ['42', '43'], bar: '1' });
   });
+
+  it('parses spaces and "+" characters correctly', () => {
+    expect(getQueryParams('test=foo%20bar')).toEqual({ test: 'foo bar' });
+    expect(getQueryParams('test=foo%2Bbar%20lab')).toEqual({ test: 'foo+bar lab' });
+
+    expect(getQueryParams('?foo=42%20hey&foo=43%20%2B&bar=1')).toEqual({ foo: ['42 hey', '43 +'], bar: '1' });
+    expect(getQueryParams('?foo=42%20hey&foo=43&bar=1')).toEqual({ foo: ['42 hey', '43'], bar: '1' });
+  });
 });
 
 describe('stringifyQueryParams(object)', () => {
@@ -67,6 +75,14 @@ describe('stringifyQueryParams(object)', () => {
 
   it('handles false value', () => {
     expect(stringifyQueryParams({ test: false, boo: true })).toBe('test=false&boo=true');
+  });
+
+  it('handles spaces and "+" characters correctly', () => {
+    expect(stringifyQueryParams({ test: 'foo bar' })).toBe('test=foo%20bar');
+
+    expect(stringifyQueryParams({ test: 'foo+bar lab' })).toBe('test=foo%2Bbar%20lab');
+
+    expect(stringifyQueryParams({ test: ['foo+bar lab', 'new+'] })).toBe('test=foo%2Bbar%20lab&test=new%2B');
   });
 
   it('converts an object to querystring when key is camelCase', () => {

--- a/packages/clerk-js/src/utils/querystring.ts
+++ b/packages/clerk-js/src/utils/querystring.ts
@@ -52,5 +52,5 @@ export const stringifyQueryParams = (
     }
   });
 
-  return queryParams.toString();
+  return queryParams.toString().replace(/\+/g, '%20');
 };


### PR DESCRIPTION
## Description

This PR fixes space encoding for query params, to match the previous the implementation of `qs` library we previously had (removed in https://github.com/clerk/javascript/pull/3430).

Previously when we were using the `qs` library the spaces in the query param value where encoded with `%20`

But now that we are casting `URLSearchParams` instance to string replaces the spaces in values with `+` and this is breaking change
 
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
