### PR TITLE
chore(backend) Make uploader user ID optional when uploading an organization logo

### DIFF
--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -44,7 +44,7 @@ type UpdateParams = {
 
 type UpdateLogoParams = {
   file: Blob | File;
-  uploaderUserId: string;
+  uploaderUserId?: string;
 };
 
 type UpdateMetadataParams = MetadataParams;
@@ -138,7 +138,9 @@ export class OrganizationAPI extends AbstractAPI {
 
     const formData = new runtime.FormData();
     formData.append('file', params?.file);
-    formData.append('uploader_user_id', params?.uploaderUserId);
+    if (params?.uploaderUserId) {
+      formData.append('uploader_user_id', params?.uploaderUserId);
+    }
 
     return this.request<Organization>({
       method: 'PUT',


### PR DESCRIPTION
## Description

This updates the backend SDK's `updateOrganizationLogo` call to make the uploaderUserId parameter optional. 

This matches the current API spec: updateOrganizationLogo

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
