### PR TITLE
chore(astro): Remove deprecated `as` prop from button components

### DIFF
--- a/.changeset/smart-rabbits-reflect.md
+++ b/.changeset/smart-rabbits-reflect.md
@@ -1,0 +1,17 @@
+---
+"@clerk/astro": minor
+---
+
+Remove deprecated `as` prop in the `<SignInButton />`, `<SignOutButton />`, and `<SignUpButton>` components. Please use the `asChild` prop if you are passing children to it.
+
+Example:
+
+```astro
+---
+import { SignInButton } from '@clerk/astro/components'
+---
+
+<SignInButton asChild>
+  <button>Custom sign in button</button>
+</SignInButton>
+```

--- a/packages/astro/src/astro-components/unstyled/SignInButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignInButton.astro
@@ -1,21 +1,14 @@
 ---
-import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignInButtonProps } from '@clerk/types'
-import type { ButtonProps } from '../../types';
-import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
-
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<ButtonProps<Tag>> & SignInButtonProps;
-
+import type { SignInButtonProps } from '@clerk/types';
+import type { AsChildProps } from '../../types';
+import { addUnstyledAttributeToFirstTag } from './utils';
 import { generateSafeId } from '@clerk/astro/internal';
+
+type Props = AsChildProps<SignInButtonProps>;
 
 const safeId = generateSafeId();
 
-if ('as' in Astro.props) {
-  logAsPropUsageDeprecation()
-}
-
 const {
-  as: Tag = 'button',
   asChild,
   forceRedirectUrl,
   fallbackRedirectUrl,
@@ -44,9 +37,9 @@ if (asChild) {
   asChild ? (
     <Fragment set:html={htmlElement} />
   ) : (
-    <Tag {...props} data-clerk-unstyled-id={safeId}>
+    <button {...props} data-clerk-unstyled-id={safeId}>
       <slot>Sign in</slot>
-    </Tag >
+    </button >
   )
 }
 

--- a/packages/astro/src/astro-components/unstyled/SignOutButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignOutButton.astro
@@ -1,21 +1,14 @@
 ---
-import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignOutOptions, Without } from '@clerk/types'
-import type { ButtonProps } from '../../types';
-import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
+import type { SignOutOptions } from '@clerk/types';
+import type { AsChildProps } from '../../types';
+import { addUnstyledAttributeToFirstTag } from './utils';
+import { generateSafeId } from '@clerk/astro/internal';
 
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<SignOutOptions & ButtonProps<Tag>>
-
-import { generateSafeId } from '@clerk/astro/internal'
+type Props = AsChildProps<SignOutOptions>;
 
 const safeId = generateSafeId();
 
-if ('as' in Astro.props) {
-  logAsPropUsageDeprecation()
-}
-
 const {
-  as: Tag = 'button',
   asChild,
   redirectUrl = '/',
   sessionId,
@@ -34,9 +27,9 @@ if (asChild) {
   asChild ? (
     <Fragment set:html={htmlElement} />
   ) : (
-    <Tag {...elementProps} data-clerk-unstyled-id={safeId}>
+    <button {...elementProps} data-clerk-unstyled-id={safeId}>
       <slot>Sign out</slot>
-    </Tag >
+    </button >
   )
 }
 

--- a/packages/astro/src/astro-components/unstyled/SignUpButton.astro
+++ b/packages/astro/src/astro-components/unstyled/SignUpButton.astro
@@ -1,21 +1,14 @@
 ---
-import type { HTMLTag, Polymorphic } from 'astro/types'
-import type { SignUpButtonProps } from '@clerk/types'
-import type { ButtonProps } from '../../types'
-import { addUnstyledAttributeToFirstTag, logAsPropUsageDeprecation } from './utils'
-
-type Props<Tag extends HTMLTag = 'button'> = Polymorphic<ButtonProps<Tag>> & SignUpButtonProps;
-
+import type { SignUpButtonProps } from '@clerk/types';
+import type { AsChildProps } from '../../types';
+import { addUnstyledAttributeToFirstTag } from './utils';
 import { generateSafeId } from '@clerk/astro/internal';
 
 const safeId = generateSafeId();
 
-if ('as' in Astro.props) {
-  logAsPropUsageDeprecation()
-}
-
+type Props = AsChildProps<SignUpButtonProps>;
+  
 const {
-  as: Tag = 'button',
   asChild,
   fallbackRedirectUrl,
   forceRedirectUrl,
@@ -46,9 +39,9 @@ if (asChild) {
   asChild ? (
     <Fragment set:html={htmlElement} />
   ) : (
-    <Tag {...props} data-clerk-unstyled-id={safeId}>
+    <button {...props} data-clerk-unstyled-id={safeId}>
       <slot>Sign up</slot>
-    </Tag >
+    </button >
   )
 }
 

--- a/packages/astro/src/astro-components/unstyled/utils.ts
+++ b/packages/astro/src/astro-components/unstyled/utils.ts
@@ -5,17 +5,3 @@
 export function addUnstyledAttributeToFirstTag(html: string, attributeValue: string): string {
   return html.replace(/(<[^>]+)>/, `$1 data-clerk-unstyled-id="${attributeValue}">`);
 }
-
-/**
- * Logs a deprecation warning when the 'as' prop is used.
- */
-export function logAsPropUsageDeprecation() {
-  if (import.meta.env.PROD) {
-    return;
-  }
-
-  console.warn(
-    `[@clerk/astro] The 'as' prop is deprecated and will be removed in a future version. ` +
-      `Use the default slot with the 'asChild' prop instead. `,
-  );
-}

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -71,15 +71,6 @@ type ProtectProps =
 
 export type { AstroClerkUpdateOptions, AstroClerkIntegrationParams, AstroClerkCreateInstanceParams, ProtectProps };
 
-export type ButtonProps<Tag> = {
-  /**
-   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
-   * Use the default slot with the 'asChild' prop instead.
-   * @example
-   * <SignInButton asChild>
-   *   <button>Sign in</button>
-   * </SignInButton>
-   */
-  as: Tag;
+export type AsChildProps<T> = T & {
   asChild?: boolean;
 };


### PR DESCRIPTION
## Description

It's been 5 months since we began deprecating the `as` prop in favor of `asChild` for customizing our unstyled components (`<SignInButton />`, `<SignUpButton />`, `<SignOutButton />`). As documented in our [component guides](https://clerk.com/docs/components/unstyled/sign-in-button#custom-usage), the `asChild` prop is the recommended approach for passing custom buttons. This PR completes the deprecation by removing the `as` prop entirely.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
