### PR TITLE
fix(repo): Use same react, react-dom peer semver

### DIFF
--- a/.changeset/chatty-walls-search.md
+++ b/.changeset/chatty-walls-search.md
@@ -1,0 +1,13 @@
+---
+'@clerk/chrome-extension': patch
+'@clerk/tanstack-start': patch
+'@clerk/react-router': patch
+'@clerk/clerk-js': patch
+'@clerk/elements': patch
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/clerk-react': patch
+'@clerk/remix': patch
+---
+
+Using the same peerDependencies semver for react and react-dom

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -64,8 +64,8 @@
     "typescript": "catalog:repo"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -93,8 +93,8 @@
     "webpack-merge": "^5.9.0"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -96,8 +96,8 @@
   },
   "peerDependencies": {
     "next": "^13.5.4 || ^14.0.3 || ^15",
-    "react": "^18.0.0 || ^19.0.0-beta",
-    "react-dom": "^18.0.0 || ^19.0.0-beta"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "peerDependenciesMeta": {
     "next": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -82,8 +82,8 @@
   },
   "peerDependencies": {
     "next": "^13.5.4 || ^14.0.3 || ^15.0.0",
-    "react": "^18 || ^19.0.0-0",
-    "react-dom": "^18 || ^19.0.0-0"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -89,8 +89,8 @@
     "typescript": "catalog:repo"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18",
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react",
     "react-router": "^7.0.2"
   },
   "engines": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,8 +89,8 @@
     "typescript": "catalog:repo"
   },
   "peerDependencies": {
-    "react": "^18 || ^19.0.0-0",
-    "react-dom": "^18 || ^19.0.0-0"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -93,8 +93,8 @@
   "peerDependencies": {
     "@remix-run/react": "^2.0.0",
     "@remix-run/server-runtime": "^2.0.0",
-    "react": ">=18",
-    "react-dom": ">=18",
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react",
     "react-router": "^6.0.0"
   },
   "engines": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -151,8 +151,8 @@
     "typescript": "catalog:repo"
   },
   "peerDependencies": {
-    "react": "^18 || ^19.0.0-0",
-    "react-dom": "^18 || ^19.0.0-0"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -79,8 +79,8 @@
   "peerDependencies": {
     "@tanstack/react-router": ">=1.81.9",
     "@tanstack/start": ">=1.81.9",
-    "react": ">=18 || >=19.0.0-beta",
-    "react-dom": ">=18 || >=19.0.0-beta"
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  peer-react:
+    react:
+      specifier: ^18.0.0 || ^19.0.0
+      version: 18.3.1
+    react-dom:
+      specifier: ^18.0.0 || ^19.0.0
+      version: 18.3.1
   react:
     '@types/react':
       specifier: 18.3.12
@@ -306,10 +313,10 @@ importers:
         specifier: workspace:^
         version: link:../shared
       react:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       webextension-polyfill:
         specifier: ^0.10.0
@@ -400,10 +407,10 @@ importers:
         specifier: 3.1.0
         version: 3.1.0(react@18.3.1)
       react:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       regenerator-runtime:
         specifier: 0.13.11
@@ -516,10 +523,10 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       react:
-        specifier: ^18.0.0 || ^19.0.0-beta
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: ^18.0.0 || ^19.0.0-beta
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       xstate:
         specifier: ^5.15.0
@@ -785,10 +792,10 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       react:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       server-only:
         specifier: 0.0.1
@@ -853,10 +860,10 @@ importers:
         specifier: workspace:^
         version: link:../types
       react:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       tslib:
         specifier: catalog:repo
@@ -899,10 +906,10 @@ importers:
         specifier: 0.7.0
         version: 0.7.0
       react:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       tslib:
         specifier: catalog:repo
@@ -951,10 +958,10 @@ importers:
         specifier: 0.7.0
         version: 0.7.0
       react:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: '>=18'
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       react-router:
         specifier: ^6.0.0
@@ -1040,10 +1047,10 @@ importers:
         specifier: 3.0.5
         version: 3.0.5
       react:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: ^18 || ^19.0.0-0
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       std-env:
         specifier: ^3.7.0
@@ -1116,10 +1123,10 @@ importers:
         specifier: workspace:^
         version: link:../types
       react:
-        specifier: '>=18 || >=19.0.0-beta'
+        specifier: catalog:peer-react
         version: 18.3.1
       react-dom:
-        specifier: '>=18 || >=19.0.0-beta'
+        specifier: catalog:peer-react
         version: 18.3.1(react@18.3.1)
       tslib:
         specifier: catalog:repo
@@ -3028,7 +3035,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.30':
     resolution: {integrity: sha512-V90TUJh9Ly8stYo8nwqIqNWCsYjE28GlVFWEhAFCUOp99foiQr8HSTpiiX5GIrprcPoWmlGoY+J5fQA29R4lFg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ catalogs:
     '@types/react': 18.3.12
     '@types/react-dom': 18.3.1
 
+  # Can be referenced through "catalog:peer-react"
+  peer-react:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+
   # Can be referenced through "catalog:repo"
   repo:
     tslib: 2.4.1


### PR DESCRIPTION
## Description

Using the same semver for both `react` and `react-dom` in peerDependencies specifiers

Related: https://github.com/clerk/javascript/pull/4753

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
