### PR TITLE
feat(clerk-js): Redirect to current page when within modal and no redirect url is provided

### DIFF
--- a/.changeset/mighty-experts-hang.md
+++ b/.changeset/mighty-experts-hang.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Redirect to the current page when within modal mode and no redirect URL is provided.

--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -102,7 +102,7 @@ function mountOpenSignInButton(element: HTMLDivElement, props) {
   const button = document.createElement('button');
   button.textContent = 'Open Sign In';
   button.onclick = () => {
-    Clerk?.openSignUp(props);
+    Clerk?.openSignIn(props);
   };
   element.appendChild(button);
 }

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -176,6 +176,7 @@ export const SignInModal = (props: SignInModalProps): JSX.Element => {
           componentName: 'SignIn',
           ...signInProps,
           routing: 'virtual',
+          mode: 'modal',
         }}
       >
         {/*TODO: Used by InvisibleRootBox, can we simplify? */}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -103,6 +103,7 @@ export const SignUpModal = (props: SignUpModalProps): JSX.Element => {
           componentName: 'SignUp',
           ...signUpProps,
           routing: 'virtual',
+          mode: 'modal',
         }}
       >
         {/*TODO: Used by InvisibleRootBox, can we simplify? */}

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -8,7 +8,7 @@ import { useEnvironment, useOptions } from '../../contexts';
 import type { ParsedQueryString } from '../../router';
 import { useRouter } from '../../router';
 import type { SignInCtx } from '../../types';
-import { getInitialValuesFromQueryParams, getRedirectUrlFromMode } from '../utils';
+import { determineRedirectUrlFromMode, getInitialValuesFromQueryParams } from '../utils';
 
 export type SignInContextType = SignInCtx & {
   navigateAfterSignIn: () => any;
@@ -55,8 +55,8 @@ export const useSignInContext = (): SignInContextType => {
     queryParams,
   );
 
-  const afterSignInUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
-  const afterSignUpUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
+  const afterSignInUrl = determineRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
+  const afterSignUpUrl = determineRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
 
   const navigateAfterSignIn = () => navigate(afterSignInUrl);
 

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -8,7 +8,7 @@ import { useEnvironment, useOptions } from '../../contexts';
 import type { ParsedQueryString } from '../../router';
 import { useRouter } from '../../router';
 import type { SignInCtx } from '../../types';
-import { getInitialValuesFromQueryParams } from '../utils';
+import { getInitialValuesFromQueryParams, getRedirectUrlFromMode } from '../utils';
 
 export type SignInContextType = SignInCtx & {
   navigateAfterSignIn: () => any;
@@ -55,12 +55,8 @@ export const useSignInContext = (): SignInContextType => {
     queryParams,
   );
 
-  const getRedirectUrl = (url: string) => {
-    return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
-  };
-
-  const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());
-  const afterSignUpUrl = getRedirectUrl(redirectUrls.getAfterSignUpUrl());
+  const afterSignInUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
+  const afterSignUpUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
 
   const navigateAfterSignIn = () => navigate(afterSignInUrl);
 

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -55,8 +55,12 @@ export const useSignInContext = (): SignInContextType => {
     queryParams,
   );
 
-  const afterSignInUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignInUrl());
-  const afterSignUpUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignUpUrl());
+  const getRedirectUrl = (url: string) => {
+    return ctx.routing === 'virtual' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
+  };
+
+  const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());
+  const afterSignUpUrl = getRedirectUrl(redirectUrls.getAfterSignUpUrl());
 
   const navigateAfterSignIn = () => navigate(afterSignInUrl);
 

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -37,7 +37,7 @@ export const useSignInContext = (): SignInContextType => {
     throw new Error(`Clerk: useSignInContext called outside of the mounted SignIn component.`);
   }
 
-  const { componentName, ..._ctx } = context;
+  const { componentName, mode, ..._ctx } = context;
   const ctx = _ctx.__experimental?.combinedProps || _ctx;
 
   const initialValuesFromQueryParams = useMemo(
@@ -56,7 +56,7 @@ export const useSignInContext = (): SignInContextType => {
   );
 
   const getRedirectUrl = (url: string) => {
-    return ctx.routing === 'virtual' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
+    return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
   };
 
   const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -41,7 +41,7 @@ export const useSignUpContext = (): SignUpContextType => {
     throw new Error('Clerk: useSignUpContext called outside of the mounted SignUp component.');
   }
 
-  const { componentName, ...ctx } = context;
+  const { componentName, mode, ...ctx } = context;
 
   const redirectUrls = new RedirectUrls(
     options,
@@ -54,7 +54,7 @@ export const useSignUpContext = (): SignUpContextType => {
   );
 
   const getRedirectUrl = (url: string) => {
-    return ctx.routing === 'virtual' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
+    return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
   };
 
   const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -53,8 +53,12 @@ export const useSignUpContext = (): SignUpContextType => {
     queryParams,
   );
 
-  const afterSignUpUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignUpUrl());
-  const afterSignInUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignInUrl());
+  const getRedirectUrl = (url: string) => {
+    return ctx.routing === 'virtual' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
+  };
+
+  const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());
+  const afterSignUpUrl = getRedirectUrl(redirectUrls.getAfterSignUpUrl());
 
   const navigateAfterSignUp = () => navigate(afterSignUpUrl);
 

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -8,7 +8,7 @@ import { useEnvironment, useOptions } from '../../contexts';
 import type { ParsedQueryString } from '../../router';
 import { useRouter } from '../../router';
 import type { SignUpCtx } from '../../types';
-import { getInitialValuesFromQueryParams } from '../utils';
+import { getInitialValuesFromQueryParams, getRedirectUrlFromMode } from '../utils';
 
 export type SignUpContextType = SignUpCtx & {
   navigateAfterSignUp: () => any;
@@ -53,12 +53,8 @@ export const useSignUpContext = (): SignUpContextType => {
     queryParams,
   );
 
-  const getRedirectUrl = (url: string) => {
-    return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
-  };
-
-  const afterSignInUrl = getRedirectUrl(redirectUrls.getAfterSignInUrl());
-  const afterSignUpUrl = getRedirectUrl(redirectUrls.getAfterSignUpUrl());
+  const afterSignInUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
+  const afterSignUpUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
 
   const navigateAfterSignUp = () => navigate(afterSignUpUrl);
 

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -8,7 +8,7 @@ import { useEnvironment, useOptions } from '../../contexts';
 import type { ParsedQueryString } from '../../router';
 import { useRouter } from '../../router';
 import type { SignUpCtx } from '../../types';
-import { getInitialValuesFromQueryParams, getRedirectUrlFromMode } from '../utils';
+import { determineRedirectUrlFromMode, getInitialValuesFromQueryParams } from '../utils';
 
 export type SignUpContextType = SignUpCtx & {
   navigateAfterSignUp: () => any;
@@ -53,8 +53,8 @@ export const useSignUpContext = (): SignUpContextType => {
     queryParams,
   );
 
-  const afterSignInUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
-  const afterSignUpUrl = getRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
+  const afterSignInUrl = determineRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignInUrl(), clerk });
+  const afterSignUpUrl = determineRedirectUrlFromMode({ mode, url: redirectUrls.getAfterSignUpUrl(), clerk });
 
   const navigateAfterSignUp = () => navigate(afterSignUpUrl);
 

--- a/packages/clerk-js/src/ui/contexts/utils.ts
+++ b/packages/clerk-js/src/ui/contexts/utils.ts
@@ -31,6 +31,9 @@ export function getInitialValuesFromQueryParams(queryString: string, params: str
 export const populateParamFromObject = createDynamicParamParser({ regex: /:(\w+)/ });
 
 type Mode = 'modal' | 'mounted' | undefined;
+/**
+ * When we're in modal mode and no redirect_url is provided, we want to redirect to the current page after sign-in or sign-up.
+ */
 export const determineRedirectUrlFromMode = ({ mode, url, clerk }: { mode: Mode; url: string; clerk: Clerk }) => {
   return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
 };

--- a/packages/clerk-js/src/ui/contexts/utils.ts
+++ b/packages/clerk-js/src/ui/contexts/utils.ts
@@ -31,6 +31,6 @@ export function getInitialValuesFromQueryParams(queryString: string, params: str
 export const populateParamFromObject = createDynamicParamParser({ regex: /:(\w+)/ });
 
 type Mode = 'modal' | 'mounted' | undefined;
-export const getRedirectUrlFromMode = ({ mode, url, clerk }: { mode: Mode; url: string; clerk: Clerk }) => {
+export const determineRedirectUrlFromMode = ({ mode, url, clerk }: { mode: Mode; url: string; clerk: Clerk }) => {
   return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
 };

--- a/packages/clerk-js/src/ui/contexts/utils.ts
+++ b/packages/clerk-js/src/ui/contexts/utils.ts
@@ -29,3 +29,8 @@ export function getInitialValuesFromQueryParams(queryString: string, params: str
 }
 
 export const populateParamFromObject = createDynamicParamParser({ regex: /:(\w+)/ });
+
+type Mode = 'modal' | 'mounted' | undefined;
+export const getRedirectUrlFromMode = ({ mode, url, clerk }: { mode: Mode; url: string; clerk: Clerk }) => {
+  return mode === 'modal' && url === '/' ? window.location.href : clerk.buildUrlWithAuth(url);
+};


### PR DESCRIPTION
## Description

For our `<SignInButton />` and `<SignUpButton />` usage when `mode="modal"` and no redirect url is provided, fallback to redirecting to the current page vs being redirected to `/`.

Resolves SDKI-616

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
