### PR TITLE
fix(clerk-js): Do not bubble up CaptchaHeartbeat errors

### DIFF
--- a/.changeset/stale-badgers-scream.md
+++ b/.changeset/stale-badgers-scream.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Make sure to catch all CaptchaHeartbeat errors

--- a/packages/clerk-js/src/core/auth/CaptchaHeartbeat.ts
+++ b/packages/clerk-js/src/core/auth/CaptchaHeartbeat.ts
@@ -15,10 +15,14 @@ export class CaptchaHeartbeat {
       return;
     }
 
-    await this.challengeAndSend();
-    this.timers.setInterval(() => {
-      void this.challengeAndSend();
-    }, this.intervalInMs());
+    try {
+      await this.challengeAndSend();
+      this.timers.setInterval(() => {
+        void this.challengeAndSend();
+      }, this.intervalInMs());
+    } catch (error) {
+      console.error('Error starting CaptchaHeartbeat:', error);
+    }
   }
 
   private async challengeAndSend() {
@@ -35,7 +39,7 @@ export class CaptchaHeartbeat {
   }
 
   private isEnabled() {
-    return !!this.clerk.__unstable__environment?.displayConfig.captchaHeartbeat;
+    return !!this.clerk.__unstable__environment?.displayConfig?.captchaHeartbeat;
   }
 
   private clientBypass() {


### PR DESCRIPTION
## Description

Make sure to catch possible exceptions in CaptchaHeartbeat to prevent them from bubbling up to the host application

Fixes: https://github.com/clerk/javascript/issues/5027


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
