### PR TITLE
fix(clerk-js): Enable captcha for development instances

### DIFF
--- a/.changeset/early-games-taste.md
+++ b/.changeset/early-games-taste.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Enable captcha for development instances

--- a/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
@@ -11,11 +11,7 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
     captchaWidgetType: _environment ? _environment.displayConfig.captchaWidgetType : null,
     captchaProvider,
     captchaPublicKeyInvisible: _environment ? _environment.displayConfig.captchaPublicKeyInvisible : null,
-    canUseCaptcha: _environment
-      ? _environment.userSettings.signUp.captcha_enabled &&
-        clerk.isStandardBrowser &&
-        clerk.instanceType === 'production'
-      : null,
+    canUseCaptcha: _environment ? _environment.userSettings.signUp.captcha_enabled && clerk.isStandardBrowser : null,
     captchaURL: fapiClient
       .buildUrl({
         path: 'cloudflare/turnstile/v0/api.js',


### PR DESCRIPTION
## Description

Enables captcha for development instances.

Previously captcha was only usable on production instances and with recent changes, we now allow development instances running on localhost or other domains to also use captcha for parity with production.

We now rely on the value in the environment to determine if captcha is enabled or not (`userSettings.signUp.captcha_enabled`). For current development instances, it is disabled by default so this will be a no-op.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: 
