### PR TITLE
chore(nextjs,clerk-js): Detect claimed keys and offer easy way to copy them

### DIFF
--- a/.changeset/wet-items-push.md
+++ b/.changeset/wet-items-push.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Introduce a new option `__internal_keylessCopyToEnvFile` for `Clerk.load()`. It is intended for internal consumption from other clerk SDKs.

--- a/.changeset/witty-moose-taste.md
+++ b/.changeset/witty-moose-taste.md
@@ -1,0 +1,6 @@
+---
+'@clerk/nextjs': patch
+---
+
+Implements a server action for copying the keys generated from the keyless mode, into an `.env.local` file.
+- If a `.env.development.local` file already exists, it will be used instead of `.env.local`.  

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2052,7 +2052,10 @@ export class Clerk implements ClerkInterface {
       void this.#componentControls?.ensureMounted().then(controls => {
         if (this.#options.__internal_claimKeylessApplicationUrl) {
           controls.updateProps({
-            options: { __internal_claimKeylessApplicationUrl: this.#options.__internal_claimKeylessApplicationUrl },
+            options: {
+              __internal_claimKeylessApplicationUrl: this.#options.__internal_claimKeylessApplicationUrl,
+              __internal_keylessCopyToEnvFile: this.#options.__internal_keylessCopyToEnvFile,
+            },
           });
         }
       });

--- a/packages/clerk-js/src/core/resources/AuthConfig.ts
+++ b/packages/clerk-js/src/core/resources/AuthConfig.ts
@@ -1,9 +1,11 @@
 import type { AuthConfigJSON, AuthConfigResource } from '@clerk/types';
 
+import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
 
 export class AuthConfig extends BaseResource implements AuthConfigResource {
   singleSessionMode!: boolean;
+  claimedAt: Date | null = null;
 
   public constructor(data: AuthConfigJSON) {
     super();
@@ -12,6 +14,7 @@ export class AuthConfig extends BaseResource implements AuthConfigResource {
 
   protected fromJSON(data: AuthConfigJSON | null): this {
     this.singleSessionMode = data ? data.single_session_mode : true;
+    this.claimedAt = data?.claimed_at ? unixEpochToDate(data.claimed_at) : null;
     return this;
   }
 }

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -520,7 +520,10 @@ const Components = (props: ComponentsProps) => {
         {__BUILD_FLAG_KEYLESS_UI__
           ? state.options?.__internal_claimKeylessApplicationUrl && (
               <LazyImpersonationFabProvider globalAppearance={state.appearance}>
-                <KeylessPrompt url={state.options.__internal_claimKeylessApplicationUrl} />
+                <KeylessPrompt
+                  url={state.options.__internal_claimKeylessApplicationUrl}
+                  onClaimed={state.options?.__internal_keylessCopyToEnvFile}
+                />
               </LazyImpersonationFabProvider>
             )
           : null}

--- a/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
+++ b/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
@@ -8,11 +8,17 @@ import { InternalThemeProvider, mqu } from '../../styledSystem';
 
 type KeylessPromptProps = {
   url?: string;
+  onClaimed?: () => Promise<void>;
 };
 
-type FabContentProps = { title?: LocalizationKey | string; signOutText: LocalizationKey | string; url: string };
+type FabContentProps = {
+  title?: LocalizationKey | string;
+  signOutText: LocalizationKey | string;
+  url: string;
+  onClaimed: (() => Promise<void>) | undefined;
+};
 
-const FabContent = ({ title, signOutText, url }: FabContentProps) => {
+const FabContent = ({ title, signOutText, url, onClaimed }: FabContentProps) => {
   return (
     <Col
       sx={t => ({
@@ -46,6 +52,27 @@ const FabContent = ({ title, signOutText, url }: FabContentProps) => {
           // handleSignOutSessionClicked(session!)
         }
       />
+      {onClaimed && (
+        <Link
+          variant='buttonLarge'
+          elementDescriptor={descriptors.impersonationFabActionLink}
+          sx={t => ({
+            alignSelf: 'flex-start',
+            color: t.colors.$primary500,
+            ':hover': {
+              cursor: 'pointer',
+            },
+          })}
+          localizationKey={'Copy keys'}
+          onClick={
+            () => {
+              onClaimed().catch();
+            }
+            // clerk-js has been loaded at this point so we can safely access session
+            // handleSignOutSessionClicked(session!)
+          }
+        />
+      )}
     </Col>
   );
 };
@@ -162,6 +189,7 @@ const _KeylessPrompt = (props: KeylessPromptProps) => {
           <FabContent
             url={props.url}
             signOutText={'Claim your keys'}
+            onClaimed={props.onClaimed}
           />
         </Flex>
       </Flex>

--- a/packages/nextjs/src/app-router/client/keyless-creator-reader.tsx
+++ b/packages/nextjs/src/app-router/client/keyless-creator-reader.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import type { NextClerkProviderProps } from '../../types';
-import { createOrReadKeylessAction } from '../keyless-actions';
+import { copyKeysInsideEnvFileAction, createOrReadKeylessAction } from '../keyless-actions';
 
 export const KeylessCreatorOrReader = (props: NextClerkProviderProps) => {
   const { children } = props;
@@ -21,5 +21,6 @@ export const KeylessCreatorOrReader = (props: NextClerkProviderProps) => {
     publishableKey: state?.publishableKey,
     __internal_claimKeylessApplicationUrl: state?.claimUrl,
     __internal_bypassMissingPublishableKey: true,
+    __internal_keylessCopyToEnvFile: copyKeysInsideEnvFileAction,
   } as any);
 };

--- a/packages/nextjs/src/app-router/keyless-actions.ts
+++ b/packages/nextjs/src/app-router/keyless-actions.ts
@@ -42,3 +42,14 @@ export async function createOrReadKeylessAction(): Promise<null | Omit<Accountle
     publishableKey,
   };
 }
+
+export async function copyKeysInsideEnvFileAction(): Promise<void> {
+  if (!canUseKeyless__server) {
+    return;
+  }
+
+  const copyKeysInsideEnvFile = await import('../server/keyless-node.js').then(m => m.copyKeysInsideEnvFile);
+  copyKeysInsideEnvFile();
+
+  void (await cookies()).delete(getKeylessCookieName());
+}

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -66,6 +66,9 @@ export async function ClerkProvider(
 
     if (newOrReadKeys) {
       const KeylessCookieSync = await import('../client/keyless-cookie-sync.js').then(mod => mod.KeylessCookieSync);
+      const copyKeysInsideEnvFileAction = await import('../keyless-actions.js').then(
+        mod => mod.copyKeysInsideEnvFileAction,
+      );
       output = (
         <KeylessCookieSync {...newOrReadKeys}>
           <ClientClerkProvider
@@ -73,6 +76,7 @@ export async function ClerkProvider(
               ...rest,
               publishableKey: newOrReadKeys.publishableKey,
               __internal_claimKeylessApplicationUrl: newOrReadKeys.claimUrl,
+              __internal_keylessCopyToEnvFile: copyKeysInsideEnvFileAction,
             })}
             nonce={await nonce}
             initialState={await statePromise}

--- a/packages/nextjs/src/server/keyless-node.ts
+++ b/packages/nextjs/src/server/keyless-node.ts
@@ -203,8 +203,10 @@ function copyKeysInsideEnvFile() {
   writeFileSync(
     existingEnvFile || nodeRuntime.path.join(process.cwd(), '.env.local'),
     `
+# Your Clerk instance keys:
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${keys.publishableKey}
 CLERK_SECRET_KEY=${keys.secretKey}
+# NOTE: You can safely remove the \`.clerk/\` directory if you like.
 `,
     {
       encoding: 'utf8',

--- a/packages/types/src/authConfig.ts
+++ b/packages/types/src/authConfig.ts
@@ -5,4 +5,9 @@ export interface AuthConfigResource extends ClerkResource {
    * Enabled single session configuration at the instance level.
    */
   singleSessionMode: boolean;
+  /**
+   * Timestamp of when the instance was claimed. This only applies to applications created with the Keyless mode.
+   * Defaults to `null`.
+   */
+  claimedAt: Date | null;
 }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -754,6 +754,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
     >;
 
     __internal_claimKeylessApplicationUrl?: string;
+    __internal_keylessCopyToEnvFile?: () => Promise<void>;
 
     /**
      * [EXPERIMENTAL] Provide the underlying host router, required for the new experimental UI components.

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -288,6 +288,7 @@ export interface SessionWithActivitiesJSON extends Omit<SessionJSON, 'user'> {
 export interface AuthConfigJSON extends ClerkResourceJSON {
   single_session_mode: boolean;
   url_based_session_syncing: boolean;
+  claimed_at: number | null;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {


### PR DESCRIPTION
## Description

Improve the Keyless mode prompt with a button that will move the generated keys from the hidden `.clerk/` directory inside `.env.development.local` or `.env.local`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
