### PR TITLE
fix(clerk-js): Use modal props for modal methods

### DIFF
--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -156,7 +156,7 @@ export interface Clerk {
    * Opens the Clerk SignIn component in a modal.
    * @param props Optional sign in configuration parameters.
    */
-  openSignIn: (props?: SignInProps) => void;
+  openSignIn: (props?: SignInModalProps) => void;
 
   /**
    * Closes the Clerk SignIn modal.
@@ -190,7 +190,7 @@ export interface Clerk {
    * Opens the Clerk SignUp component in a modal.
    * @param props Optional props that will be passed to the SignUp component.
    */
-  openSignUp: (props?: SignUpProps) => void;
+  openSignUp: (props?: SignUpModalProps) => void;
 
   /**
    * Closes the Clerk SignUp modal.
@@ -201,7 +201,7 @@ export interface Clerk {
    * Opens the Clerk UserProfile modal.
    * @param props Optional props that will be passed to the UserProfile component.
    */
-  openUserProfile: (props?: UserProfileProps) => void;
+  openUserProfile: (props?: UserProfileModalProps) => void;
 
   /**
    * Closes the Clerk UserProfile modal.
@@ -212,7 +212,7 @@ export interface Clerk {
    * Opens the Clerk OrganizationProfile modal.
    * @param props Optional props that will be passed to the OrganizationProfile component.
    */
-  openOrganizationProfile: (props?: OrganizationProfileProps) => void;
+  openOrganizationProfile: (props?: OrganizationProfileModalProps) => void;
 
   /**
    * Closes the Clerk OrganizationProfile modal.
@@ -223,7 +223,7 @@ export interface Clerk {
    * Opens the Clerk CreateOrganization modal.
    * @param props Optional props that will be passed to the CreateOrganization component.
    */
-  openCreateOrganization: (props?: CreateOrganizationProps) => void;
+  openCreateOrganization: (props?: CreateOrganizationModalProps) => void;
 
   /**
    * Closes the Clerk CreateOrganization modal.
@@ -234,7 +234,7 @@ export interface Clerk {
    * Opens the Clerk Waitlist modal.
    * @param props Optional props that will be passed to the Waitlist component.
    */
-  openWaitlist: (props?: WaitlistProps) => void;
+  openWaitlist: (props?: WaitlistModalProps) => void;
 
   /**
    * Closes the Clerk Waitlist modal.


### PR DESCRIPTION
## Description

With the current types, routing options are available in the modal methods which is not relevant in modal usage. This PR updates the types to use the modal specific types which does not include routing or path.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
