### PR TITLE
chore(repo): add explicit typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:integration:tanstack-start": "E2E_APP_ID=tanstack.start pnpm test:integration:base --grep @tanstack-start",
     "test:integration:vue": "E2E_APP_ID=vue.vite pnpm test:integration:base --grep @vue",
     "turbo:clean": "turbo daemon clean",
+    "typecheck": "FORCE_COLOR=1 turbo typecheck",
     "version-packages": "changeset version && pnpm install --lockfile-only --engine-strict=false",
     "version-packages:canary": "./scripts/canary.mjs",
     "version-packages:snapshot": "./scripts/snapshot.mjs",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -78,7 +78,8 @@
     "lint": "eslint src/",
     "lint:attw": "attw --pack . --ignore-rules no-resolution cjs-resolves-to-esm internal-resolution-error",
     "lint:publint": "pnpm copy:components && publint",
-    "publish:local": "pnpm yalc push --replace --sig"
+    "publish:local": "pnpm yalc push --replace --sig",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -89,7 +89,8 @@
     "test": "run-s test:node test:edge-runtime test:cloudflare-miniflare",
     "test:node": "vitest --environment node",
     "test:edge-runtime": "vitest --environment edge-runtime",
-    "test:cloudflare-miniflare": "vitest --environment miniflare"
+    "test:cloudflare-miniflare": "vitest --environment miniflare",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/shared": "workspace:^",

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -44,7 +44,8 @@
     "test": "jest",
     "test:cache:clear": "jest --clearCache --useStderr",
     "test:ci": "jest --maxWorkers=70%",
-    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html"
+    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/clerk-js": "workspace:^",

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -49,6 +49,7 @@
     "test:cache:clear": "jest --clearCache --useStderr",
     "test:ci": "jest --maxWorkers=70%",
     "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html",
+    "typecheck": "tsc --noEmit",
     "watch": "rspack build --config rspack.config.js --env production --watch"
   },
   "browserslist": "last 2 years, Safari > 12, iOS > 12",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -68,7 +68,8 @@
     "lint:attw": "attw --pack . --ignore-rules no-resolution",
     "lint:publint": "publint",
     "test": "jest",
-    "test:cache:clear": "jest --clearCache --useStderr"
+    "test:cache:clear": "jest --clearCache --useStderr",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/clerk-react": "workspace:^",

--- a/packages/expo-passkeys/package.json
+++ b/packages/expo-passkeys/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint src/",
     "open:android": "open -a \"Android Studio\" example/android",
     "open:ios": "xed example/ios",
-    "publish:local": "pnpm yalc push --replace  --sig"
+    "publish:local": "pnpm yalc push --replace  --sig",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/shared": "workspace:^",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -63,7 +63,8 @@
     "dev:publish": "pnpm dev -- --env.publish",
     "lint": "eslint src/",
     "publish:local": "pnpm yalc push --replace  --sig",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/clerk-js": "workspace:^",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -52,7 +52,8 @@
     "publish:local": "pnpm yalc push --replace  --sig",
     "test": "jest",
     "test:cache:clear": "jest --clearCache --useStderr",
-    "test:ci": "jest --maxWorkers=70%"
+    "test:ci": "jest --maxWorkers=70%",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -37,7 +37,8 @@
     "lint:publint": "publint",
     "publish:local": "pnpm yalc push --replace  --sig",
     "test": "jest",
-    "test:cache:clear": "jest --clearCache --useStderr"
+    "test:cache:clear": "jest --clearCache --useStderr",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -62,7 +62,8 @@
     "lint:attw": "attw --pack . --ignore-rules no-resolution unexpected-module-syntax",
     "lint:publint": "publint",
     "publish:local": "pnpm yalc push --replace --sig",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -591,7 +591,7 @@ describe('clerkMiddleware(params)', () => {
 
   describe('debug', () => {
     beforeEach(() => {
-      global.console.log.mockClear();
+      vi.mocked(global.console.log).mockClear();
     });
 
     it('outputs debug logs when used with only params', async () => {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -55,7 +55,8 @@
     "lint:attw": "attw --pack . --ignore-rules no-resolution cjs-resolves-to-esm",
     "lint:publint": "publint",
     "publish:local": "pnpm yalc push --replace --sig",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -68,7 +68,8 @@
     "lint": "eslint src/",
     "lint:attw": "attw --pack . --ignore-rules cjs-resolves-to-esm",
     "lint:publint": "publint",
-    "publish:local": "pnpm dlx yalc push --replace --sig"
+    "publish:local": "pnpm dlx yalc push --replace --sig",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,8 @@
     "lint:attw": "attw --pack .",
     "lint:publint": "publint",
     "publish:local": "pnpm yalc push --replace  --sig",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/shared": "workspace:^",

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -1151,6 +1151,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  // @ts-expect-error
   authenticateWithOKXWallet = async (params: AuthenticateWithOKXWalletParams): Promise<void> => {
     const callback = () => this.clerkjs?.authenticateWithOKXWallet(params);
     if (this.clerkjs && this.#loaded) {

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -70,7 +70,8 @@
     "lint": "eslint src/",
     "lint:attw": "attw --pack .",
     "lint:publint": "publint",
-    "publish:local": "pnpm yalc push --replace  --sig"
+    "publish:local": "pnpm yalc push --replace  --sig",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -50,7 +50,8 @@
     "lint:attw": "attw --pack .",
     "test": "jest",
     "test:cache:clear": "jest --clearCache --useStderr",
-    "test:ci": "jest --maxWorkers=70%"
+    "test:ci": "jest --maxWorkers=70%",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -130,7 +130,8 @@
     "test": "jest",
     "test:cache:clear": "jest --clearCache --useStderr",
     "test:ci": "jest --maxWorkers=70%",
-    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html"
+    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/types": "workspace:^",

--- a/packages/tailwindcss-transformer/package.json
+++ b/packages/tailwindcss-transformer/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/parser": "^7.24.5",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -56,7 +56,8 @@
     "lint": "eslint src/",
     "lint:attw": "attw --pack . --ignore-rules cjs-resolves-to-esm",
     "lint:publint": "publint",
-    "publish:local": "pnpm yalc push --replace --sig"
+    "publish:local": "pnpm yalc push --replace --sig",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -59,7 +59,8 @@
     "build": "tsup --env.NODE_ENV production",
     "clean": "rimraf ./dist",
     "dev": "tsup --watch",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/backend": "workspace:^",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -34,7 +34,8 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rimraf ./dist",
     "dev": "tsc -p tsconfig.build.json --watch",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/types": "workspace:^",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -33,7 +33,8 @@
     "build": "tsup --env.NODE_ENV production",
     "clean": "rimraf ./dist",
     "dev": "tsup --watch",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "csstype": "3.1.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,8 @@
     "bundlewatch": "pnpm dlx bundlewatch --config bundlewatch.config.json",
     "dev": "tsup --watch",
     "dev:theme-builder": "concurrently \"pnpm dev\" \"cd theme-builder && pnpm dev\"",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/elements": "workspace:^",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -48,7 +48,8 @@
     "lint:publint": "publint",
     "publish:local": "pnpm yalc push --replace --sig",
     "test": "vitest",
-    "test:ci": "vitest --maxWorkers=70%"
+    "test:ci": "vitest --maxWorkers=70%",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/shared": "workspace:^",

--- a/turbo.json
+++ b/turbo.json
@@ -138,6 +138,10 @@
     "format:check": {
       "outputs": []
     },
+    "typecheck": {
+      "dependsOn": ["build"],
+      "outputs": []
+    },
     "//#test:integration:ap-flows": {
       "dependsOn": ["@clerk/clerk-js#build", "@clerk/backend#build", "@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],


### PR DESCRIPTION
## Description

Looks like some of our packages don't have fully valid types and `tsup` does not catch it. Adding a `typecheck` script to make sure all of our code is valid TS

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
