### PR TITLE
chore(vue): Add custom pages and links

### DIFF
--- a/.changeset/four-beans-argue.md
+++ b/.changeset/four-beans-argue.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Add support for custom pages and links

--- a/integration/templates/vue-vite/src/components/CustomUserButton.vue
+++ b/integration/templates/vue-vite/src/components/CustomUserButton.vue
@@ -33,7 +33,9 @@ const isActionClicked = ref(false);
       </UserButton.Action>
     </UserButton.MenuItems>
     <UserButton.UserProfilePage label="Terms" url="terms">
-        <div slot="label-icon">Icon</div>
+      <template #labelIcon>
+        <div>Icon</div>
+      </template>
         <div>
             <h1>Custom Terms Page</h1>
             <p>This is the custom terms page</p>

--- a/integration/templates/vue-vite/src/components/CustomUserButton.vue
+++ b/integration/templates/vue-vite/src/components/CustomUserButton.vue
@@ -18,7 +18,10 @@ const isActionClicked = ref(false);
           <div>Icon</div>
         </template>
       </UserButton.Link>
-      <UserButton.Action label="Custom page" open="terms">
+      <UserButton.Action
+        label="Custom page"
+        open="terms"
+      >
         <template #labelIcon>
           <div>Icon</div>
         </template>
@@ -32,14 +35,17 @@ const isActionClicked = ref(false);
         </template>
       </UserButton.Action>
     </UserButton.MenuItems>
-    <UserButton.UserProfilePage label="Terms" url="terms">
+    <UserButton.UserProfilePage
+      label="Terms"
+      url="terms"
+    >
       <template #labelIcon>
         <div>Icon</div>
       </template>
-        <div>
-            <h1>Custom Terms Page</h1>
-            <p>This is the custom terms page</p>
-        </div>
+      <div>
+        <h1>Custom Terms Page</h1>
+        <p>This is the custom terms page</p>
+      </div>
     </UserButton.UserProfilePage>
   </UserButton>
   <div>Is action clicked: {{ isActionClicked }}</div>

--- a/integration/templates/vue-vite/src/components/CustomUserButton.vue
+++ b/integration/templates/vue-vite/src/components/CustomUserButton.vue
@@ -18,6 +18,11 @@ const isActionClicked = ref(false);
           <div>Icon</div>
         </template>
       </UserButton.Link>
+      <UserButton.Action label="Custom page" open="terms">
+        <template #labelIcon>
+          <div>Icon</div>
+        </template>
+      </UserButton.Action>
       <UserButton.Action
         label="Custom action"
         @click="isActionClicked = true"
@@ -27,6 +32,13 @@ const isActionClicked = ref(false);
         </template>
       </UserButton.Action>
     </UserButton.MenuItems>
+    <UserButton.UserProfilePage label="Terms" url="terms">
+        <div slot="label-icon">Icon</div>
+        <div>
+            <h1>Custom Terms Page</h1>
+            <p>This is the custom terms page</p>
+        </div>
+    </UserButton.UserProfilePage>
   </UserButton>
   <div>Is action clicked: {{ isActionClicked }}</div>
 </template>

--- a/integration/templates/vue-vite/src/router.ts
+++ b/integration/templates/vue-vite/src/router.ts
@@ -26,6 +26,16 @@ const routes = [
     path: '/unstyled',
     component: () => import('./views/Unstyled.vue'),
   },
+  {
+    name: 'CustomUserProfile',
+    path: '/custom-pages/user-profile',
+    component: () => import('./views/custom-pages/UserProfile.vue'),
+  },
+  {
+    name: 'CustomOrganizationProfile',
+    path: '/custom-pages/organization-profile',
+    component: () => import('./views/custom-pages/CustomOrganizationProfile.vue'),
+  },
 ];
 
 const router = createRouter({
@@ -35,6 +45,7 @@ const router = createRouter({
 
 router.beforeEach(async (to, _, next) => {
   const { isSignedIn, isLoaded } = useAuth();
+  const authenticatedPages = ['Profile', 'Admin', 'CustomUserProfile', 'CustomOrganizationProfile'];
 
   if (!isLoaded.value) {
     await waitForClerkJsLoaded(isLoaded);
@@ -42,7 +53,7 @@ router.beforeEach(async (to, _, next) => {
 
   if (isSignedIn.value && to.name === 'Sign in') {
     next('/profile');
-  } else if (!isSignedIn.value && ['Profile', 'Admin'].includes(to.name as string)) {
+  } else if (!isSignedIn.value && authenticatedPages.includes(to.name)) {
     next('/sign-in');
   } else {
     next();

--- a/integration/templates/vue-vite/src/router.ts
+++ b/integration/templates/vue-vite/src/router.ts
@@ -34,7 +34,7 @@ const routes = [
   {
     name: 'CustomOrganizationProfile',
     path: '/custom-pages/organization-profile',
-    component: () => import('./views/custom-pages/CustomOrganizationProfile.vue'),
+    component: () => import('./views/custom-pages/OrganizationProfile.vue'),
   },
 ];
 

--- a/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
+++ b/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
@@ -24,6 +24,6 @@ import { OrganizationProfile } from '@clerk/vue';
         <div>Icon</div>
       </template>
     </OrganizationProfile.Link>
-    <OrganizationProfile.Page label="security" />
+    <OrganizationProfile.Page label="general" />
   </OrganizationProfile>
 </template>

--- a/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
+++ b/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { OrganizationProfile } from '@clerk/vue';
+</script>
+
+<template>
+  <OrganizationProfile>
+    <OrganizationProfile.Page
+      label="Terms"
+      url="terms"
+    >
+      <template #labelIcon>
+        <div>Icon</div>
+      </template>
+      <div>
+        <h1>Custom Terms Page</h1>
+        <p>This is the custom terms page</p>
+      </div>
+    </OrganizationProfile.Page>
+    <OrganizationProfile.Link
+      label="Homepage"
+      url="/"
+    >
+      <<template #labelIcon>
+        <div>Icon</div>
+      </template>
+    </OrganizationProfile.Link>
+    <OrganizationProfile.Page label="security" />
+  </OrganizationProfile>
+</template>

--- a/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
+++ b/integration/templates/vue-vite/src/views/custom-pages/OrganizationProfile.vue
@@ -20,7 +20,7 @@ import { OrganizationProfile } from '@clerk/vue';
       label="Homepage"
       url="/"
     >
-      <<template #labelIcon>
+      <template #labelIcon>
         <div>Icon</div>
       </template>
     </OrganizationProfile.Link>

--- a/integration/templates/vue-vite/src/views/custom-pages/UserProfile.vue
+++ b/integration/templates/vue-vite/src/views/custom-pages/UserProfile.vue
@@ -20,7 +20,7 @@ import { UserProfile } from '@clerk/vue';
       label="Homepage"
       url="/"
     >
-      <<template #labelIcon>
+      <template #labelIcon>
         <div>Icon</div>
       </template>
     </UserProfile.Link>

--- a/integration/templates/vue-vite/src/views/custom-pages/UserProfile.vue
+++ b/integration/templates/vue-vite/src/views/custom-pages/UserProfile.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { UserProfile } from '@clerk/vue';
+</script>
+
+<template>
+  <UserProfile>
+    <UserProfile.Page
+      label="Terms"
+      url="terms"
+    >
+      <template #labelIcon>
+        <div>Icon</div>
+      </template>
+      <div>
+        <h1>Custom Terms Page</h1>
+        <p>This is the custom terms page</p>
+      </div>
+    </UserProfile.Page>
+    <UserProfile.Link
+      label="Homepage"
+      url="/"
+    >
+      <<template #labelIcon>
+        <div>Icon</div>
+      </template>
+    </UserProfile.Link>
+    <UserProfile.Page label="security" />
+  </UserProfile>
+</template>

--- a/integration/tests/vue/components.test.ts
+++ b/integration/tests/vue/components.test.ts
@@ -128,7 +128,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
     await u.po.expect.toBeSignedIn();
 
-    await u.page.goToRelative('/custom/user-profile');
+    await u.page.goToRelative('/custom-pages/user-profile');
     await u.po.userProfile.waitForMounted();
 
     // Check if custom pages and links are visible
@@ -155,7 +155,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
     await u.po.expect.toBeSignedIn();
 
-    await u.page.goToRelative('/custom/organization-profile');
+    await u.page.goToRelative('/custom-pages/organization-profile');
     await u.po.organizationSwitcher.waitForMounted();
     await u.po.organizationSwitcher.waitForAnOrganizationToSelected();
 

--- a/integration/tests/vue/components.test.ts
+++ b/integration/tests/vue/components.test.ts
@@ -66,13 +66,19 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await u.po.userButton.waitForPopover();
 
     // Check if custom menu items are visible
-    await u.po.userButton.toHaveVisibleMenuItems([/Custom link/i, /Custom action/i]);
+    await u.po.userButton.toHaveVisibleMenuItems([/Custom link/i, /Custom page/i, /Custom action/i]);
 
     // Click custom action
     await u.page.getByRole('menuitem', { name: /Custom action/i }).click();
     await expect(u.page.getByText('Is action clicked: true')).toBeVisible();
 
-    // Trigger the popover again
+    // Click custom action and check for custom page availbility
+    await u.page.getByRole('menuitem', { name: /Custom page/i }).click();
+    await u.po.userProfile.waitForUserProfileModal();
+    await expect(u.page.getByRole('heading', { name: 'Custom Terms Page' })).toBeVisible();
+
+    // Close the modal and trigger the popover again
+    await u.page.locator('.cl-modalCloseButton').click();
     await u.po.userButton.toggleTrigger();
     await u.po.userButton.waitForPopover();
 

--- a/integration/tests/vue/components.test.ts
+++ b/integration/tests/vue/components.test.ts
@@ -121,6 +121,61 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await expect(u.page.getByText(`Hello, ${fakeUser.firstName}`)).toBeVisible();
   });
 
+  test('render user profile with custom pages and links', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+    await u.page.goToRelative('/sign-in');
+    await u.po.signIn.waitForMounted();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+    await u.po.expect.toBeSignedIn();
+
+    await u.page.goToRelative('/custom/user-profile');
+    await u.po.userProfile.waitForMounted();
+
+    // Check if custom pages and links are visible
+    await expect(u.page.getByRole('button', { name: /Terms/i })).toBeVisible();
+    await expect(u.page.getByRole('button', { name: /Homepage/i })).toBeVisible();
+
+    // Navigate to custom page
+    await u.page.getByRole('button', { name: /Terms/i }).click();
+    await expect(u.page.getByRole('heading', { name: 'Custom Terms Page' })).toBeVisible();
+
+    // Check reordered default label. Security tab is now the last item.
+    await u.page.locator('.cl-navbarButton').last().click();
+    await expect(u.page.getByRole('heading', { name: 'Security' })).toBeVisible();
+
+    // Click custom link and check navigation
+    await u.page.getByRole('button', { name: /Homepage/i }).click();
+    await u.page.waitForAppUrl('/');
+  });
+
+  test('render organization profile with custom pages and links', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+    await u.page.goToRelative('/sign-in');
+    await u.po.signIn.waitForMounted();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+    await u.po.expect.toBeSignedIn();
+
+    await u.page.goToRelative('/custom/organization-profile');
+    await u.po.organizationSwitcher.waitForMounted();
+    await u.po.organizationSwitcher.waitForAnOrganizationToSelected();
+
+    // Check if custom pages and links are visible
+    await expect(u.page.getByRole('button', { name: /Terms/i })).toBeVisible();
+    await expect(u.page.getByRole('button', { name: /Homepage/i })).toBeVisible();
+
+    // Navigate to custom page
+    await u.page.getByRole('button', { name: /Terms/i }).click();
+    await expect(u.page.getByRole('heading', { name: 'Custom Terms Page' })).toBeVisible();
+
+    // Check reordered default label. General tab is now the last item.
+    await u.page.locator('.cl-navbarButton').last().click();
+    await expect(u.page.getByRole('heading', { name: 'General' })).toBeVisible();
+
+    // Click custom link and check navigation
+    await u.page.getByRole('button', { name: /Homepage/i }).click();
+    await u.page.waitForAppUrl('/');
+  });
+
   test('redirects to sign-in when unauthenticated', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
     await u.page.goToRelative('/profile');

--- a/integration/tests/vue/components.test.ts
+++ b/integration/tests/vue/components.test.ts
@@ -72,6 +72,10 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await u.page.getByRole('menuitem', { name: /Custom action/i }).click();
     await expect(u.page.getByText('Is action clicked: true')).toBeVisible();
 
+    // Trigger the popover again
+    await u.po.userButton.toggleTrigger();
+    await u.po.userButton.waitForPopover();
+
     // Click custom action and check for custom page availbility
     await u.page.getByRole('menuitem', { name: /Custom page/i }).click();
     await u.po.userProfile.waitForUserProfileModal();

--- a/packages/vue/src/components/uiComponents.ts
+++ b/packages/vue/src/components/uiComponents.ts
@@ -363,7 +363,7 @@ const _OrganizationProfile = defineComponent((props: OrganizationProfileProps, {
     customPages: customPages.value,
   }));
 
-  provide(UserProfileInjectionKey, {
+  provide(OrganizationProfileInjectionKey, {
     addCustomPage,
   });
 

--- a/packages/vue/src/errors/messages.ts
+++ b/packages/vue/src/errors/messages.ts
@@ -14,10 +14,26 @@ export const userButtonMenuLinkRenderedError =
   '<UserButton.Link /> component needs to be a direct child of `<UserButton.MenuItems />`.';
 
 export const userButtonMenuItemLinkWrongProps =
-  'Missing requirements. <UserButton.Link /> component requires props: href, label and slot: labelIcon';
+  'Missing requirements. <UserButton.Link /> component requires props: href, label and slots: labelIcon.';
 
 export const userButtonMenuItemActionWrongProps =
-  'Missing requirements. <UserButton.Action /> component requires props: label and slot: labelIcon';
+  'Missing requirements. <UserButton.Action /> component requires props: label and slots: labelIcon.';
 
 export const userButtonMenuItemsRenderedError =
   '<UserButton.MenuItems /> component needs to be a direct child of `<UserButton />`.';
+
+export const customPageWrongProps = (componentName: string) =>
+  `Missing requirements. <${componentName}.Page /> component requires props: url, label and slots: labelIcon and a default slot for page content`;
+
+export const customLinkWrongProps = (componentName: string) =>
+  `Missing requirements. <${componentName}.Link /> component requires the following props: url, label and slots: labelIcon.`;
+
+export const userProfilePageRenderedError =
+  '<UserProfile.Page /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+export const userProfileLinkRenderedError =
+  '<UserProfile.Link /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+
+export const organizationProfilePageRenderedError =
+  '<OrganizationProfile.Page /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
+export const organizationProfileLinkRenderedError =
+  '<OrganizationProfile.Link /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';

--- a/packages/vue/src/keys.ts
+++ b/packages/vue/src/keys.ts
@@ -1,6 +1,6 @@
 import type { InjectionKey } from 'vue';
 
-import type { AddCustomMenuItemParams, VueClerkInjectionKeyType } from './types';
+import type { AddCustomMenuItemParams, AddCustomPagesParams, VueClerkInjectionKeyType } from './types';
 
 export const ClerkInjectionKey = Symbol('clerk') as InjectionKey<VueClerkInjectionKeyType>;
 
@@ -10,4 +10,12 @@ export const UserButtonInjectionKey = Symbol('UserButton') as InjectionKey<{
 
 export const UserButtonMenuItemsInjectionKey = Symbol('UserButton.MenuItems') as InjectionKey<{
   addCustomMenuItem(params: AddCustomMenuItemParams): void;
+}>;
+
+export const UserProfileInjectionKey = Symbol('UserProfile') as InjectionKey<{
+  addCustomPage(params: AddCustomPagesParams): void;
+}>;
+
+export const OrganizationProfileInjectionKey = Symbol('OrganizationProfile') as InjectionKey<{
+  addCustomPage(params: AddCustomPagesParams): void;
 }>;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ClerkOptions,
   ClientResource,
   CustomMenuItem,
+  CustomPage,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
   OrganizationResource,
@@ -55,6 +56,32 @@ export type AddCustomMenuItemParams = {
     labelIcon?: Slot;
   };
   component: Component;
+};
+
+export type AddCustomPagesParams = {
+  props: CustomItemOrPageWithoutHandler<CustomPage>;
+  slots: {
+    default?: Slot;
+    labelIcon?: Slot;
+  };
+  component: Component;
+};
+
+type PageProps<T extends string> =
+  | {
+      label: string;
+      url: string;
+    }
+  | {
+      label: T;
+      url?: never;
+    };
+
+export type UserProfilePageProps = PageProps<'account' | 'security'>;
+
+export type UserProfileLinkProps = {
+  url: string;
+  label: string;
 };
 
 type ButtonActionProps<T extends string> =

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -84,6 +84,13 @@ export type UserProfileLinkProps = {
   label: string;
 };
 
+export type OrganizationProfilePageProps = PageProps<'general' | 'members'>;
+
+export type OrganizationLinkProps = {
+  url: string;
+  label: string;
+};
+
 type ButtonActionProps<T extends string> =
   | {
       label: string;

--- a/packages/vue/src/utils/useCustomElementPortal.ts
+++ b/packages/vue/src/utils/useCustomElementPortal.ts
@@ -7,6 +7,10 @@ interface RawPortal {
   slot: Slot;
 }
 
+function generateElementIdentifier() {
+  return Math.random().toString(36).substring(2, 7);
+}
+
 export const useCustomElementPortal = () => {
   const rawPortals = ref<RawPortal[]>([]);
   const portals = computed(() => {
@@ -16,16 +20,19 @@ export const useCustomElementPortal = () => {
   });
 
   const mount = (el: HTMLDivElement, slot: Slot) => {
+    const id = generateElementIdentifier();
+    el.setAttribute('data-clerk-mount-id', id);
     rawPortals.value.push({
-      id: el.id,
+      id,
       el,
       slot,
     });
   };
 
   const unmount = (el: HTMLDivElement | undefined) => {
-    if (el) {
-      const index = rawPortals.value.findIndex(portal => portal.id === el.id);
+    const id = el?.getAttribute('data-clerk-mount-id');
+    if (id) {
+      const index = rawPortals.value.findIndex(portal => portal.id === id);
       if (index !== -1) {
         rawPortals.value.splice(index, 1);
       }

--- a/packages/vue/src/utils/useCustomPages.ts
+++ b/packages/vue/src/utils/useCustomPages.ts
@@ -3,7 +3,12 @@ import type { CustomPage } from '@clerk/types';
 import type { Component } from 'vue';
 import { ref } from 'vue';
 
-import { UserProfileLink, UserProfilePage } from '../components/uiComponents';
+import {
+  OrganizationProfileLink,
+  OrganizationProfilePage,
+  UserProfileLink,
+  UserProfilePage,
+} from '../components/uiComponents';
 import { customLinkWrongProps, customPageWrongProps } from '../errors/messages';
 import type { AddCustomPagesParams } from '../types';
 import { isThatComponent } from './componentValidation';
@@ -31,8 +36,8 @@ export const useUserProfileCustomPages = () => {
 export const useOrganizationProfileCustomPages = () => {
   const { customPages, customPagesPortals, addCustomPage } = useCustomPages({
     reorderItemsLabels: ['general', 'members'],
-    PageComponent: UserProfilePage,
-    LinkComponent: UserProfileLink,
+    PageComponent: OrganizationProfilePage,
+    LinkComponent: OrganizationProfileLink,
     componentName: 'OrganizationProfile',
   });
 

--- a/packages/vue/src/utils/useCustomPages.ts
+++ b/packages/vue/src/utils/useCustomPages.ts
@@ -1,0 +1,131 @@
+import { logErrorInDevMode } from '@clerk/shared/utils';
+import type { CustomPage } from '@clerk/types';
+import type { Component } from 'vue';
+import { ref } from 'vue';
+
+import { UserProfileLink, UserProfilePage } from '../components/uiComponents';
+import { customLinkWrongProps, customPageWrongProps } from '../errors/messages';
+import type { AddCustomPagesParams } from '../types';
+import { isThatComponent } from './componentValidation';
+import { useCustomElementPortal } from './useCustomElementPortal';
+
+export const useUserProfileCustomPages = () => {
+  const { customPages, customPagesPortals, addCustomPage } = useCustomPages({
+    reorderItemsLabels: ['account', 'security'],
+    PageComponent: UserProfilePage,
+    LinkComponent: UserProfileLink,
+    componentName: 'UserProfile',
+  });
+
+  const addUserProfileCustomPage = (params: AddCustomPagesParams) => {
+    return addCustomPage(params);
+  };
+
+  return {
+    customPages,
+    customPagesPortals,
+    addCustomPage: addUserProfileCustomPage,
+  };
+};
+
+export const useOrganizationProfileCustomPages = () => {
+  const { customPages, customPagesPortals, addCustomPage } = useCustomPages({
+    reorderItemsLabels: ['general', 'members'],
+    PageComponent: UserProfilePage,
+    LinkComponent: UserProfileLink,
+    componentName: 'OrganizationProfile',
+  });
+
+  const addOrganizationProfileCustomPage = (params: AddCustomPagesParams) => {
+    return addCustomPage(params);
+  };
+
+  return {
+    customPages,
+    customPagesPortals,
+    addCustomPage: addOrganizationProfileCustomPage,
+  };
+};
+
+type UseCustomPagesParams = {
+  LinkComponent: Component;
+  PageComponent: Component;
+  reorderItemsLabels: string[];
+  componentName: string;
+};
+
+export const useCustomPages = (customPagesParams: UseCustomPagesParams) => {
+  const customPages = ref<CustomPage[]>([]);
+  const { portals: customPagesPortals, mount, unmount } = useCustomElementPortal();
+  const { PageComponent, LinkComponent, reorderItemsLabels, componentName } = customPagesParams;
+
+  const addCustomPage = (params: AddCustomPagesParams) => {
+    const { props, slots, component } = params;
+    const { label, url } = props;
+
+    if (isThatComponent(component, PageComponent)) {
+      if (isReorderItem(props, slots, reorderItemsLabels)) {
+        // This is a reordering item
+        customPages.value.push({ label });
+      } else if (isCustomPage(props, slots)) {
+        // This is a custom page
+        customPages.value.push({
+          label,
+          url,
+          mountIcon(el) {
+            mount(el, slots.labelIcon!);
+          },
+          unmountIcon: unmount,
+          mount(el) {
+            mount(el, slots.default!);
+          },
+          unmount,
+        });
+      } else {
+        logErrorInDevMode(customPageWrongProps(componentName));
+        return;
+      }
+    }
+
+    if (isThatComponent(component, LinkComponent)) {
+      if (isExternalLink(props, slots)) {
+        // This is an external link
+        customPages.value.push({
+          label,
+          url,
+          mountIcon(el) {
+            mount(el, slots.labelIcon!);
+          },
+          unmountIcon: unmount,
+        });
+      } else {
+        logErrorInDevMode(customLinkWrongProps(componentName));
+        return;
+      }
+    }
+  };
+
+  return {
+    customPages,
+    customPagesPortals,
+    addCustomPage,
+  };
+};
+
+const isReorderItem = (props: any, slots: AddCustomPagesParams['slots'], validItems: string[]): boolean => {
+  const { label, url } = props;
+  const { default: defaultSlot, labelIcon } = slots;
+  return !defaultSlot && !url && !labelIcon && validItems.some(v => v === label);
+};
+
+const isCustomPage = (props: any, slots: AddCustomPagesParams['slots']): boolean => {
+  const { label, url } = props;
+  const { default: defaultSlot, labelIcon } = slots;
+  return !!defaultSlot && !!url && !!labelIcon && !!label;
+};
+
+const isExternalLink = (props: any, slots: AddCustomPagesParams['slots']): boolean => {
+  const { label, url } = props;
+  const { default: defaultSlot, labelIcon } = slots;
+  return !defaultSlot && !!url && !!labelIcon && !!label;
+};

--- a/packages/vue/src/utils/useCustomPages.ts
+++ b/packages/vue/src/utils/useCustomPages.ts
@@ -78,10 +78,12 @@ export const useCustomPages = (customPagesParams: UseCustomPagesParams) => {
           label,
           url,
           mountIcon(el) {
+            unmount(el);
             mount(el, slots.labelIcon!);
           },
           unmountIcon: unmount,
           mount(el) {
+            unmount(el);
             mount(el, slots.default!);
           },
           unmount,
@@ -99,6 +101,7 @@ export const useCustomPages = (customPagesParams: UseCustomPagesParams) => {
           label,
           url,
           mountIcon(el) {
+            unmount(el);
             mount(el, slots.labelIcon!);
           },
           unmountIcon: unmount,

--- a/packages/vue/src/utils/useCustomPages.ts
+++ b/packages/vue/src/utils/useCustomPages.ts
@@ -78,12 +78,10 @@ export const useCustomPages = (customPagesParams: UseCustomPagesParams) => {
           label,
           url,
           mountIcon(el) {
-            unmount(el);
             mount(el, slots.labelIcon!);
           },
           unmountIcon: unmount,
           mount(el) {
-            unmount(el);
             mount(el, slots.default!);
           },
           unmount,
@@ -101,7 +99,6 @@ export const useCustomPages = (customPagesParams: UseCustomPagesParams) => {
           label,
           url,
           mountIcon(el) {
-            unmount(el);
             mount(el, slots.labelIcon!);
           },
           unmountIcon: unmount,


### PR DESCRIPTION
## Description

This PR adds support for [custom pages](https://clerk.com/docs/customization/user-profile) to the `<UserProfile />` and `<OrganizationProfile />` components of the Vue SDK.

Example usage:

```html
<script setup>
import { UserProfile } from '@clerk/vue' 
</script>

<UserProfile path="/user-profile" routing="path">
  <UserProfile.Page label="Custom Page" url="custom-page">
    <template #labelIcon>
      <div>Icon</div>
    </template>
    <div>
        <h1>Custom Terms Page</h1>
        <p>This is the custom terms page</p>
    </div>
  </UserProfile.Page>
  <UserProfile.Link label="Homepage" url="/">
    <template #labelIcon>
      <div>Icon</div>
    </template>
  </UserProfile.Link>
</UserProfile>
```

Also, unlike the React counterpart where we [loop over the `children` prop](https://github.com/clerk/javascript/blob/20d857188d3c66aaf70e4303f2fc451c76e348fc/packages/react/src/utils/useCustomPages.tsx#L108) to check for custom pages, this one uses Vue's [provide/inject](vuejs.org/guide/components/provide-inject) and [slots](https://vuejs.org/guide/components/slots) to determine the custom pages.

Just patching for now until we do a GA release

Resolves ECO-261

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
