### PR TITLE
feat(clerk-js): Add Frontend API URL to allowed redirect origins

### DIFF
--- a/.changeset/silver-dodos-invite.md
+++ b/.changeset/silver-dodos-invite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+`createAllowedRedirectOrigins` now takes the instance type into account to include Frontend API URL for development instances. This is necessary to properly support Clerk as an IdP with OAuth for development instances.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2161,7 +2161,11 @@ export class Clerk implements ClerkInterface {
     return {
       ...defaultOptions,
       ...options,
-      allowedRedirectOrigins: createAllowedRedirectOrigins(options?.allowedRedirectOrigins, this.frontendApi),
+      allowedRedirectOrigins: createAllowedRedirectOrigins(
+        options?.allowedRedirectOrigins,
+        this.frontendApi,
+        this.instanceType,
+      ),
     };
   };
 

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -511,26 +511,39 @@ describe('isAllowedRedirect', () => {
 });
 
 describe('createAllowedRedirectOrigins', () => {
-  it('contains the default allowed origin values if no value is provided', async () => {
-    const frontendApi = 'https://somename.clerk.accounts.dev';
-    const allowedRedirectOriginsValuesUndefined = createAllowedRedirectOrigins(undefined, frontendApi);
-    const allowedRedirectOriginsValuesEmptyArray = createAllowedRedirectOrigins([], frontendApi);
+  it('contains the default allowed origin values if no value is provided when production instance', () => {
+    const frontendApi = 'clerk.example.com';
+    const allowedRedirectOriginsValuesUndefined = createAllowedRedirectOrigins(undefined, frontendApi, 'production');
+    const allowedRedirectOriginsValuesEmptyArray = createAllowedRedirectOrigins([], frontendApi, 'production');
 
-    expect(allowedRedirectOriginsValuesUndefined).toEqual([
-      'http://localhost',
-      `https://${getETLDPlusOneFromFrontendApi(frontendApi)}`,
-      `https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`,
-    ]);
+    const expectedAllowedRedirectOrigins = [
+      'http://localhost', // Current location
+      `https://example.com`, // Primary domain
+      `https://*.example.com`, // Wildcard subdomains
+    ];
 
-    expect(allowedRedirectOriginsValuesEmptyArray).toEqual([
-      'http://localhost',
-      `https://${getETLDPlusOneFromFrontendApi(frontendApi)}`,
-      `https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`,
-    ]);
+    expect(allowedRedirectOriginsValuesUndefined).toEqual(expectedAllowedRedirectOrigins);
+    expect(allowedRedirectOriginsValuesEmptyArray).toEqual(expectedAllowedRedirectOrigins);
+  });
+
+  it('contains the default allowed origin values and FAPI if no value is provided when development instance', () => {
+    const frontendApi = 'foo-bar-42.clerk.accounts.dev';
+    const allowedRedirectOriginsValuesUndefined = createAllowedRedirectOrigins(undefined, frontendApi, 'development');
+    const allowedRedirectOriginsValuesEmptyArray = createAllowedRedirectOrigins([], frontendApi, 'development');
+
+    const expectedAllowedRedirectOrigins = [
+      'http://localhost', // Current location
+      `https://foo-bar-42.accounts.dev`, // Account Portal
+      `https://*.foo-bar-42.accounts.dev`, // Account Portal subdomains
+      `https://foo-bar-42.clerk.accounts.dev`, // Frontend API
+    ];
+
+    expect(allowedRedirectOriginsValuesUndefined).toEqual(expectedAllowedRedirectOrigins);
+    expect(allowedRedirectOriginsValuesEmptyArray).toEqual(expectedAllowedRedirectOrigins);
   });
 
   it('contains only the allowedRedirectOrigins options given', async () => {
-    const frontendApi = 'https://somename.clerk.accounts.dev';
+    const frontendApi = 'somename.clerk.accounts.dev';
     const allowedRedirectOriginsValues = createAllowedRedirectOrigins(
       ['https://test.host', 'https://*.test.host'],
       frontendApi,

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -384,6 +384,7 @@ export const isAllowedRedirect =
 export function createAllowedRedirectOrigins(
   allowedRedirectOrigins: Array<string | RegExp> | undefined,
   frontendApi: string,
+  instanceType?: string,
 ): (string | RegExp)[] | undefined {
   if (Array.isArray(allowedRedirectOrigins) && !!allowedRedirectOrigins.length) {
     return allowedRedirectOrigins;
@@ -396,6 +397,10 @@ export function createAllowedRedirectOrigins(
 
   origins.push(`https://${getETLDPlusOneFromFrontendApi(frontendApi)}`);
   origins.push(`https://*.${getETLDPlusOneFromFrontendApi(frontendApi)}`);
+
+  if (instanceType === 'development') {
+    origins.push(`https://${frontendApi}`);
+  }
 
   return origins;
 }


### PR DESCRIPTION
## Description

`createAllowedRedirectOrigins` now takes the instance type into account to include the Frontend API URL for development instances.

This came up while releasing the new version of Clerk as an IdP, which requires a redirect to `{frontendApi}/oauth/authorize`. For local development, this previously had to be manually added to the allowed origins. Since it's a safe URL to include by default, it makes sense to add it everytime for development instances.

Fixes: SDK-2033

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
