### PR TITLE
fix(backend): change export type to export for accessing static methods

### DIFF
--- a/.changeset/blue-geckos-hug.md
+++ b/.changeset/blue-geckos-hug.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': major
+---
+
+Changed export type to export for necessary modules to fix the issue with accessing static methods.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -87,7 +87,7 @@ export type {
 /**
  * Resources
  */
-export type {
+export {
   AccountlessApplication,
   AllowlistIdentifier,
   Client,


### PR DESCRIPTION
## Description

This PR addresses an issue where static methods could not be accessed due to the use of export type. The error encountered was:

```sh
'User' cannot be used as a value because it was exported using 'export type'.
```

### Changes
- Changed export type to export for the necessary modules to allow access to static methods.

### Testing
 - Verified that the static methods can now be accessed without any errors.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
