### PR TITLE
chore(repo): Do not lock old PRs

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           github-token: ${{ secrets.CLERK_COOKIE_PAT }}
           issue-inactive-days: '365'
-          pr-inactive-days: '365'
           issue-comment: 'This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.'
-          pr-comment: 'This PR has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.'
+          process-only: 'issues'
           log-output: true


### PR DESCRIPTION
## Description

We've been getting a lot of noise from locked PRs the last couple of weeks and it doesn't really add any value since it's so rare that people comment on old PRs. So this PR removes the functionality to lock old PRs (it'll still lock issues).

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
