### PR TITLE
chore(clerk-js): Handle `sign_up_mode_restricted` error encountered in an oauth flow

### DIFF
--- a/.changeset/honest-falcons-tie.md
+++ b/.changeset/honest-falcons-tie.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": minor
+---
+
+Handle `sign_up_mode_restricted` error encountered in an oauth flow

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -25,6 +25,7 @@ export const ERROR_CODES = {
   SAML_USER_ATTRIBUTE_MISSING: 'saml_user_attribute_missing',
   USER_LOCKED: 'user_locked',
   EXTERNAL_ACCOUNT_NOT_FOUND: 'external_account_not_found',
+  SIGN_UP_MODE_RESTRICTED: 'sign_up_mode_restricted',
 } as const;
 
 export const SIGN_IN_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username'];

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -220,6 +220,7 @@ export function _SignInStart(): JSX.Element {
           case ERROR_CODES.OAUTH_EMAIL_DOMAIN_RESERVED_BY_SAML:
           case ERROR_CODES.USER_LOCKED:
           case ERROR_CODES.EXTERNAL_ACCOUNT_NOT_FOUND:
+          case ERROR_CODES.SIGN_UP_MODE_RESTRICTED:
             card.setError(error);
             break;
           default:


### PR DESCRIPTION
## Description

Handle `sign_up_mode_restricted` error encountered in an oauth flow

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

![Screenshot 2024-09-26 at 5 34 09 PM](https://github.com/user-attachments/assets/09af735d-6ac5-48f7-ad74-43b6dfbe4c99)
