### PR TITLE
Add `sessionClaims` to `useAuth`

### DIFF
--- a/.changeset/honest-oranges-accept.md
+++ b/.changeset/honest-oranges-accept.md
@@ -1,0 +1,8 @@
+---
+'@clerk/astro': patch
+'@clerk/clerk-react': patch
+'@clerk/types': patch
+'@clerk/vue': patch
+---
+
+Expose `sessionClaims` from `useAuth` hooks

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -1,11 +1,4 @@
-import type {
-  ActJWTClaim,
-  CheckAuthorizationWithCustomPermissions,
-  Clerk,
-  GetToken,
-  OrganizationCustomRoleKey,
-  SignOut,
-} from '@clerk/types';
+import type { Clerk, GetToken, SignOut, UseAuthReturn } from '@clerk/types';
 import type { Store, StoreValue } from 'nanostores';
 import { useCallback, useSyncExternalStore } from 'react';
 
@@ -13,9 +6,6 @@ import { authAsyncStorage } from '#async-local-storage';
 
 import { $authStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
-
-type CheckAuthorizationSignedOut = undefined;
-type CheckAuthorizationWithoutOrgOrUser = (params?: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => false;
 
 /**
  * @internal
@@ -53,60 +43,6 @@ const createSignOut = () => {
   };
 };
 
-type UseAuthReturn =
-  | {
-      isLoaded: false;
-      isSignedIn: undefined;
-      userId: undefined;
-      sessionId: undefined;
-      actor: undefined;
-      orgId: undefined;
-      orgRole: undefined;
-      orgSlug: undefined;
-      has: CheckAuthorizationSignedOut;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: false;
-      userId: null;
-      sessionId: null;
-      actor: null;
-      orgId: null;
-      orgRole: null;
-      orgSlug: null;
-      has: CheckAuthorizationWithoutOrgOrUser;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: true;
-      userId: string;
-      sessionId: string;
-      actor: ActJWTClaim | null;
-      orgId: null;
-      orgRole: null;
-      orgSlug: null;
-      has: CheckAuthorizationWithoutOrgOrUser;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: true;
-      userId: string;
-      sessionId: string;
-      actor: ActJWTClaim | null;
-      orgId: string;
-      orgRole: OrganizationCustomRoleKey;
-      orgSlug: string | null;
-      has: CheckAuthorizationWithCustomPermissions;
-      signOut: SignOut;
-      getToken: GetToken;
-    };
-
 type UseAuth = () => UseAuthReturn;
 
 /**
@@ -143,8 +79,8 @@ export const useAuth: UseAuth = () => {
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
 
-  const has = useCallback(
-    (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
+  const has = useCallback<NonNullable<UseAuthReturn['has']>>(
+    params => {
       if (!params?.permission && !params?.role) {
         throw new Error(
           'Missing parameters. `has` from `useAuth` requires a permission or role key to be passed. Example usage: `has({permission: "org:posts:edit"`',

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -74,7 +74,7 @@ type UseAuth = () => UseAuthReturn;
  * }
  */
 export const useAuth: UseAuth = () => {
-  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = useStore($authStore);
+  const { sessionId, sessionClaims, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = useStore($authStore);
 
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
@@ -109,6 +109,7 @@ export const useAuth: UseAuth = () => {
       isLoaded: false,
       isSignedIn: undefined,
       sessionId,
+      sessionClaims: undefined,
       userId,
       actor: undefined,
       orgId: undefined,
@@ -125,6 +126,7 @@ export const useAuth: UseAuth = () => {
       isLoaded: true,
       isSignedIn: false,
       sessionId,
+      sessionClaims: null,
       userId,
       actor: null,
       orgId: null,
@@ -136,11 +138,12 @@ export const useAuth: UseAuth = () => {
     };
   }
 
-  if (!!sessionId && !!userId && !!orgId && !!orgRole) {
+  if (!!sessionId && !!sessionClaims && !!userId && !!orgId && !!orgRole) {
     return {
       isLoaded: true,
       isSignedIn: true,
       sessionId,
+      sessionClaims,
       userId,
       actor: actor || null,
       orgId,
@@ -152,11 +155,12 @@ export const useAuth: UseAuth = () => {
     };
   }
 
-  if (!!sessionId && !!userId && !orgId) {
+  if (!!sessionId && !!sessionClaims && !!userId && !orgId) {
     return {
       isLoaded: true,
       isSignedIn: true,
       sessionId,
+      sessionClaims,
       userId,
       actor: actor || null,
       orgId: null,

--- a/packages/react/src/contexts/AuthContext.ts
+++ b/packages/react/src/contexts/AuthContext.ts
@@ -1,9 +1,10 @@
 import { createContextAndHook } from '@clerk/shared/react';
-import type { ActJWTClaim, OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from '@clerk/types';
+import type { ActJWTClaim, JwtPayload, OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from '@clerk/types';
 
 export type AuthContextValue = {
   userId: string | null | undefined;
   sessionId: string | null | undefined;
+  sessionClaims: JwtPayload | null | undefined;
   actor: ActJWTClaim | null | undefined;
   orgId: string | null | undefined;
   orgRole: OrganizationCustomRoleKey | null | undefined;

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -38,6 +38,7 @@ export function ClerkContextProvider(props: ClerkContextProvider) {
   const {
     sessionId,
     session,
+    sessionClaims,
     userId,
     user,
     orgId,
@@ -59,9 +60,10 @@ export function ClerkContextProvider(props: ClerkContextProvider) {
       orgSlug,
       orgPermissions,
       factorVerificationAge,
+      sessionClaims,
     };
     return { value };
-  }, [sessionId, userId, actor, orgId, orgRole, orgSlug, factorVerificationAge]);
+  }, [sessionId, sessionClaims, userId, actor, orgId, orgRole, orgPermissions, orgSlug, factorVerificationAge]);
   const sessionCtx = React.useMemo(() => ({ value: session }), [sessionId, session]);
   const userCtx = React.useMemo(() => ({ value: user }), [userId, user]);
   const organizationCtx = React.useMemo(() => {

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -64,7 +64,8 @@ export const useAuth = (initialAuthState: any = {}): UseAuthReturn => {
     authContext = initialAuthState != null ? initialAuthState : {};
   }
 
-  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions, factorVerificationAge } = authContext;
+  const { sessionId, sessionClaims, userId, actor, orgId, orgRole, orgSlug, orgPermissions, factorVerificationAge } =
+    authContext;
   const isomorphicClerk = useIsomorphicClerkContext();
 
   const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
@@ -72,6 +73,7 @@ export const useAuth = (initialAuthState: any = {}): UseAuthReturn => {
 
   return useDerivedAuth({
     sessionId,
+    sessionClaims,
     userId,
     actor,
     orgId,
@@ -113,6 +115,7 @@ export const useAuth = (initialAuthState: any = {}): UseAuthReturn => {
 export function useDerivedAuth(authObject: any): UseAuthReturn {
   const {
     sessionId,
+    sessionClaims,
     userId,
     actor,
     orgId,
@@ -146,6 +149,7 @@ export function useDerivedAuth(authObject: any): UseAuthReturn {
       isLoaded: false,
       isSignedIn: undefined,
       sessionId,
+      sessionClaims: undefined,
       userId,
       actor: undefined,
       orgId: undefined,
@@ -162,6 +166,7 @@ export function useDerivedAuth(authObject: any): UseAuthReturn {
       isLoaded: true,
       isSignedIn: false,
       sessionId,
+      sessionClaims: null,
       userId,
       actor: null,
       orgId: null,
@@ -173,11 +178,12 @@ export function useDerivedAuth(authObject: any): UseAuthReturn {
     };
   }
 
-  if (!!sessionId && !!userId && !!orgId && !!orgRole) {
+  if (!!sessionId && !!sessionClaims && !!userId && !!orgId && !!orgRole) {
     return {
       isLoaded: true,
       isSignedIn: true,
       sessionId,
+      sessionClaims,
       userId,
       actor: actor || null,
       orgId,
@@ -189,11 +195,12 @@ export function useDerivedAuth(authObject: any): UseAuthReturn {
     };
   }
 
-  if (!!sessionId && !!userId && !orgId) {
+  if (!!sessionId && !!sessionClaims && !!userId && !orgId) {
     return {
       isLoaded: true,
       isSignedIn: true,
       sessionId,
+      sessionClaims,
       userId,
       actor: actor || null,
       orgId: null,

--- a/packages/shared/src/__tests__/deriveState.test.ts
+++ b/packages/shared/src/__tests__/deriveState.test.ts
@@ -3,17 +3,27 @@ import type { InitialState, Resources } from '@clerk/types';
 import { deriveState } from '../deriveState';
 
 describe('deriveState', () => {
+  const mockSessionClaims = {
+    sid: 'sess_2j1R7g3AUeKMx9M23dBO0XLEQGY',
+    sub: 'user_2U330vGHg3llBga8Oi0fzzeNAaG',
+    org_id: 'org_2U330vGHg3llBga8Oi0fzzeNAaG',
+  } as InitialState['sessionClaims'];
+
   const mockInitialState = {
-    userId: 'user_2U330vGHg3llBga8Oi0fzzeNAaG',
-    sessionId: 'sess_2j1R7g3AUeKMx9M23dBO0XLEQGY',
-    orgId: 'org_2U330vGHg3llBga8Oi0fzzeNAaG',
+    userId: mockSessionClaims.sub,
+    orgId: mockSessionClaims.org_id,
+    sessionId: mockSessionClaims.sid,
+    sessionClaims: mockSessionClaims,
   } as InitialState;
 
   const mockResources = {
     client: {},
     user: { id: mockInitialState.userId },
-    session: { id: mockInitialState.sessionId },
     organization: { id: mockInitialState.orgId },
+    session: {
+      id: mockInitialState.sessionId,
+      lastActiveToken: { jwt: { claims: mockSessionClaims } },
+    },
   } as Resources;
 
   it('uses SSR state when !clerkLoaded and initialState is provided', () => {
@@ -25,6 +35,9 @@ describe('deriveState', () => {
     expect(result.userId).toBe(mockInitialState.userId);
     expect(result.sessionId).toBe(mockInitialState.sessionId);
     expect(result.orgId).toBe(mockInitialState.orgId);
+    expect(result.sessionClaims?.sid).toBe(mockInitialState.sessionId);
+    expect(result.sessionClaims?.sub).toBe(mockInitialState.userId);
+    expect(result.sessionClaims?.org_id).toBe(mockInitialState.orgId);
   });
 
   it('handles !clerkLoaded and undefined initialState', () => {
@@ -32,5 +45,6 @@ describe('deriveState', () => {
     expect(result.userId).toBeUndefined();
     expect(result.sessionId).toBeUndefined();
     expect(result.orgId).toBeUndefined();
+    expect(result.sessionClaims).toBeUndefined();
   });
 });

--- a/packages/shared/src/deriveState.ts
+++ b/packages/shared/src/deriveState.ts
@@ -1,5 +1,6 @@
 import type {
   InitialState,
+  JwtPayload,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
   OrganizationResource,
@@ -23,6 +24,7 @@ const deriveFromSsrInitialState = (initialState: InitialState) => {
   const user = initialState.user as UserResource;
   const sessionId = initialState.sessionId;
   const session = initialState.session as SignedInSessionResource;
+  const sessionClaims = initialState.sessionClaims;
   const organization = initialState.organization as OrganizationResource;
   const orgId = initialState.orgId;
   const orgRole = initialState.orgRole as OrganizationCustomRoleKey;
@@ -36,6 +38,7 @@ const deriveFromSsrInitialState = (initialState: InitialState) => {
     user,
     sessionId,
     session,
+    sessionClaims,
     organization,
     orgId,
     orgRole,
@@ -51,6 +54,9 @@ const deriveFromClientSideState = (state: Resources) => {
   const user = state.user;
   const sessionId: string | null | undefined = state.session ? state.session.id : state.session;
   const session = state.session;
+  const sessionClaims: JwtPayload | null | undefined = state.session
+    ? state.session.lastActiveToken?.jwt?.claims
+    : state.session;
   const factorVerificationAge: [number, number] | null = state.session ? state.session.factorVerificationAge : null;
   const actor = session?.actor;
   const organization = state.organization;
@@ -67,6 +73,7 @@ const deriveFromClientSideState = (state: Resources) => {
     user,
     sessionId,
     session,
+    sessionClaims,
     organization,
     orgId,
     orgRole,

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -1,14 +1,14 @@
-import type { OrganizationCustomRoleKey } from 'organizationMembership';
-import type { SignInResource } from 'signIn';
-
 import type { SetActive, SignOut } from './clerk';
 import type { ActJWTClaim } from './jwt';
+import type { JwtPayload } from './jwtv2';
+import type { OrganizationCustomRoleKey } from './organizationMembership';
 import type {
   CheckAuthorizationWithCustomPermissions,
   GetToken,
   SessionResource,
   SignedInSessionResource,
 } from './session';
+import type { SignInResource } from './signIn';
 import type { SignUpResource } from './signUp';
 import type { UserResource } from './user';
 
@@ -37,6 +37,7 @@ export type UseAuthReturn =
        * The ID for the current session.
        */
       sessionId: undefined;
+      sessionClaims: undefined;
       actor: undefined;
       /**
        * The ID of the user's active organization.
@@ -68,6 +69,7 @@ export type UseAuthReturn =
       isSignedIn: false;
       userId: null;
       sessionId: null;
+      sessionClaims: null;
       actor: null;
       orgId: null;
       orgRole: null;
@@ -81,6 +83,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
+      sessionClaims: JwtPayload;
       actor: ActJWTClaim | null;
       orgId: null;
       orgRole: null;
@@ -94,6 +97,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
+      sessionClaims: JwtPayload;
       actor: ActJWTClaim | null;
       orgId: string;
       orgRole: OrganizationCustomRoleKey;

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,4 +1,4 @@
-import type { InstanceType } from 'instance';
+import type { InstanceType } from './instance';
 
 type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
 

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -79,7 +79,7 @@ export const useAuth: UseAuth = () => {
   const signOut: SignOut = createSignOut(clerk);
 
   const result = computed<UseAuthReturn>(() => {
-    const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = authCtx.value;
+    const { sessionId, sessionClaims, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = authCtx.value;
 
     const has = (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
       if (!params?.permission && !params?.role) {
@@ -105,6 +105,7 @@ export const useAuth: UseAuth = () => {
         isLoaded: false,
         isSignedIn: undefined,
         sessionId,
+        sessionClaims: undefined,
         userId,
         actor: undefined,
         orgId: undefined,
@@ -121,6 +122,7 @@ export const useAuth: UseAuth = () => {
         isLoaded: true,
         isSignedIn: false,
         sessionId,
+        sessionClaims: null,
         userId,
         actor: null,
         orgId: null,
@@ -132,11 +134,12 @@ export const useAuth: UseAuth = () => {
       };
     }
 
-    if (!!sessionId && !!userId && !!orgId && !!orgRole) {
+    if (!!sessionId && !!sessionClaims && !!userId && !!orgId && !!orgRole) {
       return {
         isLoaded: true,
         isSignedIn: true,
         sessionId,
+        sessionClaims,
         userId,
         actor: actor || null,
         orgId,
@@ -148,11 +151,12 @@ export const useAuth: UseAuth = () => {
       };
     }
 
-    if (!!sessionId && !!userId && !orgId) {
+    if (!!sessionId && !!sessionClaims && !!userId && !orgId) {
       return {
         isLoaded: true,
         isSignedIn: true,
         sessionId,
+        sessionClaims,
         userId,
         actor: actor || null,
         orgId: null,

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -68,8 +68,8 @@ export const clerkPlugin: Plugin = {
     const derivedState = computed(() => deriveState(loaded.value, resources.value, initialState));
 
     const authCtx = computed(() => {
-      const { sessionId, userId, orgId, actor, orgRole, orgSlug, orgPermissions } = derivedState.value;
-      return { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions };
+      const { sessionId, sessionClaims, userId, orgId, actor, orgRole, orgSlug, orgPermissions } = derivedState.value;
+      return { sessionId, sessionClaims, userId, actor, orgId, orgRole, orgSlug, orgPermissions };
     });
     const clientCtx = computed(() => resources.value.client);
     const userCtx = computed(() => derivedState.value.user);

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ClientResource,
   CustomMenuItem,
   CustomPage,
+  JwtPayload,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
   OrganizationResource,
@@ -19,6 +20,7 @@ export interface VueClerkInjectionKeyType {
   authCtx: ComputedRef<{
     userId: string | null | undefined;
     sessionId: string | null | undefined;
+    sessionClaims: JwtPayload | null | undefined;
     actor: ActJWTClaim | null | undefined;
     orgId: string | null | undefined;
     orgRole: OrganizationCustomRoleKey | null | undefined;


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Fixes #4822 

Adds `sessionClaims` to all implementations of `useAuth` (ie for react, astro and vue), to match the docs regarding custom session claims. https://clerk.com/docs/backend-requests/making/custom-session-token#use-the-custom-claims-in-your-application

Docs PR https://github.com/clerk/clerk-docs/pull/1831

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
