### PR TITLE
fix(clerk-js): Block /tokens requests until fraud detection completes

### DIFF
--- a/packages/clerk-js/src/core/fraudProtection.ts
+++ b/packages/clerk-js/src/core/fraudProtection.ts
@@ -1,0 +1,25 @@
+/**
+ * TODO: @nikos Move captcha and fraud detection logic to this class
+ */
+class FraudProtectionService {
+  private inflightRequest: Promise<unknown> | null = null;
+
+  public async execute<T extends () => Promise<any>>(cb: T): Promise<Awaited<ReturnType<T>>> {
+    if (this.inflightRequest) {
+      await this.inflightRequest;
+    }
+
+    const prom = cb();
+    this.inflightRequest = prom;
+    return prom.then(res => {
+      this.inflightRequest = null;
+      return res;
+    });
+  }
+
+  public blockUntilReady() {
+    return this.inflightRequest ? this.inflightRequest.then(() => null) : Promise.resolve();
+  }
+}
+
+export const fraudProtection = new FraudProtectionService();


### PR DESCRIPTION
## Description
Block all /token requests until the captcha challenge is solved. 

For getToken():
- this ensures that if a getToken() triggers fraud protection, all subsequent getToken() invocations will wait for the captcha challenge to be complete AND the initial getToken() to resolve
- if multiple getToken() invocation are queued, they will all resolve at the same time using the value of the first getToken. Only a single request will fire because of the in-memory token cache

For getToken({ skipCache: true }):
- similar to above, but multiple requests will be fired once the first getTOken() resolves
- we will optimize this behavior if needed


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
