### PR TITLE
feat(nextjs): Remove useAuth() error in DEV

### DIFF
--- a/.changeset/spotty-eagles-applaud.md
+++ b/.changeset/spotty-eagles-applaud.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Removing hard error during build when useAuth() is not wrapped in <ClerkProvider dynamic />
+Removing error in dev when useAuth() is not wrapped in <ClerkProvider dynamic />

--- a/.changeset/spotty-eagles-applaud.md
+++ b/.changeset/spotty-eagles-applaud.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Removing hard error during build when useAuth() is not wrapped in <ClerkProvider dynamic />

--- a/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
+++ b/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '@clerk/clerk-react';
 import { useDerivedAuth } from '@clerk/clerk-react/internal';
 import type { InitialState } from '@clerk/types';
 import { useRouter } from 'next/compat/router';
-import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import React from 'react';
 
 const PromisifiedAuthContext = React.createContext<Promise<InitialState> | InitialState | null>(null);
@@ -72,11 +71,6 @@ export function usePromisifiedAuth() {
       return useAuth();
     }
 
-    if (!resolvedData && process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
-      throw new Error(
-        'Clerk: useAuth() called in static mode, wrap this component in <ClerkProvider dynamic> to make auth data available during server-side rendering.',
-      );
-    }
     // We don't need to deal with Clerk being loaded here
     return useDerivedAuth(resolvedData);
   } else {


### PR DESCRIPTION
## Description

Related: SDKI-735

Removing the following error in development:

```
Clerk: useAuth() called in static mode, wrap this component in <ClerkProvider dynamic> to make auth data available during server-side rendering.
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
