### PR TITLE
chore(express): Set default `enableHandshake` option value to true

### DIFF
--- a/.changeset/quiet-chicken-cover.md
+++ b/.changeset/quiet-chicken-cover.md
@@ -1,0 +1,5 @@
+---
+"@clerk/express": minor
+---
+
+Enable handshake flow by default

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -18,13 +18,13 @@ describe('clerkMiddleware', () => {
     });
 
     it('throws error if secretKey is not passed as parameter', async () => {
-      const response = await runMiddleware(clerkMiddleware({ enableHandshake: true })).expect(500);
+      const response = await runMiddleware(clerkMiddleware()).expect(500);
 
       assertNoDebugHeaders(response);
     });
 
     it('works if secretKey is passed as parameter', async () => {
-      const options = { secretKey: 'sk_test_....', enableHandshake: true };
+      const options = { secretKey: 'sk_test_....' };
 
       const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
         200,
@@ -54,7 +54,7 @@ describe('clerkMiddleware', () => {
     });
 
     it('works if publishableKey is passed as parameter', async () => {
-      const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
+      const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
 
       const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
         200,
@@ -72,7 +72,7 @@ describe('clerkMiddleware', () => {
   });
 
   it('supports usage with parameters: app.use(clerkMiddleware(options))', async () => {
-    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k', enableHandshake: true };
+    const options = { publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' };
 
     const response = await runMiddleware(clerkMiddleware(options), { Cookie: '__clerk_db_jwt=deadbeef;' }).expect(
       200,
@@ -95,23 +95,23 @@ describe('clerkMiddleware', () => {
     expect(response.header).not.toHaveProperty('x-clerk-auth-custom', 'custom-value');
   });
 
-  it('disables handshake flow by default', async () => {
+  it('handshake flow supported by default', async () => {
     const response = await runMiddleware(clerkMiddleware(), {
-      Cookie: '__client_uat=1711618859;',
-      'Sec-Fetch-Dest': 'document',
-    }).expect(200);
-
-    assertNoDebugHeaders(response);
-  });
-
-  it('supports handshake flow', async () => {
-    const response = await runMiddleware(clerkMiddleware({ enableHandshake: true }), {
       Cookie: '__client_uat=1711618859;',
       'Sec-Fetch-Dest': 'document',
     }).expect(307);
 
     expect(response.header).toHaveProperty('x-clerk-auth-status', 'handshake');
     expect(response.header).toHaveProperty('location', expect.stringContaining('/v1/client/handshake?redirect_url='));
+  });
+
+  it('can disable handshake flow', async () => {
+    const response = await runMiddleware(clerkMiddleware({ enableHandshake: false }), {
+      Cookie: '__client_uat=1711618859;',
+      'Sec-Fetch-Dest': 'document',
+    }).expect(200);
+
+    assertNoDebugHeaders(response);
   });
 
   it('calls next with an error when request URL is invalid', () => {

--- a/packages/express/src/__tests__/requireAuth.test.ts
+++ b/packages/express/src/__tests__/requireAuth.test.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from 'express';
 
 import { clerkMiddleware } from '../clerkMiddleware';
 import { requireAuth } from '../requireAuth';
+import type { ExpressRequestWithAuth } from '../types';
 import { mockRequestWithAuth, runMiddleware } from './helpers';
 
 let mockAuthenticateAndDecorateRequest: jest.Mock;
@@ -76,7 +77,7 @@ describe('requireAuth', () => {
 
     mockAuthenticateAndDecorateRequest.mockImplementation((): RequestHandler => {
       return (req, _res, next) => {
-        if ((req as any).auth) {
+        if ((req as ExpressRequestWithAuth).auth) {
           return next();
         }
         const requestState = mockAuthenticateRequest({ request: req });

--- a/packages/express/src/authenticateRequest.ts
+++ b/packages/express/src/authenticateRequest.ts
@@ -99,7 +99,7 @@ const absoluteProxyUrl = (relativeOrAbsoluteUrl: string, baseUrl: string): strin
 
 export const authenticateAndDecorateRequest = (options: ClerkMiddlewareOptions = {}) => {
   const clerkClient = options.clerkClient || defaultClerkClient;
-  const enableHandshake = options.enableHandshake || false;
+  const enableHandshake = options.enableHandshake ?? true;
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const middleware: RequestHandler = async (request, response, next) => {

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -14,6 +14,8 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
    *
    * This is useful for server-rendered fullstack applications to handle
    * expired JWTs securely and maintain session continuity.
+   *
+   * @default true
    */
   enableHandshake?: boolean;
 };


### PR DESCRIPTION
## Description

This PR enables the handshake flow by default. Typically, a backend SDK will be used alongside a Clerk frontend SDK, and we aim to provide seamless integration without requiring users to manually set `enableHandshake` to `true`. Even in cases where there's no frontend SDK, authorization will be handled via headers, in which handshake is not supported.

We will still keep this option in case user wants to disable adding the debug headers (e.g. `x-clerk-auth-status`) and to still support our [backend-only SDK guide](https://clerk.com/docs/references/sdk/backend-only) in which handshake is not supported.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
