### PR TITLE
chore(backend): Deprecate usage of the `oauth_` prefix in `getUserOauthAccessToken()`

### DIFF
--- a/.changeset/violet-seas-speak.md
+++ b/.changeset/violet-seas-speak.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Deprecate usage of the `oauth_` prefix in `client.users.getUserOauthAccessToken()`.

--- a/.changeset/violet-seas-speak.md
+++ b/.changeset/violet-seas-speak.md
@@ -2,4 +2,9 @@
 '@clerk/backend': minor
 ---
 
-Deprecate usage of the `oauth_` prefix in `client.users.getUserOauthAccessToken()`.
+Deprecate usage of the `oauth_` prefix in `client.users.getUserOauthAccessToken()`. Going forward, please use the provider name without that prefix. Example:
+
+```diff
+- client.users.getUserOauthAccessToken('user_id', 'oauth_google')
++ client.users.getUserOauthAccessToken('user_id', 'google')
+```


### PR DESCRIPTION
## Description

Deprecate usage of the `oauth_` prefix in `client.users.getUserOauthAccessToken()`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
