### PR TITLE
fix(shared): Use `session_reverification_required` as api error code

### DIFF
--- a/.changeset/small-buckets-peel.md
+++ b/.changeset/small-buckets-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Replace `session_step_up_verification_required` with `session_reverification_required` as the Clerk API error code used for reverification.

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -8,6 +8,8 @@ import { createDeferredPromise } from '../../utils/createDeferredPromise';
 import { useClerk } from './useClerk';
 import { useSafeLayoutEffect } from './useSafeLayoutEffect';
 
+const CLERK_API_REVERIFICATION_ERROR_CODE = 'session_reverification_required';
+
 async function resolveResult<T>(result: Promise<T> | T): Promise<T | ReturnType<typeof reverificationError>> {
   try {
     const r = await result;
@@ -17,7 +19,7 @@ async function resolveResult<T>(result: Promise<T> | T): Promise<T | ReturnType<
     return r;
   } catch (e) {
     // Treat fapi assurance as an assurance hint
-    if (isClerkAPIResponseError(e) && e.errors.find(({ code }) => code == 'session_step_up_verification_required')) {
+    if (isClerkAPIResponseError(e) && e.errors.find(({ code }) => code === CLERK_API_REVERIFICATION_ERROR_CODE)) {
       return reverificationError();
     }
 


### PR DESCRIPTION
## Description

While this could be considered breaking, it is not since FAPI requests are not part of the Public Beta yet.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
