### PR TITLE
fix(backend): Handle "Cannot convert argument to a ByteString" errors

### DIFF
--- a/.changeset/yellow-lobsters-smile.md
+++ b/.changeset/yellow-lobsters-smile.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Handle "Cannot convert argument to a ByteString" errors

--- a/packages/backend/src/tokens/__tests__/authStatus.test.ts
+++ b/packages/backend/src/tokens/__tests__/authStatus.test.ts
@@ -30,6 +30,16 @@ export default (QUnit: QUnit) => {
       assert.strictEqual(authObject.headers.get('x-clerk-auth-reason'), 'auth-reason');
       assert.strictEqual(authObject.headers.get('x-clerk-auth-message'), 'auth-message');
     });
+
+    test('handles debug headers containing invalid unicode characters without throwing', assert => {
+      const headers = new Headers({ 'custom-header': 'value' });
+      const authObject = signedOut({} as any, 'auth-reason+RR�56', 'auth-message+RR�56', headers);
+
+      assert.strictEqual(authObject.headers.get('custom-header'), 'value');
+      assert.strictEqual(authObject.headers.get('x-clerk-auth-status'), 'signed-out');
+      assert.strictEqual(authObject.headers.get('x-clerk-auth-reason'), null);
+      assert.strictEqual(authObject.headers.get('x-clerk-auth-message'), null);
+    });
   });
 
   module('handshake', () => {

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -158,13 +158,27 @@ const withDebugHeaders = <T extends RequestState>(requestState: T): T => {
   const headers = new Headers(requestState.headers || {});
 
   if (requestState.message) {
-    headers.set(constants.Headers.AuthMessage, requestState.message);
+    try {
+      headers.set(constants.Headers.AuthMessage, requestState.message);
+    } catch (e) {
+      // headers.set can throw if unicode strings are passed to it. In this case, simply do nothing
+    }
   }
+
   if (requestState.reason) {
-    headers.set(constants.Headers.AuthReason, requestState.reason);
+    try {
+      headers.set(constants.Headers.AuthReason, requestState.reason);
+    } catch (e) {
+      /* empty */
+    }
   }
+
   if (requestState.status) {
-    headers.set(constants.Headers.AuthStatus, requestState.status);
+    try {
+      headers.set(constants.Headers.AuthStatus, requestState.status);
+    } catch (e) {
+      /* empty */
+    }
   }
 
   requestState.headers = headers;


### PR DESCRIPTION
## Description
Headers.set can throw a "Cannot convert argument to a ByteString" when trying to set/append a string containing unicode characters as headers can only accept ASCII chars in the range of [0-255]. Under certain cases, verifyToken can throw an error containing the unicode character that caused the error which then we would try to include in the debug header.

This would cause the *only current request* to fail so we are adding extra error handling to prevent this edge scenario.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
