### PR TITLE
chore(clerk-js): Use esnext as the target for dev builds

### DIFF
--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -171,10 +171,8 @@ const typescriptLoaderDev = () => {
       exclude: /node_modules/,
       loader: 'builtin:swc-loader',
       options: {
-        env: {
-          targets: 'last 0.25 years',
-        },
         jsc: {
+          target: 'esnext',
           parser: {
             syntax: 'typescript',
             tsx: true,


### PR DESCRIPTION
## Description

The bundlers produced are already different so we might as well benefit from easier debugging straight in the browser console :)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
