### PR TITLE
feat(clerk-js,types): Enable reordering name fields

### DIFF
--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -25,7 +25,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
     onlyLegalAcceptedMissing = false,
     handleEmailPhoneToggle,
   } = props;
-  const { showOptionalFields } = useAppearance().parsedLayout;
+  const { showOptionalFields, nameFieldsOrder } = useAppearance().parsedLayout;
 
   const shouldShow = (name: keyof typeof fields) => {
     // In case both email & phone are optional, then don't take into account the
@@ -53,19 +53,40 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 },
               }}
             >
-              {shouldShow('firstName') && (
-                <Form.PlainInput
-                  {...formState.firstName.props}
-                  isRequired={fields.firstName?.required}
-                  isOptional={!fields.firstName?.required}
-                />
-              )}
-              {shouldShow('lastName') && (
-                <Form.PlainInput
-                  {...formState.lastName.props}
-                  isRequired={fields.lastName?.required}
-                  isOptional={!fields.lastName?.required}
-                />
+              {nameFieldsOrder === 'default' ? (
+                <>
+                  {shouldShow('firstName') && (
+                    <Form.PlainInput
+                      {...formState.firstName.props}
+                      isRequired={fields.firstName?.required}
+                      isOptional={!fields.firstName?.required}
+                    />
+                  )}
+                  {shouldShow('lastName') && (
+                    <Form.PlainInput
+                      {...formState.lastName.props}
+                      isRequired={fields.lastName?.required}
+                      isOptional={!fields.lastName?.required}
+                    />
+                  )}
+                </>
+              ) : (
+                <>
+                  {shouldShow('lastName') && (
+                    <Form.PlainInput
+                      {...formState.lastName.props}
+                      isRequired={fields.lastName?.required}
+                      isOptional={!fields.lastName?.required}
+                    />
+                  )}
+                  {shouldShow('firstName') && (
+                    <Form.PlainInput
+                      {...formState.firstName.props}
+                      isRequired={fields.firstName?.required}
+                      isOptional={!fields.firstName?.required}
+                    />
+                  )}
+                </>
               )}
             </Form.ControlRow>
           )}

--- a/packages/clerk-js/src/ui/customizables/parseAppearance.ts
+++ b/packages/clerk-js/src/ui/customizables/parseAppearance.ts
@@ -43,6 +43,7 @@ const defaultLayout: ParsedLayout = {
   termsPageUrl: '',
   shimmer: true,
   animations: true,
+  nameFieldsOrder: 'default',
   unsafe_disableDevelopmentModeWarnings: false,
 };
 

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -572,6 +572,12 @@ export type Layout = {
    */
   logoLinkUrl?: string;
   /**
+   * Controls the order of the first name last name fields. In some languages its preferred to lead
+   * with the last name. Use `reversed` to render last name before first name.
+   * @default default
+   */
+  nameFieldsOrder?: 'default' | 'reversed';
+  /**
    * Controls the variant that will be used for the social buttons.
    * By default, the components will use block buttons if you have less than
    * 3 social providers enabled, otherwise icon buttons will be used.


### PR DESCRIPTION
## Description

Introduce new layout prop to enable reordering the First name and Last name fields as some languages have their last name typically written before the first name.

Yes, this could be accomplished with CSS currently, but introduces an issue with logical tab order and should be handled via the dom order rendering ref: https://www.w3.org/TR/WCAG20-TECHS/H4.html

```tsx
<SignUp
  appearance={{
    layout: {
      nameFieldsOrder: "reversed",
    },
  }}
/>
```

<img width="561" alt="nameFieldsOrder" src="https://github.com/user-attachments/assets/8c8fb73b-0ab2-41f1-abdc-55a975d2a77d">



Resolves SDK-1913

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
