### PR TITLE
fix(react-router): Correct types for data() usage in callback

### DIFF
--- a/.changeset/large-phones-peel.md
+++ b/.changeset/large-phones-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/react-router': patch
+---
+
+Previously, when the `data()` utility was used inside the callback of `rootAuthLoader()` type errors were thrown. These issues should be fixed now.

--- a/packages/react-router/src/ssr/types.ts
+++ b/packages/react-router/src/ssr/types.ts
@@ -102,8 +102,8 @@ type RootAuthLoaderCallbackReturn =
   | Response
   | Promise<ObjectLike>
   | ObjectLike
-  | UNSAFE_DataWithResponseInit<Record<string, unknown>>
-  | Promise<UNSAFE_DataWithResponseInit<Record<string, unknown>>>;
+  | UNSAFE_DataWithResponseInit<unknown>
+  | Promise<UNSAFE_DataWithResponseInit<unknown>>;
 
 // TODO: Figure out how to use the Route.LoaderArgs from userland code
 export type LoaderFunctionArgs = CreateServerLoaderArgs<RouteInfo>;

--- a/packages/react-router/src/ssr/types.ts
+++ b/packages/react-router/src/ssr/types.ts
@@ -8,7 +8,7 @@ import type {
   SignUpFallbackRedirectUrl,
   SignUpForceRedirectUrl,
 } from '@clerk/types';
-import type { LoaderFunction } from 'react-router';
+import type { LoaderFunction, UNSAFE_DataWithResponseInit } from 'react-router';
 import type { CreateServerLoaderArgs } from 'react-router/route-module';
 
 type Func = (...args: any[]) => unknown;
@@ -97,7 +97,13 @@ type ObjectLike = Record<string, unknown> | null;
  *
  * In the case of `null`, we will return an object containing only the authentication state.
  */
-export type RootAuthLoaderCallbackReturn = Promise<Response> | Response | Promise<ObjectLike> | ObjectLike;
+type RootAuthLoaderCallbackReturn =
+  | Promise<Response>
+  | Response
+  | Promise<ObjectLike>
+  | ObjectLike
+  | UNSAFE_DataWithResponseInit<Record<string, unknown>>
+  | Promise<UNSAFE_DataWithResponseInit<Record<string, unknown>>>;
 
 // TODO: Figure out how to use the Route.LoaderArgs from userland code
 export type LoaderFunctionArgs = CreateServerLoaderArgs<RouteInfo>;


### PR DESCRIPTION
## Description

Previously such usage would have thrown type errors:

```ts
export async function loader(args: Route.LoaderArgs) {
  return rootAuthLoader(args, async () => {
    return data({ title: "React Router Clerk Starter" }, { headers: {} });
  })
}

export function Layout({ children }: { children: React.ReactNode }) {
  const data = useRouteLoaderData<typeof loader>('root')

  return (
    // TODO
  );
}
```

We didn't account for the return type of the `data()` utility in our types. This should work now 👍 

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
