### PR TITLE
feat(backend): Set cookies from the refresh token flow

### DIFF
--- a/.changeset/good-eggs-retire.md
+++ b/.changeset/good-eggs-retire.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+`authenticateRequest()` will now set a refreshsed session cookie on the response when an expired session token is refreshed via the Clerk API.

--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -67,7 +67,7 @@ export class SessionAPI extends AbstractAPI {
     });
   }
 
-  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'token ' }): Promise<Token>;
+  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'token' }): Promise<Token>;
   public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'cookie' }): Promise<Cookies>;
   public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token>;
   public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token | Cookies> {

--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -22,7 +22,7 @@ type RefreshTokenParams = {
   request_originating_ip?: string;
   request_headers?: Record<string, string[]>;
   suffixed_cookies?: boolean;
-  format?: 'token' | 'cookies';
+  format?: 'token' | 'cookie';
 };
 
 export class SessionAPI extends AbstractAPI {
@@ -68,16 +68,16 @@ export class SessionAPI extends AbstractAPI {
   }
 
   public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'token ' }): Promise<Token>;
-  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'cookies' }): Promise<Cookies>;
+  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'cookie' }): Promise<Cookies>;
   public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token>;
   public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token | Cookies> {
     this.requireId(sessionId);
-    const { format = 'token', suffixed_cookies, ...restParams } = params;
+    const { suffixed_cookies, ...restParams } = params;
     return this.request({
       method: 'POST',
       path: joinPaths(basePath, sessionId, 'refresh'),
       bodyParams: restParams,
-      queryParams: { format, suffixed_cookies },
+      queryParams: { suffixed_cookies },
     });
   }
 }

--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -1,6 +1,7 @@
 import type { ClerkPaginationRequest, SessionStatus } from '@clerk/types';
 
 import { joinPaths } from '../../util/path';
+import type { Cookies } from '../resources/Cookies';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import type { Session } from '../resources/Session';
 import type { Token } from '../resources/Token';
@@ -20,6 +21,8 @@ type RefreshTokenParams = {
   request_origin: string;
   request_originating_ip?: string;
   request_headers?: Record<string, string[]>;
+  suffixed_cookies?: boolean;
+  format?: 'token' | 'cookies';
 };
 
 export class SessionAPI extends AbstractAPI {
@@ -64,12 +67,17 @@ export class SessionAPI extends AbstractAPI {
     });
   }
 
-  public async refreshSession(sessionId: string, params: RefreshTokenParams) {
+  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'token ' }): Promise<Token>;
+  public async refreshSession(sessionId: string, params: RefreshTokenParams & { format: 'cookies' }): Promise<Cookies>;
+  public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token>;
+  public async refreshSession(sessionId: string, params: RefreshTokenParams): Promise<Token | Cookies> {
     this.requireId(sessionId);
-    return this.request<Token>({
+    const { format = 'token', suffixed_cookies, ...restParams } = params;
+    return this.request({
       method: 'POST',
       path: joinPaths(basePath, sessionId, 'refresh'),
-      bodyParams: params,
+      bodyParams: restParams,
+      queryParams: { format, suffixed_cookies },
     });
   }
 }

--- a/packages/backend/src/api/resources/Cookies.ts
+++ b/packages/backend/src/api/resources/Cookies.ts
@@ -1,0 +1,9 @@
+import type { CookiesJSON } from './JSON';
+
+export class Cookies {
+  constructor(readonly cookies: string[]) {}
+
+  static fromJSON(data: CookiesJSON): Cookies {
+    return new Cookies(data.cookies);
+  }
+}

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -1,6 +1,7 @@
 import {
   AllowlistIdentifier,
   Client,
+  Cookies,
   DeletedObject,
   Email,
   EmailAddress,
@@ -72,6 +73,8 @@ function jsonToObject(item: any): any {
       return AllowlistIdentifier.fromJSON(item);
     case ObjectType.Client:
       return Client.fromJSON(item);
+    case ObjectType.Cookies:
+      return Cookies.fromJSON(item);
     case ObjectType.EmailAddress:
       return EmailAddress.fromJSON(item);
     case ObjectType.Email:

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -10,6 +10,7 @@ export const ObjectType = {
   AccountlessApplication: 'accountless_application',
   AllowlistIdentifier: 'allowlist_identifier',
   Client: 'client',
+  Cookies: 'cookies',
   Email: 'email',
   EmailAddress: 'email_address',
   ExternalAccount: 'external_account',
@@ -42,6 +43,11 @@ export type ObjectType = (typeof ObjectType)[keyof typeof ObjectType];
 export interface ClerkResourceJSON {
   object: ObjectType;
   id: string;
+}
+
+export interface CookiesJSON {
+  object: typeof ObjectType.Cookies;
+  cookies: string[];
 }
 
 export interface TokenJSON {

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -1,6 +1,7 @@
 export * from './AccountlessApplication';
 export * from './AllowlistIdentifier';
 export * from './Client';
+export * from './Cookies';
 export * from './DeletedObject';
 export * from './Email';
 export * from './EmailAddress';

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -972,130 +972,138 @@ describe('tokens.authenticateRequest(options)', () => {
     expect(requestState.toAuth()).toBeSignedInToAuth();
   });
 
-  test('refreshToken: returns signed in with valid refresh token cookie if token is expired and refresh token exists', async () => {
-    server.use(
-      http.get('https://api.clerk.test/v1/jwks', () => {
-        return HttpResponse.json(mockJwks);
-      }),
-    );
+  describe('refreshToken', async () => {
+    test('returns signed in with valid refresh token cookie if token is expired and refresh token exists', async () => {
+      server.use(
+        http.get('https://api.clerk.test/v1/jwks', () => {
+          return HttpResponse.json(mockJwks);
+        }),
+      );
 
-    // return cookies from endpoint
-    const refreshSession = vi.fn(() => ({
-      object: 'token',
-      jwt: mockJwt,
-    }));
+      // return cookies from endpoint
+      const refreshSession = vi.fn(() => ({
+        object: 'cookies',
+        cookies: [`__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`],
+      }));
 
-    const requestState = await authenticateRequest(
-      mockRequestWithCookies(
-        {
-          ...defaultHeaders,
-          origin: 'https://example.com',
-        },
-        { __client_uat: `12345`, __session: mockExpiredJwt, __refresh_MqCvchyS: 'can_be_anything' },
-      ),
-      mockOptions({
-        secretKey: 'test_deadbeef',
-        publishableKey: PK_LIVE,
-        apiClient: { sessions: { refreshSession } },
-      }),
-    );
+      const requestState = await authenticateRequest(
+        mockRequestWithCookies(
+          {
+            ...defaultHeaders,
+            origin: 'https://example.com',
+          },
+          { __client_uat: `12345`, __session: mockExpiredJwt, __refresh_MqCvchyS: 'can_be_anything' },
+        ),
+        mockOptions({
+          secretKey: 'test_deadbeef',
+          publishableKey: PK_LIVE,
+          apiClient: { sessions: { refreshSession } },
+        }),
+      );
 
-    expect(requestState).toBeSignedIn();
-    expect(requestState.toAuth()).toBeSignedInToAuth();
-    expect(refreshSession).toHaveBeenCalled();
-  });
+      expect(requestState).toBeSignedIn();
+      expect(requestState.toAuth()).toBeSignedInToAuth();
+      expect(requestState.headers.getSetCookie()).toContain(
+        `__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`,
+      );
+      expect(refreshSession).toHaveBeenCalled();
+    });
 
-  test('refreshToken: does not try to refresh if refresh token does not exist', async () => {
-    server.use(
-      http.get('https://api.clerk.test/v1/jwks', () => {
-        return HttpResponse.json(mockJwks);
-      }),
-    );
+    test('does not try to refresh if refresh token does not exist', async () => {
+      server.use(
+        http.get('https://api.clerk.test/v1/jwks', () => {
+          return HttpResponse.json(mockJwks);
+        }),
+      );
 
-    // return cookies from endpoint
-    const refreshSession = vi.fn(() => ({
-      object: 'token',
-      jwt: mockJwt,
-    }));
+      // return cookies from endpoint
+      const refreshSession = vi.fn(() => ({
+        object: 'cookies',
+        cookies: [`__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`],
+      }));
 
-    await authenticateRequest(
-      mockRequestWithCookies(
-        {
-          ...defaultHeaders,
-          origin: 'https://example.com',
-        },
-        { __client_uat: `12345`, __session: mockExpiredJwt },
-      ),
-      mockOptions({
-        secretKey: 'test_deadbeef',
-        publishableKey: PK_LIVE,
-        apiClient: { sessions: { refreshSession } },
-      }),
-    );
-    expect(refreshSession).not.toHaveBeenCalled();
-  });
+      await authenticateRequest(
+        mockRequestWithCookies(
+          {
+            ...defaultHeaders,
+            origin: 'https://example.com',
+          },
+          { __client_uat: `12345`, __session: mockExpiredJwt },
+        ),
+        mockOptions({
+          secretKey: 'test_deadbeef',
+          publishableKey: PK_LIVE,
+          apiClient: { sessions: { refreshSession } },
+        }),
+      );
+      expect(refreshSession).not.toHaveBeenCalled();
+    });
 
-  test('refreshToken: does not try to refresh if refresh exists but token is not expired', async () => {
-    // return cookies from endpoint
-    const refreshSession = vi.fn(() => ({
-      object: 'token',
-      jwt: mockJwt,
-    }));
+    test('does not try to refresh if refresh exists but token is not expired', async () => {
+      // return cookies from endpoint
+      const refreshSession = vi.fn(() => ({
+        object: 'cookies',
+        cookies: [`__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`],
+      }));
 
-    await authenticateRequest(
-      mockRequestWithCookies(
-        {
-          ...defaultHeaders,
-          origin: 'https://example.com',
-        },
-        // client_uat is missing, need to handshake not to refresh
-        { __session: mockJwt, __refresh_MqCvchyS: 'can_be_anything' },
-      ),
-      mockOptions({
-        secretKey: 'test_deadbeef',
-        publishableKey: PK_LIVE,
-        apiClient: { sessions: { refreshSession } },
-      }),
-    );
+      await authenticateRequest(
+        mockRequestWithCookies(
+          {
+            ...defaultHeaders,
+            origin: 'https://example.com',
+          },
+          // client_uat is missing, need to handshake not to refresh
+          { __session: mockJwt, __refresh_MqCvchyS: 'can_be_anything' },
+        ),
+        mockOptions({
+          secretKey: 'test_deadbeef',
+          publishableKey: PK_LIVE,
+          apiClient: { sessions: { refreshSession } },
+        }),
+      );
 
-    expect(refreshSession).not.toHaveBeenCalled();
-  });
+      expect(refreshSession).not.toHaveBeenCalled();
+    });
 
-  test('refreshToken: uses suffixed refresh cookie even if un-suffixed is present', async () => {
-    server.use(
-      http.get('https://api.clerk.test/v1/jwks', () => {
-        return HttpResponse.json(mockJwks);
-      }),
-    );
+    test('uses suffixed refresh cookie even if un-suffixed is present', async () => {
+      server.use(
+        http.get('https://api.clerk.test/v1/jwks', () => {
+          return HttpResponse.json(mockJwks);
+        }),
+      );
 
-    // return cookies from endpoint
-    const refreshSession = vi.fn(() => ({
-      object: 'token',
-      jwt: mockJwt,
-    }));
+      // return cookies from endpoint
+      const refreshSession = vi.fn(() => ({
+        object: 'cookies',
+        cookies: [`__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`],
+      }));
 
-    const requestState = await authenticateRequest(
-      mockRequestWithCookies(
-        {
-          ...defaultHeaders,
-          origin: 'https://example.com',
-        },
-        {
-          __client_uat: `12345`,
-          __session: mockExpiredJwt,
-          __refresh_MqCvchyS: 'can_be_anything',
-          __refresh: 'should_not_be_used',
-        },
-      ),
-      mockOptions({
-        secretKey: 'test_deadbeef',
-        publishableKey: PK_LIVE,
-        apiClient: { sessions: { refreshSession } },
-      }),
-    );
+      const requestState = await authenticateRequest(
+        mockRequestWithCookies(
+          {
+            ...defaultHeaders,
+            origin: 'https://example.com',
+          },
+          {
+            __client_uat: `12345`,
+            __session: mockExpiredJwt,
+            __refresh_MqCvchyS: 'can_be_anything',
+            __refresh: 'should_not_be_used',
+          },
+        ),
+        mockOptions({
+          secretKey: 'test_deadbeef',
+          publishableKey: PK_LIVE,
+          apiClient: { sessions: { refreshSession } },
+        }),
+      );
 
-    expect(requestState).toBeSignedIn();
-    expect(requestState.toAuth()).toBeSignedInToAuth();
-    expect(refreshSession).toHaveBeenCalled();
+      expect(requestState).toBeSignedIn();
+      expect(requestState.toAuth()).toBeSignedInToAuth();
+      expect(requestState.headers.getSetCookie()).toContain(
+        `__session_MqCvchyS=${mockJwt}; Path=/; Secure; SameSite=Lax`,
+      );
+      expect(refreshSession).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -219,7 +219,7 @@ ${error.getFullMessage()}`,
 
   async function refreshToken(
     authenticateContext: AuthenticateContext,
-  ): Promise<{ data: string; error: null } | { data: null; error: any }> {
+  ): Promise<{ data: string[]; error: null } | { data: null; error: any }> {
     // To perform a token refresh, apiClient must be defined.
     if (!options.apiClient) {
       return {
@@ -273,14 +273,16 @@ ${error.getFullMessage()}`,
 
     try {
       // Perform the actual token refresh.
-      const tokenResponse = await options.apiClient.sessions.refreshSession(decodeResult.payload.sid, {
+      const response = await options.apiClient.sessions.refreshSession(decodeResult.payload.sid, {
+        format: 'cookies',
+        suffixed_cookies: authenticateContext.usesSuffixedCookies(),
         expired_token: expiredSessionToken || '',
         refresh_token: refreshToken || '',
         request_origin: authenticateContext.clerkUrl.origin,
         // The refresh endpoint expects headers as Record<string, string[]>, so we need to transform it.
         request_headers: Object.fromEntries(Array.from(request.headers.entries()).map(([k, v]) => [k, [v]])),
       });
-      return { data: tokenResponse.jwt, error: null };
+      return { data: response.cookies, error: null };
     } catch (err: any) {
       if (err?.errors?.length) {
         if (err.errors[0].code === 'unexpected_error') {
@@ -313,11 +315,23 @@ ${error.getFullMessage()}`,
 
   async function attemptRefresh(
     authenticateContext: AuthenticateContext,
-  ): Promise<{ data: { jwtPayload: JwtPayload; sessionToken: string }; error: null } | { data: null; error: any }> {
-    const { data: sessionToken, error } = await refreshToken(authenticateContext);
-    if (!sessionToken) {
+  ): Promise<
+    | { data: { jwtPayload: JwtPayload; sessionToken: string; headers: Headers }; error: null }
+    | { data: null; error: any }
+  > {
+    const { data: cookiesToSet, error } = await refreshToken(authenticateContext);
+    if (!cookiesToSet || cookiesToSet.length === 0) {
       return { data: null, error };
     }
+
+    const headers = new Headers();
+    let sessionToken = '';
+    cookiesToSet.forEach((x: string) => {
+      headers.append('Set-Cookie', x);
+      if (getCookieName(x).startsWith(constants.Cookies.Session)) {
+        sessionToken = getCookieValue(x);
+      }
+    });
 
     // Since we're going to return a signedIn response, we need to decode the data from the new sessionToken.
     const { data: jwtPayload, errors } = await verifyToken(sessionToken, authenticateContext);
@@ -330,7 +344,7 @@ ${error.getFullMessage()}`,
         },
       };
     }
-    return { data: { jwtPayload, sessionToken }, error: null };
+    return { data: { jwtPayload, sessionToken, headers }, error: null };
   }
 
   function handleMaybeHandshakeStatus(
@@ -631,7 +645,7 @@ ${error.getFullMessage()}`,
     if (isRequestEligibleForRefresh(err, authenticateContext, request)) {
       const { data, error } = await attemptRefresh(authenticateContext);
       if (data) {
-        return signedIn(authenticateContext, data.jwtPayload, undefined, data.sessionToken);
+        return signedIn(authenticateContext, data.jwtPayload, data.headers, data.sessionToken);
       }
 
       // If there's any error, simply fallback to the handshake flow including the reason as a query parameter.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -274,7 +274,7 @@ ${error.getFullMessage()}`,
     try {
       // Perform the actual token refresh.
       const response = await options.apiClient.sessions.refreshSession(decodeResult.payload.sid, {
-        format: 'cookies',
+        format: 'cookie',
         suffixed_cookies: authenticateContext.usesSuffixedCookies(),
         expired_token: expiredSessionToken || '',
         refresh_token: refreshToken || '',


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Supports the `format=cookies` parameter for the session refresh endpoint. When this parameter is passed, the API will return an array of `set-cookie` header values to be passed along with the response.

<!-- Fixes #(issue number) -->
SDKI-832

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
