### PR TITLE
fix(backend): Add missing `reservedForSecondFactor` property to `PhoneNumberAPI` types

### DIFF
--- a/.changeset/red-rice-attend.md
+++ b/.changeset/red-rice-attend.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add missing `reservedForSecondFactor` property to `CreatePhoneNumberParams` and `UpdatePhoneNumberParams` types.

--- a/packages/backend/src/api/endpoints/PhoneNumberApi.ts
+++ b/packages/backend/src/api/endpoints/PhoneNumberApi.ts
@@ -14,6 +14,7 @@ type CreatePhoneNumberParams = {
 type UpdatePhoneNumberParams = {
   verified?: boolean;
   primary?: boolean;
+  reserved_for_second_factor?: boolean;
 };
 
 export class PhoneNumberAPI extends AbstractAPI {

--- a/packages/backend/src/api/endpoints/PhoneNumberApi.ts
+++ b/packages/backend/src/api/endpoints/PhoneNumberApi.ts
@@ -9,13 +9,13 @@ type CreatePhoneNumberParams = {
   phoneNumber: string;
   verified?: boolean;
   primary?: boolean;
-  reserved_for_second_factor?: boolean;
+  reservedForSecondFactor?: boolean;
 };
 
 type UpdatePhoneNumberParams = {
   verified?: boolean;
   primary?: boolean;
-  reserved_for_second_factor?: boolean;
+  reservedForSecondFactor?: boolean;
 };
 
 export class PhoneNumberAPI extends AbstractAPI {

--- a/packages/backend/src/api/endpoints/PhoneNumberApi.ts
+++ b/packages/backend/src/api/endpoints/PhoneNumberApi.ts
@@ -9,6 +9,7 @@ type CreatePhoneNumberParams = {
   phoneNumber: string;
   verified?: boolean;
   primary?: boolean;
+  reserved_for_second_factor?: boolean;
 };
 
 type UpdatePhoneNumberParams = {


### PR DESCRIPTION
## Description

The `reserved_for_second_factor` property is currently missing in `CreatePhoneNumberParams` and in `UpdatePhoneNumberParams`, the Typescript types for the `POST /phone_numbers` and `PATCH /phone_numbers/{id}` backend API bodies.


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
