### PR TITLE
feat(clerk-js,types,localizations): Search members on `OrganizationProfile`

### DIFF
--- a/.changeset/poor-rockets-look.md
+++ b/.changeset/poor-rockets-look.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Introduced searching for members list on `OrganizationProfile`

--- a/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
+++ b/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
@@ -19,9 +19,9 @@ export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
 
   const enterExitAnimation: ThemableCssProp = t => ({
     animation:
-      !shouldAnimate || prefersReducedMotion
-        ? 'none'
-        : `${animations.notificationAnimation} ${t.transitionDuration.$textField} ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
+      shouldAnimate && !prefersReducedMotion
+        ? `${animations.notificationAnimation} ${t.transitionDuration.$textField} ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`
+        : 'none',
   });
 
   return (

--- a/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
+++ b/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
@@ -7,19 +7,21 @@ import { animations } from '../styledSystem';
 type NotificationCountBadgeProps = PropsOfComponent<typeof NotificationBadge> & {
   notificationCount: number;
   containerSx?: ThemableCssProp;
+  shouldAnimate?: boolean;
 };
 
 export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
-  const { notificationCount, containerSx, ...restProps } = props;
+  const { notificationCount, containerSx, shouldAnimate = true, ...restProps } = props;
   const prefersReducedMotion = usePrefersReducedMotion();
   const { t } = useLocalizations();
   const localeKey = t(localizationKeys('locale'));
   const formattedNotificationCount = formatToCompactNumber(notificationCount, localeKey);
 
   const enterExitAnimation: ThemableCssProp = t => ({
-    animation: prefersReducedMotion
-      ? 'none'
-      : `${animations.notificationAnimation} ${t.transitionDuration.$textField} ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
+    animation:
+      !shouldAnimate || prefersReducedMotion
+        ? 'none'
+        : `${animations.notificationAnimation} ${t.transitionDuration.$textField} ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
   });
 
   return (

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -44,7 +44,6 @@ export const ActiveMembersList = ({ memberships, pageSize }: ActiveMembersListPr
       pageCount={memberships?.pageCount || 0}
       itemsPerPage={pageSize}
       isLoading={(memberships?.isLoading && !memberships?.data) || loadingRoles}
-      // TODO -> Add new localization key with search query - eg: "No members to display for 'foo'"
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -43,7 +43,7 @@ export const ActiveMembersList = ({ memberships, pageSize }: ActiveMembersListPr
       itemCount={memberships?.count || 0}
       pageCount={memberships?.pageCount || 0}
       itemsPerPage={pageSize}
-      isLoading={(memberships?.isLoading && !memberships?.data) || loadingRoles}
+      isLoading={(memberships?.isLoading && !memberships?.data.length) || loadingRoles}
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -44,6 +44,7 @@ export const ActiveMembersList = ({ memberships, pageSize }: ActiveMembersListPr
       pageCount={memberships?.pageCount || 0}
       itemsPerPage={pageSize}
       isLoading={(memberships?.isLoading && !memberships?.data) || loadingRoles}
+      // TODO -> Add new localization key with search query - eg: "No members to display for 'foo'"
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -8,13 +8,12 @@ import { useFetchRoles, useLocalizeCustomRoles } from '../../hooks/useFetchRoles
 import { handleError } from '../../utils';
 import { DataTable, RoleSelect, RowContainer } from './MemberListTable';
 
-const pageSize = 10;
-
 type ActiveMembersListProps = {
   memberships: ReturnType<typeof useOrganization>['memberships'];
+  pageSize: number;
 };
 
-export const ActiveMembersList = ({ memberships }: ActiveMembersListProps) => {
+export const ActiveMembersList = ({ memberships, pageSize }: ActiveMembersListProps) => {
   const card = useCardState();
   const { organization } = useOrganization();
 
@@ -44,7 +43,7 @@ export const ActiveMembersList = ({ memberships }: ActiveMembersListProps) => {
       itemCount={memberships?.count || 0}
       pageCount={memberships?.pageCount || 0}
       itemsPerPage={pageSize}
-      isLoading={memberships?.isLoading || loadingRoles}
+      isLoading={(memberships?.isLoading && !memberships?.data) || loadingRoles}
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -8,16 +8,15 @@ import { useFetchRoles, useLocalizeCustomRoles } from '../../hooks/useFetchRoles
 import { handleError } from '../../utils';
 import { DataTable, RoleSelect, RowContainer } from './MemberListTable';
 
-const membershipsParams = {
-  memberships: {
-    pageSize: 10,
-    keepPreviousData: true,
-  },
+const pageSize = 10;
+
+type ActiveMembersListProps = {
+  memberships: ReturnType<typeof useOrganization>['memberships'];
 };
 
-export const ActiveMembersList = () => {
+export const ActiveMembersList = ({ memberships }: ActiveMembersListProps) => {
   const card = useCardState();
-  const { organization, memberships } = useOrganization(membershipsParams);
+  const { organization } = useOrganization();
 
   const { options, isLoading: loadingRoles } = useFetchRoles();
 
@@ -44,7 +43,7 @@ export const ActiveMembersList = () => {
       onPageChange={n => memberships?.fetchPage?.(n)}
       itemCount={memberships?.count || 0}
       pageCount={memberships?.pageCount || 0}
-      itemsPerPage={membershipsParams.memberships.pageSize}
+      itemsPerPage={pageSize}
       isLoading={memberships?.isLoading || loadingRoles}
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.detailsTitle__emptyRow')}
       headers={[

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -4,20 +4,24 @@ import { Animated } from '../../elements';
 import { Action } from '../../elements/Action';
 import { InviteMembersScreen } from './InviteMembersScreen';
 
-export const MembersActionsRow = () => {
+type MembersActionsRowProps = {
+  actionSlot: React.ReactNode;
+};
+
+export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
   const canManageMemberships = useProtect({ permission: 'org:sys_memberships:manage' });
 
   return (
     <Action.Root animate={false}>
       <Animated asChild>
         <Flex
-          justify='end'
+          justify={actionSlot ? undefined : 'end'}
           sx={t => ({
-            // TODO  - See if this would break the component in other places
-            marginLeft: 'auto',
             padding: `${t.space.$none} ${t.space.$1}`,
           })}
+          gap={actionSlot ? 2 : undefined}
         >
+          {actionSlot}
           {canManageMemberships && (
             <Action.Trigger value='invite'>
               <Button

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -13,7 +13,7 @@ export const MembersActionsRow = () => {
         <Flex
           justify='end'
           sx={t => ({
-            width: '100%',
+            // TODO  - See if this would break the component in other places
             marginLeft: 'auto',
             padding: `${t.space.$none} ${t.space.$1}`,
           })}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -5,7 +5,7 @@ import { Action } from '../../elements/Action';
 import { InviteMembersScreen } from './InviteMembersScreen';
 
 type MembersActionsRowProps = {
-  actionSlot: React.ReactNode;
+  actionSlot?: React.ReactNode;
 };
 
 export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
@@ -15,8 +15,10 @@ export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
     <Action.Root animate={false}>
       <Animated asChild>
         <Flex
-          justify={actionSlot ? undefined : 'end'}
+          justify={actionSlot ? 'between' : 'end'}
           sx={t => ({
+            width: '100%',
+            marginLeft: 'auto',
             padding: `${t.space.$none} ${t.space.$1}`,
           })}
           gap={actionSlot ? 2 : undefined}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -25,7 +25,10 @@ export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
         >
           {actionSlot}
           {canManageMemberships && (
-            <Action.Trigger value='invite'>
+            <Action.Trigger
+              value='invite'
+              hideOnActive={!actionSlot}
+            >
               <Button
                 elementDescriptor={descriptors.membersPageInviteButton}
                 aria-label='Invite'

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -1,13 +1,14 @@
 import { useOrganization } from '@clerk/shared/react';
 import { useState } from 'react';
 
-import { Flex } from '../../../ui/customizables';
+import { Flex, localizationKeys, useLocalizations } from '../../../ui/customizables';
 import { Animated, InputWithIcon } from '../../../ui/elements';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
 
 export const MembersSearch = () => {
   const [query, setQuery] = useState<string>();
+  const { t } = useLocalizations();
 
   const { memberships } = useOrganization({
     memberships: {
@@ -16,23 +17,20 @@ export const MembersSearch = () => {
   });
 
   /* TODO - Only fire update once the user stops typing */
-  /* TODO - Consider how it'll overlap the invite input */
-  const handleSearch = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(event?.target.value);
   };
 
-  // TODO - Add descriptors
   return (
     <Animated asChild>
       <Flex sx={{ width: '100%', '& div': { width: '100%' } }}>
         <InputWithIcon
-          // TODO - Add translation keys
-          placeholder='Search'
-          aria-label='Search'
-          leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
+          type='search'
           autoCapitalize='none'
           spellCheck={false}
-          type='search'
+          aria-label='Search'
+          placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
+          leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
           onChange={handleSearch}
         />
       </Flex>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -3,12 +3,14 @@ import { useState } from 'react';
 
 import { Flex, localizationKeys, useLocalizations } from '../../../ui/customizables';
 import { Animated, InputWithIcon } from '../../../ui/elements';
+import { useDebounce } from '../../../ui/hooks';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
 
 export const MembersSearch = () => {
-  const [query, setQuery] = useState<string>();
   const { t } = useLocalizations();
+  const [search, setSearch] = useState('');
+  const query = useDebounce(search, 500);
 
   const { memberships } = useOrganization({
     memberships: {
@@ -16,14 +18,13 @@ export const MembersSearch = () => {
     },
   });
 
-  /* TODO - Only fire update once the user stops typing */
   const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(event?.target.value);
+    setSearch(event.target.value);
   };
 
   return (
     <Animated asChild>
-      <Flex sx={{ width: '100%', '& div': { width: '100%' } }}>
+      <Flex sx={{ width: '100%' }}>
         <InputWithIcon
           type='search'
           autoCapitalize='none'
@@ -32,6 +33,7 @@ export const MembersSearch = () => {
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
           leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
           onChange={handleSearch}
+          containerSx={{ width: '100%' }}
         />
       </Flex>
     </Animated>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -1,0 +1,35 @@
+import { useOrganization } from '@clerk/shared/react';
+import { useState } from 'react';
+
+import { InputWithIcon } from '../../../ui/elements';
+import { MagnifyingGlass } from '../../../ui/icons';
+import { Spinner } from '../../../ui/primitives';
+
+export const MembersSearchRow = () => {
+  const [query, setQuery] = useState<string>();
+
+  const { memberships } = useOrganization({
+    memberships: {
+      query,
+    },
+  });
+
+  /* TODO - Only fire update once the user stops typing */
+  /* TODO - Consider how it'll overlap the invite input */
+  const handleSearch = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event?.target.value);
+  };
+
+  return (
+    <InputWithIcon
+      // TODO - Add translation keys
+      placeholder='Search'
+      aria-label='Search'
+      leftIcon={memberships?.isFetching ? <MagnifyingGlass /> : <Spinner />}
+      autoCapitalize='none'
+      spellCheck={false}
+      type='search'
+      onChange={handleSearch}
+    />
+  );
+};

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -36,7 +36,6 @@ const membersSearchDebounceMs = 500;
 export const MembersSearch = ({ query, value, memberships, onSearchChange, onQueryTrigger }: MembersSearchProps) => {
   const { t } = useLocalizations();
 
-  const inputRef = useRef<HTMLInputElement | null>(null);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -81,7 +80,6 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
       <Flex sx={{ width: '100%' }}>
         <InputWithIcon
           value={value}
-          ref={inputRef}
           type='search'
           autoCapitalize='none'
           spellCheck={false}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -8,9 +8,10 @@ import { Spinner } from '../../../ui/primitives';
 type MembersSearchProps = {
   isLoading: boolean;
   onChange: (query: string) => void;
+  debounceMs?: number;
 };
 
-export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
+export const MembersSearch = ({ isLoading, onChange, debounceMs = 500 }: MembersSearchProps) => {
   const { t } = useLocalizations();
   const [search, setSearch] = useState('');
 
@@ -21,7 +22,7 @@ export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
     setSearch(event.target.value);
   };
 
-  // Updates query state to trigger query only once user stops typing
+  // Updates query state to trigger change handler only once user stops typing
   useEffect(() => {
     if (!inputRef.current) {
       return;
@@ -36,7 +37,7 @@ export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
 
         debounceTimer.current = setTimeout(() => {
           onChange(search.trim());
-        }, 500);
+        }, debounceMs);
       },
       {
         signal: controller.signal,
@@ -46,7 +47,7 @@ export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
     return () => {
       controller.abort();
     };
-  }, [search]);
+  }, [search, debounceMs, onChange]);
 
   return (
     <Animated asChild>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -1,11 +1,12 @@
 import { useOrganization } from '@clerk/shared/react';
 import { useState } from 'react';
 
-import { InputWithIcon } from '../../../ui/elements';
+import { Flex } from '../../../ui/customizables';
+import { Animated, InputWithIcon } from '../../../ui/elements';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
 
-export const MembersSearchRow = () => {
+export const MembersSearch = () => {
   const [query, setQuery] = useState<string>();
 
   const { memberships } = useOrganization({
@@ -20,16 +21,21 @@ export const MembersSearchRow = () => {
     setQuery(event?.target.value);
   };
 
+  // TODO - Add descriptors
   return (
-    <InputWithIcon
-      // TODO - Add translation keys
-      placeholder='Search'
-      aria-label='Search'
-      leftIcon={memberships?.isFetching ? <MagnifyingGlass /> : <Spinner />}
-      autoCapitalize='none'
-      spellCheck={false}
-      type='search'
-      onChange={handleSearch}
-    />
+    <Animated asChild>
+      <Flex sx={{ width: '100%', '& div': { width: '100%' } }}>
+        <InputWithIcon
+          // TODO - Add translation keys
+          placeholder='Search'
+          aria-label='Search'
+          leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
+          autoCapitalize='none'
+          spellCheck={false}
+          type='search'
+          onChange={handleSearch}
+        />
+      </Flex>
+    </Animated>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -85,10 +85,9 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
           spellCheck={false}
           aria-label='Search'
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
-          leftIcon={isFetchingNewData ? <Spinner /> : <MagnifyingGlass />}
+          leftIcon={isFetchingNewData ? <Spinner size='xs' /> : <MagnifyingGlass />}
           onKeyUp={handleKeyUp}
           onChange={handleChange}
-          containerSx={{ width: '100%' }}
         />
       </Flex>
     </Animated>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -1,39 +1,68 @@
 import { useOrganization } from '@clerk/shared/react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Flex, localizationKeys, useLocalizations } from '../../../ui/customizables';
 import { Animated, InputWithIcon } from '../../../ui/elements';
-import { useDebounce } from '../../../ui/hooks';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
 
 export const MembersSearch = () => {
   const { t } = useLocalizations();
   const [search, setSearch] = useState('');
-  const query = useDebounce(search, 500);
+  const [query, setQuery] = useState('');
 
-  // TODO (perf) -> Only trigger query once user stops typing
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const debounceTimer = useRef<NodeJS.Timeout | undefined>();
+
   const { memberships } = useOrganization({
     memberships: {
       query,
     },
   });
 
-  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
   };
+
+  // Updates query state to trigger query only once user stops typing
+  useEffect(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    inputRef.current.addEventListener(
+      'keyup',
+      () => {
+        clearTimeout(debounceTimer.current);
+
+        debounceTimer.current = setTimeout(() => {
+          setQuery(search);
+        }, 500);
+      },
+      {
+        signal: controller.signal,
+      },
+    );
+
+    return () => {
+      controller.abort();
+    };
+  }, [search]);
 
   return (
     <Animated asChild>
       <Flex sx={{ width: '100%' }}>
         <InputWithIcon
+          ref={inputRef}
           type='search'
           autoCapitalize='none'
           spellCheck={false}
           aria-label='Search'
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
           leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
-          onChange={handleSearch}
+          onChange={handleChange}
           containerSx={{ width: '100%' }}
         />
       </Flex>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -43,8 +43,8 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
     onSearchChange(event.target.value);
   };
 
-  // Trigger the `query` change on a parent component in order to
-  // refetch organization memberships once the user stops typing
+  // Debounce the input value changes until the user stops typing
+  // and trigger the `query` param setter
   useEffect(() => {
     if (!inputRef.current) {
       return;
@@ -91,6 +91,7 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
     <Animated asChild>
       <Flex sx={{ width: '100%' }}>
         <InputWithIcon
+          value={value}
           ref={inputRef}
           type='search'
           autoCapitalize='none'

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -1,4 +1,3 @@
-import { useOrganization } from '@clerk/shared/react';
 import { useEffect, useRef, useState } from 'react';
 
 import { Flex, localizationKeys, useLocalizations } from '../../../ui/customizables';
@@ -6,19 +5,17 @@ import { Animated, InputWithIcon } from '../../../ui/elements';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
 
-export const MembersSearch = () => {
+type MembersSearchProps = {
+  isLoading: boolean;
+  onChange: (query: string) => void;
+};
+
+export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
   const { t } = useLocalizations();
   const [search, setSearch] = useState('');
-  const [query, setQuery] = useState('');
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const debounceTimer = useRef<NodeJS.Timeout | undefined>();
-
-  const { memberships } = useOrganization({
-    memberships: {
-      query,
-    },
-  });
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
@@ -38,7 +35,7 @@ export const MembersSearch = () => {
         clearTimeout(debounceTimer.current);
 
         debounceTimer.current = setTimeout(() => {
-          setQuery(search);
+          onChange(search);
         }, 500);
       },
       {
@@ -61,7 +58,7 @@ export const MembersSearch = () => {
           spellCheck={false}
           aria-label='Search'
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
-          leftIcon={memberships?.isFetching ? <Spinner /> : <MagnifyingGlass />}
+          leftIcon={isLoading ? <Spinner /> : <MagnifyingGlass />}
           onChange={handleChange}
           containerSx={{ width: '100%' }}
         />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -12,6 +12,7 @@ export const MembersSearch = () => {
   const [search, setSearch] = useState('');
   const query = useDebounce(search, 500);
 
+  // TODO (perf) -> Only trigger query once user stops typing
   const { memberships } = useOrganization({
     memberships: {
       query,

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -2,7 +2,7 @@ import type { useOrganization } from '@clerk/shared/react';
 import type { GetMembersParams } from '@clerk/types';
 import { useEffect, useRef } from 'react';
 
-import { Flex, localizationKeys, useLocalizations } from '../../../ui/customizables';
+import { descriptors, Flex, Icon, localizationKeys, useLocalizations } from '../../../ui/customizables';
 import { Animated, InputWithIcon } from '../../../ui/elements';
 import { MagnifyingGlass } from '../../../ui/icons';
 import { Spinner } from '../../../ui/primitives';
@@ -85,9 +85,19 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
           spellCheck={false}
           aria-label='Search'
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
-          leftIcon={isFetchingNewData ? <Spinner size='xs' /> : <MagnifyingGlass />}
+          leftIcon={
+            isFetchingNewData ? (
+              <Spinner size='xs' />
+            ) : (
+              <Icon
+                icon={MagnifyingGlass}
+                elementDescriptor={descriptors.organizationProfileMembersSearchInputIcon}
+              />
+            )
+          }
           onKeyUp={handleKeyUp}
           onChange={handleChange}
+          elementDescriptor={descriptors.organizationProfileMembersSearchInput}
         />
       </Flex>
     </Animated>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -82,13 +82,13 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
         <InputWithIcon
           value={value}
           ref={inputRef}
-          onKeyUp={handleKeyUp}
           type='search'
           autoCapitalize='none'
           spellCheck={false}
           aria-label='Search'
           placeholder={t(localizationKeys('organizationProfile.membersPage.action__search'))}
           leftIcon={isFetchingNewData ? <Spinner /> : <MagnifyingGlass />}
+          onKeyUp={handleKeyUp}
           onChange={handleChange}
           containerSx={{ width: '100%' }}
         />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -35,7 +35,7 @@ export const MembersSearch = ({ isLoading, onChange }: MembersSearchProps) => {
         clearTimeout(debounceTimer.current);
 
         debounceTimer.current = setTimeout(() => {
-          onChange(search);
+          onChange(search.trim());
         }, 500);
       },
       {

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersSearch.tsx
@@ -40,11 +40,17 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
   const debounceTimer = useRef<NodeJS.Timeout | undefined>();
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onSearchChange(event.target.value);
+    const value = event.target.value;
+    onSearchChange(value);
+
+    const shouldClearQuery = value === '';
+    if (shouldClearQuery) {
+      onQueryTrigger(value);
+    }
   };
 
   // Debounce the input value changes until the user stops typing
-  // and trigger the `query` param setter
+  // to trigger the `query` param setter
   useEffect(() => {
     if (!inputRef.current) {
       return;
@@ -79,13 +85,12 @@ export const MembersSearch = ({ query, value, memberships, onSearchChange, onQue
     }
 
     const hasOnePageLeft = (memberships?.count ?? 0) <= ACTIVE_MEMBERS_PAGE_SIZE;
-
     if (hasOnePageLeft) {
       memberships?.fetchPage?.(1);
     }
   }, [query, memberships]);
 
-  const isFetchingNewData = !!memberships?.isLoading && !!memberships.data?.length;
+  const isFetchingNewData = value && !!memberships?.isLoading && !!memberships.data?.length;
 
   return (
     <Animated asChild>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -42,8 +42,6 @@ export const OrganizationMembers = withCardStateProvider(() => {
     invitations: canManageMemberships || undefined,
     memberships: canReadMemberships
       ? {
-          // Resets pagination offset when searching
-          pageSize: query ? undefined : ACTIVE_MEMBERS_PAGE_SIZE,
           keepPreviousData: true,
           query: query || undefined,
         }

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -34,7 +34,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
   const canReadMemberships = useProtect({ permission: 'org:sys_memberships:read' });
   const isDomainsEnabled = organizationSettings?.domains?.enabled && canManageMemberships;
 
-  const [query, setQuery] = useState<string>();
+  const [query, setQuery] = useState('');
   const [search, setSearch] = useState('');
 
   const { membershipRequests, memberships, invitations } = useOrganization({

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -40,6 +40,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
     invitations: canManageMemberships || undefined,
     memberships: canReadMemberships
       ? {
+          // Resets pagination offset when searching
           pageSize: membershipsQuery ? undefined : ACTIVE_MEMBERS_PAGE_SIZE,
           keepPreviousData: true,
           query: membershipsQuery || undefined,
@@ -47,7 +48,8 @@ export const OrganizationMembers = withCardStateProvider(() => {
       : undefined,
   });
 
-  // Resets pagination based on the number of items from a query term
+  // If searching does not happen on a initial page, resets pagination offset
+  // based on the response count
   useEffect(() => {
     if (!membershipsQuery || !memberships?.data) {
       return;
@@ -99,8 +101,9 @@ export const OrganizationMembers = withCardStateProvider(() => {
             <TabsList sx={t => ({ gap: t.space.$2 })}>
               {canReadMemberships && (
                 <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__members')}>
-                  {memberships?.data && !memberships.isLoading && (
+                  {!!memberships?.count && (
                     <NotificationCountBadge
+                      shouldAnimate={!membershipsQuery}
                       notificationCount={memberships.count}
                       colorScheme='outline'
                     />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -20,6 +20,7 @@ import { mqu } from '../../styledSystem';
 import { ActiveMembersList } from './ActiveMembersList';
 import { MembersActionsRow } from './MembersActions';
 import { MembershipWidget } from './MembershipWidget';
+import { MembersSearchRow } from './MembersSearch';
 import { OrganizationMembersTabInvitations } from './OrganizationMembersTabInvitations';
 import { OrganizationMembersTabRequests } from './OrganizationMembersTabRequests';
 
@@ -123,7 +124,23 @@ export const OrganizationMembers = withCardStateProvider(() => {
                         width: '100%',
                       }}
                     >
-                      <MembersActionsRow />
+                      <Flex
+                        sx={{
+                          width: '100%',
+
+                          gap: 2,
+                        }}
+                      >
+                        <Flex
+                          sx={t => ({
+                            flex: 1,
+                            paddingLeft: t.space.$1,
+                          })}
+                        >
+                          <MembersSearchRow />
+                        </Flex>
+                        <MembersActionsRow />
+                      </Flex>
                       <ActiveMembersList />
                     </Flex>
                   </Flex>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -35,7 +35,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
   const isDomainsEnabled = organizationSettings?.domains?.enabled && canManageMemberships;
 
   const [query, setQuery] = useState<string>();
-  const [search, setSearch] = useState<string>();
+  const [search, setSearch] = useState('');
 
   const { membershipRequests, memberships, invitations } = useOrganization({
     membershipRequests: isDomainsEnabled || undefined,
@@ -143,7 +143,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
                         actionSlot={
                           <MembersSearch
                             query={query}
-                            value={search ?? ''}
+                            value={search}
                             memberships={memberships}
                             onSearchChange={query => setSearch(query)}
                             onQueryTrigger={query => setQuery(query)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -20,7 +20,7 @@ import { mqu } from '../../styledSystem';
 import { ActiveMembersList } from './ActiveMembersList';
 import { MembersActionsRow } from './MembersActions';
 import { MembershipWidget } from './MembershipWidget';
-import { MembersSearchRow } from './MembersSearch';
+import { MembersSearch } from './MembersSearch';
 import { OrganizationMembersTabInvitations } from './OrganizationMembersTabInvitations';
 import { OrganizationMembersTabRequests } from './OrganizationMembersTabRequests';
 
@@ -124,23 +124,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
                         width: '100%',
                       }}
                     >
-                      <Flex
-                        sx={{
-                          width: '100%',
-
-                          gap: 2,
-                        }}
-                      >
-                        <Flex
-                          sx={t => ({
-                            flex: 1,
-                            paddingLeft: t.space.$1,
-                          })}
-                        >
-                          <MembersSearchRow />
-                        </Flex>
-                        <MembersActionsRow />
-                      </Flex>
+                      <MembersActionsRow actionSlot={<MembersSearch />} />
                       <ActiveMembersList />
                     </Flex>
                   </Flex>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -518,7 +518,7 @@ describe('OrganizationMembers', () => {
       await waitFor(async () =>
         expect(await findByRole('heading', { name: /invite new members/i })).toBeInTheDocument(),
       );
-      expect(inviteButton).not.toBeInTheDocument();
+      expect(inviteButton).toBeInTheDocument();
       await userEvent.click(getByRole('button', { name: 'Cancel' }));
 
       await waitFor(async () => expect(await findByRole('button', { name: 'Invite' })).toBeInTheDocument());

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
@@ -56,9 +56,7 @@ export const EmailForm = withCardStateProvider((props: EmailFormProps) => {
 
   return (
     <Wizard {...wizard.props}>
-      {/* Example of form */}
       <FormContainer
-        /* TODO - add translation keys -> organizationProfile.membersPage */
         headerTitle={localizationKeys('userProfile.emailAddressPage.title')}
         headerSubtitle={localizationKeys('userProfile.emailAddressPage.formHint')}
       >

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
@@ -56,7 +56,9 @@ export const EmailForm = withCardStateProvider((props: EmailFormProps) => {
 
   return (
     <Wizard {...wizard.props}>
+      {/* Example of form */}
       <FormContainer
+        /* TODO - add translation keys -> organizationProfile.membersPage */
         headerTitle={localizationKeys('userProfile.emailAddressPage.title')}
         headerSubtitle={localizationKeys('userProfile.emailAddressPage.formHint')}
       >

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -155,6 +155,9 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'organizationSwitcherPopoverActionButtonIcon',
   'organizationSwitcherPopoverFooter',
 
+  'organizationProfileMembersSearchInputIcon',
+  'organizationProfileMembersSearchInput',
+
   'organizationListPreviewItems',
   'organizationListPreviewItem',
   'organizationListPreviewButton',

--- a/packages/clerk-js/src/ui/elements/Action/ActionTrigger.tsx
+++ b/packages/clerk-js/src/ui/elements/Action/ActionTrigger.tsx
@@ -4,10 +4,11 @@ import { useActionContext } from './ActionRoot';
 
 type ActionTriggerProps = PropsWithChildren<{
   value: string;
+  hideOnActive?: boolean;
 }>;
 
 export const ActionTrigger = (props: ActionTriggerProps) => {
-  const { children, value } = props;
+  const { children, value, hideOnActive = true } = props;
   const { active, open } = useActionContext();
 
   const validChildren = Children.only(children);
@@ -15,7 +16,7 @@ export const ActionTrigger = (props: ActionTriggerProps) => {
     throw new Error('Children of ActionTrigger must be a valid element');
   }
 
-  if (active === value) {
+  if (hideOnActive && active === value) {
     return null;
   }
 

--- a/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
+++ b/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
@@ -18,9 +18,10 @@ export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIcon>((
           position: 'relative',
           '& .cl-internal-icon': {
             position: 'absolute',
-            left: theme.space.$4,
+            left: theme.space.$3x5,
             width: theme.sizes.$3x5,
             height: theme.sizes.$3x5,
+            pointerEvents: 'none',
           },
         },
         containerSx,

--- a/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
+++ b/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
@@ -1,33 +1,42 @@
 import React from 'react';
 
-import { Flex, Input } from '../customizables';
-import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
+import { Box, Flex, Input } from '../customizables';
+import type { PropsOfComponent } from '../styledSystem';
 
-type InputWithIcon = PropsOfComponent<typeof Input> & { leftIcon?: React.ReactElement } & {
-  containerSx?: ThemableCssProp;
-};
+type InputWithIcon = PropsOfComponent<typeof Input> & { leftIcon?: React.ReactElement };
 
 export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIcon>((props, ref) => {
-  const { leftIcon, sx, containerSx, ...rest } = props;
+  const { leftIcon, sx, ...rest } = props;
   return (
     <Flex
       center
-      sx={theme => [
-        {
-          width: '100%',
-          position: 'relative',
-          '& .cl-internal-icon': {
-            position: 'absolute',
-            left: theme.space.$3x5,
-            width: theme.sizes.$3x5,
-            height: theme.sizes.$3x5,
-            pointerEvents: 'none',
-          },
-        },
-        containerSx,
-      ]}
+      sx={{
+        width: '100%',
+        position: 'relative',
+      }}
     >
-      {leftIcon && React.cloneElement(leftIcon, { className: 'cl-internal-icon' })}
+      {leftIcon ? (
+        <Box
+          sx={theme => [
+            {
+              position: 'absolute',
+              left: theme.space.$3x5,
+              width: theme.sizes.$3x5,
+              height: theme.sizes.$3x5,
+              pointerEvents: 'none',
+              display: 'grid',
+              placeContent: 'center',
+              '& svg': {
+                position: 'absolute',
+                width: '100%',
+                height: '100%',
+              },
+            },
+          ]}
+        >
+          {leftIcon}
+        </Box>
+      ) : null}
       <Input
         {...rest}
         sx={[

--- a/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
+++ b/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
@@ -1,25 +1,30 @@
 import React from 'react';
 
 import { Flex, Input } from '../customizables';
-import type { PropsOfComponent } from '../styledSystem';
+import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 
-type InputWithIcon = PropsOfComponent<typeof Input> & { leftIcon?: React.ReactElement };
+type InputWithIcon = PropsOfComponent<typeof Input> & { leftIcon?: React.ReactElement } & {
+  containerSx?: ThemableCssProp;
+};
 
 export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIcon>((props, ref) => {
-  const { leftIcon, sx, ...rest } = props;
+  const { leftIcon, sx, containerSx, ...rest } = props;
   return (
     <Flex
       center
-      sx={theme => ({
-        width: '100%',
-        position: 'relative',
-        '& .cl-internal-icon': {
-          position: 'absolute',
-          left: theme.space.$4,
-          width: theme.sizes.$3x5,
-          height: theme.sizes.$3x5,
+      sx={theme => [
+        {
+          width: '100%',
+          position: 'relative',
+          '& .cl-internal-icon': {
+            position: 'absolute',
+            left: theme.space.$4,
+            width: theme.sizes.$3x5,
+            height: theme.sizes.$3x5,
+          },
         },
-      })}
+        containerSx,
+      ]}
     >
       {leftIcon && React.cloneElement(leftIcon, { className: 'cl-internal-icon' })}
       <Input

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -129,6 +129,7 @@ export const arSA: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'دعوة',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'إزالة عضو',
         tableHeader__actions: undefined,
@@ -449,6 +450,7 @@ export const arSA: LocalizationResource = {
       detailsLabel: 'نريد التحقق من هويتك قبل أعادة تعيين كلمة المرور',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'إنشاء حساب جديد',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'استخدم البريد الإلكتروني',
@@ -460,7 +462,6 @@ export const arSA: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'تسجيل الدخول',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'رمز التحقق',

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -450,7 +450,6 @@ export const arSA: LocalizationResource = {
       detailsLabel: 'نريد التحقق من هويتك قبل أعادة تعيين كلمة المرور',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'إنشاء حساب جديد',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'استخدم البريد الإلكتروني',
@@ -462,6 +461,7 @@ export const arSA: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'تسجيل الدخول',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'رمز التحقق',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -130,6 +130,7 @@ export const beBY: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Пригласить',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Удалить удзельніка',
         tableHeader__actions: 'Дзеянні',
@@ -454,6 +455,7 @@ export const beBY: LocalizationResource = {
       detailsLabel: 'Неабходна верыфікаваць вашу асобу перад аднаўленнем пароля',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Зарэгістравацца',
       actionLink__join_waitlist: 'Далучыцца да чаргі',
       actionLink__use_email: 'Выкарыстаць пошту',
@@ -465,7 +467,6 @@ export const beBY: LocalizationResource = {
       actionText__join_waitlist: 'Далучыцеся да чакання',
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Увайсці',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Код верыфікацыі',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -455,7 +455,6 @@ export const beBY: LocalizationResource = {
       detailsLabel: 'Неабходна верыфікаваць вашу асобу перад аднаўленнем пароля',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Зарэгістравацца',
       actionLink__join_waitlist: 'Далучыцца да чаргі',
       actionLink__use_email: 'Выкарыстаць пошту',
@@ -467,6 +466,7 @@ export const beBY: LocalizationResource = {
       actionText__join_waitlist: 'Далучыцеся да чакання',
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Увайсці',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Код верыфікацыі',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -450,7 +450,6 @@ export const bgBG: LocalizationResource = {
       detailsLabel: 'Трябва да потвърдим вашата самоличност, преди да нулираме паролата ви.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Регистрирайте се',
       actionLink__join_waitlist: 'Присъединете се към листата за изчакване',
       actionLink__use_email: 'Използвайте имейл',
@@ -462,6 +461,7 @@ export const bgBG: LocalizationResource = {
       actionText__join_waitlist: 'Все още нямате акаунт? Присъединете се към листата за изчакване.',
       subtitle: 'Добре дошли обратно! Моля, влезте, за да продължите',
       title: 'Влезте в {{applicationName}}',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Код за потвърждение',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -129,6 +129,7 @@ export const bgBG: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Покани',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Премахване на член',
         tableHeader__actions: undefined,
@@ -449,6 +450,7 @@ export const bgBG: LocalizationResource = {
       detailsLabel: 'Трябва да потвърдим вашата самоличност, преди да нулираме паролата ви.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Регистрирайте се',
       actionLink__join_waitlist: 'Присъединете се към листата за изчакване',
       actionLink__use_email: 'Използвайте имейл',
@@ -460,7 +462,6 @@ export const bgBG: LocalizationResource = {
       actionText__join_waitlist: 'Все още нямате акаунт? Присъединете се към листата за изчакване.',
       subtitle: 'Добре дошли обратно! Моля, влезте, за да продължите',
       title: 'Влезте в {{applicationName}}',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Код за потвърждение',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -130,6 +130,7 @@ export const csCZ: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Pozvat',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Odstranit člena',
         tableHeader__actions: 'Akce',
@@ -448,6 +449,7 @@ export const csCZ: LocalizationResource = {
       detailsLabel: 'Před obnovením hesla je třeba ověřit vaši totožnost.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registrovat se',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použít email',
@@ -459,7 +461,6 @@ export const csCZ: LocalizationResource = {
       actionText__join_waitlist: 'Připojit se k čekací listině',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Přihlásit se',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Ověřovací kód',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -449,7 +449,6 @@ export const csCZ: LocalizationResource = {
       detailsLabel: 'Před obnovením hesla je třeba ověřit vaši totožnost.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registrovat se',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použít email',
@@ -461,6 +460,7 @@ export const csCZ: LocalizationResource = {
       actionText__join_waitlist: 'Připojit se k čekací listině',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Přihlásit se',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Ověřovací kód',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -450,7 +450,6 @@ export const daDK: LocalizationResource = {
       detailsLabel: 'Vi skal bekræfte din identitet, før du nulstiller din adgangskode.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Tilmeld dig',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Brug email',
@@ -462,6 +461,7 @@ export const daDK: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Log ind',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Bekræftelseskode',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -129,6 +129,7 @@ export const daDK: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Inviter',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Fjern medlem',
         tableHeader__actions: 'Handlinger',
@@ -449,6 +450,7 @@ export const daDK: LocalizationResource = {
       detailsLabel: 'Vi skal bekræfte din identitet, før du nulstiller din adgangskode.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Tilmeld dig',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Brug email',
@@ -460,7 +462,6 @@ export const daDK: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Log ind',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Bekræftelseskode',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -455,7 +455,6 @@ export const deDE: LocalizationResource = {
       detailsLabel: 'Bevor wir Ihr Passwort zurücksetzen können, müssen wir Ihre Identität überprüfen.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Anmelden',
       actionLink__join_waitlist: 'Warteliste beitreten',
       actionLink__use_email: 'E-mail nutzen',
@@ -467,6 +466,7 @@ export const deDE: LocalizationResource = {
       actionText__join_waitlist: 'Warteliste beitreten',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Einloggen',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Bestätigungscode',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -132,6 +132,7 @@ export const deDE: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Einladen',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Mitglied entfernen',
         tableHeader__actions: 'Aktionen',
@@ -454,6 +455,7 @@ export const deDE: LocalizationResource = {
       detailsLabel: 'Bevor wir Ihr Passwort zurücksetzen können, müssen wir Ihre Identität überprüfen.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Anmelden',
       actionLink__join_waitlist: 'Warteliste beitreten',
       actionLink__use_email: 'E-mail nutzen',
@@ -465,7 +467,6 @@ export const deDE: LocalizationResource = {
       actionText__join_waitlist: 'Warteliste beitreten',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Einloggen',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Bestätigungscode',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -130,6 +130,7 @@ export const elGR: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Πρόσκληση',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Αφαίρεση μέλους',
         tableHeader__actions: 'Ενέργειες',
@@ -452,6 +453,7 @@ export const elGR: LocalizationResource = {
       detailsLabel: 'Πρέπει να επαληθεύσουμε την ταυτότητά σας πριν επαναφέρουμε τον κωδικό πρόσβασής σας.',
     },
     start: {
+      __experimental_titleCombined: 'Συνέχεια στο {{applicationName}}',
       actionLink: 'Εγγραφή',
       actionLink__join_waitlist: 'Εγγραφή στη λίστα αναμονής',
       actionLink__use_email: 'Χρήση email',
@@ -463,7 +465,6 @@ export const elGR: LocalizationResource = {
       actionText__join_waitlist: 'Θέλετε πρώιμη πρόσβαση;',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Σύνδεση',
-      titleCombined: 'Συνέχεια στο {{applicationName}}',
     },
     totpMfa: {
       formTitle: 'Κωδικός επαλήθευσης',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -453,7 +453,6 @@ export const elGR: LocalizationResource = {
       detailsLabel: 'Πρέπει να επαληθεύσουμε την ταυτότητά σας πριν επαναφέρουμε τον κωδικό πρόσβασής σας.',
     },
     start: {
-      __experimental_titleCombined: 'Συνέχεια στο {{applicationName}}',
       actionLink: 'Εγγραφή',
       actionLink__join_waitlist: 'Εγγραφή στη λίστα αναμονής',
       actionLink__use_email: 'Χρήση email',
@@ -465,6 +464,7 @@ export const elGR: LocalizationResource = {
       actionText__join_waitlist: 'Θέλετε πρώιμη πρόσβαση;',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Σύνδεση',
+      titleCombined: 'Συνέχεια στο {{applicationName}}',
     },
     totpMfa: {
       formTitle: 'Κωδικός επαλήθευσης',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -118,6 +118,7 @@ export const enUS: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invite',
+      action__search: 'Search',
       activeMembersTab: {
         menuAction__remove: 'Remove member',
         tableHeader__actions: 'Actions',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -130,6 +130,7 @@ export const esES: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invitar',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Quitar miembro',
         tableHeader__actions: 'Acciones',
@@ -451,6 +452,7 @@ export const esES: LocalizationResource = {
       detailsLabel: 'Necesitamos verificar tu identidad antes de restablecer tu contraseña.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Regístrese',
       actionLink__join_waitlist: 'Únase a la lista de espera',
       actionLink__use_email: 'Usar correo electrónico',
@@ -462,7 +464,6 @@ export const esES: LocalizationResource = {
       actionText__join_waitlist: '¿Te gustaría unirte a la lista de espera?',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Entrar',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificación',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -452,7 +452,6 @@ export const esES: LocalizationResource = {
       detailsLabel: 'Necesitamos verificar tu identidad antes de restablecer tu contraseña.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Regístrese',
       actionLink__join_waitlist: 'Únase a la lista de espera',
       actionLink__use_email: 'Usar correo electrónico',
@@ -464,6 +463,7 @@ export const esES: LocalizationResource = {
       actionText__join_waitlist: '¿Te gustaría unirte a la lista de espera?',
       subtitle: 'para continuar a {{applicationName}}',
       title: 'Entrar',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificación',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -130,7 +130,7 @@ export const esES: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invitar',
-      action__search: undefined,
+      action__search: 'Buscar',
       activeMembersTab: {
         menuAction__remove: 'Quitar miembro',
         tableHeader__actions: 'Acciones',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -131,6 +131,7 @@ export const esMX: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invitar',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Eliminar miembro',
         tableHeader__actions: undefined,
@@ -454,6 +455,7 @@ export const esMX: LocalizationResource = {
       detailsLabel: 'Es necesario verificar su identidad para restablecer su contraseña.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registrarse',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizar correo electrónico',
@@ -465,7 +467,6 @@ export const esMX: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Iniciar sesión',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificación',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -455,7 +455,6 @@ export const esMX: LocalizationResource = {
       detailsLabel: 'Es necesario verificar su identidad para restablecer su contraseña.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registrarse',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizar correo electrónico',
@@ -467,6 +466,7 @@ export const esMX: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Iniciar sesión',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificación',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -131,7 +131,7 @@ export const esMX: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invitar',
-      action__search: undefined,
+      action__search: 'Buscar',
       activeMembersTab: {
         menuAction__remove: 'Eliminar miembro',
         tableHeader__actions: undefined,

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -452,7 +452,6 @@ export const fiFI: LocalizationResource = {
       detailsLabel: 'Ennen salasanan nollaamista on varmistettava henkilöllisyytesi.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Rekisteröidy',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Käytä sähköpostia',
@@ -464,6 +463,7 @@ export const fiFI: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'jatkaaksesi kohteeseen {{applicationName}}',
       title: 'Kirjaudu sisään',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Todennuskoodi',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -130,6 +130,7 @@ export const fiFI: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Kutsu',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Poista jäsen',
         tableHeader__actions: undefined,
@@ -451,6 +452,7 @@ export const fiFI: LocalizationResource = {
       detailsLabel: 'Ennen salasanan nollaamista on varmistettava henkilöllisyytesi.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Rekisteröidy',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Käytä sähköpostia',
@@ -462,7 +464,6 @@ export const fiFI: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'jatkaaksesi kohteeseen {{applicationName}}',
       title: 'Kirjaudu sisään',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Todennuskoodi',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -455,7 +455,6 @@ export const frFR: LocalizationResource = {
       detailsLabel: 'Nous devons vérifier votre identité avant de réinitialiser votre mot de passe.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: "S'inscrire",
       actionLink__join_waitlist: "Rejoindre la liste d'attente",
       actionLink__use_email: 'Utiliser e-mail',
@@ -467,6 +466,7 @@ export const frFR: LocalizationResource = {
       actionText__join_waitlist: "Inscrivez-vous sur la liste d'attente",
       subtitle: 'pour continuer vers {{applicationName}}',
       title: "S'identifier",
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Le code de vérification',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -131,6 +131,7 @@ export const frFR: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Inviter',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Supprimer',
         tableHeader__actions: 'Actions',
@@ -454,6 +455,7 @@ export const frFR: LocalizationResource = {
       detailsLabel: 'Nous devons vérifier votre identité avant de réinitialiser votre mot de passe.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: "S'inscrire",
       actionLink__join_waitlist: "Rejoindre la liste d'attente",
       actionLink__use_email: 'Utiliser e-mail',
@@ -465,7 +467,6 @@ export const frFR: LocalizationResource = {
       actionText__join_waitlist: "Inscrivez-vous sur la liste d'attente",
       subtitle: 'pour continuer vers {{applicationName}}',
       title: "S'identifier",
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Le code de vérification',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -444,7 +444,6 @@ export const heIL: LocalizationResource = {
       detailsLabel: 'אנחנו צריכים לאמת את זהותך לפני שנאפס את הסיסמה שלך.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'הרשמה',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'השתמש בדוא"ל',
@@ -456,6 +455,7 @@ export const heIL: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'התחבר',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'קוד אימות',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -128,6 +128,7 @@ export const heIL: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'הזמן',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'הסר חבר',
         tableHeader__actions: undefined,
@@ -443,6 +444,7 @@ export const heIL: LocalizationResource = {
       detailsLabel: 'אנחנו צריכים לאמת את זהותך לפני שנאפס את הסיסמה שלך.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'הרשמה',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'השתמש בדוא"ל',
@@ -454,7 +456,6 @@ export const heIL: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'התחבר',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'קוד אימות',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -129,6 +129,7 @@ export const huHU: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Meghívás',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Tag eltávolítása',
         tableHeader__actions: undefined,
@@ -450,6 +451,7 @@ export const huHU: LocalizationResource = {
       detailsLabel: 'Vissza kell igazolnod az identitásod, mielőtt visszaállítod a jelszavad',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Regisztráció',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Email használata',
@@ -461,7 +463,6 @@ export const huHU: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Üdv újra! A folytatáshoz kérlek jelentkezz be.',
       title: 'Bejelentkezés a(z) {{applicationName}} fiókba',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Visszaigazoló kód',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -451,7 +451,6 @@ export const huHU: LocalizationResource = {
       detailsLabel: 'Vissza kell igazolnod az identitásod, mielőtt visszaállítod a jelszavad',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Regisztráció',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Email használata',
@@ -463,6 +462,7 @@ export const huHU: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Üdv újra! A folytatáshoz kérlek jelentkezz be.',
       title: 'Bejelentkezés a(z) {{applicationName}} fiókba',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Visszaigazoló kód',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -453,7 +453,6 @@ export const isIS: LocalizationResource = {
       detailsLabel: 'Við þurfum að staðfesta auðkenni þitt áður en við endurstillum lykilorðið þitt.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Skrá sig',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Nota netfang',
@@ -465,6 +464,7 @@ export const isIS: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Velkomin aftur! Vinsamlegast skráðu þig inn til að halda áfram',
       title: 'Skrá inn í {{applicationName}}',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Staðfestingarkóði',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -130,6 +130,7 @@ export const isIS: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Bjóða',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Fjarlægja meðlim',
         tableHeader__actions: undefined,
@@ -452,6 +453,7 @@ export const isIS: LocalizationResource = {
       detailsLabel: 'Við þurfum að staðfesta auðkenni þitt áður en við endurstillum lykilorðið þitt.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Skrá sig',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Nota netfang',
@@ -463,7 +465,6 @@ export const isIS: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Velkomin aftur! Vinsamlegast skráðu þig inn til að halda áfram',
       title: 'Skrá inn í {{applicationName}}',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Staðfestingarkóði',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -130,6 +130,7 @@ export const itIT: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invita',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Rimuovi membro',
         tableHeader__actions: 'Azioni',
@@ -450,6 +451,7 @@ export const itIT: LocalizationResource = {
       detailsLabel: 'Dobbiamo verificare la tua identità prima di resettare la tua password.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registrati',
       actionLink__join_waitlist: "Unisciti alla lista d'attesa",
       actionLink__use_email: 'Usa email',
@@ -461,7 +463,6 @@ export const itIT: LocalizationResource = {
       actionText__join_waitlist: "Unisciti alla lista d'attesa",
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Accedi',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Codice di verifica',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -451,7 +451,6 @@ export const itIT: LocalizationResource = {
       detailsLabel: 'Dobbiamo verificare la tua identità prima di resettare la tua password.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registrati',
       actionLink__join_waitlist: "Unisciti alla lista d'attesa",
       actionLink__use_email: 'Usa email',
@@ -463,6 +462,7 @@ export const itIT: LocalizationResource = {
       actionText__join_waitlist: "Unisciti alla lista d'attesa",
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Accedi',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Codice di verifica',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -451,7 +451,6 @@ export const jaJP: LocalizationResource = {
       detailsLabel: 'パスワードをリセットする前に、身元を確認する必要があります。',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'サインアップ',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'メールアドレスを使用',
@@ -463,6 +462,7 @@ export const jaJP: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'サインイン',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '検証コード',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -129,6 +129,7 @@ export const jaJP: LocalizationResource = {
     },
     membersPage: {
       action__invite: '招待',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'メンバーの削除',
         tableHeader__actions: undefined,
@@ -450,6 +451,7 @@ export const jaJP: LocalizationResource = {
       detailsLabel: 'パスワードをリセットする前に、身元を確認する必要があります。',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'サインアップ',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'メールアドレスを使用',
@@ -461,7 +463,6 @@ export const jaJP: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'サインイン',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '検証コード',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -129,6 +129,7 @@ export const koKR: LocalizationResource = {
     },
     membersPage: {
       action__invite: '초대',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: '회원 제거',
         tableHeader__actions: undefined,
@@ -445,6 +446,7 @@ export const koKR: LocalizationResource = {
       detailsLabel: '비밀번호를 재설정하기 전에 신원을 확인해야 합니다.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: '회원가입',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '이메일 사용하기',
@@ -456,7 +458,6 @@ export const koKR: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '환영합니다! 계속하려면 로그인해 주세요',
       title: '{{applicationName}}에 로그인',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '인증 코드',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -446,7 +446,6 @@ export const koKR: LocalizationResource = {
       detailsLabel: '비밀번호를 재설정하기 전에 신원을 확인해야 합니다.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: '회원가입',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '이메일 사용하기',
@@ -458,6 +457,7 @@ export const koKR: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '환영합니다! 계속하려면 로그인해 주세요',
       title: '{{applicationName}}에 로그인',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '인증 코드',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -130,6 +130,7 @@ export const mnMN: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Урих',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Гишүүнийг хасах',
         tableHeader__actions: undefined,
@@ -451,6 +452,7 @@ export const mnMN: LocalizationResource = {
       detailsLabel: 'Нууц үгээ шинэчлэхээс өмнө бид таны хувийн мэдээллийг баталгаажуулах шаардлагатай.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Бүртгүүлэх',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Имэйл ашиглах',
@@ -462,7 +464,6 @@ export const mnMN: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Тавтай морил! Үргэлжлүүлэхийн тулд нэвтэрнэ үү',
       title: '{{applicationName}} руу нэвтрэх',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Баталгаажуулах код',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -452,7 +452,6 @@ export const mnMN: LocalizationResource = {
       detailsLabel: 'Нууц үгээ шинэчлэхээс өмнө бид таны хувийн мэдээллийг баталгаажуулах шаардлагатай.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Бүртгүүлэх',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Имэйл ашиглах',
@@ -464,6 +463,7 @@ export const mnMN: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Тавтай морил! Үргэлжлүүлэхийн тулд нэвтэрнэ үү',
       title: '{{applicationName}} руу нэвтрэх',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Баталгаажуулах код',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -129,6 +129,7 @@ export const nbNO: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Inviter',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Fjern medlem',
         tableHeader__actions: undefined,
@@ -450,6 +451,7 @@ export const nbNO: LocalizationResource = {
       detailsLabel: 'Vi må bekrefte identiteten din før vi tilbakestiller passordet ditt.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Opprett konto',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Bruk e-post',
@@ -461,7 +463,6 @@ export const nbNO: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Logg inn',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifiseringskode',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -451,7 +451,6 @@ export const nbNO: LocalizationResource = {
       detailsLabel: 'Vi må bekrefte identiteten din før vi tilbakestiller passordet ditt.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Opprett konto',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Bruk e-post',
@@ -463,6 +462,7 @@ export const nbNO: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Logg inn',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifiseringskode',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -451,7 +451,6 @@ export const nlNL: LocalizationResource = {
       detailsLabel: 'Voor veiligheidsredenen is het vereist om je wachtwoord te resetten.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registreren',
       actionLink__join_waitlist: 'Meld je aan voor de wachtlijst',
       actionLink__use_email: 'Gebruik e-mail',
@@ -463,6 +462,7 @@ export const nlNL: LocalizationResource = {
       actionText__join_waitlist: 'Nog geen account?',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Inloggen',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verificatiecode',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -129,6 +129,7 @@ export const nlNL: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Uitnodigen',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Verwijder lid',
         tableHeader__actions: 'Acties',
@@ -450,6 +451,7 @@ export const nlNL: LocalizationResource = {
       detailsLabel: 'Voor veiligheidsredenen is het vereist om je wachtwoord te resetten.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registreren',
       actionLink__join_waitlist: 'Meld je aan voor de wachtlijst',
       actionLink__use_email: 'Gebruik e-mail',
@@ -461,7 +463,6 @@ export const nlNL: LocalizationResource = {
       actionText__join_waitlist: 'Nog geen account?',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Inloggen',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verificatiecode',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -129,6 +129,7 @@ export const plPL: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Zaproś',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Usuń użytkownika',
         tableHeader__actions: undefined,

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -451,7 +451,6 @@ export const ptBR: LocalizationResource = {
       detailsLabel: 'Precisamos verificar sua identidade antes de redefinir sua senha.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registre-se',
       actionLink__join_waitlist: 'Entrar na lista de espera',
       actionLink__use_email: 'Usar e-mail',
@@ -463,6 +462,7 @@ export const ptBR: LocalizationResource = {
       actionText__join_waitlist: 'Quer ser notificado quando estivermos prontos?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificação',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -129,6 +129,7 @@ export const ptBR: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Convidar',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Remover membro',
         tableHeader__actions: 'Ações',
@@ -450,6 +451,7 @@ export const ptBR: LocalizationResource = {
       detailsLabel: 'Precisamos verificar sua identidade antes de redefinir sua senha.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registre-se',
       actionLink__join_waitlist: 'Entrar na lista de espera',
       actionLink__use_email: 'Usar e-mail',
@@ -461,7 +463,6 @@ export const ptBR: LocalizationResource = {
       actionText__join_waitlist: 'Quer ser notificado quando estivermos prontos?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificação',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -129,7 +129,7 @@ export const ptBR: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Convidar',
-      action__search: undefined,
+      action__search: 'Pesquisar',
       activeMembersTab: {
         menuAction__remove: 'Remover membro',
         tableHeader__actions: 'Ações',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -449,7 +449,6 @@ export const ptPT: LocalizationResource = {
       detailsLabel: 'Precisamos verificar a sua identidade antes de redefinir a palavra-passe.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registre-se',
       actionLink__join_waitlist: 'Juntar-se à lista de espera',
       actionLink__use_email: 'Usar e-mail',
@@ -461,6 +460,7 @@ export const ptPT: LocalizationResource = {
       actionText__join_waitlist: 'Ainda não tem uma conta? Junte-se à lista de espera.',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificação',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -128,7 +128,7 @@ export const ptPT: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Convidar',
-      action__search: undefined,
+      action__search: 'Pesquisar',
       activeMembersTab: {
         menuAction__remove: 'Remover membro',
         tableHeader__actions: 'Ações',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -128,6 +128,7 @@ export const ptPT: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Convidar',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Remover membro',
         tableHeader__actions: 'Ações',
@@ -448,6 +449,7 @@ export const ptPT: LocalizationResource = {
       detailsLabel: 'Precisamos verificar a sua identidade antes de redefinir a palavra-passe.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registre-se',
       actionLink__join_waitlist: 'Juntar-se à lista de espera',
       actionLink__use_email: 'Usar e-mail',
@@ -459,7 +461,6 @@ export const ptPT: LocalizationResource = {
       actionText__join_waitlist: 'Ainda não tem uma conta? Junte-se à lista de espera.',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Entrar',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Código de verificação',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -453,7 +453,6 @@ export const roRO: LocalizationResource = {
       detailsLabel: 'Trebuie să vă verificăm identitatea înainte de a vă reseta parola.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Înscrieți-vă',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizați e-mailul',
@@ -465,6 +464,7 @@ export const roRO: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Conectați-vă',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Cod de verificare',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -131,6 +131,7 @@ export const roRO: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Invitați',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Îndepărtați membrul',
         tableHeader__actions: undefined,
@@ -452,6 +453,7 @@ export const roRO: LocalizationResource = {
       detailsLabel: 'Trebuie să vă verificăm identitatea înainte de a vă reseta parola.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Înscrieți-vă',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Utilizați e-mailul',
@@ -463,7 +465,6 @@ export const roRO: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Conectați-vă',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Cod de verificare',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -133,6 +133,7 @@ export const ruRU: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Пригласить',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Удалить участника',
         tableHeader__actions: 'Действия',
@@ -459,6 +460,7 @@ export const ruRU: LocalizationResource = {
       detailsLabel: 'Необходимо верифицировать вашу личность перед восстановлением пароля',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Зарегистрироваться',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Использовать почту',
@@ -470,7 +472,6 @@ export const ruRU: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Войти',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Верификационный код',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -460,7 +460,6 @@ export const ruRU: LocalizationResource = {
       detailsLabel: 'Необходимо верифицировать вашу личность перед восстановлением пароля',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Зарегистрироваться',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Использовать почту',
@@ -472,6 +471,7 @@ export const ruRU: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Войти',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Верификационный код',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -129,6 +129,7 @@ export const skSK: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Pozvať',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Odstrániť člena',
         tableHeader__actions: undefined,
@@ -448,6 +449,7 @@ export const skSK: LocalizationResource = {
       detailsLabel: 'Pred obnovením hesla je potrebné overiť vašu totožnosť.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registrovať sa',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použiť email',
@@ -459,7 +461,6 @@ export const skSK: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Prihlásiť sa',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Overovací kód',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -449,7 +449,6 @@ export const skSK: LocalizationResource = {
       detailsLabel: 'Pred obnovením hesla je potrebné overiť vašu totožnosť.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registrovať sa',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Použiť email',
@@ -461,6 +460,7 @@ export const skSK: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Prihlásiť sa',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Overovací kód',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -129,6 +129,7 @@ export const srRS: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Pozovi',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Ukloni člana',
         tableHeader__actions: undefined,
@@ -449,6 +450,7 @@ export const srRS: LocalizationResource = {
       detailsLabel: 'Potrebno je da potvrdimo tvoj identitet pre resetovanja lozinke.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Registruj se',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Koristi e-mail',
@@ -460,7 +462,6 @@ export const srRS: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Dobro došao nazad! Molimo prijavi se da nastaviš',
       title: 'Prijavi se na {{applicationName}}',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifikacioni kod',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -450,7 +450,6 @@ export const srRS: LocalizationResource = {
       detailsLabel: 'Potrebno je da potvrdimo tvoj identitet pre resetovanja lozinke.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Registruj se',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Koristi e-mail',
@@ -462,6 +461,7 @@ export const srRS: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'Dobro došao nazad! Molimo prijavi se da nastaviš',
       title: 'Prijavi se na {{applicationName}}',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifikacioni kod',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -453,7 +453,6 @@ export const svSE: LocalizationResource = {
       detailsLabel: 'Vi behöver verifiera din identitet innan vi återställer ditt lösenord.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Skapa konto',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Use email',
@@ -465,6 +464,7 @@ export const svSE: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Logga in',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifieringskod',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -129,6 +129,7 @@ export const svSE: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Bjud in',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Ta bort medlem',
         tableHeader__actions: 'Åtgärder',
@@ -452,6 +453,7 @@ export const svSE: LocalizationResource = {
       detailsLabel: 'Vi behöver verifiera din identitet innan vi återställer ditt lösenord.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Skapa konto',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Use email',
@@ -463,7 +465,6 @@ export const svSE: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Logga in',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Verifieringskod',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -447,7 +447,6 @@ export const thTH: LocalizationResource = {
       detailsLabel: 'เราต้องตรวจสอบตัวตนของคุณก่อนที่จะรีเซ็ตรหัสผ่าน',
     },
     start: {
-      __experimental_titleCombined: 'ดำเนินการต่อไปยัง {{applicationName}}',
       actionLink: 'สมัครสมาชิก',
       actionLink__join_waitlist: 'เข้าร่วมรายชื่อผู้รอ',
       actionLink__use_email: 'ใช้อีเมล',
@@ -459,6 +458,7 @@ export const thTH: LocalizationResource = {
       actionText__join_waitlist: 'ต้องการเข้าถึงก่อนใช่หรือไม่?',
       subtitle: 'ยินดีต้อนรับกลับ! โปรดเข้าสู่ระบบเพื่อดำเนินการต่อ',
       title: 'เข้าสู่ระบบ {{applicationName}}',
+      titleCombined: 'ดำเนินการต่อไปยัง {{applicationName}}',
     },
     totpMfa: {
       formTitle: 'รหัสการตรวจสอบ',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -129,6 +129,7 @@ export const thTH: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'เชิญ',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'ลบสมาชิก',
         tableHeader__actions: 'การดำเนินการ',
@@ -446,6 +447,7 @@ export const thTH: LocalizationResource = {
       detailsLabel: 'เราต้องตรวจสอบตัวตนของคุณก่อนที่จะรีเซ็ตรหัสผ่าน',
     },
     start: {
+      __experimental_titleCombined: 'ดำเนินการต่อไปยัง {{applicationName}}',
       actionLink: 'สมัครสมาชิก',
       actionLink__join_waitlist: 'เข้าร่วมรายชื่อผู้รอ',
       actionLink__use_email: 'ใช้อีเมล',
@@ -457,7 +459,6 @@ export const thTH: LocalizationResource = {
       actionText__join_waitlist: 'ต้องการเข้าถึงก่อนใช่หรือไม่?',
       subtitle: 'ยินดีต้อนรับกลับ! โปรดเข้าสู่ระบบเพื่อดำเนินการต่อ',
       title: 'เข้าสู่ระบบ {{applicationName}}',
-      titleCombined: 'ดำเนินการต่อไปยัง {{applicationName}}',
     },
     totpMfa: {
       formTitle: 'รหัสการตรวจสอบ',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -129,6 +129,7 @@ export const trTR: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Davet et',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Üyeyi kaldır',
         tableHeader__actions: undefined,
@@ -451,6 +452,7 @@ export const trTR: LocalizationResource = {
       detailsLabel: 'Şifrenizi sıfırlamadan önce kimliğinizi doğrulamamız gerekiyor.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Kayıt ol',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'E-posta kullan',
@@ -462,7 +464,6 @@ export const trTR: LocalizationResource = {
       actionText__join_waitlist: 'Bekleme listesine katılın',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Giriş yap',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Doğrulama kodu',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -452,7 +452,6 @@ export const trTR: LocalizationResource = {
       detailsLabel: 'Şifrenizi sıfırlamadan önce kimliğinizi doğrulamamız gerekiyor.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Kayıt ol',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'E-posta kullan',
@@ -464,6 +463,7 @@ export const trTR: LocalizationResource = {
       actionText__join_waitlist: 'Bekleme listesine katılın',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Giriş yap',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Doğrulama kodu',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -449,7 +449,6 @@ export const ukUA: LocalizationResource = {
       detailsLabel: 'Необхідно верифікувати вашу особу перед відновленням пароля',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Зареєструватися',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Використовувати пошту',
@@ -461,6 +460,7 @@ export const ukUA: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Увійти',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Верифікаційний код',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -129,6 +129,7 @@ export const ukUA: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Запросити',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Видалити учасника',
         tableHeader__actions: undefined,
@@ -448,6 +449,7 @@ export const ukUA: LocalizationResource = {
       detailsLabel: 'Необхідно верифікувати вашу особу перед відновленням пароля',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Зареєструватися',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Використовувати пошту',
@@ -459,7 +461,6 @@ export const ukUA: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Увійти',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: 'Верифікаційний код',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -129,6 +129,7 @@ export const viVN: LocalizationResource = {
     },
     membersPage: {
       action__invite: 'Mời',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: 'Gỡ bỏ thành viên',
         tableHeader__actions: undefined,
@@ -448,6 +449,7 @@ export const viVN: LocalizationResource = {
       detailsLabel: 'Chúng tôi cần xác minh danh tính của bạn trước khi đặt lại mật khẩu.',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: 'Đăng ký',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Sử dụng email',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -449,7 +449,6 @@ export const viVN: LocalizationResource = {
       detailsLabel: 'Chúng tôi cần xác minh danh tính của bạn trước khi đặt lại mật khẩu.',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: 'Đăng ký',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: 'Sử dụng email',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -126,6 +126,7 @@ export const zhCN: LocalizationResource = {
     },
     membersPage: {
       action__invite: '邀请',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: '移除成员',
         tableHeader__actions: undefined,
@@ -439,6 +440,7 @@ export const zhCN: LocalizationResource = {
       detailsLabel: '我们需要验证您的身份才能重置您的密码。',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: '注册',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用电子邮件',
@@ -450,7 +452,6 @@ export const zhCN: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '继续使用 {{applicationName}}',
       title: '登录',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '验证码',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -440,7 +440,6 @@ export const zhCN: LocalizationResource = {
       detailsLabel: '我们需要验证您的身份才能重置您的密码。',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: '注册',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用电子邮件',
@@ -452,6 +451,7 @@ export const zhCN: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '继续使用 {{applicationName}}',
       title: '登录',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '验证码',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -128,6 +128,7 @@ export const zhTW: LocalizationResource = {
     },
     membersPage: {
       action__invite: '邀請',
+      action__search: undefined,
       activeMembersTab: {
         menuAction__remove: '移除成員',
         tableHeader__actions: undefined,
@@ -445,6 +446,7 @@ export const zhTW: LocalizationResource = {
       detailsLabel: '我們需要驗證您的身份才能重設您的密碼。',
     },
     start: {
+      __experimental_titleCombined: undefined,
       actionLink: '註冊',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用電子郵件',
@@ -456,7 +458,6 @@ export const zhTW: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '繼續使用 {{applicationName}}',
       title: '登錄',
-      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '驗證碼',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -446,7 +446,6 @@ export const zhTW: LocalizationResource = {
       detailsLabel: '我們需要驗證您的身份才能重設您的密碼。',
     },
     start: {
-      __experimental_titleCombined: undefined,
       actionLink: '註冊',
       actionLink__join_waitlist: undefined,
       actionLink__use_email: '使用電子郵件',
@@ -458,6 +457,7 @@ export const zhTW: LocalizationResource = {
       actionText__join_waitlist: undefined,
       subtitle: '繼續使用 {{applicationName}}',
       title: '登錄',
+      titleCombined: undefined,
     },
     totpMfa: {
       formTitle: '驗證碼',

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -163,6 +163,7 @@ export const useOrganization: UseOrganization = params => {
           initialPage: membersSafeValues.initialPage,
           pageSize: membersSafeValues.pageSize,
           role: membersSafeValues.role,
+          query: membersSafeValues.query,
         };
 
   const invitationsParams =

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -124,6 +124,7 @@ export const useOrganization: UseOrganization = params => {
     role: undefined,
     keepPreviousData: false,
     infinite: false,
+    query: undefined,
   });
 
   const invitationsSafeValues = useWithSafeValues(invitationsListParams, {

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -277,6 +277,9 @@ export type ElementsConfig = {
   organizationSwitcherPopoverActionButtonIcon: WithOptions<'manageOrganization' | 'createOrganization'>;
   organizationSwitcherPopoverFooter: WithOptions;
 
+  organizationProfileMembersSearchInputIcon: WithOptions;
+  organizationProfileMembersSearchInput: WithOptions;
+
   organizationListPreviewItems: WithOptions;
   organizationListPreviewItem: WithOptions;
   organizationListPreviewButton: WithOptions;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -757,6 +757,7 @@ type _LocalizationResource = {
     membersPage: {
       detailsTitle__emptyRow: LocalizationValue;
       action__invite: LocalizationValue;
+      action__search: LocalizationValue;
       start: {
         headerTitle__members: LocalizationValue;
         headerTitle__invitations: LocalizationValue;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -64,6 +64,7 @@ export type GetRolesParams = ClerkPaginationParams;
 
 export type GetMembersParams = ClerkPaginationParams<{
   role?: OrganizationCustomRoleKey[];
+  query?: string;
 }>;
 
 export type GetDomainsParams = ClerkPaginationParams<{


### PR DESCRIPTION
## Description

Resolves ORGS-469

Introduces the ability to search organization memberships within `OrganizationProfile` 

--- 

#### Searching behavior

https://github.com/user-attachments/assets/6b353c27-5941-4491-9187-3bc50d033d44

#### UI with `org:sys_memberships:manage` permission 

Preserves the "Invite" button action trigger instead of hiding it:


https://github.com/user-attachments/assets/40f5bacd-fc3f-481d-b34f-d995390b6a30



#### UI without `org:sys_memberships:manage` permission

![CleanShot 2025-01-21 at 08 13 38](https://github.com/user-attachments/assets/0b44b3c4-f3a8-4a27-9ad6-cf0865f162da)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
