### PR TITLE
fix(clerk-js): Improve checkbox label alignment

### DIFF
--- a/.changeset/giant-roses-heal.md
+++ b/.changeset/giant-roses-heal.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Improve checkbox label alignment to account for wrapping labels.

--- a/packages/clerk-js/src/ui/elements/FieldControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FieldControl.tsx
@@ -221,6 +221,7 @@ const CheckboxIndicator = forwardRef<HTMLInputElement>((_, ref) => {
       focusRing={false}
       sx={t => ({
         width: 'fit-content',
+        flexShrink: 0,
         marginTop: t.space.$0x5,
       })}
     />

--- a/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
+++ b/packages/clerk-js/src/ui/elements/LegalConsentCheckbox.tsx
@@ -68,10 +68,7 @@ export const LegalCheckbox = (
 
   return (
     <Field.Root {...props}>
-      <Flex
-        align='center'
-        justify='center'
-      >
+      <Flex justify='center'>
         <Field.CheckboxIndicator />
         <FormLabel
           elementDescriptor={descriptors.formFieldRadioLabel}


### PR DESCRIPTION
## Description

Improve checkbox label alignment.

### Wrapping label

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-10-29 at 4 02 44 PM](https://github.com/user-attachments/assets/b3710e17-e7b3-4cab-a17d-d450b8ef6dd2) | ![Screenshot 2024-10-29 at 3 58 57 PM](https://github.com/user-attachments/assets/53c9d2f5-dbd9-432d-862e-b7409490e644) | 

### No wrapping label

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-10-29 at 4 03 47 PM](https://github.com/user-attachments/assets/9aba8e55-9a4e-4bde-8ed2-0b6a09973884) | ![Screenshot 2024-10-29 at 4 04 00 PM](https://github.com/user-attachments/assets/c836439a-e7cd-488f-842b-1b8f2d34f12e) | 

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
