### PR TITLE
Fix Tanstack Start Context Corruption and stop loaders from re-running.

### DIFF
--- a/.changeset/cold-tigers-scream.md
+++ b/.changeset/cold-tigers-scream.md
@@ -1,0 +1,8 @@
+---
+"@clerk/tanstack-start": patch
+---
+
+Fix Tanstack Start SSR
+
+- Stop overwriting default router context
+- Stop unnecessarily re-running route loaders

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -28,7 +28,10 @@ export function createClerkHandler<TRouter extends AnyRouter>(
 
         // Updating the TanStack router context with the Clerk context and loading the router
         router.update({
-          context: clerkInitialState,
+          context: {
+            ...router.options.context,
+            ...clerkInitialState,
+          },
         });
 
         await router.load();

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -33,8 +33,6 @@ export function createClerkHandler<TRouter extends AnyRouter>(
             ...clerkInitialState,
           },
         });
-
-        await router.load();
       } catch (error) {
         if (error instanceof Response) {
           // returning the response


### PR DESCRIPTION
## Description

This PR fixes two issues in the Tanstack Start Plugin: Currently, on the initial (server-side) rendered load, the default router context is overwritten with Clerk's initial state. This was problematic for our app because we provide the tRPC client via the default router context. Since it was overwritten on the second run, all loaders would fail. It also doesn’t seem necessary to call `router.load()`, since Tanstack Start will do that anyway, having that in here, was causing all loaders to run twice.

To test this, you can use my minimal reproduction: https://github.com/phibr0/clerk-tanstack-start-repro

1. Provide keys in a `.env` file (`VITE_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`).
2. Run `pnpm install`.
3. Run `pnpm dev`.
   - Navigate to http://localhost:3000/.
   - The route context will be logged in the server console.

![Screenshot 2024-10-27 at 12 42 38](https://github.com/user-attachments/assets/395d000e-2de7-4fba-b937-b797e13f1992)

The context is logged **once**, and the property `THIS_IS_DEFINED_IN_ROOT_ROUTE` exists.

4. Remove the patch by deleting `patchedDependencies` in the `package.json`.
5. Run `pnpm install && pnpm dev`.
   - Navigate to http://localhost:3000/.
   - The route context will be logged twice in the server console, and the second time, the `THIS_IS_DEFINED_IN_ROOT_ROUTE` property is missing.

(This is the current behavior.)

![Screenshot 2024-10-27 at 12 49 10](https://github.com/user-attachments/assets/a5ddadff-fea9-43d0-91dd-05fef472dc7c)



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
