### PR TITLE
fix(clerk-js): Pass proxyUrl to createFapiClient

### DIFF
--- a/.changeset/mighty-otters-remain.md
+++ b/.changeset/mighty-otters-remain.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix an issue where Clerk's `proxyUrl` was not being respected.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2080,6 +2080,19 @@ describe('Clerk singleton', () => {
     });
   });
 
+  describe('proxyUrl', () => {
+    describe('when proxyUrl is set', () => {
+      test('fapiClient should use Clerk.proxyUrl as its baseUrl', async () => {
+        const sut = new Clerk(productionPublishableKey, {
+          proxyUrl: 'https://proxy.com/api/__clerk',
+        });
+        await sut.load({});
+
+        expect(sut.getFapiClient().buildUrl({ path: '/me' }).href).toContain('https://proxy.com/api/__clerk/v1/me');
+      });
+    });
+  });
+
   describe('buildUrlWithAuth', () => {
     it('builds an absolute url from a relative url in development', async () => {
       const sut = new Clerk(developmentPublishableKey);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -314,6 +314,7 @@ export class Clerk implements ClerkInterface {
       getSessionId: () => {
         return this.session?.id;
       },
+      proxyUrl: this.proxyUrl,
     });
     // This line is used for the piggy-backing mechanism
     BaseResource.clerk = this;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10277,6 +10277,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensure `proxyUrl` is passed to `createFapiClient()`.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
