### PR TITLE
fix(clerk-js): Ensure callback is called when adding a MFA phone number

### DIFF
--- a/.changeset/friendly-owls-jump.md
+++ b/.changeset/friendly-owls-jump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an infinite loading state happening when successfully adding 2FA via the security tab within `<UserProfile />`.

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodeScreen.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodeScreen.tsx
@@ -41,7 +41,7 @@ export const MfaPhoneCodeScreen = withCardStateProvider((props: MfaPhoneCodeScre
       <MFAVerifyPhone
         title={localizationKeys('userProfile.mfaPhoneCodePage.title')}
         resourceRef={ref}
-        onSuccess={() => (isInstanceWithBackupCodes ? wizard.goToStep(3) : onSuccess)}
+        onSuccess={() => (isInstanceWithBackupCodes ? wizard.goToStep(3) : onSuccess())}
         onReset={() => wizard.goToStep(2)}
       />
       <AddMfa


### PR DESCRIPTION
## Description

There's an infinite loading state happening when successfully adding 2FA via the security tab on the <UserButton/> component.

Fixes SDK-2034

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
