### PR TITLE
fix(upgrade,nextjs): Update broken Clerk documentation references

### DIFF
--- a/.changeset/purple-eels-fix.md
+++ b/.changeset/purple-eels-fix.md
@@ -1,0 +1,6 @@
+---
+"@clerk/upgrade": patch
+"@clerk/nextjs": patch
+---
+
+Updates broken Clerk documentation references

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -38,6 +38,6 @@ To resolve this issue, make sure your system's clock is set to the correct time 
 
 ${verifyMessage}`;
 
-export const authSignatureInvalid = `Clerk: Unable to verify request, this usually means the Clerk middleware did not run. Ensure Clerk's middleware is properly integrated and matches the current route. For more information, see: https://clerk.com/docs/nextjs/middleware. (code=auth_signature_invalid)`;
+export const authSignatureInvalid = `Clerk: Unable to verify request, this usually means the Clerk middleware did not run. Ensure Clerk's middleware is properly integrated and matches the current route. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware. (code=auth_signature_invalid)`;
 
 export const encryptionKeyInvalid = `Clerk: Unable to decrypt request data, this usually means the encryption key is invalid. Ensure the encryption key is properly set. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;

--- a/packages/upgrade/src/components/SDKWorkflow.js
+++ b/packages/upgrade/src/components/SDKWorkflow.js
@@ -125,8 +125,8 @@ export function SDKWorkflow(props) {
                 <Newline />
                 <Text>
                   You can find more information about this change in the Clerk documentation at{' '}
-                  <Link url='https://clerk.com/docs/nextjs/rendering-modes'>
-                    https://clerk.com/docs/nextjs/rendering-modes
+                  <Link url='https://clerk.com/docs/references/nextjs/rendering-modes'>
+                    https://clerk.com/docs/references/nextjs/rendering-modes
                   </Link>
                   .
                 </Text>


### PR DESCRIPTION
## Description

Fixes some docs URLs that were linking to 404 pages due to missing `/reference` paths.


<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
