### PR TITLE
feat(express): Export `authenticateRequest`

### DIFF
--- a/.changeset/gorgeous-teachers-scream.md
+++ b/.changeset/gorgeous-teachers-scream.md
@@ -1,5 +1,11 @@
 ---
-"@clerk/express": patch
+"@clerk/express": minor
 ---
 
-Export authenticateRequest method from express sdk
+Export [`authenticateRequest` method](https://clerk.com/docs/references/backend/authenticate-request) from `@clerk/express` (in case you want to go low-level and implement flows to your specific needs). You can use it like so:
+
+```ts
+import { authenticateRequest } from "@clerk/express"
+```
+
+This function is adapted to Express' Request wrapper and as such notably different to the exported function from `@clerk/backend`. If you need to use it, be sure to import from `@clerk/express`.

--- a/.changeset/gorgeous-teachers-scream.md
+++ b/.changeset/gorgeous-teachers-scream.md
@@ -1,0 +1,5 @@
+---
+"@clerk/express": patch
+---
+
+Export authenticateRequest method from express sdk

--- a/package-lock.json
+++ b/package-lock.json
@@ -43652,7 +43652,7 @@
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "astro": "^4.16.1"
+        "astro": "^3.2.0 || ^4.0.0"
       }
     },
     "packages/astro/node_modules/nanoid": {

--- a/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/express/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`module exports should not change unless explicitly set 1`] = `
 [
+  "authenticateRequest",
   "clerkClient",
   "clerkMiddleware",
   "createClerkClient",

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -6,3 +6,4 @@ export type { ExpressRequestWithAuth } from './types';
 export { clerkMiddleware } from './clerkMiddleware';
 export { getAuth } from './getAuth';
 export { requireAuth } from './requireAuth';
+export { authenticateRequest } from './authenticateRequest';


### PR DESCRIPTION
This can be useful to use directly for express users who want to go down to bare metal

## Description

For some users of the express SDK, they may want to directly use `authenticateRequest`, which is notably different from the backend SDK version since it's adapted to express' request wrapper. This makes that possible.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
