### PR TITLE
fix(elements): Remove example mode guard from passkey event in verification flow

### DIFF
--- a/.changeset/little-adults-end.md
+++ b/.changeset/little-adults-end.md
@@ -1,0 +1,5 @@
+---
+"@clerk/elements": patch
+---
+
+Remove "example mode" guard form "AUTHENICTATE.PASSKEY" event in verification flow

--- a/packages/elements/src/internals/machines/sign-in/verification.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/verification.machine.ts
@@ -14,7 +14,7 @@ import type {
   Web3Attempt,
 } from '@clerk/types';
 import type { DoneActorEvent } from 'xstate';
-import { assign, fromPromise, log, not, sendTo, setup } from 'xstate';
+import { assign, fromPromise, log, sendTo, setup } from 'xstate';
 
 import {
   MAGIC_LINK_VERIFY_PATH_ROUTE,
@@ -270,7 +270,6 @@ const SignInVerificationMachine = setup({
       description: 'Waiting for user input',
       on: {
         'AUTHENTICATE.PASSKEY': {
-          guard: not('isExampleMode'),
           target: 'AttemptingPasskey',
           reenter: true,
         },
@@ -411,8 +410,8 @@ export const SignInFirstFactorMachine = SignInVerificationMachine.provide({
       // prepareFirstFactor, we need to assert that the input is a PrepareFirstFactor. For some reason, ESLint thinks
       // the assertion is unnecessary, and will remove it during the pre-commit hook. To prevent that, we disable the
       // rule for the line.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      const { params, parent, resendable } = input as PrepareFirstFactorInput;
+
+      const { params, parent, resendable } = input;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send
@@ -515,7 +514,7 @@ export const SignInSecondFactorMachine = SignInVerificationMachine.provide({
       ),
     ),
     prepare: fromPromise(async ({ input }) => {
-      const { params, parent, resendable } = input as PrepareSecondFactorInput;
+      const { params, parent, resendable } = input;
       const clerk = parent.getSnapshot().context.clerk;
 
       // If a prepare call has already been fired recently, don't re-send


### PR DESCRIPTION
## Description

Remove example mode guard from passkey event in verification flow

<!-- Fixes #(issue number) -->
Fixes ECO-208

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
