### PR TITLE
refactor(clerk-js,types): Replace redirectUrl with afterJoinWaitlistUrl in `<Waitlist />` component

### DIFF
--- a/.changeset/spotty-pans-give.md
+++ b/.changeset/spotty-pans-give.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Replace `redirectUrl` with `afterJoinWaitlistUrl` in `<Waitlist />` component

--- a/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
+++ b/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
@@ -40,8 +40,8 @@ export const WaitlistForm = (props: WaitlistFormProps) => {
         wizard.nextStep();
 
         setTimeout(() => {
-          if (ctx.redirectUrl) {
-            void navigate(ctx.redirectUrl);
+          if (ctx.afterJoinWaitlistUrl) {
+            void navigate(ctx.afterJoinWaitlistUrl);
           }
         }, 2000);
         return;
@@ -91,7 +91,7 @@ export const WaitlistForm = (props: WaitlistFormProps) => {
           <Header.Title localizationKey={localizationKeys('waitlist.success.title')} />
           <Header.Subtitle localizationKey={localizationKeys('waitlist.success.subtitle')} />
         </Header.Root>
-        {ctx.redirectUrl && (
+        {ctx.afterJoinWaitlistUrl && (
           <Flex
             direction='col'
             elementDescriptor={descriptors.main}

--- a/packages/clerk-js/src/ui/contexts/components/Waitlist.ts
+++ b/packages/clerk-js/src/ui/contexts/components/Waitlist.ts
@@ -6,7 +6,7 @@ import type { WaitlistCtx } from '../../types';
 
 export type WaitlistContextType = WaitlistCtx & {
   signInUrl: string;
-  redirectUrl?: string;
+  afterJoinWaitlistUrl?: string;
 };
 
 export const WaitlistContext = createContext<WaitlistCtx | null>(null);

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1308,9 +1308,9 @@ export type OrganizationListProps = {
 
 export type WaitlistProps = {
   /**
-   * Full URL or path to navigate after successful waitlist submission.
+   * Full URL or path to navigate after join waitlist.
    */
-  redirectUrl?: string;
+  afterJoinWaitlistUrl?: string;
   /**
    * Customisation options to fully match the Clerk components to your own brand.
    * These options serve as overrides and will be merged with the global `appearance`


### PR DESCRIPTION
## Description

In this pr we're replacing the `redirectUrl` with `afterJoinWaitlistUrl` in `<Waitlist />` component
We can safely replace because no one using the `<Waitlist />` component yet

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
