### PR TITLE
feat(clerk-js): Legal consent

### DIFF
--- a/.changeset/curvy-ghosts-relax.md
+++ b/.changeset/curvy-ghosts-relax.md
@@ -1,0 +1,7 @@
+---
+"@clerk/localizations": minor
+"@clerk/clerk-js": minor
+"@clerk/types": minor
+---
+
+Adding experimental support for legal consent for `<SignUp/>` component

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -2,7 +2,7 @@
   "files": [
     { "path": "./dist/clerk.browser.js", "maxSize": "68kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "44kB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "86KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "87KB" },
     { "path": "./dist/vendors*.js", "maxSize": "70KB" },
     { "path": "./dist/coinbase*.js", "maxSize": "58KB" },
     { "path": "./dist/createorganization*.js", "maxSize": "5KB" },

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1400,6 +1400,7 @@ export class Clerk implements ClerkInterface {
           return this.client?.signUp.create({
             strategy: 'google_one_tap',
             token: params.token,
+            __experimental_legalAccepted: params.__experimental_legalAccepted,
           });
         }
         throw err;
@@ -1420,6 +1421,7 @@ export class Clerk implements ClerkInterface {
     customNavigate,
     unsafeMetadata,
     strategy,
+    __experimental_legalAccepted,
   }: ClerkAuthenticateWithWeb3Params): Promise<void> => {
     if (!this.client || !this.environment) {
       return;
@@ -1442,6 +1444,7 @@ export class Clerk implements ClerkInterface {
           generateSignature,
           unsafeMetadata,
           strategy,
+          __experimental_legalAccepted,
         });
 
         if (

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -44,6 +44,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   afterCreateOrganizationUrl!: string;
   googleOneTapClientId?: string;
   showDevModeWarning!: boolean;
+  termsUrl!: string;
+  privacyPolicyUrl!: string;
 
   public constructor(data: DisplayConfigJSON) {
     super();
@@ -87,6 +89,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.afterCreateOrganizationUrl = data.after_create_organization_url;
     this.googleOneTapClientId = data.google_one_tap_client_id;
     this.showDevModeWarning = data.show_devmode_warning;
+    this.termsUrl = data.terms_url;
+    this.privacyPolicyUrl = data.privacy_policy_url;
     return this;
   }
 }

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -317,12 +317,9 @@ export class SignUp extends BaseResource implements SignUpResource {
   };
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
-    // @ts-expect-error - This is a temporary until the feature is stable
-    console.trace('params', params);
+    // @ts-expect-error - We need to remove the __experimental_legalAccepted key from the params
     params.legalAccepted = params.__experimental_legalAccepted;
     params.__experimental_legalAccepted = undefined;
-
-    console.log('params', params);
 
     return this._basePatch({
       body: normalizeUnsafeMetadata(params),

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -112,9 +112,8 @@ export class SignUp extends BaseResource implements SignUpResource {
       paramsWithCaptcha.strategy = SignUp.clerk.client?.signIn.firstFactorVerification.strategy;
     }
 
-    if (params.__experimental_legalAccepted) {
-      paramsWithCaptcha.legalAccepted = params.__experimental_legalAccepted;
-    }
+    paramsWithCaptcha.legalAccepted = params.__experimental_legalAccepted;
+    paramsWithCaptcha.__experimental_legalAccepted = undefined;
 
     return this._basePost({
       path: this.pathRoot,
@@ -318,6 +317,10 @@ export class SignUp extends BaseResource implements SignUpResource {
   };
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
+    // @ts-expect-error - This is a temporary until the feature is stable
+    params.legalAccepted = params.__experimental_legalAccepted;
+    params.__experimental_legalAccepted = undefined;
+
     return this._basePatch({
       body: normalizeUnsafeMetadata(params),
     });

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -113,8 +113,10 @@ export class SignUp extends BaseResource implements SignUpResource {
     }
 
     // TODO(@vaggelis): Remove this once the legalAccepted is stable
-    paramsWithCaptcha.legalAccepted = params.__experimental_legalAccepted;
-    paramsWithCaptcha.__experimental_legalAccepted = undefined;
+    if (typeof params.__experimental_legalAccepted !== 'undefined') {
+      paramsWithCaptcha.legalAccepted = params.__experimental_legalAccepted;
+      paramsWithCaptcha.__experimental_legalAccepted = undefined;
+    }
 
     return this._basePost({
       path: this.pathRoot,
@@ -319,9 +321,11 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
     // TODO(@vaggelis): Remove this once the legalAccepted is stable
-    // @ts-expect-error - We need to remove the __experimental_legalAccepted key from the params
-    params.legalAccepted = params.__experimental_legalAccepted;
-    params.__experimental_legalAccepted = undefined;
+    if (typeof params.__experimental_legalAccepted !== 'undefined') {
+      // @ts-expect-error - We need to remove the __experimental_legalAccepted key from the params
+      params.legalAccepted = params.__experimental_legalAccepted;
+      params.__experimental_legalAccepted = undefined;
+    }
 
     return this._basePatch({
       body: normalizeUnsafeMetadata(params),

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -112,6 +112,7 @@ export class SignUp extends BaseResource implements SignUpResource {
       paramsWithCaptcha.strategy = SignUp.clerk.client?.signIn.firstFactorVerification.strategy;
     }
 
+    // TODO(@vaggelis): Remove this once the legalAccepted is stable
     paramsWithCaptcha.legalAccepted = params.__experimental_legalAccepted;
     paramsWithCaptcha.__experimental_legalAccepted = undefined;
 
@@ -317,6 +318,7 @@ export class SignUp extends BaseResource implements SignUpResource {
   };
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
+    // TODO(@vaggelis): Remove this once the legalAccepted is stable
     // @ts-expect-error - We need to remove the __experimental_legalAccepted key from the params
     params.legalAccepted = params.__experimental_legalAccepted;
     params.__experimental_legalAccepted = undefined;

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -70,6 +70,7 @@ export class SignUp extends BaseResource implements SignUpResource {
   createdSessionId: string | null = null;
   createdUserId: string | null = null;
   abandonAt: number | null = null;
+  legalAcceptedAt: number | null = null;
 
   constructor(data: SignUpJSON | null = null) {
     super();
@@ -258,6 +259,7 @@ export class SignUp extends BaseResource implements SignUpResource {
     continueSignUp = false,
     unsafeMetadata,
     emailAddress,
+    legalAccepted,
   }: AuthenticateWithRedirectParams & {
     unsafeMetadata?: SignUpUnsafeMetadata;
   }): Promise<void> => {
@@ -268,6 +270,7 @@ export class SignUp extends BaseResource implements SignUpResource {
         actionCompleteRedirectUrl: redirectUrlComplete,
         unsafeMetadata,
         emailAddress,
+        legalAccepted,
       };
       return continueSignUp && this.id ? this.update(params) : this.create(params);
     };
@@ -328,6 +331,7 @@ export class SignUp extends BaseResource implements SignUpResource {
       this.createdUserId = data.created_user_id;
       this.abandonAt = data.abandon_at;
       this.web3wallet = data.web3_wallet;
+      this.legalAcceptedAt = data.legal_accepted_at;
     }
     return this;
   }

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -318,8 +318,11 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
     // @ts-expect-error - This is a temporary until the feature is stable
+    console.trace('params', params);
     params.legalAccepted = params.__experimental_legalAccepted;
     params.__experimental_legalAccepted = undefined;
+
+    console.log('params', params);
 
     return this._basePatch({
       body: normalizeUnsafeMetadata(params),

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -87,6 +87,7 @@ export class User extends BaseResource implements UserResource {
   createOrganizationsLimit: number | null = null;
   deleteSelfEnabled = false;
   lastSignInAt: Date | null = null;
+  legalAcceptedAt: Date | null = null;
   updatedAt: Date | null = null;
   createdAt: Date | null = null;
 
@@ -358,6 +359,10 @@ export class User extends BaseResource implements UserResource {
 
     if (data.last_sign_in_at) {
       this.lastSignInAt = unixEpochToDate(data.last_sign_in_at);
+    }
+
+    if (data.legal_accepted_at) {
+      this.legalAcceptedAt = unixEpochToDate(data.legal_accepted_at);
     }
 
     this.updatedAt = unixEpochToDate(data.updated_at);

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -193,7 +193,7 @@ function _SignUpContinue() {
             gap={8}
           >
             <SocialButtonsReversibleContainerWithDivider>
-              {(showOauthProviders || showWeb3Providers) && (
+              {(showOauthProviders || showWeb3Providers) && !onlyLegalConsentMissing && (
                 <SignUpSocialButtons
                   enableOAuthProviders={showOauthProviders}
                   enableWeb3Providers={showWeb3Providers}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -168,23 +168,21 @@ function _SignUpContinue() {
   const showOauthProviders = !hasVerifiedExternalAccount && oauthOptions.length > 0;
   const showWeb3Providers = !hasVerifiedWeb3 && web3Options.length > 0;
 
+  const headerTitle = !onlyLegalConsentMissing
+    ? localizationKeys('signUp.continue.title')
+    : localizationKeys('signUp.legalConsent.continue.title');
+
+  const headerSubtitle = !onlyLegalConsentMissing
+    ? localizationKeys('signUp.continue.subtitle')
+    : localizationKeys('signUp.legalConsent.continue.subtitle');
+
   return (
     <Flow.Part part='complete'>
       <Card.Root>
         <Card.Content>
           <Header.Root showLogo>
-            <Header.Title
-              localizationKey={
-                !onlyLegalConsentMissing ? localizationKeys('signUp.continue.title') : 'Legal requirements'
-              }
-            />
-            <Header.Subtitle
-              localizationKey={
-                !onlyLegalConsentMissing
-                  ? localizationKeys('signUp.continue.subtitle')
-                  : 'Please accept legal requirements to continue'
-              }
-            />
+            <Header.Title localizationKey={headerTitle} />
+            <Header.Subtitle localizationKey={headerSubtitle} />
           </Header.Root>
           <Card.Alert>{card.error}</Card.Alert>
           <Flex

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -171,11 +171,11 @@ function _SignUpContinue() {
 
   const headerTitle = !onlyLegalConsentMissing
     ? localizationKeys('signUp.continue.title')
-    : localizationKeys('signUp.legalConsent.continue.title');
+    : localizationKeys('signUp.__experimental_legalConsent.continue.title');
 
   const headerSubtitle = !onlyLegalConsentMissing
     ? localizationKeys('signUp.continue.subtitle')
-    : localizationKeys('signUp.legalConsent.continue.subtitle');
+    : localizationKeys('signUp.__experimental_legalConsent.continue.subtitle');
 
   return (
     <Flow.Part part='complete'>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -80,7 +80,7 @@ function _SignUpContinue() {
   } as const;
 
   const onlyLegalConsentMissing = useMemo(
-    () => signUp.missingFields.length === 1 && signUp.missingFields[0] === 'legal_accepted',
+    () => signUp.missingFields && signUp.missingFields.length === 1 && signUp.missingFields[0] === 'legal_accepted',
     [signUp.missingFields],
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -73,7 +73,7 @@ function _SignUpContinue() {
     }),
     __experimental_legalAccepted: useFormControl('__experimental_legalAccepted', '', {
       type: 'checkbox',
-      label: 'I agree to the Terms of Service and Privacy Policy',
+      label: '',
       defaultChecked: false,
       isRequired: userSettings.signUp.legal_consent_enabled || false,
     }),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -71,7 +71,7 @@ function _SignUpContinue() {
       placeholder: localizationKeys('formFieldInputPlaceholder__password'),
       validatePassword: true,
     }),
-    legalAccepted: useFormControl('legalAccepted', '', {
+    __experimental_legalAccepted: useFormControl('__experimental_legalAccepted', '', {
       type: 'checkbox',
       label: 'I agree to the Terms of Service and Privacy Policy',
       defaultChecked: false,
@@ -149,6 +149,7 @@ function _SignUpContinue() {
 
     card.setLoading();
     card.setError(undefined);
+
     return signUp
       .update(buildRequest(fieldsToSubmit))
       .then(res =>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -114,7 +114,12 @@ export const SignUpForm = (props: SignUpFormProps) => {
       )}
       <Col center>
         <CaptchaElement />
-        <Col gap={6}>
+        <Col
+          gap={6}
+          sx={{
+            width: '100%',
+          }}
+        >
           {shouldShow('__experimental_legalAccepted') && (
             <Form.ControlRow elementId='__experimental_legalAccepted'>
               <Form.LegalCheckbox

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Col, localizationKeys, useAppearance } from '../../customizables';
-import { Form } from '../../elements';
+import { Form, LegalCheckbox } from '../../elements';
 import { CaptchaElement } from '../../elements/CaptchaElement';
 import { mqu } from '../../styledSystem';
 import type { FormControlState } from '../../utils';
@@ -122,7 +122,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
         >
           {shouldShow('__experimental_legalAccepted') && (
             <Form.ControlRow elementId='__experimental_legalAccepted'>
-              <Form.LegalCheckbox
+              <LegalCheckbox
                 {...formState.__experimental_legalAccepted.props}
                 isRequired={fields.__experimental_legalAccepted?.required}
               />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -114,12 +114,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
       )}
       <Col center>
         <CaptchaElement />
-        <Col
-          gap={6}
-          sx={{
-            width: '100%',
-          }}
-        >
+        <Col gap={6}>
           {shouldShow('__experimental_legalAccepted') && (
             <Form.ControlRow elementId='__experimental_legalAccepted'>
               <Form.LegalCheckbox

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -47,15 +47,15 @@ export const SignUpForm = (props: SignUpFormProps) => {
             {shouldShow('firstName') && (
               <Form.PlainInput
                 {...formState.firstName.props}
-                isRequired={fields.firstName!.required}
-                isOptional={!fields.firstName!.required}
+                isRequired={fields.firstName?.required}
+                isOptional={!fields.firstName?.required}
               />
             )}
             {shouldShow('lastName') && (
               <Form.PlainInput
                 {...formState.lastName.props}
-                isRequired={fields.lastName!.required}
-                isOptional={!fields.lastName!.required}
+                isRequired={fields.lastName?.required}
+                isOptional={!fields.lastName?.required}
               />
             )}
           </Form.ControlRow>
@@ -64,8 +64,8 @@ export const SignUpForm = (props: SignUpFormProps) => {
           <Form.ControlRow elementId='username'>
             <Form.PlainInput
               {...formState.username.props}
-              isRequired={fields.username!.required}
-              isOptional={!fields.username!.required}
+              isRequired={fields.username?.required}
+              isOptional={!fields.username?.required}
             />
           </Form.ControlRow>
         )}
@@ -73,9 +73,9 @@ export const SignUpForm = (props: SignUpFormProps) => {
           <Form.ControlRow elementId='emailAddress'>
             <Form.PlainInput
               {...formState.emailAddress.props}
-              isRequired={fields.emailAddress!.required}
-              isOptional={!fields.emailAddress!.required}
-              isDisabled={fields.emailAddress!.disabled}
+              isRequired={fields.emailAddress?.required}
+              isOptional={!fields.emailAddress?.required}
+              isDisabled={fields.emailAddress?.disabled}
               actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
               onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
             />
@@ -85,8 +85,8 @@ export const SignUpForm = (props: SignUpFormProps) => {
           <Form.ControlRow elementId='phoneNumber'>
             <Form.PhoneInput
               {...formState.phoneNumber.props}
-              isRequired={fields.phoneNumber!.required}
-              isOptional={!fields.phoneNumber!.required}
+              isRequired={fields.phoneNumber?.required}
+              isOptional={!fields.phoneNumber?.required}
               actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
               onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
             />
@@ -96,21 +96,31 @@ export const SignUpForm = (props: SignUpFormProps) => {
           <Form.ControlRow elementId='password'>
             <Form.PasswordInput
               {...formState.password.props}
-              isRequired={fields.password!.required}
-              isOptional={!fields.password!.required}
+              isRequired={fields.password?.required}
+              isOptional={!fields.password?.required}
             />
           </Form.ControlRow>
         )}
       </Col>
       <Col center>
         <CaptchaElement />
-        <Form.ControlRow elementId='legalConsent'>
-          <Form.Checkbox {...formState.legalAccepted.props} />
-        </Form.ControlRow>
-        <Form.SubmitButton
-          hasArrow
-          localizationKey={localizationKeys('formButtonPrimary')}
-        />
+        <Col
+          gap={4}
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Form.ControlRow elementId='legalConsent'>
+            <Form.Checkbox
+              {...formState.legalAccepted.props}
+              isRequired={fields.legalAccepted?.required}
+            />
+          </Form.ControlRow>
+          <Form.SubmitButton
+            hasArrow
+            localizationKey={localizationKeys('formButtonPrimary')}
+          />
+        </Col>
       </Col>
     </Form.Root>
   );

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -13,10 +13,18 @@ type SignUpFormProps = {
   formState: Record<Exclude<keyof Fields, 'ticket'>, FormControlState<any>>;
   canToggleEmailPhone: boolean;
   handleEmailPhoneToggle: (type: ActiveIdentifier) => void;
+  onlyLegalAcceptedMissing?: boolean;
 };
 
 export const SignUpForm = (props: SignUpFormProps) => {
-  const { handleSubmit, fields, formState, canToggleEmailPhone, handleEmailPhoneToggle } = props;
+  const {
+    handleSubmit,
+    fields,
+    formState,
+    canToggleEmailPhone,
+    onlyLegalAcceptedMissing = false,
+    handleEmailPhoneToggle,
+  } = props;
   const { showOptionalFields } = useAppearance().parsedLayout;
 
   const shouldShow = (name: keyof typeof fields) => {
@@ -34,88 +42,92 @@ export const SignUpForm = (props: SignUpFormProps) => {
       onSubmit={handleSubmit}
       gap={8}
     >
-      <Col gap={6}>
-        {(shouldShow('firstName') || shouldShow('lastName')) && (
-          <Form.ControlRow
-            elementId='name'
-            sx={{
-              [mqu.sm]: {
-                flexWrap: 'wrap',
-              },
-            }}
-          >
-            {shouldShow('firstName') && (
+      {!onlyLegalAcceptedMissing && (
+        <Col gap={6}>
+          {(shouldShow('firstName') || shouldShow('lastName')) && (
+            <Form.ControlRow
+              elementId='name'
+              sx={{
+                [mqu.sm]: {
+                  flexWrap: 'wrap',
+                },
+              }}
+            >
+              {shouldShow('firstName') && (
+                <Form.PlainInput
+                  {...formState.firstName.props}
+                  isRequired={fields.firstName?.required}
+                  isOptional={!fields.firstName?.required}
+                />
+              )}
+              {shouldShow('lastName') && (
+                <Form.PlainInput
+                  {...formState.lastName.props}
+                  isRequired={fields.lastName?.required}
+                  isOptional={!fields.lastName?.required}
+                />
+              )}
+            </Form.ControlRow>
+          )}
+          {shouldShow('username') && (
+            <Form.ControlRow elementId='username'>
               <Form.PlainInput
-                {...formState.firstName.props}
-                isRequired={fields.firstName?.required}
-                isOptional={!fields.firstName?.required}
+                {...formState.username.props}
+                isRequired={fields.username?.required}
+                isOptional={!fields.username?.required}
               />
-            )}
-            {shouldShow('lastName') && (
+            </Form.ControlRow>
+          )}
+          {shouldShow('emailAddress') && (
+            <Form.ControlRow elementId='emailAddress'>
               <Form.PlainInput
-                {...formState.lastName.props}
-                isRequired={fields.lastName?.required}
-                isOptional={!fields.lastName?.required}
+                {...formState.emailAddress.props}
+                isRequired={fields.emailAddress?.required}
+                isOptional={!fields.emailAddress?.required}
+                isDisabled={fields.emailAddress?.disabled}
+                actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
+                onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
               />
-            )}
-          </Form.ControlRow>
-        )}
-        {shouldShow('username') && (
-          <Form.ControlRow elementId='username'>
-            <Form.PlainInput
-              {...formState.username.props}
-              isRequired={fields.username?.required}
-              isOptional={!fields.username?.required}
-            />
-          </Form.ControlRow>
-        )}
-        {shouldShow('emailAddress') && (
-          <Form.ControlRow elementId='emailAddress'>
-            <Form.PlainInput
-              {...formState.emailAddress.props}
-              isRequired={fields.emailAddress?.required}
-              isOptional={!fields.emailAddress?.required}
-              isDisabled={fields.emailAddress?.disabled}
-              actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
-              onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
-            />
-          </Form.ControlRow>
-        )}
-        {shouldShow('phoneNumber') && (
-          <Form.ControlRow elementId='phoneNumber'>
-            <Form.PhoneInput
-              {...formState.phoneNumber.props}
-              isRequired={fields.phoneNumber?.required}
-              isOptional={!fields.phoneNumber?.required}
-              actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
-              onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
-            />
-          </Form.ControlRow>
-        )}
-        {shouldShow('password') && (
-          <Form.ControlRow elementId='password'>
-            <Form.PasswordInput
-              {...formState.password.props}
-              isRequired={fields.password?.required}
-              isOptional={!fields.password?.required}
-            />
-          </Form.ControlRow>
-        )}
-      </Col>
+            </Form.ControlRow>
+          )}
+          {shouldShow('phoneNumber') && (
+            <Form.ControlRow elementId='phoneNumber'>
+              <Form.PhoneInput
+                {...formState.phoneNumber.props}
+                isRequired={fields.phoneNumber?.required}
+                isOptional={!fields.phoneNumber?.required}
+                actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
+                onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
+              />
+            </Form.ControlRow>
+          )}
+          {shouldShow('password') && (
+            <Form.ControlRow elementId='password'>
+              <Form.PasswordInput
+                {...formState.password.props}
+                isRequired={fields.password?.required}
+                isOptional={!fields.password?.required}
+              />
+            </Form.ControlRow>
+          )}
+        </Col>
+      )}
       <Col center>
         <CaptchaElement />
         <Col
-          gap={4}
+          gap={6}
           sx={{
             width: '100%',
           }}
         >
-          <Form.ControlRow elementId='legalConsent'>
-            <Form.Checkbox
-              {...formState.legalAccepted.props}
-              isRequired={fields.legalAccepted?.required}
-            />
-          </Form.ControlRow>
+          {shouldShow('legalAccepted') && (
+            <Form.ControlRow elementId='legalConsent'>
+              <Form.Checkbox
+                {...formState.legalAccepted.props}
+                isRequired={fields.legalAccepted?.required}
+              />
+            </Form.ControlRow>
+          )}
           <Form.SubmitButton
             hasArrow
             localizationKey={localizationKeys('formButtonPrimary')}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -120,11 +120,11 @@ export const SignUpForm = (props: SignUpFormProps) => {
             width: '100%',
           }}
         >
-          {shouldShow('legalAccepted') && (
-            <Form.ControlRow elementId='legalConsent'>
+          {shouldShow('__experimental_legalAccepted') && (
+            <Form.ControlRow elementId='__experimental_legalAccepted'>
               <Form.LegalCheckbox
-                {...formState.legalAccepted.props}
-                isRequired={fields.legalAccepted?.required}
+                {...formState.__experimental_legalAccepted.props}
+                isRequired={fields.__experimental_legalAccepted?.required}
               />
             </Form.ControlRow>
           )}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -104,6 +104,9 @@ export const SignUpForm = (props: SignUpFormProps) => {
       </Col>
       <Col center>
         <CaptchaElement />
+        <Form.ControlRow elementId='legalConsent'>
+          <Form.Checkbox {...formState.legalAccepted.props} />
+        </Form.ControlRow>
         <Form.SubmitButton
           hasArrow
           localizationKey={localizationKeys('formButtonPrimary')}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -122,7 +122,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
         >
           {shouldShow('legalAccepted') && (
             <Form.ControlRow elementId='legalConsent'>
-              <Form.Checkbox
+              <Form.LegalCheckbox
                 {...formState.legalAccepted.props}
                 isRequired={fields.legalAccepted?.required}
               />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
@@ -11,7 +11,7 @@ import { SocialButtons } from '../../elements/SocialButtons';
 import { useRouter } from '../../router';
 import { handleError } from '../../utils';
 
-export type SignUpSocialButtonsProps = SocialButtonsProps & { continueSignUp?: boolean };
+export type SignUpSocialButtonsProps = SocialButtonsProps & { continueSignUp?: boolean; legalAccepted?: boolean };
 
 export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) => {
   const clerk = useClerk();
@@ -35,6 +35,7 @@ export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) 
             redirectUrlComplete,
             strategy,
             unsafeMetadata: ctx.unsafeMetadata,
+            __experimental_legalAccepted: props.legalAccepted,
           })
           .catch(err => handleError(err, [], card.setError));
       }}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
@@ -47,6 +47,7 @@ export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) 
             signUpContinueUrl: 'continue',
             unsafeMetadata: ctx.unsafeMetadata,
             strategy,
+            __experimental_legalAccepted: props.legalAccepted,
           })
           .catch(err => handleError(err, [], card.setError));
       }}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -79,6 +79,10 @@ function _SignUpStart(): JSX.Element {
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),
     }),
+    legalAccepted: useFormControl('legalAccepted', 'false', {
+      type: 'checkbox',
+      label: 'I agree to the terms and conditions',
+    }),
     password: useFormControl('password', '', {
       type: 'password',
       label: localizationKeys('formFieldLabel__password'),
@@ -203,6 +207,8 @@ function _SignUpStart(): JSX.Element {
       // fieldsToSubmit: Constructing a fake fields object for strategy.
       fieldsToSubmit.push({ id: 'strategy', value: 'ticket', setValue: noop, onChange: noop, setError: noop } as any);
     }
+
+    console.log('fieldsToSubmit', fieldsToSubmit);
 
     // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
     // add both to the submitted fields to trigger and render an error for both respective inputs

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -80,7 +80,7 @@ function _SignUpStart(): JSX.Element {
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),
     }),
-    legalAccepted: useFormControl('legalConsent', '', {
+    __experimental_legalAccepted: useFormControl('__experimental_legalAccepted', '', {
       type: 'checkbox',
       label: 'I agree to the Terms of Service and Privacy Policy',
       defaultChecked: false,
@@ -279,7 +279,7 @@ function _SignUpStart(): JSX.Element {
                   enableOAuthProviders={showOauthProviders}
                   enableWeb3Providers={showWeb3Providers}
                   continueSignUp={missingRequirementsWithTicket}
-                  legalAccepted={Boolean(formState.legalAccepted.value)}
+                  legalAccepted={Boolean(formState.__experimental_legalAccepted.value)}
                 />
               )}
               {shouldShowForm && (
@@ -293,10 +293,10 @@ function _SignUpStart(): JSX.Element {
               )}
             </SocialButtonsReversibleContainerWithDivider>
             {!shouldShowForm && (
-              <Form.ControlRow elementId='legalConsent'>
+              <Form.ControlRow elementId='__experimental_legalAccepted'>
                 <Form.LegalCheckbox
-                  {...formState.legalAccepted.props}
-                  isRequired={fields.legalAccepted?.required}
+                  {...formState.__experimental_legalAccepted.props}
+                  isRequired={fields.__experimental_legalAccepted?.required}
                 />
               </Form.ControlRow>
             )}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -8,6 +8,7 @@ import { useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts'
 import { descriptors, Flex, Flow, localizationKeys, useAppearance, useLocalizations } from '../../customizables';
 import {
   Card,
+  Form,
   Header,
   LoadingCard,
   SocialButtonsReversibleContainerWithDivider,
@@ -79,7 +80,7 @@ function _SignUpStart(): JSX.Element {
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),
     }),
-    legalAccepted: useFormControl('legalAccepted', '', {
+    legalAccepted: useFormControl('legalConsent', '', {
       type: 'checkbox',
       label: 'I agree to the Terms of Service and Privacy Policy',
       defaultChecked: false,
@@ -278,6 +279,7 @@ function _SignUpStart(): JSX.Element {
                   enableOAuthProviders={showOauthProviders}
                   enableWeb3Providers={showWeb3Providers}
                   continueSignUp={missingRequirementsWithTicket}
+                  legalAccepted={Boolean(formState.legalAccepted.value)}
                 />
               )}
               {shouldShowForm && (
@@ -290,6 +292,14 @@ function _SignUpStart(): JSX.Element {
                 />
               )}
             </SocialButtonsReversibleContainerWithDivider>
+            {!shouldShowForm && (
+              <Form.ControlRow elementId='legalConsent'>
+                <Form.LegalCheckbox
+                  {...formState.legalAccepted.props}
+                  isRequired={fields.legalAccepted?.required}
+                />
+              </Form.ControlRow>
+            )}
             {!shouldShowForm && <CaptchaElement />}
           </Flex>
         </Card.Content>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -83,7 +83,7 @@ function _SignUpStart(): JSX.Element {
     }),
     __experimental_legalAccepted: useFormControl('__experimental_legalAccepted', '', {
       type: 'checkbox',
-      label: 'I agree to the Terms of Service and Privacy Policy',
+      label: '',
       defaultChecked: false,
       isRequired: userSettings.signUp.legal_consent_enabled || false,
     }),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   Form,
   Header,
+  LegalCheckbox,
   LoadingCard,
   SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
@@ -294,7 +295,7 @@ function _SignUpStart(): JSX.Element {
             </SocialButtonsReversibleContainerWithDivider>
             {!shouldShowForm && (
               <Form.ControlRow elementId='__experimental_legalAccepted'>
-                <Form.LegalCheckbox
+                <LegalCheckbox
                   {...formState.__experimental_legalAccepted.props}
                   isRequired={fields.__experimental_legalAccepted?.required}
                 />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -279,7 +279,7 @@ function _SignUpStart(): JSX.Element {
                   enableOAuthProviders={showOauthProviders}
                   enableWeb3Providers={showWeb3Providers}
                   continueSignUp={missingRequirementsWithTicket}
-                  legalAccepted={Boolean(formState.__experimental_legalAccepted.value)}
+                  legalAccepted={Boolean(formState.__experimental_legalAccepted.checked)}
                 />
               )}
               {shouldShowForm && (

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
@@ -78,6 +78,23 @@ describe('SignUpContinue', () => {
     expect(button.parentElement?.tagName.toUpperCase()).toBe('BUTTON');
   });
 
+  it('renders the component if there is a persisted sign up and legal accepted is missing', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress({ required: true });
+      f.withPassword({ required: true });
+      f.startSignUpWithEmailAddress();
+      f.withLegalConsent();
+      f.withTermsPrivacyPolicyUrls({
+        privacyPolicy: 'https://clerk.dev/privacy',
+        termsOfService: 'https://clerk.dev/tos',
+      });
+    });
+    render(<SignUpContinue />, { wrapper });
+    screen.getByText(/missing/i);
+    screen.getByText(/Terms Of Service/i);
+    screen.getByText(/Privacy Policy/i);
+  });
+
   it.each(OAUTH_PROVIDERS)('shows the "Continue with $name" social OAuth button', async ({ provider, name }) => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress({ required: true });

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
@@ -89,7 +89,7 @@ describe('SignUpContinue', () => {
         termsOfService: 'https://clerk.dev/tos',
       });
     });
-    render(<SignUpContinue />, { wrapper });
+    const screen = render(<SignUpContinue />, { wrapper });
     screen.getByText(/missing/i);
     screen.getByText(/Terms Of Service/i);
     screen.getByText(/Privacy Policy/i);

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
@@ -82,7 +82,7 @@ describe('SignUpContinue', () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress({ required: true });
       f.withPassword({ required: true });
-      f.startSignUpWithEmailAddress();
+      f.startSignUpWithMissingLegalAccepted();
       f.withLegalConsent();
       f.withTermsPrivacyPolicyUrls({
         privacyPolicy: 'https://clerk.dev/privacy',
@@ -90,7 +90,6 @@ describe('SignUpContinue', () => {
       });
     });
     const screen = render(<SignUpContinue />, { wrapper });
-    screen.getByText(/missing/i);
     screen.getByText(/Terms Of Service/i);
     screen.getByText(/Privacy Policy/i);
   });

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -259,6 +259,7 @@ describe('SignUpStart', () => {
   describe('Legal consent', () => {
     it('shows sign up component with legal consent checkbox', async () => {
       const { wrapper } = await createFixtures(f => {
+        f.withLegalConsent();
         f.withTermsPrivacyPolicyUrls({
           privacyPolicy: 'https://clerk.dev/privacy',
           termsOfService: 'https://clerk.dev/tos',

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -220,7 +220,7 @@ describe('SignUpStart', () => {
       });
       props.setProps({ initialValues: { emailAddress: 'foo@clerk.com' } });
 
-      render(<SignUpStart />, { wrapper });
+      const screen = render(<SignUpStart />, { wrapper });
       screen.getByDisplayValue(/foo@clerk.com/i);
     });
 
@@ -230,7 +230,7 @@ describe('SignUpStart', () => {
       });
       props.setProps({ initialValues: { phoneNumber: '+306911111111' } });
 
-      render(<SignUpStart />, { wrapper });
+      const screen = render(<SignUpStart />, { wrapper });
       screen.getByDisplayValue(/691 1111111/i);
     });
 
@@ -251,8 +251,8 @@ describe('SignUpStart', () => {
         f.withRestrictedMode();
       });
 
-      render(<SignUpStart />, { wrapper });
-      screen.getByText('Access restricted');
+      const screen = render(<SignUpStart />, { wrapper });
+      screen.getByText('Restricted access');
     });
   });
 
@@ -265,7 +265,7 @@ describe('SignUpStart', () => {
         });
       });
 
-      render(<SignUpStart />, { wrapper });
+      const screen = render(<SignUpStart />, { wrapper });
       screen.getByText('Terms of Service');
       screen.getByText('Privacy Policy');
     });

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -256,6 +256,21 @@ describe('SignUpStart', () => {
     });
   });
 
+  describe('Legal consent', () => {
+    it('shows sign up component with legal consent checkbox', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withTermsPrivacyPolicyUrls({
+          privacyPolicy: 'https://clerk.dev/privacy',
+          termsOfService: 'https://clerk.dev/tos',
+        });
+      });
+
+      render(<SignUpStart />, { wrapper });
+      screen.getByText('Terms of Service');
+      screen.getByText('Privacy Policy');
+    });
+  });
+
   describe('ticket flow', () => {
     it('calls the appropriate resource function upon detecting the ticket', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -220,7 +220,7 @@ describe('SignUpStart', () => {
       });
       props.setProps({ initialValues: { emailAddress: 'foo@clerk.com' } });
 
-      const screen = render(<SignUpStart />, { wrapper });
+      render(<SignUpStart />, { wrapper });
       screen.getByDisplayValue(/foo@clerk.com/i);
     });
 
@@ -230,7 +230,7 @@ describe('SignUpStart', () => {
       });
       props.setProps({ initialValues: { phoneNumber: '+306911111111' } });
 
-      const screen = render(<SignUpStart />, { wrapper });
+      render(<SignUpStart />, { wrapper });
       screen.getByDisplayValue(/691 1111111/i);
     });
 
@@ -251,8 +251,8 @@ describe('SignUpStart', () => {
         f.withRestrictedMode();
       });
 
-      const screen = render(<SignUpStart />, { wrapper });
-      screen.getByText('Restricted access');
+      render(<SignUpStart />, { wrapper });
+      screen.getByText('Access restricted');
     });
   });
 
@@ -265,7 +265,7 @@ describe('SignUpStart', () => {
         });
       });
 
-      const screen = render(<SignUpStart />, { wrapper });
+      render(<SignUpStart />, { wrapper });
       screen.getByText('Terms of Service');
       screen.getByText('Privacy Policy');
     });

--- a/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
@@ -16,7 +16,7 @@ const FieldKeys = [
   'lastName',
   'password',
   'ticket',
-  'legalAccepted',
+  '__experimental_legalAccepted',
 ] as const;
 export type FieldKey = (typeof FieldKeys)[number];
 
@@ -91,7 +91,7 @@ export function minimizeFieldsForExistingSignup(fields: Fields, signUp: SignUpRe
     }
 
     if (hasLegalAccepted) {
-      delete fields.legalAccepted;
+      delete fields.__experimental_legalAccepted;
     }
 
     // Hide any non-required fields
@@ -148,7 +148,7 @@ function getField(fieldKey: FieldKey, fieldProps: FieldDeterminationProps): Fiel
       return getPasswordField(fieldProps.attributes);
     case 'ticket':
       return getTicketField(fieldProps.hasTicket);
-    case 'legalAccepted':
+    case '__experimental_legalAccepted':
       return getLegalAcceptedField(fieldProps.legalConsentRequired);
     case 'username':
     case 'firstName':

--- a/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
@@ -8,7 +8,16 @@ import type { FieldState } from '../../common';
  */
 export type ActiveIdentifier = 'emailAddress' | 'phoneNumber' | null | undefined;
 
-const FieldKeys = ['emailAddress', 'phoneNumber', 'username', 'firstName', 'lastName', 'password', 'ticket'];
+const FieldKeys = [
+  'emailAddress',
+  'phoneNumber',
+  'username',
+  'firstName',
+  'lastName',
+  'password',
+  'ticket',
+  'legalAccepted',
+] as const;
 export type FieldKey = (typeof FieldKeys)[number];
 
 export type FormState<T> = {
@@ -34,10 +43,11 @@ type FieldDeterminationProps = {
   hasEmail?: boolean;
   signUp?: SignUpResource | undefined;
   isProgressiveSignUp: boolean;
+  legalConsentRequired?: boolean;
 };
 
 export function determineActiveFields(fieldProps: FieldDeterminationProps): Fields {
-  return FieldKeys.reduce((fields: Fields, fieldKey: string) => {
+  return FieldKeys.reduce((fields: Fields, fieldKey: FieldKey) => {
     const field = getField(fieldKey, fieldProps);
     if (field) {
       fields[fieldKey] = field;
@@ -50,10 +60,11 @@ export function determineActiveFields(fieldProps: FieldDeterminationProps): Fiel
 export function minimizeFieldsForExistingSignup(fields: Fields, signUp: SignUpResource) {
   if (signUp) {
     const hasEmailFilled = !!signUp.emailAddress;
-    const hasVerifiedEmail = signUp.verifications?.emailAddress?.status == 'verified';
-    const hasVerifiedPhone = signUp.verifications?.phoneNumber?.status == 'verified';
-    const hasVerifiedExternalAccount = signUp.verifications?.externalAccount?.status == 'verified';
-    const hasVerifiedWeb3Wallet = signUp.verifications?.web3Wallet?.status == 'verified';
+    const hasVerifiedEmail = signUp.verifications?.emailAddress?.status === 'verified';
+    const hasVerifiedPhone = signUp.verifications?.phoneNumber?.status === 'verified';
+    const hasVerifiedExternalAccount = signUp.verifications?.externalAccount?.status === 'verified';
+    const hasVerifiedWeb3Wallet = signUp.verifications?.web3Wallet?.status === 'verified';
+    const hasLegalAccepted = signUp.legalAcceptedAt !== null;
 
     if (hasEmailFilled && hasVerifiedEmail) {
       delete fields.emailAddress;
@@ -77,6 +88,10 @@ export function minimizeFieldsForExistingSignup(fields: Fields, signUp: SignUpRe
 
     if (signUp.username) {
       delete fields.username;
+    }
+
+    if (hasLegalAccepted) {
+      delete fields.legalAccepted;
     }
 
     // Hide any non-required fields
@@ -133,6 +148,8 @@ function getField(fieldKey: FieldKey, fieldProps: FieldDeterminationProps): Fiel
       return getPasswordField(fieldProps.attributes);
     case 'ticket':
       return getTicketField(fieldProps.hasTicket);
+    case 'legalAccepted':
+      return getLegalAcceptedField(fieldProps.legalConsentRequired);
     case 'username':
     case 'firstName':
     case 'lastName':
@@ -174,7 +191,7 @@ function getEmailAddressField({
     (!hasTicket || (hasTicket && hasEmail)) &&
     attributes.email_address.enabled &&
     attributes.email_address.used_for_first_factor &&
-    activeCommIdentifierType == 'emailAddress';
+    activeCommIdentifierType === 'emailAddress';
 
   if (!show) {
     return;
@@ -215,7 +232,7 @@ function getPhoneNumberField({
     !hasTicket &&
     attributes.phone_number.enabled &&
     attributes.phone_number.used_for_first_factor &&
-    activeCommIdentifierType == 'phoneNumber';
+    activeCommIdentifierType === 'phoneNumber';
 
   if (!show) {
     return;
@@ -249,16 +266,26 @@ function getTicketField(hasTicket?: boolean): Field | undefined {
   };
 }
 
+function getLegalAcceptedField(legalConsentRequired?: boolean): Field | undefined {
+  if (!legalConsentRequired) {
+    return;
+  }
+
+  return {
+    required: true,
+  };
+}
+
 function getGenericField(fieldKey: FieldKey, attributes: Attributes): Field | undefined {
   const attrKey = camelToSnake(fieldKey);
 
-  // @ts-ignore
+  // @ts-expect-error - TS doesn't know that the key exists
   if (!attributes[attrKey].enabled) {
     return;
   }
 
   return {
-    // @ts-ignore
+    // @ts-expect-error - TS doesn't know that the key exists
     required: attributes[attrKey].required,
   };
 }

--- a/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
@@ -97,7 +97,7 @@ export function minimizeFieldsForExistingSignup(fields: Fields, signUp: SignUpRe
     // Hide any non-required fields
     Object.entries(fields).forEach(([k, v]) => {
       if (v && !v.required) {
-        delete fields[k];
+        delete fields[k as FieldKey];
       }
     });
   }

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -234,6 +234,7 @@ const LegalCheckbox = (
             flexDirection: 'column',
           })}
         >
+          {/* TODO(@vaggelis): Handle the legal label */}
           <Text
             elementDescriptor={descriptors.formFieldRadioLabelTitle}
             variant='subtitle'

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -3,8 +3,21 @@ import type { FieldId } from '@clerk/types';
 import type { PropsWithChildren } from 'react';
 import React, { forwardRef, useState } from 'react';
 
+import { useEnvironment } from '../../ui/contexts';
 import type { LocalizationKey } from '../customizables';
-import { Button, Col, descriptors, Flex, Form as FormPrim, FormLabel, localizationKeys, Text } from '../customizables';
+import {
+  Button,
+  Col,
+  descriptors,
+  Flex,
+  Form as FormPrim,
+  FormLabel,
+  Link,
+  localizationKeys,
+  Text,
+  useAppearance,
+  useLocalizations,
+} from '../customizables';
 import { useLoadingStatus } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
 import type { OTPInputProps } from './CodeControl';
@@ -216,29 +229,75 @@ const Checkbox = (
   );
 };
 
+const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: string }) => {
+  const { t } = useLocalizations();
+  return (
+    <Text
+      variant='subtitle'
+      as='span'
+    >
+      {t(localizationKeys('signUp.legalConsent.checkbox.label__prefixText'))}
+      {props.termsUrl && (
+        <>
+          {' '}
+          <Link
+            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__termsOfServiceText')}
+            href={props.termsUrl}
+            sx={{
+              textDecoration: 'underline',
+            }}
+          />
+        </>
+      )}
+
+      {props.termsUrl && props.privacyPolicyUrl && (
+        <> {t(localizationKeys('signUp.legalConsent.checkbox.label__conjunctionText'))} </>
+      )}
+
+      {props.privacyPolicyUrl && (
+        <Link
+          localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
+          href={props.termsUrl}
+          sx={{
+            textDecoration: 'underline',
+            display: 'inline-block',
+          }}
+        />
+      )}
+    </Text>
+  );
+};
+
 const LegalCheckbox = (
   props: CommonFieldRootProps & {
     description?: string | LocalizationKey;
   },
 ) => {
+  const { displayConfig } = useEnvironment();
+  const { parsedLayout } = useAppearance();
+
+  const termsLink = parsedLayout.termsPageUrl || displayConfig.termsUrl || '/terms';
+  const privacyPolicy = parsedLayout.termsPageUrl || displayConfig.termsUrl || '/privacy';
+
   return (
     <Field.Root {...props}>
-      <Flex align='start'>
+      <Flex
+        align='start'
+        sx={t => ({
+          gap: t.space.$1x5,
+        })}
+      >
         <Field.CheckboxIndicator />
         <FormLabel
           elementDescriptor={descriptors.formFieldRadioLabel}
           htmlFor={props.itemID}
-          sx={t => ({
-            padding: `${t.space.$none} ${t.space.$2}`,
-            display: 'flex',
-            flexDirection: 'column',
-          })}
+          sx={{
+            textAlign: 'initial',
+          }}
         >
-          {/* TODO(@vaggelis): Handle the legal label */}
-          <Text
-            elementDescriptor={descriptors.formFieldRadioLabelTitle}
-            variant='subtitle'
-            localizationKey={props.label}
+          <LegalCheckboxLabel
+            termsUrl={termsLink}
+            privacyPolicyUrl={privacyPolicy}
           />
         </FormLabel>
       </Flex>

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -3,21 +3,8 @@ import type { FieldId } from '@clerk/types';
 import type { PropsWithChildren } from 'react';
 import React, { forwardRef, useState } from 'react';
 
-import { useEnvironment } from '../../ui/contexts';
 import type { LocalizationKey } from '../customizables';
-import {
-  Button,
-  Col,
-  descriptors,
-  Flex,
-  Form as FormPrim,
-  FormLabel,
-  Link,
-  localizationKeys,
-  Text,
-  useAppearance,
-  useLocalizations,
-} from '../customizables';
+import { Button, Col, descriptors, Flex, Form as FormPrim, localizationKeys } from '../customizables';
 import { useLoadingStatus } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
 import type { OTPInputProps } from './CodeControl';
@@ -229,85 +216,6 @@ const Checkbox = (
   );
 };
 
-const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: string }) => {
-  const { t } = useLocalizations();
-  return (
-    <Text
-      variant='body'
-      as='span'
-    >
-      {t(localizationKeys('signUp.legalConsent.checkbox.label__prefixText'))}
-      {props.termsUrl && (
-        <>
-          {' '}
-          <Link
-            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__termsOfServiceText')}
-            href={props.termsUrl}
-            sx={{
-              textDecoration: 'underline',
-            }}
-            isExternal
-          />
-        </>
-      )}
-
-      {props.termsUrl && props.privacyPolicyUrl && (
-        <> {t(localizationKeys('signUp.legalConsent.checkbox.label__conjunctionText'))} </>
-      )}
-
-      {props.privacyPolicyUrl && (
-        <>
-          {' '}
-          <Link
-            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
-            href={props.termsUrl}
-            sx={{
-              textDecoration: 'underline',
-              display: 'inline-block',
-            }}
-            isExternal
-          />
-        </>
-      )}
-    </Text>
-  );
-};
-
-const LegalCheckbox = (
-  props: CommonFieldRootProps & {
-    description?: string | LocalizationKey;
-  },
-) => {
-  const { displayConfig } = useEnvironment();
-  const { parsedLayout } = useAppearance();
-
-  const termsLink = parsedLayout.termsPageUrl || displayConfig.termsUrl;
-  const privacyPolicy = parsedLayout.privacyPageUrl || displayConfig.privacyPolicyUrl;
-
-  return (
-    <Field.Root {...props}>
-      <Flex
-        align='center'
-        justify='center'
-      >
-        <Field.CheckboxIndicator />
-        <FormLabel
-          elementDescriptor={descriptors.formFieldRadioLabel}
-          htmlFor={props.itemID}
-          sx={t => ({
-            paddingLeft: t.space.$1x5,
-          })}
-        >
-          <LegalCheckboxLabel
-            termsUrl={termsLink}
-            privacyPolicyUrl={privacyPolicy}
-          />
-        </FormLabel>
-      </Flex>
-    </Field.Root>
-  );
-};
-
 const RadioGroup = (
   props: Omit<PropsOfComponent<typeof Field.Root>, 'infoText' | 'type' | 'validatePassword' | 'label' | 'placeholder'>,
 ) => {
@@ -388,7 +296,6 @@ export const Form = {
   InputGroup,
   RadioGroup,
   Checkbox,
-  LegalCheckbox: LegalCheckbox,
   SubmitButton: FormSubmit,
   ResetButton: FormReset,
 };

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -246,6 +246,7 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
             sx={{
               textDecoration: 'underline',
             }}
+            isExternal
           />
         </>
       )}
@@ -255,14 +256,18 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
       )}
 
       {props.privacyPolicyUrl && (
-        <Link
-          localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
-          href={props.termsUrl}
-          sx={{
-            textDecoration: 'underline',
-            display: 'inline-block',
-          }}
-        />
+        <>
+          {' '}
+          <Link
+            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
+            href={props.termsUrl}
+            sx={{
+              textDecoration: 'underline',
+              display: 'inline-block',
+            }}
+            isExternal
+          />
+        </>
       )}
     </Text>
   );
@@ -276,8 +281,8 @@ const LegalCheckbox = (
   const { displayConfig } = useEnvironment();
   const { parsedLayout } = useAppearance();
 
-  const termsLink = parsedLayout.termsPageUrl || displayConfig.termsUrl || '/terms';
-  const privacyPolicy = parsedLayout.termsPageUrl || displayConfig.termsUrl || '/privacy';
+  const termsLink = parsedLayout.termsPageUrl || displayConfig.termsUrl;
+  const privacyPolicy = parsedLayout.privacyPageUrl || displayConfig.privacyPolicyUrl;
 
   return (
     <Field.Root {...props}>

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -233,7 +233,7 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
   const { t } = useLocalizations();
   return (
     <Text
-      variant='subtitle'
+      variant='body'
       as='span'
     >
       {t(localizationKeys('signUp.legalConsent.checkbox.label__prefixText'))}
@@ -282,18 +282,16 @@ const LegalCheckbox = (
   return (
     <Field.Root {...props}>
       <Flex
-        align='start'
-        sx={t => ({
-          gap: t.space.$1x5,
-        })}
+        align='center'
+        justify='center'
       >
         <Field.CheckboxIndicator />
         <FormLabel
           elementDescriptor={descriptors.formFieldRadioLabel}
           htmlFor={props.itemID}
-          sx={{
-            textAlign: 'initial',
-          }}
+          sx={t => ({
+            paddingLeft: t.space.$1x5,
+          })}
         >
           <LegalCheckboxLabel
             termsUrl={termsLink}

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from 'react';
 import React, { forwardRef, useState } from 'react';
 
 import type { LocalizationKey } from '../customizables';
-import { Button, Col, descriptors, Flex, Form as FormPrim, localizationKeys } from '../customizables';
+import { Button, Col, descriptors, Flex, Form as FormPrim, FormLabel, localizationKeys, Text } from '../customizables';
 import { useLoadingStatus } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
 import type { OTPInputProps } from './CodeControl';
@@ -201,6 +201,8 @@ const InputGroup = (
 const Checkbox = (
   props: CommonFieldRootProps & {
     description?: string | LocalizationKey;
+    termsLink?: string;
+    privacyLink?: string;
   },
 ) => {
   return (
@@ -209,6 +211,35 @@ const Checkbox = (
       <Flex align='start'>
         <Field.CheckboxIndicator />
         <Field.CheckboxLabel description={props.description} />
+      </Flex>
+    </Field.Root>
+  );
+};
+
+const LegalCheckbox = (
+  props: CommonFieldRootProps & {
+    description?: string | LocalizationKey;
+  },
+) => {
+  return (
+    <Field.Root {...props}>
+      <Flex align='start'>
+        <Field.CheckboxIndicator />
+        <FormLabel
+          elementDescriptor={descriptors.formFieldRadioLabel}
+          htmlFor={props.itemID}
+          sx={t => ({
+            padding: `${t.space.$none} ${t.space.$2}`,
+            display: 'flex',
+            flexDirection: 'column',
+          })}
+        >
+          <Text
+            elementDescriptor={descriptors.formFieldRadioLabelTitle}
+            variant='subtitle'
+            localizationKey={props.label}
+          />
+        </FormLabel>
       </Flex>
     </Field.Root>
   );
@@ -294,6 +325,7 @@ export const Form = {
   InputGroup,
   RadioGroup,
   Checkbox,
+  LegalCheckbox: LegalCheckbox,
   SubmitButton: FormSubmit,
   ResetButton: FormReset,
 };

--- a/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
+++ b/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useEnvironment } from '../../ui/contexts';
 import type { LocalizationKey } from '../customizables';
 import {

--- a/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
+++ b/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
@@ -20,12 +20,12 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
       variant='body'
       as='span'
     >
-      {t(localizationKeys('signUp.legalConsent.checkbox.label__prefixText'))}
+      {t(localizationKeys('signUp.__experimental_legalConsent.checkbox.label__prefixText'))}
       {props.termsUrl && (
         <>
           {' '}
           <Link
-            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__termsOfServiceText')}
+            localizationKey={localizationKeys('signUp.__experimental_legalConsent.checkbox.label__termsOfServiceText')}
             href={props.termsUrl}
             sx={{
               textDecoration: 'underline',
@@ -36,14 +36,14 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
       )}
 
       {props.termsUrl && props.privacyPolicyUrl && (
-        <> {t(localizationKeys('signUp.legalConsent.checkbox.label__conjunctionText'))} </>
+        <> {t(localizationKeys('signUp.__experimental_legalConsent.checkbox.label__conjunctionText'))} </>
       )}
 
       {props.privacyPolicyUrl && (
         <>
           {' '}
           <Link
-            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
+            localizationKey={localizationKeys('signUp.__experimental_legalConsent.checkbox.label__privacyPolicyText')}
             href={props.termsUrl}
             sx={{
               textDecoration: 'underline',

--- a/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
+++ b/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
@@ -4,7 +4,6 @@ import {
   descriptors,
   Flex,
   FormLabel,
-  Link,
   localizationKeys,
   Text,
   useAppearance,
@@ -12,47 +11,44 @@ import {
 } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 import { Field } from './FieldControl';
+import { LinkRenderer } from './LinkRenderer';
 
 const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: string }) => {
+  const { termsUrl, privacyPolicyUrl } = props;
   const { t } = useLocalizations();
+  let localizationKey: LocalizationKey | undefined;
+
+  if (termsUrl && privacyPolicyUrl) {
+    localizationKey = localizationKeys(
+      'signUp.__experimental_legalConsent.checkbox.label__termsOfServiceAndPrivacyPolicy',
+      {
+        termsOfServiceLink: props.termsUrl,
+        privacyPolicyLink: props.privacyPolicyUrl,
+      },
+    );
+  } else if (termsUrl) {
+    localizationKey = localizationKeys('signUp.__experimental_legalConsent.checkbox.label__onlyTermsOfService', {
+      termsOfServiceLink: props.termsUrl,
+    });
+  } else if (privacyPolicyUrl) {
+    localizationKey = localizationKeys('signUp.__experimental_legalConsent.checkbox.label__onlyPrivacyPolicy', {
+      privacyPolicyLink: props.privacyPolicyUrl,
+    });
+  }
+
   return (
     <Text
       variant='body'
       as='span'
     >
-      {t(localizationKeys('signUp.__experimental_legalConsent.checkbox.label__prefixText'))}
-      {props.termsUrl && (
-        <>
-          {' '}
-          <Link
-            localizationKey={localizationKeys('signUp.__experimental_legalConsent.checkbox.label__termsOfServiceText')}
-            href={props.termsUrl}
-            sx={{
-              textDecoration: 'underline',
-            }}
-            isExternal
-          />
-        </>
-      )}
-
-      {props.termsUrl && props.privacyPolicyUrl && (
-        <> {t(localizationKeys('signUp.__experimental_legalConsent.checkbox.label__conjunctionText'))} </>
-      )}
-
-      {props.privacyPolicyUrl && (
-        <>
-          {' '}
-          <Link
-            localizationKey={localizationKeys('signUp.__experimental_legalConsent.checkbox.label__privacyPolicyText')}
-            href={props.termsUrl}
-            sx={{
-              textDecoration: 'underline',
-              display: 'inline-block',
-            }}
-            isExternal
-          />
-        </>
-      )}
+      <LinkRenderer
+        text={t(localizationKey)}
+        isExternal
+        sx={t => ({
+          textDecoration: 'underline',
+          textUnderlineOffset: t.space.$1,
+        })}
+      />
     </Text>
   );
 };
@@ -82,6 +78,7 @@ export const LegalCheckbox = (
           htmlFor={props.itemID}
           sx={t => ({
             paddingLeft: t.space.$1x5,
+            textAlign: 'left',
           })}
         >
           <LegalCheckboxLabel

--- a/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
+++ b/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+import { useEnvironment } from '../../ui/contexts';
+import type { LocalizationKey } from '../customizables';
+import {
+  descriptors,
+  Flex,
+  FormLabel,
+  Link,
+  localizationKeys,
+  Text,
+  useAppearance,
+  useLocalizations,
+} from '../customizables';
+import type { PropsOfComponent } from '../styledSystem';
+import { Field } from './FieldControl';
+
+const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: string }) => {
+  const { t } = useLocalizations();
+  return (
+    <Text
+      variant='body'
+      as='span'
+    >
+      {t(localizationKeys('signUp.legalConsent.checkbox.label__prefixText'))}
+      {props.termsUrl && (
+        <>
+          {' '}
+          <Link
+            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__termsOfServiceText')}
+            href={props.termsUrl}
+            sx={{
+              textDecoration: 'underline',
+            }}
+            isExternal
+          />
+        </>
+      )}
+
+      {props.termsUrl && props.privacyPolicyUrl && (
+        <> {t(localizationKeys('signUp.legalConsent.checkbox.label__conjunctionText'))} </>
+      )}
+
+      {props.privacyPolicyUrl && (
+        <>
+          {' '}
+          <Link
+            localizationKey={localizationKeys('signUp.legalConsent.checkbox.label__privacyPolicyText')}
+            href={props.termsUrl}
+            sx={{
+              textDecoration: 'underline',
+              display: 'inline-block',
+            }}
+            isExternal
+          />
+        </>
+      )}
+    </Text>
+  );
+};
+
+type CommonFieldRootProps = Omit<PropsOfComponent<typeof Field.Root>, 'children' | 'elementDescriptor' | 'elementId'>;
+
+export const LegalCheckbox = (
+  props: CommonFieldRootProps & {
+    description?: string | LocalizationKey;
+  },
+) => {
+  const { displayConfig } = useEnvironment();
+  const { parsedLayout } = useAppearance();
+
+  const termsLink = parsedLayout.termsPageUrl || displayConfig.termsUrl;
+  const privacyPolicy = parsedLayout.privacyPageUrl || displayConfig.privacyPolicyUrl;
+
+  return (
+    <Field.Root {...props}>
+      <Flex
+        align='center'
+        justify='center'
+      >
+        <Field.CheckboxIndicator />
+        <FormLabel
+          elementDescriptor={descriptors.formFieldRadioLabel}
+          htmlFor={props.itemID}
+          sx={t => ({
+            paddingLeft: t.space.$1x5,
+          })}
+        >
+          <LegalCheckboxLabel
+            termsUrl={termsLink}
+            privacyPolicyUrl={privacyPolicy}
+          />
+        </FormLabel>
+      </Flex>
+    </Field.Root>
+  );
+};

--- a/packages/clerk-js/src/ui/elements/LinkRenderer.tsx
+++ b/packages/clerk-js/src/ui/elements/LinkRenderer.tsx
@@ -1,0 +1,44 @@
+import React, { memo, useMemo } from 'react';
+
+import { Link } from '../customizables';
+import type { PropsOfComponent } from '../styledSystem';
+
+interface LinkRendererProps extends Omit<PropsOfComponent<typeof Link>, 'href' | 'children'> {
+  text: string;
+}
+
+const LINK_REGEX = /\[([^\]]+)\]\(([^)]+)\)/g; // parses [text](url)
+
+export const LinkRenderer: React.FC<LinkRendererProps> = memo(({ text, ...linkProps }) => {
+  const memoizedLinkProps = useMemo(() => linkProps, [linkProps]);
+
+  const renderedContent = useMemo(() => {
+    const parts: (string | JSX.Element)[] = [];
+    let lastIndex = 0;
+
+    text.replace(LINK_REGEX, (match, linkText, url, offset) => {
+      if (offset > lastIndex) {
+        parts.push(text.slice(lastIndex, offset));
+      }
+      parts.push(
+        <Link
+          key={offset}
+          href={url}
+          {...memoizedLinkProps}
+        >
+          {linkText}
+        </Link>,
+      );
+      lastIndex = offset + match.length;
+      return match;
+    });
+
+    if (lastIndex < text.length) {
+      parts.push(text.slice(lastIndex));
+    }
+
+    return parts;
+  }, [text, memoizedLinkProps]);
+
+  return renderedContent;
+});

--- a/packages/clerk-js/src/ui/elements/__tests__/LinkRenderer.test.tsx
+++ b/packages/clerk-js/src/ui/elements/__tests__/LinkRenderer.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it } from '@jest/globals';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { bindCreateFixtures } from '../../utils/test/createFixtures';
+import { LinkRenderer } from '../LinkRenderer';
+
+const { createFixtures } = bindCreateFixtures('UserProfile');
+
+describe('LinkRenderer', () => {
+  it('renders a simple link', async () => {
+    const { wrapper } = await createFixtures();
+
+    const screen = render(<LinkRenderer text='I agree to the [Terms of Service](https://example.com/terms)' />, {
+      wrapper,
+    });
+
+    expect(screen.queryByRole('link', { name: 'Terms of Service' })).toBeInTheDocument();
+  });
+
+  it('renders multiple links', async () => {
+    const { wrapper } = await createFixtures();
+
+    const screen = render(
+      <LinkRenderer text='I agree to the [Terms of Service](https://example.com/terms) and [Privacy Policy](https://example.com/privacy)' />,
+      { wrapper },
+    );
+
+    expect(screen.queryByRole('link', { name: 'Terms of Service' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument();
+  });
+
+  it('does not render links with broken format', async () => {
+    const { wrapper } = await createFixtures();
+
+    const screen = render(
+      <LinkRenderer text='I agree to the [Terms of Service]https://example.com/terms) and [Privacy Policy](https://example.com/privacy)' />,
+      { wrapper },
+    );
+
+    screen.findByText('[Terms of Service]https://example.com/terms)');
+    expect(screen.queryByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument();
+  });
+});

--- a/packages/clerk-js/src/ui/elements/__tests__/LinkRenderer.test.tsx
+++ b/packages/clerk-js/src/ui/elements/__tests__/LinkRenderer.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { bindCreateFixtures } from '../../utils/test/createFixtures';
 import { LinkRenderer } from '../LinkRenderer';
 
-const { createFixtures } = bindCreateFixtures('UserProfile');
+const { createFixtures } = bindCreateFixtures('SignUp');
 
 describe('LinkRenderer', () => {
   it('renders a simple link', async () => {

--- a/packages/clerk-js/src/ui/elements/index.ts
+++ b/packages/clerk-js/src/ui/elements/index.ts
@@ -56,3 +56,4 @@ export * from './ProfileCard';
 export * from './Gauge';
 export * from './Animated';
 export * from './DevModeNotice';
+export * from './LegalConsentCheckbox';

--- a/packages/clerk-js/src/ui/localization/localizationModifiers.ts
+++ b/packages/clerk-js/src/ui/localization/localizationModifiers.ts
@@ -27,9 +27,14 @@ const numeric = (val: Date | number | string, locale?: string) => {
   }
 };
 
+const link = (val: string, label?: string) => {
+  return `[${label}](${val})`;
+};
+
 export const MODIFIERS = {
   titleize,
   timeString,
   weekday,
   numeric,
+  link,
 } as const;

--- a/packages/clerk-js/src/ui/localization/localizationModifiers.ts
+++ b/packages/clerk-js/src/ui/localization/localizationModifiers.ts
@@ -27,19 +27,9 @@ const numeric = (val: Date | number | string, locale?: string) => {
   }
 };
 
-const termsOfService = (val: string) => {
-  return `__${val}__`;
-};
-
-const privacyPolicy = (val: string) => {
-  return `__${val}__`;
-};
-
 export const MODIFIERS = {
   titleize,
   timeString,
   weekday,
   numeric,
-  termsOfService,
-  privacyPolicy,
 } as const;

--- a/packages/clerk-js/src/ui/localization/localizationModifiers.ts
+++ b/packages/clerk-js/src/ui/localization/localizationModifiers.ts
@@ -27,9 +27,19 @@ const numeric = (val: Date | number | string, locale?: string) => {
   }
 };
 
+const termsOfService = (val: string) => {
+  return `__${val}__`;
+};
+
+const privacyPolicy = (val: string) => {
+  return `__${val}__`;
+};
+
 export const MODIFIERS = {
   titleize,
   timeString,
   weekday,
   numeric,
+  termsOfService,
+  privacyPolicy,
 } as const;

--- a/packages/clerk-js/src/ui/polishedAppearance.ts
+++ b/packages/clerk-js/src/ui/polishedAppearance.ts
@@ -152,7 +152,7 @@ export const polishedAppearance: Appearance = {
         '&:checked': {
           backgroundImage: `url("data:image/svg+xml,%3Csvg width='16' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.25 8L6.5 9.75L9.75 4.25' stroke='${theme.colors.$whiteAlpha900}' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/svg%3E")`,
           borderColor: theme.colors.$transparent,
-          backgroundColor: theme.colors.$primary500,
+          backgroundColor: theme.colors.$primary900,
           backgroundSize: '100% 100%',
           backgroundPosition: 'center',
           backgroundRepeat: 'no-repeat',

--- a/packages/clerk-js/src/ui/polishedAppearance.ts
+++ b/packages/clerk-js/src/ui/polishedAppearance.ts
@@ -37,6 +37,30 @@ const inputShadowStyles = (
   };
 };
 
+const checkboxShadowStyles = (
+  theme: InternalTheme,
+  colors: { idle1: string; idle2: string; hover1: string; hover2: string; focus: string },
+) => {
+  const idleShadow = [
+    `0px 0px 0px 1px ${colors.idle1}`,
+    theme.shadows.$input.replace('{{color}}', colors.idle2),
+  ].toString();
+  const hoverShadow = [
+    `0px 0px 0px 1px ${colors.hover1}`,
+    theme.shadows.$input.replace('{{color}}', colors.hover2),
+  ].toString();
+
+  return {
+    boxShadow: idleShadow,
+    '&:hover': {
+      boxShadow: hoverShadow,
+    },
+    '&:focus-visible': {
+      boxShadow: [hoverShadow, theme.shadows.$focusRing.replace('{{color}}', colors.focus)].toString(),
+    },
+  };
+};
+
 const inputStyles = (theme: InternalTheme) => ({
   borderWidth: 0,
   ...inputShadowStyles(theme, {
@@ -144,11 +168,19 @@ export const polishedAppearance: Appearance = {
         },
       },
       checkbox: {
-        padding: `${theme.space.$1}`,
+        ...checkboxShadowStyles(theme, {
+          idle1: theme.colors.$neutralAlpha150,
+          idle2: theme.colors.$neutralAlpha100,
+          hover1: theme.colors.$neutralAlpha300,
+          hover2: theme.colors.$neutralAlpha150,
+          focus: theme.colors.$neutralAlpha150,
+        }),
+        padding: theme.space.$1,
         width: theme.sizes.$3x5,
         height: theme.sizes.$3x5,
         appearance: 'none',
         borderRadius: theme.radii.$sm,
+        border: 'none',
         '&:checked': {
           backgroundImage: `url("data:image/svg+xml,%3Csvg width='16' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.25 8L6.5 9.75L9.75 4.25' stroke='${theme.colors.$whiteAlpha900}' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/svg%3E")`,
           borderColor: theme.colors.$transparent,

--- a/packages/clerk-js/src/ui/polishedAppearance.ts
+++ b/packages/clerk-js/src/ui/polishedAppearance.ts
@@ -143,6 +143,21 @@ export const polishedAppearance: Appearance = {
           ...inputStyles(theme),
         },
       },
+      checkbox: {
+        padding: `${theme.space.$1}`,
+        width: theme.sizes.$3x5,
+        height: theme.sizes.$3x5,
+        appearance: 'none',
+        borderRadius: theme.radii.$sm,
+        '&:checked': {
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='16' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.25 8L6.5 9.75L9.75 4.25' stroke='${theme.colors.$whiteAlpha900}' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/svg%3E")`,
+          borderColor: theme.colors.$transparent,
+          backgroundColor: theme.colors.$primary500,
+          backgroundSize: '100% 100%',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+        },
+      },
       tagInputContainer: {
         ...inputStyles(theme),
       },

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -285,7 +285,15 @@ const createDisplayConfigFixtureHelpers = (environment: EnvironmentJSON) => {
   const withPreferredSignInStrategy = (opts: { strategy: DisplayConfigJSON['preferred_sign_in_strategy'] }) => {
     dc.preferred_sign_in_strategy = opts.strategy;
   };
-  return { withSupportEmail, withoutClerkBranding, withPreferredSignInStrategy };
+
+  const withTermsPrivacyPolicyUrls = (opts: {
+    termsOfService?: DisplayConfigJSON['terms_url'];
+    privacyPolicy?: DisplayConfigJSON['privacy_policy_url'];
+  }) => {
+    dc.terms_url = opts.termsOfService || '';
+    dc.privacy_policy_url = opts.privacyPolicy || '';
+  };
+  return { withSupportEmail, withoutClerkBranding, withPreferredSignInStrategy, withTermsPrivacyPolicyUrls };
 };
 
 const createOrganizationSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
@@ -487,6 +495,10 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     us.sign_up.mode = SIGN_UP_MODES.RESTRICTED;
   };
 
+  const withLegalConsent = () => {
+    us.sign_up.legal_consent_enabled = true;
+  };
+
   // TODO: Add the rest, consult pkg/generate/auth_config.go
 
   return {
@@ -505,5 +517,6 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     withPasskey,
     withPasskeySettings,
     withRestrictedMode,
+    withLegalConsent,
   };
 };

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -262,7 +262,16 @@ const createSignUpFixtureHelpers = (baseClient: ClientJSON) => {
     } as SignUpJSON;
   };
 
-  return { startSignUpWithEmailAddress, startSignUpWithPhoneNumber };
+  const startSignUpWithMissingLegalAccepted = () => {
+    baseClient.sign_up = {
+      id: 'sua_2HseAXFGN12eqlwARPMxyyUa9o9',
+      status: 'missing_requirements',
+      legal_accepted_at: null,
+      missing_fields: ['legal_accepted'],
+    } as SignUpJSON;
+  };
+
+  return { startSignUpWithEmailAddress, startSignUpWithPhoneNumber, startSignUpWithMissingLegalAccepted };
 };
 
 const createAuthConfigFixtureHelpers = (environment: EnvironmentJSON) => {

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -181,12 +181,12 @@ export const useFormControl = <Id extends string>(
   return { props, ...props, buildErrorMessage, setError, setValue, setChecked };
 };
 
-type FormControlStateLike = Pick<FormControlState, 'id' | 'value'>;
+type FormControlStateLike = Pick<FormControlState, 'id' | 'value' | 'checked' | 'type'>;
 
 export const buildRequest = (fieldStates: Array<FormControlStateLike>): Record<string, any> => {
   const request: { [x: string]: any } = {};
   fieldStates.forEach(x => {
-    request[x.id] = x.value;
+    request[x.id] = x.type !== 'checkbox' ? x.value : x.checked;
   });
   return request;
 };

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -515,7 +515,7 @@ export const enUS: LocalizationResource = {
       actionText: 'Already have an account?',
       blockButton__emailSupport: 'Email support',
     },
-    legalConsent: {
+    __experimental_legalConsent: {
       continue: {
         subtitle: 'Please read and accept the terms to continue',
         title: 'Legal consent',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -520,6 +520,12 @@ export const enUS: LocalizationResource = {
         subtitle: 'Please read and accept the terms to continue',
         title: 'Legal consent',
       },
+      checkbox: {
+        label__prefixText: 'I agree to the',
+        label__privacyPolicyText: 'Privacy Policy',
+        label__termsOfServiceText: 'Terms of Service',
+        label__conjunctionText: 'and',
+      },
     },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -515,6 +515,12 @@ export const enUS: LocalizationResource = {
       actionText: 'Already have an account?',
       blockButton__emailSupport: 'Email support',
     },
+    legalConsent: {
+      continue: {
+        subtitle: 'Please read and accept the terms to continue',
+        title: 'Legal consent',
+      },
+    },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',
   socialButtonsBlockButtonManyInView: '{{provider|titleize}}',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -521,10 +521,10 @@ export const enUS: LocalizationResource = {
         title: 'Legal consent',
       },
       checkbox: {
-        label__prefixText: 'I agree to the',
-        label__privacyPolicyText: 'Privacy Policy',
-        label__termsOfServiceText: 'Terms of Service',
-        label__conjunctionText: 'and',
+        label__termsOfServiceAndPrivacyPolicy:
+          'I agree to the {{ termsOfServiceLink || link("Terms of Service") }} and {{ privacyPolicyLink || link("Privacy Policy") }}',
+        label__onlyTermsOfService: 'I agree to the {{ termsOfServiceLink || link("Terms of Service") }}',
+        label__onlyPrivacyPolicy: 'I agree to the {{ privacyPolicyLink || link("Privacy Policy") }}',
       },
     },
   },

--- a/packages/types/src/attributes.ts
+++ b/packages/types/src/attributes.ts
@@ -1,3 +1,4 @@
 export type FirstNameAttribute = 'first_name';
 export type LastNameAttribute = 'last_name';
 export type PasswordAttribute = 'password';
+export type LegalAcceptedAttribute = 'legal_accepted';

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1287,6 +1287,7 @@ export interface ClerkAuthenticateWithWeb3Params {
   signUpContinueUrl?: string;
   unsafeMetadata?: SignUpUnsafeMetadata;
   strategy: Web3Strategy;
+  __experimental_legalAccepted?: boolean;
 }
 
 export interface AuthenticateWithMetamaskParams {
@@ -1294,6 +1295,7 @@ export interface AuthenticateWithMetamaskParams {
   redirectUrl?: string;
   signUpContinueUrl?: string;
   unsafeMetadata?: SignUpUnsafeMetadata;
+  __experimental_legalAccepted?: boolean;
 }
 
 export interface AuthenticateWithCoinbaseWalletParams {
@@ -1301,10 +1303,12 @@ export interface AuthenticateWithCoinbaseWalletParams {
   redirectUrl?: string;
   signUpContinueUrl?: string;
   unsafeMetadata?: SignUpUnsafeMetadata;
+  __experimental_legalAccepted?: boolean;
 }
 
 export interface AuthenticateWithGoogleOneTapParams {
   token: string;
+  __experimental_legalAccepted?: boolean;
 }
 
 export interface LoadedClerk extends Clerk {

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -38,6 +38,8 @@ export interface DisplayConfigJSON {
   after_create_organization_url: string;
   google_one_tap_client_id?: string;
   show_devmode_warning: boolean;
+  terms_url: string;
+  privacy_policy_url: string;
 }
 
 export interface DisplayConfigResource extends ClerkResource {
@@ -78,4 +80,6 @@ export interface DisplayConfigResource extends ClerkResource {
   afterCreateOrganizationUrl: string;
   googleOneTapClientId?: string;
   showDevModeWarning: boolean;
+  termsUrl: string;
+  privacyPolicyUrl: string;
 }

--- a/packages/types/src/elementIds.ts
+++ b/packages/types/src/elementIds.ts
@@ -20,7 +20,8 @@ export type FieldId =
   | 'deleteOrganizationConfirmation'
   | 'enrollmentMode'
   | 'affiliationEmailAddress'
-  | 'deleteExistingInvitationsSuggestions';
+  | 'deleteExistingInvitationsSuggestions'
+  | 'legalConsent';
 export type ProfileSectionId =
   | 'profile'
   | 'username'

--- a/packages/types/src/elementIds.ts
+++ b/packages/types/src/elementIds.ts
@@ -21,7 +21,7 @@ export type FieldId =
   | 'enrollmentMode'
   | 'affiliationEmailAddress'
   | 'deleteExistingInvitationsSuggestions'
-  | 'legalConsent';
+  | '__experimental_legalAccepted';
 export type ProfileSectionId =
   | 'profile'
   | 'username'

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -97,6 +97,7 @@ export interface SignUpJSON extends ClerkResourceJSON {
   created_session_id: string | null;
   created_user_id: string | null;
   abandon_at: number | null;
+  legal_accepted_at: number | null;
   verifications: SignUpVerificationsJSON | null;
 }
 
@@ -233,6 +234,7 @@ export interface UserJSON extends ClerkResourceJSON {
   create_organization_enabled: boolean;
   create_organizations_limit: number | null;
   delete_self_enabled: boolean;
+  legal_accepted_at: number | null;
   updated_at: number;
   created_at: number;
 }

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -151,6 +151,12 @@ type _LocalizationResource = {
       actionText: LocalizationValue;
       blockButton__emailSupport: LocalizationValue;
     };
+    legalConsent: {
+      continue: {
+        title: LocalizationValue;
+        subtitle: LocalizationValue;
+      };
+    };
   };
   signIn: {
     start: {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -157,10 +157,9 @@ type _LocalizationResource = {
         subtitle: LocalizationValue;
       };
       checkbox: {
-        label__prefixText: LocalizationValue;
-        label__termsOfServiceText: LocalizationValue;
-        label__privacyPolicyText: LocalizationValue;
-        label__conjunctionText: LocalizationValue;
+        label__termsOfServiceAndPrivacyPolicy: LocalizationValue;
+        label__onlyPrivacyPolicy: LocalizationValue;
+        label__onlyTermsOfService: LocalizationValue;
       };
     };
   };

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -156,6 +156,12 @@ type _LocalizationResource = {
         title: LocalizationValue;
         subtitle: LocalizationValue;
       };
+      checkbox: {
+        label__prefixText: LocalizationValue;
+        label__termsOfServiceText: LocalizationValue;
+        label__privacyPolicyText: LocalizationValue;
+        label__conjunctionText: LocalizationValue;
+      };
     };
   };
   signIn: {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -151,7 +151,7 @@ type _LocalizationResource = {
       actionText: LocalizationValue;
       blockButton__emailSupport: LocalizationValue;
     };
-    legalConsent: {
+    __experimental_legalConsent: {
       continue: {
         title: LocalizationValue;
         subtitle: LocalizationValue;

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -79,6 +79,11 @@ export type AuthenticateWithRedirectParams = {
    * Email address to use for targeting a SAML connection at sign-up
    */
   emailAddress?: string;
+
+  /**
+   * Whether the user has accepted the legal terms.
+   */
+  legalAccepted?: boolean;
 };
 
 export type RedirectUrlProp = {

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -81,9 +81,9 @@ export type AuthenticateWithRedirectParams = {
   emailAddress?: string;
 
   /**
-   * Whether the user has accepted the legal terms.
+   * Whether the user has accepted the legal requirements.
    */
-  legalAccepted?: boolean;
+  __experimental_legalAccepted?: boolean;
 };
 
 export type RedirectUrlProp = {

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -59,6 +59,7 @@ export interface SignUpResource extends ClerkResource {
   createdSessionId: string | null;
   createdUserId: string | null;
   abandonAt: number | null;
+  legalAcceptedAt: number | null;
 
   create: (params: SignUpCreateParams) => Promise<SignUpResource>;
 
@@ -161,6 +162,7 @@ export type SignUpCreateParams = Partial<
     unsafeMetadata: SignUpUnsafeMetadata;
     ticket: string;
     token: string;
+    legalAccepted: boolean;
   } & SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>
 >;
 

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -1,4 +1,4 @@
-import type { FirstNameAttribute, LastNameAttribute, PasswordAttribute } from './attributes';
+import type { FirstNameAttribute, LastNameAttribute, LegalAcceptedAttribute, PasswordAttribute } from './attributes';
 import type { AttemptEmailAddressVerificationParams, PrepareEmailAddressVerificationParams } from './emailAddress';
 import type {
   EmailAddressIdentifier,
@@ -136,7 +136,7 @@ export type AttemptVerificationParams =
       signature: string;
     };
 
-export type SignUpAttributeField = FirstNameAttribute | LastNameAttribute | PasswordAttribute;
+export type SignUpAttributeField = FirstNameAttribute | LastNameAttribute | PasswordAttribute | LegalAcceptedAttribute;
 
 // TODO: SignUpVerifiableField or SignUpIdentifier?
 export type SignUpVerifiableField =

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -163,7 +163,7 @@ export type SignUpCreateParams = Partial<
     ticket: string;
     token: string;
     legalAccepted: boolean;
-  } & SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>
+  } & Omit<SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>, 'legalAccepted'>
 >;
 
 export type SignUpUpdateParams = SignUpCreateParams;

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -90,7 +90,10 @@ export interface SignUpResource extends ClerkResource {
   ) => Promise<void>;
 
   authenticateWithWeb3: (
-    params: AuthenticateWithWeb3Params & { unsafeMetadata?: SignUpUnsafeMetadata },
+    params: AuthenticateWithWeb3Params & {
+      unsafeMetadata?: SignUpUnsafeMetadata;
+      __experimental_legalAccepted?: boolean;
+    },
   ) => Promise<SignUpResource>;
 
   authenticateWithMetamask: (params?: SignUpAuthenticateWithWeb3Params) => Promise<SignUpResource>;

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -162,7 +162,7 @@ export type SignUpCreateParams = Partial<
     unsafeMetadata: SignUpUnsafeMetadata;
     ticket: string;
     token: string;
-    legalAccepted: boolean;
+    __experimental_legalAccepted: boolean;
   } & Omit<SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>, 'legalAccepted'>
 >;
 

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -54,6 +54,7 @@ export type SignUpData = {
   progressive: boolean;
   captcha_enabled: boolean;
   mode: SignUpModes;
+  legal_consent_enabled: boolean;
 };
 
 export type PasswordSettingsData = {


### PR DESCRIPTION
## Description

This PR adds legal consent as an experimental feature and also updates the `<SignUp/>` component to display the legal consent checkbox when the legal consent requirements are enabled.

Here are some screenshots of how the`<SignUp/>` will look like:

![image](https://github.com/user-attachments/assets/c99c9ebe-2fc4-4ce8-b518-4de14f8ebb88)

![image](https://github.com/user-attachments/assets/50ca0117-e581-4755-b034-2bac630e2170)

![CleanShot 2024-10-17 at 13 08 05@2x](https://github.com/user-attachments/assets/eeea3748-a296-4766-9ad7-f091dde22cba)



<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
