### PR TITLE
fix(testing): Fix captcha triggering issue in Playwright tests

### DIFF
--- a/.changeset/smooth-insects-perform.md
+++ b/.changeset/smooth-insects-perform.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Fix captcha triggering on Playwright tests

--- a/packages/testing/src/playwright/setupClerkTestingToken.ts
+++ b/packages/testing/src/playwright/setupClerkTestingToken.ts
@@ -42,9 +42,15 @@ export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestin
     const response = await route.fetch({
       url: originalUrl.toString(),
     });
-
     const json = await response.json();
-    json.response.captcha_bypass = true;
+
+    if (json?.response?.captcha_bypass === false) {
+      json.response.captcha_bypass = true;
+    }
+
+    if (json?.client?.captcha_bypass === false) {
+      json.client.captcha_bypass = true;
+    }
 
     await route.fulfill({ response, json });
   });

--- a/packages/testing/src/playwright/setupClerkTestingToken.ts
+++ b/packages/testing/src/playwright/setupClerkTestingToken.ts
@@ -57,9 +57,8 @@ export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestin
       }
 
       await route.fulfill({
-        status: response.status(),
-        headers: response.headers(),
-        json: json,
+        response,
+        json,
       });
     } catch {
       await route.continue({

--- a/packages/testing/src/playwright/setupClerkTestingToken.ts
+++ b/packages/testing/src/playwright/setupClerkTestingToken.ts
@@ -31,7 +31,7 @@ export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestin
   }
   const apiUrl = `https://${fapiUrl}/v1/**/*`;
 
-  await page.route(apiUrl, (route, request) => {
+  await page.route(apiUrl, async (route, request) => {
     const originalUrl = new URL(request.url());
     const testingToken = process.env.CLERK_TESTING_TOKEN;
 
@@ -39,8 +39,13 @@ export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestin
       originalUrl.searchParams.set(TESTING_TOKEN_PARAM, testingToken);
     }
 
-    void route.continue({
+    const response = await route.fetch({
       url: originalUrl.toString(),
     });
+
+    const json = await response.json();
+    json.response.captcha_bypass = true;
+
+    await route.fulfill({ response, json });
   });
 };

--- a/packages/testing/src/playwright/setupClerkTestingToken.ts
+++ b/packages/testing/src/playwright/setupClerkTestingToken.ts
@@ -61,9 +61,11 @@ export const setupClerkTestingToken = async ({ page, options }: SetupClerkTestin
         json,
       });
     } catch {
-      await route.continue({
-        url: originalUrl.toString(),
-      });
+      await route
+        .continue({
+          url: originalUrl.toString(),
+        })
+        .catch(console.error);
     }
   });
 };

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -70,7 +70,7 @@ export interface ClientJSON extends ClerkResourceJSON {
   sessions: SessionJSON[];
   sign_up: SignUpJSON | null;
   sign_in: SignInJSON | null;
-  captcha_bypass?: boolean;
+  captcha_bypass?: boolean; // this is used by the @clerk/testing package
   last_active_session_id: string | null;
   cookie_expires_at: number | null;
   created_at: number;


### PR DESCRIPTION
## Description

This PR adds support for bypassing the Turnstile script when running tests on Playwright and have the Bot Protection enabled for sign-ups in the Clerk Dashboard.

Cypress support will be added in a follow-up PR

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
