### PR TITLE
feat(types,ui): Add support for `__experimental.appearance` prop

### DIFF
--- a/.changeset/unlucky-steaks-protect.md
+++ b/.changeset/unlucky-steaks-protect.md
@@ -1,0 +1,5 @@
+---
+"@clerk/types": patch
+---
+
+Fix `SignInProps`/`SignUpProps` `__experimental` type to allow for arbitrary properties

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -837,12 +837,7 @@ export type SignInProps = RoutingOptions & {
   /**
    * Enable experimental flags to gain access to new features. These flags are not guaranteed to be stable and may change drastically in between patch or minor versions.
    */
-  __experimental?: Autocomplete<
-    {
-      newComponents: boolean;
-    },
-    Record<string, any>
-  >;
+  __experimental?: Record<string, any> & { newComponents?: boolean };
 } & TransferableOption &
   SignUpForceRedirectUrl &
   SignUpFallbackRedirectUrl &
@@ -952,12 +947,7 @@ export type SignUpProps = RoutingOptions & {
   /**
    * Enable experimental flags to gain access to new features. These flags are not guaranteed to be stable and may change drastically in between patch or minor versions.
    */
-  __experimental?: Autocomplete<
-    {
-      newComponents: boolean;
-    },
-    Record<string, any>
-  >;
+  __experimental?: Record<string, any> & { newComponents?: boolean };
 } & SignInFallbackRedirectUrl &
   SignInForceRedirectUrl &
   LegacyRedirectProps &

--- a/packages/ui/src/components/sign-in/sign-in.tsx
+++ b/packages/ui/src/components/sign-in/sign-in.tsx
@@ -24,13 +24,16 @@ import { type Appearance, AppearanceProvider } from '~/contexts';
  *   where we'll consider its integration within Elements, as well as ensure
  *   bulletproof a11y.
  */
-export function SignIn({ appearance, ...rest }: { appearance?: Appearance } & SignInProps) {
+export function SignIn({ appearance, ...props }: { appearance?: Appearance } & SignInProps) {
   const [showHelp, setShowHelp] = React.useState(false);
 
+  // If __experimental.newComponents is `true`, we should use __experimental.appearance instead of appearance.
+  const componentAppearance = props.__experimental?.newComponents ? props.__experimental.appearance : appearance;
+
   return (
-    <AppearanceProvider appearance={appearance}>
+    <AppearanceProvider appearance={componentAppearance}>
       <GetHelpContext.Provider value={{ showHelp, setShowHelp }}>
-        <SignInRoot {...rest}>
+        <SignInRoot {...props}>
           {showHelp ? (
             <SignInGetHelp />
           ) : (

--- a/packages/ui/src/components/sign-up/sign-up.tsx
+++ b/packages/ui/src/components/sign-up/sign-up.tsx
@@ -8,8 +8,11 @@ import { SignUpVerifications } from '~/components/sign-up/steps/verifications';
 import { type Appearance, AppearanceProvider } from '~/contexts';
 
 export function SignUp({ appearance, ...props }: { appearance?: Appearance } & SignUpProps) {
+  // If __experimental.newComponents is `true`, we should use __experimental.appearance instead of appearance.
+  const componentAppearance = props.__experimental?.newComponents ? props.__experimental.appearance : appearance;
+
   return (
-    <AppearanceProvider appearance={appearance}>
+    <AppearanceProvider appearance={componentAppearance}>
       <SignUpRoot {...props}>
         <SignUpStart />
         <SignUpVerifications />

--- a/packages/ui/src/contexts/AppearanceContext.tsx
+++ b/packages/ui/src/contexts/AppearanceContext.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 
 import { fullTheme } from '~/themes';
 
-type AlertDescriptorIdentifier = 'alert' | 'alert__error' | 'alert__warning' | 'alertRoot' | 'alertIcon';
+type AlertDescriptorIdentifier = 'alert' | 'alert__error' | 'alert__warning' | 'alertIcon';
 type SeparatorDescriptorIdentifier = 'separator';
+type CardDescriptorIdentifier = 'logoBox' | 'logoLink' | 'logoImage';
 
 /**
  * Union of all valid descriptors used throughout the components.
  */
-export type DescriptorIdentifier = AlertDescriptorIdentifier | SeparatorDescriptorIdentifier;
+export type DescriptorIdentifier = AlertDescriptorIdentifier | SeparatorDescriptorIdentifier | CardDescriptorIdentifier;
 
 /**
  * The final resulting descriptor that gets passed to mergeDescriptors and spread on the element.

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -1,6 +1,8 @@
 import { cva, cx } from 'cva';
 import * as React from 'react';
 
+import { useAppearance } from '~/contexts';
+import { mergeDescriptors, type ParsedElementsFragment } from '~/contexts/AppearanceContext';
 import type { PolymorphicForwardRefExoticComponent, PolymorphicPropsWithoutRef } from '~/types/utils';
 
 import { ClerkLogo } from './clerk-logo';
@@ -106,9 +108,24 @@ export const Header = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
   );
 });
 
+const logoLayoutStyle = {
+  logoBox: {
+    className: 'z-1 mb-5 flex h-8 justify-center',
+  },
+  logoLink: {
+    className: '-m-0.5 rounded-sm p-0.5 outline-none focus-visible:ring',
+  },
+  logoImage: {
+    className: 'size-full object-contain',
+  },
+} satisfies ParsedElementsFragment;
+const logoVisualStyle = {
+  logoBox: {},
+  logoLink: {},
+  logoImage: {},
+} satisfies ParsedElementsFragment;
 export const Logo = React.forwardRef(function CardLogo(
   {
-    className,
     href,
     src,
     ...props
@@ -117,6 +134,7 @@ export const Logo = React.forwardRef(function CardLogo(
   },
   forwardedRef: React.ForwardedRef<HTMLImageElement>,
 ) {
+  const { elements } = useAppearance().parsedAppearance;
   if (!src) {
     return null;
   }
@@ -128,15 +146,15 @@ export const Logo = React.forwardRef(function CardLogo(
       src={src}
       size={200}
       {...props}
-      className={cx('size-full object-contain', className)}
+      {...mergeDescriptors(elements.logoImage)}
     />
   );
   return (
-    <div className='z-1 mb-5 flex h-8 justify-center'>
+    <div {...mergeDescriptors(elements.logoBox)}>
       {href ? (
         <a
           href={href}
-          className='-m-0.5 rounded-sm p-0.5 outline-none focus-visible:ring'
+          {...mergeDescriptors(elements.logoLink)}
         >
           {img}
         </a>
@@ -384,3 +402,11 @@ const FooterPageLink = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttri
     );
   },
 );
+
+export const layoutStyle = {
+  ...logoLayoutStyle,
+} satisfies ParsedElementsFragment;
+
+export const visualStyle = {
+  ...logoVisualStyle,
+} satisfies ParsedElementsFragment;

--- a/packages/ui/src/themes/full.ts
+++ b/packages/ui/src/themes/full.ts
@@ -1,8 +1,9 @@
 import { visualStyle as alertVisualStyle } from '~/primitives/alert';
+import { visualStyle as cardVisualStyle } from '~/primitives/card';
 import { visualStyle as separatorVisualStyle } from '~/primitives/separator';
 
 import { buildTheme, mergeTheme } from './buildTheme';
 import { layoutTheme } from './layout';
 
-const visualTheme = buildTheme({ ...alertVisualStyle, ...separatorVisualStyle });
+const visualTheme = buildTheme({ ...alertVisualStyle, ...cardVisualStyle, ...separatorVisualStyle });
 export const fullTheme = mergeTheme(layoutTheme, visualTheme);

--- a/packages/ui/src/themes/layout.ts
+++ b/packages/ui/src/themes/layout.ts
@@ -1,6 +1,7 @@
 import { layoutStyle as alertLayoutStyle } from '~/primitives/alert';
+import { layoutStyle as cardLayoutStyle } from '~/primitives/card';
 import { layoutStyle as separatorStyle } from '~/primitives/separator';
 
 import { buildTheme } from './buildTheme';
 
-export const layoutTheme = buildTheme({ ...alertLayoutStyle, ...separatorStyle });
+export const layoutTheme = buildTheme({ ...alertLayoutStyle, ...cardLayoutStyle, ...separatorStyle });


### PR DESCRIPTION
## Description

This PR adds support for the `__experimental.appearance` prop which is distinct from the existing `appearance` prop. If the new `SignIn`/`SignUp` component is rendered with `__experimental.newComponents`, it will pull the appearance from `__experimental.appearance` instead of `appearance`. If the components are rendered directly (outside of `clerk-js` such as in Theme Builder) they will continue to read from `appearance`.

This PR also adds descriptors to the `Card.Logo` component since we want to target it in Dashboard.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
