### PR TITLE
fix(localizations): Ensure confirm delete account text aligns with prompt

### DIFF
--- a/.changeset/thirty-jobs-leave.md
+++ b/.changeset/thirty-jobs-leave.md
@@ -2,4 +2,4 @@
 "@clerk/localizations": patch
 ---
 
-fix `frFR` confirmDeletionUserAccount text to ensure button text is enabled properly when the values match.
+Fix `frFR` confirmDeletionUserAccount text to ensure button text is enabled properly when the values match.

--- a/.changeset/thirty-jobs-leave.md
+++ b/.changeset/thirty-jobs-leave.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+fix `frFR` confirmDeletionUserAccount text to ensure button text is enabled properly when the values match.

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -108,7 +108,7 @@ export const frFR: LocalizationResource = {
   formFieldHintText__slug:
     'Un slug est un identifiant lisible qui doit être unique. Il est souvent utilisé dans les URL.',
   formFieldInputPlaceholder__backupCode: undefined,
-  formFieldInputPlaceholder__confirmDeletionUserAccount: 'Supprimer ce compte',
+  formFieldInputPlaceholder__confirmDeletionUserAccount: 'Supprimer le compte',
   formFieldInputPlaceholder__emailAddress: undefined,
   formFieldInputPlaceholder__emailAddress_username: undefined,
   formFieldInputPlaceholder__emailAddresses:


### PR DESCRIPTION
## Description

AFTER

https://github.com/user-attachments/assets/1e2f1d00-49cc-4242-bf1e-ad756eabe92b


Fixes issue where delete account button was not becoming active when the field value matched the expected string value.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
