### PR TITLE
fix(tanstack-start): Merge router context instead of updating

### DIFF
--- a/.changeset/silly-moose-tease.md
+++ b/.changeset/silly-moose-tease.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-start": patch
+---
+
+- Fixes a bug where the initial router context is getting overwritten when updating the router inside `createClerkHandler`

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -26,9 +26,9 @@ export function createClerkHandler<TRouter extends AnyRouter>(
 
         const clerkInitialState = getResponseClerkState(requestState, loadedOptions);
 
-        // Updating the TanStack router context with the Clerk context and loading the router
+        // Merging the TanStack router context with the Clerk context and loading the router
         router.update({
-          context: clerkInitialState,
+          context: { ...router.options.context, ...clerkInitialState },
         });
 
         await router.load();

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -30,8 +30,6 @@ export function createClerkHandler<TRouter extends AnyRouter>(
         router.update({
           context: { ...router.options.context, ...clerkInitialState },
         });
-
-        // await router.load();
       } catch (error) {
         if (error instanceof Response) {
           // returning the response

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -31,7 +31,7 @@ export function createClerkHandler<TRouter extends AnyRouter>(
           context: { ...router.options.context, ...clerkInitialState },
         });
 
-        await router.load();
+        // await router.load();
       } catch (error) {
         if (error instanceof Response) {
           // returning the response


### PR DESCRIPTION
## Description

This PR fixes bug where the initialisation of Clerk overwrites the context, by merging the original/existing context with the `clerkInitialState`. 

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
