### PR TITLE
fix(clerk-js): Pass `defaultOpen` prop within org switcher

### DIFF
--- a/.changeset/cyan-turtles-fly.md
+++ b/.changeset/cyan-turtles-fly.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Correctly pass `defaultOpen` prop to `OrganizationSwitcher` popover instance.

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useId } from 'react';
 
-import { AcceptedInvitationsProvider, withCoreUserGuard } from '../../contexts';
+import { AcceptedInvitationsProvider, useOrganizationSwitcherContext, withCoreUserGuard } from '../../contexts';
 import { Flow } from '../../customizables';
 import { Popover, withCardStateProvider, withFloatingTree } from '../../elements';
 import { usePopover } from '../../hooks';
@@ -8,7 +8,9 @@ import { OrganizationSwitcherPopover } from './OrganizationSwitcherPopover';
 import { OrganizationSwitcherTrigger } from './OrganizationSwitcherTrigger';
 
 const _OrganizationSwitcher = withFloatingTree(() => {
+  const { defaultOpen } = useOrganizationSwitcherContext();
   const { floating, reference, styles, toggle, isOpen, nodeId, context } = usePopover({
+    defaultOpen,
     placement: 'bottom-start',
     offset: 8,
   });


### PR DESCRIPTION
## Description

Fixes issue where `defaultOpen` prop was not being passed correctly to the `OrganizationSwitcher` popover instance.

https://github.com/user-attachments/assets/0bfd3121-28f9-4268-8bd2-3d8dcb503155


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
