### PR TITLE
fix(*): Correct type for authorizedParties

### DIFF
--- a/.changeset/dirty-cooks-pay.md
+++ b/.changeset/dirty-cooks-pay.md
@@ -1,0 +1,7 @@
+---
+'@clerk/tanstack-start': patch
+'@clerk/react-router': patch
+'@clerk/remix': patch
+---
+
+Fix incorrect type for `authorizedParties` option

--- a/packages/react-router/src/ssr/types.ts
+++ b/packages/react-router/src/ssr/types.ts
@@ -68,10 +68,9 @@ export type RootAuthLoaderOptions = {
    * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
    */
   loadOrganization?: boolean;
-  authorizedParties?: [];
   signInUrl?: string;
   signUpUrl?: string;
-} & Pick<VerifyTokenOptions, 'audience'> &
+} & Pick<VerifyTokenOptions, 'audience' | 'authorizedParties'> &
   MultiDomainAndOrProxy &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -31,10 +31,9 @@ export type RootAuthLoaderOptions = {
    * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
    */
   loadOrganization?: boolean;
-  authorizedParties?: [];
   signInUrl?: string;
   signUpUrl?: string;
-} & Pick<VerifyTokenOptions, 'audience'> &
+} & Pick<VerifyTokenOptions, 'audience' | 'authorizedParties'> &
   MultiDomainAndOrProxy &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &

--- a/packages/tanstack-start/src/server/types.ts
+++ b/packages/tanstack-start/src/server/types.ts
@@ -12,10 +12,9 @@ export type LoaderOptions = {
   publishableKey?: string;
   jwtKey?: string;
   secretKey?: string;
-  authorizedParties?: [];
   signInUrl?: string;
   signUpUrl?: string;
-} & Pick<VerifyTokenOptions, 'audience'> &
+} & Pick<VerifyTokenOptions, 'audience' | 'authorizedParties'> &
   MultiDomainAndOrProxy &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &


### PR DESCRIPTION
## Description

The `authorizedParties` TypeScript type was incorrectly set in three SDKs. This PR changes the type aliases to reuse the existing type from the Backend SDK which has the correct type.

https://github.com/clerk/javascript/blob/d450f71c89cdb71fcd339c0ba409ce4e49c4b6e7/packages/backend/src/jwt/verifyJwt.ts#L98

Fixes https://github.com/clerk/javascript/issues/4960

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
