### PR TITLE
fix(clerk-js): Redirect to current page within modal with no redirect url

### DIFF
--- a/.changeset/young-swans-sin.md
+++ b/.changeset/young-swans-sin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Redirect to the current page when within modal mode and no redirect URL is provided.

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -176,6 +176,7 @@ export const SignInModal = (props: SignInModalProps): JSX.Element => {
           componentName: 'SignIn',
           ...signInProps,
           routing: 'virtual',
+          mode: 'modal',
         }}
       >
         {/*TODO: Used by InvisibleRootBox, can we simplify? */}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -103,6 +103,7 @@ export const SignUpModal = (props: SignUpModalProps): JSX.Element => {
           componentName: 'SignUp',
           ...signUpProps,
           routing: 'virtual',
+          mode: 'modal',
         }}
       >
         {/*TODO: Used by InvisibleRootBox, can we simplify? */}

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -37,7 +37,7 @@ export const useSignInContext = (): SignInContextType => {
     throw new Error(`Clerk: useSignInContext called outside of the mounted SignIn component.`);
   }
 
-  const { componentName, ..._ctx } = context;
+  const { componentName, mode, ..._ctx } = context;
   const ctx = _ctx.__experimental?.combinedProps || _ctx;
 
   const initialValuesFromQueryParams = useMemo(
@@ -53,6 +53,7 @@ export const useSignInContext = (): SignInContextType => {
       signInForceRedirectUrl: ctx.forceRedirectUrl,
     },
     queryParams,
+    mode,
   );
 
   const afterSignInUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignInUrl());

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -41,7 +41,7 @@ export const useSignUpContext = (): SignUpContextType => {
     throw new Error('Clerk: useSignUpContext called outside of the mounted SignUp component.');
   }
 
-  const { componentName, ...ctx } = context;
+  const { componentName, mode, ...ctx } = context;
 
   const redirectUrls = new RedirectUrls(
     options,
@@ -51,6 +51,7 @@ export const useSignUpContext = (): SignUpContextType => {
       signUpForceRedirectUrl: ctx.forceRedirectUrl,
     },
     queryParams,
+    mode,
   );
 
   const afterSignUpUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignUpUrl());

--- a/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
@@ -245,14 +245,16 @@ describe('redirectUrls', () => {
       expect(redirectUrls.getAfterSignUpUrl()).toBe(`${mockWindowLocation.href}search-param-redirect-url`);
     });
 
-    it('returns current window location when in modal mode and no redirect URL is found', () => {
-      Object.defineProperty(global.window, 'location', { value: new URL('https://www.clerk.com/test') });
+    it('returns to `/` when no redirect_url is found', () => {
+      const redirectUrls = new RedirectUrls({}, {}, {});
+      expect(redirectUrls.getAfterSignInUrl()).toBe('/');
+      expect(redirectUrls.getAfterSignUpUrl()).toBe('/');
+    });
 
+    it('returns current window location when in modal mode and no redirect_url is found', () => {
       const redirectUrls = new RedirectUrls({}, {}, {}, 'modal');
-      const currentLocation = window.location.href;
-
-      expect(redirectUrls.getAfterSignInUrl()).toBe(currentLocation);
-      expect(redirectUrls.getAfterSignUpUrl()).toBe(currentLocation);
+      expect(redirectUrls.getAfterSignInUrl()).toBe(mockWindowLocation.href);
+      expect(redirectUrls.getAfterSignUpUrl()).toBe(mockWindowLocation.href);
     });
   });
 

--- a/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
@@ -252,9 +252,12 @@ describe('redirectUrls', () => {
     });
 
     it('returns current window location when in modal mode and no redirect_url is found', () => {
+      const aboutPageUrl = 'https://www.clerk.com/about';
+      mockWindowLocation = new URL(aboutPageUrl) as any as Window['location'];
+      Object.defineProperty(global.window, 'location', { value: mockWindowLocation });
       const redirectUrls = new RedirectUrls({}, {}, {}, 'modal');
-      expect(redirectUrls.getAfterSignInUrl()).toBe(mockWindowLocation.href);
-      expect(redirectUrls.getAfterSignUpUrl()).toBe(mockWindowLocation.href);
+      expect(redirectUrls.getAfterSignInUrl()).toBe(aboutPageUrl);
+      expect(redirectUrls.getAfterSignUpUrl()).toBe(aboutPageUrl);
     });
   });
 

--- a/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/redirectUrls.test.ts
@@ -244,6 +244,16 @@ describe('redirectUrls', () => {
       expect(redirectUrls.getAfterSignInUrl()).toBe(`${mockWindowLocation.href}search-param-redirect-url`);
       expect(redirectUrls.getAfterSignUpUrl()).toBe(`${mockWindowLocation.href}search-param-redirect-url`);
     });
+
+    it('returns current window location when in modal mode and no redirect URL is found', () => {
+      Object.defineProperty(global.window, 'location', { value: new URL('https://www.clerk.com/test') });
+
+      const redirectUrls = new RedirectUrls({}, {}, {}, 'modal');
+      const currentLocation = window.location.href;
+
+      expect(redirectUrls.getAfterSignInUrl()).toBe(currentLocation);
+      expect(redirectUrls.getAfterSignUpUrl()).toBe(currentLocation);
+    });
   });
 
   describe('search params', () => {

--- a/packages/clerk-js/src/utils/redirectUrls.ts
+++ b/packages/clerk-js/src/utils/redirectUrls.ts
@@ -5,6 +5,8 @@ import type { ClerkOptions, RedirectOptions } from '@clerk/types';
 import { assertNoLegacyProp, warnForNewPropShadowingLegacyProp } from './assertNoLegacyProp';
 import { isAllowedRedirect, relativeToAbsoluteUrl } from './url';
 
+type ComponentMode = 'modal' | 'mounted';
+
 export class RedirectUrls {
   private static keys: (keyof RedirectOptions)[] = [
     'signInForceRedirectUrl',
@@ -22,9 +24,9 @@ export class RedirectUrls {
   private readonly fromOptions: RedirectOptions;
   private readonly fromProps: RedirectOptions;
   private readonly fromSearchParams: RedirectOptions & { redirectUrl?: string | null };
-  private readonly mode?: 'modal' | 'mounted' | undefined;
+  private readonly mode?: ComponentMode;
 
-  constructor(options: ClerkOptions, props: RedirectOptions = {}, searchParams: any = {}, mode?: undefined) {
+  constructor(options: ClerkOptions, props: RedirectOptions = {}, searchParams: any = {}, mode?: ComponentMode) {
     this.options = options;
     this.fromOptions = this.#parse(options || {});
     this.fromProps = this.#parse(props || {});

--- a/packages/clerk-js/src/utils/redirectUrls.ts
+++ b/packages/clerk-js/src/utils/redirectUrls.ts
@@ -22,12 +22,14 @@ export class RedirectUrls {
   private readonly fromOptions: RedirectOptions;
   private readonly fromProps: RedirectOptions;
   private readonly fromSearchParams: RedirectOptions & { redirectUrl?: string | null };
+  private readonly mode?: 'modal' | 'mounted' | undefined;
 
-  constructor(options: ClerkOptions, props: RedirectOptions = {}, searchParams: any = {}) {
+  constructor(options: ClerkOptions, props: RedirectOptions = {}, searchParams: any = {}, mode?: undefined) {
     this.options = options;
     this.fromOptions = this.#parse(options || {});
     this.fromProps = this.#parse(props || {});
     this.fromSearchParams = this.#parseSearchParams(searchParams || {});
+    this.mode = mode;
   }
 
   getAfterSignInUrl() {
@@ -135,6 +137,10 @@ export class RedirectUrls {
 
     warnForNewPropShadowingLegacyProp(newKeyInUse, result, legacyPropKey, legacyValue);
     result ||= legacyValue;
+
+    if (!result && this.mode === 'modal') {
+      return window.location.href;
+    }
 
     return result || '/';
   }


### PR DESCRIPTION
## Description

When using the `<SignInButton />` or `<SignUpButton />` within modal mode and no redirect_url is provided, redirect to the current page vs `/`.

Resolves SDKI-616

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
