### PR TITLE
fix(clerk-react): Re-render `<UserButton />` when `<UserButton />` props change

### DIFF
--- a/.changeset/healthy-panthers-shave.md
+++ b/.changeset/healthy-panthers-shave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Re-render `<UserButton />` when `<UserButton />` props change

--- a/.changeset/healthy-panthers-shave.md
+++ b/.changeset/healthy-panthers-shave.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-react': patch
 ---
 
-Re-render `<UserButton />` when `<UserButton />` props change
+Fix an issue where `<UserButton />` wouldn't update when custom menu item props changed

--- a/integration/templates/react-vite/src/custom-user-button/with-dynamic-labels.tsx
+++ b/integration/templates/react-vite/src/custom-user-button/with-dynamic-labels.tsx
@@ -1,0 +1,76 @@
+import { UserButton } from '@clerk/clerk-react';
+import { useContext } from 'react';
+import { PageContext, PageContextProvider } from '../PageContext.tsx';
+import React from 'react';
+
+function Page1() {
+  const { counter, setCounter } = useContext(PageContext);
+
+  return (
+    <>
+      <h1 data-page={1}>Page 1</h1>
+      <p data-page={1}>Counter: {counter}</p>
+      <button
+        data-page={1}
+        onClick={() => setCounter(a => a + 1)}
+      >
+        Update
+      </button>
+    </>
+  );
+}
+
+export default function Page() {
+  const [open, setIsOpen] = React.useState(false);
+  const [theme, setTheme] = React.useState('light');
+  const [notifications, setNotifications] = React.useState(false);
+  const [language, setLanguage] = React.useState('en');
+
+  return (
+    <PageContextProvider>
+      <UserButton fallback={<>Loading user button</>}>
+        <UserButton.MenuItems>
+          <UserButton.Action
+            label={`Chat is ${open ? 'ON' : 'OFF'}`}
+            labelIcon={<span>🌐</span>}
+            onClick={() => setIsOpen(!open)}
+          />
+          <UserButton.Action
+            label={`Theme: ${theme === 'light' ? '☀️ Light' : '🌙 Dark'}`}
+            labelIcon={<span>🌐</span>}
+            onClick={() => setTheme(t => (t === 'light' ? 'dark' : 'light'))}
+          />
+          <UserButton.Action
+            label={`Notifications ${notifications ? '🔔 ON' : '🔕 OFF'}`}
+            labelIcon={<span>🌐</span>}
+            onClick={() => setNotifications(n => !n)}
+          />
+          <UserButton.Action
+            label={`Language: ${language.toUpperCase()}`}
+            labelIcon={<span>🌍</span>}
+            onClick={() => setLanguage(l => (l === 'en' ? 'es' : 'en'))}
+          />
+          <UserButton.Action label={'manageAccount'} />
+          <UserButton.Action label={'signOut'} />
+          <UserButton.Link
+            href={'http://clerk.com'}
+            label={'Visit Clerk'}
+            labelIcon={<span>🌐</span>}
+          />
+
+          <UserButton.Link
+            href={'/user'}
+            label={'Visit User page'}
+            labelIcon={<span>🌐</span>}
+          />
+
+          <UserButton.Action
+            label={'Custom Alert'}
+            labelIcon={<span>🔔</span>}
+            onClick={() => alert('custom-alert')}
+          />
+        </UserButton.MenuItems>
+      </UserButton>
+    </PageContextProvider>
+  );
+}

--- a/integration/templates/react-vite/src/main.tsx
+++ b/integration/templates/react-vite/src/main.tsx
@@ -10,6 +10,7 @@ import SignUp from './sign-up';
 import UserProfile from './user';
 import UserProfileCustom from './custom-user-profile';
 import UserButtonCustom from './custom-user-button';
+import UserButtonCustomDynamicLabels from './custom-user-button/with-dynamic-labels.tsx';
 import UserButtonCustomTrigger from './custom-user-button-trigger';
 import UserButton from './user-button';
 import Waitlist from './waitlist';
@@ -74,6 +75,10 @@ const router = createBrowserRouter([
       {
         path: '/custom-user-button',
         element: <UserButtonCustom />,
+      },
+      {
+        path: '/custom-user-button-dynamic-labels',
+        element: <UserButtonCustomDynamicLabels />,
       },
       {
         path: '/custom-user-button-trigger',

--- a/packages/react/src/components/ClerkHostRenderer.tsx
+++ b/packages/react/src/components/ClerkHostRenderer.tsx
@@ -63,9 +63,10 @@ export class ClerkHostRenderer extends React.PureComponent<
 
     // Remove children and customPages from props before comparing
     // children might hold circular references which deepEqual can't handle
-    // and the implementation of customPages or customMenuItems relies on props getting new references
-    const prevProps = without(_prevProps.props, 'customPages', 'customMenuItems', 'children');
-    const newProps = without(this.props.props, 'customPages', 'customMenuItems', 'children');
+    // and the implementation of customPages relies on props getting new references
+    const prevProps = without(_prevProps.props, 'customPages', 'children');
+    const newProps = without(this.props.props, 'customPages', 'children');
+
     // instead, we simply use the length of customPages to determine if it changed or not
     const customPagesChanged = prevProps.customPages?.length !== newProps.customPages?.length;
     const customMenuItemsChanged = prevProps.customMenuItems?.length !== newProps.customMenuItems?.length;


### PR DESCRIPTION
## Description

In this pr we re-render the `<UserButton />` component when the props are changing 
e.g.
Before this change the following example didn't work, the label was always `Chat is OFF`
```
 <UserButton>
    <UserButton.MenuItems>
      <UserButton.Action
        label={`Chat is ${open ? 'ON' : 'OFF'}`}
        labelIcon={<DotIcon />}
        onClick={() => setIsOpen(!open)}
      />
    </UserButton.MenuItems>
  </UserButton>
```
Now the `<UserButton />` appropriate 

https://github.com/user-attachments/assets/17463463-07e1-4eef-aeb6-75ae1b2ba918

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
