### PR TITLE
feat(clerk-js): Introduce internal Accountless UI prompt in sandbox

### DIFF
--- a/.changeset/clever-bats-own.md
+++ b/.changeset/clever-bats-own.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': patch
+---
+
+Add `__internal_claimAccountlessKeysUrl` to `ClerkOptions`.

--- a/.changeset/empty-fans-attack.md
+++ b/.changeset/empty-fans-attack.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add new internall UI component for accountless.

--- a/.changeset/empty-fans-attack.md
+++ b/.changeset/empty-fans-attack.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Add new internall UI component for accountless.
+Add new internal UI component for accountless.

--- a/packages/clerk-js/sandbox/app.js
+++ b/packages/clerk-js/sandbox/app.js
@@ -153,6 +153,9 @@ const routes = {
   '/waitlist': () => {
     Clerk.mountWaitlist(app, componentControls.waitlist.getProps() ?? {});
   },
+  '/accountless': () => {
+    Clerk.__unstable__updateProps({ options: { __internal_claimAccountlessKeysUrl: '/test-url' } });
+  },
 };
 
 /**

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -236,6 +236,14 @@
               >Waitlist</a
             >
           </li>
+          <li class="relative">
+            <a
+              class="relative isolate flex w-full rounded-md border border-white px-2 py-[0.4375rem] text-sm hover:bg-gray-50 aria-[current]:bg-gray-50"
+              href="/accountless"
+            >
+              Accountless
+            </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1963,8 +1963,10 @@ export class Clerk implements ClerkInterface {
 
   #handleAccountlessPrompt = () => {
     void this.#componentControls?.ensureMounted().then(controls => {
-      if (this.#options.claimAccountlessKeysUrl) {
-        controls.mountAccountlessPrompt(this.#options.claimAccountlessKeysUrl);
+      if (this.#options.__internal_claimAccountlessKeysUrl) {
+        controls.updateProps({
+          options: { __internal_claimAccountlessKeysUrl: this.#options.__internal_claimAccountlessKeysUrl },
+        });
       }
     });
   };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1831,6 +1831,7 @@ export class Clerk implements ClerkInterface {
     this.#clearClerkQueryParams();
 
     this.#handleImpersonationFab();
+    this.#handleAccountlessPrompt();
     return true;
   };
 
@@ -1956,6 +1957,14 @@ export class Clerk implements ClerkInterface {
       const isImpersonating = !!session?.actor;
       if (isImpersonating) {
         void this.#componentControls?.ensureMounted().then(controls => controls.mountImpersonationFab());
+      }
+    });
+  };
+
+  #handleAccountlessPrompt = () => {
+    void this.#componentControls?.ensureMounted().then(controls => {
+      if (this.#options.claimAccountlessKeysUrl) {
+        controls.mountAccountlessPrompt(this.#options.claimAccountlessKeysUrl);
       }
     });
   };

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -102,7 +102,6 @@ export type ComponentControls = {
   prefetch: (component: 'organizationSwitcher') => void;
   // Special case, as the impersonation fab mounts automatically
   mountImpersonationFab: () => void;
-  mountAccountlessPrompt: (url: string) => void;
 };
 
 interface HtmlNodeOptions {
@@ -134,7 +133,6 @@ interface ComponentsState {
   waitlistModal: null | WaitlistProps;
   nodes: Map<HTMLDivElement, HtmlNodeOptions>;
   impersonationFab: boolean;
-  accountlessPrompt: string | null;
 }
 
 let portalCt = 0;
@@ -216,7 +214,6 @@ const Components = (props: ComponentsProps) => {
     blankCaptchaModal: null,
     nodes: new Map(),
     impersonationFab: false,
-    accountlessPrompt: null,
   });
 
   const {
@@ -323,10 +320,6 @@ const Components = (props: ComponentsProps) => {
 
     componentsControls.mountImpersonationFab = () => {
       setState(s => ({ ...s, impersonationFab: true }));
-    };
-
-    componentsControls.mountAccountlessPrompt = (url: string) => {
-      setState(s => ({ ...s, accountlessPrompt: url }));
     };
 
     componentsControls.prefetch = component => {
@@ -524,9 +517,9 @@ const Components = (props: ComponentsProps) => {
           </LazyImpersonationFabProvider>
         )}
 
-        {state.accountlessPrompt && (
+        {state.options?.__internal_claimAccountlessKeysUrl && (
           <LazyImpersonationFabProvider globalAppearance={state.appearance}>
-            <AccountlessPrompt url={state.accountlessPrompt} />
+            <AccountlessPrompt url={state.options.__internal_claimAccountlessKeysUrl} />
           </LazyImpersonationFabProvider>
         )}
 

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -23,6 +23,7 @@ import type { AppearanceCascade } from './customizables/parseAppearance';
 import { useClerkModalStateParams } from './hooks/useClerkModalStateParams';
 import type { ClerkComponentName } from './lazyModules/components';
 import {
+  AccountlessPrompt,
   BlankCaptchaModal,
   CreateOrganizationModal,
   ImpersonationFab,
@@ -101,6 +102,7 @@ export type ComponentControls = {
   prefetch: (component: 'organizationSwitcher') => void;
   // Special case, as the impersonation fab mounts automatically
   mountImpersonationFab: () => void;
+  mountAccountlessPrompt: (url: string) => void;
 };
 
 interface HtmlNodeOptions {
@@ -132,6 +134,7 @@ interface ComponentsState {
   waitlistModal: null | WaitlistProps;
   nodes: Map<HTMLDivElement, HtmlNodeOptions>;
   impersonationFab: boolean;
+  accountlessPrompt: string | null;
 }
 
 let portalCt = 0;
@@ -213,6 +216,7 @@ const Components = (props: ComponentsProps) => {
     blankCaptchaModal: null,
     nodes: new Map(),
     impersonationFab: false,
+    accountlessPrompt: null,
   });
 
   const {
@@ -319,6 +323,10 @@ const Components = (props: ComponentsProps) => {
 
     componentsControls.mountImpersonationFab = () => {
       setState(s => ({ ...s, impersonationFab: true }));
+    };
+
+    componentsControls.mountAccountlessPrompt = (url: string) => {
+      setState(s => ({ ...s, accountlessPrompt: url }));
     };
 
     componentsControls.prefetch = component => {
@@ -513,6 +521,12 @@ const Components = (props: ComponentsProps) => {
         {state.impersonationFab && (
           <LazyImpersonationFabProvider globalAppearance={state.appearance}>
             <ImpersonationFab />
+          </LazyImpersonationFabProvider>
+        )}
+
+        {state.accountlessPrompt && (
+          <LazyImpersonationFabProvider globalAppearance={state.appearance}>
+            <AccountlessPrompt url={state.accountlessPrompt} />
           </LazyImpersonationFabProvider>
         )}
 

--- a/packages/clerk-js/src/ui/components/AccountlessPrompt/index.tsx
+++ b/packages/clerk-js/src/ui/components/AccountlessPrompt/index.tsx
@@ -1,0 +1,176 @@
+import type { PointerEventHandler } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { LocalizationKey } from '../../customizables';
+import { Col, descriptors, Flex, Link, Text } from '../../customizables';
+import { Portal } from '../../elements/Portal';
+import { InternalThemeProvider, mqu } from '../../styledSystem';
+
+type AccountlessPromptProps = {
+  url?: string;
+};
+
+type FabContentProps = { title?: LocalizationKey | string; signOutText: LocalizationKey | string; url: string };
+
+const FabContent = ({ title, signOutText, url }: FabContentProps) => {
+  return (
+    <Col
+      sx={t => ({
+        width: '100%',
+        paddingLeft: t.sizes.$4,
+        paddingRight: t.sizes.$6,
+        whiteSpace: 'nowrap',
+      })}
+    >
+      <Text
+        colorScheme='secondary'
+        elementDescriptor={descriptors.impersonationFabTitle}
+        variant='buttonLarge'
+        truncate
+        localizationKey={title}
+      />
+      <Link
+        variant='buttonLarge'
+        elementDescriptor={descriptors.impersonationFabActionLink}
+        sx={t => ({
+          alignSelf: 'flex-start',
+          color: t.colors.$primary500,
+          ':hover': {
+            cursor: 'pointer',
+          },
+        })}
+        localizationKey={signOutText}
+        onClick={
+          () => (window.location.href = url)
+          // clerk-js has been loaded at this point so we can safely access session
+          // handleSignOutSessionClicked(session!)
+        }
+      />
+    </Col>
+  );
+};
+
+export const _AccountlessPrompt = (props: AccountlessPromptProps) => {
+  // const { parsedInternalTheme } = useAppearance();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  //essentials for calcs
+  // const eyeWidth = parsedInternalTheme.sizes.$16;
+  // const eyeHeight = eyeWidth;
+  const topProperty = '--cl-impersonation-fab-top';
+  const rightProperty = '--cl-impersonation-fab-right';
+  const defaultTop = 109;
+  const defaultRight = 23;
+
+  const handleResize = () => {
+    const current = containerRef.current;
+    if (!current) {
+      return;
+    }
+
+    const offsetRight = window.innerWidth - current.offsetLeft - current.offsetWidth;
+    const offsetBottom = window.innerHeight - current.offsetTop - current.offsetHeight;
+
+    const outsideViewport = [current.offsetLeft, offsetRight, current.offsetTop, offsetBottom].some(o => o < 0);
+
+    if (outsideViewport) {
+      document.documentElement.style.setProperty(rightProperty, `${defaultRight}px`);
+      document.documentElement.style.setProperty(topProperty, `${defaultTop}px`);
+    }
+  };
+
+  const onPointerDown: PointerEventHandler = () => {
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener(
+      'pointerup',
+      () => {
+        window.removeEventListener('pointermove', onPointerMove);
+        handleResize();
+      },
+      { once: true },
+    );
+  };
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const current = containerRef.current;
+    if (!current) {
+      return;
+    }
+    const rightOffestBasedOnViewportAndContent = `${
+      window.innerWidth - current.offsetLeft - current.offsetWidth - e.movementX
+    }px`;
+    document.documentElement.style.setProperty(rightProperty, rightOffestBasedOnViewportAndContent);
+    document.documentElement.style.setProperty(topProperty, `${current.offsetTop - -e.movementY}px`);
+  }, []);
+
+  const repositionFabOnResize = () => {
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  };
+
+  useEffect(repositionFabOnResize, []);
+
+  if (!props.url) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <Flex
+        ref={containerRef}
+        elementDescriptor={descriptors.impersonationFab}
+        onPointerDown={onPointerDown}
+        align='center'
+        sx={t => ({
+          touchAction: 'none', //for drag to work on mobile consistently
+          position: 'fixed',
+          overflow: 'hidden',
+          top: `var(${topProperty}, ${defaultTop}px)`,
+          right: `var(${rightProperty}, ${defaultRight}px)`,
+          padding: `10px`,
+          zIndex: t.zIndices.$fab,
+          boxShadow: t.shadows.$fabShadow,
+          borderRadius: t.radii.$halfHeight, //to match the circular eye perfectly
+          backgroundColor: t.colors.$white,
+          fontFamily: t.fonts.$main,
+          ':hover': {
+            cursor: 'grab',
+          },
+          ':hover #cl-impersonationText': {
+            transition: `max-width ${t.transitionDuration.$slowest} ease, opacity 0ms ease ${t.transitionDuration.$slowest}`,
+            maxWidth: `min(calc(50vw - 2 * ${defaultRight}px), ${15}ch)`,
+            [mqu.md]: {
+              maxWidth: `min(calc(100vw - 2 * ${defaultRight}px), ${15}ch)`,
+            },
+            opacity: 1,
+          },
+        })}
+      >
+        🔓Accountless Mode
+        <Flex
+          id='cl-impersonationText'
+          sx={t => ({
+            transition: `max-width ${t.transitionDuration.$slowest} ease, opacity ${t.transitionDuration.$fast} ease`,
+            maxWidth: '0px',
+            opacity: 1,
+          })}
+        >
+          <FabContent
+            url={props.url}
+            signOutText={'Claim your keys'}
+          />
+        </Flex>
+      </Flex>
+    </Portal>
+  );
+};
+
+export const AccountlessPrompt = (props: AccountlessPromptProps) => (
+  <InternalThemeProvider>
+    <_AccountlessPrompt {...props} />
+  </InternalThemeProvider>
+);

--- a/packages/clerk-js/src/ui/lazyModules/components.ts
+++ b/packages/clerk-js/src/ui/lazyModules/components.ts
@@ -16,6 +16,7 @@ const componentImportPaths = {
   BlankCaptchaModal: () => import(/* webpackChunkName: "blankcaptcha" */ './../components/BlankCaptchaModal'),
   UserVerification: () => import(/* webpackChunkName: "userverification" */ './../components/UserVerification'),
   Waitlist: () => import(/* webpackChunkName: "waitlist" */ './../components/Waitlist'),
+  AccountlessPrompt: () => import(/* webpackChunkName: "accountlessPrompt" */ './../components/AccountlessPrompt'),
 } as const;
 
 export const SignIn = lazy(() => componentImportPaths.SignIn().then(module => ({ default: module.SignIn })));
@@ -82,6 +83,9 @@ export const BlankCaptchaModal = lazy(() =>
 
 export const ImpersonationFab = lazy(() =>
   componentImportPaths.ImpersonationFab().then(module => ({ default: module.ImpersonationFab })),
+);
+export const AccountlessPrompt = lazy(() =>
+  componentImportPaths.AccountlessPrompt().then(module => ({ default: module.AccountlessPrompt })),
 );
 
 export const preloadComponent = async (component: unknown) => {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -745,7 +745,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
       Record<string, any>
     >;
 
-    claimAccountlessKeysUrl?: string;
+    __internal_claimAccountlessKeysUrl?: string;
 
     /**
      * [EXPERIMENTAL] Provide the underlying host router, required for the new experimental UI components.

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -745,6 +745,8 @@ export type ClerkOptions = ClerkOptionsNavigation &
       Record<string, any>
     >;
 
+    claimAccountlessKeysUrl?: string;
+
     /**
      * [EXPERIMENTAL] Provide the underlying host router, required for the new experimental UI components.
      */


### PR DESCRIPTION
## Description

> [!WARNING]
> This code will also reach our customers, but the use of `__internal_claimAccountlessKeysUrl` and the fact that this prop will not be documented should prevent them from accidentally using it.

> [!NOTE]
> This will not be the final design of the prompt


![image](https://github.com/user-attachments/assets/165af88f-b2ad-4c2c-b5aa-c8d209a11d06)


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
