### PR TITLE
fix(backend): `inviterUserId` should be optional in `CreateOrganizationInvitationParams`

### DIFF
--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -78,7 +78,7 @@ type DeleteOrganizationMembershipParams = {
 
 type CreateOrganizationInvitationParams = {
   organizationId: string;
-  inviterUserId: string;
+  inviterUserId?: string;
   emailAddress: string;
   role: OrganizationMembershipRole;
   redirectUrl?: string;


### PR DESCRIPTION
## Description

Update the types to reflect the API docs: https://clerk.com/docs/references/backend/organization/create-organization-invitation

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
