### PR TITLE
fix(clerk-js): Handle gracefully Coinbase Wallet use of existing Passkey

### DIFF
--- a/.changeset/khaki-cycles-appear.md
+++ b/.changeset/khaki-cycles-appear.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Handle gracefully Coinbase Wallet use of existing Passkey

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -255,11 +255,22 @@ export class SignIn extends BaseResource implements SignInResource {
       clerkVerifyWeb3WalletCalledBeforeCreate('SignIn');
     }
 
-    const signature = await generateSignature({
-      identifier: this.identifier!,
-      nonce: nonce,
-      provider,
-    });
+    let signature: string;
+    try {
+      signature = await generateSignature({ identifier, nonce, provider });
+    } catch (err) {
+      // There is a chance that as a user when you try to setup and use the Coinbase Wallet with an existing
+      // Passkey in order to authenticate, the initial generate signature request to be rejected. For this
+      // reason we retry the request once more in order for the flow to be able to be completed successfully.
+      //
+      // error code 4001 means the user rejected the request
+      // Reference: https://docs.cdp.coinbase.com/wallet-sdk/docs/errors
+      if (provider === 'coinbase_wallet' && err.code === 4001) {
+        signature = await generateSignature({ identifier, nonce, provider });
+      } else {
+        throw err;
+      }
+    }
 
     return this.attemptFirstFactor({
       signature,


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

There is a chance that as a user when you try to setup and use the Coinbase Wallet with an existing Passkey in order to authenticate, the initial generate signature request to be rejected. For this reason we retry the request once more in order for the flow to be able to be completed successfully.

## Before

https://github.com/user-attachments/assets/e8224c4c-6386-4706-a4d9-8b4c2fa157e7

## After

https://github.com/user-attachments/assets/a1a196c3-5870-41a2-b660-344ff810e58d

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
