### PR TITLE
fix(localizations): Update translations and fix typos in `ru-RU`

### DIFF
--- a/.changeset/young-lemons-marry.md
+++ b/.changeset/young-lemons-marry.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Fix localizations and typos in ru-RU.ts

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -175,7 +175,7 @@ export const ruRU: LocalizationResource = {
     navbar: {
       description: 'Управлять вашей организацией.',
       general: 'Общее',
-      members: 'Участници',
+      members: 'Участники',
       title: 'Организация',
     },
     profilePage: {
@@ -268,10 +268,10 @@ export const ruRU: LocalizationResource = {
   organizationSwitcher: {
     action__createOrganization: 'Создать организацию',
     action__invitationAccept: 'Присоединиться',
-    action__manageOrganization: 'Управление организацией',
+    action__manageOrganization: 'Настройки',
     action__suggestionsAccept: 'Запрос на присоединение',
     notSelected: 'Организация не выбрана',
-    personalWorkspace: 'Личное рабочее пространство',
+    personalWorkspace: 'Личный профиль',
     suggestionsAcceptedLabel: 'Ожидает одобрения',
   },
   paginationButton__next: 'Вперед',


### PR DESCRIPTION
## Description

- `organizationSwitcher.action__manageOrganization` is set to `"Настройки"` because that is the common name and also the previous text was too long
- `organizationSwitcher.personalWorkspace` is set to `"Личный профиль"` because that is the common name and shorter
- fixed typo in  `organizationProfile.navbar.members`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Localizations
