### PR TITLE
feat(elements): Support SignIn.Captcha and sso-callback step

### DIFF
--- a/.changeset/rich-badgers-pump.md
+++ b/.changeset/rich-badgers-pump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': minor
+---
+
+Introduce support for `<SignIn.Captcha />` and `<SignIn.Step name='sso-callback'>`. This allows rendering of a CAPTCHA widget when a sign in attempt is transferred to a sign up attempt.

--- a/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
+++ b/packages/elements/examples/nextjs/app/sign-in/[[...sign-in]]/page.tsx
@@ -499,6 +499,7 @@ export default function SignInPage() {
             <CustomSubmit>Update Password</CustomSubmit>
           </div>
         </SignIn.Step>
+        <SignIn.Step name='sso-callback'></SignIn.Step>
       </div>
     </SignIn.Root>
   );

--- a/packages/elements/src/internals/machines/third-party/third-party.actors.ts
+++ b/packages/elements/src/internals/machines/third-party/third-party.actors.ts
@@ -78,10 +78,6 @@ export const handleRedirectCallback = fromCallback<AnyEventObject, HandleRedirec
 
     void loadedClerk.handleRedirectCallback(
       {
-        signInForceRedirectUrl: ClerkJSNavigationEvent.complete,
-        signInFallbackRedirectUrl: ClerkJSNavigationEvent.complete,
-        signUpForceRedirectUrl: ClerkJSNavigationEvent.complete,
-        signUpFallbackRedirectUrl: ClerkJSNavigationEvent.complete,
         continueSignUpUrl: ClerkJSNavigationEvent.continue,
         firstFactorUrl: ClerkJSNavigationEvent.signIn,
         resetPasswordUrl: ClerkJSNavigationEvent.resetPassword,

--- a/packages/elements/src/react/sign-in/captcha.tsx
+++ b/packages/elements/src/react/sign-in/captcha.tsx
@@ -1,0 +1,70 @@
+import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
+
+import { CAPTCHA_ELEMENT_ID } from '~/internals/constants';
+import { ClerkElementsRuntimeError } from '~/internals/errors';
+
+import { useActiveTags } from '../hooks';
+import { SignInRouterCtx } from './context';
+
+export type SignInCaptchaElement = React.ElementRef<'div'>;
+
+type CaptchaElementProps = Omit<
+  React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
+  'id' | 'children'
+>;
+
+export type SignInCaptchaProps =
+  | ({
+      asChild: true;
+      /* Must only be a self-closing element/component */
+      children: React.ReactElement;
+    } & CaptchaElementProps)
+  | ({ asChild?: false; children?: undefined } & CaptchaElementProps);
+
+/**
+ * The `<SignIn.Captcha>` component is used to render the Cloudflare Turnstile widget. It must be used within the `<SignIn.Step name="sso-callback">` component.
+ *
+ * If utilizing the `asChild` prop, the component must be a self-closing element or component. Any children passed to the immediate child component of <SignIn.Captcha> will be ignored.
+ *
+ * @param {boolean} [asChild] - If true, `<Captcha />` will render as its child element, passing along any necessary props.
+ *
+ * @example
+ * <SignIn.Root>
+ *   <SignIn.Step name="sso-callback">
+ *     <SignIn.Captcha />
+ *   </SignIn.Step>
+ * </SignIn.Root>
+ *
+ * @example
+ * <SignIn.Root>
+ *   <SignIn.Step name="sso-callback">
+ *     <SignIn.Captcha asChild>
+ *       <aside/>
+ *     </SignIn.Captcha>
+ *   </SignIn.Step>
+ * </SignIn.Root>
+ */
+
+export const SignInCaptcha = React.forwardRef<SignInCaptchaElement, SignInCaptchaProps>(
+  ({ asChild, children, ...rest }, forwardedRef) => {
+    const routerRef = SignInRouterCtx.useActorRef();
+    const activeState = useActiveTags(routerRef, 'step:callback');
+
+    if (!activeState) {
+      throw new ClerkElementsRuntimeError(
+        '<Captcha> must be used within the <SignIn.Step name="sso-callback"> component.',
+      );
+    }
+
+    const Comp = asChild ? Slot : 'div';
+
+    return (
+      <Comp
+        id={CAPTCHA_ELEMENT_ID}
+        {...rest}
+        ref={forwardedRef}
+      />
+    );
+  },
+);

--- a/packages/elements/src/react/sign-in/sso-callback.tsx
+++ b/packages/elements/src/react/sign-in/sso-callback.tsx
@@ -1,0 +1,13 @@
+import type { PropsWithChildren } from 'react';
+
+import { useActiveTags } from '~/react/hooks';
+import { SignInRouterCtx } from '~/react/sign-in/context';
+
+export type SignInSSOCallbackProps = PropsWithChildren;
+
+export function SignInSSOCallback({ children }: SignInSSOCallbackProps) {
+  const routerRef = SignInRouterCtx.useActorRef();
+  const activeState = useActiveTags(routerRef, 'step:callback');
+
+  return activeState ? children : null;
+}

--- a/packages/elements/src/react/sign-in/step.tsx
+++ b/packages/elements/src/react/sign-in/step.tsx
@@ -6,6 +6,8 @@ import { ClerkElementsRuntimeError } from '~/internals/errors';
 import { SignInChooseSession, type SignInChooseSessionProps } from './choose-session';
 import { SignInChooseStrategy, type SignInChooseStrategyProps, SignInForgotPassword } from './choose-strategy';
 import { SignInResetPassword, type SignInResetPasswordProps } from './reset-password';
+import type { SignInSSOCallbackProps } from './sso-callback';
+import { SignInSSOCallback } from './sso-callback';
 import { SignInStart, type SignInStartProps } from './start';
 import { SignInVerifications, type SignInVerificationsProps } from './verifications';
 
@@ -16,6 +18,7 @@ export const SIGN_IN_STEPS = {
   'choose-session': 'choose-session',
   'forgot-password': 'forgot-password',
   'reset-password': 'reset-password',
+  'sso-callback': 'sso-callback',
 } as const;
 
 export type TSignInStep = (typeof SIGN_IN_STEPS)[keyof typeof SIGN_IN_STEPS];
@@ -26,7 +29,8 @@ export type SignInStepProps =
   | StepWithProps<'verifications', SignInVerificationsProps>
   | StepWithProps<'choose-strategy' | 'forgot-password', SignInChooseStrategyProps>
   | StepWithProps<'reset-password', SignInResetPasswordProps>
-  | StepWithProps<'choose-session', SignInChooseSessionProps>;
+  | StepWithProps<'choose-session', SignInChooseSessionProps>
+  | StepWithProps<'sso-callback', SignInSSOCallbackProps>;
 
 /**
  * Render different steps of the sign-in flow. Initially the `'start'` step is rendered. Once a sign-in attempt has been created, `'verifications'` will be displayed. If during that verification step the user decides to choose a different method of signing in or verifying, the `'choose-strategy'` step will be displayed.
@@ -63,6 +67,8 @@ export function SignInStep(props: SignInStepProps) {
       return <SignInResetPassword {...props} />;
     case SIGN_IN_STEPS['choose-session']:
       return <SignInChooseSession {...props} />;
+    case SIGN_IN_STEPS['sso-callback']:
+      return <SignInSSOCallback {...props} />;
     default:
       throw new ClerkElementsRuntimeError(`Invalid step name. Use: ${Object.keys(SIGN_IN_STEPS).join(',')}.`);
   }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Introduces support for `<SignIn.Captcha>` as well as `<SignIn.Step name='sso-callback'>`. This allows rendering of the CAPTCHA widget when a sign in flow is transferred to a sign up flow.

Also fixes a bug with the SSO callback where a successful auth would navigate to the incorrect URL. This was due to a recent change that switched to passing a URL directly to `setActive()`, instead of `beforeEmit`.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
