### PR TITLE
fix(chrome-extension): Bundle @clerk/shared to properly tree-shake

### DIFF
--- a/.changeset/friendly-news-fix.md
+++ b/.changeset/friendly-news-fix.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': patch
+---
+
+Fix issue "Including remotely hosted code in a Manifest V3 item" that you might have seen during audit. The affected code is now bundled with the package and as such any offending code properly tree-shaken.

--- a/packages/chrome-extension/tsup.config.ts
+++ b/packages/chrome-extension/tsup.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(overrideOptions => {
     sourcemap: true,
     legacyOutput: true,
     treeshake: true,
-    noExternal: ['@clerk/clerk-react'],
+    noExternal: ['@clerk/clerk-react', '@clerk/shared'],
     external: ['use-sync-external-store'],
     define: {
       PACKAGE_NAME: `"${name}"`,


### PR DESCRIPTION
## Description

If you look at https://unpkg.com/browse/@clerk/chrome-extension@2.1.11/dist/esm/index.js you'll see that we end up with:

```js
import { setErrorThrowerOptions } from './chunk-BGR6KYCZ.js';
export { ... } from './chunk-BGR6KYCZ.js';
import './chunk-V7OWHRAI.js';
import '@clerk/shared/loadClerkJsScript';

setErrorThrowerOptions({ packageName: "@clerk/chrome-extension" });
```

The unused `import '@clerk/shared/loadClerkJsScript';` is problematic because inside is "remotely hosted code" that the Chrome extension store is flagging. In https://github.com/clerk/javascript/pull/4551 build flags were added and they work. But the unused imports are not removed during bundling.

So the fix is to also mark `@clerk/shared` _not_ external and bundle it. Then tsup seems to be able to remove those unused imports.

Fixes https://github.com/clerk/javascript/issues/4886

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
