### PR TITLE
Revert "fix(tanstack-start): Fix event handler return type mismatch"

### DIFF
--- a/.changeset/quiet-ties-walk.md
+++ b/.changeset/quiet-ties-walk.md
@@ -4,5 +4,4 @@
 
 Reverts [#5051](https://github.com/clerk/javascript/pull/5051)
 
-This reversion is no longer needed as the underlying h3 version compatibility issue 
-has been resolved upstream in the TanStack Router repository ([TanStack/router#3310](https://github.com/TanStack/router/pull/3310))
+This type change is no longer needed as the underlying `h3` version compatibility issue has been resolved upstream in the TanStack Router repository ([TanStack/router#3310](https://github.com/TanStack/router/pull/3310))

--- a/.changeset/quiet-ties-walk.md
+++ b/.changeset/quiet-ties-walk.md
@@ -1,0 +1,8 @@
+---
+"@clerk/tanstack-start": patch
+---
+
+Reverts [#5051](https://github.com/clerk/javascript/pull/5051)
+
+This reversion is no longer needed as the underlying h3 version compatibility issue 
+has been resolved upstream in the TanStack Router repository ([TanStack/router#3310](https://github.com/TanStack/router/pull/3310))

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -69,8 +69,7 @@
   "devDependencies": {
     "@tanstack/react-router": "^1.97.25",
     "@tanstack/start": "^1.97.25",
-    "esbuild-plugin-file-path-extensions": "^2.1.2",
-    "h3": "^1.13.0"
+    "esbuild-plugin-file-path-extensions": "^2.1.2"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.85.9",

--- a/packages/tanstack-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-start/src/server/middlewareHandler.ts
@@ -1,5 +1,5 @@
 import type { AnyRouter } from '@tanstack/react-router';
-import type { eventHandler } from 'h3';
+import type { EventHandler } from 'vinxi/http';
 
 import { authenticateRequest } from './authenticateRequest';
 import { loadOptions } from './loadOptions';
@@ -11,16 +11,13 @@ export type HandlerCallback<TRouter extends AnyRouter> = (ctx: {
   router: TRouter;
   responseHeaders: Headers;
 }) => Response | Promise<Response>;
-
-export type CustomizeStartHandler<TRouter extends AnyRouter> = (
-  cb: HandlerCallback<TRouter>,
-) => ReturnType<typeof eventHandler>;
+export type CustomizeStartHandler<TRouter extends AnyRouter> = (cb: HandlerCallback<TRouter>) => EventHandler;
 
 export function createClerkHandler<TRouter extends AnyRouter>(
   eventHandler: CustomizeStartHandler<TRouter>,
   clerkOptions: LoaderOptions = {},
 ) {
-  return (cb: HandlerCallback<TRouter>) => {
+  return (cb: HandlerCallback<TRouter>): EventHandler => {
     return eventHandler(async ({ request, router, responseHeaders }) => {
       try {
         const loadedOptions = loadOptions(request, clerkOptions);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,9 +963,6 @@ importers:
       esbuild-plugin-file-path-extensions:
         specifier: ^2.1.2
         version: 2.1.4
-      h3:
-        specifier: ^1.13.0
-        version: 1.14.0
 
   packages/testing:
     dependencies:


### PR DESCRIPTION
Reverts clerk/javascript#5051

This reversion is no longer needed (and didn't actually fix the issue) as the underlying h3 version compatibility issue 
has been resolved upstream in the TanStack Router repository ([TanStack/router#3310](https://github.com/TanStack/router/pull/3310))