### PR TITLE
fix(astro): Avoid importing transition functions when View Transitions is disabled

### DIFF
--- a/.changeset/itchy-icons-destroy.md
+++ b/.changeset/itchy-icons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fix an issue where custom client-side routing breaks when `<ViewTransitions />` is disabled

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -110,9 +110,14 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             `
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
             import { runInjectionScript, swapDocument } from "${buildImportPath}";
-            import { navigate, transitionEnabledOnThisPage } from "astro:transitions/client";
+
+            const transitionEnabledOnThisPage = () => {
+              return !!document.querySelector('[name="astro-view-transitions-enabled"]');
+            }
 
             if (transitionEnabledOnThisPage()) {
+              const { navigate, swapFunctions } = await import('astro:transitions/client');
+
               document.addEventListener('astro:before-swap', (e) => {
                 const clerkComponents = document.querySelector('#clerk-components');
                 // Keep the div element added by Clerk
@@ -121,7 +126,7 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
                   e.newDocument.body.appendChild(clonedEl);
                 }
 
-                e.swap = () => swapDocument(e.newDocument);
+                e.swap = () => swapDocument(swapFunctions, e.newDocument);
               });
 
               document.addEventListener('astro:page-load', async (e) => {

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -111,6 +111,9 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
             import { runInjectionScript, swapDocument } from "${buildImportPath}";
 
+            // Taken from https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L39.
+            // Importing it directly from astro:transitions/client breaks custom client-side routing
+            // even when View Transitions is disabled.
             const transitionEnabledOnThisPage = () => {
               return !!document.querySelector('[name="astro-view-transitions-enabled"]');
             }

--- a/packages/astro/src/internal/swap-document.ts
+++ b/packages/astro/src/internal/swap-document.ts
@@ -1,8 +1,8 @@
-// eslint-disable-next-line import/no-unresolved
-import { swapFunctions } from 'astro:transitions/client';
-
 const PERSIST_ATTR = 'data-astro-transition-persist';
 const EMOTION_ATTR = 'data-emotion';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type SwapFunctions = typeof import('astro:transitions/client').swapFunctions;
 
 /**
  * @internal
@@ -11,7 +11,7 @@ const EMOTION_ATTR = 'data-emotion';
  *
  * See https://docs.astro.build/en/guides/view-transitions/#building-a-custom-swap-function
  */
-export function swapDocument(doc: Document) {
+export function swapDocument(swapFunctions: SwapFunctions, doc: Document) {
   swapFunctions.deselectScripts(doc);
   swapFunctions.swapRootAttributes(doc);
 


### PR DESCRIPTION
## Description

This PR fixes an issue where custom client-side routing (using History API's pushState) triggers unexpected full page reloads due to conflicts with Astro's internal [`popstate` event handlers](https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L574)

Resolves SDK-1976

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
