### PR TITLE
fix(clerk-js): Removed nested <p> from Keyless popover

### DIFF
--- a/.changeset/wet-beers-compete.md
+++ b/.changeset/wet-beers-compete.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Remove nested <p> tag from the Keyless popover.

--- a/.changeset/wet-beers-compete.md
+++ b/.changeset/wet-beers-compete.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/clerk-js': minor
+'@clerk/clerk-js': patch
 ---
 
 Remove nested <p> tag from the Keyless popover.

--- a/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
+++ b/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
@@ -396,11 +396,11 @@ const _KeylessPrompt = (_props: KeylessPromptProps) => {
                   Dashboard.
                 </>
               ) : (
-                <p>
+                <span>
                   {isSignedIn
                     ? "You've created your first user! Link this application to your Clerk account to explore the Dashboard."
                     : 'We generated temporary API keys for you. Link this application to your Clerk account to configure it.'}
-                </p>
+                </span>
               )}
             </p>
           </div>


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
