### PR TITLE
Inject component, for astro prerendered pages with cloudflare adaptor

### DIFF
--- a/packages/astro/src/astro-components/control/Inject.astro
+++ b/packages/astro/src/astro-components/control/Inject.astro
@@ -1,0 +1,12 @@
+---
+import { getClientSafeEnv } from '@clerk/astro/server';
+import { buildClerkHotloadScript } from '@clerk/astro/server';
+const safeEnv = JSON.stringify(getClientSafeEnv(Astro.locals));
+
+const hotLoadScript = buildClerkHotloadScript(Astro.locals);
+const data = JSON.stringify(Astro.locals.auth());
+---
+
+<script id="__CLERK_ASTRO_SAFE_VARS__" type="application/json" set:html={safeEnv}></script>
+<script id="__CLERK_ASTRO_DATA__" type="application/json" set:html={data}></script>
+<Fragment set:html={hotLoadScript} />

--- a/packages/astro/src/astro-components/index.ts
+++ b/packages/astro/src/astro-components/index.ts
@@ -5,6 +5,7 @@ export { default as SignedIn } from './control/SignedIn.astro';
 export { default as SignedOut } from './control/SignedOut.astro';
 export { default as Protect } from './control/Protect.astro';
 export { default as AuthenticateWithRedirectCallback } from './control/AuthenticateWithRedirectCallback.astro';
+export { default as Inject } from './control/Inject.astro';
 
 /**
  * Unstyled Components

--- a/packages/astro/src/server/index.ts
+++ b/packages/astro/src/server/index.ts
@@ -35,6 +35,10 @@ export { clerkMiddleware } from './clerk-middleware';
 export { createRouteMatcher } from './route-matcher';
 export { clerkClient } from './clerk-client';
 
+export { buildClerkHotloadScript } from './build-clerk-hotload-script';
+
+export { getClientSafeEnv } from './get-safe-env';
+
 /**
  * This will be used to define types of Astro.Locals inside `env.d.ts`
  */


### PR DESCRIPTION
## Description

When using Astro with cloudflare adaptor, prerendered pages are not being injected with clerk scripts by the middleware, which seems to be completely skipped by Astro adaptor.

Server Islands could be a good option to sort this out, but it turns out that the middleware isn't injecting the scripts to the server islands.

This PR adds a `Inject` Astro component, that allows the developer to use clerk in  server islands in prerendered pages. 

## Checklist

- [x] `pnpm test` runs as expected.
- [ x `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new component for injecting authentication and environment data into client-side code, enhancing integration with Clerk authentication.
  - Added new utilities for accessing client-safe environment variables and generating Clerk hotload scripts.

- **Documentation**
  - Updated exports to include the new component and utilities for easier access in projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->