### PR TITLE
chore(clerk-js,types): Drop `maxAgeMinutes` from `__experimental_startVerification`

### DIFF
--- a/.changeset/fluffy-goats-protect.md
+++ b/.changeset/fluffy-goats-protect.md
@@ -1,0 +1,7 @@
+---
+"@clerk/clerk-js": minor
+"@clerk/types": minor
+---
+
+Drop `maxAgeMinutes` from `__experimental_startVerification`.
+Drop types `__experimental_SessionVerificationConfig` and `__experimental_SessionVerificationMaxAgeMinutes`.

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -122,7 +122,6 @@ export class Session extends BaseResource implements SessionResource {
 
   __experimental_startVerification = async ({
     level,
-    maxAgeMinutes,
   }: __experimental_SessionVerifyCreateParams): Promise<__experimental_SessionVerificationResource> => {
     const json = (
       await BaseResource._fetch({
@@ -130,7 +129,6 @@ export class Session extends BaseResource implements SessionResource {
         path: `/client/sessions/${this.id}/verify`,
         body: {
           level,
-          maxAgeMinutes,
         } as any,
       })
     )?.response as unknown as __experimental_SessionVerificationJSON;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -18,7 +18,6 @@ import type { ClerkResource } from './resource';
 import type {
   __experimental_ReverificationConfig,
   __experimental_SessionVerificationLevel,
-  __experimental_SessionVerificationMaxAgeMinutes,
   __experimental_SessionVerificationResource,
 } from './sessionVerification';
 import type { TokenResource } from './token';
@@ -155,7 +154,6 @@ export type GetToken = (options?: GetTokenOptions) => Promise<string | null>;
 
 export type __experimental_SessionVerifyCreateParams = {
   level: __experimental_SessionVerificationLevel;
-  maxAgeMinutes: __experimental_SessionVerificationMaxAgeMinutes;
 };
 
 export type __experimental_SessionVerifyPrepareFirstFactorParams = EmailCodeConfig | PhoneCodeConfig;

--- a/packages/types/src/sessionVerification.ts
+++ b/packages/types/src/sessionVerification.ts
@@ -17,22 +17,15 @@ export type __experimental_SessionVerificationStatus = 'needs_first_factor' | 'n
 
 export type __experimental_SessionVerificationTypes = 'veryStrict' | 'strict' | 'moderate' | 'lax';
 
-export type __experimental_SessionVerificationConfig =
-  | __experimental_SessionVerificationTypes
-  | {
-      level: __experimental_SessionVerificationLevel;
-      maxAgeMinutes: __experimental_SessionVerificationMaxAgeMinutes;
-    };
-
 export type __experimental_ReverificationConfig =
   | __experimental_SessionVerificationTypes
   | {
       level: __experimental_SessionVerificationLevel;
-      afterMinutes: __experimental_SessionVerificationMaxAgeMinutes;
+      afterMinutes: __experimental_SessionVerificationAfterMinutes;
     };
 
 export type __experimental_SessionVerificationLevel = 'firstFactor' | 'secondFactor' | 'multiFactor';
-export type __experimental_SessionVerificationMaxAgeMinutes = number;
+export type __experimental_SessionVerificationAfterMinutes = number;
 
 export type __experimental_SessionVerificationFirstFactor = EmailCodeFactor | PhoneCodeFactor | PasswordFactor;
 export type __experimental_SessionVerificationSecondFactor = PhoneCodeFactor | TOTPFactor | BackupCodeFactor;


### PR DESCRIPTION
## Description
Drop `maxAgeMinutes` from `__experimental_startVerification`.
Drop types `__experimental_SessionVerificationConfig` and `__experimental_SessionVerificationMaxAgeMinutes`.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
