### PR TITLE
fix(nextjs): Nonce not being populated in Clerk provider and browser script

### DIFF
--- a/.changeset/nervous-months-happen.md
+++ b/.changeset/nervous-months-happen.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Nonce was resolving to an empty string, added an else statement to make sure the nonce value was being updated properly.

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -43,6 +43,8 @@ export async function ClerkProvider(
       statePromise = getDynamicClerkState();
       nonce = getNonceFromCSPHeader();
     }
+  } else {
+    nonce = getNonceFromCSPHeader();
   }
 
   const output = (


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Fixes a bug where the nonce was not being applied to the Clerk browser script causing CSP errors and failing to load Clerk. 
Added an else statement to the ClerkProvider otherwise the nonce was resolving to an empty string. Potentially could be moved to line 32 of of ClerkProvider, but it may cause issues in older versions of Next. 

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
