### PR TITLE
fix(clerk-js): Always invoke an injected Web3 Wallet provider

### DIFF
--- a/.changeset/nine-penguins-grab.md
+++ b/.changeset/nine-penguins-grab.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Always invoke an injected Web3 Wallet provider, if any, to allow the user to continue the flow rather than be a no-op

--- a/packages/clerk-js/src/utils/injectedWeb3Providers.ts
+++ b/packages/clerk-js/src/utils/injectedWeb3Providers.ts
@@ -53,13 +53,15 @@ class InjectedWeb3Providers {
   }
 
   get = (provider: InjectedWeb3Provider) => {
-    // In case there is a single injected provider, use that directly.
-    // This is needed in order to support other compatible Web3 Wallets (e.g. Rabby Wallet)
-    // and maintain the previous behavior
-    if (this.#providers.length === 1) {
-      return this.#providers[0].provider;
+    const ethProvider = this.#providers.find(p => p.info.name === this.#providerIdMap[provider])?.provider;
+    if (ethProvider !== undefined) {
+      return ethProvider;
     }
-    return this.#providers.find(p => p.info.name === this.#providerIdMap[provider])?.provider;
+
+    // In case we weren't able to find the requested provider, fallback to the
+    // global injected provider instead, if any, to allow the user to continue
+    // the flow rather than be a no-op
+    return window.ethereum;
   };
 
   #onAnnouncement = (event: EIP6963AnnounceProviderEvent) => {


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

If we weren't able to find the exact requested Web3 Wallet provider, then we should fallback and use the injected provider in order for the user to be able to continue the flow

### Before

https://github.com/user-attachments/assets/2951731a-867b-47ad-ae3b-3d18a8e5ed3c

### After

https://github.com/user-attachments/assets/02dd7ece-0bcc-44ab-a695-8e2558bf5635

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
