### PR TITLE
fix(backend): Remove console error message from refresh token flow failures

### DIFF
--- a/.changeset/fair-flies-compare.md
+++ b/.changeset/fair-flies-compare.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Remove console error message from refresh token flow failures.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -629,8 +629,7 @@ ${error.getFullMessage()}`,
         return signedIn(authenticateContext, data.jwtPayload, undefined, data.sessionToken);
       }
 
-      // If there's any error, simply fallback to the handshake flow.
-      console.error('Clerk: unable to refresh token:', error?.message || error);
+      // If there's any error, simply fallback to the handshake flow including the reason as a query parameter.
       if (error?.cause?.reason) {
         refreshError = error.cause.reason;
       } else {


### PR DESCRIPTION
## Description

The `console.error` appears on the server logs of our users, and a refresh token flow can fail in a common valid scenario.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
