### PR TITLE
fix(clerk-js): Remove RHC for unsupported environments

### DIFF
--- a/.changeset/cool-teachers-join.md
+++ b/.changeset/cool-teachers-join.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removes Turnstile remotely-hosted code from builds for unsupported environments

--- a/packages/clerk-js/src/utils/captcha/getCaptchaToken.ts
+++ b/packages/clerk-js/src/utils/captcha/getCaptchaToken.ts
@@ -3,7 +3,7 @@ import type { CaptchaOptions } from './types';
 
 export const getCaptchaToken = (opts: CaptchaOptions) => {
   if (__BUILD_DISABLE_RHC__) {
-    return Promise.reject();
+    return Promise.reject(new Error('Captcha not supported in this environment'));
   }
 
   return getTurnstileToken(opts);

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -90,6 +90,10 @@ async function loadCaptcha() {
 
 async function loadCaptchaFromCloudflareURL() {
   try {
+    if (__BUILD_DISABLE_RHC__) {
+      return Promise.reject(new Error('Captcha not supported in this environment'));
+    }
+
     return await loadScript(CLOUDFLARE_TURNSTILE_ORIGINAL_URL, { defer: true });
   } catch (err) {
     console.warn(


### PR DESCRIPTION
## Description

Turnstile RHC found its way back into the `clerk.no-rhc.mjs` build. This works to remove it.

Fixes ECO-350

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
