### PR TITLE
fix(clerk-js): Always pass domain to createFapiClient()

### DIFF
--- a/.changeset/chatty-lemons-hug.md
+++ b/.changeset/chatty-lemons-hug.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes an issue where Clerk's internal API client was using the incorrect domain for satellite apps.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2051,6 +2051,35 @@ describe('Clerk singleton', () => {
     });
   });
 
+  describe('Clerk multi-domain', () => {
+    describe('when development satellite', () => {
+      it('fapiClient should not use Clerk.domain as its baseUrl', async () => {
+        const sut = new Clerk(developmentPublishableKey, {
+          domain: 'satellite.dev',
+        });
+        await sut.load({
+          isSatellite: true,
+          signInUrl: 'https://primary.dev/sign-in',
+        });
+
+        expect(sut.getFapiClient().buildUrl({ path: '/me' }).href).toContain(`https://${sut.frontendApi}/v1/me`);
+      });
+    });
+
+    describe('when production satellite', () => {
+      test('fapiClient should use Clerk.domain as its baseUrl', async () => {
+        const sut = new Clerk(productionPublishableKey, {
+          domain: 'satellite.com',
+        });
+        await sut.load({
+          isSatellite: true,
+        });
+
+        expect(sut.getFapiClient().buildUrl({ path: '/me' }).href).toContain('https://clerk.satellite.com/v1/me');
+      });
+    });
+  });
+
   describe('buildUrlWithAuth', () => {
     it('builds an absolute url from a relative url in development', async () => {
       const sut = new Clerk(developmentPublishableKey);

--- a/packages/clerk-js/src/core/__tests__/fapiClient.test.ts
+++ b/packages/clerk-js/src/core/__tests__/fapiClient.test.ts
@@ -75,6 +75,14 @@ describe('buildUrl(options)', () => {
     );
   });
 
+  it('uses domain from options if production', () => {
+    expect(
+      createFapiClient({ ...baseFapiClientOptions, domain: 'clerk.other.com', instanceType: 'production' }).buildUrl({
+        path: '/foo',
+      }).href,
+    ).toBe(`https://clerk.other.com/v1/foo?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`);
+  });
+
   it('adds _clerk_session_id as a query parameter if provided and path does not start with client or waitlist', () => {
     expect(fapiClient.buildUrl({ path: '/foo', sessionId: 'sess_42' }).href).toBe(
       `https://clerk.example.com/v1/foo?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test&_clerk_session_id=sess_42`,

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -306,10 +306,11 @@ export class Clerk implements ClerkInterface {
     this.#instanceType = publishableKey.instanceType;
 
     this.#fapiClient = createFapiClient({
-      domain: (this.instanceType === 'development' && this.isSatellite && this.domain) || undefined,
+      domain: this.domain,
       frontendApi: this.frontendApi,
       // this.instanceType is assigned above
       instanceType: this.instanceType as InstanceType,
+      isSatellite: this.isSatellite,
       getSessionId: () => {
         return this.session?.id;
       },

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -67,6 +67,7 @@ type FapiClientOptions = {
   proxyUrl?: string;
   instanceType: InstanceType;
   getSessionId: () => string | undefined;
+  isSatellite?: boolean;
 };
 
 export function createFapiClient(options: FapiClientOptions): FapiClient {
@@ -114,7 +115,7 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
       searchParams.append('rotating_token_nonce', rotatingTokenNonce);
     }
 
-    if (options.domain) {
+    if (options.domain && options.instanceType === 'development' && options.isSatellite) {
       searchParams.append('__domain', options.domain);
     }
 
@@ -144,8 +145,6 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
   function buildUrl(requestInit: FapiRequestInit): URL {
     const { path, pathPrefix = 'v1' } = requestInit;
 
-    const domainOnlyInProd = options.instanceType === 'production' ? options.domain : '';
-
     if (options.proxyUrl) {
       const proxyBase = new URL(options.proxyUrl);
       const proxyPath = proxyBase.pathname.slice(1, proxyBase.pathname.length);
@@ -158,6 +157,9 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
         { stringify: false },
       );
     }
+
+    // We only use the domain option in production, in development it should always match the frontendApi
+    const domainOnlyInProd = options.instanceType === 'production' ? options.domain : '';
 
     const baseUrl = `https://${domainOnlyInProd || options.frontendApi}`;
 


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensure `createFapiClient()` always receives a domain so we can decide if we should be using it or not.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
