### PR TITLE
chore(clerk-js): Sort organizations list alphabetically in OrganizationSwitcher

### DIFF
--- a/.changeset/cool-laws-remember.md
+++ b/.changeset/cool-laws-remember.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Sort organizations list in OrganizationSwitcher

--- a/.changeset/cool-laws-remember.md
+++ b/.changeset/cool-laws-remember.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Sort organizations list in OrganizationSwitcher
+Sort organizations list alphabetically in `OrganizationSwitcher`

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserMembershipList.tsx
@@ -48,7 +48,8 @@ export const UserMembershipList = (props: UserMembershipListProps) => {
 
   const otherOrgs = ((userMemberships.count || 0) > 0 ? userMemberships.data || [] : [])
     .map(e => e.organization)
-    .filter(o => o.id !== currentOrg?.id);
+    .filter(o => o.id !== currentOrg?.id)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   if (!user) {
     return null;


### PR DESCRIPTION
## Description

`<OrganizationSwitcher/>` displays the organizations in random order by default. It's annoying to find an organization over hundreds of randomly sorted options having no ability to search through them. This simple patch sorts the organization list alphabetically by default to make it feasible for the users to find an org when they have several alternatives.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
