### PR TITLE
chore(react-router): Bump version to v1

### DIFF
--- a/.changeset/shiny-crabs-exercise.md
+++ b/.changeset/shiny-crabs-exercise.md
@@ -1,0 +1,7 @@
+---
+'@clerk/react-router': major
+---
+
+No changes have been made to the SDK in this update. There are **no breaking changes**.
+
+This merely bumps the version to a non-zero range and moves the SDK out of beta to a stable release.


### PR DESCRIPTION
## Description

We can safely move the React Router SDK out of beta and into a non-zero version range. So this is a really _boring_ major update as-in there are no changes at all. Just a version bump ☺️ 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
