### PR TITLE
fix(vue): Fix `getToken()` hanging when Clerk is already loaded

### DIFF
--- a/.changeset/tame-wolves-sit.md
+++ b/.changeset/tame-wolves-sit.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Fix an issue where `getToken()` from `useAuth()` composable returns an empty value

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -12,12 +12,15 @@ import { useClerkContext } from './useClerkContext';
  */
 function clerkLoaded(clerk: ShallowRef<Clerk | null>) {
   return new Promise<Clerk>(resolve => {
-    const unwatch = watch(clerk, value => {
-      if (value?.loaded) {
-        unwatch();
-        resolve(clerk.value!);
-      }
-    });
+    watch(
+      clerk,
+      value => {
+        if (value?.loaded) {
+          resolve(clerk.value!);
+        }
+      },
+      { immediate: true },
+    );
   });
 }
 
@@ -73,11 +76,11 @@ type UseAuth = () => ToComputedRefs<UseAuthReturn>;
 export const useAuth: UseAuth = () => {
   const { clerk, authCtx } = useClerkContext();
 
+  const getToken: GetToken = createGetToken(clerk);
+  const signOut: SignOut = createSignOut(clerk);
+
   const result = computed<UseAuthReturn>(() => {
     const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = authCtx.value;
-
-    const getToken: GetToken = createGetToken(clerk);
-    const signOut: SignOut = createSignOut(clerk);
 
     const has = (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
       if (!params?.permission && !params?.role) {

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -16,7 +16,7 @@ function clerkLoaded(clerk: ShallowRef<Clerk | null>) {
       clerk,
       value => {
         if (value?.loaded) {
-          resolve(clerk.value!);
+          resolve(value);
         }
       },
       { immediate: true },


### PR DESCRIPTION
## Description

This PR makes sure `getToken` from `useAuth()` composable returns a token by adding `immediate: true` to the watcher. Without this option, the internal `clerkLoaded` promise would never resolve if Clerk was already loaded.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
