### PR TITLE
fix(clerk-expo): Re-export the `isClerkRuntimeError()` utility

### DIFF
--- a/.changeset/light-impalas-visit.md
+++ b/.changeset/light-impalas-visit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Re-export the `isClerkRuntimeError()` utility function from `@clerk/clerk-react`.

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -1,6 +1,12 @@
 import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';
 
-export { isClerkAPIResponseError, isEmailLinkError, isKnownError, isMetamaskError } from '@clerk/clerk-react/errors';
+export {
+  isClerkAPIResponseError,
+  isEmailLinkError,
+  isKnownError,
+  isMetamaskError,
+  isClerkRuntimeError,
+} from '@clerk/clerk-react/errors';
 
 /**
  * @deprecated Use `getClerkInstance()` instead.


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
