### PR TITLE
fix(shared): Remove `handleValueOrFn` from subpaths

### DIFF
--- a/.changeset/cyan-beds-cross.md
+++ b/.changeset/cyan-beds-cross.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Remove `handleValueOrFn` from subpaths

--- a/.changeset/cyan-beds-cross.md
+++ b/.changeset/cyan-beds-cross.md
@@ -2,4 +2,4 @@
 '@clerk/shared': patch
 ---
 
-Remove `handleValueOrFn` from subpaths
+Re-add `handleValueOrFn` to subpaths with a deprecation warning.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,6 +89,7 @@
     "error",
     "file",
     "globs",
+    "handleValueOrFn",
     "isomorphicAtob",
     "isomorphicBtoa",
     "keys",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,7 +89,6 @@
     "error",
     "file",
     "globs",
-    "handleValueOrFn",
     "isomorphicAtob",
     "isomorphicBtoa",
     "keys",

--- a/packages/shared/src/handleValueOrFn.ts
+++ b/packages/shared/src/handleValueOrFn.ts
@@ -1,0 +1,6 @@
+import { handleValueOrFn as origHandleValueOrFn } from './utils/handleValueOrFn';
+
+/**
+ * @deprecated - use `handleValueOrFn` from `@clerk/shared/utils` instead
+ */
+export const handleValueOrFn = origHandleValueOrFn;


### PR DESCRIPTION
## Description

Re-adds `handleValueOrFn` to `@clerk/shared` subpaths with a deprecation warning.

<!-- Fixes #(issue number) -->
Fixes ECO-321

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
