### PR TITLE
fix(react-router): Use useLoaderData hook

### DIFF
--- a/.changeset/flat-ants-lick.md
+++ b/.changeset/flat-ants-lick.md
@@ -2,7 +2,7 @@
 '@clerk/react-router': minor
 ---
 
-Remove need to pass `loaderData` to `<ClerkProvider>`.
+Remove the need to pass `loaderData` to `<ClerkProvider>`.
 
 Before:
 

--- a/.changeset/flat-ants-lick.md
+++ b/.changeset/flat-ants-lick.md
@@ -1,0 +1,19 @@
+---
+'@clerk/react-router': minor
+---
+
+Remove need to pass `loaderData` to `<ClerkProvider>`.
+
+Before:
+
+```tsx
+<ClerkProvider loaderData={loaderData}>
+```
+
+After:
+
+```tsx
+<ClerkProvider>
+```
+
+The data is now received internally through a `useLoaderData()` hook.

--- a/integration/templates/react-router-node/app/root.tsx
+++ b/integration/templates/react-router-node/app/root.tsx
@@ -29,9 +29,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function App({ loaderData }: Route.ComponentProps) {
+export default function App() {
   return (
-    <ClerkProvider loaderData={loaderData}>
+    <ClerkProvider>
       <main>
         <Outlet />
       </main>

--- a/packages/react-router/src/client/ReactRouterClerkProvider.tsx
+++ b/packages/react-router/src/client/ReactRouterClerkProvider.tsx
@@ -1,5 +1,6 @@
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import React from 'react';
+import { useLoaderData } from 'react-router';
 
 import {
   assertPublishableKeyInSpaMode,
@@ -8,7 +9,7 @@ import {
   warnForSsr,
 } from '../utils/assert';
 import { ClerkReactRouterOptionsProvider } from './ReactRouterOptionsContext';
-import type { ClerkState, ReactRouterClerkProviderProps, ReactRouterComponentProps } from './types';
+import type { ClerkState, ReactRouterClerkProviderProps } from './types';
 import { useAwaitableNavigate } from './useAwaitableNavigate';
 
 export * from '@clerk/clerk-react';
@@ -115,18 +116,12 @@ function ClerkProviderBase({ children, ...rest }: ClerkProviderPropsWithState) {
   );
 }
 
-type ClerkReactRouterOptions = Partial<
-  Omit<ReactRouterClerkProviderProps, 'routerPush' | 'routerReplace' | 'clerkState'>
->;
+type ClerkProviderProps = Partial<Omit<ReactRouterClerkProviderProps, 'routerPush' | 'routerReplace' | 'clerkState'>>;
 
-// TODO: Remove "any" on loaderData type
-type ClerkProviderProps = ClerkReactRouterOptions & {
-  loaderData?: ReactRouterComponentProps['loaderData'];
-};
-
-export const ClerkProvider = ({ children, loaderData, ...opts }: ClerkProviderProps) => {
+export const ClerkProvider = ({ children, ...opts }: ClerkProviderProps) => {
   let clerkState;
   const isSpaMode = _isSpaMode();
+  const loaderData: { clerkState?: ClerkState } = useLoaderData();
 
   // Don't use `loaderData` to fetch the clerk state if we're in SPA mode or if React Router is used as a library
   if (!isSpaMode && loaderData?.clerkState) {

--- a/packages/react-router/src/utils/errors.ts
+++ b/packages/react-router/src/utils/errors.ts
@@ -16,9 +16,9 @@ export async function loader(args: Route.LoaderArgs) {
   return rootAuthLoader(args)
 }
 
-export default function App({ loaderData }: Route.ComponentProps) {
+export default function App() {
   return (
-    <ClerkProvider loaderData={loaderData}>
+    <ClerkProvider>
       <Outlet />
     </ClerkProvider>
   )

--- a/playground/react-router/app/root.tsx
+++ b/playground/react-router/app/root.tsx
@@ -48,9 +48,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function App({ loaderData }: Route.ComponentProps) {
+export default function App() {
   return (
-    <ClerkProvider loaderData={loaderData}>
+    <ClerkProvider>
       <header className="flex items-center justify-center py-8 px-4">
         <SignedOut>
           <SignInButton />


### PR DESCRIPTION
## Description

Remove the need to pass `loaderData` to `<ClerkProvider>`.

Before:

```tsx
<ClerkProvider loaderData={loaderData}>
```

After:

```tsx
<ClerkProvider>
```

The data is now received internally through a `useLoaderData()` hook.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
