### PR TITLE
fix(clerk-js): Force ProviderInitialIcon to uppercase

### DIFF
--- a/packages/clerk-js/src/ui/common/ProviderInitialIcon.tsx
+++ b/packages/clerk-js/src/ui/common/ProviderInitialIcon.tsx
@@ -35,7 +35,7 @@ export const ProviderInitialIcon = (props: ProviderInitialIconProps) => {
           width: '100%',
         }}
       >
-        {value[0]}
+        {value[0].toUpperCase()}
       </Text>
     </Box>
   );


### PR DESCRIPTION
## Description

If for some reason a user uses lower case naming for custom provider, force the casing within the `<ProviderInitialIcon />` component.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-11-15 at 9 53 51 AM](https://github.com/user-attachments/assets/88c4bfff-2264-4e2a-a9cb-9d41c7c0e6e7) | ![Screenshot 2024-11-15 at 9 53 32 AM](https://github.com/user-attachments/assets/9a83fdb1-c65a-4a47-8ab8-d25ab12a223d) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
