### PR TITLE
fix(shared): Retry with exponential backoff if loadScript fails

### DIFF
--- a/.changeset/forty-laws-swim.md
+++ b/.changeset/forty-laws-swim.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/shared": patch
+---
+
+Retry with exponential backoff if loadScript fails to load the script

--- a/packages/shared/src/loadScript.ts
+++ b/packages/shared/src/loadScript.ts
@@ -1,3 +1,5 @@
+import { runWithExponentialBackOff } from './utils';
+
 const NO_DOCUMENT_ERROR = 'loadScript cannot be called when document does not exist';
 const NO_SRC_ERROR = 'loadScript cannot be called without a src';
 
@@ -11,34 +13,39 @@ type LoadScriptOptions = {
 
 export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTMLScriptElement> {
   const { async, defer, beforeLoad, crossOrigin, nonce } = opts || {};
-  return new Promise((resolve, reject) => {
-    if (!src) {
-      reject(NO_SRC_ERROR);
-    }
 
-    if (!document || !document.body) {
-      reject(NO_DOCUMENT_ERROR);
-    }
+  const load = () => {
+    return new Promise<HTMLScriptElement>((resolve, reject) => {
+      if (!src) {
+        reject(NO_SRC_ERROR);
+      }
 
-    const script = document.createElement('script');
+      if (!document || !document.body) {
+        reject(NO_DOCUMENT_ERROR);
+      }
 
-    crossOrigin && script.setAttribute('crossorigin', crossOrigin);
-    script.async = async || false;
-    script.defer = defer || false;
+      const script = document.createElement('script');
 
-    script.addEventListener('load', () => {
-      script.remove();
-      resolve(script);
+      crossOrigin && script.setAttribute('crossorigin', crossOrigin);
+      script.async = async || false;
+      script.defer = defer || false;
+
+      script.addEventListener('load', () => {
+        script.remove();
+        resolve(script);
+      });
+
+      script.addEventListener('error', () => {
+        script.remove();
+        reject();
+      });
+
+      script.src = src;
+      script.nonce = nonce;
+      beforeLoad?.(script);
+      document.body.appendChild(script);
     });
+  };
 
-    script.addEventListener('error', () => {
-      script.remove();
-      reject();
-    });
-
-    script.src = src;
-    script.nonce = nonce;
-    beforeLoad?.(script);
-    document.body.appendChild(script);
-  });
+  return runWithExponentialBackOff(load, { shouldRetry: (_, iterations) => iterations < 5 });
 }


### PR DESCRIPTION
## Description

It's impossible to inspect the error that caused `on error` or the `error` event to be fired, so I intentionally left the initial and subsequent delays short.

This is a "best effort" strategy to retry network errors while still falling back to loading the turnstile script through our proxy if loading fails due to CSP, as we cannot reliably detect that a CSP error occurred.

This change is expected to reduce the "Clerk: Failed to load" errors as well.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
