### PR TITLE
feat(clerk-js,localizations,types): Add optional combined flow signup start title

### DIFF
--- a/.changeset/wicked-squids-judge.md
+++ b/.changeset/wicked-squids-judge.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add sign up title localization for use in sign-in-or-up flow.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -282,7 +282,11 @@ function _SignUpStart(): JSX.Element {
       <Card.Root>
         <Card.Content>
           <Header.Root showLogo>
-            <Header.Title localizationKey={localizationKeys('signUp.start.title')} />
+            <Header.Title
+              localizationKey={
+                isCombinedFlow ? localizationKeys('signUp.start.titleCombined') : localizationKeys('signUp.start.title')
+              }
+            />
             <Header.Subtitle localizationKey={localizationKeys('signUp.start.subtitle')} />
           </Header.Root>
           <Card.Alert>{card.error}</Card.Alert>

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -539,6 +539,7 @@ export const arSA: LocalizationResource = {
       actionText: 'لديك حساب بالفعل؟',
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'أنشاء حساب جديد',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'للمتابعة مع {{provider|titleize}}',

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -539,7 +539,7 @@ export const arSA: LocalizationResource = {
       actionText: 'لديك حساب بالفعل؟',
       subtitle: 'للمتابعة إلى {{applicationName}}',
       title: 'أنشاء حساب جديد',
-      titleCombined: undefined,
+      titleCombined: 'أنشاء حساب جديد',
     },
   },
   socialButtonsBlockButton: 'للمتابعة مع {{provider|titleize}}',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -545,6 +545,7 @@ export const beBY: LocalizationResource = {
       actionText: 'Ужо ёсць акаўнт?',
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Стварыце Ваш акаўнт',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Працягнуць з дапамогай {{provider|titleize}}',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -545,7 +545,7 @@ export const beBY: LocalizationResource = {
       actionText: 'Ужо ёсць акаўнт?',
       subtitle: 'каб працягнуць працу ў "{{applicationName}}"',
       title: 'Стварыце Ваш акаўнт',
-      titleCombined: undefined,
+      titleCombined: 'Стварыце Ваш акаўнт',
     },
   },
   socialButtonsBlockButton: 'Працягнуць з дапамогай {{provider|titleize}}',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -540,7 +540,7 @@ export const bgBG: LocalizationResource = {
       actionText: 'Вече имате акаунт?',
       subtitle: 'Добре дошли! Моля, попълнете данните, за да започнете.',
       title: 'Създайте своя акаунт',
-      titleCombined: undefined,
+      titleCombined: 'Създайте своя акаунт',
     },
   },
   socialButtonsBlockButton: 'Продължи с {{provider|titleize}}',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -540,6 +540,7 @@ export const bgBG: LocalizationResource = {
       actionText: 'Вече имате акаунт?',
       subtitle: 'Добре дошли! Моля, попълнете данните, за да започнете.',
       title: 'Създайте своя акаунт',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Продължи с {{provider|titleize}}',

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -441,6 +441,7 @@ export const caES: LocalizationResource = {
       actionText: 'Ja tens un compte?',
       subtitle: 'Benvingut! Si us plau, completa els detalls per començar.',
       title: 'Crea el teu compte',
+      titleCombined: 'Crea el teu compte',
     },
   },
   socialButtonsBlockButton: 'Continua amb {{provider|titleize}}',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -538,6 +538,7 @@ export const csCZ: LocalizationResource = {
       actionText: 'Máte účet?',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Vytvořte si účet',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Pokračovat s {{provider|titleize}}',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -538,7 +538,7 @@ export const csCZ: LocalizationResource = {
       actionText: 'Máte účet?',
       subtitle: 'pro pokračování do {{applicationName}}',
       title: 'Vytvořte si účet',
-      titleCombined: undefined,
+      titleCombined: 'Vytvořte si účet',
     },
   },
   socialButtonsBlockButton: 'Pokračovat s {{provider|titleize}}',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -539,7 +539,7 @@ export const daDK: LocalizationResource = {
       actionText: 'Har du en konto?',
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Opret din konto',
-      titleCombined: undefined,
+      titleCombined: 'Opret din konto',
     },
   },
   socialButtonsBlockButton: 'Forsæt med {{provider|titleize}}',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -539,6 +539,7 @@ export const daDK: LocalizationResource = {
       actionText: 'Har du en konto?',
       subtitle: 'Forsæt til {{applicationName}}',
       title: 'Opret din konto',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Forsæt med {{provider|titleize}}',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -546,6 +546,7 @@ export const deDE: LocalizationResource = {
       actionText: 'Haben Sie ein Konto?',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Erstelle deinen Account',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Weiter mit {{provider|titleize}}',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -546,7 +546,7 @@ export const deDE: LocalizationResource = {
       actionText: 'Haben Sie ein Konto?',
       subtitle: 'weiter zu {{applicationName}}',
       title: 'Erstelle deinen Account',
-      titleCombined: undefined,
+      titleCombined: 'Erstelle deinen Account',
     },
   },
   socialButtonsBlockButton: 'Weiter mit {{provider|titleize}}',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -543,6 +543,7 @@ export const elGR: LocalizationResource = {
       actionText: 'Έχετε ήδη λογαριασμό;',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Δημιουργήστε τον λογαριασμό σας',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Συνέχεια με {{provider|titleize}}',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -543,7 +543,7 @@ export const elGR: LocalizationResource = {
       actionText: 'Έχετε ήδη λογαριασμό;',
       subtitle: 'για να συνεχίσετε στο {{applicationName}}',
       title: 'Δημιουργήστε τον λογαριασμό σας',
-      titleCombined: undefined,
+      titleCombined: 'Δημιουργήστε τον λογαριασμό σας',
     },
   },
   socialButtonsBlockButton: 'Συνέχεια με {{provider|titleize}}',

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -530,6 +530,7 @@ export const enGB: LocalizationResource = {
       actionText: 'Already have an account?',
       subtitle: 'Welcome! Please fill in the details to get started.',
       title: 'Create your account',
+      titleCombined: 'Create your account',
     },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -531,6 +531,7 @@ export const enUS: LocalizationResource = {
       actionText: 'Already have an account?',
       subtitle: 'Welcome! Please fill in the details to get started.',
       title: 'Create your account',
+      titleCombined: 'Create your account',
     },
   },
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -541,6 +541,7 @@ export const esES: LocalizationResource = {
       actionText: '¿Ya tienes una cuenta?',
       subtitle: 'para continuar en {{applicationName}}',
       title: 'Crea tu cuenta',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuar con {{provider|titleize}}',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -541,7 +541,7 @@ export const esES: LocalizationResource = {
       actionText: '¿Ya tienes una cuenta?',
       subtitle: 'para continuar en {{applicationName}}',
       title: 'Crea tu cuenta',
-      titleCombined: undefined,
+      titleCombined: 'Crea tu cuenta',
     },
   },
   socialButtonsBlockButton: 'Continuar con {{provider|titleize}}',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -544,6 +544,7 @@ export const esMX: LocalizationResource = {
       actionText: '¿Tienes una cuenta?',
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Crea tu cuenta',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuar con {{provider|titleize}}',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -544,7 +544,7 @@ export const esMX: LocalizationResource = {
       actionText: '¿Tienes una cuenta?',
       subtitle: 'para continuar con {{applicationName}}',
       title: 'Crea tu cuenta',
-      titleCombined: undefined,
+      titleCombined: 'Crea tu cuenta',
     },
   },
   socialButtonsBlockButton: 'Continuar con {{provider|titleize}}',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -541,7 +541,7 @@ export const fiFI: LocalizationResource = {
       actionText: 'Onko sinulla jo tili?',
       subtitle: 'Tervetuloa! Luo tili jatkaaksesi.',
       title: 'Luo tili',
-      titleCombined: undefined,
+      titleCombined: 'Luo tili',
     },
   },
   socialButtonsBlockButton: 'Jatka palvelun {{provider|titleize}} avulla',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -541,6 +541,7 @@ export const fiFI: LocalizationResource = {
       actionText: 'Onko sinulla jo tili?',
       subtitle: 'Tervetuloa! Luo tili jatkaaksesi.',
       title: 'Luo tili',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Jatka palvelun {{provider|titleize}} avulla',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -545,7 +545,7 @@ export const frFR: LocalizationResource = {
       actionText: 'Vous avez déjà un compte ?',
       subtitle: 'pour continuer vers {{applicationName}}',
       title: 'Créez votre compte',
-      titleCombined: undefined,
+      titleCombined: 'Créez votre compte',
     },
   },
   socialButtonsBlockButton: 'Continuer avec {{provider|titleize}}',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -545,6 +545,7 @@ export const frFR: LocalizationResource = {
       actionText: 'Vous avez déjà un compte ?',
       subtitle: 'pour continuer vers {{applicationName}}',
       title: 'Créez votre compte',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuer avec {{provider|titleize}}',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -533,6 +533,7 @@ export const heIL: LocalizationResource = {
       actionText: 'יש לך חשבון?',
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'צור את החשבון שלך',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'המשך עם {{provider|titleize}}',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -533,7 +533,7 @@ export const heIL: LocalizationResource = {
       actionText: 'יש לך חשבון?',
       subtitle: 'להמשיך אל {{applicationName}}',
       title: 'צור את החשבון שלך',
-      titleCombined: undefined,
+      titleCombined: 'צור את החשבון שלך',
     },
   },
   socialButtonsBlockButton: 'המשך עם {{provider|titleize}}',

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -507,6 +507,7 @@ export const hrHR: LocalizationResource = {
       actionText: 'Već imate račun?',
       subtitle: 'Dobrodošli! Molimo ispunite detalje za početak.',
       title: 'Kreirajte svoj račun',
+      titleCombined: 'Kreirajte svoj račun',
     },
   },
   socialButtonsBlockButton: 'Nastavite s {{provider|titleize}}',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -540,6 +540,7 @@ export const huHU: LocalizationResource = {
       actionText: 'Van már fiókod?',
       subtitle: 'Üdv! Kérlek add meg az adatokat, hogy elkezdhesd.',
       title: 'Fiók létrehozása',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Folytatás {{provider|titleize}} segítségével',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -540,7 +540,7 @@ export const huHU: LocalizationResource = {
       actionText: 'Van már fiókod?',
       subtitle: 'Üdv! Kérlek add meg az adatokat, hogy elkezdhesd.',
       title: 'Fiók létrehozása',
-      titleCombined: undefined,
+      titleCombined: 'Fiók létrehozása',
     },
   },
   socialButtonsBlockButton: 'Folytatás {{provider|titleize}} segítségével',

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -490,6 +490,7 @@ export const idID: LocalizationResource = {
       actionText: 'Sudah punya akun?',
       subtitle: 'Selamat datang! Silakan isi detail untuk memulai.',
       title: 'Buat akun Anda',
+      titleCombined: 'Buat akun Anda',
     },
   },
   socialButtonsBlockButton: 'Lanjutkan dengan {{provider|titleize}}',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -543,7 +543,7 @@ export const isIS: LocalizationResource = {
       actionText: 'Ertu með reikning?',
       subtitle: 'Velkomin! Vinsamlegast fylltu út upplýsingar til að byrja.',
       title: 'Stofna reikning',
-      titleCombined: undefined,
+      titleCombined: 'Stofna reikning',
     },
   },
   socialButtonsBlockButton: 'Halda áfram með {{provider|titleize}}',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -543,6 +543,7 @@ export const isIS: LocalizationResource = {
       actionText: 'Ertu með reikning?',
       subtitle: 'Velkomin! Vinsamlegast fylltu út upplýsingar til að byrja.',
       title: 'Stofna reikning',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Halda áfram með {{provider|titleize}}',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -541,7 +541,7 @@ export const itIT: LocalizationResource = {
       actionText: 'Hai già un account?',
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Crea il tuo account',
-      titleCombined: undefined,
+      titleCombined: 'Crea il tuo account',
     },
   },
   socialButtonsBlockButton: 'Continua con {{provider|titleize}}',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -541,6 +541,7 @@ export const itIT: LocalizationResource = {
       actionText: 'Hai già un account?',
       subtitle: 'per continuare su {{applicationName}}',
       title: 'Crea il tuo account',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continua con {{provider|titleize}}',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -540,7 +540,7 @@ export const jaJP: LocalizationResource = {
       actionText: 'アカウントをお持ちですか？',
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'アカウントを作成',
-      titleCombined: undefined,
+      titleCombined: 'アカウントを作成',
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}で続ける',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -540,6 +540,7 @@ export const jaJP: LocalizationResource = {
       actionText: 'アカウントをお持ちですか？',
       subtitle: '{{applicationName}}へのアクセスを続ける',
       title: 'アカウントを作成',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}で続ける',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -535,7 +535,7 @@ export const koKR: LocalizationResource = {
       actionText: '계정이 있으신가요?',
       subtitle: '환영합니다! 아래 정보를 입력해주세요.',
       title: '계정 만들기',
-      titleCombined: undefined,
+      titleCombined: '계정 만들기',
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}로 계속하기',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -535,6 +535,7 @@ export const koKR: LocalizationResource = {
       actionText: '계정이 있으신가요?',
       subtitle: '환영합니다! 아래 정보를 입력해주세요.',
       title: '계정 만들기',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}로 계속하기',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -541,7 +541,7 @@ export const mnMN: LocalizationResource = {
       actionText: 'Бүртгэлтэй юу?',
       subtitle: 'Тавтай морил! Эхлэхийн тулд дэлгэрэнгүй мэдээллийг бөглөнө үү.',
       title: 'Бүртгэл үүсгэх',
-      titleCombined: undefined,
+      titleCombined: 'Бүртгэл үүсгэх',
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}-р үргэлжлүүлэх',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -541,6 +541,7 @@ export const mnMN: LocalizationResource = {
       actionText: 'Бүртгэлтэй юу?',
       subtitle: 'Тавтай морил! Эхлэхийн тулд дэлгэрэнгүй мэдээллийг бөглөнө үү.',
       title: 'Бүртгэл үүсгэх',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}}-р үргэлжлүүлэх',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -540,7 +540,7 @@ export const nbNO: LocalizationResource = {
       actionText: 'Har du allerede en konto?',
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Opprett kontoen din',
-      titleCombined: undefined,
+      titleCombined: 'Opprett kontoen din',
     },
   },
   socialButtonsBlockButton: 'Fortsett med {{provider|titleize}}',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -540,6 +540,7 @@ export const nbNO: LocalizationResource = {
       actionText: 'Har du allerede en konto?',
       subtitle: 'for å fortsette til {{applicationName}}',
       title: 'Opprett kontoen din',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Fortsett med {{provider|titleize}}',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -540,6 +540,7 @@ export const nlNL: LocalizationResource = {
       actionText: 'Heb je al een account?',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Maak je account aan',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Ga verder met {{provider|titleize}}',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -540,7 +540,7 @@ export const nlNL: LocalizationResource = {
       actionText: 'Heb je al een account?',
       subtitle: 'om door te gaan naar {{applicationName}}',
       title: 'Maak je account aan',
-      titleCombined: undefined,
+      titleCombined: 'Maak je account aan',
     },
   },
   socialButtonsBlockButton: 'Ga verder met {{provider|titleize}}',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -545,6 +545,7 @@ export const plPL: LocalizationResource = {
       actionText: 'Masz już konto?',
       subtitle: 'aby kontynuować w {{applicationName}}',
       title: 'Utwórz swoje konto',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Kontynuuj z {{provider|titleize}}',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -545,7 +545,7 @@ export const plPL: LocalizationResource = {
       actionText: 'Masz już konto?',
       subtitle: 'aby kontynuować w {{applicationName}}',
       title: 'Utwórz swoje konto',
-      titleCombined: undefined,
+      titleCombined: 'Utwórz swoje konto',
     },
   },
   socialButtonsBlockButton: 'Kontynuuj z {{provider|titleize}}',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -544,6 +544,7 @@ export const ptBR: LocalizationResource = {
       actionText: 'Possui uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar sua conta',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -544,7 +544,7 @@ export const ptBR: LocalizationResource = {
       actionText: 'Possui uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar sua conta',
-      titleCombined: undefined,
+      titleCombined: 'Criar sua conta',
     },
   },
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -538,6 +538,7 @@ export const ptPT: LocalizationResource = {
       actionText: 'Já tem uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar a sua conta',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -538,7 +538,7 @@ export const ptPT: LocalizationResource = {
       actionText: 'Já tem uma conta?',
       subtitle: 'para continuar em {{applicationName}}',
       title: 'Criar a sua conta',
-      titleCombined: undefined,
+      titleCombined: 'Criar a sua conta',
     },
   },
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -542,6 +542,7 @@ export const roRO: LocalizationResource = {
       actionText: 'Aveți un cont?',
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Creați-vă un cont',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Continuați cu {{provider|titleize}}',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -542,7 +542,7 @@ export const roRO: LocalizationResource = {
       actionText: 'Aveți un cont?',
       subtitle: 'pentru a continua la {{applicationName}}',
       title: 'Creați-vă un cont',
-      titleCombined: undefined,
+      titleCombined: 'Creați-vă un cont',
     },
   },
   socialButtonsBlockButton: 'Continuați cu {{provider|titleize}}',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -552,6 +552,7 @@ export const ruRU: LocalizationResource = {
       actionText: 'Уже есть учетная запись?',
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Создайте Вашу учетную запись',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Продолжить с помощью {{provider|titleize}}',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -552,7 +552,7 @@ export const ruRU: LocalizationResource = {
       actionText: 'Уже есть учетная запись?',
       subtitle: 'чтобы продолжить работу в "{{applicationName}}"',
       title: 'Создайте Вашу учетную запись',
-      titleCombined: undefined,
+      titleCombined: 'Создайте Вашу учетную запись',
     },
   },
   socialButtonsBlockButton: 'Продолжить с помощью {{provider|titleize}}',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -538,6 +538,7 @@ export const skSK: LocalizationResource = {
       actionText: 'Máte účet?',
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Vytvorte si účet',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Pokračovať s {{provider|titleize}}',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -538,7 +538,7 @@ export const skSK: LocalizationResource = {
       actionText: 'Máte účet?',
       subtitle: 'pre pokračovanie do {{applicationName}}',
       title: 'Vytvorte si účet',
-      titleCombined: undefined,
+      titleCombined: 'Vytvorte si účet',
     },
   },
   socialButtonsBlockButton: 'Pokračovať s {{provider|titleize}}',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -539,7 +539,7 @@ export const srRS: LocalizationResource = {
       actionText: 'Već imaš nalog?',
       subtitle: 'Dobrodošao! Molimo popuni detalje da započneš.',
       title: 'Kreiraj svoj nalog',
-      titleCombined: undefined,
+      titleCombined: 'Kreiraj svoj nalog',
     },
   },
   socialButtonsBlockButton: 'Nastavi sa {{provider|titleize}}',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -539,6 +539,7 @@ export const srRS: LocalizationResource = {
       actionText: 'Već imaš nalog?',
       subtitle: 'Dobrodošao! Molimo popuni detalje da započneš.',
       title: 'Kreiraj svoj nalog',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Nastavi sa {{provider|titleize}}',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -543,6 +543,7 @@ export const svSE: LocalizationResource = {
       actionText: 'Har du redan ett konto?',
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Skapa ditt konto',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Fortsätt med {{provider|titleize}}',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -543,7 +543,7 @@ export const svSE: LocalizationResource = {
       actionText: 'Har du redan ett konto?',
       subtitle: 'för att fortsätta till {{applicationName}}',
       title: 'Skapa ditt konto',
-      titleCombined: undefined,
+      titleCombined: 'Skapa ditt konto',
     },
   },
   socialButtonsBlockButton: 'Fortsätt med {{provider|titleize}}',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -538,7 +538,7 @@ export const thTH: LocalizationResource = {
       actionText: 'มีบัญชีอยู่แล้วใช่หรือไม่?',
       subtitle: 'ยินดีต้อนรับ! โปรดกรอกข้อมูลเพื่อเริ่มต้น',
       title: 'สร้างบัญชีของคุณ',
-      titleCombined: undefined,
+      titleCombined: 'สร้างบัญชีของคุณ',
     },
   },
   socialButtonsBlockButton: 'ดำเนินการต่อด้วย {{provider|titleize}}',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -538,6 +538,7 @@ export const thTH: LocalizationResource = {
       actionText: 'มีบัญชีอยู่แล้วใช่หรือไม่?',
       subtitle: 'ยินดีต้อนรับ! โปรดกรอกข้อมูลเพื่อเริ่มต้น',
       title: 'สร้างบัญชีของคุณ',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'ดำเนินการต่อด้วย {{provider|titleize}}',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -541,6 +541,7 @@ export const trTR: LocalizationResource = {
       actionText: 'Hesabınız var mı?',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Hesap oluştur',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}} ile giriş yapın',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -541,7 +541,7 @@ export const trTR: LocalizationResource = {
       actionText: 'Hesabınız var mı?',
       subtitle: '{{applicationName}} ile devam etmek için',
       title: 'Hesap oluştur',
-      titleCombined: undefined,
+      titleCombined: 'Hesap oluştur',
     },
   },
   socialButtonsBlockButton: '{{provider|titleize}} ile giriş yapın',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -538,6 +538,7 @@ export const ukUA: LocalizationResource = {
       actionText: 'Уже є акаунт?',
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Створіть Ваш акаунт',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Продовжити за допомогою {{provider|titleize}}',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -538,7 +538,7 @@ export const ukUA: LocalizationResource = {
       actionText: 'Уже є акаунт?',
       subtitle: 'щоб продовжити роботу в "{{applicationName}}"',
       title: 'Створіть Ваш акаунт',
-      titleCombined: undefined,
+      titleCombined: 'Створіть Ваш акаунт',
     },
   },
   socialButtonsBlockButton: 'Продовжити за допомогою {{provider|titleize}}',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -538,6 +538,7 @@ export const viVN: LocalizationResource = {
       actionText: 'Đã có tài khoản?',
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Tạo tài khoản của bạn',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: 'Tiếp tục với {{provider|titleize}}',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -538,7 +538,7 @@ export const viVN: LocalizationResource = {
       actionText: 'Đã có tài khoản?',
       subtitle: 'để tiếp tục với {{applicationName}}',
       title: 'Tạo tài khoản của bạn',
-      titleCombined: undefined,
+      titleCombined: 'Tạo tài khoản của bạn',
     },
   },
   socialButtonsBlockButton: 'Tiếp tục với {{provider|titleize}}',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -529,6 +529,7 @@ export const zhCN: LocalizationResource = {
       actionText: '已经有账户了？',
       subtitle: '继续使用 {{applicationName}}',
       title: '创建您的账户',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '使用 {{provider|titleize}} 登录',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -529,7 +529,7 @@ export const zhCN: LocalizationResource = {
       actionText: '已经有账户了？',
       subtitle: '继续使用 {{applicationName}}',
       title: '创建您的账户',
-      titleCombined: undefined,
+      titleCombined: '创建您的账户',
     },
   },
   socialButtonsBlockButton: '使用 {{provider|titleize}} 登录',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -535,7 +535,7 @@ export const zhTW: LocalizationResource = {
       actionText: '已經有帳戶了？',
       subtitle: '繼續使用 {{applicationName}}',
       title: '創建您的帳戶',
-      titleCombined: undefined,
+      titleCombined: '創建您的帳戶',
     },
   },
   socialButtonsBlockButton: '使用 {{provider|titleize}} 登錄',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -535,6 +535,7 @@ export const zhTW: LocalizationResource = {
       actionText: '已經有帳戶了？',
       subtitle: '繼續使用 {{applicationName}}',
       title: '創建您的帳戶',
+      titleCombined: undefined,
     },
   },
   socialButtonsBlockButton: '使用 {{provider|titleize}} 登錄',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -100,6 +100,7 @@ type _LocalizationResource = {
   signUp: {
     start: {
       title: LocalizationValue;
+      titleCombined: LocalizationValue;
       subtitle: LocalizationValue;
       actionText: LocalizationValue;
       actionLink: LocalizationValue;


### PR DESCRIPTION
## Description

Add new localization for signup start within sign-in-or-up flow.

![Screenshot 2025-01-23 at 9 35 41 AM](https://github.com/user-attachments/assets/425f4f06-86f4-4ffb-accc-2574dcef928d)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
