### PR TITLE
fix(localizations): Fix de-DE key `socialButtonsBlockButtonManyInView`

### DIFF
--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -547,8 +547,7 @@ export const deDE: LocalizationResource = {
     },
   },
   socialButtonsBlockButton: 'Weiter mit {{provider|titleize}}',
-  socialButtonsBlockButtonManyInView:
-    'Zu viele Buttons angezeigt. Reduzieren Sie die Anzahl der Buttons, um fortzufahren.',
+  socialButtonsBlockButtonManyInView: '{{provider|titleize}}',
   unstable__errors: {
     already_a_member_in_organization: 'Sie sind bereits Mitglied in dieser Organisation.',
     captcha_invalid:


### PR DESCRIPTION
## Description

A previous change changed the label for buttons when multiple SSO providers are active from the provider name to a long string, which breaks the layout. This change brings the label for the key `socialButtonsBlockButtonManyInView` back to the desired one and in line with other languages.

The previous value roughly translates to "Too many buttons are shown. Reduce amount of buttons to continue"—this doesn't make any sense and is unique to the German translations. The broken string was introduced in this commit, together with other changes, so it seems it fell through the cracks: https://github.com/clerk/javascript/commit/b9a5bea404cb09d7e328d48b41bd2669feb4e518#diff-96883e89b065cc0abf16578b55e5a53c76a77b62d3ea953fa4e6064c29da93aaR550

Without the fix, the SignIn component with German translations looks like this:
<img width="495" alt="Screenshot 2025-01-13 at 09 31 43" src="https://github.com/user-attachments/assets/69d93646-c658-4bb1-8f37-ae9a5ed8b9f6" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
