### PR TITLE
fix(clerk-js): Initialize default role with form controls

### DIFF
--- a/.changeset/heavy-bulldogs-wash.md
+++ b/.changeset/heavy-bulldogs-wash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Enable "Send invitation" button when default role is loaded

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -2,7 +2,7 @@ import { isClerkAPIResponseError } from '@clerk/shared/error';
 import { useOrganization } from '@clerk/shared/react';
 import type { ClerkAPIError } from '@clerk/types';
 import type { FormEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useEnvironment } from '../../contexts';
 import { Flex } from '../../customizables';
@@ -42,9 +42,18 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
     label: localizationKeys('formFieldLabel__emailAddresses'),
   });
 
+  const defaultRole = useDefaultRole();
   const roleField = useFormControl('role', '', {
     label: localizationKeys('formFieldLabel__role'),
   });
+
+  useEffect(() => {
+    if (roleField.value || !defaultRole) {
+      return;
+    }
+
+    roleField.setValue(defaultRole);
+  }, [defaultRole, roleField]);
 
   if (!organization) {
     return null;
@@ -188,8 +197,6 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
 
   const { t } = useLocalizations();
 
-  const defaultRole = useDefaultRole();
-
   return (
     <Form.ControlRow elementId={field.id}>
       <Flex
@@ -198,7 +205,6 @@ const AsyncRoleSelect = (field: ReturnType<typeof useFormControl<'role'>>) => {
       >
         <RoleSelect
           {...field.props}
-          value={field.props.value || (defaultRole ?? '')}
           roles={options}
           isDisabled={isLoading}
           onChange={value => field.setValue(value)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -189,6 +189,69 @@ describe('InviteMembersPage', () => {
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       await waitFor(() => expect(getByRole('button', { name: /select role/i })).toBeInTheDocument());
     });
+
+    it('enables send button with default role once email address has been entered', async () => {
+      const defaultRole = 'mydefaultrole';
+
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationDomains(undefined, defaultRole);
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getRoles.mockResolvedValue({
+        total_count: 3,
+        data: [
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'member',
+            key: 'member',
+            name: 'member',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: 'admin',
+            key: 'admin',
+            name: 'Admin',
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            pathRoot: '',
+            reload: jest.fn(),
+            id: defaultRole,
+            key: defaultRole,
+            name: defaultRole,
+            description: '',
+            permissions: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      const { getByRole, userEvent, getByTestId } = render(
+        <Action.Root>
+          <InviteMembersScreen />
+        </Action.Root>,
+        { wrapper },
+      );
+
+      expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
+      expect(getByRole('button', { name: 'Send invitations' })).not.toBeDisabled();
+    });
   });
 
   describe('when submitting', () => {

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -251,6 +251,7 @@ describe('InviteMembersPage', () => {
       expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
       await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       expect(getByRole('button', { name: 'Send invitations' })).not.toBeDisabled();
+      await userEvent.click(getByRole('button', { name: /mydefaultrole/i }));
     });
   });
 


### PR DESCRIPTION
## Description

Fixes issue where "Send invitation" button is getting disabled even tho there's a default role loaded: 

https://github.com/user-attachments/assets/fe18d474-5cf3-4396-94ec-a008db7a99cf

The issue relies on the fact that we're overriding the `field.value` property when rendering it, instead of passing it to the form controls state: 

https://github.com/user-attachments/assets/c3a6696c-2e62-40b8-8e55-bb346fb528d6

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
