### PR TITLE
fix(nextjs): Convert middleware auth to async

### DIFF
--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -2,8 +2,15 @@
 // This mock SHOULD exist before the import of authenticateRequest
 import { AuthStatus, constants } from '@clerk/backend/internal';
 import { describe, expect } from '@jest/globals';
+// used to assert the mock
+import assert from 'assert';
 import type { NextFetchEvent } from 'next/server';
 import { NextRequest, NextResponse } from 'next/server';
+
+import { clerkClient } from '../clerkClient';
+import { clerkMiddleware } from '../clerkMiddleware';
+import { createRouteMatcher } from '../routeMatcher';
+import { decryptClerkRequestData } from '../utils';
 
 const publishableKey = 'pk_test_Y2xlcmsuaW5jbHVkZWQua2F0eWRpZC05Mi5sY2wuZGV2JA';
 const authenticateRequestMock = jest.fn().mockResolvedValue({
@@ -22,14 +29,6 @@ jest.mock('../clerkClient', () => {
     }),
   };
 });
-
-// used to assert the mock
-import assert from 'assert';
-
-import { clerkClient } from '../clerkClient';
-import { clerkMiddleware } from '../clerkMiddleware';
-import { createRouteMatcher } from '../routeMatcher';
-import { decryptClerkRequestData } from '../utils';
 
 /**
  * Disable console warnings about config matchers
@@ -88,8 +87,9 @@ describe('ClerkMiddleware type tests', () => {
 
   it('can be used with a handler and an optional options object', () => {
     clerkMiddlewareMock(
-      (auth, request, event) => {
-        auth().getToken();
+      async (auth, request, event) => {
+        const { getToken } = await auth();
+        await getToken();
         request.cookies.clear();
         event.sourcePage;
       },
@@ -98,8 +98,9 @@ describe('ClerkMiddleware type tests', () => {
   });
 
   it('can be used with just a handler and an optional options object', () => {
-    clerkMiddlewareMock((auth, request, event) => {
-      auth().getToken();
+    clerkMiddlewareMock(async (auth, request, event) => {
+      const { getToken } = await auth();
+      await getToken();
       request.cookies.clear();
       event.sourcePage;
     });
@@ -261,8 +262,9 @@ describe('clerkMiddleware(params)', () => {
         appendDevBrowserCookie: true,
       });
 
-      const resp = await clerkMiddleware(auth => {
-        auth().redirectToSignIn();
+      const resp = await clerkMiddleware(async auth => {
+        const { redirectToSignIn } = await auth();
+        redirectToSignIn();
       })(req, {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
@@ -277,8 +279,9 @@ describe('clerkMiddleware(params)', () => {
         appendDevBrowserCookie: true,
       });
 
-      const resp = await clerkMiddleware(auth => {
-        auth().redirectToSignIn();
+      const resp = await clerkMiddleware(async auth => {
+        const { redirectToSignIn } = await auth();
+        redirectToSignIn();
       })(req, {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
@@ -294,8 +297,9 @@ describe('clerkMiddleware(params)', () => {
         appendDevBrowserCookie: true,
       });
 
-      const resp = await clerkMiddleware(auth => {
-        auth().redirectToSignIn({ returnBackUrl: 'https://www.clerk.com/hello' });
+      const resp = await clerkMiddleware(async auth => {
+        const { redirectToSignIn } = await auth();
+        redirectToSignIn({ returnBackUrl: 'https://www.clerk.com/hello' });
       })(req, {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
@@ -313,8 +317,9 @@ describe('clerkMiddleware(params)', () => {
         appendDevBrowserCookie: true,
       });
 
-      const resp = await clerkMiddleware(auth => {
-        auth().redirectToSignIn({ returnBackUrl: null });
+      const resp = await clerkMiddleware(async auth => {
+        const { redirectToSignIn } = await auth();
+        redirectToSignIn({ returnBackUrl: null });
       })(req, {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -36,7 +36,7 @@ export type ClerkMiddlewareAuthObject = AuthObject & {
 };
 
 export interface ClerkMiddlewareAuth {
-  (): ClerkMiddlewareAuthObject;
+  (): Promise<ClerkMiddlewareAuthObject>;
   protect: AuthProtect;
 }
 
@@ -155,7 +155,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
       const protect = await createMiddlewareProtect(clerkRequest, authObject, redirectToSignIn);
 
       const authObjWithMethods: ClerkMiddlewareAuthObject = Object.assign(authObject, { redirectToSignIn });
-      const authHandler = () => authObjWithMethods;
+      const authHandler = () => Promise.resolve(authObjWithMethods);
       authHandler.protect = protect;
 
       let handlerResult: Response = NextResponse.next();

--- a/packages/upgrade/src/codemods/__tests__/__fixtures__/transform-async-request.fixtures.js
+++ b/packages/upgrade/src/codemods/__tests__/__fixtures__/transform-async-request.fixtures.js
@@ -186,6 +186,31 @@ export default clerkMiddleware(
 `,
   },
   {
+    name: 'Complex clerkMiddleware() without protect()',
+    source: `
+import { clerkMiddleware } from '@clerk/nextjs/server';
+
+export default clerkMiddleware(
+  (auth, req) => {
+    const { redirectToSignIn } = auth();
+
+    redirectToSignIn();
+  },
+);
+`,
+    output: `
+import { clerkMiddleware } from '@clerk/nextjs/server';
+
+export default clerkMiddleware(
+  async (auth, req) => {
+    const { redirectToSignIn } = await auth();
+
+    redirectToSignIn();
+  },
+);
+`,
+  },
+  {
     name: 'Does not transform other imports',
     source: `
   import { auth } from '@some/other/module';


### PR DESCRIPTION
## Description

Converts `auth` in `clerkMiddleware` to async. The API now becomes:

```ts
clerkMiddleware(async auth => {
  const { redirectToSignIn } = await auth();
})
```

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
