### PR TITLE
fix(backend): Add a new handshake reason for debug

### DIFF
--- a/.changeset/early-seahorses-warn.md
+++ b/.changeset/early-seahorses-warn.md
@@ -2,4 +2,4 @@
 "@clerk/backend": patch
 ---
 
-Add the 'expired-session-token-missing-sid-claim' handshake reason for debugging purposes
+Add the 'session-token-expired-refresh-expired-session-token-missing-sid-claim' handshake reason for debugging purposes

--- a/.changeset/early-seahorses-warn.md
+++ b/.changeset/early-seahorses-warn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add the 'expired-session-token-missing-sid-claim' handshake reason for debugging purposes

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -24,6 +24,7 @@ export const RefreshTokenErrorReason = {
   MissingSessionToken: 'missing-session-token',
   MissingRefreshToken: 'missing-refresh-token',
   ExpiredSessionTokenDecodeFailed: 'expired-session-token-decode-failed',
+  ExpiredSessionTokenMissingSidClaim: 'expired-session-token-missing-sid-claim',
   FetchError: 'fetch-error',
   UnexpectedSDKError: 'unexpected-sdk-error',
 } as const;
@@ -233,6 +234,16 @@ ${error.getFullMessage()}`,
         error: {
           message: 'Unable to decode the expired session token.',
           cause: { reason: RefreshTokenErrorReason.ExpiredSessionTokenDecodeFailed, errors: decodedErrors },
+        },
+      };
+    }
+
+    if (!decodeResult?.payload?.sid) {
+      return {
+        data: null,
+        error: {
+          message: 'Expired session token is missing the `sid` claim.',
+          cause: { reason: RefreshTokenErrorReason.ExpiredSessionTokenMissingSidClaim },
         },
       };
     }


### PR DESCRIPTION
## Description

Adds the `session-token-expired-refresh-expired-session-token-missing-sid-claim` handshake reason

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
