### PR TITLE
fix(nextjs): Ensure window is defined within `<ClerkProvider />`

### DIFF
--- a/.changeset/friendly-sloths-travel.md
+++ b/.changeset/friendly-sloths-travel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix issue within `<ClerkProvider />` where the window object is possibly undefined.

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -49,8 +49,9 @@ const useNextRouter = (): ClerkHostRouter => {
     shallowPush(path: string) {
       canUseWindowHistoryAPIs ? window.history.pushState(null, '', path) : router.push(path, {});
     },
-    pathname: () => window.location.pathname,
-    searchParams: () => new URLSearchParams(window.location.search),
+    pathname: () => (typeof window !== 'undefined' ? window.location.pathname : ''),
+    searchParams: () =>
+      typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams(),
   };
 };
 

--- a/packages/nextjs/src/pages/ClerkProvider.tsx
+++ b/packages/nextjs/src/pages/ClerkProvider.tsx
@@ -40,8 +40,9 @@ const useNextRouter = (): ClerkHostRouter => {
     shallowPush(path: string) {
       canUseWindowHistoryAPIs ? window.history.pushState(null, '', path) : router.push(path, {});
     },
-    pathname: () => window.location.pathname,
-    searchParams: () => new URLSearchParams(window.location.search),
+    pathname: () => (typeof window !== 'undefined' ? window.location.pathname : ''),
+    searchParams: () =>
+      typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams(),
   };
 };
 


### PR DESCRIPTION
## Description

Fixes issue in `<ClerkProvider />` where window is undefined.

https://clerkinc.slack.com/archives/C05GH6N5LLS/p1730730591481319?thread_ts=1730509835.841509&cid=C05GH6N5LLS

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
