### PR TITLE
chore(clerk-js): Allow single-character usernames in `<UserProfile />` validation

### DIFF
--- a/.changeset/cold-mayflies-happen.md
+++ b/.changeset/cold-mayflies-happen.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Allow single-character usernames in `<UserProfile />` validation

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
@@ -27,7 +27,7 @@ export const UsernameForm = withCardStateProvider((props: UsernameFormProps) => 
   const isUsernameRequired = userSettings.attributes.username.required;
 
   const canSubmit =
-    (isUsernameRequired ? usernameField.value.length > 1 : true) && user.username !== usernameField.value;
+    (isUsernameRequired ? usernameField.value.length > 0 : true) && user.username !== usernameField.value;
 
   const updatePassword = async () => {
     try {


### PR DESCRIPTION
## Description

In this pr we are allowing single-character usernames in `<UserProfile />` validation

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
