### PR TITLE
fix(clerk-js): Only retry oauth if captcha failed

### DIFF
--- a/.changeset/nasty-melons-cross.md
+++ b/.changeset/nasty-melons-cross.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/shared": patch
+---
+
+Only retry the OAuth flow if the captcha check failed.

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -6,6 +6,10 @@ export function isUnauthorizedError(e: any): boolean {
   return code === 'authentication_invalid' && status === 401;
 }
 
+export function isCaptchaError(e: ClerkAPIResponseError): boolean {
+  return ['captcha_invalid', 'captcha_not_enabled', 'captcha_missing_token'].includes(e.errors[0].code);
+}
+
 export function is4xxError(e: any): boolean {
   const status = e?.status;
   return !!status && status >= 400 && status < 500;


### PR DESCRIPTION
## Description
We only want to reload env and retry if the error thrown was related to captcha falling.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
