### PR TITLE
chore(shared,types): Move constants from types to shared

### DIFF
--- a/.changeset/curvy-sloths-dress.md
+++ b/.changeset/curvy-sloths-dress.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/elements': minor
+'@clerk/ui': minor
+---
+
+Replace usage of `OAUTH_PROVIDERS` and `WEB3_PROVIDERS` from `@clerk/types` to `@clerk/shared`.

--- a/.changeset/honest-news-peel.md
+++ b/.changeset/honest-news-peel.md
@@ -1,0 +1,7 @@
+---
+'@clerk/shared': minor
+---
+
+Introduce new submodules:
+- Export `OAUTH_PROVIDERS` from `@clerk/shared/oauth`
+- Export `WEB3_PROVIDERS` from `@clerk/shared/web3`

--- a/.changeset/quiet-timers-mate.md
+++ b/.changeset/quiet-timers-mate.md
@@ -1,0 +1,10 @@
+---
+'@clerk/types': minor
+---
+
+Deprecate the following constants and functions:
+- `OAUTH_PROVIDERS`
+- `getOAuthProviderData()`
+- `sortedOAuthProviders()`
+- `WEB3_PROVIDERS`
+- `getWeb3ProviderData()`

--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -1,4 +1,4 @@
-import type { Attribute, Web3Provider } from '@clerk/types';
+import type { Attribute } from '@clerk/types';
 
 import type { LocalizationKey } from '../localization/localizationKeys';
 import { localizationKeys } from '../localization/localizationKeys';
@@ -77,31 +77,3 @@ export const PREFERRED_SIGN_IN_STRATEGIES = Object.freeze({
   Password: 'password',
   OTP: 'otp',
 });
-
-interface Web3ProviderData {
-  id: string;
-  name: string;
-}
-
-type Web3Providers = {
-  [key in Web3Provider]: Web3ProviderData;
-};
-
-export const WEB3_PROVIDERS: Web3Providers = Object.freeze({
-  metamask: {
-    id: 'metamask',
-    name: 'MetaMask',
-  },
-  coinbase_wallet: {
-    id: 'coinbase_wallet',
-    name: 'Coinbase Wallet',
-  },
-  okx_wallet: {
-    id: 'okx_wallet',
-    name: 'OKX Wallet',
-  },
-});
-
-export function getWeb3ProviderData(name: Web3Provider): Web3ProviderData | undefined | null {
-  return WEB3_PROVIDERS[name];
-}

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -1,7 +1,7 @@
 import { iconImageUrl } from '@clerk/shared/constants';
+import { OAUTH_PROVIDERS } from '@clerk/shared/oauth';
+import { WEB3_PROVIDERS } from '@clerk/shared/web3';
 import type { OAuthProvider, OAuthStrategy, Web3Provider, Web3Strategy } from '@clerk/types';
-// TODO: This import shouldn't be part of @clerk/types
-import { OAUTH_PROVIDERS, WEB3_PROVIDERS } from '@clerk/types';
 
 import { useEnvironment } from '../contexts/EnvironmentContext';
 import { fromEntries } from '../utils';

--- a/packages/elements/src/utils/third-party-strategies.ts
+++ b/packages/elements/src/utils/third-party-strategies.ts
@@ -1,6 +1,8 @@
 // c.f. vendor/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx [Modified]
 
 import { iconImageUrl } from '@clerk/shared/constants';
+import { OAUTH_PROVIDERS } from '@clerk/shared/oauth';
+import { WEB3_PROVIDERS } from '@clerk/shared/web3';
 import type {
   EnvironmentResource,
   OAuthProvider,
@@ -9,7 +11,6 @@ import type {
   Web3Provider,
   Web3Strategy,
 } from '@clerk/types';
-import { OAUTH_PROVIDERS, WEB3_PROVIDERS } from '@clerk/types'; // TODO: This import shouldn't be part of @clerk/types
 
 import { fromEntries } from './clerk-js';
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -112,7 +112,9 @@
     "utils",
     "workerTimers",
     "devBrowser",
-    "object"
+    "object",
+    "oauth",
+    "web3"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/shared/src/oauth.ts
+++ b/packages/shared/src/oauth.ts
@@ -1,79 +1,5 @@
-import type { OAuthStrategy } from './strategies';
+import type { OAuthProvider, OAuthProviderData, OAuthStrategy } from '@clerk/types';
 
-export type OAuthScope = string;
-
-export interface OAuthProviderData {
-  provider: OAuthProvider;
-  strategy: OAuthStrategy;
-  name: string;
-  docsUrl: string;
-}
-
-export type FacebookOauthProvider = 'facebook';
-export type GoogleOauthProvider = 'google';
-export type HubspotOauthProvider = 'hubspot';
-export type GithubOauthProvider = 'github';
-export type TiktokOauthProvider = 'tiktok';
-export type GitlabOauthProvider = 'gitlab';
-export type DiscordOauthProvider = 'discord';
-export type TwitterOauthProvider = 'twitter';
-export type TwitchOauthProvider = 'twitch';
-export type LinkedinOauthProvider = 'linkedin';
-export type LinkedinOIDCOauthProvider = 'linkedin_oidc';
-export type DropboxOauthProvider = 'dropbox';
-export type AtlassianOauthProvider = 'atlassian';
-export type BitbucketOauthProvider = 'bitbucket';
-export type MicrosoftOauthProvider = 'microsoft';
-export type NotionOauthProvider = 'notion';
-export type AppleOauthProvider = 'apple';
-export type LineOauthProvider = 'line';
-export type InstagramOauthProvider = 'instagram';
-export type CoinbaseOauthProvider = 'coinbase';
-export type SpotifyOauthProvider = 'spotify';
-export type XeroOauthProvider = 'xero';
-export type BoxOauthProvider = 'box';
-export type SlackOauthProvider = 'slack';
-export type LinearOauthProvider = 'linear';
-export type XOauthProvider = 'x';
-export type EnstallOauthProvider = 'enstall';
-export type HuggingfaceOAuthProvider = 'huggingface';
-export type CustomOauthProvider = `custom_${string}`;
-
-export type OAuthProvider =
-  | FacebookOauthProvider
-  | GoogleOauthProvider
-  | HubspotOauthProvider
-  | GithubOauthProvider
-  | TiktokOauthProvider
-  | GitlabOauthProvider
-  | DiscordOauthProvider
-  | TwitterOauthProvider
-  | TwitchOauthProvider
-  | LinkedinOauthProvider
-  | LinkedinOIDCOauthProvider
-  | DropboxOauthProvider
-  | AtlassianOauthProvider
-  | BitbucketOauthProvider
-  | MicrosoftOauthProvider
-  | NotionOauthProvider
-  | AppleOauthProvider
-  | LineOauthProvider
-  | InstagramOauthProvider
-  | CoinbaseOauthProvider
-  | SpotifyOauthProvider
-  | XeroOauthProvider
-  | BoxOauthProvider
-  | SlackOauthProvider
-  | LinearOauthProvider
-  | XOauthProvider
-  | EnstallOauthProvider
-  | HuggingfaceOAuthProvider
-  | CustomOauthProvider;
-
-/**
- * @deprecated This utility will be dropped in the next major release.
- * You can import it from `@clerk/shared/oauth`.
- */
 export const OAUTH_PROVIDERS: OAuthProviderData[] = [
   {
     provider: 'google',
@@ -250,9 +176,6 @@ interface getOAuthProviderDataProps {
   strategy?: OAuthStrategy;
 }
 
-/**
- * @deprecated This utility will be dropped in the next major release.
- */
 export function getOAuthProviderData({
   provider,
   strategy,
@@ -262,23 +185,4 @@ export function getOAuthProviderData({
   }
 
   return OAUTH_PROVIDERS.find(oauth_provider => oauth_provider.strategy == strategy);
-}
-
-/**
- * @deprecated This utility will be dropped in the next major release.
- */
-export function sortedOAuthProviders(sortingArray: OAuthStrategy[]) {
-  return OAUTH_PROVIDERS.slice().sort((a, b) => {
-    let aPos = sortingArray.indexOf(a.strategy);
-    if (aPos == -1) {
-      aPos = Number.MAX_SAFE_INTEGER;
-    }
-
-    let bPos = sortingArray.indexOf(b.strategy);
-    if (bPos == -1) {
-      bPos = Number.MAX_SAFE_INTEGER;
-    }
-
-    return aPos - bPos;
-  });
 }

--- a/packages/shared/src/web3.ts
+++ b/packages/shared/src/web3.ts
@@ -1,0 +1,19 @@
+import type { Web3ProviderData } from '@clerk/types';
+
+export const WEB3_PROVIDERS: Web3ProviderData[] = [
+  {
+    provider: 'metamask',
+    strategy: 'web3_metamask_signature',
+    name: 'MetaMask',
+  },
+  {
+    provider: 'coinbase_wallet',
+    strategy: 'web3_coinbase_wallet_signature',
+    name: 'Coinbase Wallet',
+  },
+  {
+    provider: 'okx_wallet',
+    strategy: 'web3_okx_wallet_signature',
+    name: 'OKX Wallet',
+  },
+];

--- a/packages/types/src/web3.ts
+++ b/packages/types/src/web3.ts
@@ -12,6 +12,10 @@ export type OKXWalletWeb3Provider = 'okx_wallet';
 
 export type Web3Provider = MetamaskWeb3Provider | CoinbaseWalletWeb3Provider | OKXWalletWeb3Provider;
 
+/**
+ * @deprecated This constant will be dropped in the next major release.
+ * You can import it from `@clerk/shared/web3`.
+ */
 export const WEB3_PROVIDERS: Web3ProviderData[] = [
   {
     provider: 'metamask',
@@ -35,6 +39,9 @@ interface getWeb3ProviderDataProps {
   strategy?: Web3Strategy;
 }
 
+/**
+ * @deprecated This utility will be dropped in the next major release.
+ */
 export function getWeb3ProviderData({
   provider,
   strategy,

--- a/packages/ui/src/descriptors.ts
+++ b/packages/ui/src/descriptors.ts
@@ -1,4 +1,6 @@
-import { OAUTH_PROVIDERS, type OAuthProvider, WEB3_PROVIDERS, type Web3Provider } from '@clerk/types';
+import { OAUTH_PROVIDERS } from '@clerk/shared/oauth';
+import { WEB3_PROVIDERS } from '@clerk/shared/web3';
+import type { OAuthProvider, Web3Provider } from '@clerk/types';
 
 export const DESCRIPTORS = [
   // Alert


### PR DESCRIPTION
## Description

This PR deprecate the runtime utilities exported from `@clerk/types` and moves only the used ones from `@clerk/shared`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
