### PR TITLE
fix(nextjs): Include protect types in `auth`

### DIFF
--- a/.changeset/selfish-pianos-push.md
+++ b/.changeset/selfish-pianos-push.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Bug fix: Include protect types in `auth`

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -66,6 +66,6 @@ auth.protect = async (...args) => {
     redirect,
   });
 
-  // @ts-ignore
+  // @ts-expect-error TS flattens all possible combinations of the for AuthProtect signatures in a union.
   return protect(...args);
 };

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -14,7 +14,6 @@ type Auth = AuthObject & { redirectToSignIn: RedirectFun<ReturnType<typeof redir
 
 export interface AuthFn {
   (): Promise<Auth>;
-
   protect: AuthProtect;
 }
 

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -5,13 +5,20 @@ import { notFound, redirect } from 'next/navigation';
 import { PUBLISHABLE_KEY, SIGN_IN_URL, SIGN_UP_URL } from '../../server/constants';
 import { createGetAuth } from '../../server/createGetAuth';
 import { authAuthHeaderMissing } from '../../server/errors';
+import type { AuthProtect } from '../../server/protect';
 import { createProtect } from '../../server/protect';
 import { decryptClerkRequestData, getAuthKeyFromRequest, getHeader } from '../../server/utils';
 import { buildRequestLike } from './utils';
 
 type Auth = AuthObject & { redirectToSignIn: RedirectFun<ReturnType<typeof redirect>> };
 
-export async function auth(): Promise<Auth> {
+export interface AuthFn {
+  (): Promise<Auth>;
+
+  protect: AuthProtect;
+}
+
+export const auth: AuthFn = async () => {
   require('server-only');
 
   const request = await buildRequestLike();
@@ -44,9 +51,9 @@ export async function auth(): Promise<Auth> {
   };
 
   return Object.assign(authObject, { redirectToSignIn });
-}
+};
 
-auth.protect = async (...args: any[]) => {
+auth.protect = async (...args) => {
   require('server-only');
 
   const request = await buildRequestLike();
@@ -59,5 +66,7 @@ auth.protect = async (...args: any[]) => {
     notFound,
     redirect,
   });
+
+  // @ts-ignore
   return protect(...args);
 };


### PR DESCRIPTION
## Description

During #4366 we typed the arguments of `protect()` for page/route/action as `any`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
