### PR TITLE
chore(repo): Disable Cypress binary installation on CI

### DIFF
--- a/.github/actions/init-blacksmith/action.yml
+++ b/.github/actions/init-blacksmith/action.yml
@@ -114,6 +114,8 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - name: Install PNPM Dependencies
+      env:
+        CYPRESS_INSTALL_BINARY: 0
       run: pnpm install
       shell: bash
 

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -114,9 +114,9 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - name: Install PNPM Dependencies
-      run: pnpm install
       env:
         CYPRESS_INSTALL_BINARY: 0
+      run: pnpm install
       shell: bash
 
     - name: Get Playwright Version

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -114,7 +114,9 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - name: Install PNPM Dependencies
-      run: pnpm install 
+      run: pnpm install
+      env:
+        CYPRESS_INSTALL_BINARY: 0
       shell: bash
 
     - name: Get Playwright Version


### PR DESCRIPTION
## Description

The Cypress binary is being needlessly installed on every CI setup phase, however we're not using it. As such, we can cut out a few seconds out of each CI run.

~4 seconds on each runner = ~1m48s in total billable time.

```
.../cypress@13.9.0/node_modules/cypress postinstall: Note: Skipping binary installation: Environment variable CYPRESS_INSTALL_BINARY = 0.
.../cypress@13.9.0/node_modules/cypress postinstall: Done
```

Fixes: ECO-251

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI
