### PR TITLE
fix(clerk-js): Fix stale `SignIn` object on `authenticateWithRedirect` for enterprise custom flows

### DIFF
--- a/.changeset/spicy-toes-behave.md
+++ b/.changeset/spicy-toes-behave.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes stale `SignIn` object on `authenticateWithRedirect` for `saml` and `enterprise_sso` custom flows
+
+Previously, the same connection identifier would be used on every `authenticateWithRedirect` call leading to redirecting to the wrong identity provider

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -336,6 +336,7 @@ export function _SignInStart(): JSX.Element {
       strategy: 'enterprise_sso',
       redirectUrl,
       redirectUrlComplete,
+      continueSignIn: true,
     });
   };
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -289,6 +289,7 @@ describe('SignInStart', () => {
         strategy: 'enterprise_sso',
         redirectUrl: 'http://localhost/#/sso-callback',
         redirectUrlComplete: '/',
+        continueSignIn: true,
       });
     });
   });
@@ -312,6 +313,7 @@ describe('SignInStart', () => {
         strategy: 'enterprise_sso',
         redirectUrl: 'http://localhost/#/sso-callback',
         redirectUrlComplete: '/',
+        continueSignIn: true,
       });
     });
   });

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -65,6 +65,11 @@ export type AuthenticateWithRedirectParams = {
   continueSignUp?: boolean;
 
   /**
+   * Whether to continue existing SignIn (if present) or create a new SignIn.
+   */
+  continueSignIn?: boolean;
+
+  /**
    * One of the supported OAuth providers you can use to authenticate with, eg 'oauth_google'.
    * Alternatively `saml` or `enterprise_sso`, to authenticate with Enterprise SSO.
    */


### PR DESCRIPTION
## Description

Resolves ORGS-540

Currently, `authenticateWithRedirect` always uses the existing `SignIn` for `saml` or `enterprise_sso` strategy, even if the identifier gets changed by the user in a custom flow, which leads to an issue where FAPI queries the wrong enterprise connection:

https://github.com/user-attachments/assets/3ba67507-1ec8-4861-9350-fd13f4abc3bc

Our `SignInStart` component always creates a new `SignIn`; therefore, the flow above works smoothly: https://github.com/clerk/javascript/blob/e1820558624c61f5e76e2d8e1c8132a844005a5a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx#L299-L312 

#### With fix 

This PR introduces a new `continueSignIn` option for `signIn.authenticateWithRedirect`, which defaults to `false`, therefore it'll create a new `SignIn` object on every call. 

Within `SignInStart`, we pass `continueSignIn` as `false` in order to reuse the current `SignIn` created, in order to avoid calling `signIn.create` twice.

https://github.com/user-attachments/assets/bf2ccb59-b165-423f-8cbb-a4a912269d78

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
