### PR TITLE
chore(nextjs)!: Require `CLERK_ENCRYPTION_KEY` for `secretKey` as dynamic key

### DIFF
--- a/.changeset/pretty-forks-repeat.md
+++ b/.changeset/pretty-forks-repeat.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": major
+---
+
+Throws error if the `CLERK_ENCRYPTION_KEY` is missing when the `secretKey` option is specified in `clerkMiddleware`. For more information, please refer to the [Dynamic keys docs](https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys).

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -99,3 +99,5 @@ For additional information about middleware, please visit https://clerk.com/docs
 export const authSignatureInvalid = `Clerk: Unable to verify request, this usually means the Clerk middleware did not run. Ensure Clerk's middleware is properly integrated and matches the current route. For more information, see: https://clerk.com/docs/nextjs/middleware. (code=auth_signature_invalid)`;
 
 export const encryptionKeyInvalid = `Clerk: Unable to decrypt request data, this usually means the encryption key is invalid. Ensure the encryption key is properly set. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
+export const encryptionKeyMissing =
+  'Clerk: Missing `CLERK_ENCRYPTION_KEY`. Required for propagating `secretKey` middleware option. See docs: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_missing)';


### PR DESCRIPTION
## Description

Resolves SDKI-485 

Prepares for the major release, replacing the previous warning for missing `CLERK_ENCRYPTION_KEY` with an actual error.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [X] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
