### PR TITLE
fix(repo): PR title linter

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install PNPM
         uses: pnpm/action-setup@v4
+          with:
+            version: 9.13.0
 
       - name: Lint Pull Request Title
         run: |


### PR DESCRIPTION
## Description

Specifying `pnpm` version in the PR title linter action. Seeing the following error in CI:

```
Error: No pnpm version is specified.
  Please specify it by one of the following ways:
    - in the GitHub Action config with the key "version"
    - in the package.json with the key "packageManager"
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
