### PR TITLE
chore(react-router): Bump `react-router` peer dependency

### DIFF
--- a/.changeset/thin-laws-lie.md
+++ b/.changeset/thin-laws-lie.md
@@ -2,4 +2,4 @@
 "@clerk/react-router": minor
 ---
 
-Bump `react-router` peer dependency to `^7.1.2` for upstream context mismatch fix
+Bump `react-router` peer dependency to `^7.1.2` as this version fixes [React context mismatches](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v712)

--- a/.changeset/thin-laws-lie.md
+++ b/.changeset/thin-laws-lie.md
@@ -1,0 +1,5 @@
+---
+"@clerk/react-router": minor
+---
+
+Bump `react-router` peer dependency to `^7.1.2` for upstream context mismatch fix

--- a/integration/templates/react-router-library/package.json
+++ b/integration/templates/react-router-library/package.json
@@ -12,7 +12,7 @@
     "@clerk/react-router": "^0.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.0.2"
+    "react-router": "^7.1.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/integration/templates/react-router-node/package.json
+++ b/integration/templates/react-router-node/package.json
@@ -10,15 +10,15 @@
   },
   "dependencies": {
     "@clerk/react-router": "latest",
-    "@react-router/node": "^7.0.2",
-    "@react-router/serve": "^7.0.2",
+    "@react-router/node": "^7.1.2",
+    "@react-router/serve": "^7.1.2",
     "isbot": "^5.1.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.0.2"
+    "react-router": "^7.1.2"
   },
   "devDependencies": {
-    "@react-router/dev": "^7.0.2",
+    "@react-router/dev": "^7.1.2",
     "@types/node": "^20",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -31,7 +31,7 @@
 
 ### Prerequisites
 
-- React Router `^7.0.2` or later
+- React Router `^7.1.2` or later
 - React 18 or later
 - Node.js `>=20.0.0` or later
 - An existing Clerk application. [Create your account for free](https://dashboard.clerk.com/sign-up?utm_source=github&utm_medium=clerk_react-router).

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -83,12 +83,12 @@
     "@clerk/eslint-config-custom": "workspace:*",
     "@types/cookie": "^0.6.0",
     "esbuild-plugin-file-path-extensions": "^2.1.3",
-    "react-router": "7.0.2"
+    "react-router": "7.1.2"
   },
   "peerDependencies": {
     "react": "catalog:peer-react",
     "react-dom": "catalog:peer-react",
-    "react-router": "^7.0.2"
+    "react-router": "^7.1.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/playground/react-router/package.json
+++ b/playground/react-router/package.json
@@ -10,15 +10,15 @@
   },
   "dependencies": {
     "@clerk/react-router": "latest",
-    "@react-router/node": "^7.0.2",
-    "@react-router/serve": "^7.0.2",
+    "@react-router/node": "^7.1.2",
+    "@react-router/serve": "^7.1.2",
     "isbot": "^5.1.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.0.2"
+    "react-router": "^7.1.2"
   },
   "devDependencies": {
-    "@react-router/dev": "^7.0.2",
+    "@react-router/dev": "^7.1.2",
     "@types/node": "^20",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,8 +817,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3
       react-router:
-        specifier: 7.0.2
-        version: 7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.1.2
+        version: 7.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/remix:
     dependencies:
@@ -12440,8 +12440,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@7.0.2:
-    resolution: {integrity: sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==}
+  react-router@7.1.2:
+    resolution: {integrity: sha512-KeallSO30KLpIe/ZZqfk6pCJ1c+5JhMxl3SCS3Zx1LgaGuQbgLDmjuNi6KZ5LnAV9sWjbmBWGRw8Um/Pw6BExg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -29806,7 +29806,7 @@ snapshots:
       '@remix-run/router': 1.9.0
       react: 18.3.1
 
-  react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@types/cookie': 0.6.0
       cookie: 1.0.2


### PR DESCRIPTION
## Description

This PR bumps `react-router` peer dependency to [`^7.1.2`](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v712) for upstream context mismatch fix.

Fixes https://github.com/clerk/javascript/issues/4826

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
