### PR TITLE
chore(shared): Improve formatting of ClerkRuntimeError message

### DIFF
--- a/.changeset/nine-kids-matter.md
+++ b/.changeset/nine-kids-matter.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Improve formatting of ClerkRuntimeError message to include error code.

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -155,12 +155,16 @@ export class ClerkRuntimeError extends Error {
   code: string;
 
   constructor(message: string, { code }: { code: string }) {
-    super(message);
+    const prefix = '🔒 Clerk:';
+    const regex = new RegExp(prefix.replace(' ', '\\s*'), 'i');
+    const sanitized = message.replace(regex, '');
+    const _message = `${prefix}\n${sanitized.trim()}\n\n(Code: "${code}")\n`;
+    super(_message);
 
     Object.setPrototypeOf(this, ClerkRuntimeError.prototype);
 
     this.code = code;
-    this.message = message;
+    this.message = _message;
     this.clerkRuntimeError = true;
   }
 


### PR DESCRIPTION
## Description

- `toString()` is not guaranteed to be called 
- Always prefix with `🔒 Clerk:`
- Append the error code in the error message, so devs know which error code to check against immediately

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
