### PR TITLE
fix(astro): Prevent Netlify from doing a handshake redirect loop

### DIFF
--- a/.changeset/hungry-fishes-invent.md
+++ b/.changeset/hungry-fishes-invent.md
@@ -2,4 +2,4 @@
 "@clerk/astro": patch
 ---
 
-Fix handshake redirect loop with Netlify adapter
+Fix handshake redirect loop in Netlify deployments

--- a/.changeset/hungry-fishes-invent.md
+++ b/.changeset/hungry-fishes-invent.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fix handshake redirect loop with Netlify adapter

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -109,17 +109,10 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             'page',
             `
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
-            import { runInjectionScript, swapDocument } from "${buildImportPath}";
+            import { removeNetlifyCacheBustParam, runInjectionScript, swapDocument } from "${buildImportPath}";
 
-            function removeClerkQueryParam(param) {
-              const url = new URL(window.location.href);
-              if (url.searchParams.has(param)) {
-                url.searchParams.delete(param);
-                window.history.replaceState(window.history.state, '', url);
-              }
-            }
-
-            removeClerkQueryParam('__netlify_clerk_cache_bust');
+            // Fix an issue with infinite reload in Netlify and Clerk dev instance
+            removeNetlifyCacheBustParam();
 
             // Taken from https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L39.
             // Importing it directly from astro:transitions/client breaks custom client-side routing

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -111,6 +111,16 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
             import { runInjectionScript, swapDocument } from "${buildImportPath}";
 
+            function removeTemporaryNetlifyClerkQueryParam(param) {
+              const url = new URL(window.location.href);
+              if (url.searchParams.has(param)) {
+                url.searchParams.delete(param);
+                window.history.replaceState(window.history.state, '', url);
+              }
+            }
+
+            removeTemporaryNetlifyClerkQueryParam('__netlify_clerk_cache_bust');
+
             // Taken from https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L39.
             // Importing it directly from astro:transitions/client breaks custom client-side routing
             // even when View Transitions is disabled.

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -111,7 +111,7 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
             import { runInjectionScript, swapDocument } from "${buildImportPath}";
 
-            function removeTemporaryNetlifyClerkQueryParam(param) {
+            function removeClerkQueryParam(param) {
               const url = new URL(window.location.href);
               if (url.searchParams.has(param)) {
                 url.searchParams.delete(param);
@@ -119,7 +119,7 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
               }
             }
 
-            removeTemporaryNetlifyClerkQueryParam('__netlify_clerk_cache_bust');
+            removeClerkQueryParam('__netlify_clerk_cache_bust');
 
             // Taken from https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L39.
             // Importing it directly from astro:transitions/client breaks custom client-side routing

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -111,7 +111,7 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             ${command === 'dev' ? `console.log("${packageName}","Initialize Clerk: page")` : ''}
             import { removeNetlifyCacheBustParam, runInjectionScript, swapDocument } from "${buildImportPath}";
 
-            // Fix an issue with infinite reload in Netlify and Clerk dev instance
+            // Fix an issue with infinite redirect in Netlify and Clerk dev instance
             removeNetlifyCacheBustParam();
 
             // Taken from https://github.com/withastro/astro/blob/e10b03e88c22592fbb42d7245b65c4f486ab736d/packages/astro/src/transitions/router.ts#L39.

--- a/packages/astro/src/internal/index.ts
+++ b/packages/astro/src/internal/index.ts
@@ -14,3 +14,4 @@ export { runInjectionScript };
 
 export { generateSafeId } from './utils/generateSafeId';
 export { swapDocument } from './swap-document';
+export { NETLIFY_CACHE_BUST_PARAM, removeNetlifyCacheBustParam } from './remove-query-param';

--- a/packages/astro/src/internal/remove-query-param.ts
+++ b/packages/astro/src/internal/remove-query-param.ts
@@ -1,0 +1,13 @@
+export const NETLIFY_CACHE_BUST_PARAM = '__netlify_clerk_cache_bust';
+
+/**
+ * Removes the temporary cache bust parameter that prevents infinite redirects
+ * in Netlify and Clerk's dev instance.
+ */
+export function removeNetlifyCacheBustParam() {
+  const url = new URL(window.location.href);
+  if (url.searchParams.has(NETLIFY_CACHE_BUST_PARAM)) {
+    url.searchParams.delete(NETLIFY_CACHE_BUST_PARAM);
+    window.history.replaceState(window.history.state, '', url);
+  }
+}

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -243,9 +243,8 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
  * in Netlify and Clerk's dev instance.
  */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
-  const isHandshakeUrl = locationHeader.includes('/v1/client/handshake');
   const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
-  if (!isHandshakeUrl && !hasHandshakeQueryParam) {
+  if (!hasHandshakeQueryParam) {
     const url = new URL(locationHeader);
     url.searchParams.append(NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
     requestState.headers.set('Location', url.toString());

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -238,8 +238,9 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
    PUBLIC_CLERK_IS_SATELLITE='true'`;
 
 /**
- * Adds a cache bust parameter to non-handshake redirects to prevent infinite redirects
- * in Netlify and Clerk's dev instance.
+ * Prevents infinite redirects in Netlify's functions
+ * by adding a cache bust parameter to the original redirect URL. This ensures Netlify
+ * doesn't serve a cached response during the authentication flow.
  */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
   const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -1,7 +1,7 @@
 import type { AuthObject, ClerkClient } from '@clerk/backend';
 import type { AuthenticateRequestOptions, ClerkRequest, RedirectFun, RequestState } from '@clerk/backend/internal';
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
-import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
+import { isDevelopmentFromPublishableKey, isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
 import { handleValueOrFn } from '@clerk/shared/utils';
@@ -243,9 +243,9 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
  * doesn't serve a cached response during the authentication flow.
  */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
-  // Only run on Netlify environment
+  // Only run on Netlify environment and Clerk development instance
   // eslint-disable-next-line turbo/no-undeclared-env-vars
-  if (!process.env.NETLIFY) {
+  if (!process.env.NETLIFY || !isDevelopmentFromPublishableKey(requestState.publishableKey)) {
     return;
   }
 

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -82,7 +82,6 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
       createAuthenticateRequestOptions(clerkRequest, options, context),
     );
 
-    console.log('requestState', requestState);
     const locationHeader = requestState.headers.get(constants.Headers.Location);
     if (locationHeader) {
       handleNetlifyCacheInDevInstance(locationHeader, requestState);
@@ -244,6 +243,7 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
  */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
   const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
+  // If location header is the original URL before the handshake redirects, add cache bust param
   if (!hasHandshakeQueryParam) {
     const url = new URL(locationHeader);
     url.searchParams.append(NETLIFY_CACHE_BUST_PARAM, Date.now().toString());

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -245,16 +245,14 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
   // Only run on Netlify environment and Clerk development instance
   // eslint-disable-next-line turbo/no-undeclared-env-vars
-  if (!process.env.NETLIFY || !isDevelopmentFromPublishableKey(requestState.publishableKey)) {
-    return;
-  }
-
-  const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
-  // If location header is the original URL before the handshake redirects, add cache bust param
-  if (!hasHandshakeQueryParam) {
-    const url = new URL(locationHeader);
-    url.searchParams.append(NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
-    requestState.headers.set('Location', url.toString());
+  if (import.meta.env.NETLIFY && isDevelopmentFromPublishableKey(requestState.publishableKey)) {
+    const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
+    // If location header is the original URL before the handshake redirects, add cache bust param
+    if (!hasHandshakeQueryParam) {
+      const url = new URL(locationHeader);
+      url.searchParams.append(NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
+      requestState.headers.set('Location', url.toString());
+    }
   }
 }
 

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -83,6 +83,12 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
 
     const locationHeader = requestState.headers.get(constants.Headers.Location);
     if (locationHeader) {
+      if (!locationHeader.includes('client/handshake') && !locationHeader.includes('__clerk_handshake')) {
+        const url = new URL(locationHeader);
+        url.searchParams.append('__netlify_clerk_cache_bust', Date.now().toString());
+        requestState.headers.set('Location', url.toString());
+      }
+
       const res = new Response(null, { status: 307, headers: requestState.headers });
       return decorateResponseWithObservabilityHeaders(res, requestState);
     } else if (requestState.status === AuthStatus.Handshake) {

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -243,6 +243,12 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
  * doesn't serve a cached response during the authentication flow.
  */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
+  // Only run on Netlify environment
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  if (!process.env.NETLIFY) {
+    return;
+  }
+
   const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
   // If location header is the original URL before the handshake redirects, add cache bust param
   if (!hasHandshakeQueryParam) {

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -10,6 +10,7 @@ import type { APIContext } from 'astro';
 // @ts-ignore
 import { authAsyncStorage } from '#async-local-storage';
 
+import { NETLIFY_CACHE_BUST_PARAM } from '../internal';
 import { buildClerkHotloadScript } from './build-clerk-hotload-script';
 import { clerkClient } from './clerk-client';
 import { createCurrentUser } from './current-user';
@@ -237,12 +238,16 @@ Check if signInUrl is missing from your configuration or if it is not an absolut
    PUBLIC_CLERK_SIGN_IN_URL='SOME_URL'
    PUBLIC_CLERK_IS_SATELLITE='true'`;
 
+/**
+ * Adds a cache bust parameter to non-handshake redirects to prevent infinite redirects
+ * in Netlify and Clerk's dev instance.
+ */
 function handleNetlifyCacheInDevInstance(locationHeader: string, requestState: RequestState) {
   const isHandshakeUrl = locationHeader.includes('/v1/client/handshake');
   const hasHandshakeQueryParam = locationHeader.includes('__clerk_handshake');
   if (!isHandshakeUrl && !hasHandshakeQueryParam) {
     const url = new URL(locationHeader);
-    url.searchParams.append('__netlify_clerk_cache_bust', Date.now().toString());
+    url.searchParams.append(NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
     requestState.headers.set('Location', url.toString());
   }
 }


### PR DESCRIPTION
## Description

Netlify caches the responses from pages. When the middleware initiates a handshake redirect and returns to the original URL, Netlify serves the cached response (along with the cookies), leading to an infinite handshake redirect loop.

I've tried using Netlify's [cache key variations](https://docs.netlify.com/platform/caching/#cache-key-variation) but it doesn't seem to work.

This PR adds a cache bust parameter to the original URL to prevent Netlify from serving the cached response. The parameter is automatically removed from the URL after the page loads.

I don't have e2e tests for it, but you can compare the ff.:

1. https://astro-clerk-template.netlify.app - one without fix, notice the redirect loop after signing in
2. https://deploy-preview-2--astro-clerk-template.netlify.app - the one with fix, should work as expected after signing in and handshake flow

Resolves ECO-202

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
