### PR TITLE
chore(clerk-expo-passkeys): fix breaking changes

### DIFF
--- a/.changeset/fifty-cameras-tease.md
+++ b/.changeset/fifty-cameras-tease.md
@@ -1,0 +1,6 @@
+---
+'@clerk/expo-passkeys': patch
+'@clerk/clerk-expo': patch
+---
+- Replaced import { Buffer } from 'node:buffer' with import { Buffer } from 'buffer'.
+- Moved @clerk/expo-passkeys to a devDependency in @clerk/clerk-expo.

--- a/packages/expo-passkeys/.eslintrc.js
+++ b/packages/expo-passkeys/.eslintrc.js
@@ -4,4 +4,12 @@ module.exports = {
   settings: {
     'import/ignore': ['node_modules/react-native/index\\.js$'],
   },
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['node:*'],
+      },
+    ],
+  },
 };

--- a/packages/expo-passkeys/src/utils.ts
+++ b/packages/expo-passkeys/src/utils.ts
@@ -1,6 +1,5 @@
-import { Buffer } from 'node:buffer';
-
 import { ClerkWebAuthnError } from '@clerk/shared/error';
+import { Buffer } from 'buffer';
 export { ClerkWebAuthnError };
 
 export function encodeBase64(data: ArrayLike<number> | ArrayBufferLike) {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -62,7 +62,6 @@
   "dependencies": {
     "@clerk/clerk-js": "workspace:*",
     "@clerk/clerk-react": "workspace:*",
-    "@clerk/expo-passkeys": "workspace:*",
     "@clerk/shared": "workspace:*",
     "@clerk/types": "workspace:*",
     "base-64": "^1.0.0",
@@ -71,6 +70,7 @@
   },
   "devDependencies": {
     "@clerk/eslint-config-custom": "workspace:*",
+    "@clerk/expo-passkeys": "workspace:*",
     "@types/base-64": "^1.0.2",
     "@types/node": "^20.11.24",
     "@types/react": "18.3.12",
@@ -83,6 +83,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
+    "@clerk/expo-passkeys": ">=0.0.6",
     "expo-auth-session": ">=5",
     "expo-local-authentication": ">=13.5.0",
     "expo-secure-store": ">=12.4.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -93,6 +93,9 @@
     "react-native": ">=0.73"
   },
   "peerDependenciesMeta": {
+    "@clerk/expo-passkeys": {
+      "optional": true
+    },
     "expo-local-authentication": {
       "optional": true
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,9 +567,6 @@ importers:
       '@clerk/clerk-react':
         specifier: workspace:*
         version: link:../react
-      '@clerk/expo-passkeys':
-        specifier: workspace:*
-        version: link:../expo-passkeys
       '@clerk/shared':
         specifier: workspace:*
         version: link:../shared
@@ -596,7 +593,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-custom
       '@clerk/expo-passkeys':
-        specifier: 0.0.6
+        specifier: workspace:*
         version: link:../expo-passkeys
       '@types/base-64':
         specifier: ^1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
       '@clerk/eslint-config-custom':
         specifier: workspace:*
         version: link:../eslint-config-custom
+      '@clerk/expo-passkeys':
+        specifier: 0.0.6
+        version: link:../expo-passkeys
       '@types/base-64':
         specifier: ^1.0.2
         version: 1.0.2


### PR DESCRIPTION
## Description

In this commit, we are importing the `Buffer` from `buffer` instead of `node:buffer`.


We are also moving the `@clerk/expo-passkeys` back to `devDependencies` at `@clerk/clerk-expo`



## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
