### PR TITLE
fix(clerk-js): Handle gracefully yet unknown to our components Web3 providers

### DIFF
--- a/.changeset/hot-pants-change.md
+++ b/.changeset/hot-pants-change.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Handle gracefully yet unknown to our components Web3 providers

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -23,6 +23,7 @@ type ThirdPartyProviderToDataMap = {
 };
 
 const oauthStrategies = OAUTH_PROVIDERS.map(p => p.strategy);
+const web3Strategies = WEB3_PROVIDERS.map(p => p.strategy);
 
 const providerToDisplayData: ThirdPartyProviderToDataMap = fromEntries(
   [...OAUTH_PROVIDERS, ...WEB3_PROVIDERS].map(p => {
@@ -89,9 +90,12 @@ export const useEnabledThirdPartyProviders = () => {
     return aName.localeCompare(bName);
   });
 
+  // Filter out any Web3 strategies that are not yet known, they are not included in our types.
+  const knownWeb3Strategies = web3FirstFactors.filter(s => web3Strategies.includes(s));
+
   return {
-    strategies: [...knownSocialProviderStrategies, ...web3FirstFactors, ...customSocialProviderStrategies],
-    web3Strategies: [...web3FirstFactors],
+    strategies: [...knownSocialProviderStrategies, ...knownWeb3Strategies, ...customSocialProviderStrategies],
+    web3Strategies: knownWeb3Strategies,
     authenticatableOauthStrategies,
     strategyToDisplayData: strategyToDisplayData,
     providerToDisplayData: providerToDisplayData,


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

If FAPI returns a Web3 provider that is not yet known to our types and components, then we fail to render them. We fix that by filtering them out, as we do for OAuth

## Before

<img width="599" alt="Screenshot 2024-10-01 at 9 58 43 AM" src="https://github.com/user-attachments/assets/bb2b3d63-ba02-41d7-8c3f-c2af1193ee06">

## After

<img width="543" alt="Screenshot 2024-10-01 at 9 59 09 AM" src="https://github.com/user-attachments/assets/bb262a80-2b08-4511-a5a7-b72022f0f411">

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
