### PR TITLE
chore(clerk-js): Update `OrganizationSwitcher` popover action to include label

### DIFF
--- a/.changeset/lemon-terms-begin.md
+++ b/.changeset/lemon-terms-begin.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Replace `OrganizationSwitcher` popover small gear icon with labelled action
+Update `OrganizationSwitcher` popover action to include label

--- a/.changeset/lemon-terms-begin.md
+++ b/.changeset/lemon-terms-begin.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Replace `OrganizationSwitcher` popover small gear icon with labelled action

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -8,7 +8,6 @@ import { useEnvironment, useOrganizationSwitcherContext } from '../../contexts';
 import { descriptors, Flex, localizationKeys } from '../../customizables';
 import {
   Actions,
-  ExtraSmallAction,
   OrganizationPreview,
   PersonalWorkspacePreview,
   PopoverCard,
@@ -105,20 +104,6 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       });
     };
 
-    const manageOrganizationSmallIconButton = (
-      <ExtraSmallAction
-        elementDescriptor={descriptors.organizationSwitcherPopoverActionButton}
-        elementId={descriptors.organizationSwitcherPopoverActionButton.setId('manageOrganization')}
-        iconBoxElementDescriptor={descriptors.organizationSwitcherPopoverActionButtonIconBox}
-        iconBoxElementId={descriptors.organizationSwitcherPopoverActionButtonIconBox.setId('manageOrganization')}
-        iconElementDescriptor={descriptors.organizationSwitcherPopoverActionButtonIcon}
-        iconElementId={descriptors.organizationSwitcherPopoverActionButtonIcon.setId('manageOrganization')}
-        icon={CogFilled}
-        onClick={() => handleItemClick()}
-        trailing={<NotificationCountBadgeManageButton />}
-      />
-    );
-
     const manageOrganizationButton = (
       <SmallAction
         elementDescriptor={descriptors.organizationSwitcherPopoverActionButton}
@@ -195,7 +180,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
               padding: `${t.space.$4} ${t.space.$5}`,
             })}
           />
-          <Actions role='menu'>{manageOrganizationSmallIconButton}</Actions>
+          <Actions role='menu'>{manageOrganizationButton}</Actions>
         </Flex>
       );
 


### PR DESCRIPTION
## Description

Resolves ORGS-246

Replaces `OrganizationSwitcher` small gear icon action with a labeled button to make it less confusing to end-users.

Now:

![CleanShot 2024-10-08 at 19 35 37](https://github.com/user-attachments/assets/dc500121-41c5-4eb7-a4b9-615c87e4f8b4)

Previously:

![CleanShot 2024-10-08 at 19 44 44](https://github.com/user-attachments/assets/f03891eb-cbb3-4ddd-b612-6666974dd901)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
