### PR TITLE
fix(clerk-expo): Accept custom redirect URL for SSO callback

### DIFF
--- a/.changeset/flat-horses-battle.md
+++ b/.changeset/flat-horses-battle.md
@@ -1,0 +1,16 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Accept custom `redirectURL` for SSO callback via `startSSOFlow`
+
+Usage:
+
+```ts
+await startSSOFlow({
+  strategy: "oauth_google",
+  redirectUrl: AuthSession.makeRedirectUri({
+    path: "dashboard"
+  }),
+});
+```


### PR DESCRIPTION
## Description

#### Context

The ability to pass a custom redirect URL was removed on the first version of `useSSO`, testing back then, deep linking wasn't working for both platforms (iOS and Android), and the assumption was to leverage a fixed URL to parse the nonce token. 

However, deep linking is working on Android and some developers are falling into a 404 context.


#### Changes

This PR allows providing a custom redirect URL to `startSSOFlow`, and also returns the result of `WebBrowser.openAuthSessionAsync` so developers can debug it's output on cases where the native configuration could be wrong, such as lacking permissions to open web browsers from the application manifest.

 Here's an OAuth flow deep linking to a custom redirect URL on Android:

https://github.com/user-attachments/assets/7dc06677-890c-4333-8dab-2dc10447c7c1

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
