### PR TITLE
fix(clerk-js): Allow __webpack_public_path__ to be set for CJS and ESM builds

### DIFF
--- a/packages/chrome-extension/jest.setup.ts
+++ b/packages/chrome-extension/jest.setup.ts
@@ -3,3 +3,4 @@ import { chrome } from 'jest-chrome';
 // @ts-expect-error - required for the browser polyfill
 chrome.runtime.id = 'chrome-extension-test';
 Object.assign(global, { chrome, browser: chrome });
+Object.assign(global, { __webpack_public_path__: '' });

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -272,6 +272,7 @@ const prodConfig = ({ mode }) => {
     output: {
       filename: '[name].mjs',
       libraryTarget: 'module',
+      publicPath: '',
     },
     plugins: [
       // Include the lazy chunks in the bundle as well
@@ -283,13 +284,20 @@ const prodConfig = ({ mode }) => {
     ],
   });
 
-  const clerkCjs = merge(clerkEsm, {
+  const clerkCjs = merge(entryForVariant(variants.clerk), common({ mode }), commonForProd(), {
     output: {
       filename: '[name].js',
       libraryTarget: 'commonjs',
-      chunkFormat: 'commonjs',
-      scriptType: 'text/javascript',
+      publicPath: '',
     },
+    plugins: [
+      // Include the lazy chunks in the bundle as well
+      // so that the final bundle can be imported and bundled again
+      // by a different bundler, eg the webpack instance used by react-scripts
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+    ],
   });
 
   return [clerkBrowser, clerkHeadless, clerkHeadlessBrowser, clerkEsm, clerkCjs];


### PR DESCRIPTION
…M builds

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
