### PR TITLE
fix(backend): Add `query` to `GetInvitationListParams`

### DIFF
--- a/.changeset/spotty-berries-bake.md
+++ b/.changeset/spotty-berries-bake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+add `query` to `GetInvitationListParams`

--- a/.changeset/spotty-berries-bake.md
+++ b/.changeset/spotty-berries-bake.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-add `query` to `GetInvitationListParams`
+Add property `query` to `GetInvitationListParams` to allow filtering based on `email_address` or `id`.

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -24,10 +24,21 @@ type GetInvitationListParams = ClerkPaginationRequest<{
    *
    * import { createClerkClient } from '@clerk/backend';
    * const clerkClient = createClerkClient(...)
-   * await clerkClient.invitations.getInvitationList({ status: 'revoked })
+   * await clerkClient.invitations.getInvitationList({ status: 'revoked' })
    *
    */
   status?: 'accepted' | 'pending' | 'revoked';
+  /**
+   * Filters invitations based on `email_address` or `id`.
+   *
+   * @example
+   * get all invitations for a specific email address
+   * import { createClerkClient } from '@clerk/backend';
+   * const clerkClient = createClerkClient(...)
+   * await clerkClient.invitations.getInvitationList({ query: 'user@example.com' })
+   *
+   */
+  query?: string;
 }>;
 
 export class InvitationAPI extends AbstractAPI {


### PR DESCRIPTION
## Description

Added a `query` param for `GetInvitationList` API request params type.
I did this according to https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/ListInvitations
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [x] other: types update
