### PR TITLE
feat(nextjs): No ezheaders

### DIFF
--- a/.changeset/hungry-bugs-repeat.md
+++ b/.changeset/hungry-bugs-repeat.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': minor
 ---
 
-no ezheaders
+Remove usage of `ezheaders` 

--- a/.changeset/hungry-bugs-repeat.md
+++ b/.changeset/hungry-bugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': minor
+---
+
+no ezheaders

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -70,7 +70,6 @@
     "@clerk/shared": "workspace:*",
     "@clerk/types": "workspace:*",
     "crypto-js": "4.2.0",
-    "ezheaders": "0.1.0",
     "server-only": "0.0.1",
     "tslib": "catalog:repo"
   },

--- a/packages/nextjs/src/app-router/server-actions.ts
+++ b/packages/nextjs/src/app-router/server-actions.ts
@@ -1,11 +1,11 @@
 'use server';
 
-import { getCookies } from 'ezheaders';
+import { cookies } from 'next/headers';
 
 // This function needs to be async as we'd like to support next versions in the range of [14.1.2,14.2.0)
 // These versions required 'use server' files to export async methods only. This check was later relaxed
 // and the async is no longer required in newer next versions.
 // ref: https://github.com/vercel/next.js/pull/62821
 export async function invalidateCacheAction(): Promise<void> {
-  void (await getCookies()).delete(`__clerk_invalidate_cache_cookie_${Date.now()}`);
+  void (await cookies()).delete(`__clerk_invalidate_cache_cookie_${Date.now()}`
 }

--- a/packages/nextjs/src/app-router/server-actions.ts
+++ b/packages/nextjs/src/app-router/server-actions.ts
@@ -7,5 +7,5 @@ import { cookies } from 'next/headers';
 // and the async is no longer required in newer next versions.
 // ref: https://github.com/vercel/next.js/pull/62821
 export async function invalidateCacheAction(): Promise<void> {
-  void (await cookies()).delete(`__clerk_invalidate_cache_cookie_${Date.now()}`
+  void (await cookies()).delete(`__clerk_invalidate_cache_cookie_${Date.now()}`);
 }

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -1,6 +1,6 @@
 import type { AuthObject } from '@clerk/backend';
 import type { InitialState, Without } from '@clerk/types';
-import { header } from 'ezheaders';
+import { headers } from 'next/headers';
 import nextPkg from 'next/package.json';
 import React from 'react';
 
@@ -21,7 +21,7 @@ const getDynamicClerkState = React.cache(async function getDynamicClerkState() {
 });
 
 const getNonceFromCSPHeader = React.cache(async function getNonceFromCSPHeader() {
-  return getScriptNonceFromHeader((await header('Content-Security-Policy')) || '') || '';
+  return getScriptNonceFromHeader((await headers()).get('Content-Security-Policy') || '') || '';
 });
 
 export async function ClerkProvider(

--- a/packages/nextjs/src/app-router/server/utils.ts
+++ b/packages/nextjs/src/app-router/server/utils.ts
@@ -22,9 +22,10 @@ export const isPrerenderingBailout = (e: unknown) => {
 export async function buildRequestLike() {
   try {
     // Dynamically import next/headers, otherwise Next12 apps will break
-    // @ts-ignore: Cannot find module 'next/headers' or its corresponding type declarations.ts(2307)
-    const { getHeaders } = await import('ezheaders');
-    return new NextRequest('https://placeholder.com', { headers: await getHeaders() });
+    // @ts-expect-error: Cannot find module 'next/headers' or its corresponding type declarations.ts(2307)
+    const { headers } = await import('next/headers');
+    const resolvedHeaders = await headers();
+    return new NextRequest('https://placeholder.com', { headers: resolvedHeaders });
   } catch (e: any) {
     // rethrow the error when react throws a prerendering bailout
     // https://nextjs.org/docs/messages/ppr-caught-error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,9 +784,6 @@ importers:
       crypto-js:
         specifier: 4.2.0
         version: 4.2.0
-      ezheaders:
-        specifier: 0.1.0
-        version: 0.1.0(next@14.2.16(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react:
         specifier: ^18 || ^19.0.0-0
         version: 18.3.1
@@ -8654,11 +8651,6 @@ packages:
   extsprintf@1.3.0:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
-
-  ezheaders@0.1.0:
-    resolution: {integrity: sha512-U0wdCs2dS+IzFuxyHGyw1aWhiunW22sGqnyH4yQsovkgqUvO4YSbzQ5BQzV6HY4oFlNnK+TbFGJj8rvvX5aN7w==}
-    peerDependencies:
-      next: ^13.5.4 || ^14 || ^15
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -25226,10 +25218,6 @@ snapshots:
       - supports-color
 
   extsprintf@1.3.0: {}
-
-  ezheaders@0.1.0(next@14.2.16(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
-    dependencies:
-      next: 14.2.16(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   fast-decode-uri-component@1.0.1: {}
 


### PR DESCRIPTION
## Description

The current build of `ezheaders` is causing issues in downstream projects with `vitest` . Removing the package for now.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
