### PR TITLE
Add bun in the crypto section of the package.json imports.

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
       "edge-light": "./dist/runtime/browser/crypto.mjs",
       "worker": "./dist/runtime/browser/crypto.mjs",
       "browser": "./dist/runtime/browser/crypto.mjs",
+      "bun": "./dist/runtime/browser/crypto.mjs",
       "node": {
         "require": "./dist/runtime/node/crypto.js",
         "import": "./dist/runtime/node/crypto.mjs"


### PR DESCRIPTION
## Description

Hi there,

I am trying to add clerk to a tanstack start project running with bun.
The production command is failing with the following error:

> error: Cannot find package '#crypto' from '/home/runner/work/start-clerk-bun-repro/start-clerk-bun-repro/.output/server/node_modules/@clerk/backend/dist/chunk-G4VEKB6A.mjs'

(full minimal repro is there -> https://github.com/p9f/start-clerk-bun-repro)

It appears that adding bun to the package.json imports map (this PR) fixes it.

Even if you don't officially support bun, would you consider merging this?

Thanks

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
