### PR TITLE
fix(clerk-js): Only call ensureMounted() if necessary

### DIFF
--- a/.changeset/tame-glasses-smoke.md
+++ b/.changeset/tame-glasses-smoke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an issue that caused Clerk's UI code to load even before components were rendered.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2093,16 +2093,16 @@ export class Clerk implements ClerkInterface {
   };
 
   #handleKeylessPrompt = () => {
-    void this.#componentControls?.ensureMounted().then(controls => {
-      if (this.#options.__internal_claimKeylessApplicationUrl) {
+    if (this.#options.__internal_claimKeylessApplicationUrl) {
+      void this.#componentControls?.ensureMounted().then(controls => {
         controls.updateProps({
           options: {
             __internal_claimKeylessApplicationUrl: this.#options.__internal_claimKeylessApplicationUrl,
             __internal_copyInstanceKeysUrl: this.#options.__internal_copyInstanceKeysUrl,
           },
         });
-      }
-    });
+      });
+    }
   };
 
   #buildUrl = (


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensure the clerk-js UI chunks aren't loaded due to the `ensureMounted()` call within `handleKeylessPrompt()`, which is only necessary if a specific Clerk option is passed.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
