### PR TITLE
chore(repo): Increase timeouts and retries in CI

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -12,9 +12,9 @@ export const common: PlaywrightTestConfig = {
   snapshotDir: './tests/snapshots',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 5 : 0,
   timeout: 90_000,
-  maxFailures: process.env.CI ? 1 : undefined,
+  maxFailures: process.env.CI ? 5 : undefined,
   workers: process.env.CI ? '50%' : '70%',
   reporter: process.env.CI ? 'line' : 'list',
   use: {

--- a/integration/testUtils/appPageObject.ts
+++ b/integration/testUtils/appPageObject.ts
@@ -35,7 +35,7 @@ export const createAppPageObject = (testArgs: { page: Page }, app: Application) 
       if (opts.searchParams) {
         url.search = opts.searchParams.toString();
       }
-      return page.goto(url.toString(), { timeout: opts.timeout ?? 10000 });
+      return page.goto(url.toString(), { timeout: opts.timeout ?? 20000 });
     },
     waitForClerkJsLoaded: async () => {
       return page.waitForFunction(() => {


### PR DESCRIPTION
## Description

This PR increases our `retries`, `maxFailures`, and `timeout` in CI in an effort to combat some of our flaky tests.

The hypothesis is that our runners are simply being overwhelmed during more complicated tests like sessions, which runs multiple applications and a proxy server. These increases are intended to suss out whether we might see better pass rates if we throw more hardware at the problem.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
