### PR TITLE
fix(clerk-js): Fix layout shift when Smart CAPTCHA executes an interactive challenge

### DIFF
--- a/.changeset/tough-suns-sparkle.md
+++ b/.changeset/tough-suns-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix layout shift when Smart CAPTCHA is about to execute.

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -4,6 +4,6 @@ import { Box } from '../customizables';
 export const CaptchaElement = () => (
   <Box
     id={CAPTCHA_ELEMENT_ID}
-    sx={t => ({ display: 'none', marginBottom: t.space.$6, alignSelf: 'center' })}
+    sx={{ display: 'block', alignSelf: 'center' }}
   />
 );

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -4,6 +4,6 @@ import { Box } from '../customizables';
 export const CaptchaElement = () => (
   <Box
     id={CAPTCHA_ELEMENT_ID}
-    sx={{ display: 'block', alignSelf: 'center' }}
+    sx={{ display: 'block', alignSelf: 'center', maxHeight: '0' }}
   />
 );

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -173,6 +173,8 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
             } else {
               const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
               if (visibleWidget) {
+                visibleWidget.style.maxHeight = 'unset';
+                visibleWidget.style.minHeight = '68px';
                 visibleWidget.style.marginBottom = '1.5rem';
               }
             }
@@ -226,6 +228,12 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
     const invisibleWidget = document.querySelector(`.${CAPTCHA_INVISIBLE_CLASSNAME}`);
     if (invisibleWidget) {
       document.body.removeChild(invisibleWidget);
+    }
+    const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
+    if (visibleWidget) {
+      visibleWidget.style.maxHeight = '0';
+      visibleWidget.style.minHeight = 'unset';
+      visibleWidget.style.marginBottom = 'unset';
     }
   }
 

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -174,7 +174,7 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
               const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
               if (visibleWidget) {
                 visibleWidget.style.maxHeight = 'unset';
-                visibleWidget.style.minHeight = '68px';
+                visibleWidget.style.minHeight = '68px'; // this is the height of the Turnstile widget
                 visibleWidget.style.marginBottom = '1.5rem';
               }
             }

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -136,7 +136,6 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
     if (visibleDiv) {
       captchaWidgetType = 'smart';
       widgetContainerQuerySelector = `#${CAPTCHA_ELEMENT_ID}`;
-      visibleDiv.style.display = 'block';
     } else {
       console.error(
         'Cannot initialize Smart CAPTCHA widget because the `clerk-captcha` DOM element was not found; falling back to Invisible CAPTCHA widget. If you are using a custom flow, visit https://clerk.com/docs/custom-flows/bot-sign-up-protection for instructions',
@@ -166,12 +165,16 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
             closeModal?.();
             resolve([token, id]);
           },
-          'before-interactive-callback': async () => {
+          'before-interactive-callback': () => {
             if (modalWrapperQuerySelector) {
               const el = document.querySelector(modalWrapperQuerySelector) as HTMLElement;
               el?.style.setProperty('visibility', 'visible');
               el?.style.setProperty('pointer-events', 'all');
-              return;
+            } else {
+              const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
+              if (visibleWidget) {
+                visibleWidget.style.marginBottom = '1.5rem';
+              }
             }
           },
           'error-callback': function (errorCode) {
@@ -223,10 +226,6 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
     const invisibleWidget = document.querySelector(`.${CAPTCHA_INVISIBLE_CLASSNAME}`);
     if (invisibleWidget) {
       document.body.removeChild(invisibleWidget);
-    }
-    const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
-    if (visibleWidget) {
-      visibleWidget.style.display = 'none';
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes the layout shift caused by the Turnstile script, especially when in Smart mode there was no interactive challenge.

Before (Smart without interaction):

https://github.com/user-attachments/assets/ec682c00-8d0a-4284-b30c-14bc924158b3

After (Smart without interaction):

https://github.com/user-attachments/assets/230aa11e-6fb2-4e5e-973b-d2d0d30aca93

After (Smart with interaction):

https://github.com/user-attachments/assets/4092672d-dfd8-449b-b6d9-0de8c347b9aa


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
