### PR TITLE
fix(clerk-js): Add support for loading Turnstile from Cloudflare host

### DIFF
--- a/.changeset/odd-squids-dress.md
+++ b/.changeset/odd-squids-dress.md
@@ -2,4 +2,6 @@
 "@clerk/clerk-js": patch
 ---
 
-Try loading Turnstile from Cloudflare host.
+Improve bot detection by loading the Turnstile SDK directly from CloudFlare.
+
+If loading fails due to CSP rules, load it through FAPI instead.

--- a/.changeset/odd-squids-dress.md
+++ b/.changeset/odd-squids-dress.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Try loading Turnstile from Cloudflare host.

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -3,6 +3,8 @@ import type { CaptchaWidgetType } from '@clerk/types';
 
 import { CAPTCHA_ELEMENT_ID, CAPTCHA_INVISIBLE_CLASSNAME } from './constants';
 
+const CLOUDFLARE_TURSTILE_ORIGINAL_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+
 interface RenderOptions {
   /**
    * Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation.
@@ -69,19 +71,36 @@ export const shouldRetryTurnstileErrorCode = (errorCode: string) => {
   return !!codesWithRetries.find(w => errorCode.startsWith(w));
 };
 
-async function loadCaptcha(url: string) {
+async function loadCaptcha(fallbackUrl: string) {
   if (!window.turnstile) {
     try {
-      await loadScript(url, { defer: true });
+      await loadCaptchaFromCloudflareURL();
     } catch {
-      // Rethrow with specific message
-      console.error('Clerk: Failed to load the CAPTCHA script from the URL: ', url);
-      throw {
-        captchaError: 'captcha_script_failed_to_load',
-      };
+      await loadCaptchaFromFAPIProxiedURL(fallbackUrl);
     }
   }
   return window.turnstile;
+}
+
+async function loadCaptchaFromCloudflareURL() {
+  try {
+    await loadScript(CLOUDFLARE_TURSTILE_ORIGINAL_URL, { defer: true });
+  } catch (err) {
+    console.error('Clerk: Failed to load the CAPTCHA script from the original Cloudflare URL.');
+    throw err;
+  }
+}
+
+async function loadCaptchaFromFAPIProxiedURL(fallbackUrl: string) {
+  try {
+    await loadScript(fallbackUrl, { defer: true });
+  } catch {
+    // Rethrow with specific message
+    console.error('Clerk: Failed to load the CAPTCHA script from the URL: ', fallbackUrl);
+    throw {
+      captchaError: 'captcha_script_failed_to_load',
+    };
+  }
 }
 
 /*

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -3,7 +3,7 @@ import type { CaptchaWidgetType } from '@clerk/types';
 
 import { CAPTCHA_ELEMENT_ID, CAPTCHA_INVISIBLE_CLASSNAME } from './constants';
 
-const CLOUDFLARE_TURSTILE_ORIGINAL_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+const CLOUDFLARE_TURNSTILE_ORIGINAL_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
 
 interface RenderOptions {
   /**
@@ -84,7 +84,7 @@ async function loadCaptcha(fallbackUrl: string) {
 
 async function loadCaptchaFromCloudflareURL() {
   try {
-    await loadScript(CLOUDFLARE_TURSTILE_ORIGINAL_URL, { defer: true });
+    await loadScript(CLOUDFLARE_TURNSTILE_ORIGINAL_URL, { defer: true });
   } catch (err) {
     console.error('Clerk: Failed to load the CAPTCHA script from the original Cloudflare URL.');
     throw err;


### PR DESCRIPTION
## Description

This PR adds support for loading the Turnstile CAPTCHA script from the Cloudflare host. If the script fails to load from the Cloudflare URL, it falls back to a FAPI-proxied URL.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
