### PR TITLE
feat(clerk-js,types): Add `socialButtonsRoot` descriptor

### DIFF
--- a/.changeset/tiny-brooms-learn.md
+++ b/.changeset/tiny-brooms-learn.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add `socialButtonsRoot` descriptor.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -3,7 +3,7 @@
     { "path": "./dist/clerk.js", "maxSize": "707kB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "75kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "48kB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "88KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "89KB" },
     { "path": "./dist/vendors*.js", "maxSize": "70KB" },
     { "path": "./dist/coinbase*.js", "maxSize": "58KB" },
     { "path": "./dist/createorganization*.js", "maxSize": "5KB" },

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -47,6 +47,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'backRow',
   'backLink',
 
+  'socialButtonsRoot',
   'socialButtons',
   'socialButtonsIconButton',
   'socialButtonsBlockButton',

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -88,6 +88,7 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
     <Flex
       direction='col'
       gap={2}
+      elementDescriptor={descriptors.socialButtonsRoot}
     >
       {strategyRows.map((row, rowIndex) => (
         <Grid

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -166,6 +166,7 @@ export type ElementsConfig = {
   footerPages: WithOptions;
   footerPagesLink: WithOptions<'help' | 'terms' | 'privacy'>;
 
+  socialButtonsRoot: WithOptions;
   socialButtons: WithOptions;
   socialButtonsIconButton: WithOptions<OAuthProvider | Web3Provider, LoadingState>;
   socialButtonsBlockButton: WithOptions<OAuthProvider | Web3Provider, LoadingState>;


### PR DESCRIPTION
## Description

I noticed in https://github.com/clerk/clerk-docs/pull/1777 that we're documenting hiding the social buttons in certain situations. Currently hiding social buttons results in extra space between rendered in its place since the parent wrapping div is not being hidden as there is not descriptor on the element, which results in the gap showing between the wrapping div and the following elements. This PR introduces a descriptor to hide the social buttons wrapping div.


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
