### PR TITLE
fix(nextjs): Always use nextUrl to build rewritten URLs

### DIFF
--- a/.changeset/brave-steaks-press.md
+++ b/.changeset/brave-steaks-press.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Always use nextUrl to build rewritten URLs

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -171,7 +171,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
         );
         handlerResult = userHandlerResult || handlerResult;
       } catch (e: any) {
-        handlerResult = handleControlFlowErrors(e, clerkRequest, requestState);
+        handlerResult = handleControlFlowErrors(e, clerkRequest, request, requestState);
       }
 
       // TODO @nikos: we need to make this more generic
@@ -314,11 +314,16 @@ const createMiddlewareProtect = (
 // especially when copy-pasting code from one place to another.
 // This function handles the known errors thrown by the APIs described above,
 // and returns the appropriate response.
-const handleControlFlowErrors = (e: any, clerkRequest: ClerkRequest, requestState: RequestState): Response => {
+const handleControlFlowErrors = (
+  e: any,
+  clerkRequest: ClerkRequest,
+  nextRequest: NextRequest,
+  requestState: RequestState,
+): Response => {
   if (isNextjsNotFoundError(e)) {
     // Rewrite to a bogus URL to force not found error
     return setHeader(
-      NextResponse.rewrite(`${clerkRequest.clerkUrl.origin}/clerk_${Date.now()}`),
+      NextResponse.rewrite(new URL(`/clerk_${Date.now()}`, nextRequest.url)),
       constants.Headers.AuthReason,
       'protect-rewrite',
     );

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -323,6 +323,9 @@ const handleControlFlowErrors = (
   if (isNextjsNotFoundError(e)) {
     // Rewrite to a bogus URL to force not found error
     return setHeader(
+      // This is an internal rewrite purely to trigger a not found error. We do not want Next.js to think that the
+      // destination URL is a valid page, so we use `nextRequest.url` as the base for the fake URL, which Next.js
+      // understands is an internal URL and won't run middleware against the request.
       NextResponse.rewrite(new URL(`/clerk_${Date.now()}`, nextRequest.url)),
       constants.Headers.AuthReason,
       'protect-rewrite',


### PR DESCRIPTION
## Description

In our middleware, we rewrite protected pages to a known fake page to trigger a not found error. Previously, we utilized the `Origin` header to determine the base URL to rewrite to, which triggered an actual page request in Next.js 15, resulting in an infinite loop of middleware invocations. This PR adjusts the base origin of the rewrite to use `nextRequest.url`, which Next.js will always understand as an internal page, thus not triggering an additional invocation of middleware.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
