### PR TITLE
[Core 1 backport] fix(clerk-js): Improvements on Smart bot protection

### DIFF
--- a/.changeset/eighty-tigers-doubt.md
+++ b/.changeset/eighty-tigers-doubt.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Improvements on Smart bot protection
+
+- Fix bot protection layout shift on the sign-up form.
+- Fix the transfer flow when captcha is interactive.

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "turbo:clean": "turbo daemon clean",
     "update:lockfile": "npm run nuke && npm install -D --arch=x64 --platform=linux turbo && npm install -D --arch=arm64 --platform=darwin turbo",
     "version": "changeset version && ./scripts/version-info.sh",
+    "version-packages:snapshot": "./scripts/snapshot.mjs",
     "version:canary": "./scripts/canary.mjs",
-    "version:snapshot": "./scripts/snapshot.mjs",
     "yalc:all": "for d in packages/*/; do echo $d; cd $d; yalc push --replace --sig; cd '../../'; done"
   },
   "devDependencies": {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -101,7 +101,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
         </Form.ControlRow>
       )}
       <Col center>
-        <CaptchaElement />
+        <CaptchaElement maxHeight='0' />
         <Form.SubmitButton>Continue</Form.SubmitButton>
       </Col>
     </Form.Root>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -273,7 +273,7 @@ function _SignUpStart(): JSX.Element {
               />
             )}
           </SocialButtonsReversibleContainerWithDivider>
-          {!shouldShowForm && <CaptchaElement />}
+          {!shouldShowForm && <CaptchaElement maxHeight='0' />}
         </Flex>
         <Footer.Root>
           <Footer.Action elementId='signUp'>

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -1,9 +1,13 @@
 import { CAPTCHA_ELEMENT_ID } from '../../utils/captcha';
 import { Box } from '../customizables';
 
-export const CaptchaElement = () => (
+type CaptchaElementProps = {
+  maxHeight?: string;
+};
+
+export const CaptchaElement = ({ maxHeight }: CaptchaElementProps) => (
   <Box
     id={CAPTCHA_ELEMENT_ID}
-    sx={t => ({ display: 'none', marginBottom: t.space.$6, alignSelf: 'center' })}
+    sx={{ display: 'block', alignSelf: 'center', maxHeight }}
   />
 );

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -41,6 +41,10 @@ interface RenderOptions {
    */
   'error-callback'?: (errorCode: string) => void;
   /**
+   * A JavaScript callback invoked before the challenge enters interactive mode.
+   */
+  'before-interactive-callback'?: () => void;
+  /**
    * A JavaScript callback invoked when a given client/browser is not supported by the widget.
    */
   'unsupported-callback'?: () => boolean;
@@ -145,7 +149,6 @@ export const getTunstileToken = async (captchaOptions: {
         } else {
           const visibleDiv = document.getElementById(CAPTCHA_ELEMENT_ID);
           if (visibleDiv) {
-            visibleDiv.style.display = 'block';
             widgetDiv = visibleDiv;
           } else {
             console.error('Captcha DOM element not found. Using invisible captcha widget.');
@@ -162,6 +165,14 @@ export const getTunstileToken = async (captchaOptions: {
           'refresh-expired': 'auto',
           callback: function (token: string) {
             resolve([token, id]);
+          },
+          'before-interactive-callback': () => {
+            const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
+            if (visibleWidget) {
+              visibleWidget.style.maxHeight = 'unset';
+              visibleWidget.style.minHeight = '68px'; // this is the height of the Turnstile widget
+              visibleWidget.style.marginBottom = '1.5rem';
+            }
           },
           'error-callback': function (errorCode) {
             errorCodes.push(errorCode);
@@ -211,7 +222,9 @@ export const getTunstileToken = async (captchaOptions: {
       if (isInvisibleWidget) {
         document.body.removeChild(widgetDiv as HTMLElement);
       } else {
-        (widgetDiv as HTMLElement).style.display = 'none';
+        (widgetDiv as HTMLElement).style.maxHeight = '0';
+        (widgetDiv as HTMLElement).style.minHeight = 'unset';
+        (widgetDiv as HTMLElement).style.marginBottom = 'unset';
       }
     }
   }


### PR DESCRIPTION
This PR is a Core 1 backport of the following fixes:

- Fix bot protection layout shift on the sign-up form. #4924 
- Fix the transfer flow when CAPTCHA is interactive. #4941 

https://github.com/user-attachments/assets/1f3372aa-5106-41f1-bc3b-cfadd4395434



## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
