### PR TITLE
chore(clerk-react,nextjs): Re-export `isClerkRuntimeError`

### DIFF
--- a/.changeset/chilly-kids-cry.md
+++ b/.changeset/chilly-kids-cry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Re-export `isClerkRuntimeError` from `@clerk/clerk-react/errors`.

--- a/.changeset/early-mice-marry.md
+++ b/.changeset/early-mice-marry.md
@@ -1,0 +1,6 @@
+---
+'@clerk/nextjs': patch
+---
+
+- Re-export `isClerkRuntimeError` from `@clerk/clerk-react/errors`.
+- Fixes and issue where `isClerkAPIError` would only exist in the client bundle. 

--- a/packages/nextjs/src/client-boundary/hooks.ts
+++ b/packages/nextjs/src/client-boundary/hooks.ts
@@ -15,6 +15,7 @@ export {
 
 export {
   isClerkAPIResponseError,
+  isClerkRuntimeError,
   isEmailLinkError,
   isKnownError,
   isMetamaskError,

--- a/packages/nextjs/src/errors.ts
+++ b/packages/nextjs/src/errors.ts
@@ -1,7 +1,9 @@
 export {
-  isClerkAPIResponseError,
+  isClerkRuntimeError,
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
   EmailLinkErrorCode,
 } from './client-boundary/hooks';
+
+export { isClerkAPIResponseError } from '@clerk/clerk-react/errors';

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -1,5 +1,6 @@
 export {
   isClerkAPIResponseError,
+  isClerkRuntimeError,
   isEmailLinkError,
   isKnownError,
   isMetamaskError,


### PR DESCRIPTION
## Description

Also fixes #4591 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
