### PR TITLE
fix(vue): Make sure Clerk object is available before accessing properties

### DIFF
--- a/packages/vue/src/composables/useSignIn.ts
+++ b/packages/vue/src/composables/useSignIn.ts
@@ -41,14 +41,14 @@ export const useSignIn: UseSignIn = () => {
   });
 
   const result = computed<UseSignInReturn>(() => {
-    if (!clientCtx.value) {
+    if (!clerk.value || !clientCtx.value) {
       return { isLoaded: false, signIn: undefined, setActive: undefined };
     }
 
     return {
       isLoaded: true,
       signIn: clientCtx.value.signIn,
-      setActive: clerk.value!.setActive,
+      setActive: clerk.value.setActive,
     };
   });
 

--- a/packages/vue/src/composables/useSignUp.ts
+++ b/packages/vue/src/composables/useSignUp.ts
@@ -41,14 +41,14 @@ export const useSignUp: UseSignUp = () => {
   });
 
   const result = computed<UseSignUpReturn>(() => {
-    if (!clientCtx.value) {
+    if (!clerk.value || !clientCtx.value) {
       return { isLoaded: false, signUp: undefined, setActive: undefined };
     }
 
     return {
       isLoaded: true,
       signUp: clientCtx.value.signUp,
-      setActive: clerk.value!.setActive,
+      setActive: clerk.value.setActive,
     };
   });
 


### PR DESCRIPTION
## Description

This PR makes sure the `Clerk` object is available before accessing any properties inside composables. Right now we're skipping that and causing TypeErrors when trying to access properties like `setActive` before Clerk is available.

Resolves ECO-279

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
