### PR TITLE
fix(clerk-js): Move ui package to devDependencies

### DIFF
--- a/.changeset/khaki-weeks-give.md
+++ b/.changeset/khaki-weeks-give.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Move `@clerk/ui` to `devDependencies`

--- a/package-lock.json
+++ b/package-lock.json
@@ -44377,7 +44377,6 @@
         "@clerk/localizations": "3.4.0",
         "@clerk/shared": "2.10.1",
         "@clerk/types": "4.28.0",
-        "@clerk/ui": "0.1.10",
         "@coinbase/wallet-sdk": "4.0.4",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
@@ -44395,6 +44394,7 @@
       },
       "devDependencies": {
         "@clerk/eslint-config-custom": "*",
+        "@clerk/ui": "0.1.10",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@rsdoctor/webpack-plugin": "^0.4.4",
         "@svgr/webpack": "^6.2.1",

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -53,7 +53,6 @@
     "@clerk/localizations": "3.4.0",
     "@clerk/shared": "2.10.1",
     "@clerk/types": "4.28.0",
-    "@clerk/ui": "0.1.10",
     "@coinbase/wallet-sdk": "4.0.4",
     "@emotion/cache": "11.11.0",
     "@emotion/react": "11.11.1",
@@ -71,6 +70,7 @@
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "*",
+    "@clerk/ui": "0.1.10",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@rsdoctor/webpack-plugin": "^0.4.4",
     "@svgr/webpack": "^6.2.1",


### PR DESCRIPTION
## Description

This PR moves `@clerk/ui` to `devDependencies`. This is because the `ui` package is bundled by Webpack, and does not need to be separately installed by the package manager when a user installs `@clerk/clerk-js`.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
