### PR TITLE
fix(nextjs): Do not set cookie during cache invalidation

### DIFF
--- a/.changeset/fair-dots-invite.md
+++ b/.changeset/fair-dots-invite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fixes an issue where Next.js cache invalidation was incorrectly setting a cookie.

--- a/packages/nextjs/src/app-router/server-actions.ts
+++ b/packages/nextjs/src/app-router/server-actions.ts
@@ -1,11 +1,11 @@
 'use server';
 
-import { cookie } from 'ezheaders';
+import { getCookies } from 'ezheaders';
 
 // This function needs to be async as we'd like to support next versions in the range of [14.1.2,14.2.0)
 // These versions required 'use server' files to export async methods only. This check was later relaxed
 // and the async is no longer required in newer next versions.
 // ref: https://github.com/vercel/next.js/pull/62821
 export async function invalidateCacheAction(): Promise<void> {
-  await cookie(`__clerk_invalidate_cache_cookie_${Date.now()}`, '');
+  void (await getCookies()).delete(`__clerk_invalidate_cache_cookie_${Date.now()}`);
 }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensure a cookie doesn't get set when the cache invalidation server action is called.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
