### PR TITLE
chore(clerk-js): Preserve password input focus on error

### DIFF
--- a/.changeset/brave-plants-lick.md
+++ b/.changeset/brave-plants-lick.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Maintain focus on password input after error during sign in flow.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -45,6 +45,7 @@ const usePasswordControl = (props: SignInFactorOnePasswordProps) => {
 
 export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps) => {
   const { onShowAlternativeMethodsClick, onPasswordPwned } = props;
+  const passwordInputRef = React.useRef<HTMLInputElement>(null);
   const card = useCardState();
   const { setActive } = useClerk();
   const signIn = useCoreSignIn();
@@ -87,6 +88,8 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
         }
 
         handleError(err, [passwordControl], card.setError);
+
+        setTimeout(() => passwordInputRef.current?.focus(), 0);
       });
   };
 
@@ -129,6 +132,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
               <Form.ControlRow elementId={passwordControl.id}>
                 <Form.PasswordInput
                   {...passwordControl.props}
+                  ref={passwordInputRef}
                   autoFocus
                 />
               </Form.ControlRow>


### PR DESCRIPTION
## Description

Maintain focus on password input after error in sign in first factor.

https://github.com/user-attachments/assets/e57f501e-9053-4724-9753-6380b362624f

Fixes SDKI-664

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
