### PR TITLE
fix(clerk-js): Fix broken enterprise connection icon for custom SAML provider

### DIFF
--- a/.changeset/friendly-trains-love.md
+++ b/.changeset/friendly-trains-love.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix broken enterprise connection icon for custom SAML provider

--- a/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
@@ -1,4 +1,3 @@
-import { iconImageUrl } from '@clerk/shared/constants';
 import { useUser } from '@clerk/shared/react';
 import type { EnterpriseAccountResource, OAuthProvider } from '@clerk/types';
 
@@ -83,7 +82,6 @@ const EnterpriseAccount = ({ account }: { account: EnterpriseAccountResource }) 
 const EnterpriseAccountProviderIcon = ({ account }: { account: EnterpriseAccountResource }) => {
   const { provider, enterpriseConnection } = account;
 
-  const isCustomOAuthProvider = provider.startsWith('oauth_custom_');
   const providerWithoutPrefix = provider.replace(/(oauth_|saml_)/, '').trim() as OAuthProvider;
   const connectionName = enterpriseConnection?.name ?? providerWithoutPrefix;
 
@@ -93,15 +91,6 @@ const EnterpriseAccountProviderIcon = ({ account }: { account: EnterpriseAccount
     sx: (theme: any) => ({ width: theme.sizes.$4 }),
     elementId: descriptors.enterpriseButtonsProviderIcon.setId(account.provider),
   };
-
-  if (!isCustomOAuthProvider) {
-    return (
-      <Image
-        {...commonImageProps}
-        src={iconImageUrl(providerWithoutPrefix)}
-      />
-    );
-  }
 
   return enterpriseConnection?.logoPublicUrl ? (
     <Image


### PR DESCRIPTION
## Description

Resolves ORGS-434


Previously, it was merging the provider key to our CDN URL, therefore SAML custom was resolving to an invalid path/asset:

![image](https://github.com/user-attachments/assets/27e3b5c9-622b-4e80-8584-8ce3568f3861)

FAPI already returns a logo URL which is serialized for each enterprise connection type, and we can always trust that now instead of concatenating manually.

<!-- Fixes #(issue number) -->


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
