### PR TITLE
fix(dev-cli): Fix `clerk-dev` Next.js detection

### DIFF
--- a/.changeset/shaggy-donuts-cry.md
+++ b/.changeset/shaggy-donuts-cry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/dev-cli': patch
+---
+
+Fix framework detection for Next.js. `clerk-dev` will now check for `next` as a dependency.

--- a/packages/dev-cli/src/commands/setup.js
+++ b/packages/dev-cli/src/commands/setup.js
@@ -40,7 +40,7 @@ function hasPackage(packages, dependency) {
 async function detectFramework() {
   const { dependencies, devDependencies } = await getDependencies(join(process.cwd(), 'package.json'));
 
-  const IS_NEXT = hasFile('next.config.js') || hasFile('next.config.mjs');
+  const IS_NEXT = hasFile('next.config.js') || hasFile('next.config.mjs') || hasPackage(dependencies, 'next');
   if (IS_NEXT) {
     return 'nextjs';
   }

--- a/packages/dev-cli/src/commands/setup.js
+++ b/packages/dev-cli/src/commands/setup.js
@@ -40,7 +40,7 @@ function hasPackage(packages, dependency) {
 async function detectFramework() {
   const { dependencies, devDependencies } = await getDependencies(join(process.cwd(), 'package.json'));
 
-  const IS_NEXT = hasFile('next.config.js') || hasFile('next.config.mjs') || hasPackage(dependencies, 'next');
+  const IS_NEXT = hasPackage(dependencies, 'next');
   if (IS_NEXT) {
     return 'nextjs';
   }


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Currently, we're only checking for a `next.config` file to determine if Next.js is being used. We can make this more robust by checking for a `next` dependency. This fixes an issue where your local dev keys would not be properly added to a Next.js project.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
