### PR TITLE
fix(clerk-js): Rethrow errors if not requires_captcha during init

### DIFF
--- a/.changeset/ten-taxis-decide.md
+++ b/.changeset/ten-taxis-decide.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+fix(clerk-js): Rethrow errors if not requires_captcha during init

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1898,6 +1898,8 @@ export class Clerk implements ClerkInterface {
             await initEnvironmentPromise;
             initComponents();
             await initClient();
+          } else {
+            throw e;
           }
         });
 


### PR DESCRIPTION
## Description

Rethrow unrelated errors during init so they can be caught by the normal retry mechanism that existed before the fraud engine changes

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
