### PR TITLE
chore(nextjs): Improve experience when swapping keys on Keyless mode

### DIFF
--- a/.changeset/young-beans-trade.md
+++ b/.changeset/young-beans-trade.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Improve experience when swapping keys on Keyless mode.

--- a/.changeset/young-beans-trade.md
+++ b/.changeset/young-beans-trade.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Improve experience when swapping keys on Keyless mode.
+Improves the error message when changing keys in development causes a subsequent request to fail.

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -42,4 +42,4 @@ export const authSignatureInvalid = `Clerk: Unable to verify request, this usual
 
 export const encryptionKeyInvalid = `Clerk: Unable to decrypt request data, this usually means the encryption key is invalid. Ensure the encryption key is properly set. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
 
-export const encryptionKeyInvalidDev = `Clerk: Unable to decrypt request data.\n\nRefresh the page if your .env file was just updated. In the issue persists ensure the encryption key is valid and properly set.\n\nFor more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
+export const encryptionKeyInvalidDev = `Clerk: Unable to decrypt request data.\n\nRefresh the page if your .env file was just updated. If the issue persists, ensure the encryption key is valid and properly set.\n\nFor more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -41,3 +41,5 @@ ${verifyMessage}`;
 export const authSignatureInvalid = `Clerk: Unable to verify request, this usually means the Clerk middleware did not run. Ensure Clerk's middleware is properly integrated and matches the current route. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware. (code=auth_signature_invalid)`;
 
 export const encryptionKeyInvalid = `Clerk: Unable to decrypt request data, this usually means the encryption key is invalid. Ensure the encryption key is properly set. For more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
+
+export const encryptionKeyInvalidDev = `Clerk: Unable to decrypt request data.\n\nRefresh the page if your .env file was just updated. In the issue persists ensure the encryption key is valid and properly set.\n\nFor more information, see: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;


### PR DESCRIPTION
## Description

In Keyless mode it is expected that the user will eventually set keys as environment variables. When they do that, the nextjs server will restart, but there seems to be a mismatch because first the rendering lifecycle runs with the new keys and then the keys are updated in the middleware. This causes an error to be thrown to the user which we can actually improve.


**For the happy path**: we avoid displaying that error by retrying to decrypt data with the dummy key.

**For any other case**: when swapping keys or going back to headless you will now see this (see picture). this does not only reply to keyless.

![image](https://github.com/user-attachments/assets/5eb3c7d9-6b49-46af-9ad2-a4ee6173ae96)




<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
