### PR TITLE
feat: Add localization of 'Add a passkey' button

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -222,7 +222,7 @@ const AddPasskeyButton = ({ onClick }: { onClick?: () => void }) => {
   return (
     <ProfileSection.ArrowButton
       id='passkeys'
-      localizationKey={'Add a passkey'}
+      localizationKey={localizationKeys('userProfile.start.passkeysSection.addButton')}
       onClick={handleCreatePasskey}
     />
   );

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -864,6 +864,7 @@ export const enUS: LocalizationResource = {
         },
       },
       passkeysSection: {
+        addButton: 'Add a passkey',
         menuAction__destructive: 'Remove',
         menuAction__rename: 'Rename',
         title: 'Passkeys',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -435,6 +435,7 @@ type _LocalizationResource = {
       };
       passkeysSection: {
         title: LocalizationValue;
+        addButton: LocalizationValue;
         menuAction__rename: LocalizationValue;
         menuAction__destructive: LocalizationValue;
       };


### PR DESCRIPTION
## Description

Within the Passkeys section on the User Profile page, there is an 'Add a passkey' button for adding passkeys. This button currently does not support localization. This PR allows for localization of this button.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
