### PR TITLE
chore(nextjs,clerk-react,clerk-js): Drop the mounted variant of `UserVerification`

### DIFF
--- a/.changeset/breezy-crabs-crash.md
+++ b/.changeset/breezy-crabs-crash.md
@@ -11,4 +11,3 @@ Removes:
 - `<__experimental_UserVerification/>`
 - `__experimental_mountUserVerification()`
 - `__experimental_unmountUserVerification()`
-- `__experimental_UserVerificationProps`

--- a/.changeset/breezy-crabs-crash.md
+++ b/.changeset/breezy-crabs-crash.md
@@ -1,0 +1,14 @@
+---
+"@clerk/clerk-js": minor
+"@clerk/nextjs": minor
+"@clerk/clerk-react": minor
+"@clerk/types": minor
+---
+
+Drop the experimental mounted variant of `UserVerification`.
+
+Removes:
+- `<__experimental_UserVerification/>`
+- `__experimental_mountUserVerification()`
+- `__experimental_unmountUserVerification()`
+- `__experimental_UserVerificationProps`

--- a/packages/chrome-extension/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/chrome-extension/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -27,7 +27,6 @@ exports[`public exports should not include a breaking change 1`] = `
   "SignedOut",
   "UserButton",
   "UserProfile",
-  "__experimental_UserVerification",
   "useAuth",
   "useClerk",
   "useEmailLink",

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -18,7 +18,6 @@ import { logger } from '@clerk/shared/logger';
 import { eventPrebuiltComponentMounted, TelemetryCollector } from '@clerk/shared/telemetry';
 import type {
   __experimental_UserVerificationModalProps,
-  __experimental_UserVerificationProps,
   ActiveSessionResource,
   AuthenticateWithCoinbaseWalletParams,
   AuthenticateWithGoogleOneTapParams,
@@ -509,38 +508,6 @@ export class Clerk implements ClerkInterface {
   };
 
   public unmountSignIn = (node: HTMLDivElement): void => {
-    this.assertComponentsReady(this.#componentControls);
-    void this.#componentControls.ensureMounted().then(controls =>
-      controls.unmountComponent({
-        node,
-      }),
-    );
-  };
-
-  public __experimental_mountUserVerification = (
-    node: HTMLDivElement,
-    props?: __experimental_UserVerificationProps,
-  ): void => {
-    this.assertComponentsReady(this.#componentControls);
-    if (noUserExists(this)) {
-      if (this.#instanceType === 'development') {
-        throw new ClerkRuntimeError(warnings.cannotOpenUserProfile, {
-          code: 'cannot_render_user_missing',
-        });
-      }
-      return;
-    }
-    void this.#componentControls.ensureMounted({ preloadHint: 'UserVerification' }).then(controls =>
-      controls.mountComponent({
-        name: 'UserVerification',
-        appearanceKey: 'userVerification',
-        node,
-        props,
-      }),
-    );
-  };
-
-  public __experimental_unmountUserVerification = (node: HTMLDivElement): void => {
     this.assertComponentsReady(this.#componentControls);
     void this.#componentControls.ensureMounted().then(controls =>
       controls.unmountComponent({

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -26,7 +26,6 @@ export {
   SignOutButton,
   SignUpButton,
   UserButton,
-  __experimental_UserVerification,
   GoogleOneTap,
 } from '@clerk/clerk-react';
 

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -30,7 +30,6 @@ export {
   SignUpButton,
   UserButton,
   UserProfile,
-  __experimental_UserVerification,
   GoogleOneTap,
 } from './client-boundary/uiComponents';
 

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,7 +3,6 @@ export {
   SignIn,
   UserProfile,
   UserButton,
-  __experimental_UserVerification,
   OrganizationSwitcher,
   OrganizationProfile,
   CreateOrganization,

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -1,7 +1,6 @@
 import { logErrorInDevMode, without } from '@clerk/shared';
 import { isDeeplyEqual } from '@clerk/shared/react';
 import type {
-  __experimental_UserVerificationProps,
   CreateOrganizationProps,
   GoogleOneTapProps,
   OrganizationListProps,
@@ -259,20 +258,6 @@ export const UserButton: UserButtonExportType = Object.assign(_UserButton, {
   Action: MenuAction,
   Link: MenuLink,
 });
-
-export const __experimental_UserVerification = withClerk(
-  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<__experimental_UserVerificationProps>>) => {
-    return (
-      <Portal
-        mount={clerk.__experimental_mountUserVerification}
-        unmount={clerk.__experimental_unmountUserVerification}
-        updateProps={(clerk as any).__unstable__updateProps}
-        props={props}
-      />
-    );
-  },
-  '__experimental_UserVerification',
-);
 
 export function OrganizationProfilePage({ children }: PropsWithChildren<OrganizationProfilePageProps>) {
   logErrorInDevMode(organizationProfilePageRenderedError);

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -108,7 +108,6 @@ type IsomorphicLoadedClerk = Without<
   | 'mountSignUp'
   | 'mountSignIn'
   | 'mountUserProfile'
-  | '__experimental_mountUserVerification'
   | 'client'
 > & {
   // TODO: Align return type and parms
@@ -154,7 +153,6 @@ type IsomorphicLoadedClerk = Without<
   mountSignUp: (node: HTMLDivElement, props: SignUpProps) => void;
   mountSignIn: (node: HTMLDivElement, props: SignInProps) => void;
   mountUserProfile: (node: HTMLDivElement, props: UserProfileProps) => void;
-  __experimental_mountUserVerification: (node: HTMLDivElement, props: __experimental_UserVerificationProps) => void;
   client: ClientResource | undefined;
 };
 
@@ -178,7 +176,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
   private premountCreateOrganizationNodes = new Map<HTMLDivElement, CreateOrganizationProps>();
   private premountOrganizationSwitcherNodes = new Map<HTMLDivElement, OrganizationSwitcherProps>();
   private premountOrganizationListNodes = new Map<HTMLDivElement, OrganizationListProps>();
-  private premountUserVerificationNodes = new Map<HTMLDivElement, __experimental_UserVerificationProps>();
   private premountMethodCalls = new Map<MethodName<BrowserClerk>, MethodCallback>();
   // A separate Map of `addListener` method calls to handle multiple listeners.
   private premountAddListenerCalls = new Map<
@@ -541,10 +538,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       clerkjs.mountUserProfile(node, props);
     });
 
-    this.premountUserVerificationNodes.forEach((props: __experimental_UserVerificationProps, node: HTMLDivElement) => {
-      clerkjs.__experimental_mountUserVerification(node, props);
-    });
-
     this.premountUserButtonNodes.forEach((props: UserButtonProps, node: HTMLDivElement) => {
       clerkjs.mountUserButton(node, props);
     });
@@ -765,22 +758,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       this.clerkjs.unmountSignIn(node);
     } else {
       this.premountSignInNodes.delete(node);
-    }
-  };
-
-  __experimental_mountUserVerification = (node: HTMLDivElement, props: __experimental_UserVerificationProps): void => {
-    if (this.clerkjs && this.#loaded) {
-      this.clerkjs.__experimental_mountUserVerification(node, props);
-    } else {
-      this.premountUserVerificationNodes.set(node, props);
-    }
-  };
-
-  __experimental_unmountUserVerification = (node: HTMLDivElement): void => {
-    if (this.clerkjs && this.#loaded) {
-      this.clerkjs.__experimental_unmountUserVerification(node);
-    } else {
-      this.premountUserVerificationNodes.delete(node);
     }
   };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -243,27 +243,6 @@ export interface Clerk {
   unmountSignIn: (targetNode: HTMLDivElement) => void;
 
   /**
-   * Mounts a user reverification flow component at the target element.
-   *
-   * @experimantal This API is still under active development and may change at any moment.
-   * @param targetNode Target node to mount the UserVerification component from.
-   * @param props user verification configuration parameters.
-   */
-  __experimental_mountUserVerification: (
-    targetNode: HTMLDivElement,
-    props?: __experimental_UserVerificationProps,
-  ) => void;
-
-  /**
-   * Unmount a user reverification flow component from the target element.
-   * If there is no component mounted at the target node, results in a noop.
-   *
-   * @experimantal This API is still under active development and may change at any moment.
-   * @param targetNode Target node to unmount the UserVerification component from.
-   */
-  __experimental_unmountUserVerification: (targetNode: HTMLDivElement) => void;
-
-  /**
    * Mounts a sign up flow component at the target element.
    *
    * @param targetNode Target node to mount the SignUp component.
@@ -869,7 +848,7 @@ export type SignInModalProps = WithoutRouting<SignInProps>;
 /**
  * @experimantal
  */
-export type __experimental_UserVerificationProps = RoutingOptions & {
+type __experimental_UserVerificationProps = RoutingOptions & {
   /**
    * Non-awaitable callback for when verification is completed successfully
    */

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -848,7 +848,7 @@ export type SignInModalProps = WithoutRouting<SignInProps>;
 /**
  * @experimantal
  */
-type __experimental_UserVerificationProps = RoutingOptions & {
+export type __experimental_UserVerificationProps = RoutingOptions & {
   /**
    * Non-awaitable callback for when verification is completed successfully
    */


### PR DESCRIPTION
## Description

Drop the experimental mounted variant of `UserVerification`.

Removes:
- `<__experimental_UserVerification/>`
- `__experimental_mountUserVerification()`
- `__experimental_unmountUserVerification()`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
