### PR TITLE
chore(elements): Align clerk dependencies

### DIFF
--- a/.changeset/late-kiwis-warn.md
+++ b/.changeset/late-kiwis-warn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Remove @clerk/clerk-react as a dev depedency. Move @clerk/shared to depedencies (previously devDepedencies).

--- a/package-lock.json
+++ b/package-lock.json
@@ -45783,7 +45783,8 @@
       "version": "0.15.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.25.0",
+        "@clerk/shared": "2.9.0",
+        "@clerk/types": "4.25.0",
         "@radix-ui/react-form": "^0.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@xstate/react": "^4.1.1",
@@ -45791,9 +45792,7 @@
         "xstate": "^5.15.0"
       },
       "devDependencies": {
-        "@clerk/clerk-react": "5.11.0",
         "@clerk/eslint-config-custom": "*",
-        "@clerk/shared": "2.9.0",
         "@statelyai/inspect": "^0.4.0",
         "@types/node": "^18.19.33",
         "@types/react": "*",
@@ -45809,7 +45808,6 @@
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "@clerk/shared": "^2.0.0",
         "react": "^18.0.0 || ^19.0.0-beta",
         "react-dom": "^18.0.0 || ^19.0.0-beta"
       },

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -71,7 +71,8 @@
     "test:cache:clear": "jest --clearCache --useStderr"
   },
   "dependencies": {
-    "@clerk/types": "^4.25.0",
+    "@clerk/shared": "2.9.0",
+    "@clerk/types": "4.25.0",
     "@radix-ui/react-form": "^0.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@xstate/react": "^4.1.1",
@@ -79,9 +80,7 @@
     "xstate": "^5.15.0"
   },
   "devDependencies": {
-    "@clerk/clerk-react": "5.11.0",
     "@clerk/eslint-config-custom": "*",
-    "@clerk/shared": "2.9.0",
     "@statelyai/inspect": "^0.4.0",
     "@types/node": "^18.19.33",
     "@types/react": "*",
@@ -94,7 +93,6 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@clerk/shared": "^2.0.0",
     "react": "^18.0.0 || ^19.0.0-beta",
     "react-dom": "^18.0.0 || ^19.0.0-beta"
   },


### PR DESCRIPTION
## Description

Building `@clerk/ui` no longer depends on `@clerk/react`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
