### PR TITLE
chore(backend,nextjs,types): Prevent system permissions usage in server-side

### DIFF
--- a/.changeset/fair-bobcats-pull.md
+++ b/.changeset/fair-bobcats-pull.md
@@ -1,0 +1,8 @@
+---
+'@clerk/backend': patch
+'@clerk/types': patch
+---
+
+Add type-level validation to prevent server-side usage of system permissions
+
+System permissions (e.g., `org:sys_domains:manage`) are intentionally excluded from session claims to maintain reasonable JWT sizes. For more information, refer to our docs: https://clerk.com/docs/organizations/roles-permissions#system-permissions

--- a/.changeset/fair-bobcats-pull.md
+++ b/.changeset/fair-bobcats-pull.md
@@ -1,6 +1,7 @@
 ---
 '@clerk/backend': patch
 '@clerk/types': patch
+'@clerk/nextjs': patch
 ---
 
 Add type-level validation to prevent server-side usage of system permissions

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -1,7 +1,7 @@
 import { createCheckAuthorization } from '@clerk/shared/authorization';
 import type {
   ActClaim,
-  CheckAuthorizationWithCustomPermissions,
+  CheckAuthorizationFromSessionClaims,
   JwtPayload,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
@@ -42,7 +42,7 @@ export type SignedInAuthObject = {
    */
   factorVerificationAge: [number, number] | null;
   getToken: ServerGetToken;
-  has: CheckAuthorizationWithCustomPermissions;
+  has: CheckAuthorizationFromSessionClaims;
   debug: AuthObjectDebug;
 };
 
@@ -65,7 +65,7 @@ export type SignedOutAuthObject = {
    */
   factorVerificationAge: null;
   getToken: ServerGetToken;
-  has: CheckAuthorizationWithCustomPermissions;
+  has: CheckAuthorizationFromSessionClaims;
   debug: AuthObjectDebug;
 };
 

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -52,7 +52,7 @@ export const auth: AuthFn = async () => {
   return Object.assign(authObject, { redirectToSignIn });
 };
 
-auth.protect = async (...args) => {
+auth.protect = async (...args: any[]) => {
   require('server-only');
 
   const request = await buildRequestLike();
@@ -66,6 +66,5 @@ auth.protect = async (...args) => {
     redirect,
   });
 
-  // @ts-expect-error TS flattens all possible combinations of the for AuthProtect signatures in a union.
   return protect(...args);
 };

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -117,6 +117,10 @@ describe('ClerkMiddleware type tests', () => {
     clerkMiddlewareMock(async (auth, _event, _request) => {
       // @ts-expect-error - system permissions are not allowed
       (await auth()).has({ permission: 'org:sys_foo' });
+      // @ts-expect-error - system permissions are not allowed
+      await auth.protect(has => has({ permission: 'org:sys_foo' }));
+      // @ts-expect-error - system permissions are not allowed
+      await auth.protect({ permission: 'org:sys_foo' });
     });
   });
 

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -113,6 +113,13 @@ describe('ClerkMiddleware type tests', () => {
     clerkMiddlewareMock();
   });
 
+  it('prevents usage of system permissions with auth.has()', () => {
+    clerkMiddlewareMock(async (auth, _event, _request) => {
+      // @ts-expect-error - system permissions are not allowed
+      (await auth()).has({ permission: 'org:sys_foo' });
+    });
+  });
+
   describe('Multi domain', () => {
     const defaultProps = { publishableKey: '', secretKey: '' };
 

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -2,8 +2,11 @@ import type { AuthObject } from '@clerk/backend';
 import type { RedirectFun, SignedInAuthObject } from '@clerk/backend/internal';
 import { constants } from '@clerk/backend/internal';
 import type {
+  CheckAuthorizationFromSessionClaims,
+  CheckAuthorizationParamsFromSessionClaims,
   CheckAuthorizationParamsWithCustomPermissions,
   CheckAuthorizationWithCustomPermissions,
+  OrganizationCustomPermissionKey,
 } from '@clerk/types';
 
 import { constants as nextConstants } from '../constants';
@@ -15,10 +18,13 @@ type AuthProtectOptions = { unauthorizedUrl?: string; unauthenticatedUrl?: strin
  * Throws a Nextjs notFound error if user is not authenticated or authorized.
  */
 export interface AuthProtect {
-  (params?: CheckAuthorizationParamsWithCustomPermissions, options?: AuthProtectOptions): Promise<SignedInAuthObject>;
+  <P extends OrganizationCustomPermissionKey>(
+    params?: CheckAuthorizationParamsFromSessionClaims<P>,
+    options?: AuthProtectOptions,
+  ): Promise<SignedInAuthObject>;
 
   (
-    params?: (has: CheckAuthorizationWithCustomPermissions) => boolean,
+    params?: (has: CheckAuthorizationFromSessionClaims) => boolean,
     options?: AuthProtectOptions,
   ): Promise<SignedInAuthObject>;
 

--- a/packages/react/src/hooks/__tests__/useAuth.test.tsx
+++ b/packages/react/src/hooks/__tests__/useAuth.test.tsx
@@ -188,4 +188,12 @@ describe('useDerivedAuth', () => {
     expect(current.has?.({ permission: 'test' })).toBe('mocked-result');
     expect(mockHas).toHaveBeenCalledWith({ permission: 'test' });
   });
+
+  it('allows to pass system permissions', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useDerivedAuth({ sessionId: null, userId: null }));
+
+    current.has?.({ permission: 'org:sys_foo' });
+  });
 });

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -97,7 +97,7 @@ export interface JwtPayload extends CustomJwtSessionClaims {
   org_role?: OrganizationCustomRoleKey;
 
   /**
-   * Active organization role
+   * Active organization permissions
    */
   org_permissions?: OrganizationCustomPermissionKey[];
 

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -69,7 +69,6 @@ export type OrganizationCustomRoleKey = ClerkAuthorization extends Placeholder
   : Base['role'];
 
 export type OrganizationSystemPermissionPrefix = 'org:sys_';
-
 export type OrganizationSystemPermissionKey =
   | `${OrganizationSystemPermissionPrefix}domains:manage`
   | `${OrganizationSystemPermissionPrefix}profile:manage`

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -68,13 +68,15 @@ export type OrganizationCustomRoleKey = ClerkAuthorization extends Placeholder
     : Base['role']
   : Base['role'];
 
+export type OrganizationSystemPermissionPrefix = 'org:sys_';
+
 export type OrganizationSystemPermissionKey =
-  | 'org:sys_domains:manage'
-  | 'org:sys_profile:manage'
-  | 'org:sys_profile:delete'
-  | 'org:sys_memberships:read'
-  | 'org:sys_memberships:manage'
-  | 'org:sys_domains:read';
+  | `${OrganizationSystemPermissionPrefix}domains:manage`
+  | `${OrganizationSystemPermissionPrefix}profile:manage`
+  | `${OrganizationSystemPermissionPrefix}profile:delete`
+  | `${OrganizationSystemPermissionPrefix}memberships:read`
+  | `${OrganizationSystemPermissionPrefix}memberships:manage`
+  | `${OrganizationSystemPermissionPrefix}domains:read`;
 
 /**
  * OrganizationPermissionKey is a combination of system and custom permissions.

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -30,25 +30,6 @@ type DisallowSystemPermissions<P extends string> = P extends `${OrganizationSyst
   ? 'System permissions are not included in session claims and cannot be used on the server-side'
   : P;
 
-/**
- * Type guard for server-side authorization checks using session claims.
- * System permissions are not allowed since they are not included
- * in session claims and cannot be verified on the server side.
- */
-export type CheckAuthorizationFromSessionClaims = <P extends OrganizationCustomPermissionKey>(
-  isAuthorizedParams: WithReverification<
-    | {
-        role: OrganizationCustomRoleKey;
-        permission?: never;
-      }
-    | {
-        role?: never;
-        permission: DisallowSystemPermissions<P>;
-      }
-    | { role?: never; permission?: never }
-  >,
-) => boolean;
-
 export type CheckAuthorizationFn<Params> = (isAuthorizedParams: Params) => boolean;
 
 export type CheckAuthorizationWithCustomPermissions =
@@ -85,6 +66,27 @@ type CheckAuthorizationParams = WithReverification<
       role?: never;
       permission?: never;
     }
+>;
+
+/**
+ * Type guard for server-side authorization checks using session claims.
+ * System permissions are not allowed since they are not included
+ * in session claims and cannot be verified on the server side.
+ */
+export type CheckAuthorizationFromSessionClaims = <P extends OrganizationCustomPermissionKey>(
+  isAuthorizedParams: CheckAuthorizationParamsFromSessionClaims<P>,
+) => boolean;
+
+export type CheckAuthorizationParamsFromSessionClaims<P extends OrganizationCustomPermissionKey> = WithReverification<
+  | {
+      role: OrganizationCustomRoleKey;
+      permission?: never;
+    }
+  | {
+      role?: never;
+      permission: DisallowSystemPermissions<P>;
+    }
+  | { role?: never; permission?: never }
 >;
 
 export interface SessionResource extends ClerkResource {

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -15,6 +15,7 @@ import type {
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
   OrganizationPermissionKey,
+  OrganizationSystemPermissionPrefix,
 } from './organizationMembership';
 import type { ClerkResource } from './resource';
 import type {
@@ -24,6 +25,29 @@ import type {
 } from './sessionVerification';
 import type { TokenResource } from './token';
 import type { UserResource } from './user';
+
+type DisallowSystemPermissions<P extends string> = P extends `${OrganizationSystemPermissionPrefix}${string}`
+  ? 'System permissions are not included in session claims and cannot be used on the server-side'
+  : P;
+
+/**
+ * Type guard for server-side authorization checks using session claims.
+ * System permissions are not allowed since they are not included
+ * in session claims and cannot be verified on the server side.
+ */
+export type CheckAuthorizationFromSessionClaims = <P extends OrganizationCustomPermissionKey>(
+  isAuthorizedParams: WithReverification<
+    | {
+        role: OrganizationCustomRoleKey;
+        permission?: never;
+      }
+    | {
+        role?: never;
+        permission: DisallowSystemPermissions<P>;
+      }
+    | { role?: never; permission?: never }
+  >,
+) => boolean;
 
 export type CheckAuthorizationFn<Params> = (isAuthorizedParams: Params) => boolean;
 


### PR DESCRIPTION
## Description

Resolves ORGS-441

#### Context

System permissions (e.g., `org:sys_domains:manage`) are intentionally excluded from session claims to maintain reasonable JWT sizes. While these permissions work in client-side authorization checks (where they're validated against FAPI organization memberships), they cannot be verified server-side.

#### Problem

Despite documentation updates, developers continue to use server-side authorization checks with system permissions, leading to confusion and support tickets.

#### Solution

Add type-level validation to catch misuse of system permissions during development. I've opted not to introduce a runtime warning since developers might ignore it.

![CleanShot 2024-12-19 at 14 02 48](https://github.com/user-attachments/assets/df24a9fe-f369-4e12-b7bd-8d06407cf54f)

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
