### PR TITLE
fix(clerk-js): Persist "this" when revoking a session, from UserProfile

### DIFF
--- a/.changeset/mean-apples-approve.md
+++ b/.changeset/mean-apples-approve.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Being able to revoke a session from UserProfile.

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -15,6 +15,8 @@ export const ActiveDevicesSection = () => {
 
   const { data: sessions, isLoading } = useFetch(user?.getSessions, 'user-sessions');
 
+  console.log('alll', sessions);
+
   return (
     <ProfileSection.Root
       title={localizationKeys('userProfile.start.activeDevicesSection.title')}
@@ -48,7 +50,7 @@ export const ActiveDevicesSection = () => {
 const DeviceItem = ({ session }: { session: SessionWithActivitiesResource }) => {
   const isCurrent = useSession().session?.id === session.id;
   const status = useLoadingStatus();
-  const [revokeSession] = useReverification(session.revoke);
+  const [revokeSession] = useReverification(session.revoke.bind(session));
 
   const revoke = async () => {
     if (isCurrent || !session) {

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -15,8 +15,6 @@ export const ActiveDevicesSection = () => {
 
   const { data: sessions, isLoading } = useFetch(user?.getSessions, 'user-sessions');
 
-  console.log('alll', sessions);
-
   return (
     <ProfileSection.Root
       title={localizationKeys('userProfile.start.activeDevicesSection.title')}

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
@@ -113,6 +113,7 @@ describe('SecurityPage', () => {
             isMobile: false,
           },
           actor: null,
+          revoke: jest.fn().mockResolvedValue({}),
         } as any as SessionWithActivitiesResource,
         {
           pathRoot: '/me/sessions',
@@ -131,6 +132,7 @@ describe('SecurityPage', () => {
             isMobile: false,
           },
           actor: null,
+          revoke: jest.fn().mockResolvedValue({}),
         } as any as SessionWithActivitiesResource,
       ]),
     );


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
