### PR TITLE
chore(backend): Allow to create organizations without initial owner

### DIFF
--- a/.changeset/sharp-crabs-wave.md
+++ b/.changeset/sharp-crabs-wave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Allow creating organizations without an initial owner to facilitate B2B onboarding flows

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -31,7 +31,7 @@ type CreateParams = {
   name: string;
   slug?: string;
   /* The User id for the user creating the organization. The user will become an administrator for the organization. */
-  createdBy: string;
+  createdBy?: string;
   maxAllowedMemberships?: number;
 } & MetadataParams;
 

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -157,7 +157,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   admin_delete_enabled: boolean;
   public_metadata: OrganizationPublicMetadata | null;
   private_metadata?: OrganizationPrivateMetadata;
-  created_by: string;
+  created_by?: string;
   created_at: number;
   updated_at: number;
 }

--- a/packages/backend/src/api/resources/Organization.ts
+++ b/packages/backend/src/api/resources/Organization.ts
@@ -7,7 +7,6 @@ export class Organization {
     readonly slug: string | null,
     readonly imageUrl: string,
     readonly hasImage: boolean,
-    readonly createdBy: string,
     readonly createdAt: number,
     readonly updatedAt: number,
     readonly publicMetadata: OrganizationPublicMetadata | null = {},
@@ -15,6 +14,7 @@ export class Organization {
     readonly maxAllowedMemberships: number,
     readonly adminDeleteEnabled: boolean,
     readonly membersCount?: number,
+    readonly createdBy?: string,
   ) {}
 
   static fromJSON(data: OrganizationJSON): Organization {
@@ -24,7 +24,6 @@ export class Organization {
       data.slug,
       data.image_url || '',
       data.has_image,
-      data.created_by,
       data.created_at,
       data.updated_at,
       data.public_metadata,
@@ -32,6 +31,7 @@ export class Organization {
       data.max_allowed_memberships,
       data.admin_delete_enabled,
       data.members_count,
+      data.created_by,
     );
   }
 }


### PR DESCRIPTION
## Description

Resolves ORGS-144, ORGS-392

As part of SSO per org (https://github.com/clerk/clerk_go/pull/7782), we've updated BAPI to allow creating organizations without an owner therefore turning `createdBy` from required to optional. This unblocks B2B customers to create empty organizations as part of onboarding. 

Docs PR: https://github.com/clerk/clerk-docs/pull/1754


#### Is this a breaking change?

Proposing this a minor version update, although not a breaking change [according to our definitions](https://clerk.com/docs/backend-requests/versioning/overview#what-constitutes-a-breaking-change), some customers might be relying on the fact that organizations always have an owner.

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [X] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
