### PR TITLE
fix(expo-passkeys): Correct turborepo outputs

### DIFF
--- a/.changeset/eleven-doors-shop.md
+++ b/.changeset/eleven-doors-shop.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/expo-passkeys': patch
 ---
-
-Fixing the turborepo repo outputs of the build task

--- a/.changeset/eleven-doors-shop.md
+++ b/.changeset/eleven-doors-shop.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo-passkeys': patch
+---
+
+Fixing the turborepo repo outputs of the build task

--- a/packages/expo-passkeys/turbo.json
+++ b/packages/expo-passkeys/turbo.json
@@ -1,0 +1,19 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/__snapshots__/**",
+        "!CHANGELOG.md",
+        "!coverage/**",
+        "!build/**",
+        "!examples/**",
+        "!node_modules/**"
+      ],
+      "outputLogs": "new-only",
+      "outputs": ["build"]
+    }
+  }
+}

--- a/packages/expo-passkeys/turbo.json
+++ b/packages/expo-passkeys/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "!**/__snapshots__/**",

--- a/packages/expo-passkeys/turbo.json
+++ b/packages/expo-passkeys/turbo.json
@@ -9,7 +9,7 @@
         "!CHANGELOG.md",
         "!coverage/**",
         "!build/**",
-        "!examples/**",
+        "!example/**",
         "!node_modules/**"
       ],
       "outputLogs": "new-only",

--- a/packages/expo-passkeys/turbo.json
+++ b/packages/expo-passkeys/turbo.json
@@ -1,7 +1,7 @@
 {
   "extends": ["//"],
   "tasks": {
-    "test": {
+    "build": {
       "dependsOn": ["build"],
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## Description

Correcting the `output` of `@clerk/expo-passkeys` build task to include the `build` dir

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
