### PR TITLE
fix(clerk-js): Move signup id check into an effect within continue step

### DIFF
--- a/.changeset/clean-rivers-sleep.md
+++ b/.changeset/clean-rivers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an issue during sign-up flow where a user lands on the continue step, and proceeds successfully through the sign-up process and gets redirected to AP sign-up due to signUp.id being undefined.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -3,7 +3,13 @@ import React, { useEffect, useMemo } from 'react';
 
 import { useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts';
 import { descriptors, Flex, Flow, localizationKeys } from '../../customizables';
-import { Card, Header, SocialButtonsReversibleContainerWithDivider, withCardStateProvider } from '../../elements';
+import {
+  Card,
+  Header,
+  LoadingCard,
+  SocialButtonsReversibleContainerWithDivider,
+  withCardStateProvider,
+} from '../../elements';
 import { useCardState } from '../../elements/contexts';
 import { useRouter } from '../../router';
 import type { FormControlState } from '../../utils';
@@ -85,6 +91,10 @@ function _SignUpContinue() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (!signUp.id) {
+    return <LoadingCard />;
+  }
 
   const hasEmail = !!formState.emailAddress.value;
   const hasVerifiedExternalAccount = signUp.verifications?.externalAccount?.status == 'verified';

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -1,15 +1,9 @@
 import { useClerk } from '@clerk/shared/react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts';
 import { descriptors, Flex, Flow, localizationKeys } from '../../customizables';
-import {
-  Card,
-  Header,
-  LoadingCard,
-  SocialButtonsReversibleContainerWithDivider,
-  withCardStateProvider,
-} from '../../elements';
+import { Card, Header, SocialButtonsReversibleContainerWithDivider, withCardStateProvider } from '../../elements';
 import { useCardState } from '../../elements/contexts';
 import { useRouter } from '../../router';
 import type { FormControlState } from '../../utils';
@@ -84,11 +78,13 @@ function _SignUpContinue() {
     [signUp.missingFields],
   );
 
-  // Redirect to sign-up if there is no persisted sign-up
-  if (!signUp.id) {
-    void navigate(displayConfig.signUpUrl);
-    return <LoadingCard />;
-  }
+  useEffect(() => {
+    // Redirect to sign-up if there is no persisted sign-up
+    if (!signUp.id) {
+      void navigate(displayConfig.signUpUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const hasEmail = !!formState.emailAddress.value;
   const hasVerifiedExternalAccount = signUp.verifications?.externalAccount?.status == 'verified';

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
@@ -18,6 +18,15 @@ describe('SignUpContinue', () => {
     screen.getByText(/missing/i);
   });
 
+  it('does not render the form if there is not a persisted sign up', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress({ required: true });
+      f.withPassword({ required: true });
+    });
+    render(<SignUpContinue />, { wrapper });
+    expect(screen.queryByText(/missing/i)).toBeNull();
+  });
+
   it('navigates to the sign up page if there is not a persisted sign up', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true });

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpContinue.test.tsx
@@ -18,15 +18,6 @@ describe('SignUpContinue', () => {
     screen.getByText(/missing/i);
   });
 
-  it('does not render the form if there is not a persisted sign up', async () => {
-    const { wrapper } = await createFixtures(f => {
-      f.withEmailAddress({ required: true });
-      f.withPassword({ required: true });
-    });
-    render(<SignUpContinue />, { wrapper });
-    expect(screen.queryByText(/missing/i)).toBeNull();
-  });
-
   it('navigates to the sign up page if there is not a persisted sign up', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true });


### PR DESCRIPTION
## Description

Fixes an issue during sign-up flow where a user lands on the continue step, and proceeds successfully through the sign-up process and gets redirected to AP sign-up due to `signUp.id` being undefined.

BEFORE:

https://github.com/user-attachments/assets/3e18db33-6c23-41fe-bfbb-d9d05b55272e

AFTER:

https://github.com/user-attachments/assets/a87c5140-d585-4431-9c11-88b18e8d662f

Fixes SDKI-785

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
