### PR TITLE
fix(nextjs): Do not run invalidateCacheAction on v15

### DIFF
--- a/.changeset/nasty-weeks-hear.md
+++ b/.changeset/nasty-weeks-hear.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Do not run `invalidateCacheAction` on Next.js v15 during `onBeforeSetActive` due to v15's less aggressive router cache.

--- a/integration/templates/next-app-router/src/app/page.tsx
+++ b/integration/templates/next-app-router/src/app/page.tsx
@@ -17,6 +17,7 @@ export default function Home() {
       <ul>
         <li>
           <Link href='/page-protected'>Page Protected</Link>
+          <Link href='/protected'>Protected</Link>
         </li>
       </ul>
     </main>

--- a/integration/templates/next-app-router/src/app/protected/page.tsx
+++ b/integration/templates/next-app-router/src/app/protected/page.tsx
@@ -1,3 +1,10 @@
+import Link from 'next/link';
+
 export default function Page() {
-  return <div>Protected</div>;
+  return (
+    <>
+      <div data-testid='protected'>Protected</div>
+      <Link href='/'>Home</Link>
+    </>
+  );
 }

--- a/integration/tests/sign-out-smoke.test.ts
+++ b/integration/tests/sign-out-smoke.test.ts
@@ -68,6 +68,24 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('sign out 
     const client_id_after_sign_out = await u.page.locator('p[data-clerk-id]').innerHTML();
     expect(client_id).toEqual(client_id_after_sign_out);
   });
+
+  test('Protected routes do not persist after sign out', async ({ page, context }) => {
+    const u = createTestUtils({ app, page, context });
+
+    await u.po.signIn.goTo();
+    await u.po.signIn.waitForMounted();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+    await u.po.expect.toBeSignedIn();
+
+    await u.page.getByRole('link', { name: 'Protected', exact: true }).click();
+    await u.page.getByTestId('protected').waitFor();
+    await u.page.getByRole('link', { name: 'Home' }).click();
+    await u.page.getByRole('button', { name: 'Open user button' }).click();
+
+    await u.page.getByRole('menuitem', { name: 'Sign out' }).click();
+    await u.page.getByRole('link', { name: 'Protected', exact: true }).click();
+    await u.page.waitForURL(/sign-in\?redirect_url/);
+  });
 });
 
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes_destroy_client] })(


### PR DESCRIPTION
## Description

This PR updates the `onBeforeSetActive` handler to only run the `invalidateCacheAction` server action on Next.js v14, since the router cache in v15 is less aggressive. This also works around an issue when v15 apps are deployed to Vercel where server actions reject when their response is rewritten by middleware, causing sign out functionality on protected routes to not work correctly.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
