### PR TITLE
feat(clerk-js): Emit sandbox to dist on build

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -27,7 +27,9 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "headless"
+    "headless",
+    "!dist/index.html",
+    "!dist/sandbox.js"
   ],
   "scripts": {
     "build": "pnpm build:bundle && pnpm build:declarations",
@@ -39,7 +41,7 @@
     "clean": "rimraf ./dist",
     "dev": "rspack serve --config rspack.config.js",
     "dev:headless": "rspack serve --config rspack.config.js --env variant=\"clerk.headless.browser\"",
-    "dev:sandbox": "rspack serve --config rspack.config.js --env devOrigin=http://localhost:4000",
+    "dev:sandbox": "rspack serve --config rspack.config.js --env devOrigin=http://localhost:4000 --env sandbox=1",
     "lint": "eslint src/",
     "lint:attw": "attw --pack .",
     "lint:publint": "publint || true",

--- a/packages/clerk-js/sandbox/app.js
+++ b/packages/clerk-js/sandbox/app.js
@@ -86,5 +86,7 @@ function addCurrentRouteIndicator(currentRoute) {
       signUpUrl: '/sign-up',
     });
     renderCurrentRoute();
+  } else {
+    console.error(`Unknown route: "${route}".`);
   }
 })();

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -200,12 +200,12 @@
     <!-- This app is in the Team SDK organization. -->
     <script
       type="text/javascript"
-      src="/npm/clerk.browser.js"
+      src="/<%= htmlRspackPlugin.files.js[0] %>"
       data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
     ></script>
     <script
       type="text/javascript"
-      src="/app.js"
+      src="/<%= htmlRspackPlugin.files.js[1] %>"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

This PR updates the sandbox in `clerk-js` to support publishing the `dist` folder to Vercel previews. This will allow us to have previews of our clerk-js components for every PR that updates clerk-js.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
