### PR TITLE
chore(localizations): Update "profile" treatment on latin-american spanish

### DIFF
--- a/.changeset/shaggy-rocks-look.md
+++ b/.changeset/shaggy-rocks-look.md
@@ -1,0 +1,7 @@
+---
+"@clerk/localizations": patch
+---
+
+Update "profile" translations for en-MX.ts
+- `userProfile.profilePage.title`
+- `userProfile.start.profileSection.primaryButton`

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -820,7 +820,7 @@ export const esMX: LocalizationResource = {
       imageFormTitle: 'Imagen de perfil',
       readonly: 'Tu información de perfil ha sido proporcionada por la conexión de empresa y no se puede editar.',
       successMessage: 'Tu perfil ha sido actualizado.',
-      title: 'Actualizar Cuenta',
+      title: 'Actualizar perfil',
     },
     start: {
       activeDevicesSection: {
@@ -892,7 +892,7 @@ export const esMX: LocalizationResource = {
         title: 'Números telefónicos',
       },
       profileSection: {
-        primaryButton: undefined,
+        primaryButton: 'Actualizar perfil',
         title: 'Perfil',
       },
       usernameSection: {


### PR DESCRIPTION
## Description

Changing the translation of "profile" to "perfil"

Before: 
![image](https://github.com/user-attachments/assets/b6e9d1ac-4e5d-4700-953d-1d9188743008)

After:
![image](https://github.com/user-attachments/assets/3f706b46-f024-493f-bb9d-c2c7f9cf7b95)

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.

## Type of change

- [x] other: Localization update
