### PR TITLE
fix(clerk-js): Do not send stale field value when creating email address and username

### DIFF
--- a/.changeset/lucky-shrimps-switch.md
+++ b/.changeset/lucky-shrimps-switch.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Fixes an issue in `UserProfile` where a new email address could use the last submitted value from the previous form, leading to stale data being saved.
+Fixes an issue in `UserProfile` where email and username forms could retain stale values from the previous render, leading to incorrect data being sent to FAPI

--- a/.changeset/lucky-shrimps-switch.md
+++ b/.changeset/lucky-shrimps-switch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an issue in `UserProfile` where a new email address could use the last submitted value from the previous form, leading to stale data being saved.

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
@@ -22,7 +22,7 @@ export const EmailForm = withCardStateProvider((props: EmailFormProps) => {
   const environment = useEnvironment();
   const preferEmailLinks = emailLinksEnabledForInstance(environment);
 
-  const [createEmailAddress] = useReverification(() => user?.createEmailAddress({ email: emailField.value }));
+  const [createEmailAddress] = useReverification((email: string) => user?.createEmailAddress({ email }));
 
   const emailAddressRef = React.useRef<EmailAddressResource | undefined>(user?.emailAddresses.find(a => a.id === id));
   const wizard = useWizard({
@@ -44,7 +44,7 @@ export const EmailForm = withCardStateProvider((props: EmailFormProps) => {
     if (!user) {
       return;
     }
-    return createEmailAddress()
+    return createEmailAddress(emailField.value)
       .then(res => {
         emailAddressRef.current = res;
         wizard.nextStep();

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
@@ -12,7 +12,7 @@ export const UsernameForm = withCardStateProvider((props: UsernameFormProps) => 
   const { onSuccess, onReset } = props;
   const { user } = useUser();
 
-  const [updateUsername] = useReverification(() => user?.update({ username: usernameField.value }));
+  const [updateUsername] = useReverification((username: string) => user?.update({ username }));
 
   const { userSettings } = useEnvironment();
   const card = useCardState();
@@ -33,7 +33,7 @@ export const UsernameForm = withCardStateProvider((props: UsernameFormProps) => 
 
   const submitUpdate = async () => {
     try {
-      await updateUsername();
+      await updateUsername(usernameField.value);
       onSuccess();
     } catch (e) {
       handleError(e, [usernameField], card.setError);


### PR DESCRIPTION
## Description

Resolves SDK-1999

Stale values were sent to the FAPI methods on `useReverification` callback. This PR fixes the issue by passing form field values as arguments on the form handler, instead of accessing the state reference.

https://github.com/user-attachments/assets/46c1dc90-e0a1-4841-871e-e20b0eadd760

Refer to the following logs (first happens within the component, and second within the FAPI `createEmailAddress` closure)

![image](https://github.com/user-attachments/assets/d905fd98-0a95-4e0c-8ae3-5909e6092a1c)

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
