### PR TITLE
feat(shared): Cast `EmailLinkErrorCode` as const

### DIFF
--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -214,7 +214,7 @@ export const EmailLinkErrorCode = {
   Expired: 'expired',
   Failed: 'failed',
   ClientMismatch: 'client_mismatch',
-};
+} as const;
 
 const DefaultMessages = Object.freeze({
   InvalidProxyUrlErrorMessage: `The proxyUrl passed to Clerk is invalid. The expected value for proxyUrl is an absolute URL or a relative path with a leading '/'. (key={{url}})`,


### PR DESCRIPTION
## Description

Cast EmailLinkErrorCode as const to help users with types within custom flows.

```tsx
import { EmailLinkErrorCode } from '@clerk/nextjs/errors'

type EmailLinkError = typeof EmailLinkErrorCode[keyof typeof EmailLinkErrorCode];

const getStatus = (err: EmailLinkError): EmailLinkError => {
  if (err === EmailLinkErrorCode.Expired) {
    return 'expired'
  }

  if (err === EmailLinkErrorCode.ClientMismatch) {
    return 'client_mismatch'
  }

  return 'failed'
}
```

Resolves SDK-2055

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
