### PR TITLE
fix(backend): Satellite domains dev sync

### DIFF
--- a/.changeset/grumpy-foxes-sneeze.md
+++ b/.changeset/grumpy-foxes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fixes an issue with the satellite sync flow for development instances.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -71,7 +71,7 @@ expect.extend({
       };
     } else {
       return {
-        message: () => `expected to be signed out`,
+        message: () => `expected to be signed out, but got ${received.status}`,
         pass: false,
       };
     }
@@ -190,7 +190,7 @@ expect.extend({
       };
     } else {
       return {
-        message: () => `expected to be signed in`,
+        message: () => `expected to be signed in, but got ${received.status}`,
         pass: false,
       };
     }
@@ -603,6 +603,42 @@ describe('tokens.authenticateRequest(options)', () => {
     expect(requestState.toAuth()).toBeNull();
   });
 
+  test('cookieToken: redirects to signInUrl when is satellite dev and not synced', async () => {
+    server.use(
+      http.get('https://api.clerk.test/v1/jwks', () => {
+        return HttpResponse.json(mockJwks);
+      }),
+    );
+
+    const requestState = await authenticateRequest(
+      mockRequestWithCookies(
+        {},
+        {
+          __client_uat: '0',
+        },
+      ),
+      mockOptions({
+        secretKey: 'deadbeef',
+        publishableKey: PK_TEST,
+        clientUat: '0',
+        isSatellite: true,
+        signInUrl: 'https://primary.dev/sign-in',
+        domain: 'satellite.dev',
+      }),
+    );
+
+    expect(requestState).toMatchHandshake({
+      reason: AuthErrorReason.SatelliteCookieNeedsSyncing,
+      isSatellite: true,
+      signInUrl: 'https://primary.dev/sign-in',
+      domain: 'satellite.dev',
+    });
+    expect(requestState.message).toBe('');
+    expect(requestState.headers.get('location')).toMatchInlineSnapshot(
+      `"https://primary.dev/sign-in?__clerk_redirect_url=http%3A%2F%2Fexample.com%2Fpath"`,
+    );
+  });
+
   test('cookieToken: returns signed out is satellite but a non-browser request [11y]', async () => {
     const requestState = await authenticateRequest(
       mockRequestWithCookies(
@@ -650,6 +686,32 @@ describe('tokens.authenticateRequest(options)', () => {
     });
     expect(requestState.message).toBe('');
     expect(requestState.toAuth()).toBeNull();
+  });
+
+  test('cookieToken: does not trigger satellite sync if just synced', async () => {
+    const requestState = await authenticateRequest(
+      mockRequestWithCookies(
+        {},
+        {
+          __clerk_db_jwt: mockJwt,
+        },
+        `http://satellite.example/path?__clerk_synced=true`,
+      ),
+      mockOptions({
+        secretKey: 'sk_test_deadbeef',
+        signInUrl: 'http://primary.example/sign-in',
+        isSatellite: true,
+        domain: 'satellite.example',
+      }),
+    );
+
+    expect(requestState).toBeSignedOut({
+      reason: AuthErrorReason.SessionTokenAndUATMissing,
+      isSatellite: true,
+      domain: 'satellite.example',
+      signInUrl: 'http://primary.example/sign-in',
+    });
+    expect(requestState.toAuth()).toBeSignedOutToAuth();
   });
 
   test('cookieToken: returns handshake when app is not satellite and responds to syncing on dev instances[12y]', async () => {

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -634,8 +634,8 @@ describe('tokens.authenticateRequest(options)', () => {
       domain: 'satellite.dev',
     });
     expect(requestState.message).toBe('');
-    expect(requestState.headers.get('location')).toMatchInlineSnapshot(
-      `"https://primary.dev/sign-in?__clerk_redirect_url=http%3A%2F%2Fexample.com%2Fpath"`,
+    expect(requestState.headers.get('location')).toEqual(
+      `https://primary.dev/sign-in?__clerk_redirect_url=http%3A%2F%2Fexample.com%2Fpath`,
     );
   });
 

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -521,7 +521,11 @@ ${error.getFullMessage()}`,
     }
 
     // Multi-domain development sync flow
-    if (authenticateContext.instanceType === 'development' && isRequestEligibleForMultiDomainSync) {
+    if (
+      authenticateContext.instanceType === 'development' &&
+      isRequestEligibleForMultiDomainSync &&
+      !authenticateContext.clerkUrl.searchParams.has(constants.QueryParameters.ClerkSynced)
+    ) {
       // initiate MD sync
 
       // signInUrl exists, checked at the top of `authenticateRequest`
@@ -529,10 +533,6 @@ ${error.getFullMessage()}`,
       redirectURL.searchParams.append(
         constants.QueryParameters.ClerkRedirectUrl,
         authenticateContext.clerkUrl.toString(),
-      );
-      redirectURL.searchParams.append(
-        constants.QueryParameters.HandshakeReason,
-        AuthErrorReason.SatelliteCookieNeedsSyncing,
       );
       const headers = new Headers({ [constants.Headers.Location]: redirectURL.toString() });
       return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.SatelliteCookieNeedsSyncing, '', headers);
@@ -554,11 +554,9 @@ ${error.getFullMessage()}`,
         );
       }
       redirectBackToSatelliteUrl.searchParams.append(constants.QueryParameters.ClerkSynced, 'true');
-      const authErrReason = AuthErrorReason.PrimaryRespondsToSyncing;
-      redirectBackToSatelliteUrl.searchParams.append(constants.QueryParameters.HandshakeReason, authErrReason);
 
       const headers = new Headers({ [constants.Headers.Location]: redirectBackToSatelliteUrl.toString() });
-      return handleMaybeHandshakeStatus(authenticateContext, authErrReason, '', headers);
+      return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.PrimaryRespondsToSyncing, '', headers);
     }
     /**
      * End multi-domain sync flows


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
The dev satellite sync relies on the `__clerk_synced` query parameter to indicate termination of the sync flow. We recently removed the check for `__clerk_synced`, but it needs to be re-added for the dev sync flow when communicating with the primary application.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
