### PR TITLE
fix(repo): Update actions/upload-artifacts to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: pnpm turbo lint $TURBO_ARGS --only -- --quiet
 
       - name: Upload Turbo Summary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ env.TURBO_SUMMARIZE == 'true' }}
         continue-on-error: true
         with:


### PR DESCRIPTION
## Description

We are using a deprecated GH action that will stop working soon: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Seems to already be failing on some PRs: https://github.com/clerk/javascript/actions/runs/12811667573/job/35721593254?pr=4788

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
