### PR TITLE
chore(vue): Expose `initialValues` prop within `<SignInButton />` and `<SignUpButton />`

### DIFF
--- a/.changeset/shiny-pandas-love.md
+++ b/.changeset/shiny-pandas-love.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Add `initialValues` option to `<SignInButton />` and `<SignUpButton />` components.

--- a/packages/vue/src/components/SignInButton.ts
+++ b/packages/vue/src/components/SignInButton.ts
@@ -6,7 +6,7 @@ import { assertSingleChild, normalizeWithDefaultValue } from '../utils';
 
 type SignInButtonProps = Pick<
   SignInProps,
-  'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signUpForceRedirectUrl' | 'signUpFallbackRedirectUrl'
+  'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signUpForceRedirectUrl' | 'signUpFallbackRedirectUrl' | 'initialValues'
 >;
 
 export const SignInButton = defineComponent(
@@ -42,6 +42,13 @@ export const SignInButton = defineComponent(
     };
   },
   {
-    props: ['signUpForceRedirectUrl', 'signUpFallbackRedirectUrl', 'fallbackRedirectUrl', 'forceRedirectUrl', 'mode'],
+    props: [
+      'signUpForceRedirectUrl',
+      'signUpFallbackRedirectUrl',
+      'fallbackRedirectUrl',
+      'forceRedirectUrl',
+      'mode',
+      'initialValues',
+    ],
   },
 );

--- a/packages/vue/src/components/SignUpButton.ts
+++ b/packages/vue/src/components/SignUpButton.ts
@@ -8,7 +8,7 @@ type SignUpButtonProps = {
   unsafeMetadata?: SignUpUnsafeMetadata;
 } & Pick<
   SignUpProps,
-  'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signInForceRedirectUrl' | 'signInFallbackRedirectUrl'
+  'fallbackRedirectUrl' | 'forceRedirectUrl' | 'signInForceRedirectUrl' | 'signInFallbackRedirectUrl' | 'initialValues'
 >;
 
 export const SignUpButton = defineComponent(
@@ -51,6 +51,7 @@ export const SignUpButton = defineComponent(
       'fallbackRedirectUrl',
       'forceRedirectUrl',
       'mode',
+      'initialValues',
     ],
   },
 );


### PR DESCRIPTION
## Description

We are exposing the `initialValues` prop in the React SDK within unstyled components [here](https://github.com/clerk/javascript/pull/4567). This PR ports that into the Vue SDK.

```vue
<template>
  <SignUpButton
    :initial-values="{ emailAddress: 'example@clerk.dev' }"
  />
</template>
```

No major version yet so just patching this one

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
