### PR TITLE
fix(nextjs): Redirect to sign-up based on clerk_status

### DIFF
--- a/.changeset/eighty-jars-destroy.md
+++ b/.changeset/eighty-jars-destroy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Redirect to sign-up based on clerk_status

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -94,6 +94,7 @@ export function _SignInStart(): JSX.Element {
   const [hasSwitchedByAutofill, setHasSwitchedByAutofill] = useState(false);
 
   const organizationTicket = getClerkQueryParam('__clerk_ticket') || '';
+  const clerkStatus = getClerkQueryParam('__clerk_status') || '';
 
   const standardFormAttributes = userSettings.enabledFirstFactorIdentifiers;
   const web3FirstFactors = userSettings.web3FirstFactors;
@@ -170,6 +171,13 @@ export function _SignInStart(): JSX.Element {
 
   useEffect(() => {
     if (!organizationTicket) {
+      return;
+    }
+
+    if (clerkStatus === 'sign_up') {
+      // We explicitly navigate to 'create' in the combined flow to trigger a client-side navigation. Navigating to
+      // signUpUrl triggers a full page reload when used with the hash router.
+      navigate(isCombinedFlow ? 'create' : signUpUrl);
       return;
     }
 
@@ -410,7 +418,9 @@ export function _SignInStart(): JSX.Element {
     return components[identifierField.type as keyof typeof components];
   }, [identifierField.type]);
 
-  if (status.isLoading) {
+  if (status.isLoading || clerkStatus === 'sign_up') {
+    // clerkStatus being sign_up will trigger a navigation to the sign up flow, so show a loading card instead of
+    // rendering the sign in flow.
     return <LoadingCard />;
   }
 

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -16,7 +16,7 @@ const ClerkQueryParams = [
 type ClerkQueryParam = (typeof ClerkQueryParams)[number];
 
 type ClerkQueryParamsToValuesMap = {
-  __clerk_status: VerificationStatus;
+  __clerk_status: VerificationStatus | TicketStatus;
 } & Record<(typeof ClerkQueryParams)[number], string>;
 
 export type VerificationStatus =
@@ -26,6 +26,8 @@ export type VerificationStatus =
   | 'verified'
   | 'verified_switch_tab'
   | 'client_mismatch';
+
+type TicketStatus = 'sign_in' | 'sign_up';
 
 export function getClerkQueryParam<T extends ClerkQueryParam>(param: T): ClerkQueryParamsToValuesMap[T] | null {
   const val = new URL(window.location.href).searchParams.get(param);


### PR DESCRIPTION
## Description

This PR updates the `SignIn` component to navigate to `SignUp` (either the nested combined flow route or the full-page `SignUp` component) based on the `__clerk_status` parameter passed with ticket flows.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
