### PR TITLE
feat(upgrade): Improve CLI output

### DIFF
--- a/.changeset/wild-guests-occur.md
+++ b/.changeset/wild-guests-occur.md
@@ -1,0 +1,5 @@
+---
+"@clerk/upgrade": patch
+---
+
+Updating the CLI output to match the DX of core-1 to core-2 migration

--- a/packages/upgrade/src/components/Codemod.js
+++ b/packages/upgrade/src/components/Codemod.js
@@ -35,7 +35,7 @@ export function Codemod(props) {
       .finally(() => {
         callback(true);
       });
-  }, [glob]);
+  }, [callback, glob, transform]);
 
   return (
     <>

--- a/packages/upgrade/src/components/SDKWorkflow.js
+++ b/packages/upgrade/src/components/SDKWorkflow.js
@@ -83,7 +83,7 @@ export function SDKWorkflow(props) {
             <>
               <Text>
                 Looks like you are already on the latest version of <Text bold>@clerk/{sdk}</Text>. Would you like to
-                run the associated codemod?.
+                run the associated codemod?
               </Text>
               <Select
                 options={[

--- a/packages/upgrade/src/components/SDKWorkflow.js
+++ b/packages/upgrade/src/components/SDKWorkflow.js
@@ -25,9 +25,11 @@ export function SDKWorkflow(props) {
   const { packageManager, sdk } = props;
 
   const [done, setDone] = useState(false);
+  const [runCodemod, setRunCodemod] = useState(false);
   const [upgradeComplete, setUpgradeComplete] = useState(false);
 
-  const version = getClerkSdkVersion(sdk);
+  // eslint-disable-next-line no-unused-vars
+  const [version, setVersion] = useState(getClerkSdkVersion(sdk));
 
   if (sdk !== 'nextjs') {
     return (
@@ -41,6 +43,18 @@ export function SDKWorkflow(props) {
   return (
     <>
       <Header />
+      <Text>
+        Clerk SDK used: <Text color='green'>@clerk/{sdk}</Text>
+      </Text>
+      <Text>
+        Migrating from version: <Text color='green'>{version}</Text>
+      </Text>
+      {runCodemod ? (
+        <Text>
+          Executing codemod: <Text color='green'>yes</Text>
+        </Text>
+      ) : null}
+      <Newline />
       {version === 5 && (
         <>
           <UpgradeSDK
@@ -57,32 +71,34 @@ export function SDKWorkflow(props) {
           ) : null}
         </>
       )}
-      {!done && version === 6 && (
+      {version === 6 && (
         <>
-          <Text>
-            Looks like you are already on the latest version of <Text bold>@clerk/{sdk}</Text>. Would you like to run
-            the associated codemod?.
-          </Text>
-          {upgradeComplete ? (
+          {runCodemod ? (
             <Codemod
               sdk={sdk}
               callback={setDone}
               transform='transform-async-request'
             />
           ) : (
-            <Select
-              options={[
-                { label: 'yes', value: 'yes' },
-                { label: 'no', value: 'no' },
-              ]}
-              onChange={value => {
-                if (value === 'yes') {
-                  setUpgradeComplete(true);
-                } else {
-                  setDone(true);
-                }
-              }}
-            />
+            <>
+              <Text>
+                Looks like you are already on the latest version of <Text bold>@clerk/{sdk}</Text>. Would you like to
+                run the associated codemod?.
+              </Text>
+              <Select
+                options={[
+                  { label: 'yes', value: 'yes' },
+                  { label: 'no', value: 'no' },
+                ]}
+                onChange={value => {
+                  if (value === 'yes') {
+                    setRunCodemod(true);
+                  } else {
+                    setDone(true);
+                  }
+                }}
+              />
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
## Description

Improving the output of `clerk-upgrade` CLI command to match the styling of core-1 to core-2 migration


<img width="530" alt="Screenshot 2024-10-23 at 10 18 38 AM" src="https://github.com/user-attachments/assets/c3cfbc1f-27df-4c13-81a9-6b7ffa7bf659">

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
