### PR TITLE
fix(clerk-js,types): Reuse existing sign-up if available

### DIFF
--- a/.changeset/purple-foxes-develop.md
+++ b/.changeset/purple-foxes-develop.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Introduced an `upsert` method to the `SignUp` resource, which reuses the existing sign-up attempt ID if it exists. This was an obvious oversight in the ticket flow, so `SignUpStart` has been updated to use this instead.

--- a/.changeset/purple-foxes-develop.md
+++ b/.changeset/purple-foxes-develop.md
@@ -3,4 +3,5 @@
 '@clerk/types': minor
 ---
 
-Introduced an `upsert` method to the `SignUp` resource, which reuses the existing sign-up attempt ID if it exists. This was an obvious oversight in the ticket flow, so `SignUpStart` has been updated to use this instead.
+- Introduced an `upsert` method to the `SignUp` resource, which reuses the existing sign-up attempt ID if it exists.
+- Fix a ticket flow issue on `<SignUp />` component, where in some rare cases the initial ticket/context is lost, because of creating a new sign-up attempt ID.

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -367,6 +367,10 @@ export class SignUp extends BaseResource implements SignUpResource {
     });
   };
 
+  upsert = (params: SignUpCreateParams | SignUpUpdateParams): Promise<SignUpResource> => {
+    return this.id ? this.update(params) : this.create(params);
+  };
+
   validatePassword: ReturnType<typeof createValidatePassword> = (password, cb) => {
     if (SignUp.clerk.__unstable__environment?.userSettings.passwordSettings) {
       return createValidatePassword({

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -216,7 +216,14 @@ function _SignUpStart(): JSX.Element {
     if (fields.ticket) {
       const noop = () => {};
       // fieldsToSubmit: Constructing a fake fields object for strategy.
-      fieldsToSubmit.push({ id: 'strategy', value: 'ticket', setValue: noop, onChange: noop, setError: noop } as any);
+      fieldsToSubmit.push({
+        id: 'strategy',
+        value: 'ticket',
+        clearFeedback: noop,
+        setValue: noop,
+        onChange: noop,
+        setError: noop,
+      } as any);
     }
 
     // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
@@ -236,7 +243,7 @@ function _SignUpStart(): JSX.Element {
     const redirectUrlComplete = ctx.afterSignUpUrl || '/';
 
     return signUp
-      .create(buildRequest(fieldsToSubmit))
+      .upsert(buildRequest(fieldsToSubmit))
       .then(res =>
         completeSignUpFlow({
           signUp: res,

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -66,6 +66,8 @@ export interface SignUpResource extends ClerkResource {
 
   update: (params: SignUpUpdateParams) => Promise<SignUpResource>;
 
+  upsert: (params: SignUpCreateParams | SignUpUpdateParams) => Promise<SignUpResource>;
+
   prepareVerification: (params: PrepareVerificationParams) => Promise<SignUpResource>;
 
   attemptVerification: (params: AttemptVerificationParams) => Promise<SignUpResource>;


### PR DESCRIPTION
## Description

Currently, when a user lands on the sign-up component with a ticket, it sends a request to the Clerk API and starts a new sign-up attempt. If the process requires a password, it will start another new sign-up attempt on submit, losing the original context.

The issue occurs mainly when the server responds with a `422` error because of e.g. a pwned password. If the user then switches to an OAuth strategy, the initial sign-up attempt should be reused with the same context instead of starting over and potentially losing data.

This PR fixes the issue by adding an `upsert` method to the `SignUp` resource. This method reuses the existing sign-up attempt ID if one already exists. While this change could have been made directly in place, adding this new method seems to me like a cleaner approach. No strong opinions here though to revert to that.

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
