### PR TITLE
feat(clerk-js,nextjs,clerk-react,types): Introduce `<Waitlist />` component

### DIFF
--- a/.changeset/nine-squids-buy.md
+++ b/.changeset/nine-squids-buy.md
@@ -1,0 +1,14 @@
+---
+"@clerk/localizations": minor
+"@clerk/clerk-js": minor
+"@clerk/nextjs": minor
+"@clerk/clerk-react": minor
+"@clerk/types": minor
+---
+New Feature: Introduce the `<Waitlist />` component and the `waitlist` sign up mode.
+
+- Allow users to request access with an email address via the new `<Waitlist />` component.
+- Show `Join waitlist` prompt from `<SignIn />` component when mode is `waitlist`.
+- Appropriate the text in the Sign Up component when mode is `waitlist`.
+- Added `joinWaitlist()` method in `Clerk` singleton.
+- Added `redirectToWaitlist()` method in `Clerk` singleton to allow user to redirect to waitlist page.

--- a/packages/chrome-extension/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/chrome-extension/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -27,6 +27,7 @@ exports[`public exports should not include a breaking change 1`] = `
   "SignedOut",
   "UserButton",
   "UserProfile",
+  "Waitlist",
   "__experimental_useReverification",
   "useAuth",
   "useClerk",

--- a/packages/clerk-js/src/core/__tests__/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.redirects.test.ts
@@ -36,6 +36,7 @@ const mockDisplayConfigWithSameOrigin = {
   homeUrl: 'http://test.host/home',
   createOrganizationUrl: 'http://test.host/create-organization',
   organizationProfileUrl: 'http://test.host/organization-profile',
+  waitlistUrl: 'http://test.host/waitlist',
 } as DisplayConfig;
 
 const mockDisplayConfigWithDifferentOrigin = {
@@ -45,6 +46,7 @@ const mockDisplayConfigWithDifferentOrigin = {
   homeUrl: 'http://another-test.host/home',
   createOrganizationUrl: 'http://another-test.host/create-organization',
   organizationProfileUrl: 'http://another-test.host/organization-profile',
+  waitlistUrl: 'http://another-test.host/waitlist',
 } as DisplayConfig;
 
 const mockUserSettings = {
@@ -96,7 +98,7 @@ describe('Clerk singleton - Redirects', () => {
 
   afterEach(() => mockNavigate.mockReset());
 
-  describe('.redirectTo(SignUp|SignIn|UserProfile|AfterSignIn|AfterSignUp|CreateOrganization|OrganizationProfile)', () => {
+  describe('.redirectTo(SignUp|SignIn|UserProfile|AfterSignIn|AfterSignUp|CreateOrganization|OrganizationProfile|Waitlist)', () => {
     let clerkForProductionInstance: Clerk;
     let clerkForDevelopmentInstance: Clerk;
 
@@ -188,6 +190,13 @@ describe('Clerk singleton - Redirects', () => {
 
         expect(mockNavigate.mock.calls[0][0]).toBe('/organization-profile');
         expect(mockNavigate.mock.calls[1][0]).toBe('/organization-profile');
+      });
+
+      it('redirects to waitlitUrl', async () => {
+        await clerkForDevelopmentInstance.redirectToWaitlist();
+        expect(mockNavigate).toHaveBeenCalledWith('/waitlist', {
+          windowNavigate: expect.any(Function),
+        });
       });
     });
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,6 +28,7 @@ import type {
   HandleEmailLinkVerificationParams,
   HandleOAuthCallbackParams,
   InstanceType,
+  JoinWaitlistParams,
   ListenerCallback,
   LoadedClerk,
   NavigateOptions,
@@ -53,6 +54,8 @@ import type {
   UserButtonProps,
   UserProfileProps,
   UserResource,
+  WaitlistProps,
+  WaitlistResource,
   Web3Provider,
 } from '@clerk/types';
 
@@ -111,6 +114,7 @@ import {
   EmailLinkErrorCode,
   Environment,
   Organization,
+  Waitlist,
 } from './resources/internal';
 import { warnings } from './warnings';
 
@@ -503,6 +507,18 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls.ensureMounted().then(controls => controls.closeModal('createOrganization'));
   };
 
+  public openWaitlist = (props?: WaitlistProps): void => {
+    this.assertComponentsReady(this.#componentControls);
+    void this.#componentControls
+      .ensureMounted({ preloadHint: 'Waitlist' })
+      .then(controls => controls.openModal('waitlist', props || {}));
+  };
+
+  public closeWaitlist = (): void => {
+    this.assertComponentsReady(this.#componentControls);
+    void this.#componentControls.ensureMounted().then(controls => controls.closeModal('waitlist'));
+  };
+
   public mountSignIn = (node: HTMLDivElement, props?: SignInProps): void => {
     if (props && props.__experimental?.newComponents && this.__experimental_ui) {
       this.__experimental_ui.mount('SignIn', node, props);
@@ -733,6 +749,25 @@ export class Clerk implements ClerkInterface {
   };
 
   public unmountUserButton = (node: HTMLDivElement): void => {
+    this.assertComponentsReady(this.#componentControls);
+    void this.#componentControls?.ensureMounted().then(controls => controls.unmountComponent({ node }));
+  };
+
+  public mountWaitlist = (node: HTMLDivElement, props?: WaitlistProps) => {
+    this.assertComponentsReady(this.#componentControls);
+    void this.#componentControls?.ensureMounted({ preloadHint: 'Waitlist' }).then(controls =>
+      controls.mountComponent({
+        name: 'Waitlist',
+        appearanceKey: 'waitlist',
+        node,
+        props,
+      }),
+    );
+
+    this.telemetry?.record(eventPrebuiltComponentMounted('Waitlist', props));
+  };
+
+  public unmountWaitlist = (node: HTMLDivElement): void => {
     this.assertComponentsReady(this.#componentControls);
     void this.#componentControls?.ensureMounted().then(controls => controls.unmountComponent({ node }));
   };
@@ -974,6 +1009,16 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(this.#options.afterSignOutUrl);
   }
 
+  public buildWaitlistUrl(): string {
+    if (!this.environment || !this.environment.displayConfig) {
+      return '';
+    }
+
+    const waitlistUrl = this.#options['waitlistUrl'] || this.environment.displayConfig.waitlistUrl;
+
+    return buildURL({ base: waitlistUrl }, { stringify: true });
+  }
+
   public buildAfterMultiSessionSingleSignOutUrl(): string {
     if (!this.#options.afterMultiSessionSingleSignOutUrl) {
       return this.buildUrlWithAuth(
@@ -1084,6 +1129,13 @@ export class Clerk implements ClerkInterface {
   public redirectToAfterSignOut = async (): Promise<unknown> => {
     if (inBrowser()) {
       return this.navigate(this.buildAfterSignOutUrl());
+    }
+    return;
+  };
+
+  public redirectToWaitlist = async (): Promise<unknown> => {
+    if (inBrowser()) {
+      return this.navigate(this.buildWaitlistUrl());
     }
     return;
   };
@@ -1480,6 +1532,9 @@ export class Clerk implements ClerkInterface {
 
   public getOrganization = async (organizationId: string): Promise<OrganizationResource> =>
     Organization.get(organizationId);
+
+  public joinWaitlist = async ({ emailAddress }: JoinWaitlistParams): Promise<WaitlistResource> =>
+    Waitlist.join({ emailAddress });
 
   public updateEnvironment(environment: EnvironmentResource): asserts this is { environment: EnvironmentResource } {
     this.environment = environment;

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -36,4 +36,5 @@ export const DEBOUNCE_MS = 350;
 export const SIGN_UP_MODES: Record<string, SignUpModes> = {
   PUBLIC: 'public',
   RESTRICTED: 'restricted',
+  WAITLIST: 'waitlist',
 };

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -46,6 +46,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   showDevModeWarning!: boolean;
   termsUrl!: string;
   privacyPolicyUrl!: string;
+  waitlistUrl!: string;
 
   public constructor(data: DisplayConfigJSON) {
     super();
@@ -91,6 +92,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.showDevModeWarning = data.show_devmode_warning;
     this.termsUrl = data.terms_url;
     this.privacyPolicyUrl = data.privacy_policy_url;
+    this.waitlistUrl = data.waitlist_url;
     return this;
   }
 }

--- a/packages/clerk-js/src/core/resources/Waitlist.ts
+++ b/packages/clerk-js/src/core/resources/Waitlist.ts
@@ -1,0 +1,40 @@
+import type { JoinWaitlistParams, WaitlistJSON, WaitlistResource } from '@clerk/types';
+
+import { unixEpochToDate } from '../../utils/date';
+import { BaseResource } from './internal';
+
+export class Waitlist extends BaseResource implements WaitlistResource {
+  pathRoot = '/waitlist';
+
+  id = '';
+  updatedAt: Date | null = null;
+  createdAt: Date | null = null;
+
+  constructor(data: WaitlistJSON) {
+    super();
+    this.fromJSON(data);
+  }
+
+  protected fromJSON(data: WaitlistJSON | null): this {
+    if (!data) {
+      return this;
+    }
+
+    this.id = data.id;
+    this.updatedAt = unixEpochToDate(data.updated_at);
+    this.createdAt = unixEpochToDate(data.created_at);
+    return this;
+  }
+
+  static async join(params: JoinWaitlistParams): Promise<WaitlistResource> {
+    const json = (
+      await BaseResource._fetch<WaitlistJSON>({
+        path: '/waitlist',
+        method: 'POST',
+        body: params as any,
+      })
+    )?.response as unknown as WaitlistJSON;
+
+    return new Waitlist(json);
+  }
+}

--- a/packages/clerk-js/src/core/resources/__tests__/Waitlist.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Waitlist.test.ts
@@ -1,0 +1,14 @@
+import { Waitlist } from '../internal';
+
+describe('Waitlist', () => {
+  it('has the same initial properties', () => {
+    const waitlist = new Waitlist({
+      object: 'waitlist',
+      id: 'test_id',
+      created_at: 12345,
+      updated_at: 5678,
+    });
+
+    expect(waitlist).toMatchSnapshot();
+  });
+});

--- a/packages/clerk-js/src/core/resources/__tests__/__snapshots__/Waitlist.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__tests__/__snapshots__/Waitlist.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Waitlist has the same initial properties 1`] = `
+Waitlist {
+  "createdAt": 1970-01-01T00:00:12.345Z,
+  "id": "test_id",
+  "pathRoot": "/waitlist",
+  "updatedAt": 1970-01-01T00:00:05.678Z,
+}
+`;

--- a/packages/clerk-js/src/core/resources/index.ts
+++ b/packages/clerk-js/src/core/resources/index.ts
@@ -18,3 +18,4 @@ export * from './Token';
 export * from './User';
 export * from './Verification';
 export * from './Web3Wallet';
+export * from './Waitlist';

--- a/packages/clerk-js/src/core/resources/internal.ts
+++ b/packages/clerk-js/src/core/resources/internal.ts
@@ -32,3 +32,4 @@ export * from './User';
 export * from './UserOrganizationInvitation';
 export * from './Verification';
 export * from './Web3Wallet';
+export * from './Waitlist';

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -12,6 +12,7 @@ import type {
   SignInProps,
   SignUpProps,
   UserProfileProps,
+  WaitlistProps,
 } from '@clerk/types';
 import React, { Suspense } from 'react';
 
@@ -30,6 +31,7 @@ import {
   SignUpModal,
   UserProfileModal,
   UserVerificationModal,
+  WaitlistModal,
 } from './lazyModules/components';
 import {
   LazyComponentRenderer,
@@ -65,7 +67,8 @@ export type ComponentControls = {
       | 'userProfile'
       | 'organizationProfile'
       | 'createOrganization'
-      | 'userVerification',
+      | 'userVerification'
+      | 'waitlist',
   >(
     modal: T,
     props: T extends 'signIn'
@@ -74,7 +77,9 @@ export type ComponentControls = {
         ? SignUpProps
         : T extends 'userVerification'
           ? __experimental_UserVerificationProps
-          : UserProfileProps,
+          : T extends 'waitlist'
+            ? WaitlistProps
+            : UserProfileProps,
   ) => void;
   closeModal: (
     modal:
@@ -84,7 +89,8 @@ export type ComponentControls = {
       | 'userProfile'
       | 'organizationProfile'
       | 'createOrganization'
-      | 'userVerification',
+      | 'userVerification'
+      | 'waitlist',
     options?: {
       notify?: boolean;
     },
@@ -119,6 +125,7 @@ interface ComponentsState {
   organizationProfileModal: null | OrganizationProfileProps;
   createOrganizationModal: null | CreateOrganizationProps;
   organizationSwitcherPrefetch: boolean;
+  waitlistModal: null | WaitlistProps;
   nodes: Map<HTMLDivElement, HtmlNodeOptions>;
   impersonationFab: boolean;
 }
@@ -183,6 +190,7 @@ const componentNodes = Object.freeze({
   UserProfile: 'userProfileModal',
   OrganizationProfile: 'organizationProfileModal',
   CreateOrganization: 'createOrganizationModal',
+  Waitlist: 'waitlistModal',
 }) as any;
 
 const Components = (props: ComponentsProps) => {
@@ -197,6 +205,7 @@ const Components = (props: ComponentsProps) => {
     organizationProfileModal: null,
     createOrganizationModal: null,
     organizationSwitcherPrefetch: false,
+    waitlistModal: null,
     nodes: new Map(),
     impersonationFab: false,
   });
@@ -209,6 +218,7 @@ const Components = (props: ComponentsProps) => {
     userVerificationModal,
     organizationProfileModal,
     createOrganizationModal,
+    waitlistModal,
     nodes,
   } = state;
 
@@ -334,6 +344,7 @@ const Components = (props: ComponentsProps) => {
     >
       <SignInModal {...signInModal} />
       <SignUpModal {...signInModal} />
+      <WaitlistModal {...waitlistModal} />
     </LazyModalRenderer>
   );
 
@@ -350,6 +361,7 @@ const Components = (props: ComponentsProps) => {
     >
       <SignInModal {...signUpModal} />
       <SignUpModal {...signUpModal} />
+      <WaitlistModal {...waitlistModal} />
     </LazyModalRenderer>
   );
 
@@ -427,6 +439,22 @@ const Components = (props: ComponentsProps) => {
     </LazyModalRenderer>
   );
 
+  const mountedWaitlistModal = (
+    <LazyModalRenderer
+      globalAppearance={state.appearance}
+      appearanceKey={'waitlist'}
+      componentAppearance={waitlistModal?.appearance}
+      flowName={'waitlist'}
+      onClose={() => componentsControls.closeModal('waitlist')}
+      onExternalNavigate={() => componentsControls.closeModal('waitlist')}
+      startPath={buildVirtualRouterUrl({ base: '/waitlist', path: urlStateParam?.path })}
+      componentName={'WaitlistModal'}
+    >
+      <WaitlistModal {...waitlistModal} />
+      <SignInModal {...waitlistModal} />
+    </LazyModalRenderer>
+  );
+
   return (
     <Suspense fallback={''}>
       <LazyProviders
@@ -455,6 +483,7 @@ const Components = (props: ComponentsProps) => {
         {userVerificationModal && mountedUserVerificationModal}
         {organizationProfileModal && mountedOrganizationProfileModal}
         {createOrganizationModal && mountedCreateOrganizationModal}
+        {waitlistModal && mountedWaitlistModal}
         {state.impersonationFab && (
           <LazyImpersonationFabProvider globalAppearance={state.appearance}>
             <ImpersonationFab />

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -80,6 +80,7 @@ export const SignIn: React.ComponentType<SignInProps> = withCoreSessionSwitchGua
 export const SignInModal = (props: SignInModalProps): JSX.Element => {
   const signInProps = {
     signUpUrl: `/${VIRTUAL_ROUTER_BASE_PATH}/sign-up`,
+    waitlistUrl: `/${VIRTUAL_ROUTER_BASE_PATH}/waitlist`,
     ...props,
   };
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -65,7 +65,7 @@ export function _SignInStart(): JSX.Element {
   const signIn = useCoreSignIn();
   const { navigate } = useRouter();
   const ctx = useSignInContext();
-  const { afterSignInUrl, signUpUrl } = ctx;
+  const { afterSignInUrl, signUpUrl, waitlistUrl } = ctx;
   const supportEmail = useSupportEmail();
   const identifierAttributes = useMemo<SignInStartIdentifier[]>(
     () => groupIdentifiers(userSettings.enabledFirstFactorIdentifiers),
@@ -417,6 +417,15 @@ export function _SignInStart(): JSX.Element {
               <Card.ActionLink
                 localizationKey={localizationKeys('signIn.start.actionLink')}
                 to={clerk.buildUrlWithAuth(signUpUrl)}
+              />
+            </Card.Action>
+          )}
+          {userSettings.signUp.mode === SIGN_UP_MODES.WAITLIST && (
+            <Card.Action elementId='signIn'>
+              <Card.ActionText localizationKey={localizationKeys('signIn.start.actionText__join_waitlist')} />
+              <Card.ActionLink
+                localizationKey={localizationKeys('signIn.start.actionLink__join_waitlist')}
+                to={clerk.buildUrlWithAuth(waitlistUrl)}
               />
             </Card.Action>
           )}

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -134,6 +134,17 @@ describe('SignInStart', () => {
     });
   });
 
+  describe('Waitlist mode', () => {
+    it('shows the waitlist message', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withWaitlistMode();
+      });
+      render(<SignInStart />, { wrapper });
+      screen.getByText('Join waitlist');
+    });
+  });
+
   describe('Social OAuth', () => {
     it.each(OAUTH_PROVIDERS)('shows the "Continue with $name" social OAuth button', async ({ provider, name }) => {
       const { wrapper } = await createFixtures(f => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -92,6 +92,7 @@ export const SignUp: React.ComponentType<SignUpProps> = withCoreSessionSwitchGua
 export const SignUpModal = (props: SignUpModalProps): JSX.Element => {
   const signUpProps = {
     signInUrl: `/${VIRTUAL_ROUTER_BASE_PATH}/sign-in`,
+    waitlistUrl: `/${VIRTUAL_ROUTER_BASE_PATH}/waitlist`,
     ...props,
   };
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpRestrictedAccess.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpRestrictedAccess.tsx
@@ -1,21 +1,34 @@
 import { useClerk } from '@clerk/shared/react';
 
-import { useSignUpContext } from '../../contexts';
+import { SIGN_UP_MODES } from '../../../core/constants';
+import { useEnvironment, useSignUpContext } from '../../contexts';
 import { Button, Flex, Icon, localizationKeys } from '../../customizables';
 import { Card, Header } from '../../elements';
 import { useCardState } from '../../elements/contexts';
 import { useSupportEmail } from '../../hooks/useSupportEmail';
 import { Block } from '../../icons';
-
+import { useRouter } from '../../router';
 export const SignUpRestrictedAccess = () => {
   const clerk = useClerk();
   const card = useCardState();
-  const { signInUrl } = useSignUpContext();
+  const { navigate } = useRouter();
+  const { signInUrl, waitlistUrl } = useSignUpContext();
   const supportEmail = useSupportEmail();
+  const { userSettings } = useEnvironment();
+  const { mode } = userSettings.signUp;
 
   const handleEmailSupport = () => {
     window.location.href = `mailto:${supportEmail}`;
   };
+
+  const handleWaitlistNavigate = async () => {
+    await navigate(clerk.buildUrlWithAuth(waitlistUrl));
+  };
+
+  const subtitle =
+    mode === SIGN_UP_MODES.RESTRICTED
+      ? localizationKeys('signUp.restrictedAccess.subtitle')
+      : localizationKeys('signUp.restrictedAccess.subtitleWaitlist');
 
   return (
     <Card.Root>
@@ -30,10 +43,10 @@ export const SignUpRestrictedAccess = () => {
             })}
           />
           <Header.Title localizationKey={localizationKeys('signUp.restrictedAccess.title')} />
-          <Header.Subtitle localizationKey={localizationKeys('signUp.restrictedAccess.subtitle')} />
+          <Header.Subtitle localizationKey={subtitle} />
         </Header.Root>
         <Card.Alert>{card.error}</Card.Alert>
-        {supportEmail && (
+        {mode === SIGN_UP_MODES.RESTRICTED && supportEmail && (
           <Flex
             direction='col'
             gap={4}
@@ -41,7 +54,17 @@ export const SignUpRestrictedAccess = () => {
             <Button
               localizationKey={localizationKeys('signUp.restrictedAccess.blockButton__emailSupport')}
               onClick={handleEmailSupport}
-              hasArrow
+            />
+          </Flex>
+        )}
+        {mode === SIGN_UP_MODES.WAITLIST && (
+          <Flex
+            direction='col'
+            gap={4}
+          >
+            <Button
+              localizationKey={localizationKeys('signUp.restrictedAccess.blockButton__joinWaitlist')}
+              onClick={handleWaitlistNavigate}
             />
           </Flex>
         )}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -257,7 +257,7 @@ function _SignUpStart(): JSX.Element {
     (!hasTicket || missingRequirementsWithTicket) && userSettings.authenticatableSocialStrategies.length > 0;
   const showWeb3Providers = !hasTicket && userSettings.web3FirstFactors.length > 0;
 
-  if (mode === SIGN_UP_MODES.RESTRICTED && !hasTicket) {
+  if (mode !== SIGN_UP_MODES.PUBLIC && !hasTicket) {
     return <SignUpRestrictedAccess />;
   }
 

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -250,9 +250,20 @@ describe('SignUpStart', () => {
       const { wrapper } = await createFixtures(f => {
         f.withRestrictedMode();
       });
+      render(<SignUpStart />, { wrapper });
+      screen.getByText('Access restricted');
+    });
+  });
+
+  describe('Waitlist signup', () => {
+    it('shows the restricted component with waitlist mode', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withWaitlistMode();
+      });
 
       render(<SignUpStart />, { wrapper });
       screen.getByText('Access restricted');
+      screen.getByText('Join waitlist');
     });
   });
 

--- a/packages/clerk-js/src/ui/components/Waitlist/Waitlist.tsx
+++ b/packages/clerk-js/src/ui/components/Waitlist/Waitlist.tsx
@@ -1,0 +1,62 @@
+import { useClerk } from '@clerk/shared/react';
+import type { WaitlistModalProps } from '@clerk/types';
+
+import { ComponentContext, useWaitlistContext } from '../../contexts';
+import { Flow, localizationKeys } from '../../customizables';
+import { Card, withCardStateProvider } from '../../elements';
+import { Route, VIRTUAL_ROUTER_BASE_PATH } from '../../router';
+import { useFormControl } from '../../utils';
+import { WaitlistForm } from './WaitlistForm';
+
+const _Waitlist = () => {
+  const clerk = useClerk();
+  const ctx = useWaitlistContext();
+  const { signInUrl } = ctx;
+
+  const formState = {
+    emailAddress: useFormControl('emailAddress', '', {
+      type: 'email',
+      label: localizationKeys('formFieldLabel__emailAddress'),
+      placeholder: localizationKeys('formFieldInputPlaceholder__emailAddress'),
+    }),
+  };
+
+  return (
+    <Flow.Root flow='waitlist'>
+      <Card.Root>
+        <Card.Content>
+          <WaitlistForm formState={formState} />
+        </Card.Content>
+        <Card.Footer>
+          <Card.Action elementId='waitlist'>
+            <Card.ActionText localizationKey={localizationKeys('waitlist.start.actionText')} />
+            <Card.ActionLink
+              localizationKey={localizationKeys('waitlist.start.actionLink')}
+              to={clerk.buildUrlWithAuth(signInUrl)}
+            />
+          </Card.Action>
+        </Card.Footer>
+      </Card.Root>
+    </Flow.Root>
+  );
+};
+
+export const Waitlist = withCardStateProvider(_Waitlist);
+
+export const WaitlistModal = (props: WaitlistModalProps): JSX.Element => {
+  const waitlistProps = {
+    signInUrl: `/${VIRTUAL_ROUTER_BASE_PATH}/sign-in`,
+    ...props,
+    routing: 'virtual',
+  };
+
+  return (
+    <Route path='waitlist'>
+      <ComponentContext.Provider value={{ ...waitlistProps, componentName: 'Waitlist', mode: 'modal' }}>
+        <div>
+          <Waitlist />
+        </div>
+      </ComponentContext.Provider>
+    </Route>
+  );
+};

--- a/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
+++ b/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
@@ -1,0 +1,125 @@
+import { useClerk } from '@clerk/shared/react';
+import type { JoinWaitlistParams } from '@clerk/types';
+
+import { useWizard, Wizard } from '../../common';
+import { useWaitlistContext } from '../../contexts';
+import { Col, descriptors, Flex, Icon, localizationKeys, Text } from '../../customizables';
+import { Card, Form, Header, useCardState } from '../../elements';
+import { useLoadingStatus } from '../../hooks';
+import { SpinnerJumbo } from '../../icons';
+import { useRouter } from '../../router';
+import { animations } from '../../styledSystem';
+import { type FormControlState, handleError } from '../../utils';
+import type { Fields } from './waitlistFormHelpers';
+
+type WaitlistFormProps = {
+  formState: Record<keyof Fields, FormControlState<any>>;
+};
+
+export const WaitlistForm = (props: WaitlistFormProps) => {
+  const clerk = useClerk();
+  const card = useCardState();
+  const status = useLoadingStatus();
+  const { navigate } = useRouter();
+  const ctx = useWaitlistContext();
+  const { formState } = props;
+  const wizard = useWizard({ onNextStep: () => card.setError(undefined) });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    status.setLoading();
+    card.setLoading();
+    card.setError(undefined);
+
+    const joinWaitlistParams: JoinWaitlistParams = { emailAddress: formState.emailAddress.value };
+
+    await clerk
+      .joinWaitlist(joinWaitlistParams)
+      .then(() => {
+        wizard.nextStep();
+
+        setTimeout(() => {
+          if (ctx.redirectUrl) {
+            void navigate(ctx.redirectUrl);
+          }
+        }, 2000);
+        return;
+      })
+      .catch(error => {
+        handleError(error, [], card.setError);
+      })
+      .finally(() => {
+        status.setIdle();
+        card.setIdle();
+      });
+  };
+
+  return (
+    <Wizard {...wizard.props}>
+      <Col gap={6}>
+        <Header.Root>
+          <Header.Title localizationKey={localizationKeys('waitlist.start.title')} />
+          <Header.Subtitle localizationKey={localizationKeys('waitlist.start.subtitle')} />
+        </Header.Root>
+        <Card.Alert>{card.error}</Card.Alert>
+        <Flex
+          direction='col'
+          elementDescriptor={descriptors.main}
+          gap={6}
+        >
+          <Form.Root
+            onSubmit={handleSubmit}
+            gap={8}
+          >
+            <Col gap={6}>
+              <Form.ControlRow elementId='emailAddress'>
+                <Form.PlainInput
+                  {...formState.emailAddress.props}
+                  isRequired
+                />
+              </Form.ControlRow>
+            </Col>
+            <Col center>
+              <Form.SubmitButton localizationKey={localizationKeys('waitlist.start.formButton')} />
+            </Col>
+          </Form.Root>
+        </Flex>
+      </Col>
+      <Col gap={6}>
+        <Header.Root>
+          <Header.Title localizationKey={localizationKeys('waitlist.success.title')} />
+          <Header.Subtitle localizationKey={localizationKeys('waitlist.success.subtitle')} />
+        </Header.Root>
+        {ctx.redirectUrl && (
+          <Flex
+            direction='col'
+            elementDescriptor={descriptors.main}
+            gap={6}
+          >
+            <Col center>
+              <Flex
+                gap={2}
+                align='center'
+              >
+                <Icon
+                  icon={SpinnerJumbo}
+                  sx={t => ({
+                    margin: 'auto',
+                    width: t.sizes.$6,
+                    height: t.sizes.$6,
+                    animation: `${animations.spinning} 1s linear infinite`,
+                  })}
+                />
+                <Text
+                  colorScheme='secondary'
+                  localizationKey={localizationKeys('waitlist.success.message')}
+                />
+              </Flex>
+            </Col>
+          </Flex>
+        )}
+      </Col>
+    </Wizard>
+  );
+};

--- a/packages/clerk-js/src/ui/components/Waitlist/__tests__/Waitlist.test.tsx
+++ b/packages/clerk-js/src/ui/components/Waitlist/__tests__/Waitlist.test.tsx
@@ -1,0 +1,46 @@
+import type { WaitlistResource } from '@clerk/types';
+
+import { render, screen } from '../../../../testUtils';
+import { bindCreateFixtures } from '../../../utils/test/createFixtures';
+import { Waitlist } from '../Waitlist';
+
+const { createFixtures } = bindCreateFixtures('Waitlist');
+
+describe('Waitlist', () => {
+  it('should render the waitlist', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withWaitlistMode();
+    });
+    render(<Waitlist />, { wrapper });
+
+    screen.getByText('Enter your email address and we’ll let you know when your spot is ready');
+    screen.getByRole('button', { name: 'Join the waitlist' });
+  });
+
+  it('should go to success step', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withWaitlistMode();
+    });
+    fixtures.clerk.joinWaitlist.mockResolvedValueOnce({ id: 'wle_2lEkeknQndRH0q3ImmFdJI4PbXh' } as WaitlistResource);
+    const { userEvent } = render(<Waitlist />, { wrapper });
+    await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
+    await userEvent.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+
+    expect(fixtures.clerk.joinWaitlist).toHaveBeenCalled();
+
+    screen.getByText('Thanks for joining the waitlist!');
+  });
+
+  it('should have the correct sign-in url', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withWaitlistMode();
+    });
+    fixtures.clerk.joinWaitlist.mockResolvedValueOnce({ id: 'wle_2lEkeknQndRH0q3ImmFdJI4PbXh' } as WaitlistResource);
+    render(<Waitlist />, { wrapper });
+
+    const signInLink = screen.getByText(/Already have access/i).nextElementSibling;
+    expect(signInLink?.textContent).toBe('Sign in');
+    expect(signInLink?.tagName.toUpperCase()).toBe('A');
+    expect(signInLink?.getAttribute('href')).toMatch(fixtures.environment.displayConfig.signInUrl);
+  });
+});

--- a/packages/clerk-js/src/ui/components/Waitlist/index.ts
+++ b/packages/clerk-js/src/ui/components/Waitlist/index.ts
@@ -1,0 +1,1 @@
+export * from './Waitlist';

--- a/packages/clerk-js/src/ui/components/Waitlist/waitlistFormHelpers.ts
+++ b/packages/clerk-js/src/ui/components/Waitlist/waitlistFormHelpers.ts
@@ -1,0 +1,11 @@
+const FieldKeys = ['emailAddress'];
+
+export type FieldKey = (typeof FieldKeys)[number];
+
+export type Field = {
+  required: boolean;
+};
+
+export type Fields = {
+  [key in FieldKey]: Field | undefined;
+};

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -24,6 +24,7 @@ import type {
   UserButtonCtx,
   UserProfileCtx,
   UserVerificationCtx,
+  WaitlistCtx,
 } from '../types';
 import type { CustomPageContent } from '../utils';
 import {
@@ -57,6 +58,7 @@ export type SignUpContextType = SignUpCtx & {
   authQueryString: string | null;
   afterSignUpUrl: string;
   afterSignInUrl: string;
+  waitlistUrl: string;
 };
 
 export const useSignUpContext = (): SignUpContextType => {
@@ -96,10 +98,12 @@ export const useSignUpContext = (): SignUpContextType => {
   // from the `path` prop instead, when the routing is set to 'path'.
   let signUpUrl = (ctx.routing === 'path' && ctx.path) || options.signUpUrl || displayConfig.signUpUrl;
   let signInUrl = ctx.signInUrl || options.signInUrl || displayConfig.signInUrl;
+  let waitlistUrl = ctx.waitlistUrl || options.waitlistUrl || displayConfig.waitlistUrl;
 
   const preservedParams = redirectUrls.getPreservedSearchParams();
   signInUrl = buildURL({ base: signInUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
   signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+  waitlistUrl = buildURL({ base: waitlistUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
 
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
@@ -109,6 +113,7 @@ export const useSignUpContext = (): SignUpContextType => {
     componentName,
     signInUrl,
     signUpUrl,
+    waitlistUrl,
     secondFactorUrl,
     afterSignUpUrl,
     afterSignInUrl,
@@ -129,6 +134,7 @@ export type SignInContextType = SignInCtx & {
   afterSignUpUrl: string;
   afterSignInUrl: string;
   transferable: boolean;
+  waitlistUrl: string;
 };
 
 export const useSignInContext = (): SignInContextType => {
@@ -168,10 +174,12 @@ export const useSignInContext = (): SignInContextType => {
   // from the `path` prop instead, when the routing is set to 'path'.
   let signInUrl = (ctx.routing === 'path' && ctx.path) || options.signInUrl || displayConfig.signInUrl;
   let signUpUrl = ctx.signUpUrl || options.signUpUrl || displayConfig.signUpUrl;
+  let waitlistUrl = ctx.waitlistUrl || options.waitlistUrl || displayConfig.waitlistUrl;
 
   const preservedParams = redirectUrls.getPreservedSearchParams();
   signInUrl = buildURL({ base: signInUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
   signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+  waitlistUrl = buildURL({ base: waitlistUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
 
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
@@ -181,6 +189,7 @@ export const useSignInContext = (): SignInContextType => {
     componentName,
     signUpUrl,
     signInUrl,
+    waitlistUrl,
     afterSignInUrl,
     afterSignUpUrl,
     navigateAfterSignIn,
@@ -654,5 +663,25 @@ export const useGoogleOneTapContext = () => {
     ...ctx,
     componentName,
     generateCallbackUrls,
+  };
+};
+
+export type WaitlistContextType = WaitlistCtx & {
+  signInUrl: string;
+  redirectUrl?: string;
+};
+
+export const useWaitlistContext = (): WaitlistContextType => {
+  const { componentName, ...ctx } = (React.useContext(ComponentContext) || {}) as WaitlistCtx;
+  const { displayConfig } = useEnvironment();
+  const options = useOptions();
+
+  let signInUrl = ctx.signInUrl || options.signInUrl || displayConfig.signInUrl;
+  signInUrl = buildURL({ base: signInUrl }, { stringify: true });
+
+  return {
+    ...ctx,
+    componentName,
+    signInUrl,
   };
 };

--- a/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/FlowMetadataContext.tsx
@@ -12,7 +12,8 @@ type FlowMetadata = {
     | 'createOrganization'
     | 'organizationSwitcher'
     | 'organizationList'
-    | 'oneTap';
+    | 'oneTap'
+    | 'waitlist';
   part?:
     | 'start'
     | 'emailCode'

--- a/packages/clerk-js/src/ui/icons/index.ts
+++ b/packages/clerk-js/src/ui/icons/index.ts
@@ -62,3 +62,4 @@ export { default as Organization } from './organization.svg';
 export { default as Users } from './users.svg';
 export { default as Fingerprint } from './fingerprint.svg';
 export { default as Block } from './block.svg';
+export { default as SpinnerJumbo } from './spinner-jumbo.svg';

--- a/packages/clerk-js/src/ui/icons/spinner-jumbo.svg
+++ b/packages/clerk-js/src/ui/icons/spinner-jumbo.svg
@@ -1,0 +1,11 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.25 11.66L12.2499 11.66" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 13.25L8.5 13.2499" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.25 8L3.2501 8" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.75 4.32996L4.75007 4.33003" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.75 11.66L4.75007 11.6599" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 2.75V2.7501" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.75 8L13.7499 8" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.25 4.33002L12.2499 4.33009" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.75 8C13.75 5.10051 11.3995 2.75 8.5 2.75" stroke="#747686" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/clerk-js/src/ui/lazyModules/components.ts
+++ b/packages/clerk-js/src/ui/lazyModules/components.ts
@@ -14,6 +14,7 @@ const componentImportPaths = {
   ImpersonationFab: () => import(/* webpackChunkName: "impersonationfab" */ './../components/ImpersonationFab'),
   GoogleOneTap: () => import(/* webpackChunkName: "onetap" */ './../components/GoogleOneTap'),
   UserVerification: () => import(/* webpackChunkName: "userverification" */ './../components/UserVerification'),
+  Waitlist: () => import(/* webpackChunkName: "waitlist" */ './../components/Waitlist'),
 } as const;
 
 export const SignIn = lazy(() => componentImportPaths.SignIn().then(module => ({ default: module.SignIn })));
@@ -68,6 +69,12 @@ export const OrganizationList = lazy(() =>
   componentImportPaths.OrganizationList().then(module => ({ default: module.OrganizationList })),
 );
 
+export const Waitlist = lazy(() => componentImportPaths.Waitlist().then(module => ({ default: module.Waitlist })));
+
+export const WaitlistModal = lazy(() =>
+  componentImportPaths.Waitlist().then(module => ({ default: module.WaitlistModal })),
+);
+
 export const ImpersonationFab = lazy(() =>
   componentImportPaths.ImpersonationFab().then(module => ({ default: module.ImpersonationFab })),
 );
@@ -93,6 +100,8 @@ export const ClerkComponents = {
   CreateOrganizationModal,
   UserVerificationModal,
   GoogleOneTap,
+  Waitlist,
+  WaitlistModal,
 };
 
 export type ClerkComponentName = keyof typeof ClerkComponents;

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -9,6 +9,7 @@ import type {
   SignUpProps,
   UserButtonProps,
   UserProfileProps,
+  WaitlistProps,
 } from '@clerk/types';
 
 export type {
@@ -21,6 +22,7 @@ export type {
   OrganizationProfileProps,
   CreateOrganizationProps,
   OrganizationListProps,
+  WaitlistProps,
   __experimental_UserVerificationProps,
 };
 
@@ -33,6 +35,7 @@ export type AvailableComponentProps =
   | OrganizationProfileProps
   | CreateOrganizationProps
   | OrganizationListProps
+  | WaitlistProps
   | __experimental_UserVerificationProps;
 
 type ComponentMode = 'modal' | 'mounted';
@@ -86,6 +89,11 @@ export type GoogleOneTapCtx = GoogleOneTapProps & {
   componentName: 'GoogleOneTap';
 };
 
+export type WaitlistCtx = WaitlistProps & {
+  componentName: 'Waitlist';
+  mode?: ComponentMode;
+};
+
 export type AvailableComponentCtx =
   | SignInCtx
   | SignUpCtx
@@ -96,4 +104,5 @@ export type AvailableComponentCtx =
   | CreateOrganizationCtx
   | OrganizationSwitcherCtx
   | OrganizationListCtx
-  | GoogleOneTapCtx;
+  | GoogleOneTapCtx
+  | WaitlistCtx;

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -508,6 +508,10 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     us.sign_up.legal_consent_enabled = true;
   };
 
+  const withWaitlistMode = () => {
+    us.sign_up.mode = SIGN_UP_MODES.WAITLIST;
+  };
+
   // TODO: Add the rest, consult pkg/generate/auth_config.go
 
   return {
@@ -527,5 +531,6 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     withPasskeySettings,
     withRestrictedMode,
     withLegalConsent,
+    withWaitlistMode,
   };
 };

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -189,6 +189,7 @@ const createBaseUserSettings = (): UserSettingsJSON => {
       progressive: true,
       captcha_enabled: false,
       disable_hibp: false,
+      mode: 'public',
     },
     restrictions: {
       allowlist: {

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -450,12 +450,14 @@ export const arSA: LocalizationResource = {
     },
     start: {
       actionLink: 'إنشاء حساب جديد',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'استخدم البريد الإلكتروني',
       actionLink__use_email_username: 'استخدم البريد الإلكتروني أو اسم المستخدم',
       actionLink__use_passkey: 'استخدم مفتاح المرور بدلاً من ذلك',
       actionLink__use_phone: 'استخدم رقم الجوال',
       actionLink__use_username: 'استخدم اسم المستخدم',
       actionText: 'ليس لديك حساب؟',
+      actionText__join_waitlist: undefined,
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'تسجيل الدخول',
     },
@@ -467,6 +469,17 @@ export const arSA: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'إدخل كلمة المرور',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'تسجيل الدخول',
       actionText: 'ليس لديك حساب؟',
@@ -508,6 +521,15 @@ export const arSA: LocalizationResource = {
       resendButton: 'لم يصلك الرمز؟ حاول مرة أخرى',
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'تحقق من هاتفك',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'تسجيل الدخول',
@@ -877,6 +899,20 @@ export const arSA: LocalizationResource = {
       successMessage: 'تمت إضافة المحفظة الى حسابك.',
       title: 'إضافة محفظة web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -454,12 +454,14 @@ export const beBY: LocalizationResource = {
     },
     start: {
       actionLink: 'Зарэгістравацца',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Выкарыстаць пошту',
       actionLink__use_email_username: 'Выкарыстаць пошту або імя карыстальніка',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Выкарыстаць нумар тэлефона',
       actionLink__use_username: 'Выкарыстаць імя карыстальніка',
       actionText: 'Няма ўліковага запісу?',
+      actionText__join_waitlist: undefined,
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Увайсці',
     },
@@ -471,6 +473,17 @@ export const beBY: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Увядзіце ваш пароль',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Увайсці',
       actionText: 'Ужо ёсць уліковы запіс?',
@@ -512,6 +525,15 @@ export const beBY: LocalizationResource = {
       resendButton: 'Пераадправіць код',
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Верыфікуйце Ваш нумар тэлефона',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Увайсці',
@@ -789,7 +811,6 @@ export const beBY: LocalizationResource = {
       successMessage: 'Ваш профіль быў абноўлены.',
       title: 'Абнавіць профіль',
     },
-
     start: {
       activeDevicesSection: {
         destructiveAction: 'Выйсці з прылады',
@@ -891,6 +912,20 @@ export const beBY: LocalizationResource = {
       successMessage: 'Кашалёк быў дададзены да вашага ўліковага запісу.',
       title: 'Дадаць web3 кашалёк',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -450,12 +450,14 @@ export const bgBG: LocalizationResource = {
     },
     start: {
       actionLink: 'Регистрирайте се',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Използвайте имейл',
       actionLink__use_email_username: 'Използвайте имейл или потребителско име',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Използвайте телефон',
       actionLink__use_username: 'Използвайте потребителско име',
       actionText: 'Нямате акаунт?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Добре дошли обратно! Моля, влезте, за да продължите',
       title: 'Влезте в {{applicationName}}',
     },
@@ -468,6 +470,17 @@ export const bgBG: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Въведете вашата парола',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Влезте',
       actionText: 'Вече имате акаунт?',
@@ -509,6 +522,15 @@ export const bgBG: LocalizationResource = {
       resendButton: 'Не сте получили код? Изпрати отново',
       subtitle: 'Въведете кода за потвърждение, изпратен на вашия телефон',
       title: 'Потвърдете вашия телефон',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Влезте',
@@ -884,6 +906,20 @@ export const bgBG: LocalizationResource = {
       successMessage: 'Портфейлът беше добавен към вашия профил.',
       title: 'Добави web3 портфейл',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -449,12 +449,14 @@ export const csCZ: LocalizationResource = {
     },
     start: {
       actionLink: 'Registrovat se',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použít email',
       actionLink__use_email_username: 'Použít email nebo uživatelské jméno',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Použít telefon',
       actionLink__use_username: 'Použít uživatelské jméno',
       actionText: 'Nemáte účet?',
+      actionText__join_waitlist: undefined,
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Přihlásit se',
     },
@@ -466,6 +468,17 @@ export const csCZ: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Zadejte své heslo',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Přihlásit se',
       actionText: 'Máte účet?',
@@ -507,6 +520,15 @@ export const csCZ: LocalizationResource = {
       resendButton: 'Znovu poslat kód',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Ověřte svůj telefon',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Přihlásit se',
@@ -880,6 +902,20 @@ export const csCZ: LocalizationResource = {
       successMessage: 'Peněženka byla přidána k vašemu účtu.',
       title: 'Přidat web3 peněženku',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -450,12 +450,14 @@ export const daDK: LocalizationResource = {
     },
     start: {
       actionLink: 'Tilmeld dig',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Brug email',
       actionLink__use_email_username: 'Brug email eller brugernavn',
       actionLink__use_passkey: 'Brug adgangsnøgle',
       actionLink__use_phone: 'Brug telefon',
       actionLink__use_username: 'Brug brugernavn',
       actionText: 'Ingen konto?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Log ind',
     },
@@ -467,6 +469,17 @@ export const daDK: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Indtast din adgangskode',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Log ind',
       actionText: 'Har du en konto?',
@@ -508,6 +521,15 @@ export const daDK: LocalizationResource = {
       resendButton: 'Send kode igen',
       subtitle: 'Fortsæt til {{applicationName}}',
       title: 'Bekræft din telefon',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Log ind',
@@ -882,6 +904,20 @@ export const daDK: LocalizationResource = {
       successMessage: 'Tegnebogen er blevet tilføjet til din konto.',
       title: 'Tilføj web3-tegnebog',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -456,12 +456,14 @@ export const deDE: LocalizationResource = {
     },
     start: {
       actionLink: 'Anmelden',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'E-mail nutzen',
       actionLink__use_email_username: 'E-mail oder Benutzernamen nutzen',
       actionLink__use_passkey: 'Passkey nutzen',
       actionLink__use_phone: 'Mobiltelefon nutzen',
       actionLink__use_username: 'Benutzername nutzen',
       actionText: 'Kein Account?',
+      actionText__join_waitlist: undefined,
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Einloggen',
     },
@@ -474,6 +476,17 @@ export const deDE: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Geben Sie Ihr Passwort ein',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Einloggen',
       actionText: 'Haben Sie ein Konto?',
@@ -515,6 +528,15 @@ export const deDE: LocalizationResource = {
       resendButton: 'Code erneut senden',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Verifizieren Sie Ihre Telefonnummer',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Einloggen',
@@ -896,6 +918,20 @@ export const deDE: LocalizationResource = {
       successMessage: 'Die Brieftasche wurde Ihrem Konto hinzugefügt.',
       title: 'Web3-Wallet hinzufügen',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -451,12 +451,14 @@ export const elGR: LocalizationResource = {
     },
     start: {
       actionLink: 'Εγγραφή',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Χρήση email',
       actionLink__use_email_username: 'Χρήση email ή ονόματος χρήστη',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Χρήση τηλεφώνου',
       actionLink__use_username: 'Χρήση ονόματος χρήστη',
       actionText: 'Δεν έχετε λογαριασμό;',
+      actionText__join_waitlist: undefined,
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Σύνδεση',
     },
@@ -468,6 +470,17 @@ export const elGR: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Εισαγωγή κωδικού πρόσβασης',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Σύνδεση',
       actionText: 'Έχετε ήδη λογαριασμό;',
@@ -509,6 +522,15 @@ export const elGR: LocalizationResource = {
       resendButton: 'Δεν λάβατε κωδικό; Αποστολή ξανά',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Επαληθεύστε το τηλέφωνό σας',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Σύνδεση',
@@ -890,6 +912,20 @@ export const elGR: LocalizationResource = {
       successMessage: 'Το πορτοφόλι έχει προστεθεί στον λογαριασμό σας.',
       title: 'Προσθήκη web3 πορτοφολιού',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -440,12 +440,14 @@ export const enUS: LocalizationResource = {
     },
     start: {
       actionLink: 'Sign up',
+      actionLink__join_waitlist: 'Join waitlist',
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
       actionLink__use_passkey: 'Use passkey instead',
       actionLink__use_phone: 'Use phone',
       actionLink__use_username: 'Use username',
       actionText: 'Don’t have an account?',
+      actionText__join_waitlist: 'Want early access?',
       subtitle: 'Welcome back! Please sign in to continue',
       title: 'Sign in to {{applicationName}}',
     },
@@ -457,6 +459,18 @@ export const enUS: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Enter your password',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: 'I agree to the {{ privacyPolicyLink || link("Privacy Policy") }}',
+        label__onlyTermsOfService: 'I agree to the {{ termsOfServiceLink || link("Terms of Service") }}',
+        label__termsOfServiceAndPrivacyPolicy:
+          'I agree to the {{ termsOfServiceLink || link("Terms of Service") }} and {{ privacyPolicyLink || link("Privacy Policy") }}',
+      },
+      continue: {
+        subtitle: 'Please read and accept the terms to continue',
+        title: 'Legal consent',
+      },
+    },
     continue: {
       actionLink: 'Sign in',
       actionText: 'Already have an account?',
@@ -500,6 +514,15 @@ export const enUS: LocalizationResource = {
       subtitle: 'Enter the verification code sent to your phone',
       title: 'Verify your phone',
     },
+    restrictedAccess: {
+      actionLink: 'Sign in',
+      actionText: 'Already have an account?',
+      blockButton__emailSupport: 'Email support',
+      blockButton__joinWaitlist: 'Join waitlist',
+      subtitle: 'Sign ups are currently disabled. If you believe you should have access, please contact support.',
+      subtitleWaitlist: 'Sign ups are currently disabled. To be the first to know when we launch, join the waitlist.',
+      title: 'Access restricted',
+    },
     start: {
       actionLink: 'Sign in',
       actionLink__use_email: 'Use email instead',
@@ -507,25 +530,6 @@ export const enUS: LocalizationResource = {
       actionText: 'Already have an account?',
       subtitle: 'Welcome! Please fill in the details to get started.',
       title: 'Create your account',
-    },
-    restrictedAccess: {
-      title: 'Access restricted',
-      subtitle: 'Sign ups are currently disabled. If you believe you should have access, please contact support.',
-      actionLink: 'Sign in',
-      actionText: 'Already have an account?',
-      blockButton__emailSupport: 'Email support',
-    },
-    __experimental_legalConsent: {
-      continue: {
-        subtitle: 'Please read and accept the terms to continue',
-        title: 'Legal consent',
-      },
-      checkbox: {
-        label__termsOfServiceAndPrivacyPolicy:
-          'I agree to the {{ termsOfServiceLink || link("Terms of Service") }} and {{ privacyPolicyLink || link("Privacy Policy") }}',
-        label__onlyTermsOfService: 'I agree to the {{ termsOfServiceLink || link("Terms of Service") }}',
-        label__onlyPrivacyPolicy: 'I agree to the {{ privacyPolicyLink || link("Privacy Policy") }}',
-      },
     },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',
@@ -896,6 +900,20 @@ export const enUS: LocalizationResource = {
       successMessage: 'The wallet has been added to your account.',
       title: 'Add web3 wallet',
       web3WalletButtonsBlockButton: '{{provider|titleize}}',
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: 'Sign in',
+      actionText: 'Already have access?',
+      formButton: 'Join the waitlist',
+      subtitle: 'Enter your email address and we’ll let you know when your spot is ready',
+      title: 'Join the waitlist',
+    },
+    success: {
+      message: 'You will be redirected soon...',
+      subtitle: 'We’ll be in touch when your spot is ready',
+      title: 'Thanks for joining the waitlist!',
     },
   },
 } as const;

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -451,12 +451,14 @@ export const esES: LocalizationResource = {
     },
     start: {
       actionLink: 'Regístrese',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Usar correo electrónico',
       actionLink__use_email_username: 'Usar correo electrónico o nombre de usuario',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Usar teléfono',
       actionLink__use_username: 'Usar nombre de usuario',
       actionText: '¿No tienes cuenta?',
+      actionText__join_waitlist: undefined,
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Entrar',
     },
@@ -468,6 +470,17 @@ export const esES: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Ingresa tu contraseña',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Entrar',
       actionText: '¿Tiene una cuenta?',
@@ -509,6 +522,15 @@ export const esES: LocalizationResource = {
       resendButton: 'Re-enviar código',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Verifique su teléfono',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Entrar',
@@ -888,6 +910,20 @@ export const esES: LocalizationResource = {
       successMessage: 'La billetera ha sido agregada a su cuenta.',
       title: 'Añadir billetera Web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -455,12 +455,14 @@ export const esMX: LocalizationResource = {
     },
     start: {
       actionLink: 'Registrarse',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizar correo electrónico',
       actionLink__use_email_username: 'Utilizar correo electrónico o nombre de usuario',
       actionLink__use_passkey: 'Usar llave de acceso',
       actionLink__use_phone: 'Utilizar teléfono',
       actionLink__use_username: 'Utilizar nombre de usuario',
       actionText: '¿No tiene cuenta?',
+      actionText__join_waitlist: undefined,
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Iniciar sesión',
     },
@@ -472,6 +474,17 @@ export const esMX: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Ingresa tu contraseña',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Entrar',
       actionText: '¿Tiene una cuenta?',
@@ -513,6 +526,15 @@ export const esMX: LocalizationResource = {
       resendButton: 'Reenviar código',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Verifique su teléfono',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Acceder',
@@ -890,6 +912,20 @@ export const esMX: LocalizationResource = {
       successMessage: 'La billetera ha sido agregada a su cuenta.',
       title: 'Añadir web3 billetera',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -452,12 +452,14 @@ export const fiFI: LocalizationResource = {
     },
     start: {
       actionLink: 'Rekisteröidy',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Käytä sähköpostia',
       actionLink__use_email_username: 'Käytä sähköpostia tai käyttäjänimeä',
       actionLink__use_passkey: 'Käytä pääsyavainta',
       actionLink__use_phone: 'Käytä puhelinta',
       actionLink__use_username: 'Käytä käyttäjänimeä',
       actionText: 'Eikö sinulla ole tiliä?',
+      actionText__join_waitlist: undefined,
       subtitle: 'jatkaaksesi kohteeseen {{applicationName}}',
       title: 'Kirjaudu sisään',
     },
@@ -469,6 +471,17 @@ export const fiFI: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Syötä salasanasi',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Kirjaudu sisään',
       actionText: 'Onko sinulla jo tili?',
@@ -510,6 +523,15 @@ export const fiFI: LocalizationResource = {
       resendButton: 'Etkö saanut koodia? Lähetä uudelleen',
       subtitle: 'Syötä puhelimeesi lähetetty koodi jatkaaksesi.',
       title: 'Tarkista puhelimesi',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Kirjaudu sisään',
@@ -886,6 +908,20 @@ export const fiFI: LocalizationResource = {
       successMessage: 'Web3-lompakko on lisätty tilillesi.',
       title: 'Lisää web3-lompakko',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -454,12 +454,14 @@ export const frFR: LocalizationResource = {
     },
     start: {
       actionLink: "S'inscrire",
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utiliser e-mail',
       actionLink__use_email_username: "Utiliser l'e-mail ou le nom d'utilisateur",
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Utiliser téléphone',
       actionLink__use_username: "Utiliser le nom d'utilisateur",
       actionText: "Vous n'avez pas encore de compte ?",
+      actionText__join_waitlist: undefined,
       subtitle: 'pour continuer vers {{applicationName}}',
       title: "S'identifier",
     },
@@ -471,6 +473,17 @@ export const frFR: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Tapez votre mot de passe',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: "S'identifier",
       actionText: 'Vous avez déjà un compte ?',
@@ -512,6 +525,15 @@ export const frFR: LocalizationResource = {
       resendButton: 'Renvoyer le code',
       subtitle: 'pour continuer vers {{applicationName}}',
       title: 'Vérifiez votre téléphone',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: "S'identifier",
@@ -890,6 +912,20 @@ export const frFR: LocalizationResource = {
       successMessage: 'Le portefeuille a été ajouté à votre compte.',
       title: 'Ajouter un portefeuille Web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -444,12 +444,14 @@ export const heIL: LocalizationResource = {
     },
     start: {
       actionLink: 'הרשמה',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'השתמש בדוא"ל',
       actionLink__use_email_username: 'השתמש בדוא"ל או שם משתמש',
       actionLink__use_passkey: 'השתמש במפתח סיסמה במקום',
       actionLink__use_phone: 'השתמש בטלפון',
       actionLink__use_username: 'השתמש בשם משתמש',
       actionText: 'אין לך חשבון?',
+      actionText__join_waitlist: undefined,
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'התחבר',
     },
@@ -461,6 +463,17 @@ export const heIL: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'הזן את הסיסמה שלך',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'התחבר',
       actionText: 'יש לך חשבון?',
@@ -502,6 +515,15 @@ export const heIL: LocalizationResource = {
       resendButton: 'שלח קוד שוב',
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'אמת את מספר הטלפון שלך',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'התחבר',
@@ -864,6 +886,20 @@ export const heIL: LocalizationResource = {
       successMessage: 'הארנק התווסף לחשבון שלך.',
       title: 'הוסף ארנק web3',
       web3WalletButtonsBlockButton: '{{provider|titleize}}',
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -451,12 +451,14 @@ export const huHU: LocalizationResource = {
     },
     start: {
       actionLink: 'Regisztráció',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Email használata',
       actionLink__use_email_username: 'Használd az emailded vagy a felhasználóneved',
       actionLink__use_passkey: 'Passkey használata',
       actionLink__use_phone: 'Telefon használata',
       actionLink__use_username: 'Felhasználónév használata',
       actionText: 'Nincs fiókod?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Üdv újra! A folytatáshoz kérlek jelentkezz be.',
       title: 'Bejelentkezés a(z) {{applicationName}} fiókba',
     },
@@ -468,6 +470,17 @@ export const huHU: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Írd be a jelszavad',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Bejelentkezés',
       actionText: 'Van már fiókod?',
@@ -509,6 +522,15 @@ export const huHU: LocalizationResource = {
       resendButton: 'Nem kaptad meg a kódot? Újraküldés',
       subtitle: 'Írd be a visszaigazoló kódot, amit a telefonodra kaptál',
       title: 'Erősítsd meg a telefonszámod',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Bejelentkezés',
@@ -887,6 +909,20 @@ export const huHU: LocalizationResource = {
       successMessage: 'A tárca sikeresen hozzáadva a fiókodhoz.',
       title: 'Web3 tárca hozzáadása',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -453,12 +453,14 @@ export const isIS: LocalizationResource = {
     },
     start: {
       actionLink: 'Skrá sig',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Nota netfang',
       actionLink__use_email_username: 'Nota netfang eða notendanafn',
       actionLink__use_passkey: 'Nota lykil í staðinn',
       actionLink__use_phone: 'Nota síma',
       actionLink__use_username: 'Nota notendanafn',
       actionText: 'Ertu ekki með reikning?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Velkomin aftur! Vinsamlegast skráðu þig inn til að halda áfram',
       title: 'Skrá inn í {{applicationName}}',
     },
@@ -470,6 +472,17 @@ export const isIS: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Sláðu inn lykilorðið þitt',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Skrá inn',
       actionText: 'Ertu með reikning?',
@@ -512,6 +525,15 @@ export const isIS: LocalizationResource = {
       resendButton: 'Fékkstu ekki kóða? Senda aftur',
       subtitle: 'Sláðu inn staðfestingarkóðann sem sendur var á símanúmerið þitt',
       title: 'Staðfesta símanúmer',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Skrá inn',
@@ -890,6 +912,20 @@ export const isIS: LocalizationResource = {
       successMessage: 'Veskið hefur verið bætt við reikninginn þinn.',
       title: 'Bæta við web3 veski',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -451,12 +451,14 @@ export const itIT: LocalizationResource = {
     },
     start: {
       actionLink: 'Registrati',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Usa email',
       actionLink__use_email_username: 'Usa email o username',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Usa telefono',
       actionLink__use_username: 'Usa username',
       actionText: 'Non hai un account?',
+      actionText__join_waitlist: undefined,
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Accedi',
     },
@@ -468,6 +470,17 @@ export const itIT: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Inserisci la tua password',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Accedi',
       actionText: 'Hai un account?',
@@ -509,6 +522,15 @@ export const itIT: LocalizationResource = {
       resendButton: 'Rinvia codice',
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Verifica il tuo numero di telefono',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Accedi',
@@ -886,6 +908,20 @@ export const itIT: LocalizationResource = {
       successMessage: 'Il wallet é stato aggiunto al tuo account.',
       title: 'Aggiungi web3 wallet',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -451,12 +451,14 @@ export const jaJP: LocalizationResource = {
     },
     start: {
       actionLink: 'サインアップ',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'メールアドレスを使用',
       actionLink__use_email_username: 'メールアドレスまたはユーザー名を使用',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: '電話番号を使用',
       actionLink__use_username: 'ユーザー名を使用',
       actionText: 'アカウントをお持ちでないですか？',
+      actionText__join_waitlist: undefined,
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'サインイン',
     },
@@ -468,6 +470,17 @@ export const jaJP: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'パスワードを入力してください',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'サインイン',
       actionText: 'アカウントをお持ちですか？',
@@ -509,6 +522,15 @@ export const jaJP: LocalizationResource = {
       resendButton: 'コードを再送信',
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: '電話番号を確認',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'サインイン',
@@ -879,6 +901,20 @@ export const jaJP: LocalizationResource = {
       successMessage: 'ウォレットがアカウントに追加されました。',
       title: 'Web3ウォレットの追加',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -446,12 +446,14 @@ export const koKR: LocalizationResource = {
     },
     start: {
       actionLink: '회원가입',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: '이메일 사용하기',
       actionLink__use_email_username: '이메일 또는 사용자 이름 사용하기',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: '휴대폰 번호 사용하기',
       actionLink__use_username: '사용자 이름 사용하기',
       actionText: '계정이 없으신가요?',
+      actionText__join_waitlist: undefined,
       subtitle: '환영합니다! 계속하려면 로그인해 주세요',
       title: '{{applicationName}}에 로그인',
     },
@@ -463,6 +465,17 @@ export const koKR: LocalizationResource = {
   },
   signInEnterPasswordTitle: '비밀번호를 입력하세요',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: '로그인',
       actionText: '계정이 있으신가요?',
@@ -504,6 +517,15 @@ export const koKR: LocalizationResource = {
       resendButton: '코드 재전송',
       subtitle: '휴대폰으로 전송된 인증 코드를 입력하세요',
       title: '휴대폰 번호 인증',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: '로그인하기',
@@ -870,6 +892,20 @@ export const koKR: LocalizationResource = {
       successMessage: '지갑이 계정에 추가되었습니다ß.',
       title: 'web3 지갑 추가',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -452,12 +452,14 @@ export const mnMN: LocalizationResource = {
     },
     start: {
       actionLink: 'Бүртгүүлэх',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Имэйл ашиглах',
       actionLink__use_email_username: 'Имэйл эсвэл хэрэглэгчийн нэр ашиглах',
       actionLink__use_passkey: 'Passkey ашиглах',
       actionLink__use_phone: 'Утсаа ашиглах',
       actionLink__use_username: 'Хэрэглэгчийн нэрийг ашиглах',
       actionText: 'Бүртгэлгүй юу?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Тавтай морил! Үргэлжлүүлэхийн тулд нэвтэрнэ үү',
       title: '{{applicationName}} руу нэвтрэх',
     },
@@ -469,6 +471,17 @@ export const mnMN: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Нууц үгээ оруулна уу',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Нэвтрэх',
       actionText: 'Бүртгэлтэй юу?',
@@ -510,6 +523,15 @@ export const mnMN: LocalizationResource = {
       resendButton: 'Код хүлээж аваагүй юу? Дахин илгээх',
       subtitle: 'Таны утсанд илгээсэн баталгаажуулах кодыг оруулна уу',
       title: 'Утсаар баталгаажуулах',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Нэвтрэх',
@@ -885,6 +907,20 @@ export const mnMN: LocalizationResource = {
       successMessage: 'Таны бүртгэлд web3 wallet нэмэгдлээ.',
       title: 'Web3 wallet нэмэх',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -451,12 +451,14 @@ export const nbNO: LocalizationResource = {
     },
     start: {
       actionLink: 'Opprett konto',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Bruk e-post',
       actionLink__use_email_username: 'Bruk e-post eller brukernavn',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Bruk telefon',
       actionLink__use_username: 'Bruk brukernavn',
       actionText: 'Ingen konto?',
+      actionText__join_waitlist: undefined,
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Logg inn',
     },
@@ -468,6 +470,17 @@ export const nbNO: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Skriv inn passordet ditt',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Logg inn',
       actionText: 'Har du allerede en konto?',
@@ -509,6 +522,15 @@ export const nbNO: LocalizationResource = {
       resendButton: 'Send kode på nytt',
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Verifiser telefonen din',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Logg inn',
@@ -884,6 +906,20 @@ export const nbNO: LocalizationResource = {
       successMessage: 'Lommeboken har blitt lagt til kontoen din.',
       title: 'Legg til web3-lommebok',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -451,12 +451,14 @@ export const nlNL: LocalizationResource = {
     },
     start: {
       actionLink: 'Registreren',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Gebruik e-mail',
       actionLink__use_email_username: 'Gebruik e-mail of gebruikersnaam',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Gebruik telefoon',
       actionLink__use_username: 'Gebruik gebruikersnaam',
       actionText: 'Geen account?',
+      actionText__join_waitlist: undefined,
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Inloggen',
     },
@@ -468,6 +470,17 @@ export const nlNL: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Vul je wachtwoord in',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Inloggen',
       actionText: 'Heb je een account?',
@@ -510,6 +523,15 @@ export const nlNL: LocalizationResource = {
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Bevestig je telefoonnummer',
     },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
+    },
     start: {
       actionLink: 'Inloggen',
       actionLink__use_email: 'Gebruik e-mail',
@@ -522,6 +544,7 @@ export const nlNL: LocalizationResource = {
   socialButtonsBlockButton: 'Ga verder met {{provider|titleize}}',
   socialButtonsBlockButtonManyInView: 'Ga verder met {{provider|titleize}}',
   unstable__errors: {
+    already_a_member_in_organization: undefined,
     captcha_invalid:
       'Sign up unsuccessful due to failed security validations. Please refresh the page to try again or reach out to support for more assistance.',
     captcha_unavailable:
@@ -539,6 +562,7 @@ export const nlNL: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Achternaam moet minder dan 256 tekens bevatten.',
     form_param_max_length_exceeded__name: 'Naam moet minder dan 256 tekens bevatten.',
     form_param_nil: undefined,
+    form_param_value_invalid: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
     form_password_not_strong_enough: 'Je wachtwoord is niet sterk genoeg.',
@@ -551,6 +575,10 @@ export const nlNL: LocalizationResource = {
     form_username_invalid_length: undefined,
     identification_deletion_failed: 'Je kunt je laatste identificatie niet verwijderen.',
     not_allowed_access: undefined,
+    organization_domain_blocked: undefined,
+    organization_domain_common: undefined,
+    organization_membership_quota_exceeded: undefined,
+    organization_minimum_permissions_needed: undefined,
     passkey_already_exists: 'Deze passkey bestaat al.',
     passkey_not_supported: 'Passkeys worden niet ondersteund door deze browser.',
     passkey_pa_not_supported: 'Passkeys worden niet ondersteund door deze browser.',
@@ -875,6 +903,20 @@ export const nlNL: LocalizationResource = {
       successMessage: 'De portefeuille is toegevoegd aan dit account.',
       title: 'Web3 portefeuille toevoegen.',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -450,12 +450,14 @@ export const plPL: LocalizationResource = {
     },
     start: {
       actionLink: 'Zarejestruj się',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Użyj adresu e-mail',
       actionLink__use_email_username: 'Użyj adresu e-mail lub nazwy użytkownika',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Użyj numeru telefonu',
       actionLink__use_username: 'Użyj nazwy użytkownika',
       actionText: 'Nie masz konta?',
+      actionText__join_waitlist: undefined,
       subtitle: 'aby przejść do {{applicationName}}',
       title: 'Zaloguj się',
     },
@@ -467,6 +469,17 @@ export const plPL: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Wprowadź swoje hasło',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Zaloguj się',
       actionText: 'Masz już konto?',
@@ -513,7 +526,9 @@ export const plPL: LocalizationResource = {
       actionLink: undefined,
       actionText: undefined,
       blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
       subtitle: undefined,
+      subtitleWaitlist: undefined,
       title: undefined,
     },
     start: {
@@ -890,6 +905,20 @@ export const plPL: LocalizationResource = {
       successMessage: 'Portfel został dodany do Twojego konta.',
       title: 'Dodaj portfel web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -451,12 +451,14 @@ export const ptBR: LocalizationResource = {
     },
     start: {
       actionLink: 'Registre-se',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Usar e-mail',
       actionLink__use_email_username: 'Usar e-mail ou nome de usuário',
       actionLink__use_passkey: 'Ou use sua chave de acesso',
       actionLink__use_phone: 'Usar telefone',
       actionLink__use_username: 'Usar nome de usuário',
       actionText: 'Não possui uma conta?',
+      actionText__join_waitlist: undefined,
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
     },
@@ -468,6 +470,17 @@ export const ptBR: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Insira sua senha',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Entrar',
       actionText: 'Possui uma conta?',
@@ -510,6 +523,15 @@ export const ptBR: LocalizationResource = {
       resendButton: 'Não recebeu o código? Reenviar',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Verifique seu telefone',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Entrar',
@@ -888,6 +910,20 @@ export const ptBR: LocalizationResource = {
       successMessage: 'A carteira foi adicionada à sua conta.',
       title: 'Adicionar carteira Web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -449,12 +449,14 @@ export const ptPT: LocalizationResource = {
     },
     start: {
       actionLink: 'Registre-se',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Usar e-mail',
       actionLink__use_email_username: 'Usar e-mail ou nome de utilizador',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Usar telemóvel',
       actionLink__use_username: 'Usar nome de utilizador',
       actionText: 'Não possui uma conta?',
+      actionText__join_waitlist: undefined,
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
     },
@@ -466,6 +468,17 @@ export const ptPT: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Insira a sua palavra-passe',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Entrar',
       actionText: 'Já possui uma conta?',
@@ -507,6 +520,15 @@ export const ptPT: LocalizationResource = {
       resendButton: 'Não recebeu o código? Reenviar',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Verifique o seu telemóvel',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Entrar',
@@ -881,6 +903,20 @@ export const ptPT: LocalizationResource = {
       successMessage: 'A carteira foi adicionada à sua conta.',
       title: 'Adicionar carteira Web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -453,12 +453,14 @@ export const roRO: LocalizationResource = {
     },
     start: {
       actionLink: 'Înscrieți-vă',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizați e-mailul',
       actionLink__use_email_username: 'Utilizați e-mail sau nume de utilizator',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Utilizați telefonul',
       actionLink__use_username: 'Utilizați numele de utilizator',
       actionText: 'Nu aveți cont?',
+      actionText__join_waitlist: undefined,
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Conectați-vă',
     },
@@ -470,6 +472,17 @@ export const roRO: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Introduceți parola dvs',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Conectați-vă',
       actionText: 'Aveți un cont?',
@@ -511,6 +524,15 @@ export const roRO: LocalizationResource = {
       resendButton: 'Nu ați primit un cod? Trimiteți din nou',
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Verificarea telefonului dvs',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Conectați-vă',
@@ -892,6 +914,20 @@ export const roRO: LocalizationResource = {
       successMessage: 'Portofelul a fost adăugat în contul dumneavoastră.',
       title: 'Adăugați portofelul web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -460,12 +460,14 @@ export const ruRU: LocalizationResource = {
     },
     start: {
       actionLink: 'Зарегистрироваться',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Использовать почту',
       actionLink__use_email_username: 'Использовать почту или имя пользователя',
       actionLink__use_passkey: 'Использовать ключ доступа вместо этого',
       actionLink__use_phone: 'Использовать номер телефона',
       actionLink__use_username: 'Использовать имя пользователя',
       actionText: 'Нет учетной записи?',
+      actionText__join_waitlist: undefined,
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Войти',
     },
@@ -477,6 +479,18 @@ export const ruRU: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Введите Ваш пароль',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: 'Я согласен с {{ privacyPolicyLink || link("Политика конфиденциальности") }}',
+        label__onlyTermsOfService: 'Я согласен с {{ termsOfServiceLink || link("Условия обслуживания") }}',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Я согласен с {{ termsOfServiceLink || link("Условия обслуживания") }} и {{ privacyPolicyLink || link("Политика конфиденциальности") }}',
+      },
+      continue: {
+        subtitle: 'Пожалуйста, прочитайте и примите условия, чтобы продолжить.',
+        title: 'Юридическое согласие',
+      },
+    },
     continue: {
       actionLink: 'Войти',
       actionText: 'Уже есть учетная запись?',
@@ -520,6 +534,16 @@ export const ruRU: LocalizationResource = {
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Верифицируйте Ваш номер телефона',
     },
+    restrictedAccess: {
+      actionLink: 'Войти',
+      actionText: 'Уже есть учетная запись?',
+      blockButton__emailSupport: 'Написать в поддержку',
+      blockButton__joinWaitlist: undefined,
+      subtitle:
+        'Регистрация в данный момент отключена. Если вы считаете, что у вас должен быть доступ, пожалуйста, свяжитесь с поддержкой.',
+      subtitleWaitlist: undefined,
+      title: 'Доступ ограничен',
+    },
     start: {
       actionLink: 'Войти',
       actionLink__use_email: 'Использовать электронную почту вместо этого',
@@ -527,26 +551,6 @@ export const ruRU: LocalizationResource = {
       actionText: 'Уже есть учетная запись?',
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Создайте Вашу учетную запись',
-    },
-    restrictedAccess: {
-      title: 'Доступ ограничен',
-      subtitle:
-        'Регистрация в данный момент отключена. Если вы считаете, что у вас должен быть доступ, пожалуйста, свяжитесь с поддержкой.',
-      actionLink: 'Войти',
-      actionText: 'Уже есть учетная запись?',
-      blockButton__emailSupport: 'Написать в поддержку',
-    },
-    __experimental_legalConsent: {
-      continue: {
-        subtitle: 'Пожалуйста, прочитайте и примите условия, чтобы продолжить.',
-        title: 'Юридическое согласие',
-      },
-      checkbox: {
-        label__termsOfServiceAndPrivacyPolicy:
-          'Я согласен с {{ termsOfServiceLink || link("Условия обслуживания") }} и {{ privacyPolicyLink || link("Политика конфиденциальности") }}',
-        label__onlyTermsOfService: 'Я согласен с {{ termsOfServiceLink || link("Условия обслуживания") }}',
-        label__onlyPrivacyPolicy: 'Я согласен с {{ privacyPolicyLink || link("Политика конфиденциальности") }}',
-      },
     },
   },
   socialButtonsBlockButton: 'Продолжить с помощью {{provider|titleize}}',
@@ -919,6 +923,20 @@ export const ruRU: LocalizationResource = {
       successMessage: 'Кошелек был добавлен к вашей учетной записи.',
       title: 'Добавить web3 кошелек',
       web3WalletButtonsBlockButton: '{{provider|titleize}}',
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -449,12 +449,14 @@ export const skSK: LocalizationResource = {
     },
     start: {
       actionLink: 'Registrovať sa',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použiť email',
       actionLink__use_email_username: 'Použiť email alebo užívateľské meno',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Použiť telefón',
       actionLink__use_username: 'Použiť užívateľské meno',
       actionText: 'Nemáte účet?',
+      actionText__join_waitlist: undefined,
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Prihlásiť sa',
     },
@@ -466,6 +468,17 @@ export const skSK: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Zadajte svoje heslo',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Prihlásiť sa',
       actionText: 'Máte účet?',
@@ -507,6 +520,15 @@ export const skSK: LocalizationResource = {
       resendButton: 'Znovu poslať kód',
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Overte svoj telefón',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Prihlásiť sa',
@@ -880,6 +902,20 @@ export const skSK: LocalizationResource = {
       successMessage: 'Peňaženka bola pridaná k vášmu účtu.',
       title: 'Pridať web3 peňaženku',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -450,12 +450,14 @@ export const srRS: LocalizationResource = {
     },
     start: {
       actionLink: 'Registruj se',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Koristi e-mail',
       actionLink__use_email_username: 'Koristi e-mail ili korisničko ime',
       actionLink__use_passkey: 'Koristi ključ za prolaz umesto toga',
       actionLink__use_phone: 'Koristi telefon',
       actionLink__use_username: 'Koristi korisničko ime',
       actionText: 'Nemaš nalog?',
+      actionText__join_waitlist: undefined,
       subtitle: 'Dobro došao nazad! Molimo prijavi se da nastaviš',
       title: 'Prijavi se na {{applicationName}}',
     },
@@ -467,6 +469,17 @@ export const srRS: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Unesi svoju lozinku',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Prijavi se',
       actionText: 'Već imaš nalog?',
@@ -508,6 +521,15 @@ export const srRS: LocalizationResource = {
       resendButton: 'Nisi primio kod? Pošalji ponovo',
       subtitle: 'Unesi verifikacioni kod poslat na tvoj telefon',
       title: 'Verifikuj svoj telefon',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Prijavi se',
@@ -883,6 +905,20 @@ export const srRS: LocalizationResource = {
       successMessage: 'Novčanik je dodat na tvoj nalog.',
       title: 'Dodaj web3 novčanik',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -453,12 +453,14 @@ export const svSE: LocalizationResource = {
     },
     start: {
       actionLink: 'Skapa konto',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Use email',
       actionLink__use_email_username: 'Use email or username',
       actionLink__use_passkey: 'Använd passkey istället',
       actionLink__use_phone: 'Använd telefon',
       actionLink__use_username: 'Använd användarnamn',
       actionText: 'Har du inget konto?',
+      actionText__join_waitlist: undefined,
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Logga in',
     },
@@ -470,6 +472,17 @@ export const svSE: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Ange ditt lösenord',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Logga in',
       actionText: 'Har du redan ett konto?',
@@ -513,6 +526,15 @@ export const svSE: LocalizationResource = {
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Verifiera din telefon',
     },
+    restrictedAccess: {
+      actionLink: 'Tillbaka till inloggning',
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: 'Åtkomst till denna app är begränsad och en inbjudan krävs för att registrera sig.',
+      subtitleWaitlist: undefined,
+      title: 'Begränsad åtkomst',
+    },
     start: {
       actionLink: 'Logga in',
       actionLink__use_email: 'Använd e-post istället',
@@ -520,11 +542,6 @@ export const svSE: LocalizationResource = {
       actionText: 'Har du redan ett konto?',
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Skapa ditt konto',
-    },
-    restrictedAccess: {
-      title: 'Begränsad åtkomst',
-      subtitle: 'Åtkomst till denna app är begränsad och en inbjudan krävs för att registrera sig.',
-      actionLink: 'Tillbaka till inloggning',
     },
   },
   socialButtonsBlockButton: 'Fortsätt med {{provider|titleize}}',
@@ -890,6 +907,20 @@ export const svSE: LocalizationResource = {
       successMessage: 'Plånboken har lagts till i ditt konto.',
       title: 'Lägg till web3-plånbok',
       web3WalletButtonsBlockButton: '{{provider|titleize}}',
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -447,12 +447,14 @@ export const thTH: LocalizationResource = {
     },
     start: {
       actionLink: 'สมัครสมาชิก',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'ใช้อีเมล',
       actionLink__use_email_username: 'ใช้อีเมลหรือชื่อผู้ใช้',
       actionLink__use_passkey: 'ใช้พาสคีย์แทน',
       actionLink__use_phone: 'ใช้โทรศัพท์',
       actionLink__use_username: 'ใช้ชื่อผู้ใช้',
       actionText: 'ไม่มีบัญชีหรือ?',
+      actionText__join_waitlist: undefined,
       subtitle: 'ยินดีต้อนรับกลับ! กรุณาเข้าสู่ระบบเพื่อดำเนินการต่อ',
       title: 'เข้าสู่ระบบ {{applicationName}}',
     },
@@ -464,6 +466,17 @@ export const thTH: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'ใส่รหัสผ่านของคุณ',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'เข้าสู่ระบบ',
       actionText: 'มีบัญชีอยู่แล้วใช่หรือไม่?',
@@ -505,6 +518,15 @@ export const thTH: LocalizationResource = {
       resendButton: 'ไม่ได้รับรหัส? ส่งใหม่',
       subtitle: 'ใส่รหัสยืนยันที่ส่งไปยังโทรศัพท์ของคุณ',
       title: 'ยืนยันโทรศัพท์ของคุณ',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'เข้าสู่ระบบ',
@@ -875,6 +897,20 @@ export const thTH: LocalizationResource = {
       successMessage: 'วอลเล็ตได้ถูกเพิ่มเข้าไปในบัญชีของคุณแล้ว',
       title: 'เพิ่มวอลเล็ต Web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -452,12 +452,14 @@ export const trTR: LocalizationResource = {
     },
     start: {
       actionLink: 'Kayıt ol',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'E-posta kullan',
       actionLink__use_email_username: 'E-posta veya kullanıcı adı kullan',
       actionLink__use_passkey: 'Bunun yerine geçiş anahtarını kullanın',
       actionLink__use_phone: 'Telefon kullan',
       actionLink__use_username: 'Kullanıcı adı kullan',
       actionText: 'Hesabınız yok mu?',
+      actionText__join_waitlist: undefined,
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Giriş yap',
     },
@@ -469,6 +471,17 @@ export const trTR: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Şifrenizi girin',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Giriş yap',
       actionText: 'Hesabınız var mı?',
@@ -510,6 +523,15 @@ export const trTR: LocalizationResource = {
       resendButton: 'Kodu tekrar gönder',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Telefon numaranızı doğrulayın',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Giriş yap',
@@ -885,6 +907,20 @@ export const trTR: LocalizationResource = {
       successMessage: 'Web3 cüzdanınız hesabınıza eklendi.',
       title: 'Web3 cüzdanı ekle',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -449,12 +449,14 @@ export const ukUA: LocalizationResource = {
     },
     start: {
       actionLink: 'Зареєструватися',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Використовувати пошту',
       actionLink__use_email_username: "Використовувати пошту або ім'я користувача",
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Використовувати номер телефону',
       actionLink__use_username: "Використовувати ім'я користувача",
       actionText: 'Немає акаунта?',
+      actionText__join_waitlist: undefined,
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Увійти',
     },
@@ -466,6 +468,17 @@ export const ukUA: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Введіть Ваш пароль',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Увійти',
       actionText: 'Уже є акаунт?',
@@ -507,6 +520,15 @@ export const ukUA: LocalizationResource = {
       resendButton: 'Не отримали код? Повторно відправити',
       subtitle: 'продовжити з {{applicationName}}',
       title: 'Підтвердіть свій телефон',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Увійти',
@@ -881,6 +903,20 @@ export const ukUA: LocalizationResource = {
       successMessage: 'Гаманець було додано до вашого облікового запису.',
       title: 'Додати web3 гаманець',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -449,12 +449,14 @@ export const viVN: LocalizationResource = {
     },
     start: {
       actionLink: 'Đăng ký',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Sử dụng email',
       actionLink__use_email_username: 'Sử dụng email hoặc tên đăng nhập',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: 'Sử dụng số điện thoại',
       actionLink__use_username: 'Sử dụng tên đăng nhập',
       actionText: 'Chưa có tài khoản?',
+      actionText__join_waitlist: undefined,
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Đăng nhập',
     },
@@ -466,6 +468,17 @@ export const viVN: LocalizationResource = {
   },
   signInEnterPasswordTitle: 'Nhập mật khẩu của bạn',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: 'Đăng nhập',
       actionText: 'Đã có tài khoản?',
@@ -507,6 +520,15 @@ export const viVN: LocalizationResource = {
       resendButton: 'Không nhận được mã? Gửi lại',
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Xác minh số điện thoại của bạn',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: 'Đăng nhập',
@@ -881,6 +903,20 @@ export const viVN: LocalizationResource = {
       successMessage: 'Ví đã được thêm vào tài khoản của bạn.',
       title: 'Thêm ví web3',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -440,12 +440,14 @@ export const zhCN: LocalizationResource = {
     },
     start: {
       actionLink: '注册',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用电子邮件',
       actionLink__use_email_username: '使用电子邮件或用户名',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: '使用电话',
       actionLink__use_username: '使用用户名',
       actionText: '还没有账户？',
+      actionText__join_waitlist: undefined,
       subtitle: '继续使用 {{applicationName}}',
       title: '登录',
     },
@@ -457,6 +459,17 @@ export const zhCN: LocalizationResource = {
   },
   signInEnterPasswordTitle: '输入您的密码',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: '登录',
       actionText: '已经有账户了？',
@@ -498,6 +511,15 @@ export const zhCN: LocalizationResource = {
       resendButton: '重新发送验证码',
       subtitle: '继续使用 {{applicationName}}',
       title: '验证您的电话',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: '登录',
@@ -855,6 +877,20 @@ export const zhCN: LocalizationResource = {
       successMessage: '钱包已被添加到您的账户。',
       title: '添加web3钱包',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -446,12 +446,14 @@ export const zhTW: LocalizationResource = {
     },
     start: {
       actionLink: '註冊',
+      actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用電子郵件',
       actionLink__use_email_username: '使用電子郵件或使用者名稱',
       actionLink__use_passkey: undefined,
       actionLink__use_phone: '使用電話',
       actionLink__use_username: '使用使用者名稱',
       actionText: '還沒有帳戶？',
+      actionText__join_waitlist: undefined,
       subtitle: '繼續使用 {{applicationName}}',
       title: '登錄',
     },
@@ -463,6 +465,17 @@ export const zhTW: LocalizationResource = {
   },
   signInEnterPasswordTitle: '輸入您的密碼',
   signUp: {
+    __experimental_legalConsent: {
+      checkbox: {
+        label__onlyPrivacyPolicy: undefined,
+        label__onlyTermsOfService: undefined,
+        label__termsOfServiceAndPrivacyPolicy: undefined,
+      },
+      continue: {
+        subtitle: undefined,
+        title: undefined,
+      },
+    },
     continue: {
       actionLink: '登錄',
       actionText: '已經有帳戶了？',
@@ -504,6 +517,15 @@ export const zhTW: LocalizationResource = {
       resendButton: '重新發送驗證碼',
       subtitle: '繼續使用 {{applicationName}}',
       title: '驗證您的電話',
+    },
+    restrictedAccess: {
+      actionLink: undefined,
+      actionText: undefined,
+      blockButton__emailSupport: undefined,
+      blockButton__joinWaitlist: undefined,
+      subtitle: undefined,
+      subtitleWaitlist: undefined,
+      title: undefined,
     },
     start: {
       actionLink: '登錄',
@@ -865,6 +887,20 @@ export const zhTW: LocalizationResource = {
       successMessage: '錢包已被添加到您的帳戶。',
       title: '添加web3錢包',
       web3WalletButtonsBlockButton: undefined,
+    },
+  },
+  waitlist: {
+    start: {
+      actionLink: undefined,
+      actionText: undefined,
+      formButton: undefined,
+      subtitle: undefined,
+      title: undefined,
+    },
+    success: {
+      message: undefined,
+      subtitle: undefined,
+      title: undefined,
     },
   },
 } as const;

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -27,6 +27,7 @@ export {
   SignUpButton,
   UserButton,
   GoogleOneTap,
+  Waitlist,
 } from '@clerk/clerk-react';
 
 // The assignment of UserProfile with BaseUserProfile props is used

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -31,6 +31,7 @@ export {
   UserButton,
   UserProfile,
   GoogleOneTap,
+  Waitlist,
 } from './client-boundary/uiComponents';
 
 /**

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -8,6 +8,7 @@ export {
   CreateOrganization,
   OrganizationList,
   GoogleOneTap,
+  Waitlist,
 } from './uiComponents';
 
 export {

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -11,6 +11,7 @@ import type {
   SignUpProps,
   UserButtonProps,
   UserProfileProps,
+  WaitlistProps,
   Without,
 } from '@clerk/types';
 import type { PropsWithChildren } from 'react';
@@ -475,3 +476,14 @@ export const GoogleOneTap = withClerk(({ clerk, ...props }: WithClerkProp<Google
     />
   );
 }, 'GoogleOneTap');
+
+export const Waitlist = withClerk(({ clerk, ...props }: WithClerkProp<WaitlistProps>) => {
+  return (
+    <Portal
+      mount={clerk.mountWaitlist}
+      unmount={clerk.unmountWaitlist}
+      updateProps={(clerk as any).__unstable__updateProps}
+      props={props}
+    />
+  );
+}, 'Waitlist');

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -19,6 +19,7 @@ import type {
   HandleEmailLinkVerificationParams,
   HandleOAuthCallbackParams,
   InstanceType,
+  JoinWaitlistParams,
   ListenerCallback,
   LoadedClerk,
   OrganizationListProps,
@@ -41,6 +42,8 @@ import type {
   UserButtonProps,
   UserProfileProps,
   UserResource,
+  WaitlistProps,
+  WaitlistResource,
   Without,
 } from '@clerk/types';
 
@@ -91,6 +94,7 @@ type IsomorphicLoadedClerk = Without<
   | 'buildAfterSignOutUrl'
   | 'buildAfterMultiSessionSingleSignOutUrl'
   | 'buildUrlWithAuth'
+  | 'buildWaitlistUrl'
   | 'handleRedirectCallback'
   | 'handleGoogleOneTapCallback'
   | 'handleUnauthenticated'
@@ -100,6 +104,7 @@ type IsomorphicLoadedClerk = Without<
   | 'authenticateWithGoogleOneTap'
   | 'createOrganization'
   | 'getOrganization'
+  | 'joinWaitlist'
   | 'mountUserButton'
   | 'mountOrganizationList'
   | 'mountOrganizationSwitcher'
@@ -108,6 +113,7 @@ type IsomorphicLoadedClerk = Without<
   | 'mountSignUp'
   | 'mountSignIn'
   | 'mountUserProfile'
+  | 'mountWaitlist'
   | 'client'
 > & {
   // TODO: Align return type and parms
@@ -125,6 +131,8 @@ type IsomorphicLoadedClerk = Without<
   createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource | void>;
   // TODO: Align return type (maybe not possible or correct)
   getOrganization: (organizationId: string) => Promise<OrganizationResource | void>;
+  // TODO: Align return type
+  joinWaitlist: (params: JoinWaitlistParams) => Promise<WaitlistResource | void>;
 
   // TODO: Align return type
   buildSignInUrl: (opts?: RedirectOptions) => string | void;
@@ -145,6 +153,8 @@ type IsomorphicLoadedClerk = Without<
   // TODO: Align return type
   buildAfterMultiSessionSingleSignOutUrl: () => string | void;
   // TODO: Align optional props
+  buildWaitlistUrl: () => string | void;
+  // TODO: Align optional props
   mountUserButton: (node: HTMLDivElement, props: UserButtonProps) => void;
   mountOrganizationList: (node: HTMLDivElement, props: OrganizationListProps) => void;
   mountOrganizationSwitcher: (node: HTMLDivElement, props: OrganizationSwitcherProps) => void;
@@ -153,6 +163,7 @@ type IsomorphicLoadedClerk = Without<
   mountSignUp: (node: HTMLDivElement, props: SignUpProps) => void;
   mountSignIn: (node: HTMLDivElement, props: SignInProps) => void;
   mountUserProfile: (node: HTMLDivElement, props: UserProfileProps) => void;
+  mountWaitlist: (node: HTMLDivElement, props: WaitlistProps) => void;
   client: ClientResource | undefined;
 };
 
@@ -168,6 +179,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
   private preopenUserProfile?: null | UserProfileProps = null;
   private preopenOrganizationProfile?: null | OrganizationProfileProps = null;
   private preopenCreateOrganization?: null | CreateOrganizationProps = null;
+  private preOpenWaitlist?: null | WaitlistProps = null;
   private premountSignInNodes = new Map<HTMLDivElement, SignInProps>();
   private premountSignUpNodes = new Map<HTMLDivElement, SignUpProps>();
   private premountUserProfileNodes = new Map<HTMLDivElement, UserProfileProps>();
@@ -177,6 +189,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
   private premountOrganizationSwitcherNodes = new Map<HTMLDivElement, OrganizationSwitcherProps>();
   private premountOrganizationListNodes = new Map<HTMLDivElement, OrganizationListProps>();
   private premountMethodCalls = new Map<MethodName<BrowserClerk>, MethodCallback>();
+  private premountWaitlistNodes = new Map<HTMLDivElement, WaitlistProps>();
   // A separate Map of `addListener` method calls to handle multiple listeners.
   private premountAddListenerCalls = new Map<
     ListenerCallback,
@@ -366,6 +379,15 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  buildWaitlistUrl = (): string | void => {
+    const callback = () => this.clerkjs?.buildWaitlistUrl() || '';
+    if (this.clerkjs && this.#loaded) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('buildWaitlistUrl', callback);
+    }
+  };
+
   buildUrlWithAuth = (to: string): string | void => {
     const callback = () => this.clerkjs?.buildUrlWithAuth(to) || '';
     if (this.clerkjs && this.#loaded) {
@@ -526,6 +548,10 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       clerkjs.openCreateOrganization(this.preopenCreateOrganization);
     }
 
+    if (this.preOpenWaitlist !== null) {
+      clerkjs.openWaitlist(this.preOpenWaitlist);
+    }
+
     this.premountSignInNodes.forEach((props: SignInProps, node: HTMLDivElement) => {
       clerkjs.mountSignIn(node, props);
     });
@@ -544,6 +570,10 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
 
     this.premountOrganizationListNodes.forEach((props: OrganizationListProps, node: HTMLDivElement) => {
       clerkjs.mountOrganizationList(node, props);
+    });
+
+    this.premountWaitlistNodes.forEach((props: WaitlistProps, node: HTMLDivElement) => {
+      clerkjs.mountWaitlist(node, props);
     });
 
     this.#loaded = true;
@@ -729,6 +759,22 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  openWaitlist = (props?: WaitlistProps): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.openWaitlist(props);
+    } else {
+      this.preOpenWaitlist = props;
+    }
+  };
+
+  closeWaitlist = (): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.closeWaitlist();
+    } else {
+      this.preOpenWaitlist = null;
+    }
+  };
+
   openSignUp = (props?: SignUpProps): void => {
     if (this.clerkjs && this.#loaded) {
       this.clerkjs.openSignUp(props);
@@ -882,6 +928,22 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  mountWaitlist = (node: HTMLDivElement, props: WaitlistProps): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.mountWaitlist(node, props);
+    } else {
+      this.premountWaitlistNodes.set(node, props);
+    }
+  };
+
+  unmountWaitlist = (node: HTMLDivElement): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.unmountWaitlist(node);
+    } else {
+      this.premountWaitlistNodes.delete(node);
+    }
+  };
+
   addListener = (listener: ListenerCallback): UnsubscribeCallback => {
     if (this.clerkjs) {
       return this.clerkjs.addListener(listener);
@@ -994,6 +1056,16 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  redirectToWaitlist = async (): Promise<unknown> => {
+    const callback = () => this.clerkjs?.redirectToWaitlist();
+    if (this.clerkjs && this.#loaded) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('redirectToWaitlist', callback);
+      return;
+    }
+  };
+
   handleRedirectCallback = (params: HandleOAuthCallbackParams): void => {
     const callback = () => this.clerkjs?.handleRedirectCallback(params);
     if (this.clerkjs && this.#loaded) {
@@ -1089,6 +1161,15 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return callback() as Promise<OrganizationResource>;
     } else {
       this.premountMethodCalls.set('getOrganization', callback);
+    }
+  };
+
+  joinWaitlist = async (params: JoinWaitlistParams): Promise<WaitlistResource | void> => {
+    const callback = () => this.clerkjs?.joinWaitlist(params);
+    if (this.clerkjs && this.#loaded) {
+      return callback() as Promise<WaitlistResource>;
+    } else {
+      this.premountMethodCalls.set('joinWaitlist', callback);
     }
   };
 

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -632,6 +632,7 @@ export type OrganizationListTheme = Theme;
 export type OrganizationProfileTheme = Theme;
 export type CreateOrganizationTheme = Theme;
 export type UserVerificationTheme = Theme;
+export type WaitlistTheme = Theme;
 
 export type Appearance<T = Theme> = T & {
   /**
@@ -674,4 +675,8 @@ export type Appearance<T = Theme> = T & {
    * Theme overrides that only apply to the `<CreateOrganization />` component
    */
   oneTap?: T;
+  /**
+   * Theme overrides that only apply to the `<Waitlist />` component
+   */
+  waitlist?: T;
 };

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -40,6 +40,7 @@ export interface DisplayConfigJSON {
   show_devmode_warning: boolean;
   terms_url: string;
   privacy_policy_url: string;
+  waitlist_url: string;
 }
 
 export interface DisplayConfigResource extends ClerkResource {
@@ -82,4 +83,5 @@ export interface DisplayConfigResource extends ClerkResource {
   showDevModeWarning: boolean;
   termsUrl: string;
   privacyPolicyUrl: string;
+  waitlistUrl: string;
 }

--- a/packages/types/src/elementIds.ts
+++ b/packages/types/src/elementIds.ts
@@ -48,7 +48,7 @@ export type OrganizationPreviewId =
   | 'organizationSwitcherListedOrganization'
   | 'organizationSwitcherActiveOrganization';
 
-export type CardActionId = 'havingTrouble' | 'alternativeMethods' | 'signUp' | 'signIn' | 'usePasskey';
+export type CardActionId = 'havingTrouble' | 'alternativeMethods' | 'signUp' | 'signIn' | 'usePasskey' | 'waitlist';
 
 export type MenuId = 'invitation' | 'member' | ProfileSectionId;
 export type SelectId = 'countryCode' | 'role';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,3 +61,4 @@ export * from './pagination';
 export * from './passkey';
 export * from './customMenuItems';
 export * from './samlConnection';
+export * from './waitlist';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -531,3 +531,10 @@ export interface SamlAccountConnectionJSON extends ClerkResourceJSON {
   created_at: number;
   updated_at: number;
 }
+
+export interface WaitlistJSON extends ClerkResourceJSON {
+  object: 'waitlist';
+  id: string;
+  created_at: number;
+  updated_at: number;
+}

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -147,9 +147,11 @@ type _LocalizationResource = {
     restrictedAccess: {
       title: LocalizationValue;
       subtitle: LocalizationValue;
+      subtitleWaitlist: LocalizationValue;
       actionLink: LocalizationValue;
       actionText: LocalizationValue;
       blockButton__emailSupport: LocalizationValue;
+      blockButton__joinWaitlist: LocalizationValue;
     };
     __experimental_legalConsent: {
       continue: {
@@ -174,6 +176,8 @@ type _LocalizationResource = {
       actionLink__use_username: LocalizationValue;
       actionLink__use_email_username: LocalizationValue;
       actionLink__use_passkey: LocalizationValue;
+      actionText__join_waitlist: LocalizationValue;
+      actionLink__join_waitlist: LocalizationValue;
     };
     password: {
       title: LocalizationValue;
@@ -799,6 +803,20 @@ type _LocalizationResource = {
     nextDay: LocalizationValue;
     next6Days: LocalizationValue;
     numeric: LocalizationValue;
+  };
+  waitlist: {
+    start: {
+      title: LocalizationValue;
+      subtitle: LocalizationValue;
+      formButton: LocalizationValue;
+      actionText: LocalizationValue;
+      actionLink: LocalizationValue;
+    };
+    success: {
+      title: LocalizationValue;
+      subtitle: LocalizationValue;
+      message: LocalizationValue;
+    };
   };
 };
 

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -47,7 +47,7 @@ export type SignInData = {
   };
 };
 
-export type SignUpModes = 'public' | 'restricted';
+export type SignUpModes = 'public' | 'restricted' | 'waitlist';
 
 export type SignUpData = {
   allowlist_only: boolean;

--- a/packages/types/src/waitlist.ts
+++ b/packages/types/src/waitlist.ts
@@ -1,0 +1,7 @@
+import type { ClerkResource } from './resource';
+
+export interface WaitlistResource extends ClerkResource {
+  id: string;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -71,6 +71,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         },
       }}
       {...pageProps}
+      waitlistUrl='/waitlist'
     >
       <AppBar
         onChangeTheme={e => setSelectedTheme(e.target.value as any)}

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -2,8 +2,11 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
 import styles from '../styles/Home.module.css';
+import { useClerk } from '@clerk/nextjs';
 
 const Home: NextPage = () => {
+  const clerk = useClerk();
+
   return (
     <div className={styles.container}>
       <Head>
@@ -48,6 +51,12 @@ const Home: NextPage = () => {
           </li>
           <li>
             <Link href={'/user-examples'}>User examples</Link>
+          </li>
+          <li>
+            <Link href={'/waitlist'}>Waitlist</Link>
+          </li>
+          <li>
+            <button type='button' onClick={() => clerk.redirectToWaitlist()}>Redirect to waitlist</button>
           </li>
         </ul>
       </main>

--- a/playground/nextjs/pages/waitlist/index.tsx
+++ b/playground/nextjs/pages/waitlist/index.tsx
@@ -1,0 +1,19 @@
+import type {  NextPage } from 'next';
+import { Waitlist, useClerk } from '@clerk/nextjs';
+
+const WaitlistPage: NextPage = () => {
+  const clerk = useClerk();
+
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <Waitlist />
+      </div>
+      <div style={{ textAlign: 'center' , marginTop: '1rem' }}>
+        <button type='button' onClick={() => clerk.openWaitlist()}>open waitlist</button>
+      </div>
+    </>
+  )
+}
+
+export default WaitlistPage;


### PR DESCRIPTION
## Description

Show `Join waitlist` promt from `<SignIn />` component when mode is `waitlist`
Change the text in `RestrictedAccess` component when mode is `waitlist`
Introduce `<Waitlist />` component to allow users to join in the waitlist via email
Introduce `joinWaitlist` method in `clerk` class
Introduce `redirectToWaitlist` function in `clerk` class to allow user to redirect to waitlist page


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

### `<SignIn />` Component with `sign_up.mode = waitlist`
![Screenshot 2024-10-23 at 5 07 42 PM](https://github.com/user-attachments/assets/f0515cd3-b99a-49a2-b2a0-8278d912eb80)

### `<SignUp />` Component with `sign_up.mode = waitlist`
![Screenshot 2024-10-23 at 5 07 35 PM](https://github.com/user-attachments/assets/a3eba543-124f-4d99-90c0-bf409dc7e4fc)

### `<Waitlist />` Component 
![Screenshot 2024-10-23 at 5 07 48 PM](https://github.com/user-attachments/assets/69e8b952-fca2-40ae-9e58-253022c24577)

### `<Waitlist />` Component success screen
![Screenshot 2024-10-23 at 5 08 19 PM](https://github.com/user-attachments/assets/f81257c7-5b87-4868-86f5-60d8ef2599e7)

### `<Waitlist />` Component success screen with `redirectUrl` presented
![Screenshot 2024-10-23 at 5 08 07 PM](https://github.com/user-attachments/assets/5ce1e528-0bfc-422d-8705-971b08aecf75)





