### PR TITLE
fix(clerk-js): Ensure updated session is emitted on user change

### DIFF
--- a/.changeset/bright-carpets-beam.md
+++ b/.changeset/bright-carpets-beam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix a bug where the the Clerk event listener was not emitting updates when a Session's user data changes.

--- a/packages/clerk-js/src/utils/memoizeStateListenerCallback.ts
+++ b/packages/clerk-js/src/utils/memoizeStateListenerCallback.ts
@@ -32,7 +32,8 @@ function sessionChanged(prev: SessionResource, next: SessionResource): boolean {
     prev.id !== next.id ||
     prev.updatedAt.getTime() < next.updatedAt.getTime() ||
     sessionFVAChanged(prev, next) ||
-    sessionUserMembershipPermissionsChanged(prev, next)
+    sessionUserMembershipPermissionsChanged(prev, next) ||
+    sessionUserChanged(prev, next)
   );
 }
 
@@ -57,6 +58,13 @@ function sessionFVAChanged(prev: SessionResource, next: SessionResource): boolea
     return prevFVA[0] !== nextFVA[0] || prevFVA[1] !== nextFVA[1];
   }
   return prevFVA !== nextFVA;
+}
+
+function sessionUserChanged(prev: SessionResource, next: SessionResource): boolean {
+  if (!!prev.user !== !!next.user) {
+    return true;
+  }
+  return !!prev.user && !!next.user && userChanged(prev.user, next.user);
 }
 
 function sessionUserMembershipPermissionsChanged(prev: SessionResource, next: SessionResource): boolean {


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

Fixes a bug where an updated Session resource is not emitted from Clerk if only the user data has changed. This causes an issue for our React hooks where the internal state is not updated by Clerk even though the underlying Clerk data has changed, so the return value of `useSession()` can drift from `Clerk.session`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
