### PR TITLE
chore(nextjs): Gracefully handle failure to create keyless

### DIFF
--- a/.changeset/kind-crabs-unite.md
+++ b/.changeset/kind-crabs-unite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Gracefully handle failure to create keyless.

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -123,11 +123,11 @@ const NextClientClerkProvider = (props: NextClerkProviderProps) => {
   );
 };
 
-export const ClientClerkProvider = (props: NextClerkProviderProps) => {
-  const { children, ...rest } = props;
+export const ClientClerkProvider = (props: NextClerkProviderProps & { disableKeyless?: boolean }) => {
+  const { children, disableKeyless = false, ...rest } = props;
   const safePublishableKey = mergeNextClerkPropsWithEnv(rest).publishableKey;
 
-  if (safePublishableKey || !canUseKeyless) {
+  if (safePublishableKey || !canUseKeyless || disableKeyless) {
     return <NextClientClerkProvider {...rest}>{children}</NextClientClerkProvider>;
   }
 

--- a/packages/nextjs/src/app-router/client/keyless-creator-reader.tsx
+++ b/packages/nextjs/src/app-router/client/keyless-creator-reader.tsx
@@ -19,8 +19,8 @@ export const KeylessCreatorOrReader = (props: NextClerkProviderProps) => {
   return React.cloneElement(children, {
     key: state?.publishableKey,
     publishableKey: state?.publishableKey,
-    __internal_claimKeylessApplicationUrl: state?.claimUrl,
-    __internal_copyInstanceKeysUrl: state?.apiKeysUrl,
+    __internal_keyless_claimKeylessApplicationUrl: state?.claimUrl,
+    __internal_keyless_copyInstanceKeysUrl: state?.apiKeysUrl,
     __internal_bypassMissingPublishableKey: true,
   } as any);
 };

--- a/packages/nextjs/src/app-router/keyless-actions.ts
+++ b/packages/nextjs/src/app-router/keyless-actions.ts
@@ -3,6 +3,7 @@ import type { AccountlessApplication } from '@clerk/backend';
 import { cookies, headers } from 'next/headers';
 import { redirect, RedirectType } from 'next/navigation';
 
+import { errorThrower } from '../server/errorThrower';
 import { detectClerkMiddleware } from '../server/headers-utils';
 import { getKeylessCookieName } from '../server/keyless';
 import { canUseKeyless } from '../utils/feature-flags';
@@ -35,9 +36,10 @@ export async function createOrReadKeylessAction(): Promise<null | Omit<Accountle
     return null;
   }
 
-  const result = await import('../server/keyless-node.js').then(m => m.createOrReadKeyless());
+  const result = await import('../server/keyless-node.js').then(m => m.createOrReadKeyless()).catch(() => null);
 
   if (!result) {
+    errorThrower.throwMissingPublishableKeyError();
     return null;
   }
 

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -85,7 +85,9 @@ export async function ClerkProvider(
   if (shouldRunAsKeyless) {
     // NOTE: Create or read keys on every render. Usually this means only on hard refresh or hard navigations.
 
-    const newOrReadKeys = await import('../../server/keyless-node.js').then(mod => mod.createOrReadKeyless());
+    const newOrReadKeys = await import('../../server/keyless-node.js')
+      .then(mod => mod.createOrReadKeyless())
+      .catch(() => null);
     const { keylessLogger, createConfirmationMessage, createKeylessModeMessage } = await import(
       '../../server/keyless-log-cache.js'
     );
@@ -142,6 +144,18 @@ export async function ClerkProvider(
 
         output = <KeylessCookieSync {...newOrReadKeys}>{clientProvider}</KeylessCookieSync>;
       }
+    } else {
+      // When case keyless should run, but keys are not available, then fallback to throwing for missing keys
+      output = (
+        <ClientClerkProvider
+          {...mergeNextClerkPropsWithEnv(rest)}
+          nonce={await generateNonce()}
+          initialState={await generateStatePromise()}
+          disableKeyless
+        >
+          {children}
+        </ClientClerkProvider>
+      );
     }
   }
 

--- a/packages/nextjs/src/server/keyless-node.ts
+++ b/packages/nextjs/src/server/keyless-node.ts
@@ -123,7 +123,7 @@ const isFileWritingLocked = () => {
   return isCreatingFile || existsSync(CLERK_LOCK);
 };
 
-async function createOrReadKeyless(): Promise<AccountlessApplication | undefined> {
+async function createOrReadKeyless(): Promise<AccountlessApplication | null> {
   const { writeFileSync, mkdirSync } = safeNodeRuntimeFs();
 
   /**
@@ -131,7 +131,7 @@ async function createOrReadKeyless(): Promise<AccountlessApplication | undefined
    * Using both an in-memory and file system lock seems to be the most effective solution.
    */
   if (isFileWritingLocked()) {
-    return undefined;
+    return null;
   }
 
   lockFileWriting();
@@ -156,26 +156,29 @@ async function createOrReadKeyless(): Promise<AccountlessApplication | undefined
    * At this step, it is safe to create new keys and store them.
    */
   const client = createClerkClientWithOptions({});
-  const accountlessApplication = await client.__experimental_accountlessApplications.createAccountlessApplication();
+  const accountlessApplication = await client.__experimental_accountlessApplications
+    .createAccountlessApplication()
+    .catch(() => null);
 
-  writeFileSync(CONFIG_PATH, JSON.stringify(accountlessApplication), {
-    encoding: 'utf8',
-    mode: '0777',
-    flag: 'w',
-  });
+  if (accountlessApplication) {
+    writeFileSync(CONFIG_PATH, JSON.stringify(accountlessApplication), {
+      encoding: 'utf8',
+      mode: '0777',
+      flag: 'w',
+    });
 
-  // TODO-KEYLESS: Add link to official documentation.
-  const README_NOTIFICATION = `
+    // TODO-KEYLESS: Add link to official documentation.
+    const README_NOTIFICATION = `
 ## DO NOT COMMIT
 This directory is auto-generated from \`@clerk/nextjs\` because you are running in Keyless mode. Avoid committing the \`.clerk/\` directory as it includes the secret key of the unclaimed instance.
   `;
 
-  writeFileSync(README_PATH, README_NOTIFICATION, {
-    encoding: 'utf8',
-    mode: '0777',
-    flag: 'w',
-  });
-
+    writeFileSync(README_PATH, README_NOTIFICATION, {
+      encoding: 'utf8',
+      mode: '0777',
+      flag: 'w',
+    });
+  }
   /**
    * Clean up locks.
    */


### PR DESCRIPTION
## Description

If keys are not explicitly set, keyless will kick in, if keyless creation fails, then fallback to throwing error for missing publishable key

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
