### PR TITLE
fix(repo): Run pnpm install before PR title lint

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -29,4 +29,5 @@ jobs:
 
       - name: Lint Pull Request Title
         run: |
+          pnpm install
           echo '${{ github.event.pull_request.title }}' | pnpm commitlint --config commitlint.config.ts


### PR DESCRIPTION
## Description

We need to install the repo deps before running `pnpm commitlint`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
