### PR TITLE
chore(clerk-js, clerk-react,types): Rename assurance to reverification

### DIFF
--- a/.changeset/purple-goats-applaud.md
+++ b/.changeset/purple-goats-applaud.md
@@ -1,0 +1,13 @@
+---
+"@clerk/clerk-js": minor
+"@clerk/shared": minor
+"@clerk/clerk-react": minor
+"@clerk/types": minor
+---
+
+Rename `__experimental_assurance` to `__experimental_reverification`.
+
+- Supported levels are now are `firstFactor`, `secondFactor`, `multiFactor`.
+- Support maxAge is now replaced by maxAgeMinutes and afterMinutes depending on usage.
+- Introduced `____experimental_SessionVerificationTypes` that abstracts away the level and maxAge
+  - Allowed values 'veryStrict' | 'strict' | 'moderate' | 'lax'

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.browser.js", "maxSize": "65kB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "64.5kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "43kB" },
     { "path": "./dist/ui-common*.js", "maxSize": "86KB" },
     { "path": "./dist/vendors*.js", "maxSize": "70KB" },

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -122,7 +122,7 @@ export class Session extends BaseResource implements SessionResource {
 
   __experimental_startVerification = async ({
     level,
-    maxAge,
+    maxAgeMinutes,
   }: __experimental_SessionVerifyCreateParams): Promise<__experimental_SessionVerificationResource> => {
     const json = (
       await BaseResource._fetch({
@@ -130,7 +130,7 @@ export class Session extends BaseResource implements SessionResource {
         path: `/client/sessions/${this.id}/verify`,
         body: {
           level,
-          maxAge,
+          maxAgeMinutes,
         } as any,
       })
     )?.response as unknown as __experimental_SessionVerificationJSON;

--- a/packages/clerk-js/src/core/resources/__tests__/Session.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Session.test.ts
@@ -311,9 +311,9 @@ describe('Session', () => {
 
       const isAuthorized = session.checkAuthorization({
         permission: 'org:sys_profile:delete',
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -338,9 +338,9 @@ describe('Session', () => {
 
       const isAuthorized = session.checkAuthorization({
         permission: 'org:sys_profile:delete',
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -362,9 +362,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -386,9 +386,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -410,9 +410,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -434,9 +434,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -458,9 +458,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -482,10 +482,7 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
-        },
+        __experimental_reverification: 'strict',
       });
 
       expect(isAuthorized).toBe(false);
@@ -506,10 +503,7 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
-        },
+        __experimental_reverification: 'veryStrict',
       });
 
       expect(isAuthorized).toBe(true);
@@ -530,9 +524,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -554,9 +548,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -578,9 +572,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -602,9 +596,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -626,9 +620,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -650,9 +644,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -674,10 +668,7 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
-        },
+        __experimental_reverification: 'strict',
       });
 
       expect(isAuthorized).toBe(false);
@@ -686,7 +677,7 @@ describe('Session', () => {
     /**
      * Test for invalid input
      */
-    it('incorrect params for __experimental_assurance', async () => {
+    it('incorrect params for __experimental_reverification', async () => {
       const session = new Session({
         status: 'active',
         id: 'session_1',
@@ -701,17 +692,17 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
+        __experimental_reverification: {
           //@ts-expect-error
           level: 'any level',
-          maxAge: 'A1.10min',
+          afterMinutes: 10,
         },
       });
 
       expect(isAuthorized).toBe(false);
     });
 
-    it('incorrect params for __experimental_assurance', async () => {
+    it('incorrect params for __experimental_reverification', async () => {
       const session = new Session({
         status: 'active',
         id: 'session_1',
@@ -726,18 +717,18 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
+        __experimental_reverification: {
           //@ts-expect-error
           level: 'any level',
           //@ts-expect-error
-          maxAge: 'som-value',
+          afterMinutes: 'some-value',
         },
       });
 
       expect(isAuthorized).toBe(false);
     });
 
-    it('incorrect params for __experimental_assurance', async () => {
+    it('incorrect params for __experimental_reverification', async () => {
       const session = new Session({
         status: 'active',
         id: 'session_1',
@@ -752,10 +743,52 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
+        __experimental_reverification: 'invalid-value',
+      });
+
+      expect(isAuthorized).toBe(false);
+    });
+
+    it('incorrect params for __experimental_reverification', async () => {
+      const session = new Session({
+        status: 'active',
+        id: 'session_1',
+        object: 'session',
+        user: createUser(),
+        last_active_organization_id: null,
+        last_active_token: { object: 'token', jwt: mockJwt },
+        actor: null,
+        created_at: new Date().getTime(),
+        updated_at: new Date().getTime(),
+        factor_verification_age: [0, 0],
+      } as SessionJSON);
+
+      const isAuthorized = session.checkAuthorization({
+        __experimental_reverification: 123,
+      });
+
+      expect(isAuthorized).toBe(false);
+    });
+
+    it('incorrect params for __experimental_reverification', async () => {
+      const session = new Session({
+        status: 'active',
+        id: 'session_1',
+        object: 'session',
+        user: createUser(),
+        last_active_organization_id: null,
+        last_active_token: { object: 'token', jwt: mockJwt },
+        actor: null,
+        created_at: new Date().getTime(),
+        updated_at: new Date().getTime(),
+        factor_verification_age: [0, 0],
+      } as SessionJSON);
+
+      const isAuthorized = session.checkAuthorization({
+        __experimental_reverification: {
+          level: 'firstFactor',
           //@ts-expect-error
-          maxAge: 100,
+          afterMinutes: '10',
         },
       });
 
@@ -780,9 +813,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L3.multiFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'multiFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -804,9 +837,9 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: 10,
         },
       });
 
@@ -828,10 +861,7 @@ describe('Session', () => {
       } as SessionJSON);
 
       const isAuthorized = session.checkAuthorization({
-        __experimental_assurance: {
-          level: 'L2.secondFactor',
-          maxAge: 'A1.10min',
-        },
+        __experimental_reverification: 'strict',
       });
 
       expect(isAuthorized).toBe(true);

--- a/packages/clerk-js/src/ui/components/UserVerification/useUserVerificationSession.tsx
+++ b/packages/clerk-js/src/ui/components/UserVerification/useUserVerificationSession.tsx
@@ -10,9 +10,9 @@ const useUserVerificationSession = () => {
   const data = useFetch(
     session ? session.__experimental_startVerification : undefined,
     {
-      level: level || 'L2.secondFactor',
+      level: level || 'secondFactor',
       // TODO(STEP-UP): Figure out if this needs to be a prop
-      maxAge: 'A1.10min',
+      maxAge: 10,
     },
     {
       throttleTime: 300,

--- a/packages/clerk-js/src/ui/components/UserVerification/useUserVerificationSession.tsx
+++ b/packages/clerk-js/src/ui/components/UserVerification/useUserVerificationSession.tsx
@@ -12,7 +12,7 @@ const useUserVerificationSession = () => {
     {
       level: level || 'secondFactor',
       // TODO(STEP-UP): Figure out if this needs to be a prop
-      maxAge: 10,
+      maxAgeMinutes: 10,
     },
     {
       throttleTime: 300,

--- a/packages/react/src/hooks/__tests__/useAuth.test.ts
+++ b/packages/react/src/hooks/__tests__/useAuth.test.ts
@@ -11,6 +11,12 @@ describe('useAuth type tests', () => {
       expectTypeOf({} as const).toMatchTypeOf<ParamsOfHas>();
     });
 
+    it('has({randomKey}) is not allowed', () => {
+      expectTypeOf({
+        randomKey: '',
+      }).not.toMatchTypeOf<ParamsOfHas>();
+    });
+
     it('has({role: string}) is allowed', () => {
       expectTypeOf({ role: 'org:admin' }).toMatchTypeOf<ParamsOfHas>();
     });
@@ -22,64 +28,85 @@ describe('useAuth type tests', () => {
     it('has with role and assurance is allowed', () => {
       expectTypeOf({
         role: 'org:admin',
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: 10,
         },
       } as const).toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('has with permission and assurance is allowed', () => {
+    it('has with permission and reverification is allowed', () => {
       expectTypeOf({
         permission: 'org:edit:posts',
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: 10,
         },
       } as const).toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('has({assurance: {level, maxAge}}) is allowed', () => {
+    it('has({reverification: {level, maxAge}}) is allowed', () => {
       expectTypeOf({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'A1.10min',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: 10,
         },
       } as const).toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('assurance with other strings as maxAge should throw', () => {
+    it('reverification with other values as maxAge should throw', () => {
       expectTypeOf({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 'some-value',
+        __experimental_reverification: {
+          level: 'firstFactor',
+          afterMinutes: '10',
         },
       } as const).not.toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('assurance with number as maxAge should throw', () => {
+    it('veryStrict reverification is allowed', () => {
       expectTypeOf({
-        __experimental_assurance: {
-          level: 'L1.firstFactor',
-          maxAge: 1000,
-        },
+        __experimental_reverification: 'veryStrict',
+      } as const).toMatchTypeOf<ParamsOfHas>();
+    });
+
+    it('strict reverification is allowed', () => {
+      expectTypeOf({
+        __experimental_reverification: 'strict',
+      } as const).toMatchTypeOf<ParamsOfHas>();
+    });
+
+    it('moderate reverification is allowed', () => {
+      expectTypeOf({
+        __experimental_reverification: 'moderate',
+      } as const).toMatchTypeOf<ParamsOfHas>();
+    });
+
+    it('lax reverification is allowed', () => {
+      expectTypeOf({
+        __experimental_reverification: 'lax',
+      } as const).toMatchTypeOf<ParamsOfHas>();
+    });
+
+    it('random reverification is not allowed', () => {
+      expectTypeOf({
+        __experimental_reverification: 'random',
       } as const).not.toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('assurance with other strings as level should throw', () => {
+    it('reverification with other strings as level should throw', () => {
       expectTypeOf({
-        __experimental_assurance: {
+        __experimental_reverification: {
           level: 'some-factor',
-          maxAge: 'A1.10min',
+          afterMinutes: 10,
         },
       } as const).not.toMatchTypeOf<ParamsOfHas>();
     });
 
-    it('assurance with number as level should throw', () => {
+    it('reverification with number as level should throw', () => {
       expectTypeOf({
-        __experimental_assurance: {
+        __experimental_reverification: {
           level: 2,
-          maxAge: 'A1.10min',
+          afterMinutes: 10,
         },
       } as const).not.toMatchTypeOf<ParamsOfHas>();
     });

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -1,7 +1,6 @@
 import type {
   __experimental_ReverificationConfig,
   __experimental_SessionVerificationLevel,
-  __experimental_SessionVerificationMaxAge,
   __experimental_SessionVerificationTypes,
   CheckAuthorizationWithCustomPermissions,
   OrganizationCustomPermissionKey,
@@ -56,9 +55,9 @@ const ALLOWED_LEVELS = new Set<__experimental_SessionVerificationLevel>(['firstF
 const ALLOWED_TYPES = new Set<__experimental_SessionVerificationTypes>(['veryStrict', 'strict', 'moderate', 'lax']);
 
 // Helper functions
-const isValidMaxAge = (maxAge: __experimental_SessionVerificationMaxAge) => typeof maxAge === 'number' && maxAge > 0;
-const isValidLevel = (level: __experimental_SessionVerificationLevel) => ALLOWED_LEVELS.has(level);
-const isValidVerificationType = (type: __experimental_SessionVerificationTypes) => ALLOWED_TYPES.has(type);
+const isValidMaxAge = (maxAge: any) => typeof maxAge === 'number' && maxAge > 0;
+const isValidLevel = (level: any) => ALLOWED_LEVELS.has(level);
+const isValidVerificationType = (type: any) => ALLOWED_TYPES.has(type);
 
 /**
  * Checks if a user has the required organization-level authorization.

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -1,12 +1,17 @@
 import type {
+  __experimental_ReverificationConfig,
   __experimental_SessionVerificationLevel,
   __experimental_SessionVerificationMaxAge,
+  __experimental_SessionVerificationTypes,
   CheckAuthorizationWithCustomPermissions,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
 } from '@clerk/types';
 
-type MaxAgeMap = Record<__experimental_SessionVerificationMaxAge, number>;
+type TypesToConfig = Record<
+  __experimental_SessionVerificationTypes,
+  Exclude<__experimental_ReverificationConfig, __experimental_SessionVerificationTypes>
+>;
 type AuthorizationOptions = {
   userId: string | null | undefined;
   orgId: string | null | undefined;
@@ -22,34 +27,38 @@ type CheckOrgAuthorization = (
 
 type CheckStepUpAuthorization = (
   params: {
-    __experimental_assurance?: {
-      level: __experimental_SessionVerificationLevel;
-      maxAge: __experimental_SessionVerificationMaxAge;
-    };
+    __experimental_reverification?: __experimental_ReverificationConfig;
   },
   { __experimental_factorVerificationAge }: AuthorizationOptions,
 ) => boolean | null;
 
-const MAX_AGE_TO_MINUTES: MaxAgeMap = {
-  'A1.10min': 10,
-  'A2.1hr': 60,
-  'A3.4hr': 240, //4 * 60
-  'A4.1day': 1440, //24 * 60,
-  'A5.1wk': 10080, //7 * 24 * 60,
+const TYPES_TO_OBJECTS: TypesToConfig = {
+  veryStrict: {
+    afterMinutes: 10,
+    level: 'multiFactor',
+  },
+  strict: {
+    afterMinutes: 10,
+    level: 'secondFactor',
+  },
+  moderate: {
+    afterMinutes: 60,
+    level: 'secondFactor',
+  },
+  lax: {
+    afterMinutes: 1_440,
+    level: 'secondFactor',
+  },
 };
 
-const ALLOWED_MAX_AGES = new Set<__experimental_SessionVerificationMaxAge>(
-  Object.keys(MAX_AGE_TO_MINUTES) as __experimental_SessionVerificationMaxAge[],
-);
-const ALLOWED_LEVELS = new Set<__experimental_SessionVerificationLevel>([
-  'L1.firstFactor',
-  'L2.secondFactor',
-  'L3.multiFactor',
-]);
+const ALLOWED_LEVELS = new Set<__experimental_SessionVerificationLevel>(['firstFactor', 'secondFactor', 'multiFactor']);
+
+const ALLOWED_TYPES = new Set<__experimental_SessionVerificationTypes>(['veryStrict', 'strict', 'moderate', 'lax']);
 
 // Helper functions
-const isValidMaxAge = (maxAge: __experimental_SessionVerificationMaxAge) => ALLOWED_MAX_AGES.has(maxAge);
+const isValidMaxAge = (maxAge: __experimental_SessionVerificationMaxAge) => typeof maxAge === 'number' && maxAge > 0;
 const isValidLevel = (level: __experimental_SessionVerificationLevel) => ALLOWED_LEVELS.has(level);
+const isValidVerificationType = (type: __experimental_SessionVerificationTypes) => ALLOWED_TYPES.has(type);
 
 /**
  * Checks if a user has the required organization-level authorization.
@@ -74,6 +83,25 @@ const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
   return null;
 };
 
+const validateReverificationConfig = (config: __experimental_ReverificationConfig | undefined) => {
+  const convertConfigToObject = (config: __experimental_ReverificationConfig) => {
+    if (typeof config === 'string') {
+      return TYPES_TO_OBJECTS[config];
+    }
+    return config;
+  };
+
+  if (typeof config === 'string' && isValidVerificationType(config)) {
+    return convertConfigToObject.bind(null, config);
+  }
+
+  if (typeof config === 'object' && isValidLevel(config.level) && isValidMaxAge(config.afterMinutes)) {
+    return convertConfigToObject.bind(null, config);
+  }
+
+  return false;
+};
+
 /**
  * Evaluates if the user meets step-up authentication requirements.
  * Compares the user's factor verification ages against the specified maxAge.
@@ -81,29 +109,29 @@ const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
  * @returns null, if requirements or verification data are missing.
  */
 const checkStepUpAuthorization: CheckStepUpAuthorization = (params, { __experimental_factorVerificationAge }) => {
-  if (!params.__experimental_assurance || !__experimental_factorVerificationAge) {
-    return null;
-  }
-  const { level, maxAge } = params.__experimental_assurance;
-
-  if (!isValidLevel(level) || !isValidMaxAge(maxAge)) {
+  if (!params.__experimental_reverification || !__experimental_factorVerificationAge) {
     return null;
   }
 
+  const isValidReverification = validateReverificationConfig(params.__experimental_reverification);
+  if (!isValidReverification) {
+    return null;
+  }
+
+  const { level, afterMinutes } = isValidReverification();
   const [factor1Age, factor2Age] = __experimental_factorVerificationAge;
-  const maxAgeInMinutes = MAX_AGE_TO_MINUTES[maxAge];
 
   // -1 indicates the factor group (1fa,2fa) is not enabled
   // -1 for 1fa is not a valid scenario, but we need to make sure we handle it properly
-  const isValidFactor1 = factor1Age !== -1 ? maxAgeInMinutes > factor1Age : null;
-  const isValidFactor2 = factor2Age !== -1 ? maxAgeInMinutes > factor2Age : null;
+  const isValidFactor1 = factor1Age !== -1 ? afterMinutes > factor1Age : null;
+  const isValidFactor2 = factor2Age !== -1 ? afterMinutes > factor2Age : null;
 
   switch (level) {
-    case 'L1.firstFactor':
+    case 'firstFactor':
       return isValidFactor1;
-    case 'L2.secondFactor':
+    case 'secondFactor':
       return factor2Age !== -1 ? isValidFactor2 : isValidFactor1;
-    case 'L3.multiFactor':
+    case 'multiFactor':
       return factor2Age === -1 ? isValidFactor1 : isValidFactor1 && isValidFactor2;
   }
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -861,8 +861,8 @@ export type __experimental_UserVerificationProps = RoutingOptions & {
 
   /**
    * Defines the steps of the verification flow.
-   * When `L3.multiFactor` is used, the user will be prompt for a first factor flow followed by a second factor flow.
-   * @default `'L2.secondFactor'`
+   * When `multiFactor` is used, the user will be prompt for a first factor flow followed by a second factor flow.
+   * @default `'secondFactor'`
    */
   level?: __experimental_SessionVerificationLevel;
 

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -16,6 +16,7 @@ import type {
 } from './organizationMembership';
 import type { ClerkResource } from './resource';
 import type {
+  __experimental_ReverificationConfig,
   __experimental_SessionVerificationLevel,
   __experimental_SessionVerificationMaxAge,
   __experimental_SessionVerificationResource,
@@ -39,10 +40,7 @@ export type CheckAuthorizationParamsWithCustomPermissions = (
     }
   | { role?: never; permission?: never }
 ) & {
-  __experimental_assurance?: {
-    level: __experimental_SessionVerificationLevel;
-    maxAge: __experimental_SessionVerificationMaxAge;
-  };
+  __experimental_reverification?: __experimental_ReverificationConfig;
 };
 
 export type CheckAuthorization = CheckAuthorizationFn<CheckAuthorizationParams>;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -18,7 +18,7 @@ import type { ClerkResource } from './resource';
 import type {
   __experimental_ReverificationConfig,
   __experimental_SessionVerificationLevel,
-  __experimental_SessionVerificationMaxAge,
+  __experimental_SessionVerificationMaxAgeMinutes,
   __experimental_SessionVerificationResource,
 } from './sessionVerification';
 import type { TokenResource } from './token';
@@ -59,10 +59,7 @@ type CheckAuthorizationParams = (
       permission?: never;
     }
 ) & {
-  __experimental_assurance?: {
-    level: __experimental_SessionVerificationLevel;
-    maxAge: __experimental_SessionVerificationMaxAge;
-  };
+  __experimental_reverification?: __experimental_ReverificationConfig;
 };
 
 export interface SessionResource extends ClerkResource {
@@ -158,7 +155,7 @@ export type GetToken = (options?: GetTokenOptions) => Promise<string | null>;
 
 export type __experimental_SessionVerifyCreateParams = {
   level: __experimental_SessionVerificationLevel;
-  maxAge: __experimental_SessionVerificationMaxAge;
+  maxAgeMinutes: __experimental_SessionVerificationMaxAgeMinutes;
 };
 
 export type __experimental_SessionVerifyPrepareFirstFactorParams = EmailCodeConfig | PhoneCodeConfig;

--- a/packages/types/src/sessionVerification.ts
+++ b/packages/types/src/sessionVerification.ts
@@ -14,8 +14,25 @@ export interface __experimental_SessionVerificationResource extends ClerkResourc
 }
 
 export type __experimental_SessionVerificationStatus = 'needs_first_factor' | 'needs_second_factor' | 'complete';
-export type __experimental_SessionVerificationLevel = 'L1.firstFactor' | 'L2.secondFactor' | 'L3.multiFactor';
-export type __experimental_SessionVerificationMaxAge = 'A1.10min' | 'A2.1hr' | 'A3.4hr' | 'A4.1day' | 'A5.1wk';
+
+export type __experimental_SessionVerificationTypes = 'veryStrict' | 'strict' | 'moderate' | 'lax';
+
+export type __experimental_SessionVerificationConfig =
+  | __experimental_SessionVerificationTypes
+  | {
+      level: __experimental_SessionVerificationLevel;
+      maxAgeMinutes: __experimental_SessionVerificationMaxAge;
+    };
+
+export type __experimental_ReverificationConfig =
+  | __experimental_SessionVerificationTypes
+  | {
+      level: __experimental_SessionVerificationLevel;
+      afterMinutes: __experimental_SessionVerificationMaxAge;
+    };
+
+export type __experimental_SessionVerificationLevel = 'firstFactor' | 'secondFactor' | 'multiFactor';
+export type __experimental_SessionVerificationMaxAge = number;
 
 export type __experimental_SessionVerificationFirstFactor = EmailCodeFactor | PhoneCodeFactor | PasswordFactor;
 export type __experimental_SessionVerificationSecondFactor = PhoneCodeFactor | TOTPFactor | BackupCodeFactor;

--- a/packages/types/src/sessionVerification.ts
+++ b/packages/types/src/sessionVerification.ts
@@ -21,18 +21,18 @@ export type __experimental_SessionVerificationConfig =
   | __experimental_SessionVerificationTypes
   | {
       level: __experimental_SessionVerificationLevel;
-      maxAgeMinutes: __experimental_SessionVerificationMaxAge;
+      maxAgeMinutes: __experimental_SessionVerificationMaxAgeMinutes;
     };
 
 export type __experimental_ReverificationConfig =
   | __experimental_SessionVerificationTypes
   | {
       level: __experimental_SessionVerificationLevel;
-      afterMinutes: __experimental_SessionVerificationMaxAge;
+      afterMinutes: __experimental_SessionVerificationMaxAgeMinutes;
     };
 
 export type __experimental_SessionVerificationLevel = 'firstFactor' | 'secondFactor' | 'multiFactor';
-export type __experimental_SessionVerificationMaxAge = number;
+export type __experimental_SessionVerificationMaxAgeMinutes = number;
 
 export type __experimental_SessionVerificationFirstFactor = EmailCodeFactor | PhoneCodeFactor | PasswordFactor;
 export type __experimental_SessionVerificationSecondFactor = PhoneCodeFactor | TOTPFactor | BackupCodeFactor;


### PR DESCRIPTION
## Description

Rename `__experimental_assurance` to `__experimental_reverification`.

- Supported levels are now are `firstFactor`, `secondFactor`, `multiFactor`.
- Support maxAge is now replaced by maxAgeMinutes and afterMinutes depending on usage.
- Introduced `____experimental_SessionVerificationTypes` that abstracts away the level and maxAge
  - Allowed values 'veryStrict' | 'strict' | 'moderate' | 'lax'

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
