### PR TITLE
fix(clerk-js): Ensure only one action is present in UserProfile sections

### DIFF
--- a/.changeset/seven-games-arrive.md
+++ b/.changeset/seven-games-arrive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ensure only one action is open per section within `UserProfile`.

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsMenu.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsMenu.tsx
@@ -10,7 +10,7 @@ import { useEnabledThirdPartyProviders } from '../../hooks';
 import { useRouter } from '../../router';
 import { handleError, sleep } from '../../utils';
 
-const ConnectMenuButton = (props: { strategy: OAuthStrategy }) => {
+const ConnectMenuButton = (props: { strategy: OAuthStrategy; onClick?: () => void }) => {
   const { strategy } = props;
   const card = useCardState();
   const { user } = useUser();
@@ -95,7 +95,7 @@ const ConnectMenuButton = (props: { strategy: OAuthStrategy }) => {
   );
 };
 
-export const AddConnectedAccount = () => {
+export const AddConnectedAccount = ({ onClick }: { onClick?: () => void }) => {
   const { user } = useUser();
   const { strategies } = useEnabledThirdPartyProviders();
 
@@ -114,6 +114,7 @@ export const AddConnectedAccount = () => {
     <ProfileSection.ActionMenu
       triggerLocalizationKey={localizationKeys('userProfile.start.connectedAccountsSection.primaryButton')}
       id='connectedAccounts'
+      onClick={onClick}
     >
       {unconnectedStrategies.map(strategy => (
         <ConnectMenuButton

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -1,5 +1,6 @@
 import { useReverification, useUser } from '@clerk/shared/react';
 import type { ExternalAccountResource, OAuthProvider, OAuthScope, OAuthStrategy } from '@clerk/types';
+import { Fragment } from 'react';
 
 import { appendModalState } from '../../../utils';
 import { ProviderInitialIcon } from '../../common';
@@ -89,6 +90,7 @@ const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => 
   const { navigate } = useRouter();
   const { user } = useUser();
   const card = useCardState();
+  const accountId = account.id;
 
   const isModal = mode === 'modal';
   const redirectUrl = isModal
@@ -158,7 +160,7 @@ const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => 
     );
 
   return (
-    <Action.Root key={account.id}>
+    <Fragment key={account.id}>
       <ProfileSection.Item id='connectedAccounts'>
         <Flex sx={t => ({ overflow: 'hidden', gap: t.space.$2 })}>
           <ImageOrInitial />
@@ -181,7 +183,7 @@ const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => 
           </Box>
         </Flex>
 
-        <ConnectedAccountMenu />
+        <ConnectedAccountMenu account={account} />
       </ProfileSection.Item>
       {shouldDisplayReconnect && (
         <Box
@@ -222,24 +224,25 @@ const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => 
         </Text>
       )}
 
-      <Action.Open value='remove'>
+      <Action.Open value={`remove-${accountId}`}>
         <Action.Card variant='destructive'>
           <RemoveConnectedAccountScreen accountId={account.id} />
         </Action.Card>
       </Action.Open>
-    </Action.Root>
+    </Fragment>
   );
 };
 
-const ConnectedAccountMenu = () => {
+const ConnectedAccountMenu = ({ account }: { account: ExternalAccountResource }) => {
   const { open } = useActionContext();
+  const accountId = account.id;
 
   const actions = (
     [
       {
         label: localizationKeys('userProfile.start.connectedAccountsSection.destructiveActionTitle'),
         isDestructive: true,
-        onClick: () => open('remove'),
+        onClick: () => open(`remove-${accountId}`),
       },
     ] satisfies (PropsOfComponent<typeof ThreeDotsMenu>['actions'][0] | null)[]
   ).filter(a => a !== null) as PropsOfComponent<typeof ThreeDotsMenu>['actions'];

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -1,6 +1,6 @@
 import { useReverification, useUser } from '@clerk/shared/react';
 import type { ExternalAccountResource, OAuthProvider, OAuthScope, OAuthStrategy } from '@clerk/types';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 
 import { appendModalState } from '../../../utils';
 import { ProviderInitialIcon } from '../../common';
@@ -52,6 +52,7 @@ export const ConnectedAccountsSection = withCardStateProvider(
     const { user } = useUser();
     const card = useCardState();
     const hasExternalAccounts = Boolean(user?.externalAccounts?.length);
+    const [actionValue, setActionValue] = useState<string | null>(null);
 
     if (!user || (!shouldAllowCreation && !hasExternalAccounts)) {
       return null;
@@ -69,7 +70,10 @@ export const ConnectedAccountsSection = withCardStateProvider(
         id='connectedAccounts'
       >
         <Card.Alert>{card.error}</Card.Alert>
-        <Action.Root>
+        <Action.Root
+          value={actionValue}
+          onChange={setActionValue}
+        >
           <ProfileSection.ItemList id='connectedAccounts'>
             {accounts.map(account => (
               <ConnectedAccount
@@ -78,7 +82,7 @@ export const ConnectedAccountsSection = withCardStateProvider(
               />
             ))}
           </ProfileSection.ItemList>
-          {shouldAllowCreation && <AddConnectedAccount />}
+          {shouldAllowCreation && <AddConnectedAccount onClick={() => setActionValue(null)} />}
         </Action.Root>
       </ProfileSection.Root>
     );

--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -1,6 +1,6 @@
 import { useClerk, useReverification, useUser } from '@clerk/shared/react';
 import type { PasskeyResource } from '@clerk/types';
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { Col, Flex, localizationKeys, Text, useLocalizations } from '../../customizables';
 import {
@@ -89,6 +89,7 @@ export const UpdatePasskeyForm = withCardStateProvider((props: UpdatePasskeyForm
 
 export const PasskeySection = () => {
   const { user } = useUser();
+  const [actionValue, setActionValue] = useState<string | null>(null);
 
   if (!user) {
     return null;
@@ -100,7 +101,10 @@ export const PasskeySection = () => {
       centered={false}
       id='passkeys'
     >
-      <Action.Root>
+      <Action.Root
+        value={actionValue}
+        onChange={setActionValue}
+      >
         <ProfileSection.ItemList id='passkeys'>
           {user.passkeys.map(passkey => {
             const passkeyId = passkey.id;
@@ -126,7 +130,7 @@ export const PasskeySection = () => {
             );
           })}
 
-          <AddPasskeyButton />
+          <AddPasskeyButton onClick={() => setActionValue(null)} />
         </ProfileSection.ItemList>
       </Action.Root>
     </ProfileSection.Root>
@@ -193,13 +197,14 @@ const ActiveDeviceMenu = ({ passkey }: { passkey: PasskeyResource }) => {
 };
 
 // TODO-PASSKEYS: Should the error be scope to the section ?
-const AddPasskeyButton = () => {
+const AddPasskeyButton = ({ onClick }: { onClick?: () => void }) => {
   const card = useCardState();
   const { isSatellite } = useClerk();
   const { user } = useUser();
   const [createPasskey] = useReverification(() => user?.createPasskey());
 
   const handleCreatePasskey = async () => {
+    onClick?.();
     if (!user) {
       return;
     }

--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -1,6 +1,6 @@
 import { useClerk, useReverification, useUser } from '@clerk/shared/react';
 import type { PasskeyResource } from '@clerk/types';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Col, Flex, localizationKeys, Text, useLocalizations } from '../../customizables';
 import {
@@ -100,30 +100,35 @@ export const PasskeySection = () => {
       centered={false}
       id='passkeys'
     >
-      <ProfileSection.ItemList id='passkeys'>
-        {user.passkeys.map(passkey => (
-          <Action.Root key={passkey.id}>
-            <PasskeyItem
-              key={passkey.id}
-              {...passkey}
-            />
+      <Action.Root>
+        <ProfileSection.ItemList id='passkeys'>
+          {user.passkeys.map(passkey => {
+            const passkeyId = passkey.id;
+            return (
+              <Fragment key={passkeyId}>
+                <PasskeyItem
+                  key={passkeyId}
+                  {...passkey}
+                />
 
-            <Action.Open value='remove'>
-              <Action.Card variant='destructive'>
-                <RemovePasskeyScreen passkey={passkey} />
-              </Action.Card>
-            </Action.Open>
+                <Action.Open value={`remove-${passkeyId}`}>
+                  <Action.Card variant='destructive'>
+                    <RemovePasskeyScreen passkey={passkey} />
+                  </Action.Card>
+                </Action.Open>
 
-            <Action.Open value='rename'>
-              <Action.Card>
-                <PasskeyScreen passkey={passkey} />
-              </Action.Card>
-            </Action.Open>
-          </Action.Root>
-        ))}
+                <Action.Open value={`rename-${passkeyId}`}>
+                  <Action.Card>
+                    <PasskeyScreen passkey={passkey} />
+                  </Action.Card>
+                </Action.Open>
+              </Fragment>
+            );
+          })}
 
-        <AddPasskeyButton />
-      </ProfileSection.ItemList>
+          <AddPasskeyButton />
+        </ProfileSection.ItemList>
+      </Action.Root>
     </ProfileSection.Root>
   );
 };
@@ -138,7 +143,7 @@ const PasskeyItem = (props: PasskeyResource) => {
       }}
     >
       <PasskeyInfo {...props} />
-      <ActiveDeviceMenu />
+      <ActiveDeviceMenu passkey={props} />
     </ProfileSection.Item>
   );
 };
@@ -168,18 +173,19 @@ const PasskeyInfo = (props: PasskeyResource) => {
   );
 };
 
-const ActiveDeviceMenu = () => {
+const ActiveDeviceMenu = ({ passkey }: { passkey: PasskeyResource }) => {
   const { open } = useActionContext();
+  const passkeyId = passkey.id;
 
   const actions = [
     {
       label: localizationKeys('userProfile.start.passkeysSection.menuAction__rename'),
-      onClick: () => open('rename'),
+      onClick: () => open(`rename-${passkeyId}`),
     },
     {
       label: localizationKeys('userProfile.start.passkeysSection.menuAction__destructive'),
       isDestructive: true,
-      onClick: () => open('remove'),
+      onClick: () => open(`remove-${passkeyId}`),
     },
   ] satisfies PropsOfComponent<typeof ThreeDotsMenu>['actions'];
 

--- a/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
@@ -1,5 +1,6 @@
 import { useUser } from '@clerk/shared/react';
 import type { PhoneNumberResource } from '@clerk/types';
+import { Fragment } from 'react';
 
 import { Badge, Box, Flex, localizationKeys, Text } from '../../customizables';
 import { ProfileSection, ThreeDotsMenu, useCardState } from '../../elements';
@@ -51,9 +52,10 @@ export const PhoneSection = ({ shouldAllowCreation = true }: { shouldAllowCreati
     >
       <Action.Root>
         <ProfileSection.ItemList id='phoneNumbers'>
-          {sortIdentificationBasedOnVerification(user?.phoneNumbers, user?.primaryPhoneNumberId).map(phone => (
-            <Action.Root key={phone.id}>
-              <Action.Closed value=''>
+          {sortIdentificationBasedOnVerification(user?.phoneNumbers, user?.primaryPhoneNumberId).map(phone => {
+            const phoneId = phone.id;
+            return (
+              <Fragment key={phoneId}>
                 <ProfileSection.Item id='phoneNumbers'>
                   <Box sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
                     <Flex
@@ -63,7 +65,7 @@ export const PhoneSection = ({ shouldAllowCreation = true }: { shouldAllowCreati
                       <Text sx={t => ({ color: t.colors.$colorText })}>
                         {stringToFormattedPhoneString(phone.phoneNumber)}
                       </Text>
-                      {user?.primaryPhoneNumberId === phone.id && (
+                      {user?.primaryPhoneNumberId === phoneId && (
                         <Badge localizationKey={localizationKeys('badge__primary')} />
                       )}
                       {phone.verification.status !== 'verified' && (
@@ -74,21 +76,21 @@ export const PhoneSection = ({ shouldAllowCreation = true }: { shouldAllowCreati
 
                   <PhoneMenu phone={phone} />
                 </ProfileSection.Item>
-              </Action.Closed>
 
-              <Action.Open value='remove'>
-                <Action.Card variant='destructive'>
-                  <RemovePhoneScreen phoneId={phone.id} />
-                </Action.Card>
-              </Action.Open>
+                <Action.Open value={`remove-${phoneId}`}>
+                  <Action.Card variant='destructive'>
+                    <RemovePhoneScreen phoneId={phoneId} />
+                  </Action.Card>
+                </Action.Open>
 
-              <Action.Open value='verify'>
-                <Action.Card>
-                  <PhoneScreen phoneId={phone.id} />
-                </Action.Card>
-              </Action.Open>
-            </Action.Root>
-          ))}
+                <Action.Open value={`verify-${phoneId}`}>
+                  <Action.Card>
+                    <PhoneScreen phoneId={phoneId} />
+                  </Action.Card>
+                </Action.Open>
+              </Fragment>
+            );
+          })}
           {shouldAllowCreation && (
             <>
               <Action.Trigger value='add'>
@@ -114,6 +116,7 @@ const PhoneMenu = ({ phone }: { phone: PhoneNumberResource }) => {
   const card = useCardState();
   const { open } = useActionContext();
   const { user } = useUser();
+  const phoneId = phone.id;
 
   if (!user) {
     return null;
@@ -131,7 +134,7 @@ const PhoneMenu = ({ phone }: { phone: PhoneNumberResource }) => {
         ? {
             label: localizationKeys('userProfile.start.phoneNumbersSection.detailsAction__primary'),
             // TODO-STEPUP: Is this a sensitive action ?
-            onClick: () => open('verify'),
+            onClick: () => open(`verify-${phoneId}`),
           }
         : null,
       !isPrimary && isVerified
@@ -144,13 +147,13 @@ const PhoneMenu = ({ phone }: { phone: PhoneNumberResource }) => {
       !isPrimary && !isVerified
         ? {
             label: localizationKeys('userProfile.start.phoneNumbersSection.detailsAction__unverified'),
-            onClick: () => open('verify'),
+            onClick: () => open(`verify-${phoneId}`),
           }
         : null,
       {
         label: localizationKeys('userProfile.start.phoneNumbersSection.destructiveAction'),
         isDestructive: true,
-        onClick: () => open('remove'),
+        onClick: () => open(`remove-${phoneId}`),
       },
     ] satisfies (PropsOfComponent<typeof ThreeDotsMenu>['actions'][0] | null)[]
   ).filter(a => a !== null) as PropsOfComponent<typeof ThreeDotsMenu>['actions'];

--- a/packages/clerk-js/src/ui/components/UserProfile/Web3Form.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/Web3Form.tsx
@@ -7,7 +7,7 @@ import { ProfileSection, useCardState, withCardStateProvider } from '../../eleme
 import { useEnabledThirdPartyProviders } from '../../hooks';
 import { getFieldError, handleError } from '../../utils';
 
-export const AddWeb3WalletActionMenu = withCardStateProvider(() => {
+export const AddWeb3WalletActionMenu = withCardStateProvider(({ onClick }: { onClick?: () => void }) => {
   const card = useCardState();
   const { user } = useUser();
   const { strategies, strategyToDisplayData } = useEnabledThirdPartyProviders();
@@ -56,6 +56,7 @@ export const AddWeb3WalletActionMenu = withCardStateProvider(() => {
       <ProfileSection.ActionMenu
         id='web3Wallets'
         triggerLocalizationKey={localizationKeys('userProfile.start.web3WalletsSection.primaryButton')}
+        onClick={onClick}
       >
         {unconnectedStrategies.map(strategy => (
           <ProfileSection.ActionMenuItem

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsSection.test.tsx
@@ -276,4 +276,29 @@ describe('ConnectedAccountsSection ', () => {
       expect(queryByRole('heading', { name: /Remove connected account/i })).not.toBeInTheDocument();
     });
   });
+
+  describe('Handles opening/closing actions', () => {
+    it('closes remove account form when connect account action is clicked', async () => {
+      const { wrapper } = await createFixtures(withConnections);
+      const { userEvent, getByText, getByRole, queryByRole } = render(<ConnectedAccountsSection />, { wrapper });
+
+      const item = getByText(/github/i);
+      const menuButton = item.parentElement?.parentElement?.parentElement?.parentElement?.children?.[1];
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+      getByRole('menuitem', { name: /remove/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove/i }));
+      await waitFor(() => getByRole('heading', { name: /remove connected account/i }));
+
+      await expect(queryByRole('heading', { name: /remove connected account/i })).toBeInTheDocument();
+
+      // TODO: Figure out why this is not working as expected
+      // await userEvent.click(getByRole('button', { name: /connect account/i }));
+
+      // await waitFor(() =>
+      //   expect(queryByRole('heading', { name: /remove connected account/i })).not.toBeInTheDocument(),
+      // );
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsSection.test.tsx
@@ -279,10 +279,10 @@ describe('ConnectedAccountsSection ', () => {
 
   describe('Handles opening/closing actions', () => {
     it('closes remove account form when connect account action is clicked', async () => {
-      const { wrapper } = await createFixtures(withConnections);
+      const { wrapper } = await createFixtures(withSomeConnections);
       const { userEvent, getByText, getByRole, queryByRole } = render(<ConnectedAccountsSection />, { wrapper });
 
-      const item = getByText(/github/i);
+      const item = getByText(/google/i);
       const menuButton = item.parentElement?.parentElement?.parentElement?.parentElement?.children?.[1];
       await act(async () => {
         await userEvent.click(menuButton!);
@@ -293,12 +293,11 @@ describe('ConnectedAccountsSection ', () => {
 
       await expect(queryByRole('heading', { name: /remove connected account/i })).toBeInTheDocument();
 
-      // TODO: Figure out why this is not working as expected
-      // await userEvent.click(getByRole('button', { name: /connect account/i }));
+      await userEvent.click(getByRole('button', { name: /connect account/i }));
 
-      // await waitFor(() =>
-      //   expect(queryByRole('heading', { name: /remove connected account/i })).not.toBeInTheDocument(),
-      // );
+      await waitFor(() =>
+        expect(queryByRole('heading', { name: /remove connected account/i })).not.toBeInTheDocument(),
+      );
     });
   });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailsSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailsSection.test.tsx
@@ -200,8 +200,8 @@ describe('EmailSection', () => {
 
       fixtures.clerk.user?.emailAddresses[0].destroy.mockResolvedValue();
 
-      await userEvent.click(getByRole('button', { name: 'Add email address' }));
-      await waitFor(() => getByRole('heading', { name: /Add email address/i }));
+      await userEvent.click(getByRole('button', { name: /add email address/i }));
+      await waitFor(() => getByRole('heading', { name: /add email address/i }));
 
       const item = getByText(emails[0]);
       const menuButton = getMenuItemFromText(item);
@@ -211,10 +211,10 @@ describe('EmailSection', () => {
 
       getByRole('menuitem', { name: /remove email/i });
       await userEvent.click(getByRole('menuitem', { name: /remove email/i }));
-      await waitFor(() => getByRole('heading', { name: /Remove email address/i }));
+      await waitFor(() => getByRole('heading', { name: /remove email address/i }));
 
-      await waitFor(() => expect(queryByRole('heading', { name: /Remove email address/i })).toBeInTheDocument());
-      await waitFor(() => expect(queryByRole('heading', { name: /Add email address/i })).not.toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /remove email address/i })).toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /add email address/i })).not.toBeInTheDocument());
     });
 
     it('closes remove email address form when add email address action is clicked', async () => {
@@ -236,13 +236,13 @@ describe('EmailSection', () => {
 
       getByRole('menuitem', { name: /remove email/i });
       await userEvent.click(getByRole('menuitem', { name: /remove email/i }));
-      await waitFor(() => getByRole('heading', { name: /Remove email address/i }));
+      await waitFor(() => getByRole('heading', { name: /remove email address/i }));
 
-      await userEvent.click(getByRole('button', { name: 'Add email address' }));
-      await waitFor(() => getByRole('heading', { name: /Add email address/i }));
+      await userEvent.click(getByRole('button', { name: /add email address/i }));
+      await waitFor(() => getByRole('heading', { name: /add email address/i }));
 
-      await waitFor(() => expect(queryByRole('heading', { name: /Remove email address/i })).not.toBeInTheDocument());
-      await waitFor(() => expect(queryByRole('heading', { name: /Add email address/i })).toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /remove email address/i })).not.toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /add email address/i })).toBeInTheDocument());
     });
   });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailsSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailsSection.test.tsx
@@ -187,4 +187,62 @@ describe('EmailSection', () => {
       });
     });
   });
+
+  describe('Handles opening/closing actions', () => {
+    it('closes add email form when remove an email address action is clicked', async () => {
+      const { wrapper, fixtures } = await createFixtures(withEmails);
+      const { getByText, userEvent, getByRole, queryByRole } = render(
+        <CardStateProvider>
+          <EmailsSection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      fixtures.clerk.user?.emailAddresses[0].destroy.mockResolvedValue();
+
+      await userEvent.click(getByRole('button', { name: 'Add email address' }));
+      await waitFor(() => getByRole('heading', { name: /Add email address/i }));
+
+      const item = getByText(emails[0]);
+      const menuButton = getMenuItemFromText(item);
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+
+      getByRole('menuitem', { name: /remove email/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove email/i }));
+      await waitFor(() => getByRole('heading', { name: /Remove email address/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /Remove email address/i })).toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /Add email address/i })).not.toBeInTheDocument());
+    });
+
+    it('closes remove email address form when add email address action is clicked', async () => {
+      const { wrapper, fixtures } = await createFixtures(withEmails);
+      const { getByText, userEvent, getByRole, queryByRole } = render(
+        <CardStateProvider>
+          <EmailsSection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      fixtures.clerk.user?.emailAddresses[0].destroy.mockResolvedValue();
+
+      const item = getByText(emails[0]);
+      const menuButton = getMenuItemFromText(item);
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+
+      getByRole('menuitem', { name: /remove email/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove email/i }));
+      await waitFor(() => getByRole('heading', { name: /Remove email address/i }));
+
+      await userEvent.click(getByRole('button', { name: 'Add email address' }));
+      await waitFor(() => getByRole('heading', { name: /Add email address/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /Remove email address/i })).not.toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /Add email address/i })).toBeInTheDocument());
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/MfaPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/MfaPage.test.tsx
@@ -340,4 +340,51 @@ describe('MfaPage', () => {
       expect(fixtures.clerk.user?.disableTOTP).toHaveBeenCalled();
     });
   });
+
+  describe('Handles opening/closing actions', () => {
+    it('closes remove sms code form when add two-step verification action is clicked', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
+        f.withUser({
+          phone_numbers: [
+            {
+              phone_number: '+306911111111',
+              id: 'id',
+              reserved_for_second_factor: true,
+              verification: { status: 'verified', strategy: 'phone_code' } as VerificationJSON,
+            },
+          ],
+          two_factor_enabled: true,
+        });
+      });
+
+      const { getByText, userEvent, getByRole, queryByRole } = render(
+        <CardStateProvider>
+          <MfaSection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+      await waitFor(() => getByText('Two-step verification'));
+
+      const itemButton = getByText(/\+30 691 1111111/i)?.parentElement?.parentElement?.parentElement?.children[1];
+
+      expect(itemButton).toBeDefined();
+
+      await act(async () => {
+        await userEvent.click(itemButton!);
+      });
+      await waitFor(() => getByText(/^remove$/i));
+      await userEvent.click(getByText(/^remove$/i));
+
+      await expect(queryByRole('heading', { name: /remove two-step verification/i })).toBeInTheDocument();
+
+      await act(async () => {
+        await userEvent.click(getByRole('button', { name: /Add two-step verification/i }));
+      });
+
+      await waitFor(() =>
+        expect(queryByRole('heading', { name: /remove two-step verification/i })).not.toBeInTheDocument(),
+      );
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasskeysSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasskeysSection.test.tsx
@@ -203,4 +203,32 @@ describe('PasskeySection', () => {
       });
     });
   });
+
+  describe('Handles opening/closing actions', () => {
+    it('closes remove passkey form when add a passkey action is clicked', async () => {
+      const { wrapper } = await createFixtures(withPasskeys);
+      const { getByRole, userEvent, getByText, queryByRole } = render(
+        <CardStateProvider>
+          <PasskeySection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      const item = getByText(passkeys[0].name);
+      const menuButton = getMenuItemFromText(item);
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+
+      getByRole('menuitem', { name: /remove/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove/i }));
+      await waitFor(() => getByRole('heading', { name: /remove passkey/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /remove passkey/i })).toBeInTheDocument());
+
+      await userEvent.click(getByRole('button', { name: /add a passkey/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /remove passkey/i })).not.toBeInTheDocument());
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PhoneSection.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PhoneSection.test.tsx
@@ -204,5 +204,63 @@ describe('PhoneSection', () => {
     });
   });
 
+  describe('Handles opening/closing actions', () => {
+    it('closes add phone number form when remove an phone number action is clicked', async () => {
+      const { wrapper, fixtures } = await createFixtures(withNumberCofig);
+      const { getByText, userEvent, getByRole, queryByRole } = render(
+        <CardStateProvider>
+          <PhoneSection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      fixtures.clerk.user?.phoneNumbers[0].destroy.mockResolvedValue();
+
+      await userEvent.click(getByRole('button', { name: /add phone number/i }));
+      await waitFor(() => getByRole('heading', { name: /add phone number/i }));
+
+      const item = getByText(numbers[0]);
+      const menuButton = getMenuItemFromText(item);
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+
+      getByRole('menuitem', { name: /remove phone number/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove phone number/i }));
+      await waitFor(() => getByRole('heading', { name: /remove phone number/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /remove phone number/i })).toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /add phone number/i })).not.toBeInTheDocument());
+    });
+
+    it('closes remove phone number form when add phone number action is clicked', async () => {
+      const { wrapper, fixtures } = await createFixtures(withNumberCofig);
+      const { getByText, userEvent, getByRole, queryByRole } = render(
+        <CardStateProvider>
+          <PhoneSection />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      fixtures.clerk.user?.phoneNumbers[0].destroy.mockResolvedValue();
+
+      const item = getByText(numbers[0]);
+      const menuButton = getMenuItemFromText(item);
+      await act(async () => {
+        await userEvent.click(menuButton!);
+      });
+
+      getByRole('menuitem', { name: /remove phone number/i });
+      await userEvent.click(getByRole('menuitem', { name: /remove phone number/i }));
+      await waitFor(() => getByRole('heading', { name: /remove phone number/i }));
+
+      await userEvent.click(getByRole('button', { name: /add phone number/i }));
+      await waitFor(() => getByRole('heading', { name: /add phone number/i }));
+
+      await waitFor(() => expect(queryByRole('heading', { name: /remove phone number/i })).not.toBeInTheDocument());
+      await waitFor(() => expect(queryByRole('heading', { name: /add phone number/i })).toBeInTheDocument());
+    });
+  });
+
   it.todo('Test for verification of added phone number');
 });

--- a/packages/clerk-js/src/ui/elements/Action/ActionRoot.tsx
+++ b/packages/clerk-js/src/ui/elements/Action/ActionRoot.tsx
@@ -4,7 +4,11 @@ import { useCallback, useState } from 'react';
 
 import { Animated } from '..';
 
-type ActionRootProps = PropsWithChildren<{ animate?: boolean }>;
+type ActionRootProps = PropsWithChildren<{
+  animate?: boolean;
+  value?: string | null;
+  onChange?: (value: string | null) => void;
+}>;
 
 type ActionOpen = (value: string) => void;
 
@@ -15,16 +19,29 @@ export const [ActionContext, useActionContext, _] = createContextAndHook<{
 }>('ActionContext');
 
 export const ActionRoot = (props: ActionRootProps) => {
-  const { animate = true, children } = props;
-  const [active, setActive] = useState<string | null>(null);
+  const { animate = true, children, value: controlledValue, onChange } = props;
+  const [internalValue, setInternalValue] = useState<string | null>(null);
+
+  const active = controlledValue !== undefined ? controlledValue : internalValue;
 
   const close = useCallback(() => {
-    setActive(null);
-  }, []);
+    if (onChange) {
+      onChange(null);
+    } else {
+      setInternalValue(null);
+    }
+  }, [onChange]);
 
-  const open: ActionOpen = useCallback(value => {
-    setActive(value);
-  }, []);
+  const open: ActionOpen = useCallback(
+    newValue => {
+      if (onChange) {
+        onChange(newValue);
+      } else {
+        setInternalValue(newValue);
+      }
+    },
+    [onChange],
+  );
 
   const body = <ActionContext.Provider value={{ value: { active, open, close } }}>{children}</ActionContext.Provider>;
 

--- a/packages/clerk-js/src/ui/elements/Section.tsx
+++ b/packages/clerk-js/src/ui/elements/Section.tsx
@@ -268,10 +268,11 @@ type ProfileSectionActionMenuProps = {
   triggerLocalizationKey?: LocalizationKey;
   triggerSx?: ThemableCssProp;
   id: ProfileSectionId;
+  onClick?: () => void;
 };
 
 export const ProfileSectionActionMenu = (props: ProfileSectionActionMenuProps) => {
-  const { children, triggerLocalizationKey, id, triggerSx } = props;
+  const { children, triggerLocalizationKey, id, triggerSx, onClick } = props;
   return (
     <Flex
       sx={{
@@ -292,6 +293,7 @@ export const ProfileSectionActionMenu = (props: ProfileSectionActionMenuProps) =
             ]}
             leftIcon={Plus}
             leftIconSx={t => ({ width: t.sizes.$4, height: t.sizes.$4 })}
+            onClick={onClick}
           />
         </MenuTrigger>
         <MenuList


### PR DESCRIPTION
## Description

- Currently within user profile, you can open both add and remove section forms at once which leads to some awkward UX
- This PR updates some logic to only be able to render one at a time

**BEFORE**

https://github.com/user-attachments/assets/b88b9c85-4df1-4bc2-8d20-7e5d1272cdce

**AFTER**

https://github.com/user-attachments/assets/a8fd20b0-18b4-4754-8e0f-b8442900f835

Fixes SDKI-817

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
