### PR TITLE
fix(clerk-js): Add the render query param on the captcha script

### DIFF
--- a/.changeset/serious-moose-design.md
+++ b/.changeset/serious-moose-design.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Add the `render=explicit` parameter to the Turnstile script.

--- a/.changeset/serious-moose-design.md
+++ b/.changeset/serious-moose-design.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Add the `render=explicit` parameter to the Turnstile script.
+Add the `?render=explicit` query parameter to the Turnstile script.

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -3,7 +3,9 @@ import type { CaptchaWidgetType } from '@clerk/types';
 
 import { CAPTCHA_ELEMENT_ID, CAPTCHA_INVISIBLE_CLASSNAME } from './constants';
 
-const CLOUDFLARE_TURNSTILE_ORIGINAL_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+// We use the explicit render mode to be able to control when the widget is rendered.
+// CF docs: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#disable-implicit-rendering
+const CLOUDFLARE_TURNSTILE_ORIGINAL_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
 
 interface RenderOptions {
   /**
@@ -87,7 +89,7 @@ async function loadCaptchaFromCloudflareURL() {
     return await loadScript(CLOUDFLARE_TURNSTILE_ORIGINAL_URL, { defer: true });
   } catch (err) {
     console.warn(
-      'Clerk: Failed to load the CAPTCHA script from Clouflare. If you see a CSP error in your browser, please add the necessary CSP rules to your app. Visit https://clerk.com/docs/security/clerk-csp for more information.',
+      'Clerk: Failed to load the CAPTCHA script from Cloudflare. If you see a CSP error in your browser, please add the necessary CSP rules to your app. Visit https://clerk.com/docs/security/clerk-csp for more information.',
     );
     throw err;
   }


### PR DESCRIPTION
## Description

This PR adds the `?render=explicit` query param on the CF Turnstile script URL.

Currently, the script is working because the Turnstile script fallbacks to 'explicit' rendering when there is no `cf-turnstile` element in the DOM, and we use `clerk-captcha` and `clerk-invisible-captcha` for the DOM elements.

However, it's better to be explicit about the rendering strategy so that we can avoid accidental issues in the future.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
