### PR TITLE
fix(clerk-js): Do not use CF proxy as fallback for challenges.cloudflare.com

### DIFF
--- a/.changeset/yellow-cycles-invent.md
+++ b/.changeset/yellow-cycles-invent.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Stop falling back to the Clerk proxy worker if turnstile fails to load as it is not as accurate as challenges.cloudflare.com

--- a/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
+++ b/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
@@ -12,14 +12,13 @@ export class CaptchaChallenge {
    * always use the fallback key.
    */
   public async invisible() {
-    const { captchaSiteKey, canUseCaptcha, captchaURL, captchaPublicKeyInvisible } = retrieveCaptchaInfo(this.clerk);
+    const { captchaSiteKey, canUseCaptcha, captchaPublicKeyInvisible } = retrieveCaptchaInfo(this.clerk);
 
-    if (canUseCaptcha && captchaSiteKey && captchaURL && captchaPublicKeyInvisible) {
+    if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       return getCaptchaToken({
         siteKey: captchaPublicKeyInvisible,
         invisibleSiteKey: captchaPublicKeyInvisible,
         widgetType: 'invisible',
-        scriptUrl: captchaURL,
         captchaProvider: 'turnstile',
       }).catch(e => {
         if (e.captchaError) {
@@ -41,15 +40,14 @@ export class CaptchaChallenge {
    * Managed challenged start as non-interactive and escalate to interactive if necessary.
    */
   public async managedOrInvisible(opts?: Partial<CaptchaOptions>) {
-    const { captchaSiteKey, canUseCaptcha, captchaURL, captchaWidgetType, captchaProvider, captchaPublicKeyInvisible } =
+    const { captchaSiteKey, canUseCaptcha, captchaWidgetType, captchaProvider, captchaPublicKeyInvisible } =
       retrieveCaptchaInfo(this.clerk);
 
-    if (canUseCaptcha && captchaSiteKey && captchaURL && captchaPublicKeyInvisible) {
+    if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       return getCaptchaToken({
         siteKey: captchaSiteKey,
         widgetType: captchaWidgetType,
         invisibleSiteKey: captchaPublicKeyInvisible,
-        scriptUrl: captchaURL,
         captchaProvider,
         ...opts,
       }).catch(e => {

--- a/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
@@ -1,9 +1,7 @@
 import type { Clerk } from '../../core/clerk';
-import { createFapiClient } from '../../core/fapiClient';
 
 export const retrieveCaptchaInfo = (clerk: Clerk) => {
   const _environment = clerk.__unstable__environment;
-  const fapiClient = createFapiClient(clerk);
   const captchaProvider = _environment ? _environment.displayConfig.captchaProvider : 'turnstile';
 
   return {
@@ -12,12 +10,5 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
     captchaProvider,
     captchaPublicKeyInvisible: _environment ? _environment.displayConfig.captchaPublicKeyInvisible : null,
     canUseCaptcha: _environment ? _environment.userSettings.signUp.captcha_enabled && clerk.isStandardBrowser : null,
-    captchaURL: fapiClient
-      .buildUrl({
-        path: 'cloudflare/turnstile/v0/api.js',
-        pathPrefix: '',
-        search: '?render=explicit',
-      })
-      .toString(),
   };
 };

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -78,13 +78,11 @@ export const shouldRetryTurnstileErrorCode = (errorCode: string) => {
   return !!codesWithRetries.find(w => errorCode.startsWith(w));
 };
 
-async function loadCaptcha(fallbackUrl: string) {
+async function loadCaptcha() {
   if (!window.turnstile) {
-    await loadCaptchaFromCloudflareURL()
-      .catch(() => loadCaptchaFromFAPIProxiedURL(fallbackUrl))
-      .catch(() => {
-        throw { captchaError: 'captcha_script_failed_to_load' };
-      });
+    await loadCaptchaFromCloudflareURL().catch(() => {
+      throw { captchaError: 'captcha_script_failed_to_load' };
+    });
   }
   return window.turnstile;
 }
@@ -100,16 +98,6 @@ async function loadCaptchaFromCloudflareURL() {
   }
 }
 
-async function loadCaptchaFromFAPIProxiedURL(fallbackUrl: string) {
-  try {
-    return await loadScript(fallbackUrl, { defer: true });
-  } catch (err) {
-    // Rethrow with specific message
-    console.error('Clerk: Failed to load the CAPTCHA script from the URL: ', fallbackUrl);
-    throw err;
-  }
-}
-
 /*
  * How this function works:
  * The widgetType is either 'invisible' or 'smart'.
@@ -118,9 +106,9 @@ async function loadCaptchaFromFAPIProxiedURL(fallbackUrl: string) {
  *  not exist, the invisibleSiteKey is used as a fallback and the widget is rendered in a hidden div at the bottom of the body.
  */
 export const getTurnstileToken = async (opts: CaptchaOptions) => {
-  const { siteKey, scriptUrl, widgetType, invisibleSiteKey } = opts;
+  const { siteKey, widgetType, invisibleSiteKey } = opts;
   const { modalContainerQuerySelector, modalWrapperQuerySelector, closeModal, openModal } = opts;
-  const captcha: Turnstile = await loadCaptcha(scriptUrl);
+  const captcha: Turnstile = await loadCaptcha();
   const errorCodes: (string | number)[] = [];
 
   let captchaToken = '';

--- a/packages/clerk-js/src/utils/captcha/types.ts
+++ b/packages/clerk-js/src/utils/captcha/types.ts
@@ -2,7 +2,6 @@ import type { CaptchaProvider, CaptchaWidgetType } from '@clerk/types';
 
 export type CaptchaOptions = {
   siteKey: string;
-  scriptUrl: string;
   widgetType: CaptchaWidgetType;
   invisibleSiteKey: string;
   captchaProvider: CaptchaProvider;


### PR DESCRIPTION
## Description

The turnstile script now returns 403 if proxied through the worker. This is a change on the CF side, so we: 

1. removed the code from the worker
2. removed the fallback logic from clerkjs
3. if challenges.cloudflare.com fails, then the clerkjs will send a captha_error payload instead of falling back to the proxy


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
