### PR TITLE
fix(clerk-js): Init options on updateProps

### DIFF
--- a/.changeset/nine-pets-rhyme.md
+++ b/.changeset/nine-pets-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Re-init window.Clerk options when `ClerkProvider` props change in `@clerk/clerk-react`


### PR DESCRIPTION
We need to re-init the options during the updateProps() call  in order to keep the options passed to ClerkProvider in sync with the state of clerk-js. If we don't init the options here again, the following scenario is possible:
1. User renders <ClerkProvider propA={undefined} propB={1} />
2. clerk-js initializes propA with a default value
3. The customer update propB independently of propA and window.Clerk.updateProps is called
4. If we don't merge the new props with the current options, propA will be reset to undefined

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
