### PR TITLE
fix(nextjs): do not build test file declarations

### DIFF
--- a/.changeset/young-llamas-prove.md
+++ b/.changeset/young-llamas-prove.md
@@ -1,5 +1,2 @@
 ---
-"@clerk/nextjs": patch
 ---
-
-Excluding test declartion files from module builds

--- a/.changeset/young-llamas-prove.md
+++ b/.changeset/young-llamas-prove.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Excluding test declartion files from module builds

--- a/packages/nextjs/tsconfig.declarations.json
+++ b/packages/nextjs/tsconfig.declarations.json
@@ -1,12 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true,
-    "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true,
+    "declarationDir": "./dist/types",
     "declarationMap": true,
-    "sourceMap": false,
-    "declarationDir": "./dist/types"
-  }
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "skipLibCheck": true,
+    "sourceMap": false
+  },
+  "exclude": ["**/__tests__/**/*"]
 }


### PR DESCRIPTION
## Description

Noticed that `@clerk/nextjs` was building declaration files for files in `__tests__` directory. Adding this directory to the `exclude` in testing tsconfig.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
