### PR TITLE
chore(nextjs,tanstack-start,remix): Drop path routing requirement for CreateOrganization

### DIFF
--- a/.changeset/many-ads-move.md
+++ b/.changeset/many-ads-move.md
@@ -1,0 +1,7 @@
+---
+'@clerk/tanstack-start': minor
+'@clerk/nextjs': minor
+'@clerk/remix': minor
+---
+
+Drop path routing requirement for `<CreateOrganization/>`.

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -1,24 +1,18 @@
 'use client';
 
 import {
-  CreateOrganization as BaseCreateOrganization,
   OrganizationProfile as BaseOrganizationProfile,
   SignIn as BaseSignIn,
   SignUp as BaseSignUp,
   UserProfile as BaseUserProfile,
 } from '@clerk/clerk-react';
-import type {
-  CreateOrganizationProps,
-  OrganizationProfileProps,
-  SignInProps,
-  SignUpProps,
-  UserProfileProps,
-} from '@clerk/types';
+import type { OrganizationProfileProps, SignInProps, SignUpProps, UserProfileProps } from '@clerk/types';
 import React from 'react';
 
 import { useEnforceCorrectRoutingProps } from './hooks/useEnforceRoutingProps';
 
 export {
+  CreateOrganization,
   OrganizationList,
   OrganizationSwitcher,
   SignInButton,
@@ -40,10 +34,6 @@ export const UserProfile: typeof BaseUserProfile = Object.assign(
   },
   { ...BaseUserProfile },
 );
-
-export const CreateOrganization = (props: CreateOrganizationProps) => {
-  return <BaseCreateOrganization {...useEnforceCorrectRoutingProps('CreateOrganization', props)} />;
-};
 
 // The assignment of OrganizationProfile with BaseOrganizationProfile props is used
 // to support the CustomPage functionality (eg OrganizationProfile.Page)

--- a/packages/remix/src/client/uiComponents.tsx
+++ b/packages/remix/src/client/uiComponents.tsx
@@ -1,18 +1,11 @@
 import {
-  CreateOrganization as BaseCreateOrganization,
   OrganizationProfile as BaseOrganizationProfile,
   SignIn as BaseSignIn,
   SignUp as BaseSignUp,
   UserProfile as BaseUserProfile,
 } from '@clerk/clerk-react';
 import { useRoutingProps } from '@clerk/clerk-react/internal';
-import type {
-  CreateOrganizationProps,
-  OrganizationProfileProps,
-  SignInProps,
-  SignUpProps,
-  UserProfileProps,
-} from '@clerk/types';
+import type { OrganizationProfileProps, SignInProps, SignUpProps, UserProfileProps } from '@clerk/types';
 import React from 'react';
 
 import { usePathnameWithoutSplatRouteParams } from './usePathnameWithoutSplatRouteParams';
@@ -28,11 +21,6 @@ export const UserProfile: typeof BaseUserProfile = Object.assign(
   },
   { ...BaseUserProfile },
 );
-
-export const CreateOrganization = (props: CreateOrganizationProps) => {
-  const path = usePathnameWithoutSplatRouteParams();
-  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props, { path })} />;
-};
 
 // The assignment of OrganizationProfile with BaseOrganizationProfile props is used
 // to support the CustomPage functionality (eg OrganizationProfile.Page)

--- a/packages/tanstack-start/src/client/index.ts
+++ b/packages/tanstack-start/src/client/index.ts
@@ -1,2 +1,2 @@
 export * from './ClerkProvider';
-export { SignIn, SignUp, OrganizationProfile, OrganizationList, CreateOrganization, UserProfile } from './uiComponents';
+export { SignIn, SignUp, OrganizationProfile, OrganizationList, UserProfile } from './uiComponents';

--- a/packages/tanstack-start/src/client/uiComponents.tsx
+++ b/packages/tanstack-start/src/client/uiComponents.tsx
@@ -1,5 +1,4 @@
 import {
-  CreateOrganization as BaseCreateOrganization,
   OrganizationList as BaseOrganizationList,
   OrganizationProfile as BaseOrganizationProfile,
   SignIn as BaseSignIn,
@@ -7,13 +6,7 @@ import {
   UserProfile as BaseUserProfile,
 } from '@clerk/clerk-react';
 import { useRoutingProps } from '@clerk/clerk-react/internal';
-import type {
-  CreateOrganizationProps,
-  OrganizationProfileProps,
-  SignInProps,
-  SignUpProps,
-  UserProfileProps,
-} from '@clerk/types';
+import type { OrganizationProfileProps, SignInProps, SignUpProps, UserProfileProps } from '@clerk/types';
 import { useLocation, useParams } from '@tanstack/react-router';
 
 const usePathnameWithoutSplatRouteParams = () => {
@@ -45,11 +38,6 @@ export const UserProfile: typeof BaseUserProfile = Object.assign(
   },
   { ...BaseUserProfile },
 );
-
-export const CreateOrganization = (props: CreateOrganizationProps) => {
-  const path = usePathnameWithoutSplatRouteParams();
-  return <BaseCreateOrganization {...useRoutingProps('CreateOrganization', props, { path })} />;
-};
 
 // The assignment of OrganizationProfile with BaseOrganizationProfile props is used
 // to support the CustomPage functionality (eg OrganizationProfile.Page)


### PR DESCRIPTION
## Description

Seems unnecessary and annoying, to require path routing and dynamic routes for a component that does not use internal routing.

![Image 2-12-24 at 11 53 AM](https://github.com/user-attachments/assets/b363c739-506d-4366-8587-3e6afa20bf3f)

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**


  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
