### PR TITLE
fix(clerk-js): Avoid triggering email code verification twice on React strict mode

### DIFF
--- a/.changeset/witty-cougars-tickle.md
+++ b/.changeset/witty-cougars-tickle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Avoid triggering email code verification twice on React strict mode

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -54,6 +54,8 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       .catch(err => handleError(err, [], card.setError));
   };
 
+  console.log(props.factor, shouldAvoidPrepare);
+
   useFetch(
     shouldAvoidPrepare
       ? undefined
@@ -63,8 +65,11 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
             .then(() => props.onFactorPrepare())
             .catch(err => handleError(err, [], card.setError)),
     {
-      name: 'prepare',
-      strategy: props.factor.strategy,
+      name: 'signIn.prepareFirstFactor',
+      factor: props.factor,
+    },
+    {
+      staleTime: 100,
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -1,12 +1,12 @@
 import { isUserLockedError } from '@clerk/shared/error';
 import { useClerk } from '@clerk/shared/react';
 import type { EmailCodeFactor, PhoneCodeFactor, ResetPasswordCodeFactor } from '@clerk/types';
-import React from 'react';
 
 import { clerkInvalidFAPIResponse } from '../../../core/errors';
 import { useCoreSignIn, useSignInContext } from '../../contexts';
 import type { VerificationCodeCardProps } from '../../elements';
 import { useCardState, VerificationCodeCard } from '../../elements';
+import { useFetch } from '../../hooks';
 import { useSupportEmail } from '../../hooks/useSupportEmail';
 import type { LocalizationKey } from '../../localization';
 import { useRouter } from '../../router';
@@ -37,22 +37,36 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   const supportEmail = useSupportEmail();
   const clerk = useClerk();
 
+  const shouldAvoidPrepare = signIn.firstFactorVerification.status === 'verified' && props.factorAlreadyPrepared;
+
   const goBack = () => {
     return navigate('../');
   };
 
-  React.useEffect(() => {
-    if (!props.factorAlreadyPrepared) {
-      prepare();
-    }
-  }, []);
-
   const prepare = () => {
+    if (shouldAvoidPrepare) {
+      return;
+    }
+
     void signIn
       .prepareFirstFactor(props.factor)
       .then(() => props.onFactorPrepare())
       .catch(err => handleError(err, [], card.setError));
   };
+
+  useFetch(
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signIn
+            ?.prepareFirstFactor(props.factor)
+            .then(() => props.onFactorPrepare())
+            .catch(err => handleError(err, [], card.setError)),
+    {
+      name: 'prepare',
+      strategy: props.factor.strategy,
+    },
+  );
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
     signIn

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -54,8 +54,6 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       .catch(err => handleError(err, [], card.setError));
   };
 
-  console.log(props.factor, shouldAvoidPrepare);
-
   useFetch(
     shouldAvoidPrepare
       ? undefined


### PR DESCRIPTION
## Description

#### Before

https://github.com/user-attachments/assets/346dc624-08f6-49cb-822d-c9309c6d08b9

#### After

https://github.com/user-attachments/assets/f4b6cde4-08db-4485-858c-86dc8575b60e

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
