### PR TITLE
fix(tanstack-start): Load router after updating context

### DIFF
--- a/.changeset/mighty-ears-cough.md
+++ b/.changeset/mighty-ears-cough.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-start": patch
+---
+
+Revert to loading router after updating the context

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -30,6 +30,8 @@ export function createClerkHandler<TRouter extends AnyRouter>(
         router.update({
           context: { ...router.options.context, ...clerkInitialState },
         });
+
+        await router.load();
       } catch (error) {
         if (error instanceof Response) {
           // returning the response


### PR DESCRIPTION
## Description

This PR brings back the `router.load` after the context is updated in the middlewareHandler

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
