### PR TITLE
fix(backend): Align Session resource with OpenAPI spec

### DIFF
--- a/.changeset/bright-mangos-grow.md
+++ b/.changeset/bright-mangos-grow.md
@@ -2,4 +2,7 @@
 '@clerk/backend': minor
 ---
 
-Align Session resource with OpenAPI spec
+Update Session resource with new properties to align with OpenAPI spec
+- `lastActiveOrganizationId`
+- `latestActivity`
+- `actor`

--- a/.changeset/bright-mangos-grow.md
+++ b/.changeset/bright-mangos-grow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Align Session resource with OpenAPI spec

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -231,13 +231,13 @@ export interface RedirectUrlJSON extends ClerkResourceJSON {
 
 export interface SessionActivityJSON extends ClerkResourceJSON {
   id: string;
-  device_type: string;
+  device_type?: string;
   is_mobile: boolean;
-  browser_name: string;
-  browser_version: string;
-  ip_address: string;
-  city: string;
-  country: string;
+  browser_name?: string;
+  browser_version?: string;
+  ip_address?: string;
+  city?: string;
+  country?: string;
 }
 
 export interface SessionJSON extends ClerkResourceJSON {
@@ -245,9 +245,9 @@ export interface SessionJSON extends ClerkResourceJSON {
   client_id: string;
   user_id: string;
   status: string;
-  last_active_organization_id: string | null;
+  last_active_organization_id?: string;
   actor: Record<string, unknown> | null;
-  latest_activity: SessionActivityJSON | null;
+  latest_activity?: SessionActivityJSON;
   last_active_at: number;
   expire_at: number;
   abandon_at: number;

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -229,13 +229,25 @@ export interface RedirectUrlJSON extends ClerkResourceJSON {
   updated_at: number;
 }
 
+export interface SessionActivityJSON extends ClerkResourceJSON {
+  id: string;
+  device_type: string;
+  is_mobile: boolean;
+  browser_name: string;
+  browser_version: string;
+  ip_address: string;
+  city: string;
+  country: string;
+}
+
 export interface SessionJSON extends ClerkResourceJSON {
   object: typeof ObjectType.Session;
   client_id: string;
   user_id: string;
   status: string;
-  last_active_organization_id?: string;
-  actor?: Record<string, unknown>;
+  last_active_organization_id: string | null;
+  actor: Record<string, unknown> | null;
+  latest_activity: SessionActivityJSON | null;
   last_active_at: number;
   expire_at: number;
   abandon_at: number;

--- a/packages/backend/src/api/resources/Session.ts
+++ b/packages/backend/src/api/resources/Session.ts
@@ -3,25 +3,25 @@ import type { SessionActivityJSON, SessionJSON } from './JSON';
 export class SessionActivity {
   constructor(
     readonly id: string,
-    readonly deviceType: string,
     readonly isMobile: boolean,
-    readonly browserName: string,
-    readonly browserVersion: string,
-    readonly ipAddress: string,
-    readonly city: string,
-    readonly country: string,
+    readonly ipAddress?: string,
+    readonly city?: string,
+    readonly country?: string,
+    readonly browserVersion?: string,
+    readonly browserName?: string,
+    readonly deviceType?: string,
   ) {}
 
   static fromJSON(data: SessionActivityJSON): SessionActivity {
     return new SessionActivity(
       data.id,
-      data.device_type,
       data.is_mobile,
-      data.browser_name,
-      data.browser_version,
       data.ip_address,
       data.city,
       data.country,
+      data.browser_version,
+      data.browser_name,
+      data.device_type,
     );
   }
 }
@@ -37,8 +37,8 @@ export class Session {
     readonly abandonAt: number,
     readonly createdAt: number,
     readonly updatedAt: number,
-    readonly lastActiveOrganizationId: string | null,
-    readonly latestActivity: SessionActivity | null = null,
+    readonly lastActiveOrganizationId?: string,
+    readonly latestActivity?: SessionActivity,
     readonly actor: Record<string, unknown> | null = null,
   ) {}
 

--- a/packages/backend/src/api/resources/Session.ts
+++ b/packages/backend/src/api/resources/Session.ts
@@ -1,4 +1,30 @@
-import type { SessionJSON } from './JSON';
+import type { SessionActivityJSON, SessionJSON } from './JSON';
+
+export class SessionActivity {
+  constructor(
+    readonly id: string,
+    readonly deviceType: string,
+    readonly isMobile: boolean,
+    readonly browserName: string,
+    readonly browserVersion: string,
+    readonly ipAddress: string,
+    readonly city: string,
+    readonly country: string,
+  ) {}
+
+  static fromJSON(data: SessionActivityJSON): SessionActivity {
+    return new SessionActivity(
+      data.id,
+      data.device_type,
+      data.is_mobile,
+      data.browser_name,
+      data.browser_version,
+      data.ip_address,
+      data.city,
+      data.country,
+    );
+  }
+}
 
 export class Session {
   constructor(
@@ -11,6 +37,9 @@ export class Session {
     readonly abandonAt: number,
     readonly createdAt: number,
     readonly updatedAt: number,
+    readonly lastActiveOrganizationId: string | null,
+    readonly latestActivity: SessionActivity | null = null,
+    readonly actor: Record<string, unknown> | null = null,
   ) {}
 
   static fromJSON(data: SessionJSON): Session {
@@ -24,6 +53,9 @@ export class Session {
       data.abandon_at,
       data.created_at,
       data.updated_at,
+      data.last_active_organization_id,
+      data.latest_activity && SessionActivity.fromJSON(data.latest_activity),
+      data.actor,
     );
   }
 }


### PR DESCRIPTION
## Description

This PR aligns the `Session` resource in the `@clerk/backend` SDK to match the OpenAPI spec of Backend API
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
