### PR TITLE
feat(elements): Add support for `restricted` mode

### DIFF
--- a/.changeset/three-timers-sneeze.md
+++ b/.changeset/three-timers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": minor
+---
+
+Adds `restricted-access` Step for invite-only applications

--- a/.changeset/three-timers-sneeze.md
+++ b/.changeset/three-timers-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"@clerk/elements": minor
+'@clerk/elements': minor
 ---
 
-Adds `restricted-access` Step for invite-only applications
+Adds `restricted` Step for restricted sign-up mode

--- a/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
@@ -228,7 +228,7 @@ export default function SignUpPage() {
           </SignUp.Strategy>
         </SignUp.Step>
 
-        <SignUp.Step name='restricted-access'>
+        <SignUp.Step name='restricted'>
           <H1>Restricted Access</H1>
           <P>Access to this app is limited, and an invitation is required to sign up.</P>
         </SignUp.Step>

--- a/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-up/[[...sign-up]]/page.tsx
@@ -227,6 +227,11 @@ export default function SignUpPage() {
             <CustomResendable />
           </SignUp.Strategy>
         </SignUp.Step>
+
+        <SignUp.Step name='restricted-access'>
+          <H1>Restricted Access</H1>
+          <P>Access to this app is limited, and an invitation is required to sign up.</P>
+        </SignUp.Step>
       </div>
     </SignUp.Root>
   );

--- a/packages/elements/src/internals/constants/index.ts
+++ b/packages/elements/src/internals/constants/index.ts
@@ -1,8 +1,15 @@
+import type { SignUpModes } from '@clerk/types';
+
 import { safeAccess } from '~/utils/safe-access';
 
 export const SSO_CALLBACK_PATH_ROUTE = '/sso-callback';
 export const CHOOSE_SESSION_PATH_ROUTE = '/choose';
 export const MAGIC_LINK_VERIFY_PATH_ROUTE = '/verify';
+
+export const SIGN_UP_MODES: Record<string, SignUpModes> = {
+  PUBLIC: 'public',
+  RESTRICTED: 'restricted',
+};
 
 // TODO: remove reliance on next-specific variables here
 export const SIGN_IN_DEFAULT_BASE_PATH = safeAccess(

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -317,7 +317,7 @@ export const SignUpRouterMachine = setup({
         },
         {
           guard: 'isRestrictedWithoutTicket',
-          target: 'RestrictedAccess',
+          target: 'Restricted',
         },
         {
           actions: { type: 'navigateInternal', params: { force: true, path: '/' } },
@@ -486,8 +486,8 @@ export const SignUpRouterMachine = setup({
         ],
       },
     },
-    RestrictedAccess: {
-      tags: ['step:restricted-access'],
+    Restricted: {
+      tags: ['step:restricted'],
       on: {
         NEXT: 'Start',
       },

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -297,10 +297,6 @@ export const SignUpRouterMachine = setup({
           ],
         },
         {
-          guard: 'isRestrictedWithoutTicket',
-          target: 'RestrictedAccess',
-        },
-        {
           guard: 'needsCallback',
           target: 'Callback',
         },
@@ -318,6 +314,10 @@ export const SignUpRouterMachine = setup({
           guard: or(['needsContinue', 'hasClerkTransfer']),
           actions: { type: 'navigateInternal', params: { force: true, path: '/continue' } },
           target: 'Continue',
+        },
+        {
+          guard: 'isRestrictedWithoutTicket',
+          target: 'RestrictedAccess',
         },
         {
           actions: { type: 'navigateInternal', params: { force: true, path: '/' } },

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -26,7 +26,7 @@ export const SignUpRouterSteps = {
   verification: 'step:verification',
   callback: 'step:callback',
   error: 'step:error',
-  restrictedAccess: 'step:restricted-access',
+  restricted: 'step:restricted',
 } as const;
 
 export type SignUpRouterSteps = keyof typeof SignUpRouterSteps;

--- a/packages/elements/src/internals/machines/sign-up/router.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.types.ts
@@ -26,6 +26,7 @@ export const SignUpRouterSteps = {
   verification: 'step:verification',
   callback: 'step:callback',
   error: 'step:error',
+  restrictedAccess: 'step:restricted-access',
 } as const;
 
 export type SignUpRouterSteps = keyof typeof SignUpRouterSteps;

--- a/packages/elements/src/react/sign-up/restricted-access.tsx
+++ b/packages/elements/src/react/sign-up/restricted-access.tsx
@@ -1,0 +1,20 @@
+import type { FormProps } from '~/react/common/form';
+import { Form } from '~/react/common/form';
+import { useActiveTags } from '~/react/hooks';
+import { SignUpRouterCtx } from '~/react/sign-up/context';
+
+export type SignUpRestrictedAccessProps = FormProps;
+
+export function SignUpRestrictedAccess(props: SignUpRestrictedAccessProps) {
+  const routerRef = SignUpRouterCtx.useActorRef();
+  const activeState = useActiveTags(routerRef, 'step:restricted-access');
+
+  return activeState ? (
+    <Form
+      // TODO: Update when sign-up flow is consolidated
+      // @ts-expect-error - `flowActor` is not a valid prop for `Form`
+      flowActor={routerRef}
+      {...props}
+    />
+  ) : null;
+}

--- a/packages/elements/src/react/sign-up/restricted.tsx
+++ b/packages/elements/src/react/sign-up/restricted.tsx
@@ -3,11 +3,11 @@ import { Form } from '~/react/common/form';
 import { useActiveTags } from '~/react/hooks';
 import { SignUpRouterCtx } from '~/react/sign-up/context';
 
-export type SignUpRestrictedAccessProps = FormProps;
+export type SignUpRestrictedProps = FormProps;
 
-export function SignUpRestrictedAccess(props: SignUpRestrictedAccessProps) {
+export function SignUpRestricted(props: SignUpRestrictedProps) {
   const routerRef = SignUpRouterCtx.useActorRef();
-  const activeState = useActiveTags(routerRef, 'step:restricted-access');
+  const activeState = useActiveTags(routerRef, 'step:restricted');
 
   return activeState ? (
     <Form

--- a/packages/elements/src/react/sign-up/step.tsx
+++ b/packages/elements/src/react/sign-up/step.tsx
@@ -5,6 +5,8 @@ import { ClerkElementsRuntimeError } from '~/internals/errors';
 
 import type { SignUpContinueProps } from './continue';
 import { SignUpContinue } from './continue';
+import type { SignUpRestrictedAccessProps } from './restricted-access';
+import { SignUpRestrictedAccess } from './restricted-access';
 import type { SignUpStartProps } from './start';
 import { SignUpStart } from './start';
 import type { SignUpVerificationsProps } from './verifications';
@@ -14,6 +16,7 @@ export const SIGN_UP_STEPS = {
   start: 'start',
   continue: 'continue',
   verifications: 'verifications',
+  restrictedAccess: 'restricted-access',
 } as const;
 
 export type TSignUpStep = (typeof SIGN_UP_STEPS)[keyof typeof SIGN_UP_STEPS];
@@ -22,7 +25,8 @@ type StepWithProps<N extends TSignUpStep, T> = { name: N } & T;
 export type SignUpStepProps =
   | StepWithProps<'start', SignUpStartProps>
   | StepWithProps<'continue', SignUpContinueProps>
-  | StepWithProps<'verifications', SignUpVerificationsProps>;
+  | StepWithProps<'verifications', SignUpVerificationsProps>
+  | StepWithProps<'restricted-access', SignUpRestrictedAccessProps>;
 
 /**
  * Render different steps of the sign-up flow. Initially the `'start'` step is rendered. Optionally, you can render additional fields in the `'continue'` step. Once a sign-up attempt has been created, `'verifications'` will be displayed.
@@ -50,7 +54,11 @@ export function SignUpStep(props: SignUpStepProps) {
       return <SignUpContinue {...props} />;
     case SIGN_UP_STEPS.verifications:
       return <SignUpVerifications {...props} />;
+    case SIGN_UP_STEPS.restrictedAccess:
+      return <SignUpRestrictedAccess {...props} />;
     default:
-      throw new ClerkElementsRuntimeError(`Invalid step name. Use 'start', 'continue', or 'verifications'.`);
+      throw new ClerkElementsRuntimeError(
+        `Invalid step name. Use 'start', 'continue', 'verifications', or 'restricted-access'.`,
+      );
   }
 }

--- a/packages/elements/src/react/sign-up/step.tsx
+++ b/packages/elements/src/react/sign-up/step.tsx
@@ -5,8 +5,8 @@ import { ClerkElementsRuntimeError } from '~/internals/errors';
 
 import type { SignUpContinueProps } from './continue';
 import { SignUpContinue } from './continue';
-import type { SignUpRestrictedAccessProps } from './restricted-access';
-import { SignUpRestrictedAccess } from './restricted-access';
+import type { SignUpRestrictedProps } from './restricted';
+import { SignUpRestricted } from './restricted';
 import type { SignUpStartProps } from './start';
 import { SignUpStart } from './start';
 import type { SignUpVerificationsProps } from './verifications';
@@ -16,7 +16,7 @@ export const SIGN_UP_STEPS = {
   start: 'start',
   continue: 'continue',
   verifications: 'verifications',
-  restrictedAccess: 'restricted-access',
+  restricted: 'restricted',
 } as const;
 
 export type TSignUpStep = (typeof SIGN_UP_STEPS)[keyof typeof SIGN_UP_STEPS];
@@ -26,7 +26,7 @@ export type SignUpStepProps =
   | StepWithProps<'start', SignUpStartProps>
   | StepWithProps<'continue', SignUpContinueProps>
   | StepWithProps<'verifications', SignUpVerificationsProps>
-  | StepWithProps<'restricted-access', SignUpRestrictedAccessProps>;
+  | StepWithProps<'restricted', SignUpRestrictedProps>;
 
 /**
  * Render different steps of the sign-up flow. Initially the `'start'` step is rendered. Optionally, you can render additional fields in the `'continue'` step. Once a sign-up attempt has been created, `'verifications'` will be displayed.
@@ -54,11 +54,11 @@ export function SignUpStep(props: SignUpStepProps) {
       return <SignUpContinue {...props} />;
     case SIGN_UP_STEPS.verifications:
       return <SignUpVerifications {...props} />;
-    case SIGN_UP_STEPS.restrictedAccess:
-      return <SignUpRestrictedAccess {...props} />;
+    case SIGN_UP_STEPS.restricted:
+      return <SignUpRestricted {...props} />;
     default:
       throw new ClerkElementsRuntimeError(
-        `Invalid step name. Use 'start', 'continue', 'verifications', or 'restricted-access'.`,
+        `Invalid step name. Use 'start', 'continue', 'verifications', or 'restricted'.`,
       );
   }
 }


### PR DESCRIPTION
## Description

Adds support for "restricted" apps when users attempt to sign-up without a ticket.

```tsx
<SignUp.Step name='restricted'>
  <h1>Restricted Access</h1>
  <p>Access to this app is limited, and an invitation is required to sign up.</p>
</SignUp.Step>
```

Fixes SDKI-675

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
