### PR TITLE
chore(e2e): Run keyless e2e tests in staging database

### DIFF
--- a/integration/models/applicationConfig.ts
+++ b/integration/models/applicationConfig.ts
@@ -170,7 +170,8 @@ export const applicationConfig = () => {
             [...env.privateVariables]
               .filter(([_, v]) => v)
               .map(([k, v]) => `${envFormatters.private(k)}=${v}`)
-              .join('\n'),
+              .join('\n') +
+            '\n',
         );
       };
       return defaultWriter;

--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -24,11 +24,16 @@ export const instanceKeys = getInstanceKeys();
 
 const base = environmentConfig()
   .setEnvVariable('public', 'CLERK_TELEMETRY_DISABLED', true)
+  .setEnvVariable('public', 'CLERK_KEYLESS_DISABLED', true)
   .setEnvVariable('public', 'CLERK_SIGN_IN_URL', '/sign-in')
   .setEnvVariable('public', 'CLERK_SIGN_UP_URL', '/sign-up')
   .setEnvVariable('public', 'CLERK_JS_URL', constants.E2E_APP_CLERK_JS || 'http://localhost:18211/clerk.browser.js');
 
-const withKeyless = base.clone().setEnvVariable('public', 'CLERK_ENABLE_KEYLESS', true);
+const withKeyless = base
+  .clone()
+  // Creates keyless applications in our staging database.
+  .setEnvVariable('private', 'CLERK_API_URL', 'https://api.clerkstage.dev')
+  .setEnvVariable('public', 'CLERK_KEYLESS_DISABLED', false);
 
 const withEmailCodes = base
   .clone()

--- a/integration/tests/next-quickstart-keyless.test.ts
+++ b/integration/tests/next-quickstart-keyless.test.ts
@@ -25,11 +25,15 @@ const mockClaimedInstanceEnvironmentCall = async (page: Page) => {
 test.describe('Keyless mode @quickstart', () => {
   test.describe.configure({ mode: 'serial' });
   let app: Application;
+  let dashboardUrl = 'https://dashboard.clerk.com/';
 
   test.beforeAll(async () => {
     app = await commonSetup.commit();
     await app.setup();
     await app.withEnv(appConfigs.envs.withKeyless);
+    if (appConfigs.envs.withKeyless.privateVariables.get('CLERK_API_URL')?.includes('clerkstage')) {
+      dashboardUrl = 'https://dashboard.clerkstage.dev/';
+    }
     await app.dev();
   });
 
@@ -74,7 +78,7 @@ test.describe('Keyless mode @quickstart', () => {
 
     await newPage.waitForLoadState();
     await newPage.waitForURL(url => {
-      const urlToReturnTo = 'https://dashboard.clerk.com/apps/claim?token=';
+      const urlToReturnTo = `${dashboardUrl}apps/claim?token=`;
       return (
         url.pathname === '/apps/claim/sign-in' &&
         url.searchParams.get('sign_in_force_redirect_url')?.startsWith(urlToReturnTo) &&
@@ -102,11 +106,9 @@ test.describe('Keyless mode @quickstart', () => {
     ]);
 
     await newPage.waitForLoadState();
-    await newPage.waitForURL(url =>
-      url.href.startsWith(
-        'https://dashboard.clerk.com/sign-in?redirect_url=https%3A%2F%2Fdashboard.clerk.com%2Fapps%2Fapp_',
-      ),
-    );
+    await newPage.waitForURL(url => {
+      return url.href.startsWith(`${dashboardUrl}sign-in?redirect_url=${encodeURIComponent(dashboardUrl)}apps%2Fapp_`);
+    });
   });
 
   test('Claimed application with keys inside .env, on dismiss, keyless prompt is removed.', async ({


### PR DESCRIPTION
## Description

Keyless applications on e2e tests are never claimed and that hurts some of our metrics. This PR switches to the staging database for keyless applications, until we have a proper fix that all teams are happy with.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
