### PR TITLE
chore(express): Refactor `requireAuth` and `clerkMiddleware` middlewares

### DIFF
--- a/.changeset/wise-dryers-perform.md
+++ b/.changeset/wise-dryers-perform.md
@@ -1,0 +1,6 @@
+---
+"@clerk/express": minor
+---
+
+Make the `requireAuth` middleware redirect to sign-in URL instead of forwarding errors, and remove custom handler option from `clerkMiddleware`.
+

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -84,7 +84,7 @@ The `requireAuth()` middleware functions similarly to `clerkMiddleware()`, but a
 The sign-in path will be read from the `signInUrl` option or the `CLERK_SIGN_IN_URL` environment variable if available.
 
 ```js
-import { clerkMiddleware, requireAuth } from '@clerk/express';
+import { requireAuth } from '@clerk/express';
 import express from 'express';
 
 const app = express();

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -62,59 +62,44 @@ import 'dotenv/config';
 
 ### `clerkMiddleware()`
 
-The `clerkMiddleware()` helper integrates Clerk authentication into your Express application. It is required to be set in the middleware chain before using other Clerk utilities, such as `requireAuth` and `getAuth()`.
+The `clerkMiddleware()` function checks the request's cookies and headers for a session JWT and, if found, attaches the [`Auth`](https://clerk.com/docs/references/nextjs/auth-object#auth-object) object to the request object under the `auth` key.
 
 ```js
 import { clerkMiddleware } from '@clerk/express';
+import express from 'express';
 
 const app = express();
 
 // Pass no parameters
 app.use(clerkMiddleware());
 
-// Pass a function that will run as middleware
-app.use(clerkMiddleware(handler));
-
 // Pass options
 app.use(clerkMiddleware(options));
-
-// Pass both
-app.use(clerkMiddleware(handler, options));
 ```
 
 ### `requireAuth`
 
-`requireAuth` is a middleware function that you can use to protect routes in your Express.js application. This function checks if the user is authenticated, and passes an `UnauthorizedError` to the next middleware if they are not.
+The `requireAuth()` middleware functions similarly to `clerkMiddleware()`, but also protects your routes by redirecting unauthenticated users to the sign-in page.
 
-`clerkMiddleware()` is required to be set in the middleware chain before this util is used.
+The sign-in path will be read from the `signInUrl` option or the `CLERK_SIGN_IN_URL` environment variable if available.
 
 ```js
-import { clerkMiddleware, requireAuth, UnauthorizedError } from '@clerk/express';
+import { clerkMiddleware, requireAuth } from '@clerk/express';
 import express from 'express';
 
 const app = express();
 
-const port = 3000;
-
 // Apply centralized middleware
-app.use(clerkMiddleware());
+app.use(requireAuth());
 
-// Define a protected route
-app.get('/protected', requireAuth, (req, res) => {
+// Apply middleware to a specific route
+app.get('/protected', requireAuth(), (req, res) => {
   res.send('This is a protected route');
 });
 
-app.use((err, req, res, next) => {
-  if (err instanceof UnauthorizedError) {
-    res.status(401).send('Unauthorized');
-  } else {
-    next(err);
-  }
-});
-
-// Start the server and listen on the specified port
-app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
+// Custom sign-in URL
+app.get('/admin', requireAuth({ signInUrl: '/sign-in' }), (req, res) => {
+  res.send('This is a protected route');
 });
 ```
 
@@ -127,7 +112,6 @@ import { clerkMiddleware, getAuth, ForbiddenError } from '@clerk/express';
 import express from 'express';
 
 const app = express();
-const port = 3000;
 
 // Apply centralized middleware
 app.use(clerkMiddleware());
@@ -146,11 +130,6 @@ hasPermission = (request, response, next) => {
 };
 
 app.get('/path', requireAuth, hasPermission, (req, res) => res.json(req.auth));
-
-// Start the server and listen on the specified port
-app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
-});
 ```
 
 ### `clerkClient`
@@ -164,15 +143,10 @@ import { clerkClient } from '@clerk/express';
 import express from 'express';
 
 const app = express();
-const port = 3000;
 
-const users = await clerkClient.users.getUserList();
-
-app.get('/users', requireAuth, (req, res) => res.json(users));
-
-// Start the server and listen on the specified port
-app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
+app.get('/users', requireAuth, async (req, res) => {
+  const users = await clerkClient.users.getUserList();
+  return res.json({ users });
 });
 ```
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -108,7 +108,7 @@ app.get('/protected', requireAuth({ signInUrl: '/sign-in' }), (req, res) => {
 The `getAuth()` helper retrieves authentication state from the request object. See the [Next.js reference documentation](https://clerk.com/docs/references/nextjs/get-auth) for more information on how to use it.
 
 ```js
-import { clerkMiddleware, getAuth, ForbiddenError } from '@clerk/express';
+import { clerkMiddleware, getAuth } from '@clerk/express';
 import express from 'express';
 
 const app = express();
@@ -122,8 +122,7 @@ hasPermission = (request, response, next) => {
 
   // Handle if the user is not authorized
   if (!auth.has({ permission: 'org:admin:testpermission' })) {
-    // Catch this inside an error-handling middleware
-    return next(new ForbiddenError());
+    return response.status(403).send('Unauthorized');
   }
 
   return next();

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -98,7 +98,7 @@ app.get('/protected', requireAuth(), (req, res) => {
 });
 
 // Custom sign-in URL
-app.get('/admin', requireAuth({ signInUrl: '/sign-in' }), (req, res) => {
+app.get('/protected', requireAuth({ signInUrl: '/sign-in' }), (req, res) => {
   res.send('This is a protected route');
 });
 ```

--- a/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`module exports should not change unless explicitly set 1`] = `
 [
-  "ForbiddenError",
-  "UnauthorizedError",
   "clerkClient",
   "clerkMiddleware",
   "createClerkClient",

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -83,35 +83,6 @@ describe('clerkMiddleware', () => {
     assertSignedOutDebugHeaders(response);
   });
 
-  it('supports usage with request handler: app.use(clerkMiddleware(requestHandler))', async () => {
-    const handler: RequestHandler = (_req, res, next) => {
-      res.setHeader('x-clerk-auth-custom', 'custom-value');
-      return next();
-    };
-
-    const response = await runMiddleware(clerkMiddleware(handler, { enableHandshake: true }), {
-      Cookie: '__clerk_db_jwt=deadbeef;',
-    }).expect(200, 'Hello world!');
-
-    expect(response.header).toHaveProperty('x-clerk-auth-custom', 'custom-value');
-    assertSignedOutDebugHeaders(response);
-  });
-
-  it('supports usage with parameters and request handler: app.use(clerkMiddleware(requestHandler, options))', async () => {
-    const handler: RequestHandler = (_req, res, next) => {
-      res.setHeader('x-clerk-auth-custom', 'custom-value');
-      return next();
-    };
-    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
-
-    const response = await runMiddleware(clerkMiddleware(handler, options), {
-      Cookie: '__clerk_db_jwt=deadbeef;',
-    }).expect(200, 'Hello world!');
-
-    expect(response.header).toHaveProperty('x-clerk-auth-custom', 'custom-value');
-    assertSignedOutDebugHeaders(response);
-  });
-
   it('throws error if clerkMiddleware is not executed before requireAuth', async () => {
     const customMiddleware: RequestHandler = (_request, response, next) => {
       response.setHeader('x-custom-middleware', 'custom');
@@ -165,7 +136,7 @@ describe('clerkMiddleware', () => {
     const res = {} as Response;
     const mockNext = jest.fn();
 
-    clerkMiddleware()[0](req, res, mockNext);
+    clerkMiddleware()(req, res, mockNext);
 
     expect(mockNext.mock.calls[0][0].message).toBe('Invalid URL');
 

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -2,7 +2,6 @@ import type { Request, RequestHandler, Response } from 'express';
 
 import { clerkMiddleware } from '../clerkMiddleware';
 import { getAuth } from '../getAuth';
-import { requireAuth } from '../requireAuth';
 import { assertNoDebugHeaders, assertSignedOutDebugHeaders, runMiddleware } from './helpers';
 
 describe('clerkMiddleware', () => {
@@ -81,18 +80,6 @@ describe('clerkMiddleware', () => {
     );
 
     assertSignedOutDebugHeaders(response);
-  });
-
-  it('throws error if clerkMiddleware is not executed before requireAuth', async () => {
-    const customMiddleware: RequestHandler = (_request, response, next) => {
-      response.setHeader('x-custom-middleware', 'custom');
-      return next();
-    };
-
-    const response = await runMiddleware([requireAuth, customMiddleware]).expect(500);
-
-    assertNoDebugHeaders(response);
-    expect(response.header).not.toHaveProperty('x-clerk-auth-custom', 'custom-value');
   });
 
   it('throws error if clerkMiddleware is not executed before getAuth', async () => {

--- a/packages/express/src/__tests__/helpers.ts
+++ b/packages/express/src/__tests__/helpers.ts
@@ -18,6 +18,7 @@ export function mockResponse(): ExpressResponse {
   return {
     status: jest.fn().mockReturnThis(),
     send: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
   } as unknown as ExpressResponse;
 }
 

--- a/packages/express/src/__tests__/requireAuth.test.ts
+++ b/packages/express/src/__tests__/requireAuth.test.ts
@@ -1,55 +1,68 @@
-import type { NextFunction, Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import type { RequestHandler } from 'express';
 
-import { requireAuth, UnauthorizedError } from '../requireAuth';
-import { mockRequest, mockRequestWithAuth, mockResponse } from './helpers';
+import { requireAuth } from '../requireAuth';
+import type { ClerkMiddlewareOptions } from '../types';
+import { mockRequestWithAuth, runMiddleware } from './helpers';
 
-// This middleware is used to handle the UnauthorizedError thrown by requireAuth
-// See https://expressjs.com/en/guide/error-handling.html for handling errors in Express
-const errorHandler = (err: Error, _req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
-  if (err instanceof UnauthorizedError) {
-    return res.status(401).send('Unauthorized');
-  }
+let mockAuthenticateAndDecorateRequest: jest.Mock;
 
-  return next(err);
-};
+jest.mock('../authenticateRequest', () => ({
+  authenticateAndDecorateRequest: (options: ClerkMiddlewareOptions = {}) => mockAuthenticateAndDecorateRequest(options),
+}));
 
 describe('requireAuth', () => {
-  it('throws error if clerkMiddleware is not executed before this middleware', async () => {
-    expect(() => requireAuth(mockRequest(), mockResponse(), () => undefined)).toThrow(
-      /The "clerkMiddleware" should be registered before using "requireAuth"/,
+  beforeEach(() => {
+    mockAuthenticateAndDecorateRequest = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('should redirect to sign-in page when user is not authenticated', async () => {
+    process.env.CLERK_SIGN_IN_URL = '/sign-in';
+    mockAuthenticateAndDecorateRequest.mockImplementation((): RequestHandler => {
+      return (req, _res, next) => {
+        Object.assign(req, mockRequestWithAuth());
+        next();
+      };
+    });
+
+    const response = await runMiddleware(requireAuth());
+
+    expect(mockAuthenticateAndDecorateRequest).toHaveBeenCalled();
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('/sign-in');
+  });
+
+  it('should call next() when user is authenticated', async () => {
+    mockAuthenticateAndDecorateRequest.mockImplementation((): RequestHandler => {
+      return (req, _res, next) => {
+        Object.assign(req, mockRequestWithAuth({ userId: 'user_123' }));
+        next();
+      };
+    });
+
+    const response = await runMiddleware(requireAuth());
+
+    expect(mockAuthenticateAndDecorateRequest).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(response.text).toBe('Hello world!');
+  });
+
+  it('should redirect to custom sign-in path when specified', async () => {
+    mockAuthenticateAndDecorateRequest.mockImplementation((): RequestHandler => {
+      return (req, _res, next) => {
+        Object.assign(req, mockRequestWithAuth({ userId: null }));
+        next();
+      };
+    });
+
+    const response = await runMiddleware(
+      requireAuth({
+        signInUrl: '/custom-sign-in',
+      }),
     );
-  });
 
-  it('passes UnauthorizedError to next for unauthenticated requests', () => {
-    const request = mockRequestWithAuth();
-    const response = mockResponse();
-    const next = jest.fn();
-
-    requireAuth(request, response, next);
-
-    // Simulate how Express would call the error middleware
-    const error = next.mock.calls[0][0];
-    errorHandler(error, request, response, next);
-
-    expect(response.status).toHaveBeenCalledWith(401);
-    expect(response.send).toHaveBeenCalledWith('Unauthorized');
-  });
-
-  it('allows access for authenticated requests', async () => {
-    const request = mockRequestWithAuth({ userId: 'user_1234' });
-    const response = mockResponse();
-    const next = jest.fn();
-
-    requireAuth(request, response, next);
-
-    // Simulate a protected route
-    const protectedRoute = (_req: ExpressRequest, res: ExpressResponse) => {
-      res.status(200).send('Welcome, user_1234');
-    };
-
-    protectedRoute(request, response);
-
-    expect(response.status).toHaveBeenCalledWith(200);
-    expect(response.send).toHaveBeenCalledWith('Welcome, user_1234');
+    expect(mockAuthenticateAndDecorateRequest).toHaveBeenCalled();
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('/custom-sign-in');
   });
 });

--- a/packages/express/src/authenticateRequest.ts
+++ b/packages/express/src/authenticateRequest.ts
@@ -7,8 +7,12 @@ import type { RequestHandler, Response } from 'express';
 import type { IncomingMessage } from 'http';
 
 import { clerkClient as defaultClerkClient } from './clerkClient';
-import { satelliteAndMissingProxyUrlAndDomain, satelliteAndMissingSignInUrl } from './errors';
-import type { AuthenticateRequestParams, ClerkMiddlewareOptions } from './types';
+import {
+  multipleMiddlewaresDetected,
+  satelliteAndMissingProxyUrlAndDomain,
+  satelliteAndMissingSignInUrl,
+} from './errors';
+import type { AuthenticateRequestParams, ClerkMiddlewareOptions, ExpressRequestWithAuth } from './types';
 import { loadApiEnv, loadClientEnv } from './utils';
 
 const authenticateRequest = (opts: AuthenticateRequestParams) => {
@@ -103,6 +107,10 @@ export const authenticateAndDecorateRequest = (options: ClerkMiddlewareOptions =
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const middleware: RequestHandler = async (request, response, next) => {
+    if ((request as ExpressRequestWithAuth).auth) {
+      throw new Error(multipleMiddlewaresDetected);
+    }
+
     try {
       const requestState = await authenticateRequest({
         clerkClient,

--- a/packages/express/src/authenticateRequest.ts
+++ b/packages/express/src/authenticateRequest.ts
@@ -3,14 +3,15 @@ import { AuthStatus, createClerkRequest } from '@clerk/backend/internal';
 import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
 import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from '@clerk/shared/proxy';
-import type { Response } from 'express';
+import type { RequestHandler, Response } from 'express';
 import type { IncomingMessage } from 'http';
 
+import { clerkClient as defaultClerkClient } from './clerkClient';
 import { satelliteAndMissingProxyUrlAndDomain, satelliteAndMissingSignInUrl } from './errors';
-import type { AuthenticateRequestParams } from './types';
+import type { AuthenticateRequestParams, ClerkMiddlewareOptions } from './types';
 import { loadApiEnv, loadClientEnv } from './utils';
 
-export const authenticateRequest = (opts: AuthenticateRequestParams) => {
+const authenticateRequest = (opts: AuthenticateRequestParams) => {
   const { clerkClient, request, options } = opts;
   const { jwtKey, authorizedParties, audience } = options || {};
 
@@ -62,7 +63,7 @@ const incomingMessageToRequest = (req: IncomingMessage): Request => {
   });
 };
 
-export const setResponseHeaders = (requestState: RequestState, res: Response): Error | undefined => {
+const setResponseHeaders = (requestState: RequestState, res: Response): Error | undefined => {
   if (requestState.headers) {
     requestState.headers.forEach((value, key) => res.appendHeader(key, value));
   }
@@ -94,4 +95,39 @@ const absoluteProxyUrl = (relativeOrAbsoluteUrl: string, baseUrl: string): strin
     return relativeOrAbsoluteUrl;
   }
   return new URL(relativeOrAbsoluteUrl, baseUrl).toString();
+};
+
+export const authenticateAndDecorateRequest = (options: ClerkMiddlewareOptions = {}) => {
+  const clerkClient = options.clerkClient || defaultClerkClient;
+  const enableHandshake = options.enableHandshake || false;
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  const middleware: RequestHandler = async (request, response, next) => {
+    try {
+      const requestState = await authenticateRequest({
+        clerkClient,
+        request,
+        options,
+      });
+
+      if (enableHandshake) {
+        const err = setResponseHeaders(requestState, response);
+        if (err) {
+          return next(err);
+        }
+        if (response.writableEnded) {
+          return;
+        }
+      }
+
+      const auth = requestState.toAuth();
+      Object.assign(request, { auth });
+
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  return middleware;
 };

--- a/packages/express/src/authenticateRequest.ts
+++ b/packages/express/src/authenticateRequest.ts
@@ -7,15 +7,11 @@ import type { RequestHandler, Response } from 'express';
 import type { IncomingMessage } from 'http';
 
 import { clerkClient as defaultClerkClient } from './clerkClient';
-import {
-  multipleMiddlewaresDetected,
-  satelliteAndMissingProxyUrlAndDomain,
-  satelliteAndMissingSignInUrl,
-} from './errors';
+import { satelliteAndMissingProxyUrlAndDomain, satelliteAndMissingSignInUrl } from './errors';
 import type { AuthenticateRequestParams, ClerkMiddlewareOptions, ExpressRequestWithAuth } from './types';
 import { loadApiEnv, loadClientEnv } from './utils';
 
-const authenticateRequest = (opts: AuthenticateRequestParams) => {
+export const authenticateRequest = (opts: AuthenticateRequestParams) => {
   const { clerkClient, request, options } = opts;
   const { jwtKey, authorizedParties, audience } = options || {};
 
@@ -108,7 +104,7 @@ export const authenticateAndDecorateRequest = (options: ClerkMiddlewareOptions =
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const middleware: RequestHandler = async (request, response, next) => {
     if ((request as ExpressRequestWithAuth).auth) {
-      throw new Error(multipleMiddlewaresDetected);
+      return next();
     }
 
     try {

--- a/packages/express/src/clerkMiddleware.ts
+++ b/packages/express/src/clerkMiddleware.ts
@@ -2,26 +2,20 @@ import type { RequestHandler } from 'express';
 
 import { authenticateRequest, setResponseHeaders } from './authenticateRequest';
 import { clerkClient as defaultClerkClient } from './clerkClient';
-import { middlewareNotInvoked } from './errors';
-import type { ClerkMiddleware, ClerkMiddlewareOptions } from './types';
-import { defaultHandler } from './utils';
+import type { ClerkMiddlewareOptions } from './types';
 
-const usedWithoutInvocation = (args: unknown[]) => {
-  return (
-    args.length === 3 && typeof args[0] === 'object' && typeof args[1] === 'object' && typeof args[2] === 'function'
-  );
-};
-
-const parseHandlerAndOptions = (args: unknown[]) => {
-  return [
-    typeof args[0] === 'function' ? args[0] : undefined,
-    (args.length === 2 ? args[1] : typeof args[0] === 'function' ? {} : args[0]) || {},
-  ] as [RequestHandler | undefined, ClerkMiddlewareOptions];
-};
-
-export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
-  const [handler, options] = parseHandlerAndOptions(args);
-
+/**
+ * @example
+ * app.use(clerkMiddleware(options));
+ *
+ * @example
+ * const clerkClient = createClerkClient({ ... });
+ * app.use(clerkMiddleware({ clerkClient }));
+ *
+ * @example
+ * app.use(clerkMiddleware());
+ */
+export const clerkMiddleware = (options: ClerkMiddlewareOptions = {}): RequestHandler => {
   const clerkClient = options.clerkClient || defaultClerkClient;
   const enableHandshake = options.enableHandshake || false;
 
@@ -52,9 +46,5 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
     }
   };
 
-  if (usedWithoutInvocation(args)) {
-    throw new Error(middlewareNotInvoked);
-  }
-
-  return [middleware, handler || defaultHandler];
+  return middleware;
 };

--- a/packages/express/src/clerkMiddleware.ts
+++ b/packages/express/src/clerkMiddleware.ts
@@ -4,6 +4,10 @@ import { authenticateAndDecorateRequest } from './authenticateRequest';
 import type { ClerkMiddlewareOptions } from './types';
 
 /**
+ * Middleware that integrates Clerk authentication into your Express application.
+ * It checks the request's cookies and headers for a session JWT and, if found,
+ * attaches the Auth object to the request object under the `auth` key.
+ *
  * @example
  * app.use(clerkMiddleware(options));
  *

--- a/packages/express/src/errors.ts
+++ b/packages/express/src/errors.ts
@@ -1,6 +1,6 @@
 const createErrorMessage = (msg: string) => {
   return `🔒 Clerk: ${msg.trim()}
-  
+
   For more info, check out the docs: https://clerk.com/docs,
   or come say hi in our discord server: https://clerk.com/discord
   `;
@@ -17,9 +17,11 @@ const app = express();
 app.use(clerkMiddleware());
 `);
 
-export const middlewareNotInvoked = createErrorMessage(
-  `The "clerkMiddleware" should be invoked. Use "clerkMiddleware()"`,
-);
+export const multipleMiddlewaresDetected = createErrorMessage(`
+Multiple Clerk middlewares detected.
+Only one middleware should be registered.
+Use either 'clerkMiddleware()' or 'requireAuth()', but not both.
+`);
 
 export const satelliteAndMissingProxyUrlAndDomain =
   'Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl';

--- a/packages/express/src/errors.ts
+++ b/packages/express/src/errors.ts
@@ -17,12 +17,6 @@ const app = express();
 app.use(clerkMiddleware());
 `);
 
-export const multipleMiddlewaresDetected = createErrorMessage(`
-Multiple Clerk middlewares detected.
-Only one middleware should be registered.
-Use either 'clerkMiddleware()' or 'requireAuth()', but not both.
-`);
-
 export const satelliteAndMissingProxyUrlAndDomain =
   'Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl';
 export const satelliteAndMissingSignInUrl = `

--- a/packages/express/src/getAuth.ts
+++ b/packages/express/src/getAuth.ts
@@ -9,7 +9,7 @@ import { requestHasAuthObject } from './utils';
  *
  * @param {ExpressRequest} req - The current request object.
  * @returns {AuthObject} Object with information about the request state and claims.
- * @throws {Error} `clerkMiddleware` is required to be set in the middleware chain before this util is used.
+ * @throws {Error} `clerkMiddleware` or `requireAuth` is required to be set in the middleware chain before this util is used.
  */
 export const getAuth = (req: ExpressRequest): AuthObject => {
   if (!requestHasAuthObject(req)) {

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -2,7 +2,7 @@ export * from '@clerk/backend';
 
 export { clerkClient } from './clerkClient';
 
-export type { ClerkMiddleware, ExpressRequestWithAuth } from './types';
+export type { ExpressRequestWithAuth } from './types';
 export { clerkMiddleware } from './clerkMiddleware';
 export { getAuth } from './getAuth';
 export { requireAuth, ForbiddenError, UnauthorizedError } from './requireAuth';

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -5,4 +5,4 @@ export { clerkClient } from './clerkClient';
 export type { ExpressRequestWithAuth } from './types';
 export { clerkMiddleware } from './clerkMiddleware';
 export { getAuth } from './getAuth';
-export { requireAuth, ForbiddenError, UnauthorizedError } from './requireAuth';
+export { requireAuth } from './requireAuth';

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express';
 
 import { authenticateAndDecorateRequest } from './authenticateRequest';
-import type { ClerkMiddlewareOptions } from './types';
+import type { ClerkMiddlewareOptions, ExpressRequestWithAuth } from './types';
 
 /**
  * Middleware to require authentication for user requests.
@@ -45,8 +45,7 @@ export const requireAuth = (options: ClerkMiddlewareOptions = {}): RequestHandle
 
       const signInUrl = options.signInUrl || process.env.CLERK_SIGN_IN_URL || '/';
 
-      // @ts-expect-error: TODO, type this
-      if (!request.auth?.userId) {
+      if (!(request as ExpressRequestWithAuth).auth?.userId) {
         return response.redirect(signInUrl);
       }
 

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -4,64 +4,6 @@ import { authenticateAndDecorateRequest } from './authenticateRequest';
 import type { ClerkMiddlewareOptions } from './types';
 
 /**
- * This error is typically thrown by the `requireAuth` middleware when
- * a request is made to a protected route without proper authentication.
- *
- * @class
- * @extends Error
- *
- * @example
- * // This error is usually handled in an Express error handling middleware
- * app.use((err, req, res, next) => {
- *   if (err instanceof UnauthorizedError) {
- *     res.status(401).send('Unauthorized');
- *   } else {
- *     next(err);
- *   }
- * });
- */
-export class UnauthorizedError extends Error {
-  constructor() {
-    super('Unauthorized');
-    this.name = 'UnauthorizedError';
-  }
-}
-
-/**
- * This error is typically used when a user is authenticated but lacks the necessary permissions
- * to access a resource or perform an action.
- *
- * @class
- * @extends Error
- *
- * @example
- * // This error can be used in custom authorization middleware
- * const checkPermission = (req, res, next) => {
- *   const auth = getAuth(req)
- *   if (!auth.has({ permission: 'permission' })) {
- *     return next(new ForbiddenError());
- *   }
- *   next();
- * };
- *
- * @example
- * // This error is usually handled in an Express error handling middleware
- * app.use((err, req, res, next) => {
- *   if (err instanceof ForbiddenError) {
- *     res.status(403).send('Forbidden');
- *   } else {
- *     next(err);
- *   }
- * });
- */
-export class ForbiddenError extends Error {
-  constructor() {
-    super('Forbidden');
-    this.name = 'ForbiddenError';
-  }
-}
-
-/**
  * Middleware to require authentication for user requests.
  * Redirects unauthenticated requests to the sign-in page.
  *

--- a/packages/express/src/requireAuth.ts
+++ b/packages/express/src/requireAuth.ts
@@ -5,34 +5,32 @@ import type { ClerkMiddlewareOptions, ExpressRequestWithAuth } from './types';
 
 /**
  * Middleware to require authentication for user requests.
- * Redirects unauthenticated requests to the sign-in page.
+ * Redirects unauthenticated requests to the sign-in url.
  *
  * @example
  * // Basic usage
  * import { requireAuth } from '@clerk/express'
  *
- * router.get('/path', requireAuth(), getHandler)
- * //or
  * router.use(requireAuth())
+ * //or
+ * router.get('/path', requireAuth(), getHandler)
  *
  * @example
  * // Customizing the sign-in path
- * router.use(requireAuth({ signInPath: '/custom-signin' }))
+ * router.use(requireAuth({ signInUrl: '/sign-in' }))
  *
  * @example
  * // Combining with permission check
- * import { requireAuth, ForbiddenError } from '@clerk/express'
+ * import { getAuth, requireAuth } from '@clerk/express'
  *
  * const hasPermission = (req, res, next) => {
  *    const auth = getAuth(req)
  *    if (!auth.has({ permission: 'permission' })) {
- *      return next(new ForbiddenError())
+ *      return res.status(403).send('Forbidden')
  *    }
  *    return next()
  * }
  * router.get('/path', requireAuth(), hasPermission, getHandler)
- *
- * @throws {Error} If `clerkMiddleware` is not set in the middleware chain before this util is used.
  */
 export const requireAuth = (options: ClerkMiddlewareOptions = {}): RequestHandler => {
   const authMiddleware = authenticateAndDecorateRequest(options);

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -1,6 +1,6 @@
 import type { AuthObject, createClerkClient } from '@clerk/backend';
 import type { AuthenticateRequestOptions } from '@clerk/backend/internal';
-import type { Request as ExpressRequest, RequestHandler } from 'express';
+import type { Request as ExpressRequest } from 'express';
 
 export type ExpressRequestWithAuth = ExpressRequest & { auth: AuthObject };
 
@@ -17,35 +17,6 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
    */
   enableHandshake?: boolean;
 };
-
-/**
- * Middleware for Express that handles authentication and authorization with Clerk.
- * For more details, please refer to the docs: https://clerk.com/docs/references/express/overview?utm_source=github&utm_medium=expres
- */
-export interface ClerkMiddleware {
-  /**
-   * @example
-   * const handler = (request, response, next) => {
-   *   ...;
-   *   // if next is not called the request will be terminated or hung.
-   *   return next();
-   * }
-   * app.use(clerkMiddleware(handler, options));
-   */
-  (handler: RequestHandler, options?: ClerkMiddlewareOptions): RequestHandler[];
-  /**
-   * @example
-   * app.use(clerkMiddleware(options));
-   *
-   * @example
-   * const clerkClient = createClerkClient({ ... });
-   * app.use(clerkMiddleware({ clerkClient }));
-   *
-   * @example
-   * app.use(clerkMiddleware());
-   */
-  (options?: ClerkMiddlewareOptions): RequestHandler[];
-}
 
 type ClerkClient = ReturnType<typeof createClerkClient>;
 export type AuthenticateRequestParams = {

--- a/packages/express/src/utils.ts
+++ b/packages/express/src/utils.ts
@@ -1,5 +1,5 @@
 import { isTruthy } from '@clerk/shared/underscore';
-import type { Request as ExpressRequest, RequestHandler } from 'express';
+import type { Request as ExpressRequest } from 'express';
 
 import type { ExpressRequestWithAuth } from './types';
 
@@ -36,5 +36,3 @@ export const loadApiEnv = () => {
     },
   };
 };
-
-export const defaultHandler: RequestHandler = (_req, _res, next) => next();


### PR DESCRIPTION
## Description

This PR refactors both `clerkMiddleware` and `requireAuth` Express middlewares to simplify DX and reduce confusion when choosing between middlewares:

1. `clerkMiddleware`

Removed option to pass a handler. It does not do anything at all, which can be replaced by a one-liner from userland:

```ts
// Before
app.use(clerkMiddleware((req, res, next) => {
  // req.auth here is undefined so it's not useful at all
}));

// After
app.use(clerkMiddleware());
app.use((req, res, next) => {
  // do stuff
})
```

2. `requireAuth`

Is now using the same logic as `clerkMiddleware` (use `authenticateRequest` and attach `auth` to `request`), except it will redirect to `signInUrl` if unauthenticated instead of calling `next(new Error())`. So you can have `requireAuth` middleware without `clerkMiddleware`:

```ts
// Before - sends error to error middleware
app.use(clerkMiddleware());
app.get('/protected', requireAuth, (req, res) => {
  res.send('This is a protected route');
});

app.use((err, req, res, next) => {
  if (err instanceof UnauthorizedError) {
    res.status(401).send('Unauthorized');
  } else {
    next(err);
  }
});


// After - redirects to signInUrl

// Apply centralized middleware
app.use(requireAuth());

// Apply middleware to a specific route
app.get('/protected', requireAuth({ signInUrl: '/sign-in }), (req, res) => {
  res.send('This is a protected route');
});
```

Other removed exports:

- `UnauthorizedError` (not used anywhere)
- `ForbiddenError` (not used anywhere)

Documentation for this one is still being worked on, we didn't announce the SDK formally, so I think `minor` update is good. The documentation will have migration guide from `@clerk/clerk-sdk-node` to `@clerk/express`. anyway.

Resolves ECO-201

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
