### PR TITLE
fix(clerk-js): Fix custom username field error to allow fallbacks

### DIFF
--- a/.changeset/hip-spiders-punch.md
+++ b/.changeset/hip-spiders-punch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes username form field errors to display messages according to the respective code sent in the error response.

--- a/packages/clerk-js/src/ui/utils/usernameUtils.ts
+++ b/packages/clerk-js/src/ui/utils/usernameUtils.ts
@@ -8,19 +8,28 @@ type LocalizationConfigProps = {
   usernameSettings: Pick<UsernameSettingsData, 'max_length' | 'min_length'>;
 };
 
-export const createUsernameError = (errors: ClerkAPIError[], localizationConfig: LocalizationConfigProps) => {
+const INVALID_LENGTH = 'form_username_invalid_length';
+
+export const createUsernameError = (
+  errors: ClerkAPIError[],
+  localizationConfig: LocalizationConfigProps,
+): ClerkAPIError | string | undefined => {
   const { t, usernameSettings } = localizationConfig;
 
+  const clerkApiError = errors[0] as ClerkAPIError | undefined;
+
   if (!localizationConfig) {
-    return errors[0].longMessage;
+    return clerkApiError;
   }
 
-  const msg = t(
-    localizationKeys('unstable__errors.form_username_invalid_length', {
-      min_length: usernameSettings.min_length,
-      max_length: usernameSettings.max_length,
-    }),
-  );
+  if (clerkApiError?.code === INVALID_LENGTH) {
+    return t(
+      localizationKeys(`unstable__errors.${INVALID_LENGTH}`, {
+        min_length: usernameSettings.min_length,
+        max_length: usernameSettings.max_length,
+      }),
+    );
+  }
 
-  return msg;
+  return clerkApiError;
 };


### PR DESCRIPTION
## Description

We need to let any other errors that don't match the conditions for a custom error to go through and let localization handle them.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
