### PR TITLE
feat(ui): Add `<RouterLink />` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44923,6 +44923,7 @@
         "@clerk/localizations": "3.1.2",
         "@clerk/shared": "2.9.0",
         "@clerk/types": "4.25.0",
+        "@clerk/ui": "0.1.9",
         "@coinbase/wallet-sdk": "4.0.4",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
@@ -49166,7 +49167,6 @@
       "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-react": "file:../react",
         "@clerk/elements": "file:../elements",
         "@clerk/shared": "file:../shared",
         "@clerk/types": "file:../types",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,13 +29,13 @@
     "./*": {
       "import": {
         "types": "./dist/components/*.d.mts",
-        "default": "./dist/components/*.mjs",
-        "browser": "./dist/components/*.mjs"
+        "browser": "./dist/components/*.mjs",
+        "default": "./dist/components/*.mjs"
       },
       "require": {
         "types": "./dist/components/*.d.ts",
-        "default": "./dist/components/*.js",
-        "browser": "./dist/components/*.js"
+        "browser": "./dist/components/*.js",
+        "default": "./dist/components/*.js"
       }
     },
     "./styles.css": "./dist/styles.css"

--- a/packages/ui/src/common/password-field.tsx
+++ b/packages/ui/src/common/password-field.tsx
@@ -9,21 +9,28 @@ import EyeSlashSm from '~/primitives/icons/eye-slash-sm';
 import EyeSm from '~/primitives/icons/eye-sm';
 import { translatePasswordError } from '~/utils/make-localizable';
 
-export function PasswordField({
-  alternativeFieldTrigger,
-  className,
-  label,
-  name = 'password',
-  ...props
-}: {
-  alternativeFieldTrigger?: React.ReactNode;
-  validatePassword?: boolean;
-  name?: 'password' | 'confirmPassword';
-  /**
-   * **Note:** this prop is required as the `label` differs depending on the context (e.g. new password)
-   */
-  label: React.ReactNode;
-} & Omit<React.ComponentProps<typeof Common.Input>, 'autoCapitalize' | 'autoComplete' | 'spellCheck' | 'type'>) {
+export const PasswordField = React.forwardRef(function PasswordField(
+  {
+    alternativeFieldTrigger,
+    className,
+    fieldClassName,
+    fieldRef,
+    label,
+    name = 'password',
+    ...props
+  }: {
+    alternativeFieldTrigger?: React.ReactNode;
+    validatePassword?: boolean;
+    name?: 'password' | 'confirmPassword';
+    /**
+     * **Note:** this prop is required as the `label` differs depending on the context (e.g. new password)
+     */
+    label: React.ReactNode;
+    fieldRef?: React.Ref<HTMLDivElement>;
+    fieldClassName?: string;
+  } & Omit<React.ComponentProps<typeof Common.Input>, 'autoCapitalize' | 'autoComplete' | 'spellCheck' | 'type'>,
+  forwardedRef: React.ForwardedRef<HTMLInputElement>,
+) {
   const [type, setType] = React.useState('password');
   const id = React.useId();
   const { t, locale } = useLocalizations();
@@ -33,7 +40,10 @@ export function PasswordField({
       name={name}
       asChild
     >
-      <Field.Root>
+      <Field.Root
+        className={fieldClassName}
+        ref={fieldRef}
+      >
         <Common.Label asChild>
           <Field.Label>
             {label}
@@ -48,6 +58,7 @@ export function PasswordField({
                   type={type}
                   className={cx('pe-7', className)}
                   {...props}
+                  ref={forwardedRef}
                   aria-describedby={props.validatePassword && state !== 'idle' ? id : undefined}
                   asChild
                 >
@@ -121,4 +132,4 @@ export function PasswordField({
       </Field.Root>
     </Common.Field>
   );
-}
+});

--- a/packages/ui/src/common/router-link.tsx
+++ b/packages/ui/src/common/router-link.tsx
@@ -1,0 +1,28 @@
+import { useClerkHostRouter } from '@clerk/shared/router';
+import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
+
+export const RouterLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    asChild?: boolean;
+  }
+>(function RouterLink({ asChild, children, href, ...props }, forwardedRef) {
+  const router = useClerkHostRouter();
+  const Comp = asChild ? Slot : 'a';
+  return (
+    <Comp
+      ref={forwardedRef}
+      {...props}
+      href={href}
+      onClick={e => {
+        e.preventDefault();
+        if (href) {
+          router.push(href);
+        }
+      }}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/ui/src/components/sign-in/steps/start.tsx
+++ b/packages/ui/src/components/sign-in/steps/start.tsx
@@ -13,6 +13,7 @@ import { GlobalError } from '~/common/global-error';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
 import { PhoneNumberOrUsernameField } from '~/common/phone-number-or-username-field';
+import { RouterLink } from '~/common/router-link';
 import { UsernameField } from '~/common/username-field';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
 import { SIGN_UP_MODES } from '~/constants/user-settings';
@@ -200,10 +201,12 @@ export function SignInStart() {
                   <Card.FooterAction>
                     <Card.FooterActionText>
                       {t('signIn.start.actionText')}{' '}
-                      <Card.FooterActionLink href={clerk.buildUrlWithAuth(signUpUrl || '')}>
-                        {' '}
-                        {t('signIn.start.actionLink')}
-                      </Card.FooterActionLink>
+                      <RouterLink
+                        asChild
+                        href={clerk.buildUrlWithAuth(signUpUrl || '/sign-up')}
+                      >
+                        <Card.FooterActionLink>{t('signIn.start.actionLink')}</Card.FooterActionLink>
+                      </RouterLink>
                     </Card.FooterActionText>
                   </Card.FooterAction>
                 ) : null}

--- a/packages/ui/src/components/sign-up/steps/continue.tsx
+++ b/packages/ui/src/components/sign-up/steps/continue.tsx
@@ -1,5 +1,6 @@
 import * as Common from '@clerk/elements/common';
 import * as SignUp from '@clerk/elements/sign-up';
+import { useClerk } from '@clerk/shared/react';
 
 import { EmailField } from '~/common/email-field';
 import { FirstNameField } from '~/common/first-name-field';
@@ -7,17 +8,21 @@ import { GlobalError } from '~/common/global-error';
 import { LastNameField } from '~/common/last-name-field';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
+import { RouterLink } from '~/common/router-link';
 import { UsernameField } from '~/common/username-field';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
 import { useAttributes } from '~/hooks/use-attributes';
 import { useCard } from '~/hooks/use-card';
 import { useDevModeWarning } from '~/hooks/use-dev-mode-warning';
 import { useLocalizations } from '~/hooks/use-localizations';
+import { useOptions } from '~/hooks/use-options';
 import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
 import CaretRightLegacySm from '~/primitives/icons/caret-right-legacy-sm';
 
 export function SignUpContinue() {
+  const clerk = useClerk();
+  const { signInUrl } = useOptions();
   const { t } = useLocalizations();
   const { enabled: firstNameEnabled, required: firstNameRequired } = useAttributes('first_name');
   const { enabled: lastNameEnabled, required: lastNameRequired } = useAttributes('last_name');
@@ -114,7 +119,12 @@ export function SignUpContinue() {
                 <Card.FooterAction>
                   <Card.FooterActionText>
                     {t('signUp.continue.actionText')}{' '}
-                    <Card.FooterActionLink href='/sign-in'>{t('signUp.continue.actionLink')}</Card.FooterActionLink>
+                    <RouterLink
+                      asChild
+                      href={clerk.buildUrlWithAuth(signInUrl || '/sign-in')}
+                    >
+                      <Card.FooterActionLink>{t('signUp.continue.actionLink')}</Card.FooterActionLink>
+                    </RouterLink>
                   </Card.FooterActionText>
                 </Card.FooterAction>
               </Card.Footer>

--- a/packages/ui/src/components/sign-up/steps/start.tsx
+++ b/packages/ui/src/components/sign-up/steps/start.tsx
@@ -10,6 +10,7 @@ import { GlobalError } from '~/common/global-error';
 import { LastNameField } from '~/common/last-name-field';
 import { PasswordField } from '~/common/password-field';
 import { PhoneNumberField } from '~/common/phone-number-field';
+import { RouterLink } from '~/common/router-link';
 import { UsernameField } from '~/common/username-field';
 import { LOCALIZATION_NEEDED } from '~/constants/localizations';
 import { useAppearance } from '~/contexts';
@@ -20,6 +21,7 @@ import { useDisplayConfig } from '~/hooks/use-display-config';
 import { useEnabledConnections } from '~/hooks/use-enabled-connections';
 import { useEnvironment } from '~/hooks/use-environment';
 import { useLocalizations } from '~/hooks/use-localizations';
+import { useOptions } from '~/hooks/use-options';
 import { Button } from '~/primitives/button';
 import * as Card from '~/primitives/card';
 import CaretRightLegacySm from '~/primitives/icons/caret-right-legacy-sm';
@@ -27,6 +29,7 @@ import { Separator } from '~/primitives/separator';
 
 export function SignUpStart() {
   const clerk = useClerk();
+  const { signInUrl } = useOptions();
   const enabledConnections = useEnabledConnections();
   const { userSettings } = useEnvironment();
   const { t } = useLocalizations();
@@ -170,7 +173,12 @@ export function SignUpStart() {
                 <Card.FooterAction>
                   <Card.FooterActionText>
                     {t('signUp.start.actionText')}{' '}
-                    <Card.FooterActionLink href='/sign-in'>{t('signUp.start.actionLink')}</Card.FooterActionLink>
+                    <RouterLink
+                      asChild
+                      href={clerk.buildUrlWithAuth(signInUrl || '/sign-in')}
+                    >
+                      <Card.FooterActionLink>{t('signUp.start.actionLink')}</Card.FooterActionLink>
+                    </RouterLink>
                   </Card.FooterActionText>
                 </Card.FooterAction>
               </Card.Footer>

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -1,4 +1,3 @@
-import { useClerkHostRouter } from '@clerk/shared/router';
 import { cva, cx } from 'cva';
 import * as React from 'react';
 
@@ -357,21 +356,11 @@ export const FooterActionButton = React.forwardRef<HTMLButtonElement, React.Butt
 
 export const FooterActionLink = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
   function CardFooterActionLink({ children, className, ...props }, forwardedRef) {
-    const router = useClerkHostRouter();
-
-    const { href, ...rest } = props;
     return (
       <a
         ref={forwardedRef}
         data-card-footer-action-link=''
-        {...rest}
-        href={href}
-        onClick={e => {
-          e.preventDefault();
-          if (href) {
-            router.push(href);
-          }
-        }}
+        {...props}
         className={footerActionButton({ className })}
       >
         {children}

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -1,3 +1,4 @@
+import { useClerkHostRouter } from '@clerk/shared/router';
 import { cva, cx } from 'cva';
 import * as React from 'react';
 
@@ -356,11 +357,21 @@ export const FooterActionButton = React.forwardRef<HTMLButtonElement, React.Butt
 
 export const FooterActionLink = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
   function CardFooterActionLink({ children, className, ...props }, forwardedRef) {
+    const router = useClerkHostRouter();
+
+    const { href, ...rest } = props;
     return (
       <a
         ref={forwardedRef}
         data-card-footer-action-link=''
-        {...props}
+        {...rest}
+        href={href}
+        onClick={e => {
+          e.preventDefault();
+          if (href) {
+            router.push(href);
+          }
+        }}
         className={footerActionButton({ className })}
       >
         {children}


### PR DESCRIPTION
## Description

Implements `<RouterLink />` component to allow navigations without full page reloads when navigating between `SignIn`/`SignUp` flows.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
