### PR TITLE
fix(upgrade): Remove unused getMajorVersion function

### DIFF
--- a/.changeset/tiny-moose-appear.md
+++ b/.changeset/tiny-moose-appear.md
@@ -1,0 +1,5 @@
+---
+'@clerk/upgrade': patch
+---
+
+Remove an internal function that was executed but its return value wasn't used. In some instances this function threw an error.

--- a/packages/upgrade/src/app.js
+++ b/packages/upgrade/src/app.js
@@ -6,7 +6,6 @@ import { Header } from './components/Header.js';
 import { Scan } from './components/Scan.js';
 import { SDKWorkflow } from './components/SDKWorkflow.js';
 import SDKS from './constants/sdks.js';
-import { getClerkMajorVersion } from './util/get-clerk-version.js';
 import guessFrameworks from './util/guess-framework.js';
 
 /**
@@ -34,7 +33,6 @@ export default function App(props) {
   const [sdkGuessConfirmed, setSdkGuessConfirmed] = useState(false);
   const [sdkGuessAttempted, setSdkGuessAttempted] = useState(false);
   const [fromVersion, setFromVersion] = useState(props.fromVersion);
-  const [fromVersionGuessAttempted, setFromVersionGuessAttempted] = useState(false);
 
   const [toVersion, setToVersion] = useState(props.toVersion);
   const [dir, setDir] = useState(props.dir);
@@ -42,7 +40,6 @@ export default function App(props) {
   const [configComplete, setConfigComplete] = useState(false);
   const [configVerified, setConfigVerified] = useState(false);
   const [uuid, setUuid] = useState();
-  let fromVersionGuess = false;
 
   if (yolo) {
     setSdks(SDKS.map(s => s.value));
@@ -75,12 +72,6 @@ export default function App(props) {
     setUuid(_uuid);
     setSdkGuesses(guesses);
     setSdkGuessAttempted(true);
-  }
-
-  // We try to guess which version of Clerk they are using
-  if (isEmpty(sdks) && !fromVersion && !fromVersionGuess && !fromVersionGuessAttempted) {
-    fromVersionGuess = getClerkMajorVersion();
-    setFromVersionGuessAttempted(true);
   }
 
   // No support for v3 or below, sadly

--- a/packages/upgrade/src/util/get-clerk-version.js
+++ b/packages/upgrade/src/util/get-clerk-version.js
@@ -1,12 +1,6 @@
 import { readPackageSync } from 'read-pkg';
 import semverRegex from 'semver-regex';
 
-export function getClerkMajorVersion() {
-  const pkg = readPackageSync();
-  const clerk = pkg.dependencies.clerk;
-  return clerk ? semverRegex().exec(clerk)[0][0] : false;
-}
-
 export function getClerkSdkVersion(sdk) {
   const pkg = readPackageSync();
   const clerkSdk = pkg.dependencies[`@clerk/${sdk}`];


### PR DESCRIPTION
## Description

A user reported this error while running the upgrade tool on their repo:

```shell
Cannot read properties of null (reading '0')

node_modules/@clerk/upgrade/dist/util/get-clerk-version.js:6:43
```

This comes from these lines:

```js
const clerk = pkg.dependencies.clerk;
return clerk ? semverRegex().exec(clerk)[0][0] : false;
```

`clerk` will always be `undefined` because `read-pkg` doesn't normalize namespaced packages in such a way. It e.g. returns back `dependencies: { '@clerk/nextjs': '^5.11.2', 'read-pkg': '^9.0.1' },`.
But for whatever reason for this user the regex is executed.

Anyways, the function is unused anyways and the desired functionality is already fulfilled by the `guessFrameworks` function.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
