### PR TITLE
chore(astro): Add backwards compatibility for ignoring prerendered routes in Astro middleware

### DIFF
--- a/.changeset/tame-lamps-rule.md
+++ b/.changeset/tame-lamps-rule.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Add backwards compatibility for ignoring prerendered routes in Astro

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -62,7 +62,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
 
   const astroMiddleware: AstroMiddleware = async (context, next) => {
     // if the current page is prerendered, do nothing
-    if ('isPrerendered' in context && context.isPrerendered) {
+    if (isPrerenderedPage(context)) {
       return next();
     }
 
@@ -127,6 +127,15 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   };
 
   return astroMiddleware;
+};
+
+const isPrerenderedPage = (context: APIContext) => {
+  return (
+    // for Astro v5
+    ('isPrerendered' in context && context.isPrerendered) ||
+    // for Astro v4
+    ('_isPrerendered' in context && context._isPrerendered)
+  );
 };
 
 // TODO-SHARED: Duplicate from '@clerk/nextjs'


### PR DESCRIPTION
## Description

This PR is a follow up to #4640 which ignores prerendered routes in Clerk Astro middleware.

The v4 version of Astro uses [`_isPrerendered`](https://github.com/withastro/astro/blob/6eac6ba7331c3af7c2b704dc15a133748a2fd18b/packages/astro/src/core/render-context.ts#L248) property while v5 uses [`isPrerendered`](https://github.com/withastro/astro/blob/84ce4be5227cf71ac3f7c82c90718625fe58b1f6/packages/astro/src/core/render-context.ts#L310).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
