### PR TITLE
fix(nextjs): Improve page detection for Next 15

### DIFF
--- a/.changeset/fluffy-eyes-arrive.md
+++ b/.changeset/fluffy-eyes-arrive.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": minor
+---
+
+Bug fix: Correctly redirect to sign in page in Next 15.

--- a/packages/nextjs/src/server/nextFetcher.ts
+++ b/packages/nextjs/src/server/nextFetcher.ts
@@ -12,7 +12,14 @@ type NextFetcher = Fetcher & {
  * Full type can be found https://github.com/vercel/next.js/blob/6185444e0a944a82e7719ac37dad8becfed86acd/packages/next/src/client/components/static-generation-async-storage.external.ts#L4
  */
 interface StaticGenerationAsyncStorage {
+  /**
+   * Available for Next 14
+   */
   readonly pagePath?: string;
+  /**
+   * Available for Next 15
+   */
+  readonly page?: string;
 }
 
 function isNextFetcher(fetch: Fetcher | NextFetcher): fetch is NextFetcher {

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -134,7 +134,19 @@ const isAppRouterInternalNavigation = (req: Request) =>
 
 const isPagePathAvailable = () => {
   const __fetch = globalThis.fetch;
-  return Boolean(isNextFetcher(__fetch) ? __fetch.__nextGetStaticStore().getStore()?.pagePath : false);
+
+  if (!isNextFetcher(__fetch)) {
+    return false;
+  }
+
+  const { page, pagePath } = __fetch.__nextGetStaticStore().getStore() || {};
+
+  return Boolean(
+    // available on next@14
+    pagePath ||
+      // available on next@15
+      page,
+  );
 };
 
 const isPagesRouterInternalNavigation = (req: Request) => !!req.headers.get(nextConstants.Headers.NextjsData);


### PR DESCRIPTION

## Description

In next 15, the `next-url` header exists while in dev mode, but it's missing in the production build so we need to update our fallback detection as well.

Also `__fetch.__nextGetStaticStore().getStore().pagePath` has been replaced with `__fetch.__nextGetStaticStore().getStore().page`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
