### PR TITLE
fix(clerk-react): Make `signOutOptions` prop functional

### DIFF
--- a/.changeset/beige-bananas-look.md
+++ b/.changeset/beige-bananas-look.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-react": patch
+---
+
+Fix `signOutOptions` prop usage in `<SignOutButton />` component

--- a/packages/react/src/components/SignOutButton.tsx
+++ b/packages/react/src/components/SignOutButton.tsx
@@ -18,7 +18,7 @@ export const SignOutButton = withClerk(
     children = normalizeWithDefaultValue(children, 'Sign out');
     const child = assertSingleChild(children)('SignOutButton');
 
-    const clickHandler = () => clerk.signOut({ redirectUrl });
+    const clickHandler = () => clerk.signOut({ redirectUrl, ...signOutOptions });
     const wrappedChildClickHandler: React.MouseEventHandler = async e => {
       await safeExecute((child as any).props.onClick)(e);
       return clickHandler();

--- a/packages/react/src/components/__tests__/SignOutButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignOutButton.test.tsx
@@ -24,6 +24,8 @@ jest.mock('../withClerk', () => {
   };
 });
 
+const url = 'https://www.clerk.com';
+
 describe('<SignOutButton />', () => {
   beforeAll(() => {
     console.error = jest.fn();
@@ -43,6 +45,24 @@ describe('<SignOutButton />', () => {
     userEvent.click(btn);
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
+    });
+  });
+
+  it('handles redirectUrl prop', async () => {
+    render(<SignOutButton redirectUrl={url} />);
+    const btn = screen.getByText('Sign out');
+    userEvent.click(btn);
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: url });
+    });
+  });
+
+  it('handles signOutOptions prop', async () => {
+    render(<SignOutButton signOutOptions={{ redirectUrl: url, sessionId: 'sess_1yDceUR8SIKtQ0gIOO8fNsW7nhe' }} />);
+    const btn = screen.getByText('Sign out');
+    userEvent.click(btn);
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: url, sessionId: 'sess_1yDceUR8SIKtQ0gIOO8fNsW7nhe' });
     });
   });
 


### PR DESCRIPTION
## Description

Our [docs](https://clerk.com/docs/components/unstyled/sign-out-button#properties) indicate that the `<SignOutButton />` component accepts a [`signOutOptions`](https://clerk.com/docs/components/unstyled/sign-out-button#sign-out-options) object, which allows you to customize behavior such as [signing out of a specific session](https://clerk.com/docs/components/unstyled/sign-out-button#sign-out-of-a-specific-session). We already accept the prop, but we don't use it in the component at all. This PR fixes that.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
