### PR TITLE
fix(e2e): Use new config plugin type

### DIFF
--- a/integration/templates/tanstack-start/app.config.ts
+++ b/integration/templates/tanstack-start/app.config.ts
@@ -3,7 +3,7 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
   vite: {
-    plugins: () => [
+    plugins: [
       tsConfigPaths({
         projects: ['./tsconfig.json'],
       }),


### PR DESCRIPTION
## Description

`config.plugins` now expects an array instead of a function that returns an array. This was changed in [this PR to TanStack Start](https://github.com/TanStack/router/pull/2544/files).

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
