### PR TITLE
fix(nextjs): Shallow routing for in-component navigations

### DIFF
--- a/.changeset/quiet-ladybugs-reply.md
+++ b/.changeset/quiet-ladybugs-reply.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix shallow internal-component navigation.

--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -98,7 +98,9 @@ const NextClientClerkProvider = (props: NextClerkProviderProps) => {
 
   const mergedProps = mergeNextClerkPropsWithEnv({
     ...props,
+    // @ts-expect-error Error because of the stricter types of internal `push`
     routerPush: push,
+    // @ts-expect-error Error because of the stricter types of internal `replace`
     routerReplace: replace,
   });
 

--- a/packages/nextjs/src/app-router/client/useInternalNavFun.ts
+++ b/packages/nextjs/src/app-router/client/useInternalNavFun.ts
@@ -15,7 +15,7 @@ export const useInternalNavFun = (props: {
   windowNav: typeof window.history.pushState | typeof window.history.replaceState | undefined;
   routerNav: AppRouterInstance['push'] | AppRouterInstance['replace'];
   name: string;
-}) => {
+}): NavigationFunction => {
   const { windowNav, routerNav, name } = props;
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
@@ -68,8 +68,8 @@ export const useInternalNavFun = (props: {
     }
   }, [pathname, isPending]);
 
-  return useCallback((to: string) => {
-    return getClerkNavigationObject(name).fun(to);
+  return useCallback<NavigationFunction>((to, metadata) => {
+    return getClerkNavigationObject(name).fun(to, metadata);
     // We are not expecting name to change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/nextjs/src/global.d.ts
+++ b/packages/nextjs/src/global.d.ts
@@ -14,14 +14,24 @@ declare namespace NodeJS {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type NextClerkProviderProps = import('./types').NextClerkProviderProps;
+type RequireMetadata<T extends (to: any, metadata?: any) => any> = T extends (
+  to: infer To,
+  metadata?: infer Metadata,
+) => infer R
+  ? (to: To, metadata: Metadata) => R
+  : never;
+
+type NavigationFunction =
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  | RequireMetadata<NonNullable<import('./types').NextClerkProviderProps['routerPush']>>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  | RequireMetadata<NonNullable<import('./types').NextClerkProviderProps['routerReplace']>>;
 
 interface Window {
   __clerk_internal_navigations: Record<
     string,
     {
-      fun: NonNullable<NextClerkProviderProps['routerPush'] | NextClerkProviderProps['routerReplace']>;
+      fun: NavigationFunction;
       promisesBuffer: Array<() => void> | undefined;
     }
   >;

--- a/packages/types/src/snapshots.ts
+++ b/packages/types/src/snapshots.ts
@@ -30,9 +30,7 @@ import type {
 import type { OrganizationSettingsJSON } from './organizationSettings';
 import type { SignInJSON } from './signIn';
 import type { UserSettingsJSON } from './userSettings';
-import type { Nullable } from './utils';
-
-type Override<T, U> = Omit<T, keyof U> & U;
+import type { Nullable, Override } from './utils';
 
 export type SignInJSONSnapshot = Override<
   Nullable<SignInJSON, 'status' | 'identifier' | 'supported_first_factors' | 'supported_second_factors'>,

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -100,3 +100,11 @@ export type Autocomplete<U extends T, T = string> = U | (T & Record<never, never
 export type Without<T, W> = {
   [P in keyof T as Exclude<P, W>]: T[P];
 };
+
+/**
+ * Overrides the type of existing properties
+ * const obj =  { a: string, b: number }  as const;
+ * type Value = Override<typeof obj, { b: string }>
+ * Value contains: { a:string, b: string }
+ */
+export type Override<T, U> = Omit<T, keyof U> & U;


### PR DESCRIPTION
## Description

### Before (notice the brief flash of the page)

https://github.com/user-attachments/assets/f79e0336-b85d-4222-9ba6-2d189ef1921a

### After
https://github.com/user-attachments/assets/de4029bc-9657-46d3-9566-b1d4bc08a2fd





<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
