### PR TITLE
fix(clerk-js): Pass signInUrl to sign up context when in combined flow

### DIFF
--- a/.changeset/violet-years-dream.md
+++ b/.changeset/violet-years-dream.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Pass the `signInUrl` throught to the sign up context when within the combined flow.

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -151,6 +151,7 @@ function SignInRoot() {
     ssoCallbackUrl: signInContext.ssoCallbackUrl,
     forceRedirectUrl: signInContext.signUpForceRedirectUrl,
     fallbackRedirectUrl: signInContext.signUpFallbackRedirectUrl,
+    signInUrl: signInContext.signInUrl,
     ...normalizeRoutingOptions({ routing: signInContext?.routing, path: signInContext?.path }),
   } as SignUpContextType;
 


### PR DESCRIPTION
## Description

Ensure when within the combined flow, the signInUrl is passed correctly to the sign-up components.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
