### PR TITLE
fix(clerk-js): Bundle CSS into CJS and ESM bundles

### DIFF
--- a/packages/clerk-js/src/ui/new/renderer.tsx
+++ b/packages/clerk-js/src/ui/new/renderer.tsx
@@ -2,7 +2,7 @@ import { ClerkInstanceContext, OptionsContext } from '@clerk/shared/react';
 import type { ClerkHostRouter } from '@clerk/shared/router';
 import { ClerkHostRouterContext } from '@clerk/shared/router';
 import type { ClerkOptions, LoadedClerk } from '@clerk/types';
-import stylesheetURL from '@clerk/ui/styles.css';
+import stylesheetURLOrContent from '@clerk/ui/styles.css';
 import type { ElementType, ReactNode } from 'react';
 import { createElement, lazy } from 'react';
 import { createPortal } from 'react-dom';
@@ -43,12 +43,22 @@ export function init({ wrapper }: { wrapper: ElementType }) {
     document.body.appendChild(rootElement);
 
     // Just for completeness, we check to see if we've already added the stylesheet to the DOM.
-    const STYLESHEET_SIGIL = 'data-clerk-styles';
-    const existingStylesheet = document.querySelector(`link[${STYLESHEET_SIGIL}]`);
+    const STYLESHEET_SIGIL = 'data-clerk-injected-styles';
+    const existingStylesheet = document.querySelector(`[${STYLESHEET_SIGIL}]`);
     if (!existingStylesheet) {
-      const stylesheet = document.createElement('link');
-      stylesheet.href = stylesheetURL;
-      stylesheet.rel = 'stylesheet';
+      let stylesheet: HTMLLinkElement | HTMLStyleElement;
+
+      if (stylesheetURLOrContent.endsWith('.css')) {
+        // stylesheetURLOrContent is a URL to a stylesheet
+        stylesheet = document.createElement('link');
+        (stylesheet as HTMLLinkElement).href = stylesheetURLOrContent;
+        (stylesheet as HTMLLinkElement).rel = 'stylesheet';
+      } else {
+        // stylesheetURLOrContent is CSS
+        stylesheet = document.createElement('style');
+        stylesheet.textContent = stylesheetURLOrContent;
+      }
+
       stylesheet.setAttribute(STYLESHEET_SIGIL, '');
       // Add as first stylesheet so that application styles take precedence over our styles.
       document.head.prepend(stylesheet);


### PR DESCRIPTION
## Description

This PR updates the CJS and ESM builds of `clerk-js` to bundle imported CSS files instead of emitting a URL to the file. This is required since we don't have the capability to dynamically load anything on account of not knowing the public path (like we do in our browser bundles). This impacts consumers who directly consume the `clerk.js` and `clerk.mjs` bundles of `clerk-js`, which includes Chrome extensions (and possibly others).

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
