### PR TITLE
fix(clerk-js): Fix Smart Bot Protection in development instances

### DIFF
--- a/.changeset/brown-feet-perform.md
+++ b/.changeset/brown-feet-perform.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Fix Smart CAPTCHA on development instances
+Fix Smart Bot protection on development instances

--- a/.changeset/brown-feet-perform.md
+++ b/.changeset/brown-feet-perform.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix Smart CAPTCHA on development instances

--- a/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
@@ -10,11 +10,7 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
     captchaWidgetType: _environment ? _environment.displayConfig.captchaWidgetType : null,
     captchaProvider,
     captchaPublicKeyInvisible: _environment ? _environment.displayConfig.captchaPublicKeyInvisible : null,
-    canUseCaptcha: _environment
-      ? _environment.userSettings.signUp.captcha_enabled &&
-        clerk.isStandardBrowser &&
-        clerk.instanceType === 'production'
-      : null,
+    canUseCaptcha: _environment ? _environment.userSettings.signUp.captcha_enabled && clerk.isStandardBrowser : null,
     captchaURL: fapiClient
       .buildUrl({
         path: captchaProvider == 'hcaptcha' ? 'hcaptcha/1/api.js' : 'cloudflare/turnstile/v0/api.js',


### PR DESCRIPTION
## Description

Smart Bot Protection on development instances that use Core 1 does not work as expected. This is because we run Turnstile only if the instance is a production instance. This was changed in Core 2, but this change should have been backported to Core 1 too.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
