### PR TITLE
fix(clerk-js): Show error during instant password error

### DIFF
--- a/.changeset/clean-goats-jam.md
+++ b/.changeset/clean-goats-jam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Show password error for incorrect passwords during instant password verification.

--- a/integration/tests/sign-in-flow.test.ts
+++ b/integration/tests/sign-in-flow.test.ts
@@ -123,6 +123,15 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('sign in f
     await u.po.expect.toBeSignedOut();
   });
 
+  test('cannot sign in with email and wrong instant password', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+    await u.po.signIn.goTo();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: 'wrong-password' });
+    await expect(u.page.getByText(/password you entered is incorrect/i)).toBeVisible();
+
+    await u.po.expect.toBeSignedOut();
+  });
+
   test('cannot sign in with wrong password but can sign in with email', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -308,7 +308,6 @@ export function _SignInStart(): JSX.Element {
             await authenticateWithEnterpriseSSO();
             break;
           }
-          console.log(res);
           return navigate('factor-one');
         case 'needs_second_factor':
           return navigate('factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -308,6 +308,7 @@ export function _SignInStart(): JSX.Element {
             await authenticateWithEnterpriseSSO();
             break;
           }
+          console.log(res);
           return navigate('factor-one');
         case 'needs_second_factor':
           return navigate('factor-two');
@@ -355,7 +356,7 @@ export function _SignInStart(): JSX.Element {
     );
 
     if (instantPasswordError) {
-      await signInWithFields(identifierField);
+      handleError(e, [instantPasswordField], card.setError);
     } else if (alreadySignedInError) {
       const sid = alreadySignedInError.meta!.sessionId!;
       await clerk.setActive({ session: sid, redirectUrl: afterSignInUrl });


### PR DESCRIPTION
## Description

When an password is incorrectly autofilled during sign-in, render an incorrect password error vs moving to first factor.

https://github.com/user-attachments/assets/48b4bc58-476f-49d7-815c-57e60b32f425

Fixes SDK-2029

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
