### PR TITLE
feat(clerk-js): Include a `claimed_at` property inside AuthConfig

### DIFF
--- a/.changeset/slow-cars-worry.md
+++ b/.changeset/slow-cars-worry.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add `claimedAt` proprty inside AuthConfig for the environment. It describes when a instance that was created from the Keyless mode was finally claimed.

--- a/packages/clerk-js/src/core/resources/AuthConfig.ts
+++ b/packages/clerk-js/src/core/resources/AuthConfig.ts
@@ -1,9 +1,11 @@
 import type { AuthConfigJSON, AuthConfigResource } from '@clerk/types';
 
+import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
 
 export class AuthConfig extends BaseResource implements AuthConfigResource {
   singleSessionMode!: boolean;
+  claimedAt: Date | null = null;
 
   public constructor(data: AuthConfigJSON) {
     super();
@@ -12,6 +14,7 @@ export class AuthConfig extends BaseResource implements AuthConfigResource {
 
   protected fromJSON(data: AuthConfigJSON | null): this {
     this.singleSessionMode = data ? data.single_session_mode : true;
+    this.claimedAt = data?.claimed_at ? unixEpochToDate(data.claimed_at) : null;
     return this;
   }
 }

--- a/packages/types/src/authConfig.ts
+++ b/packages/types/src/authConfig.ts
@@ -5,4 +5,9 @@ export interface AuthConfigResource extends ClerkResource {
    * Enabled single session configuration at the instance level.
    */
   singleSessionMode: boolean;
+  /**
+   * Timestamp of when the instance was claimed. This only applies to applications created with the Keyless mode.
+   * Defaults to `null`.
+   */
+  claimedAt: Date | null;
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -288,6 +288,7 @@ export interface SessionWithActivitiesJSON extends Omit<SessionJSON, 'user'> {
 export interface AuthConfigJSON extends ClerkResourceJSON {
   single_session_mode: boolean;
   url_based_session_syncing: boolean;
+  claimed_at: number | null;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {


### PR DESCRIPTION
## Description

`claimed_at` is a timestamp of when the instance was claimed. This only applies to applications created with the Keyless mode.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
