### PR TITLE
feat(clerk-react): Expose `initialValues` within `<SignInButton />`

### DIFF
--- a/.changeset/friendly-melons-argue.md
+++ b/.changeset/friendly-melons-argue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': minor
+---
+
+Add `initialValues` option to `<SignInButton />` component.

--- a/packages/react/src/components/SignInButton.tsx
+++ b/packages/react/src/components/SignInButton.tsx
@@ -6,8 +6,15 @@ import { assertSingleChild, normalizeWithDefaultValue, safeExecute } from '../ut
 import { withClerk } from './withClerk';
 
 export const SignInButton = withClerk(({ clerk, children, ...props }: WithClerkProp<SignInButtonProps>) => {
-  const { signUpFallbackRedirectUrl, forceRedirectUrl, fallbackRedirectUrl, signUpForceRedirectUrl, mode, ...rest } =
-    props;
+  const {
+    signUpFallbackRedirectUrl,
+    forceRedirectUrl,
+    fallbackRedirectUrl,
+    signUpForceRedirectUrl,
+    mode,
+    initialValues,
+    ...rest
+  } = props;
   children = normalizeWithDefaultValue(children, 'Sign in');
   const child = assertSingleChild(children)('SignInButton');
 
@@ -17,6 +24,7 @@ export const SignInButton = withClerk(({ clerk, children, ...props }: WithClerkP
       fallbackRedirectUrl,
       signUpFallbackRedirectUrl,
       signUpForceRedirectUrl,
+      initialValues,
     };
 
     if (mode === 'modal') {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -112,7 +112,11 @@ type ButtonProps = {
 export type SignInButtonProps = ButtonProps &
   Pick<
     SignInProps,
-    'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signUpForceRedirectUrl' | 'signUpFallbackRedirectUrl'
+    | 'fallbackRedirectUrl'
+    | 'forceRedirectUrl'
+    | 'signUpForceRedirectUrl'
+    | 'signUpFallbackRedirectUrl'
+    | 'initialValues'
   >;
 
 export type SignUpButtonProps = {


### PR DESCRIPTION
## Description

Follow up to https://github.com/clerk/javascript/pull/4567

```tsx
<SignInButton
  initialValues={{
    emailAddress: "example@clerk.dev",
  }}
/>
```
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
