### PR TITLE
chore(repo): Use pnpmDedupe for Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,7 +42,7 @@
   prHourlyLimit: 4,
   prConcurrentLimit: 16,
   postUpdateOptions: [
-    "npmDedupe",
+    "pnpmDedupe",
   ],
   semanticCommitScope: "repo",
   commitMessageLowerCase: "never",
@@ -1524,7 +1524,7 @@
     },
     {
       matchManagers: [
-        "npm",
+        "pnpm",
       ],
       matchDepTypes: [
         "engines",

--- a/renovate.json5
+++ b/renovate.json5
@@ -1524,7 +1524,7 @@
     },
     {
       matchManagers: [
-        "pnpm",
+        "npm",
       ],
       matchDepTypes: [
         "engines",

--- a/scripts/renovate-config-generator.mjs
+++ b/scripts/renovate-config-generator.mjs
@@ -30,7 +30,7 @@ const rules = new Map();
  */
 const defaultRules = [
   {
-    matchManagers: ['pnpm'],
+    matchManagers: ['npm'],
     matchDepTypes: ['engines'],
     matchPackageNames: ['node'],
     enabled: false,

--- a/scripts/renovate-config-generator.mjs
+++ b/scripts/renovate-config-generator.mjs
@@ -30,7 +30,7 @@ const rules = new Map();
  */
 const defaultRules = [
   {
-    matchManagers: ['npm'],
+    matchManagers: ['pnpm'],
     matchDepTypes: ['engines'],
     matchPackageNames: ['node'],
     enabled: false,
@@ -199,7 +199,7 @@ const renovateConfig = {
   rangeStrategy: 'bump',
   prHourlyLimit: 4,
   prConcurrentLimit: 16,
-  postUpdateOptions: ['npmDedupe'],
+  postUpdateOptions: ['pnpmDedupe'],
   semanticCommitScope: 'repo',
   commitMessageLowerCase: 'never',
   packageRules: Array.from(rules.values()).flat().concat(defaultRules),


### PR DESCRIPTION
## Description

Our Renovate PRs fail due to the dedupe check. Since we previously used npm we didn't change the [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions) to account for that. Afterwards the Renovate PRs should be ready without us having to run dedupe.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
