### PR TITLE
fix(nextjs): Detect middlware usage to avoid infinite loop on Keyless mode

### DIFF
--- a/.changeset/thirty-fireants-cough.md
+++ b/.changeset/thirty-fireants-cough.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Bug fix: Avoid infinite redirect loop on Keyless mode by detecting if `clerkMiddleware()` is used in the application.

--- a/packages/nextjs/src/app-router/keyless-actions.ts
+++ b/packages/nextjs/src/app-router/keyless-actions.ts
@@ -1,12 +1,11 @@
 'use server';
 import type { AccountlessApplication } from '@clerk/backend';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { redirect, RedirectType } from 'next/navigation';
 
+import { detectClerkMiddleware } from '../server/headers-utils';
 import { getKeylessCookieName } from '../server/keyless';
-import { detectClerkMiddleware } from '../server/utils';
 import { canUseKeyless__server } from '../utils/feature-flags';
-import { buildRequestLike } from './server/utils';
 
 export async function syncKeylessConfigAction(args: AccountlessApplication & { returnUrl: string }): Promise<void> {
   const { claimUrl, publishableKey, secretKey, returnUrl } = args;
@@ -16,8 +15,10 @@ export async function syncKeylessConfigAction(args: AccountlessApplication & { r
     httpOnly: true,
   });
 
-  const request = await buildRequestLike();
+  const request = new Request('https://placeholder.com', { headers: await headers() });
 
+  // We cannot import `NextRequest` due to a bundling issue with server actions in Next.js 13.
+  // @ts-expect-error Request will work as well
   if (detectClerkMiddleware(request)) {
     /**
      * Force middleware to execute to read the new keys from the cookies and populate the authentication state correctly.

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -5,9 +5,10 @@ import { notFound, redirect } from 'next/navigation';
 import { PUBLISHABLE_KEY, SIGN_IN_URL, SIGN_UP_URL } from '../../server/constants';
 import { createGetAuth } from '../../server/createGetAuth';
 import { authAuthHeaderMissing } from '../../server/errors';
+import { getAuthKeyFromRequest, getHeader } from '../../server/headers-utils';
 import type { AuthProtect } from '../../server/protect';
 import { createProtect } from '../../server/protect';
-import { decryptClerkRequestData, getAuthKeyFromRequest, getHeader } from '../../server/utils';
+import { decryptClerkRequestData } from '../../server/utils';
 import { buildRequestLike } from './utils';
 
 type Auth = AuthObject & { redirectToSignIn: RedirectFun<ReturnType<typeof redirect>> };

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -2,8 +2,9 @@ import { constants } from '@clerk/backend/internal';
 
 import { buildRequestLike, isPrerenderingBailout } from '../app-router/server/utils';
 import { createClerkClientWithOptions } from './createClerkClient';
+import { getHeader } from './headers-utils';
 import { clerkMiddlewareRequestDataStorage } from './middleware-storage';
-import { decryptClerkRequestData, getHeader } from './utils';
+import { decryptClerkRequestData } from './utils';
 
 /**
  * Constructs a BAPI client that accesses request data within the runtime.

--- a/packages/nextjs/src/server/createGetAuth.ts
+++ b/packages/nextjs/src/server/createGetAuth.ts
@@ -6,8 +6,9 @@ import { isTruthy } from '@clerk/shared/underscore';
 import { withLogger } from '../utils/debugLogger';
 import { getAuthDataFromRequest } from './data/getAuthDataFromRequest';
 import { getAuthAuthHeaderMissing } from './errors';
+import { getHeader } from './headers-utils';
 import type { RequestLike } from './types';
-import { assertAuthStatus, getCookie, getHeader } from './utils';
+import { assertAuthStatus, getCookie } from './utils';
 
 export const createGetAuth = ({
   noAuthStatusMessage,

--- a/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
+++ b/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
@@ -4,8 +4,9 @@ import { decodeJwt } from '@clerk/backend/jwt';
 
 import type { LoggerNoCommit } from '../../utils/debugLogger';
 import { API_URL, API_VERSION, PUBLISHABLE_KEY, SECRET_KEY } from '../constants';
+import { getAuthKeyFromRequest, getHeader } from '../headers-utils';
 import type { RequestLike } from '../types';
-import { assertTokenSignature, decryptClerkRequestData, getAuthKeyFromRequest, getHeader } from '../utils';
+import { assertTokenSignature, decryptClerkRequestData } from '../utils';
 
 /**
  * Given a request object, builds an auth object from the request data. Used in server-side environments to get access

--- a/packages/nextjs/src/server/headers-utils.ts
+++ b/packages/nextjs/src/server/headers-utils.ts
@@ -1,0 +1,53 @@
+import { constants } from '@clerk/backend/internal';
+import type { NextRequest } from 'next/server';
+
+import type { RequestLike } from './types';
+
+export function getCustomAttributeFromRequest(req: RequestLike, key: string): string | null | undefined {
+  // @ts-expect-error - TS doesn't like indexing into RequestLike
+  return key in req ? req[key] : undefined;
+}
+
+export function getAuthKeyFromRequest(
+  req: RequestLike,
+  key: keyof typeof constants.Attributes,
+): string | null | undefined {
+  return getCustomAttributeFromRequest(req, constants.Attributes[key]) || getHeader(req, constants.Headers[key]);
+}
+
+export function getHeader(req: RequestLike, name: string): string | null | undefined {
+  if (isNextRequest(req) || isRequestWebAPI(req)) {
+    return req.headers.get(name);
+  }
+
+  // If no header has been determined for IncomingMessage case, check if available within private `socket` headers
+  // When deployed to vercel, req.headers for API routes is a `IncomingHttpHeaders` key-val object which does not follow
+  // the Headers spec so the name is no longer case-insensitive.
+  return req.headers[name] || req.headers[name.toLowerCase()] || (req.socket as any)?._httpMessage?.getHeader(name);
+}
+
+export function detectClerkMiddleware(req: RequestLike): boolean {
+  return Boolean(getAuthKeyFromRequest(req, 'AuthStatus'));
+}
+
+export function isNextRequest(val: unknown): val is NextRequest {
+  try {
+    const { headers, nextUrl, cookies } = (val || {}) as NextRequest;
+    return (
+      typeof headers?.get === 'function' &&
+      typeof nextUrl?.searchParams.get === 'function' &&
+      typeof cookies?.get === 'function'
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
+export function isRequestWebAPI(val: unknown): val is Request {
+  try {
+    const { headers } = (val || {}) as Request;
+    return typeof headers?.get === 'function';
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -197,10 +197,12 @@ export const redirectAdapter = (url: string | URL) => {
   return NextResponse.redirect(url, { headers: { [constants.Headers.ClerkRedirectTo]: 'true' } });
 };
 
-export function assertAuthStatus(req: RequestLike, error: string) {
-  const authStatus = getAuthKeyFromRequest(req, 'AuthStatus');
+export function detectClerkMiddleware(req: RequestLike): boolean {
+  return Boolean(getAuthKeyFromRequest(req, 'AuthStatus'));
+}
 
-  if (!authStatus) {
+export function assertAuthStatus(req: RequestLike, error: string) {
+  if (!detectClerkMiddleware(req)) {
     throw new Error(error);
   }
 }

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -21,30 +21,8 @@ import {
   missingSignInUrlInDev,
 } from './errors';
 import { errorThrower } from './errorThrower';
+import { detectClerkMiddleware, isNextRequest } from './headers-utils';
 import type { RequestLike } from './types';
-
-export function getCustomAttributeFromRequest(req: RequestLike, key: string): string | null | undefined {
-  // @ts-expect-error - TS doesn't like indexing into RequestLike
-  return key in req ? req[key] : undefined;
-}
-
-export function getAuthKeyFromRequest(
-  req: RequestLike,
-  key: keyof typeof constants.Attributes,
-): string | null | undefined {
-  return getCustomAttributeFromRequest(req, constants.Attributes[key]) || getHeader(req, constants.Headers[key]);
-}
-
-export function getHeader(req: RequestLike, name: string): string | null | undefined {
-  if (isNextRequest(req)) {
-    return req.headers.get(name);
-  }
-
-  // If no header has been determined for IncomingMessage case, check if available within private `socket` headers
-  // When deployed to vercel, req.headers for API routes is a `IncomingHttpHeaders` key-val object which does not follow
-  // the Headers spec so the name is no longer case-insensitive.
-  return req.headers[name] || req.headers[name.toLowerCase()] || (req.socket as any)?._httpMessage?.getHeader(name);
-}
 
 export function getCookie(req: RequestLike, name: string): string | undefined {
   if (isNextRequest(req)) {
@@ -59,19 +37,6 @@ export function getCookie(req: RequestLike, name: string): string | undefined {
     return typeof reqCookieOrString === 'string' ? reqCookieOrString : reqCookieOrString.value;
   }
   return req.cookies[name];
-}
-
-function isNextRequest(val: unknown): val is NextRequest {
-  try {
-    const { headers, nextUrl, cookies } = (val || {}) as NextRequest;
-    return (
-      typeof headers?.get === 'function' &&
-      typeof nextUrl?.searchParams.get === 'function' &&
-      typeof cookies?.get === 'function'
-    );
-  } catch (e) {
-    return false;
-  }
 }
 
 const OVERRIDE_HEADERS = 'x-middleware-override-headers';
@@ -196,10 +161,6 @@ export const handleMultiDomainAndProxy = (clerkRequest: ClerkRequest, opts: Auth
 export const redirectAdapter = (url: string | URL) => {
   return NextResponse.redirect(url, { headers: { [constants.Headers.ClerkRedirectTo]: 'true' } });
 };
-
-export function detectClerkMiddleware(req: RequestLike): boolean {
-  return Boolean(getAuthKeyFromRequest(req, 'AuthStatus'));
-}
 
 export function assertAuthStatus(req: RequestLike, error: string) {
   if (!detectClerkMiddleware(req)) {


### PR DESCRIPTION
## Description

When `clerkMiddleware` is not used in an application we know that any attempt to use `await auth()` will fail, so we don't need to force "middleware" to rerun in order for our server side helpers to have the correct keys. Accessing them will certainly fail either way.

In this scenario, we could have simply perform `detectClerkMiddleware()` inside the Server ClerkProvider, but we want to avoid doing that since that will opt in all routes into dynamic rendering implicitly which may annoy many developers.

### Necessary changes
Calling `buildRequestLike` inside a server action in Next.js will cause the application to break due to bundling issues of the framework that cause `fs` to leak into he client. For that reason, I've adjusted the implementation to work with the standard `Request` from WebAPI.



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
