### PR TITLE
chore(clerk-js): Add virtual routing deprecation warning

### DIFF
--- a/.changeset/friendly-ears-bow.md
+++ b/.changeset/friendly-ears-bow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add virtual routing deprecation warning.

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -1,3 +1,4 @@
+import { deprecated } from '@clerk/shared/deprecated';
 import type { Appearance } from '@clerk/types';
 import React, { lazy, Suspense } from 'react';
 
@@ -56,6 +57,9 @@ type LazyComponentRendererProps = React.PropsWithChildren<
 type PortalProps = Parameters<typeof Portal>[0];
 
 export const LazyComponentRenderer = (props: LazyComponentRendererProps) => {
+  if (props.componentProps.routing === 'virtual') {
+    deprecated('routing="virtual"', 'Use routing="hash" instead.');
+  }
   return (
     <AppearanceProvider
       globalAppearance={props.globalAppearance}


### PR DESCRIPTION
## Description

Adding a deprecation warning for virtual routing usage, that is to be removed in the next major release.

Resolves SDKI-858

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
