### PR TITLE
chore(clerk-react): Improve JSDoc comments

### DIFF
--- a/.changeset/witty-ladybugs-fix.md
+++ b/.changeset/witty-ladybugs-fix.md
@@ -1,0 +1,8 @@
+---
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/clerk-react': patch
+'@clerk/types': patch
+---
+
+Improve JSDoc comments to provide better IntelliSense in your IDE

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -12,9 +12,7 @@ import { auth } from './auth';
  * - counts towards the [Backend API request rate limit](https://clerk.com/docs/backend-requests/resources/rate-limits#rate-limits).
  *
  * @example
- * ```tsx
- * // app/page.tsx
- *
+ * ```tsx {{ filename: 'app/page.tsx' }}
  * import { currentUser } from '@clerk/nextjs/server'
  *
  * export default async function Page() {

--- a/packages/nextjs/src/server/buildClerkProps.ts
+++ b/packages/nextjs/src/server/buildClerkProps.ts
@@ -12,11 +12,9 @@ type BuildClerkProps = (req: RequestLike, authState?: BuildClerkPropsInitState) 
  * Clerk uses `buildClerkProps` to inform the client-side helpers of the authentication state of the user. This function is used SSR in the `getServerSideProps` function of your Next.js application.
  *
  * @example
- * **Basic usage**
+ * ### Basic usage
  *
- * ```tsx
- * // pages/myServerSidePage.tsx
- *
+ * ```tsx {{ filename: 'pages/myServerSidePage.tsx' }}
  * import { getAuth, buildClerkProps } from '@clerk/nextjs/server'
  * import { GetServerSideProps } from 'next'
  *
@@ -33,13 +31,11 @@ type BuildClerkProps = (req: RequestLike, authState?: BuildClerkPropsInitState) 
  * ```
  *
  * @example
- * **Usage with `clerkClient`**
+ * ### Usage with `clerkClient`
  *
  * The `clerkClient` allows you to access the Clerk API. You can use this to retrieve or update data.
  *
- * ```tsx
- * // pages/api/example.ts
- *
+ * ```tsx {{ filename: 'pages/api/example.ts' }}
  * import { getAuth, buildClerkProps, clerkClient } from '@clerk/nextjs/server'
  * import { GetServerSideProps } from 'next'
  *

--- a/packages/nextjs/src/server/createGetAuth.ts
+++ b/packages/nextjs/src/server/createGetAuth.ts
@@ -84,12 +84,11 @@ export const createSyncGetAuth = ({
  * @returns The `Auth` object. See the [Auth reference](https://clerk.com/docs/references/backend/types/auth-object) for more information.
  *
  * @example
- * **Protect API routes**
+ * ### Protect API routes
  *
  * The following example demonstrates how to protect an API route by checking if the `userId` is present in the `getAuth()` response.
  *
- * ```tsx
- * // app/api/example/route.ts
+ * ```tsx {{ filename: 'app/api/example/route.ts' }}
  * import { getAuth } from '@clerk/nextjs/server'
  * import type { NextApiRequest, NextApiResponse } from 'next'
  *
@@ -107,13 +106,11 @@ export const createSyncGetAuth = ({
  * ```
  *
  * @example
- * **Usage with `getToken()`**
+ * ### Usage with `getToken()`
  *
  * `getAuth()` returns [`getToken()`](https://clerk.com/docs/references/backend/types/auth-object#get-token), which is a method that returns the current user's session token or a custom JWT template.
  *
- * ```tsx
- * // app/api/example/route.ts
- *
+ * ```tsx {{ filename: 'app/api/example/route.ts' }}
  * import { getAuth } from '@clerk/nextjs/server'
  * import type { NextApiRequest, NextApiResponse } from 'next'
  *
@@ -130,13 +127,11 @@ export const createSyncGetAuth = ({
  * ```
  *
  * @example
- * **Usage with `clerkClient`**
+ * ### Usage with `clerkClient`
  *
  * `clerkClient` is used to access the [Backend SDK](https://clerk.com/docs/references/backend/overview), which exposes Clerk's Backend API resources. You can use `getAuth()` to pass authentication information that many of the Backend SDK methods require, like the user's ID.
  *
- * ```tsx
- * // app/api/example/route.ts
- *
+ * ```tsx {{ filename: 'app/api/example/route.ts' }}
  * import { clerkClient, getAuth } from '@clerk/nextjs/server'
  * import type { NextApiRequest, NextApiResponse } from 'next'
  *

--- a/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
+++ b/packages/react/src/hooks/__tests__/useRoutingProps.test.tsx
@@ -16,7 +16,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('defaults to path routing and a path prop is required', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props);
       return <div>{JSON.stringify(options)}</div>;
     };
@@ -27,7 +27,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('the path option is ignored when "hash" routing prop', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props, { path: '/path-option' });
       return <div>{JSON.stringify(options)}</div>;
     };
@@ -43,7 +43,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('the path option is ignored when "virtual" routing prop', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props, { path: '/path-option' });
       return <div>{JSON.stringify(options)}</div>;
     };
@@ -59,7 +59,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('throws error when "hash" routing and path prop are set', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props);
       return <div>{JSON.stringify(options)}</div>;
     };
@@ -77,7 +77,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('throws error when "virtual" routing and path prop are set', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props);
       return <div>{JSON.stringify(options)}</div>;
     };
@@ -95,7 +95,7 @@ describe('useRoutingProps()', () => {
   });
 
   test('path prop has priority over path option', () => {
-    const TestingComponent = props => {
+    const TestingComponent = (props: any) => {
       const options = useRoutingProps('TestingComponent', props, { path: '/path-option' });
       return <div>{JSON.stringify(options)}</div>;
     };

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -9,32 +9,52 @@ import { invalidStateError } from '../errors/messages';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
 import { createGetToken, createSignOut } from './utils';
 
-type UseAuth = (initialAuthState?: any) => UseAuthReturn;
-
 /**
- * Returns the current auth state, the user and session ids and the `getToken`
- * that can be used to retrieve the given template or the default Clerk token.
- *
- * Until Clerk loads, `isLoaded` will be set to `false`.
- * Once Clerk loads, `isLoaded` will be set to `true`, and you can
- * safely access the `userId` and `sessionId` variables.
- *
- * For projects using NextJs or Remix, you can have immediate access to this data during SSR
- * simply by using the `ClerkProvider`.
+ * The `useAuth()` hook provides access to the current user's authentication state and methods to manage the active session.
  *
  * @example
+ *
+ * The following example demonstrates how to use the `useAuth()` hook to access the current auth state, like whether the user is signed in or not. It also includes a basic example for using the `getToken()` method to retrieve a session token for fetching data from an external resource.
+ *
+ * ```tsx {{ filename: 'src/pages/ExternalDataPage.tsx' }}
  * import { useAuth } from '@clerk/clerk-react'
  *
- * function Hello() {
- *   const { isSignedIn, sessionId, userId } = useAuth();
- *   if(isSignedIn) {
- *     return null;
+ * export default function ExternalDataPage() {
+ *   const { userId, sessionId, getToken, isLoaded, isSignedIn } = useAuth()
+ *
+ *   const fetchExternalData = async () => {
+ *     const token = await getToken()
+ *
+ *     // Fetch data from an external API
+ *     const response = await fetch('https://api.example.com/data', {
+ *       headers: {
+ *         Authorization: `Bearer ${token}`,
+ *       },
+ *     })
+ *
+ *     return response.json()
  *   }
- *   console.log(sessionId, userId)
- *   return <div>...</div>
+ *
+ *   if (!isLoaded) {
+ *     return <div>Loading...</div>
+ *   }
+ *
+ *   if (!isSignedIn) {
+ *     return <div>Sign in to view this page</div>
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <p>
+ *         Hello, {userId}! Your current active session is {sessionId}.
+ *       </p>
+ *       <button onClick={fetchExternalData}>Fetch Data</button>
+ *     </div>
+ *   )
  * }
+ * ```
  */
-export const useAuth: UseAuth = (initialAuthState = {}) => {
+export const useAuth = (initialAuthState: any = {}): UseAuthReturn => {
   useAssertWrappedByClerkProvider('useAuth');
 
   const authContextFromHook = useAuthContext();
@@ -77,7 +97,7 @@ export const useAuth: UseAuth = (initialAuthState = {}) => {
  * session and user identifiers, organization roles, and a `has` function for authorization checks.
  * Additionally, it provides `signOut` and `getToken` functions if applicable.
  *
- * Example usage:
+ * @example
  * ```tsx
  * const {
  *   isLoaded,

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -5,9 +5,38 @@ import type { UseSignInReturn } from '@clerk/types';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
 
-type UseSignIn = () => UseSignInReturn;
-
-export const useSignIn: UseSignIn = () => {
+/**
+ * The `useSignIn()` hook provides access to the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in attempt and manage the sign-in flow. You can use this to create a [custom sign-in flow](https://clerk.com/docs/custom-flows/overview#sign-in-flow).
+ *
+ * @example
+ * ### Check the current state of a sign-in
+ *
+ * The following example uses the `useSignIn()` hook to access the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which contains the current sign-in attempt status and methods to create a new sign-in attempt. The `isLoaded` property is used to handle the loading state.
+ *
+ * ```tsx {{ filename: 'src/pages/SignInPage.tsx' }}
+ * import { useSignIn } from '@clerk/clerk-react'
+ *
+ * export default function SignInPage() {
+ *   const { isLoaded, signIn } = useSignIn()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
+ *   }
+ *
+ *   return <div>The current sign-in attempt status is {signIn?.status}.</div>
+ * }
+ * ```
+ *
+ * @example
+ * ### Create a custom sign-in flow with `useSignIn()`
+ *
+ * The `useSignIn()` hook can also be used to build fully custom sign-in flows, if Clerk's prebuilt components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` hook to create custom flows, see the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+ *
+ * ```
+ * ```
+ */
+export const useSignIn = (): UseSignInReturn => {
   useAssertWrappedByClerkProvider('useSignIn');
 
   const isomorphicClerk = useIsomorphicClerkContext();

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -5,9 +5,38 @@ import type { UseSignUpReturn } from '@clerk/types';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvider';
 
-type UseSignUp = () => UseSignUpReturn;
-
-export const useSignUp: UseSignUp = () => {
+/**
+ * The `useSignUp()` hook provides access to the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up attempt and manage the sign-up flow. You can use this to create a [custom sign-up flow](https://clerk.com/docs/custom-flows/overview#sign-up-flow).
+ *
+ * @example
+ * ### Check the current state of a sign-up
+ *
+ * The following example uses the `useSignUp()` hook to access the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which contains the current sign-up attempt status and methods to create a new sign-up attempt. The `isLoaded` property is used to handle the loading state.
+ *
+ * ```tsx {{ filename: 'src/pages/SignUpPage.tsx' }}
+ * import { useSignUp } from '@clerk/clerk-react'
+ *
+ * export default function SignUpPage() {
+ *   const { isLoaded, signUp } = useSignUp()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
+ *   }
+ *
+ *   return <div>The current sign-up attempt status is {signUp?.status}.</div>
+ * }
+ * ```
+ *
+ * @example
+ * ### Create a custom sign-up flow with `useSignUp()`
+ *
+ * The `useSignUp()` hook can also be used to build fully custom sign-up flows, if Clerk's prebuilt components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` hook to create custom flows, see the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+ *
+ * ```tsx
+ * ```
+ */
+export const useSignUp = (): UseSignUpReturn => {
   useAssertWrappedByClerkProvider('useSignUp');
 
   const isomorphicClerk = useIsomorphicClerkContext();

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -1151,7 +1151,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
-  authenticateWithOKXWallet = async (params: AuthenticateWithOKXWalletParams): Promise<void> => {
+  authenticateWithOKXWallet = async (params?: AuthenticateWithOKXWalletParams): Promise<void> => {
     const callback = () => this.clerkjs?.authenticateWithOKXWallet(params);
     if (this.clerkjs && this.#loaded) {
       return callback() as Promise<void>;

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/hooks/index.ts"]
+}

--- a/packages/shared/src/react/hooks/useClerk.ts
+++ b/packages/shared/src/react/hooks/useClerk.ts
@@ -2,6 +2,28 @@ import type { LoadedClerk } from '@clerk/types';
 
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext } from '../contexts';
 
+/**
+ * The `useClerk()` hook provides access to the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object, allowing you to build alternatives to any Clerk Component.
+ *
+ * @warning
+ * This composable should only be used for advanced use cases, such as building a completely custom OAuth flow or as an escape hatch to access to the `Clerk` object.
+ *
+ * @returns The `Clerk` object, which includes all the methods and properties listed in the [`Clerk` reference](https://clerk.com/docs/references/javascript/clerk/clerk).
+ *
+ * @example
+ *
+ * The following example uses the `useClerk()` hook to access the `clerk` object. The `clerk` object is used to call the [`openSignIn()`](https://clerk.com/docs/references/javascript/clerk/clerk#sign-in) method to open the sign-in modal.
+ *
+ * ```tsx {{ filename: 'src/Home.tsx' }}
+ * import { useClerk } from '@clerk/clerk-react'
+ *
+ * export default function Home() {
+ *   const clerk = useClerk()
+ *
+ *   return <button onClick={() => clerk.openSignIn({})}>Sign in</button>
+ * }
+ * ```
+ */
 export const useClerk = (): LoadedClerk => {
   useAssertWrappedByClerkProvider('useClerk');
   return useClerkInstanceContext();

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -22,9 +22,21 @@ import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDef
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
 
 type UseOrganizationParams = {
+  /**
+   * If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `enrollmentMode` property of type [`OrganizationEnrollmentMode`](https://clerk.com/docs/references/react/use-organization#organization-enrollment-mode) and any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization#shared-properties).
+   */
   domains?: true | PaginatedHookConfig<GetDomainsParams>;
+  /**
+   * If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `status` property of type [`OrganizationInvitationStatus`](https://clerk.com/docs/references/react/use-organization#organization-invitation-status) and any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization#shared-properties).
+   */
   membershipRequests?: true | PaginatedHookConfig<GetMembershipRequestParams>;
+  /**
+   * If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `role` property of type [`OrganizationCustomRoleKey[]`](https://clerk.com/docs/references/react/use-organization#organization-custome-role-key) and any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization#shared-properties).
+   */
   memberships?: true | PaginatedHookConfig<GetMembersParams>;
+  /**
+   * If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `status` property of type [`OrganizationInvitationStatus`](https://clerk.com/docs/references/react/use-organization#organization-invitation-status) and any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization#shared-properties).
+   */
   invitations?: true | PaginatedHookConfig<GetInvitationsParams>;
 };
 
@@ -32,39 +44,102 @@ type UseOrganization = <T extends UseOrganizationParams>(
   params?: T,
 ) =>
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * The currently active organization.
+       */
       organization: undefined;
+      /**
+       * The current organization membership.
+       */
       membership: undefined;
+      /**
+       * Includes a paginated list of the organization's domains.
+       */
       domains: PaginatedResourcesWithDefault<OrganizationDomainResource>;
+      /**
+       * Includes a paginated list of the organization's membership requests.
+       */
       membershipRequests: PaginatedResourcesWithDefault<OrganizationMembershipRequestResource>;
+      /**
+       * Includes a paginated list of the organization's memberships.
+       */
       memberships: PaginatedResourcesWithDefault<OrganizationMembershipResource>;
+      /**
+       * Includes a paginated list of the organization's invitations.
+       */
       invitations: PaginatedResourcesWithDefault<OrganizationInvitationResource>;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * The currently active organization.
+       */
       organization: OrganizationResource;
+      /**
+       * The current organization membership.
+       */
       membership: undefined;
+      /**
+       * Includes a paginated list of the organization's domains.
+       */
       domains: PaginatedResourcesWithDefault<OrganizationDomainResource>;
+      /**
+       * Includes a paginated list of the organization's membership requests.
+       */
       membershipRequests: PaginatedResourcesWithDefault<OrganizationMembershipRequestResource>;
+      /**
+       * Includes a paginated list of the organization's memberships.
+       */
       memberships: PaginatedResourcesWithDefault<OrganizationMembershipResource>;
+      /**
+       * Includes a paginated list of the organization's invitations.
+       */
       invitations: PaginatedResourcesWithDefault<OrganizationInvitationResource>;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: boolean;
+      /**
+       * The currently active organization.
+       */
       organization: OrganizationResource | null;
+      /**
+       * The current organization membership.
+       */
       membership: OrganizationMembershipResource | null | undefined;
+      /**
+       * Includes a paginated list of the organization's domains.
+       */
       domains: PaginatedResources<
         OrganizationDomainResource,
         T['membershipRequests'] extends { infinite: true } ? true : false
       > | null;
+      /**
+       * Includes a paginated list of the organization's membership requests.
+       */
       membershipRequests: PaginatedResources<
         OrganizationMembershipRequestResource,
         T['membershipRequests'] extends { infinite: true } ? true : false
       > | null;
+      /**
+       * Includes a paginated list of the organization's memberships.
+       */
       memberships: PaginatedResources<
         OrganizationMembershipResource,
         T['memberships'] extends { infinite: true } ? true : false
       > | null;
+      /**
+       * Includes a paginated list of the organization's invitations.
+       */
       invitations: PaginatedResources<
         OrganizationInvitationResource,
         T['invitations'] extends { infinite: true } ? true : false
@@ -89,6 +164,9 @@ const undefinedPaginatedResource = {
   setData: undefined,
 } as const;
 
+/**
+ * The `useOrganization()` hook retrieves attributes of the currently active organization.
+ */
 export const useOrganization: UseOrganization = params => {
   const {
     domains: domainListParams,

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -17,8 +17,17 @@ import type { PaginatedHookConfig, PaginatedResources, PaginatedResourcesWithDef
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
 
 type UseOrganizationListParams = {
+  /**
+   * `true` or an object with any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization-list#shared-properties). If set to `true`, all default properties will be used.
+   */
   userMemberships?: true | PaginatedHookConfig<GetUserOrganizationMembershipParams>;
+  /**
+   * `true` or an object with [`status: OrganizationInvitationStatus`](https://clerk.com/docs/references/react/use-organization-list#organization-invitation-status) or any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization-list#shared-properties). If set to `true`, all default properties will be used.
+   */
   userInvitations?: true | PaginatedHookConfig<GetUserOrganizationInvitationsParams>;
+  /**
+   * `true` or an object with [`status: OrganizationSuggestionsStatus | OrganizationSuggestionStatus[]`](https://clerk.com/docs/references/react/use-organization-list#organization-suggestion-status) or any of the properties described in [Shared properties](https://clerk.com/docs/references/react/use-organization-list#shared-properties). If set to `true`, all default properties will be used.
+   */
   userSuggestions?: true | PaginatedHookConfig<GetUserOrganizationSuggestionsParams>;
 };
 
@@ -44,31 +53,70 @@ type UseOrganizationList = <T extends UseOrganizationListParams>(
   params?: T,
 ) =>
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * A function that returns a `Promise` which resolves to the newly created `Organization`.
+       */
       createOrganization: undefined;
+      /**
+       * A function that sets the active session and/or organization.
+       */
       setActive: undefined;
+      /**
+       * Returns `PaginatedResources` which includes a list of the user's organization memberships.
+       */
       userMemberships: PaginatedResourcesWithDefault<OrganizationMembershipResource>;
+      /**
+       * Returns `PaginatedResources` which includes a list of the user's organization invitations.
+       */
       userInvitations: PaginatedResourcesWithDefault<UserOrganizationInvitationResource>;
+      /**
+       * Returns `PaginatedResources` which includes a list of suggestions for organizations that the user can join.
+       */
       userSuggestions: PaginatedResourcesWithDefault<OrganizationSuggestionResource>;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: boolean;
+      /**
+       * A function that returns a `Promise` which resolves to the newly created `Organization`.
+       */
       createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource>;
+      /**
+       * A function that sets the active session and/or organization.
+       */
       setActive: SetActive;
+      /**
+       * Returns `PaginatedResources` which includes a list of the user's organization memberships.
+       */
       userMemberships: PaginatedResources<
         OrganizationMembershipResource,
         T['userMemberships'] extends { infinite: true } ? true : false
       >;
+      /**
+       * Returns `PaginatedResources` which includes a list of the user's organization invitations.
+       */
       userInvitations: PaginatedResources<
         UserOrganizationInvitationResource,
         T['userInvitations'] extends { infinite: true } ? true : false
       >;
+      /**
+       * Returns `PaginatedResources` which includes a list of suggestions for organizations that the user can join.
+       */
       userSuggestions: PaginatedResources<
         OrganizationSuggestionResource,
         T['userSuggestions'] extends { infinite: true } ? true : false
       >;
     };
 
+/**
+ * The `useOrganizationList()` hook provides access to the current user's organization memberships, invitations, and suggestions. It also includes methods for creating new organizations and managing the active organization.
+ */
 export const useOrganizationList: UseOrganizationList = params => {
   const { userMemberships, userInvitations, userSuggestions } = params || {};
 

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -30,8 +30,17 @@ async function resolveResult<T>(result: Promise<T> | T): Promise<T | ReturnType<
 
 type ExcludeClerkError<T, P> = T extends { clerk_error: any } ? (P extends { throwOnCancel: true } ? never : null) : T;
 
+/**
+ * The optional options object.
+ */
 type UseReverificationOptions = {
+  /**
+   * A callback function that is invoked when the user cancels the reverification process.
+   */
   onCancel?: () => void;
+  /**
+   * Determines if an error should throw when the user cancels the reverification process. Defaults to `false`.
+   */
   throwOnCancel?: boolean;
 };
 
@@ -110,22 +119,66 @@ type UseReverificationResult<
 > = readonly [(...args: Parameters<Fetcher>) => Promise<ExcludeClerkError<Awaited<ReturnType<Fetcher>>, Options>>];
 
 /**
- * Receives a fetcher async function and returned an enhanced fetcher that automatically handles the reverification flow
- * by displaying a prebuilt UI component when the request from the fetcher fails with a reverification error response.
+ * The `useReverification()` hook is used to handle a session's reverification flow. If a request requires reverification, a modal will display, prompting the user to verify their credentials. Upon successful verification, the original request will automatically retry.
  *
- * While the UI component is displayed the promise is still pending.
- * On success: the original request is retried one more time.
- * On error:
- * (1) by default the fetcher will return `null` and the `onCancel` callback will be executed.
- * (2) when `throwOnCancel: true` instead of returning null, the returned fetcher will throw a `ClerkRuntimeError`.
+ * @warning
+ *
+ * This feature is currently in public beta. **It is not recommended for production use.**
+ *
+ * Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.5.0` or later, `@clerk/clerk-react@5.17.0` or later, and `@clerk/clerk-js@5.35.0` or later.
  *
  * @example
- * A simple example:
+ * ### Handle cancellation of the reverification process
  *
- * function Hello() {
- *   const [fetchBalance] = useReverification(()=> fetch('/transfer-balance',{method:"POST"}));
- *   return <button onClick={fetchBalance}>...</button>
+ * The following example demonstrates how to handle scenarios where a user cancels the reverification flow, such as closing the modal, which might result in `myData` being `null`.
+ *
+ * In the following example, `myFetcher` would be a function in your backend that fetches data from the route that requires reverification. See the [guide on how to require reverification](https://clerk.com/docs/guides/reverification) for more information.
+ *
+ * ```tsx {{ filename: 'src/components/MyButton.tsx' }}
+ * import { useReverification } from '@clerk/react'
+ *
+ * export function MyButton() {
+ *   const [enhancedFetcher] = useReverification(myFetcher)
+ *
+ *   const handleClick = async () => {
+ *     const myData = await enhancedFetcher()
+ *     // If `myData` is null, the user canceled the reverification process
+ *     // You can choose how your app responds. This example returns null.
+ *     if (!myData) return
+ *   }
+ *
+ *   return <button onClick={handleClick}>Update User</button>
  * }
+ * ```
+ *
+ * @example
+ * ### Handle `throwOnCancel`
+ *
+ * When `throwOnCancel` is set to `true`, the fetcher will throw a `ClerkRuntimeError` with the code `"reverification_cancelled"` if the user cancels the reverification flow (for example, by closing the modal). This error can be caught and handled according to your app's needs. For example, by displaying a toast notification to the user or silently ignoring the cancellation.
+ *
+ * In this example, `myFetcher` would be a function in your backend that fetches data from the route that requires reverification. See the [guide on how to require reverification](https://clerk.com/docs/guides/reverification) for more information.
+ *
+ * ```tsx {{ filename: 'src/components/MyButton.tsx' }}
+ * import { useReverification } from '@clerk/clerk-react'
+ * import { isClerkRuntimeError } from '@clerk/clerk-react/errors'
+ *
+ * export function MyButton() {
+ *   const [enhancedFetcher] = useReverification(myFetcher, { throwOnCancel: true })
+ *
+ *   const handleClick = async () => {
+ *     try {
+ *       const myData = await enhancedFetcher()
+ *     } catch (e) {
+ *       // Handle if user cancels the reverification process
+ *       if (isClerkRuntimeError(e) && e.code === 'reverification_cancelled') {
+ *         console.error('User cancelled reverification', e.code)
+ *       }
+ *     }
+ *   }
+ *
+ *   return <button onClick={handleClick}>Update user</button>
+ * }
+ * ```
  */
 function useReverification<
   Fetcher extends (...args: any[]) => Promise<any> | undefined,

--- a/packages/shared/src/react/hooks/useSession.ts
+++ b/packages/shared/src/react/hooks/useSession.ts
@@ -5,22 +5,35 @@ import { useAssertWrappedByClerkProvider, useSessionContext } from '../contexts'
 type UseSession = () => UseSessionReturn;
 
 /**
- * Returns the current auth state and if a session exists, the session object.
- *
- * Until Clerk loads and initializes, `isLoaded` will be set to `false`.
- * Once Clerk loads, `isLoaded` will be set to `true`, and you can
- * safely access `isSignedIn` state and `session`.
+ * The `useSession()` hook provides access to the current user's [`Session`](https://clerk.com/docs/references/javascript/session) object, as well as helpers for setting the active session.
  *
  * @example
+ * ### Access the `Session` object
+ *
+ * The following example uses the `useSession()` hook to access the `Session` object, which has the `lastActiveAt` property. The `lastActiveAt` property is a `Date` object used to show the time the session was last active.
+ *
+ * ```tsx {{ filename: 'src/Home.tsx' }}
  * import { useSession } from '@clerk/clerk-react'
  *
- * function Hello() {
- *   const { isSignedIn, session } = useSession();
- *   if(!isSignedIn) {
- *     return null;
+ * export default function Home() {
+ *   const { isLoaded, session, isSignedIn } = useSession()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
  *   }
- *   return <div>{session.updatedAt}</div>
+ *   if (!isSignedIn) {
+ *     // Handle signed out state
+ *     return null
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <p>This session has been active since {session.lastActiveAt.toLocaleString()}</p>
+ *     </div>
+ *   )
  * }
+ * ```
  */
 export const useSession: UseSession = () => {
   useAssertWrappedByClerkProvider('useSession');

--- a/packages/shared/src/react/hooks/useSessionList.ts
+++ b/packages/shared/src/react/hooks/useSessionList.ts
@@ -2,9 +2,34 @@ import type { UseSessionListReturn } from '@clerk/types';
 
 import { useAssertWrappedByClerkProvider, useClerkInstanceContext, useClientContext } from '../contexts';
 
-type UseSessionList = () => UseSessionListReturn;
-
-export const useSessionList: UseSessionList = () => {
+/**
+ * The `useSessionList()` hook returns an array of [`Session`](https://clerk.com/docs/references/javascript/session) objects that have been registered on the client device.
+ *
+ * @example
+ * ### Get a list of sessions
+ *
+ * The following example uses `useSessionList()` to get a list of sessions that have been registered on the client device. The `sessions` property is used to show the number of times the user has visited the page.
+ *
+ * ```tsx {{ filename: 'src/Home.tsx' }}
+ * import { useSessionList } from '@clerk/clerk-react'
+ *
+ * export default function Home() {
+ *   const { isLoaded, sessions } = useSessionList()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <p>Welcome back. You've been here {sessions.length} times before.</p>
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export const useSessionList = (): UseSessionListReturn => {
   useAssertWrappedByClerkProvider('useSessionList');
 
   const isomorphicClerk = useClerkInstanceContext();

--- a/packages/shared/src/react/hooks/useUser.ts
+++ b/packages/shared/src/react/hooks/useUser.ts
@@ -3,22 +3,103 @@ import type { UseUserReturn } from '@clerk/types';
 import { useAssertWrappedByClerkProvider, useUserContext } from '../contexts';
 
 /**
- * Returns the current auth state and if a user is signed in, the user object.
- *
- * Until Clerk loads and initializes, `isLoaded` will be set to `false`.
- * Once Clerk loads, `isLoaded` will be set to `true`, and you can
- * safely access `isSignedIn` state and `user`.
+ * The `useUser()` hook provides access to the current user's [`User`](https://clerk.com/docs/references/javascript/user/user) object, which contains all the data for a single user in your application and provides methods to manage their account. This hook also allows you to check if the user is signed in and if Clerk has loaded and initialized.
  *
  * @example
+ * ### Get the current user
+ *
+ * The following example uses the `useUser()` hook to access the [`User`](https://clerk.com/docs/references/javascript/user/user) object, which contains the current user's data such as their full name. The `isLoaded` and `isSignedIn` properties are used to handle the loading state and to check if the user is signed in, respectively.
+ *
+ * ```tsx {{ filename: 'src/Example.tsx' }}
+ * export default function Example() {
+ *   const { isSignedIn, user, isLoaded } = useUser()
+ *
+ *   if (!isLoaded) {
+ *     return <div>Loading...</div>
+ *   }
+ *
+ *   if (!isSignedIn) {
+ *     return <div>Sign in to view this page</div>
+ *   }
+ *
+ *   return <div>Hello {user.firstName}!</div>
+ * }
+ * ```
+ *
+ * @example
+ * ### Update user data
+ *
+ * The following example uses the `useUser()` hook to access the [`User`](https://clerk.com/docs/references/javascript/user/user) object, which calls the [`update()`](https://clerk.com/docs/references/javascript/user/user#update) method to update the current user's information.
+ *
+ * ```tsx {{ filename: 'src/Home.tsx' }}
  * import { useUser } from '@clerk/clerk-react'
  *
- * function Hello() {
- *   const { isSignedIn, user } = useUser();
- *   if(!isSignedIn) {
- *     return null;
+ * export default function Home() {
+ *   const { isLoaded, user } = useUser()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
  *   }
- *   return <div>Hello, {user.firstName}</div>
+ *
+ *   if (!user) return null
+ *
+ *   const updateUser = async () => {
+ *     await user.update({
+ *       firstName: 'John',
+ *       lastName: 'Doe',
+ *     })
+ *   }
+ *
+ *   return (
+ *     <>
+ *       <button onClick={updateUser}>Update your name</button>
+ *       <p>user.firstName: {user?.firstName}</p>
+ *       <p>user.lastName: {user?.lastName}</p>
+ *     </>
+ *   )
  * }
+ * ```
+ *
+ * @example
+ * ### Reload user data
+ *
+ * The following example uses the `useUser()` hook to access the [`User`](https://clerk.com/docs/references/javascript/user/user) object, which calls the [`reload()`](https://clerk.com/docs/references/javascript/user/user#reload) method to get the latest user's information.
+ *
+ * ```tsx {{ filename: 'src/Home.tsx' }}
+ * import { useUser } from '@clerk/clerk-react'
+ *
+ * export default function Home() {
+ *   const { isLoaded, user } = useUser()
+ *
+ *   if (!isLoaded) {
+ *     // Handle loading state
+ *     return null
+ *   }
+ *
+ *   if (!user) return null
+ *
+ *   const updateUser = async () => {
+ *     // Update data via an API endpoint
+ *     const updateMetadata = await fetch('/api/updateMetadata')
+ *
+ *     // Check if the update was successful
+ *     if (updateMetadata.message !== 'success') {
+ *       throw new Error('Error updating')
+ *     }
+ *
+ *     // If the update was successful, reload the user data
+ *     await user.reload()
+ *   }
+ *
+ *   return (
+ *     <>
+ *       <button onClick={updateUser}>Update your metadata</button>
+ *       <p>user role: {user?.publicMetadata.role}</p>
+ *     </>
+ *   )
+ * }
+ * ```
  */
 export function useUser(): UseUserReturn {
   useAssertWrappedByClerkProvider('useUser');

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -8,21 +8,70 @@ export type CacheSetter<CData = any> = (
   data?: CData | ((currentData?: CData) => Promise<undefined | CData> | undefined | CData),
 ) => Promise<CData | undefined>;
 
+/**
+ * @interface
+ */
 export type PaginatedResources<T = unknown, Infinite = false> = {
+  /**
+   * An array that contains the fetched data.
+   */
   data: T[];
+  /**
+   * The total count of data that exist remotely.
+   */
   count: number;
+  /**
+   * Clerk's API response error object.
+   */
   error: ClerkAPIResponseError | null;
+  /**
+   * A boolean that is `true` if there is an ongoing request and there is no fetched data.
+   */
   isLoading: boolean;
+  /**
+   * A boolean that is `true` if there is an ongoing request or a revalidation.
+   */
   isFetching: boolean;
+  /**
+   * A boolean that indicates the request failed.
+   */
   isError: boolean;
+  /**
+   * A number that indicates the current page.
+   */
   page: number;
+  /**
+   * A number that indicates the total amount of pages. It is calculated based on `count`, `initialPage`, and `pageSize`.
+   */
   pageCount: number;
+  /**
+   * A function that triggers a specific page to be loaded.
+   */
   fetchPage: ValueOrSetter<number>;
+  /**
+   *
+   * A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page => Math.max(0, page - 1))`.
+   */
   fetchPrevious: () => void;
+  /**
+   * A helper function that triggers the next page to be loaded. This is the same as `fetchPage(page => Math.min(pageCount, page + 1))`.
+   */
   fetchNext: () => void;
+  /**
+   * A boolean that indicates if there are available pages to be fetched.
+   */
   hasNextPage: boolean;
+  /**
+   * A boolean that indicates if there are available pages to be fetched.
+   */
   hasPreviousPage: boolean;
+  /**
+   * A function that triggers a revalidation of the current page.
+   */
   revalidate: () => Promise<void>;
+  /**
+   * A function that allows you to set the data manually.
+   */
   setData: Infinite extends true
     ? // Array of pages of data
       CacheSetter<(ClerkPaginatedResponse<T> | undefined)[]>
@@ -37,29 +86,29 @@ export type PaginatedResourcesWithDefault<T> = {
 
 export type PaginatedHookConfig<T> = T & {
   /**
-   * Persists the previous pages with new ones in the same array
+   * If `true`, newly fetched data will be appended to the existing list rather than replacing it. Useful for implementing infinite scroll functionality. Defaults to `false`.
    */
   infinite?: boolean;
   /**
-   * Return the previous key's data until the new data has been loaded
+   * If `true`, the previous data will be kept in the cache until new data is fetched. Defaults to `false`.
    */
   keepPreviousData?: boolean;
 };
 
 export type PagesOrInfiniteConfig = PaginatedHookConfig<{
   /**
-   * Should a request be triggered
+   * If `true`, a request will be triggered. Defaults to `true`.
    */
   enabled?: boolean;
 }>;
 
 export type PagesOrInfiniteOptions = {
   /**
-   * This the starting point for your fetched results. The initial value persists between re-renders
+   * A number that specifies which page to fetch. For example, if `initialPage` is set to 10, it will skip the first 9 pages and fetch the 10th page. Defaults to `1`.
    */
   initialPage?: number;
   /**
-   * Maximum number of items returned per request. The initial value persists between re-renders
+   * A number that specifies the maximum number of results to return per page. Defaults to `10`.
    */
   pageSize?: number;
 };

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -502,7 +502,7 @@ export type Variables = {
   /**
    * The font weight the components will use. By default, the components will use the 400, 500, 600 and 700 weights
    * for normal, medium, semibold and bold text respectively.
-   * You can override the default weights by passing a {@FontWeightScale} object
+   * You can override the default weights by passing a {@link FontWeightScale} object
    * @default { normal: 400, medium: 500, semibold: 600, bold: 700 };
    */
   fontWeight?: FontWeightScale;

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -15,102 +15,369 @@ import type { UserResource } from './user';
 type CheckAuthorizationSignedOut = undefined;
 type CheckAuthorizationWithoutOrgOrUser = (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => false;
 
+/**
+ * Return values of the `useAuth()` hook
+ */
 export type UseAuthReturn =
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
       isSignedIn: undefined;
+      /**
+       * The ID of the current user.
+       */
       userId: undefined;
+      /**
+       * The ID for the current session.
+       */
       sessionId: undefined;
       actor: undefined;
+      /**
+       * The ID of the user's active organization.
+       */
       orgId: undefined;
+      /**
+       * The current user's role in their active organization.
+       */
       orgRole: undefined;
+      /**
+       * The URL-friendly identifier of the user's active organization.
+       */
       orgSlug: undefined;
+      /**
+       * A function that checks if the user has specific permissions or roles. See the [reference doc](https://clerk.com/docs/references/backend/types/auth-object#has).
+       */
       has: CheckAuthorizationSignedOut;
+      /**
+       * A function that signs out the current user. Returns a promise that resolves when complete. See the [reference doc](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out).
+       */
       signOut: SignOut;
+      /**
+       * A function that retrieves the current user's session token or a custom JWT template. Returns a promise that resolves to the token. See the [reference doc](https://clerk.com/docs/references/javascript/session#get-token).
+       */
       getToken: GetToken;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
       isSignedIn: false;
+      /**
+       * The ID of the current user.
+       */
       userId: null;
+      /**
+       * The ID for the current session.
+       */
       sessionId: null;
       actor: null;
+      /**
+       * The ID of the user's active organization.
+       */
       orgId: null;
+      /**
+       * The current user's role in their active organization.
+       */
       orgRole: null;
+      /**
+       * The URL-friendly identifier of the user's active organization.
+       */
       orgSlug: null;
+      /**
+       * A function that checks if the user has specific permissions or roles. See the [reference doc](https://clerk.com/docs/references/backend/types/auth-object#has).
+       */
       has: CheckAuthorizationWithoutOrgOrUser;
+      /**
+       * A function that signs out the current user. Returns a promise that resolves when complete. See the [reference doc](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out).
+       */
       signOut: SignOut;
+      /**
+       * A function that retrieves the current user's session token or a custom JWT template. Returns a promise that resolves to the token. See the [reference doc](https://clerk.com/docs/references/javascript/session#get-token).
+       */
       getToken: GetToken;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
       isSignedIn: true;
+      /**
+       * The ID of the current user.
+       */
       userId: string;
+      /**
+       * The ID for the current session.
+       */
       sessionId: string;
       actor: ActJWTClaim | null;
+      /**
+       * The ID of the user's active organization.
+       */
       orgId: null;
+      /**
+       * The current user's role in their active organization.
+       */
       orgRole: null;
+      /**
+       * The URL-friendly identifier of the user's active organization.
+       */
       orgSlug: null;
+      /**
+       * A function that checks if the user has specific permissions or roles. See the [reference doc](https://clerk.com/docs/references/backend/types/auth-object#has).
+       */
       has: CheckAuthorizationWithCustomPermissions;
+      /**
+       * A function that signs out the current user. Returns a promise that resolves when complete. See the [reference doc](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out).
+       */
       signOut: SignOut;
+      /**
+       * A function that retrieves the current user's session token or a custom JWT template. Returns a promise that resolves to the token. See the [reference doc](https://clerk.com/docs/references/javascript/session#get-token).
+       */
       getToken: GetToken;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
       isSignedIn: true;
+      /**
+       * The ID of the current user.
+       */
       userId: string;
+      /**
+       * The ID for the current session.
+       */
       sessionId: string;
       actor: ActJWTClaim | null;
+      /**
+       * The ID of the user's active organization.
+       */
       orgId: string;
+      /**
+       * The current user's role in their active organization.
+       */
       orgRole: OrganizationCustomRoleKey;
+      /**
+       * The URL-friendly identifier of the user's active organization.
+       */
       orgSlug: string | null;
+      /**
+       * A function that checks if the user has specific permissions or roles. See the [reference doc](https://clerk.com/docs/references/backend/types/auth-object#has).
+       */
       has: CheckAuthorizationWithCustomPermissions;
+      /**
+       * A function that signs out the current user. Returns a promise that resolves when complete. See the [reference doc](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out).
+       */
       signOut: SignOut;
+      /**
+       * A function that retrieves the current user's session token or a custom JWT template. Returns a promise that resolves to the token. See the [reference doc](https://clerk.com/docs/references/javascript/session#get-token).
+       */
       getToken: GetToken;
     };
 
+/**
+ * Return values of the `useSignIn()` hook
+ */
 export type UseSignInReturn =
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * An object that contains the current sign-in attempt status and methods to create a new sign-in attempt.
+       */
       signIn: undefined;
+      /**
+       * A function that sets the active session.
+       */
       setActive: undefined;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * An object that contains the current sign-in attempt status and methods to create a new sign-in attempt.
+       */
       signIn: SignInResource;
+      /**
+       * A function that sets the active session.
+       */
       setActive: SetActive;
     };
 
+/**
+ * Return values of the `useSignUp()` hook
+ */
 export type UseSignUpReturn =
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
+       */
       signUp: undefined;
+      /**
+       * A function that sets the active session.
+       */
       setActive: undefined;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
+       */
       signUp: SignUpResource;
+      /**
+       * A function that sets the active session.
+       */
       setActive: SetActive;
     };
 
+/**
+ * Return values of the `useSession()` hook
+ */
 export type UseSessionReturn =
-  | { isLoaded: false; isSignedIn: undefined; session: undefined }
-  | { isLoaded: true; isSignedIn: false; session: null }
-  | { isLoaded: true; isSignedIn: true; session: ActiveSessionResource };
+  | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
+      isLoaded: false;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: undefined;
+      /**
+       * Holds the current active session for the user.
+       */
+      session: undefined;
+    }
+  | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
+      isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: false;
+      /**
+       * Holds the current active session for the user.
+       */
+      session: null;
+    }
+  | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
+      isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: true;
+      /**
+       * Holds the current active session for the user.
+       */
+      session: ActiveSessionResource;
+    };
 
+/**
+ * Return values of the `useSessionList()` hook
+ */
 export type UseSessionListReturn =
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: false;
+      /**
+       * A list of sessions that have been registered on the client device.
+       */
       sessions: undefined;
+      /**
+       * A function that sets the active session and/or organization.
+       */
       setActive: undefined;
     }
   | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
       isLoaded: true;
+      /**
+       * A list of sessions that have been registered on the client device.
+       */
       sessions: SessionResource[];
+      /**
+       * A function that sets the active session and/or organization.
+       */
       setActive: SetActive;
     };
 
+/**
+ * Return values of the `useUser()` hook
+ */
 export type UseUserReturn =
-  | { isLoaded: false; isSignedIn: undefined; user: undefined }
-  | { isLoaded: true; isSignedIn: false; user: null }
-  | { isLoaded: true; isSignedIn: true; user: UserResource };
+  | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
+      isLoaded: false;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: undefined;
+      /**
+       * The `User` object for the current user. If the user isn't signed in, `user` will be `null`.
+       */
+      user: undefined;
+    }
+  | {
+      isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: false;
+      /**
+       * The `User` object for the current user. If the user isn't signed in, `user` will be `null`.
+       */
+      user: null;
+    }
+  | {
+      /**
+       * A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+       */
+      isLoaded: true;
+      /**
+       * A boolean that indicates whether a user is currently signed in.
+       */
+      isSignedIn: true;
+      /**
+       * The `User` object for the current user. If the user isn't signed in, `user` will be `null`.
+       */
+      user: UserResource;
+    };

--- a/packages/types/typedoc.json
+++ b/packages/types/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"]
+}

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+    "noImplicitReturns": false,
+    "strict": false,
+    "importHelpers": false
+  },
+  "exclude": ["node_modules", "dist", "**/dist/**", "packages/*/dist/**", "**/*.test.ts', '**/*.test.tsx"]
 }

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -6,7 +6,7 @@ const IGNORE_LIST = [
   '.DS_Store',
   'dev-cli',
   'expo-passkeys',
-  'tailwind-css-transformer',
+  'tailwindcss-transformer',
   'testing',
   'themes',
   'ui',
@@ -29,10 +29,6 @@ const config = {
   // TODO: Once we're happy with the output the JSON should be written to a non-gitignored location as we want to consume it in other places
   json: './.typedoc/output.json',
   entryPointStrategy: 'packages',
-  excludePrivate: true,
-  blockTags: [...OptionDefaults.blockTags, '@warning', '@note', '@important'],
-  modifierTags: [...OptionDefaults.modifierTags],
-  exclude: ['**/*+(.spec|.test).ts'],
   plugin: ['typedoc-plugin-missing-exports'],
   packageOptions: {
     includeVersion: false,
@@ -43,8 +39,11 @@ const config = {
     excludeInternal: true,
     excludeNotDocumented: true,
     gitRevision: 'main',
+    blockTags: [...OptionDefaults.blockTags, '@warning', '@note', '@important'],
+    modifierTags: [...OptionDefaults.modifierTags],
+    exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
-  entryPoints: getPackages(),
+  entryPoints: ['packages/nextjs', 'packages/react', 'packages/backend', 'packages/types'], // getPackages(),
 };
 
 export default config;


### PR DESCRIPTION
## Description

Improve and add JSDoc comments to the public API of `@clerk/clerk-react` to document all client-side helpers (later with Typedoc). Since some of the hooks are in `@clerk/shared` you'll also see changes there.

Some comments are duplicated and _not_ DRY, unfortunately you can't add a comment to a type alias and use that instead. TypeScript doesn't support that 😢 

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
