### PR TITLE
fix(shared): Update isEmailLinkError check to look for err name

### DIFF
--- a/.changeset/popular-mails-jam.md
+++ b/.changeset/popular-mails-jam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Updates error handling check within isEmailLinkError to fix issue where email link errors were not properly returning true.

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -201,12 +201,13 @@ export class EmailLinkError extends Error {
   constructor(code: string) {
     super(code);
     this.code = code;
+    this.name = 'EmailLinkError' as const;
     Object.setPrototypeOf(this, EmailLinkError.prototype);
   }
 }
 
 export function isEmailLinkError(err: Error): err is EmailLinkError {
-  return err instanceof EmailLinkError;
+  return err.name === 'EmailLinkError';
 }
 
 export const EmailLinkErrorCode = {


### PR DESCRIPTION
## Description

Fixes an issue in custom flow within a next.js project where `isEmailLinkError` is always returning false for the following code due to checking for the instance of EmailLinkError and multiple versions of share packages being included.

```tsx
try {
  await handleEmailLinkVerification({
    ...
  });
} catch (err: any) {
  if (isEmailLinkError(err)) {
    ...
  }
}
```

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
