### PR TITLE
fix(clerk-js): Use correct email link redirect_url based on intent

### DIFF
--- a/packages/clerk-js/src/ui/common/__tests__/redirects.test.ts
+++ b/packages/clerk-js/src/ui/common/__tests__/redirects.test.ts
@@ -2,127 +2,173 @@ import { buildEmailLinkRedirectUrl, buildSSOCallbackURL } from '../redirects';
 
 describe('buildEmailLinkRedirectUrl(routing, baseUrl)', () => {
   it('defaults to hash based routing strategy on empty routing', function () {
-    expect(buildEmailLinkRedirectUrl({ path: '', authQueryString: '' } as any, '')).toBe('http://localhost/#/verify');
+    expect(
+      buildEmailLinkRedirectUrl({ ctx: { path: '', authQueryString: '' } as any, baseUrl: '', intent: 'sign-in' }),
+    ).toBe('http://localhost/#/verify');
   });
 
   it('returns the magic link redirect url for components using path based routing ', function () {
-    expect(buildEmailLinkRedirectUrl({ routing: 'path', authQueryString: '' } as any, '')).toBe(
-      'http://localhost/verify',
-    );
-
-    expect(buildEmailLinkRedirectUrl({ routing: 'path', path: '/sign-in', authQueryString: '' } as any, '')).toBe(
-      'http://localhost/sign-in/verify',
-    );
+    expect(
+      buildEmailLinkRedirectUrl({
+        ctx: { routing: 'path', authQueryString: '' } as any,
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
+    ).toBe('http://localhost/verify');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: { routing: 'path', path: '/sign-in', authQueryString: '' } as any,
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
+    ).toBe('http://localhost/sign-in/verify');
+
+    expect(
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'path',
           path: '',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/verify?redirectUrl=https://clerk.com');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'path',
           path: '/sign-in',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/sign-in/verify?redirectUrl=https://clerk.com');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'path',
           path: '/sign-in',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        'https://accounts.clerk.com/sign-in',
-      ),
+        baseUrl: 'https://accounts.clerk.com/sign-in',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/sign-in/verify?redirectUrl=https://clerk.com');
   });
 
   it('returns the magic link redirect url for components using hash based routing ', function () {
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'hash',
           authQueryString: '',
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/#/verify');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'hash',
           path: '/sign-in',
           authQueryString: null,
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/#/verify');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'hash',
           path: '',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/#/verify?redirectUrl=https://clerk.com');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'hash',
           path: '/sign-in',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        '',
-      ),
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/#/verify?redirectUrl=https://clerk.com');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'hash',
           path: '/sign-in',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        'https://accounts.clerk.com/sign-in',
-      ),
+        baseUrl: 'https://accounts.clerk.com/sign-in',
+        intent: 'sign-in',
+      }),
     ).toBe('http://localhost/#/verify?redirectUrl=https://clerk.com');
   });
 
   it('returns the magic link redirect url for components using virtual routing ', function () {
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'virtual',
           authQueryString: 'redirectUrl=https://clerk.com',
         } as any,
-        'https://accounts.clerk.com/sign-in',
-      ),
+        baseUrl: 'https://accounts.clerk.com/sign-in',
+        intent: 'sign-in',
+      }),
     ).toBe('https://accounts.clerk.com/sign-in#/verify?redirectUrl=https://clerk.com');
 
     expect(
-      buildEmailLinkRedirectUrl(
-        {
+      buildEmailLinkRedirectUrl({
+        ctx: {
           routing: 'virtual',
         } as any,
-        'https://accounts.clerk.com/sign-in',
-      ),
+        baseUrl: 'https://accounts.clerk.com/sign-in',
+        intent: 'sign-in',
+      }),
     ).toBe('https://accounts.clerk.com/sign-in#/verify');
+  });
+
+  it('returns the magic link redirect url for components using the combined flow based on intent', function () {
+    expect(
+      buildEmailLinkRedirectUrl({
+        ctx: {
+          routing: 'path',
+          path: '/sign-up',
+          isCombinedFlow: true,
+        } as any,
+        baseUrl: '',
+        intent: 'sign-up',
+      }),
+    ).toBe('http://localhost/sign-up/create/verify');
+
+    expect(
+      buildEmailLinkRedirectUrl({
+        ctx: {
+          routing: 'path',
+          path: '/sign-in',
+          isCombinedFlow: true,
+        } as any,
+        baseUrl: '',
+        intent: 'sign-in',
+      }),
+    ).toBe('http://localhost/sign-in/verify');
   });
 });
 

--- a/packages/clerk-js/src/ui/common/redirects.ts
+++ b/packages/clerk-js/src/ui/common/redirects.ts
@@ -4,10 +4,15 @@ import type { SignInContextType, SignUpContextType, UserProfileContextType } fro
 export const SSO_CALLBACK_PATH_ROUTE = '/sso-callback';
 export const MAGIC_LINK_VERIFY_PATH_ROUTE = '/verify';
 
-export function buildEmailLinkRedirectUrl(
-  ctx: SignInContextType | SignUpContextType | UserProfileContextType,
-  baseUrl: string | undefined = '',
-): string {
+export function buildEmailLinkRedirectUrl({
+  ctx,
+  baseUrl = '',
+  intent = 'sign-in',
+}: {
+  ctx: SignInContextType | SignUpContextType | UserProfileContextType;
+  baseUrl: string | undefined;
+  intent?: 'sign-in' | 'sign-up' | 'profile';
+}): string {
   const { routing, authQueryString, path } = ctx;
   const isCombinedFlow = 'isCombinedFlow' in ctx && ctx.isCombinedFlow;
   return buildRedirectUrl({
@@ -15,7 +20,8 @@ export function buildEmailLinkRedirectUrl(
     baseUrl,
     authQueryString,
     path,
-    endpoint: isCombinedFlow ? `/create${MAGIC_LINK_VERIFY_PATH_ROUTE}` : MAGIC_LINK_VERIFY_PATH_ROUTE,
+    endpoint:
+      isCombinedFlow && intent === 'sign-up' ? `/create${MAGIC_LINK_VERIFY_PATH_ROUTE}` : MAGIC_LINK_VERIFY_PATH_ROUTE,
   });
 }
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
@@ -45,7 +45,7 @@ export const SignInFactorOneEmailLinkCard = (props: SignInFactorOneEmailLinkCard
   const startEmailLinkVerification = () => {
     startEmailLinkFlow({
       emailAddressId: props.factor.emailAddressId,
-      redirectUrl: buildEmailLinkRedirectUrl(signInContext, signInUrl),
+      redirectUrl: buildEmailLinkRedirectUrl({ ctx: signInContext, baseUrl: signInUrl, intent: 'sign-in' }),
     })
       .then(res => handleVerificationResult(res))
       .catch(err => {

--- a/packages/clerk-js/src/ui/components/UserProfile/VerifyWithLink.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/VerifyWithLink.tsx
@@ -37,7 +37,7 @@ export const VerifyWithLink = (props: VerifyWithLinkProps) => {
     const { routing } = profileContext;
     const baseUrl = routing === 'virtual' ? displayConfig.userProfileUrl : '';
 
-    const redirectUrl = buildEmailLinkRedirectUrl(profileContext, baseUrl);
+    const redirectUrl = buildEmailLinkRedirectUrl({ ctx: profileContext, baseUrl, intent: 'profile' });
     startEmailLinkFlow({ redirectUrl })
       .then(() => nextStep())
       .catch(err => handleError(err, [], card.setError));


### PR DESCRIPTION
## Description

This PR updates the `buildEmailLinkRedirectUrl` utility to factor in the intent of the redirect URL when calculating the URL. This results in sign-in links pointing to `/sign-in/verify` and sign up links in the combined flow pointing to `/sign-in/create/verify`. This prevents an issue where signing in using the combined flow generates a redirect_url pointing to `/sign-in/create/verify` which results in language pertaining to sign-up.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
