### PR TITLE
chore(clerk-js,types): Add afterJoinWaitlistUrl to DisplayConfig resource

### DIFF
--- a/.changeset/spotty-books-tie.md
+++ b/.changeset/spotty-books-tie.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add afterJoinWaitlistUrl to DisplayConfig resource

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -47,6 +47,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   termsUrl!: string;
   privacyPolicyUrl!: string;
   waitlistUrl!: string;
+  afterJoinWaitlistUrl!: string;
 
   public constructor(data: DisplayConfigJSON) {
     super();
@@ -93,6 +94,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.termsUrl = data.terms_url;
     this.privacyPolicyUrl = data.privacy_policy_url;
     this.waitlistUrl = data.waitlist_url;
+    this.afterJoinWaitlistUrl = data.after_join_waitlist_url;
     return this;
   }
 }

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -41,6 +41,7 @@ export interface DisplayConfigJSON {
   terms_url: string;
   privacy_policy_url: string;
   waitlist_url: string;
+  after_join_waitlist_url: string;
 }
 
 export interface DisplayConfigResource extends ClerkResource {
@@ -84,4 +85,5 @@ export interface DisplayConfigResource extends ClerkResource {
   termsUrl: string;
   privacyPolicyUrl: string;
   waitlistUrl: string;
+  afterJoinWaitlistUrl: string;
 }


### PR DESCRIPTION
## Description
This pr adds afterJoinWaitlistUrl to DisplayConfig resource
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
