### PR TITLE
fix(backend): Expose permissions field for OrganizationMembership

### DIFF
--- a/.changeset/eight-kids-attack.md
+++ b/.changeset/eight-kids-attack.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Expose `permissions` field for `OrganizationMembership` resource

--- a/packages/backend/src/api/resources/OrganizationMembership.ts
+++ b/packages/backend/src/api/resources/OrganizationMembership.ts
@@ -6,6 +6,7 @@ export class OrganizationMembership {
   constructor(
     readonly id: string,
     readonly role: OrganizationMembershipRole,
+    readonly permissions: string[],
     readonly publicMetadata: OrganizationMembershipPublicMetadata = {},
     readonly privateMetadata: OrganizationMembershipPrivateMetadata = {},
     readonly createdAt: number,
@@ -18,6 +19,7 @@ export class OrganizationMembership {
     return new OrganizationMembership(
       data.id,
       data.role,
+      data.permissions,
       data.public_metadata,
       data.private_metadata,
       data.created_at,


### PR DESCRIPTION
## Description

This PR exposes the `permissions` field on the `OrganizationMembership` resource.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
