### PR TITLE
fix(clerk-js): Use authQueryString when building callback URLs

### DIFF
--- a/.changeset/five-plants-sin.md
+++ b/.changeset/five-plants-sin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an issue where certain query parameters were not preserved during the SSO callback.

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -82,17 +82,20 @@ export const useSignInContext = (): SignInContextType => {
   signInUrl = buildURL({ base: signInUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
   signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
   waitlistUrl = buildURL({ base: waitlistUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
+
+  const authQueryString = redirectUrls.toSearchParams().toString();
+
   const emailLinkRedirectUrl = buildRedirectUrl({
     routing: ctx.routing,
     baseUrl: signUpUrl,
-    authQueryString: '',
+    authQueryString,
     path: ctx.path,
     endpoint: isCombinedFlow ? '/create' + MAGIC_LINK_VERIFY_PATH_ROUTE : MAGIC_LINK_VERIFY_PATH_ROUTE,
   });
   const ssoCallbackUrl = buildRedirectUrl({
     routing: ctx.routing,
     baseUrl: signUpUrl,
-    authQueryString: '',
+    authQueryString,
     path: ctx.path,
     endpoint: isCombinedFlow ? '/create' + SSO_CALLBACK_PATH_ROUTE : SSO_CALLBACK_PATH_ROUTE,
   });
@@ -121,7 +124,7 @@ export const useSignInContext = (): SignInContextType => {
     signUpContinueUrl,
     queryParams,
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
-    authQueryString: redirectUrls.toSearchParams().toString(),
+    authQueryString,
     isCombinedFlow,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -77,12 +77,14 @@ export const useSignUpContext = (): SignUpContextType => {
   signUpUrl = buildURL({ base: signUpUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
   waitlistUrl = buildURL({ base: waitlistUrl, hashSearchParams: [queryParams, preservedParams] }, { stringify: true });
 
+  const authQueryString = redirectUrls.toSearchParams().toString();
+
   const emailLinkRedirectUrl =
     ctx.emailLinkRedirectUrl ??
     buildRedirectUrl({
       routing: ctx.routing,
       baseUrl: signUpUrl,
-      authQueryString: '',
+      authQueryString,
       path: ctx.path,
       endpoint: isCombinedFlow ? '/create' + MAGIC_LINK_VERIFY_PATH_ROUTE : MAGIC_LINK_VERIFY_PATH_ROUTE,
     });
@@ -91,7 +93,7 @@ export const useSignUpContext = (): SignUpContextType => {
     buildRedirectUrl({
       routing: ctx.routing,
       baseUrl: signUpUrl,
-      authQueryString: '',
+      authQueryString,
       path: ctx.path,
       endpoint: isCombinedFlow ? '/create' + SSO_CALLBACK_PATH_ROUTE : SSO_CALLBACK_PATH_ROUTE,
     });
@@ -113,7 +115,7 @@ export const useSignUpContext = (): SignUpContextType => {
     navigateAfterSignUp,
     queryParams,
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
-    authQueryString: redirectUrls.toSearchParams().toString(),
+    authQueryString,
     isCombinedFlow,
   };
 };


### PR DESCRIPTION
## Description

This PR fixes an issue where certain query parameters were not preserved due to us passing an empty `authQueryString` to the `buildRedirectUrl` call for `ssoCallbackUrl`. This resulted in the generation of `ssoCallbackUrl` values that did not retain important parameters such as `sign_in_force_redirect_url`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
