### PR TITLE
feat(clerk-js): Add support for primitive span usage

### DIFF
--- a/packages/clerk-js/src/ui/customizables/index.ts
+++ b/packages/clerk-js/src/ui/customizables/index.ts
@@ -60,3 +60,5 @@ export const Tbody = makeCustomizable(sanitizeDomProps(Primitives.Tbody));
 export const Tr = makeCustomizable(sanitizeDomProps(Primitives.Tr));
 export const Th = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Th)));
 export const Td = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Td)));
+
+export const Span = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Span)));

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -2,7 +2,7 @@ import { createContextAndHook } from '@clerk/shared/react';
 import React, { useCallback } from 'react';
 
 import type { LocalizationKey } from '../customizables';
-import { Button, Col, descriptors, Flex, Heading, Icon, Text, useLocalizations } from '../customizables';
+import { Button, Col, descriptors, Flex, Heading, Icon, Span, Text, useLocalizations } from '../customizables';
 import type { ElementDescriptor, ElementId } from '../customizables/elementDescriptors';
 import { useNavigateToFlowStart, usePopover } from '../hooks';
 import { Menu } from '../icons';
@@ -47,7 +47,6 @@ export const NavBar = (props: NavBarProps) => {
   const { close } = useNavbarContext();
   const { navigate } = useRouter();
   const { navigateToFlowStart } = useNavigateToFlowStart();
-  const { t } = useLocalizations();
   const router = useRouter();
 
   const handleNavigate = (route: NavbarRoute) => {
@@ -105,7 +104,7 @@ export const NavBar = (props: NavBarProps) => {
             minHeight: t.space.$8,
           })}
         >
-          {t(r.name)}
+          <Span localizationKey={r.name} />
         </NavButton>
       ))}
     </Col>

--- a/packages/clerk-js/src/ui/primitives/Span.tsx
+++ b/packages/clerk-js/src/ui/primitives/Span.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const Span = React.forwardRef<
+  HTMLSpanElement,
+  React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>
+>((props, ref) => {
+  return (
+    <span
+      {...props}
+      ref={ref}
+    />
+  );
+});

--- a/packages/clerk-js/src/ui/primitives/index.ts
+++ b/packages/clerk-js/src/ui/primitives/index.ts
@@ -26,3 +26,4 @@ export * from './Tr';
 export * from './Th';
 export * from './Td';
 export * from './NotificationBadge';
+export * from './Span';


### PR DESCRIPTION
## Description

Currently userprofile navbar buttons don't have visible localization keys since the have a icon within the button, since when a localizationKey is provided, the icon gets removed due to [makeLocalizeable](https://github.com/clerk/javascript/blob/main/packages/clerk-js/src/ui/localization/makeLocalizable.tsx#L35-L55) converting the children to a string. I had trouble tracking down the localization key for the navbar buttons since it was not visible in the dom as expected.

I am proposing introducing a generic <Span /> that can be used to hold the localization key. Text as span currently carries styles that may not be intended in use.

Example:

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-11-22 at 1 00 03 PM](https://github.com/user-attachments/assets/44ac7082-72ec-41e3-8c50-8e461a2d6cb7) | ![Screenshot 2024-11-22 at 12 58 25 PM](https://github.com/user-attachments/assets/681a0e6c-feb2-4814-9abc-6b21f744bcb0) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
