### PR TITLE
feat(nextjs): Allow eager clerkClient() access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35965,6 +35965,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-deep/-/proxy-deep-4.0.1.tgz",
+      "integrity": "sha512-7Ojq0fbemOGGpRBbExicriLljomgJ32t9jL8HV+FvpqU/UYzowLKVhJyRYcCMBeAGCz++rK2maNzuZYbqjAVPw=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
       "dev": true,
@@ -46373,6 +46378,7 @@
         "@clerk/shared": "2.10.1",
         "@clerk/types": "4.28.0",
         "crypto-js": "4.2.0",
+        "proxy-deep": "^4.0.1",
         "server-only": "0.0.1",
         "tslib": "2.4.1"
       },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -72,6 +72,7 @@
     "@clerk/shared": "2.10.1",
     "@clerk/types": "4.28.0",
     "crypto-js": "4.2.0",
+    "proxy-deep": "^4.0.1",
     "server-only": "0.0.1",
     "tslib": "2.4.1"
   },

--- a/packages/nextjs/src/server/__tests__/clerkClient.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkClient.test.ts
@@ -15,4 +15,15 @@ describe('clerkClient', () => {
       'User-Agent': '@clerk/nextjs@0.0.0-test',
     });
   });
+
+  it('should allow client usage before client is initialized', async () => {
+    await clerkClient().users.getUser('user_test');
+
+    expect(global.fetch).toBeCalled();
+    expect((global.fetch as any).mock.calls[0][1].headers).toMatchObject({
+      Authorization: 'Bearer TEST_SECRET_KEY',
+      'Content-Type': 'application/json',
+      'User-Agent': '@clerk/nextjs@0.0.0-test',
+    });
+  });
 });


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Allow eager access to the return of `clerkClient()` even though it now returns a promise.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
