### PR TITLE
fix(clerk-react): Prevent `UserProfileModal` re-render in `<UserButton />` with custom props

### DIFF
--- a/.changeset/sharp-owls-live.md
+++ b/.changeset/sharp-owls-live.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Fix an infinity re-render issue in `UserProfileModal` when we pass `userProfileProps` in `<UserButton />` and we have `customMenuItems` and `customPages`

--- a/integration/templates/react-vite/src/custom-user-button/with-dynamic-label-and-custom-pages.tsx
+++ b/integration/templates/react-vite/src/custom-user-button/with-dynamic-label-and-custom-pages.tsx
@@ -10,7 +10,10 @@ export default function Page() {
 
   return (
     <PageContextProvider>
-      <UserButton fallback={<>Loading user button</>}>
+      <UserButton
+        fallback={<>Loading user button</>}
+        userProfileProps={{ appearance: { elements: { modalBackdrop: { zIndex: '100' } } } }}
+      >
         <UserButton.MenuItems>
           <UserButton.Action
             label={`Chat is ${open ? 'ON' : 'OFF'}`}
@@ -52,6 +55,13 @@ export default function Page() {
             onClick={() => alert('custom-alert')}
           />
         </UserButton.MenuItems>
+        <UserButton.UserProfilePage
+          label='Notifications Page'
+          url='notifications'
+          labelIcon={<span>🔔</span>}
+        >
+          <h1 data-page='notifications-page'>Notifications page</h1>
+        </UserButton.UserProfilePage>
       </UserButton>
     </PageContextProvider>
   );

--- a/integration/templates/react-vite/src/main.tsx
+++ b/integration/templates/react-vite/src/main.tsx
@@ -11,6 +11,7 @@ import UserProfile from './user';
 import UserProfileCustom from './custom-user-profile';
 import UserButtonCustom from './custom-user-button';
 import UserButtonCustomDynamicLabels from './custom-user-button/with-dynamic-labels.tsx';
+import UserButtonCustomDynamicLabelsAndCustomPages from './custom-user-button/with-dynamic-label-and-custom-pages.tsx';
 import UserButtonCustomTrigger from './custom-user-button-trigger';
 import UserButton from './user-button';
 import Waitlist from './waitlist';
@@ -84,6 +85,10 @@ const router = createBrowserRouter([
       {
         path: '/custom-user-button-dynamic-labels',
         element: <UserButtonCustomDynamicLabels />,
+      },
+      {
+        path: '/custom-user-button-dynamic-labels-and-custom-pages',
+        element: <UserButtonCustomDynamicLabelsAndCustomPages />,
       },
       {
         path: '/custom-user-button-trigger',


### PR DESCRIPTION

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
