### PR TITLE
fix(clerk-js): Preserve __clerk_ticket for internal sign-in navigation

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -173,9 +173,13 @@ export function _SignInStart(): JSX.Element {
     }
 
     if (clerkStatus === 'sign_up') {
+      const paramsToForward = new URLSearchParams();
+      if (organizationTicket) {
+        paramsToForward.set('__clerk_ticket', organizationTicket);
+      }
       // We explicitly navigate to 'create' in the combined flow to trigger a client-side navigation. Navigating to
       // signUpUrl triggers a full page reload when used with the hash router.
-      navigate(isCombinedFlow ? 'create' : signUpUrl);
+      void navigate(isCombinedFlow ? `create` : signUpUrl, { searchParams: paramsToForward });
       return;
     }
 
@@ -374,10 +378,6 @@ export function _SignInStart(): JSX.Element {
       }
 
       clerk.client.signUp[attribute] = identifierField.value;
-      const paramsToForward = new URLSearchParams();
-      if (organizationTicket) {
-        paramsToForward.set('__clerk_ticket', organizationTicket);
-      }
 
       const redirectUrl = buildSSOCallbackURL(ctx, displayConfig.signUpUrl);
       const redirectUrlComplete = ctx.afterSignUpUrl || '/';

--- a/packages/clerk-js/src/ui/components/SignIn/handleCombinedFlowTransfer.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/handleCombinedFlowTransfer.ts
@@ -1,13 +1,14 @@
 import type { LoadedClerk, SignUpModes, SignUpResource } from '@clerk/types';
 
 import { SIGN_UP_MODES } from '../../../core/constants';
+import type { RouteContextValue } from '../../router/RouteContext';
 import { completeSignUpFlow } from '../SignUp/util';
 
 type HandleCombinedFlowTransferProps = {
   identifierAttribute: 'emailAddress' | 'phoneNumber' | 'username';
   identifierValue: string;
   signUpMode: SignUpModes;
-  navigate: (to: string) => Promise<unknown>;
+  navigate: RouteContextValue['navigate'];
   organizationTicket?: string;
   afterSignUpUrl: string;
   clerk: LoadedClerk;
@@ -78,7 +79,7 @@ export function handleCombinedFlowTransfer({
       .catch(err => handleError(err));
   }
 
-  return navigate(`create?${paramsToForward.toString()}`);
+  return navigate(`create`, { searchParams: paramsToForward });
 }
 
 function hasOptionalFields(signUp: SignUpResource) {

--- a/packages/clerk-js/src/ui/router/Route.tsx
+++ b/packages/clerk-js/src/ui/router/Route.tsx
@@ -58,8 +58,11 @@ export function Route(props: RouteProps): JSX.Element | null {
 
   const [indexPath, fullPath] = newPaths(router.indexPath, router.fullPath, props.path, props.index);
 
-  const resolve = (to: string) => {
+  const resolve = (to: string, { searchParams }: { searchParams?: URLSearchParams } = {}) => {
     const url = new URL(to, window.location.origin + fullPath + '/');
+    if (searchParams) {
+      url.search = searchParams.toString();
+    }
     url.pathname = trimTrailingSlash(url.pathname);
     return url;
   };
@@ -109,8 +112,8 @@ export function Route(props: RouteProps): JSX.Element | null {
           return newGetMatchData(path, index) ? true : false;
         },
         resolve: resolve,
-        navigate: (to: string) => {
-          const toURL = resolve(to);
+        navigate: (to: string, { searchParams } = {}) => {
+          const toURL = resolve(to, { searchParams });
           return router.baseNavigate(toURL);
         },
         refresh: router.refresh,

--- a/packages/clerk-js/src/ui/router/RouteContext.tsx
+++ b/packages/clerk-js/src/ui/router/RouteContext.tsx
@@ -9,7 +9,7 @@ export interface RouteContextValue {
   currentPath: string;
   matches: (path?: string, index?: boolean) => boolean;
   baseNavigate: (toURL: URL) => Promise<unknown>;
-  navigate: (to: string) => Promise<unknown>;
+  navigate: (to: string, options?: { searchParams?: URLSearchParams }) => Promise<unknown>;
   resolve: (to: string) => URL;
   refresh: () => void;
   params: { [key: string]: string };


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
- Ensure the `__clerk_ticket` query parameter is preserved when navigating internally.
- Adds a new `searchParams` option to our internal router `navigate()` method to allow passing structured search params, instead of relying on concatenating them onto the `to` argument.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
