### PR TITLE
fix(nuxt): Optimize `@clerk/vue`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -79,6 +79,11 @@ export default defineNuxtModule<ModuleOptions>({
     // Handle Nuxt-specific imports (e.g #imports)
     nuxt.options.build.transpile.push(resolver.resolve('./runtime'));
 
+    // Optimize @clerk/vue to avoid missing injection Symbol key errors
+    nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps || {};
+    nuxt.options.vite.optimizeDeps.include = nuxt.options.vite.optimizeDeps.include || [];
+    nuxt.options.vite.optimizeDeps.include.push('@clerk/vue');
+
     // Add the `@clerk/vue` plugin
     addPlugin(resolver.resolve('./runtime/plugin'));
 


### PR DESCRIPTION
## Description

This PR optimizes `@clerk/vue` for Vite's dependency optimization to prevent duplicate versions (registered and unregistered) from being created. This addresses an error that occurs when running an app with the `@clerk/nuxt` module installed on first load:

<img width="808" alt="Screenshot 2024-12-19 at 7 18 36 PM" src="https://github.com/user-attachments/assets/2f0ccfc3-c936-4dac-aeef-61c4f7400192" />

To reproduce this error:
1. Clone and run the [quickstart](https://github.com/clerk/clerk-nuxt-quickstart) in dev mode, or
2. In the quickstart project, remove `node_modules/.cache` and run `npm run dev`

A similar fix was implemented [here](https://github.com/bootstrap-vue-next/bootstrap-vue-next/pull/1761).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
