### PR TITLE
fix(ui): Use regular version ranges for internal packages

### DIFF
--- a/.changeset/light-cooks-wink.md
+++ b/.changeset/light-cooks-wink.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": patch
+---
+
+Update internal dependencies to use public version ranges instead of file-based paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -47959,9 +47959,9 @@
       "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/elements": "file:../elements",
-        "@clerk/shared": "file:../shared",
-        "@clerk/types": "file:../types",
+        "@clerk/elements": "0.17.0",
+        "@clerk/shared": "2.10.0",
+        "@clerk/types": "4.27.0",
         "@formkit/auto-animate": "^0.8.2",
         "@radix-ui/react-slot": "^1.1.0",
         "cmdk": "^1.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,9 +52,9 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@clerk/elements": "file:../elements",
-    "@clerk/shared": "file:../shared",
-    "@clerk/types": "file:../types",
+    "@clerk/elements": "0.17.0",
+    "@clerk/shared": "2.10.0",
+    "@clerk/types": "4.27.0",
     "@formkit/auto-animate": "^0.8.2",
     "@radix-ui/react-slot": "^1.1.0",
     "cmdk": "^1.0.0",


### PR DESCRIPTION
## Description

Replaces file-based ranges in `@clerk/ui` for internal packages with our pinned versions we use in other packages.

Fixes https://github.com/clerk/javascript/issues/4395

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
