### PR TITLE
feat(clerk-js,elements): Pass params through `build*Url()` methods

### DIFF
--- a/.changeset/neat-planets-raise.md
+++ b/.changeset/neat-planets-raise.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+'@clerk/elements': patch
+---
+
+- `@clerk/clerk-js`, `@clerk/types`: Add `redirectUrl` option to `buildAfterSignInUrl()` and `buildAfterSignUpUrl()` methods.
+- `@clerk/elements`: Ensure redirect_url params passed to Elements components are always passed to Clerk's underlying `build*Url()` methods.

--- a/integration/tests/elements/next-sign-in.test.ts
+++ b/integration/tests/elements/next-sign-in.test.ts
@@ -52,6 +52,20 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('Next.js S
     await u.po.expect.toBeSignedIn();
   });
 
+  test('does not allow arbitrary redirect URLs on sign in', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+    await u.po.signIn.goTo({
+      searchParams: new URLSearchParams({ redirect_url: 'https://evil.com' }),
+      headlessSelector: '[data-test-id="sign-in-step-start"]',
+    });
+
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+
+    expect(u.page.url()).not.toContain('https://evil.com');
+
+    await u.po.expect.toBeSignedIn();
+  });
+
   test('sign in with email code', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
     await u.po.signIn.goTo({ headlessSelector: '[data-test-id="sign-in-step-start"]' });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1045,12 +1045,16 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(this.environment.displayConfig.homeUrl);
   }
 
-  public buildAfterSignInUrl(): string {
-    return this.buildUrlWithAuth(new RedirectUrls(this.#options).getAfterSignInUrl());
+  public buildAfterSignInUrl({ redirectUrl }: { redirectUrl?: string | null } = {}): string {
+    return this.buildUrlWithAuth(
+      new RedirectUrls(this.#options, {}, { redirect_url: redirectUrl }).getAfterSignInUrl(),
+    );
   }
 
-  public buildAfterSignUpUrl(): string {
-    return this.buildUrlWithAuth(new RedirectUrls(this.#options).getAfterSignUpUrl());
+  public buildAfterSignUpUrl({ redirectUrl }: { redirectUrl?: string | null } = {}): string {
+    return this.buildUrlWithAuth(
+      new RedirectUrls(this.#options, {}, { redirect_url: redirectUrl }).getAfterSignUpUrl(),
+    );
   }
 
   public buildAfterSignOutUrl(): string {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1045,16 +1045,12 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(this.environment.displayConfig.homeUrl);
   }
 
-  public buildAfterSignInUrl({ redirectUrl }: { redirectUrl?: string | null } = {}): string {
-    return this.buildUrlWithAuth(
-      new RedirectUrls(this.#options, {}, { redirect_url: redirectUrl }).getAfterSignInUrl(),
-    );
+  public buildAfterSignInUrl({ params }: { params?: URLSearchParams } = {}): string {
+    return this.buildUrlWithAuth(new RedirectUrls(this.#options, {}, params).getAfterSignInUrl());
   }
 
-  public buildAfterSignUpUrl({ redirectUrl }: { redirectUrl?: string | null } = {}): string {
-    return this.buildUrlWithAuth(
-      new RedirectUrls(this.#options, {}, { redirect_url: redirectUrl }).getAfterSignUpUrl(),
-    );
+  public buildAfterSignUpUrl({ params }: { params?: URLSearchParams } = {}): string {
+    return this.buildUrlWithAuth(new RedirectUrls(this.#options, {}, params).getAfterSignUpUrl());
   }
 
   public buildAfterSignOutUrl(): string {

--- a/packages/clerk-js/src/utils/redirectUrls.ts
+++ b/packages/clerk-js/src/utils/redirectUrls.ts
@@ -163,9 +163,12 @@ export class RedirectUrls {
     assertNoLegacyProp(obj);
     const res = {} as typeof this.fromSearchParams;
     RedirectUrls.keys.forEach(key => {
-      res[key] = obj[camelToSnake(key)];
+      if (obj instanceof URLSearchParams) {
+        res[key] = obj.get(camelToSnake(key));
+      } else {
+        res[key] = obj[camelToSnake(key)];
+      }
     });
-    res['redirectUrl'] = obj.redirect_url;
     return applyFunctionToObj(this.#filterRedirects(this.#toAbsoluteUrls(filterProps(res, Boolean))), val =>
       val.toString(),
     );

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -91,7 +91,7 @@ export const SignInRouterMachine = setup({
       void context.clerk.setActive({
         session,
         redirectUrl: context.clerk.buildAfterSignInUrl({
-          redirectUrl: context.router?.searchParams().get('redirect_url'),
+          params: context.router?.searchParams(),
         }),
       });
 
@@ -202,7 +202,7 @@ export const SignInRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignInUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -219,7 +219,7 @@ export const SignInRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignInUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -236,7 +236,7 @@ export const SignInRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignInUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -332,7 +332,7 @@ export const SignInRouterMachine = setup({
               type: 'navigateExternal',
               params: ({ context }) => ({
                 path: context.clerk.buildAfterSignInUrl({
-                  redirectUrl: context.router?.searchParams().get('redirect_url'),
+                  params: context.router?.searchParams(),
                 }),
               }),
             },

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -90,7 +90,9 @@ export const SignInRouterMachine = setup({
 
       void context.clerk.setActive({
         session,
-        redirectUrl: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+        redirectUrl: context.clerk.buildAfterSignInUrl({
+          redirectUrl: context.router?.searchParams().get('redirect_url'),
+        }),
       });
 
       enqueue.raise({ type: 'RESET' }, { delay: 2000 }); // Reset machine after 2s delay.
@@ -199,8 +201,9 @@ export const SignInRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signInUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignInUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -215,8 +218,9 @@ export const SignInRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signInUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignInUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -231,8 +235,9 @@ export const SignInRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signInUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignInUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -326,7 +331,9 @@ export const SignInRouterMachine = setup({
             {
               type: 'navigateExternal',
               params: ({ context }) => ({
-                path: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignInUrl(),
+                path: context.clerk.buildAfterSignInUrl({
+                  redirectUrl: context.router?.searchParams().get('redirect_url'),
+                }),
               }),
             },
           ],

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -81,7 +81,9 @@ export const SignUpRouterMachine = setup({
 
       void context.clerk.setActive({
         session,
-        redirectUrl: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+        redirectUrl: context.clerk.buildAfterSignUpUrl({
+          redirectUrl: context.router?.searchParams().get('redirect_url'),
+        }),
       });
     },
     delayedReset: raise({ type: 'RESET' }, { delay: 3000 }), // Reset machine after 3s delay.
@@ -199,8 +201,9 @@ export const SignUpRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -215,8 +218,9 @@ export const SignUpRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -231,8 +235,9 @@ export const SignUpRouterMachine = setup({
               ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete:
-            context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+          redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
+            redirectUrl: context.router?.searchParams().get('redirect_url'),
+          }),
         },
       })),
     },
@@ -313,7 +318,9 @@ export const SignUpRouterMachine = setup({
             {
               type: 'navigateExternal',
               params: ({ context }) => ({
-                path: context.router?.searchParams().get('redirect_url') || context.clerk.buildAfterSignUpUrl(),
+                path: context.clerk.buildAfterSignUpUrl({
+                  redirectUrl: context.router?.searchParams().get('redirect_url'),
+                }),
               }),
             },
           ],

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -82,7 +82,7 @@ export const SignUpRouterMachine = setup({
       void context.clerk.setActive({
         session,
         redirectUrl: context.clerk.buildAfterSignUpUrl({
-          redirectUrl: context.router?.searchParams().get('redirect_url'),
+          params: context.router?.searchParams(),
         }),
       });
     },
@@ -202,7 +202,7 @@ export const SignUpRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -219,7 +219,7 @@ export const SignUpRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -236,7 +236,7 @@ export const SignUpRouterMachine = setup({
               : context.router?.basePath
           }${SSO_CALLBACK_PATH_ROUTE}`,
           redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
-            redirectUrl: context.router?.searchParams().get('redirect_url'),
+            params: context.router?.searchParams(),
           }),
         },
       })),
@@ -319,7 +319,7 @@ export const SignUpRouterMachine = setup({
               type: 'navigateExternal',
               params: ({ context }) => ({
                 path: context.clerk.buildAfterSignUpUrl({
-                  redirectUrl: context.router?.searchParams().get('redirect_url'),
+                  params: context.router?.searchParams(),
                 }),
               }),
             },

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -443,12 +443,12 @@ export interface Clerk {
   /**
    * Returns the configured afterSignInUrl of the instance.
    */
-  buildAfterSignInUrl(): string;
+  buildAfterSignInUrl({ redirectUrl }?: { redirectUrl?: string | null }): string;
 
   /**
    * Returns the configured afterSignInUrl of the instance.
    */
-  buildAfterSignUpUrl(): string;
+  buildAfterSignUpUrl({ redirectUrl }?: { redirectUrl?: string | null }): string;
 
   /**
    * Returns the configured afterSignOutUrl of the instance.

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -443,12 +443,12 @@ export interface Clerk {
   /**
    * Returns the configured afterSignInUrl of the instance.
    */
-  buildAfterSignInUrl({ redirectUrl }?: { redirectUrl?: string | null }): string;
+  buildAfterSignInUrl({ params }?: { params?: URLSearchParams }): string;
 
   /**
    * Returns the configured afterSignInUrl of the instance.
    */
-  buildAfterSignUpUrl({ redirectUrl }?: { redirectUrl?: string | null }): string;
+  buildAfterSignUpUrl({ params }?: { params?: URLSearchParams }): string;
 
   /**
    * Returns the configured afterSignOutUrl of the instance.


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Ensures `redirect_url` parameters passed to Elements components are always passed through `build*Url()` methods before use. Also updates the methods to accept a `params` option.

```ts
Clerk.buildAfterSignInUrl({ params: new URLSearchParams({ redirect_url: '/dashboard' }) })
```

<!-- Fixes #(issue number) -->
fixes SDKI-854

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
