### PR TITLE
fix(clerk-js): Prevent infinite loop when client is blocked

### DIFF
--- a/.changeset/tasty-socks-hide.md
+++ b/.changeset/tasty-socks-hide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Prevent infinite loop when the client is blocked

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1493,15 +1493,24 @@ export class Clerk implements ClerkInterface {
     if (!this.client || !this.session) {
       return;
     }
-    const newClient = await Client.getOrCreateInstance().fetch();
-    this.updateClient(newClient);
-    if (this.session) {
-      return;
+    try {
+      const newClient = await Client.getOrCreateInstance().fetch();
+      this.updateClient(newClient);
+      if (this.session) {
+        return;
+      }
+      if (opts.broadcast) {
+        this.#broadcastSignOutEvent();
+      }
+      return this.setActive({ session: null });
+    } catch (err) {
+      // Handle the 403 Forbidden
+      if (err.status === 403) {
+        return this.setActive({ session: null });
+      } else {
+        throw err;
+      }
     }
-    if (opts.broadcast) {
-      this.#broadcastSignOutEvent();
-    }
-    return this.setActive({ session: null });
   };
 
   public authenticateWithGoogleOneTap = async (

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -118,13 +118,10 @@ export abstract class BaseResource {
       const message = errors?.[0]?.long_message;
       const code = errors?.[0]?.code;
 
-      const isCaptchaRequired = code === 'requires_captcha';
-      const isClientEndpointBlocked = requestInit.path === '/client' && code === 'resource_forbidden';
-
       // if the status is 401, we need to handle unauthenticated as we did before
       // otherwise, we are going to ignore the requires_captcha error
       // as we're going to handle it by triggering the captcha challenge
-      if (status === 401 && !isCaptchaRequired && !isClientEndpointBlocked) {
+      if (status === 401 && code !== 'requires_captcha') {
         await BaseResource.clerk.handleUnauthenticated();
       }
 

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -118,10 +118,13 @@ export abstract class BaseResource {
       const message = errors?.[0]?.long_message;
       const code = errors?.[0]?.code;
 
+      const isCaptchaRequired = code === 'requires_captcha';
+      const isClientEndpointBlocked = requestInit.path === '/client' && code === 'resource_forbidden';
+
       // if the status is 401, we need to handle unauthenticated as we did before
       // otherwise, we are going to ignore the requires_captcha error
       // as we're going to handle it by triggering the captcha challenge
-      if (status === 401 && code !== 'requires_captcha') {
+      if (status === 401 && !isCaptchaRequired && !isClientEndpointBlocked) {
         await BaseResource.clerk.handleUnauthenticated();
       }
 


### PR DESCRIPTION
## Description

This fix prevents the browser from getting into an infinite loop when the `/v1/client` endpoint returns `403`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
