### PR TITLE
feat(remix): Automatically use dynamic path for OrganizationProfile and UserProfile

### DIFF
--- a/.changeset/four-hats-allow.md
+++ b/.changeset/four-hats-allow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': patch
+---
+
+Automatically use dynamic path for OrganizationProfiler and UserProfile.

--- a/packages/remix/src/client/index.ts
+++ b/packages/remix/src/client/index.ts
@@ -1,4 +1,4 @@
 export * from './RemixClerkProvider';
 export { ClerkApp } from './ClerkApp';
 export { WithClerkState } from './types';
-export { SignIn, SignUp } from './uiComponents';
+export { SignIn, SignUp, OrganizationProfile, UserProfile } from './uiComponents';


### PR DESCRIPTION
## Description

exports from the "enhanced" UserProfile and OrganizationProfile where ignored, instead the one from `@clerk/clerk-react` were exported until now.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
