### PR TITLE
feat(clerk-js): Add support for loading UI styles as first CSS stylesheet

### DIFF
--- a/packages/clerk-js/global.d.ts
+++ b/packages/clerk-js/global.d.ts
@@ -1,4 +1,0 @@
-declare module '*.module.scss' {
-  const content: Record<string, string>;
-  export default content;
-}

--- a/packages/clerk-js/src/global.d.ts
+++ b/packages/clerk-js/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '@clerk/ui/styles.css' {
+  const content: string;
+  export default content;
+}

--- a/packages/clerk-js/src/ui/new/renderer.tsx
+++ b/packages/clerk-js/src/ui/new/renderer.tsx
@@ -42,11 +42,17 @@ export function init({ wrapper }: { wrapper: ElementType }) {
     rootElement.setAttribute('id', 'clerk-components');
     document.body.appendChild(rootElement);
 
-    const stylesheet = document.createElement('link');
-    stylesheet.href = stylesheetURL;
-    stylesheet.rel = 'stylesheet';
-    // Add as first stylesheet so that application styles take precedence over our styles.
-    document.head.prepend(stylesheet);
+    // Just for completeness, we check to see if we've already added the stylesheet to the DOM.
+    const STYLESHEET_SIGIL = 'data-clerk-styles';
+    const existingStylesheet = document.querySelector(`link[${STYLESHEET_SIGIL}]`);
+    if (!existingStylesheet) {
+      const stylesheet = document.createElement('link');
+      stylesheet.href = stylesheetURL;
+      stylesheet.rel = 'stylesheet';
+      stylesheet.setAttribute(STYLESHEET_SIGIL, '');
+      // Add as first stylesheet so that application styles take precedence over our styles.
+      document.head.prepend(stylesheet);
+    }
   }
 
   const root = createRoot(rootElement);

--- a/packages/clerk-js/src/ui/new/renderer.tsx
+++ b/packages/clerk-js/src/ui/new/renderer.tsx
@@ -1,10 +1,9 @@
-// TODO: don't import here
-import '@clerk/ui/styles.css';
-
+//@ts-ignore - This is treated as a string export by Webpack
 import { ClerkInstanceContext, OptionsContext } from '@clerk/shared/react';
 import type { ClerkHostRouter } from '@clerk/shared/router';
 import { ClerkHostRouterContext } from '@clerk/shared/router';
 import type { ClerkOptions, LoadedClerk } from '@clerk/types';
+import stylesheetURL from '@clerk/ui/styles.css';
 import type { ElementType, ReactNode } from 'react';
 import { createElement, lazy } from 'react';
 import { createPortal } from 'react-dom';
@@ -43,6 +42,12 @@ export function init({ wrapper }: { wrapper: ElementType }) {
     rootElement = document.createElement('div');
     rootElement.setAttribute('id', 'clerk-components');
     document.body.appendChild(rootElement);
+
+    const stylesheet = document.createElement('link');
+    stylesheet.href = stylesheetURL;
+    stylesheet.rel = 'stylesheet';
+    // Add as first stylesheet so that application styles take precedence over our styles.
+    document.head.prepend(stylesheet);
   }
 
   const root = createRoot(rootElement);

--- a/packages/clerk-js/src/ui/new/renderer.tsx
+++ b/packages/clerk-js/src/ui/new/renderer.tsx
@@ -1,8 +1,8 @@
-//@ts-ignore - This is treated as a string export by Webpack
 import { ClerkInstanceContext, OptionsContext } from '@clerk/shared/react';
 import type { ClerkHostRouter } from '@clerk/shared/router';
 import { ClerkHostRouterContext } from '@clerk/shared/router';
 import type { ClerkOptions, LoadedClerk } from '@clerk/types';
+//@ts-ignore - This is treated as a string export by Webpack
 import stylesheetURL from '@clerk/ui/styles.css';
 import type { ElementType, ReactNode } from 'react';
 import { createElement, lazy } from 'react';

--- a/packages/clerk-js/src/ui/new/renderer.tsx
+++ b/packages/clerk-js/src/ui/new/renderer.tsx
@@ -2,7 +2,6 @@ import { ClerkInstanceContext, OptionsContext } from '@clerk/shared/react';
 import type { ClerkHostRouter } from '@clerk/shared/router';
 import { ClerkHostRouterContext } from '@clerk/shared/router';
 import type { ClerkOptions, LoadedClerk } from '@clerk/types';
-//@ts-ignore - This is treated as a string export by Webpack
 import stylesheetURL from '@clerk/ui/styles.css';
 import type { ElementType, ReactNode } from 'react';
 import { createElement, lazy } from 'react';

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -106,9 +106,6 @@ const common = ({ mode }) => {
         },
       },
     },
-    experiments: {
-      css: true,
-    },
   };
 };
 
@@ -173,12 +170,21 @@ const typescriptLoaderDev = () => {
   };
 };
 
+/** @type { () => (import('webpack').RuleSetRule) } */
+const clerkUICSSLoader = () => {
+  // This emits a module exporting the URL to the styles.css file.
+  return {
+    test: /packages\/ui\/dist\/styles\.css/,
+    type: 'asset/resource',
+  };
+};
+
 /** @type { () => (import('webpack').Configuration) } */
 const commonForProd = () => {
   return {
     devtool: undefined,
     module: {
-      rules: [svgLoader(), typescriptLoaderProd()],
+      rules: [svgLoader(), typescriptLoaderProd(), clerkUICSSLoader()],
     },
     output: {
       path: path.resolve(__dirname, 'dist'),
@@ -297,7 +303,7 @@ const devConfig = ({ mode, env }) => {
   const commonForDev = () => {
     return {
       module: {
-        rules: [svgLoader(), typescriptLoaderDev()],
+        rules: [svgLoader(), typescriptLoaderDev(), clerkUICSSLoader()],
       },
       plugins: [
         new ReactRefreshWebpackPlugin({ overlay: { sockHost: devUrl.host } }),


### PR DESCRIPTION
## Description

This PR adds support for inserting the new UI stylesheet as the first stylesheet in the document. This is to allow user styles to take precedence over our own. For example:

```
// @clerk/ui/styles.css
.cl-button { display: flex; }
```

```
// app/style.css
.hidden { display: none; }
```

If the UI stylesheet appears _after_ the app stylesheet in the DOM, `cl-button` will override `hidden` given they have the same specificity. By _prepending_ our stylesheet, we allow our users' styles to take precedence.

To support this, I had to remove Webpack's experimental support for CSS which doesn't currently support emitting the URL of the stylesheet; it always wants to append it to the DOM.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
