### PR TITLE
fix(nextjs): accept async callback for ClerkMiddlewareOptionsCallback

### DIFF
--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -59,7 +59,7 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
   debug?: boolean;
 };
 
-type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions;
+type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions | Promise<ClerkMiddlewareOptions>;
 
 /**
  * Middleware for Next.js that handles authentication and authorization with Clerk.
@@ -102,7 +102,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
   return clerkMiddlewareRequestDataStorage.run(clerkMiddlewareRequestDataStore, () => {
     const baseNextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
       // Handles the case where `options` is a callback function to dynamically access `NextRequest`
-      const resolvedParams = typeof params === 'function' ? params(request) : params;
+      const resolvedParams = typeof params === 'function' ? await params(request) : params;
 
       const keyless = getKeylessCookieValue(name => request.cookies.get(name)?.value);
 
@@ -223,7 +223,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
         return returnBackFromKeylessSync(request);
       }
 
-      const resolvedParams = typeof params === 'function' ? params(request) : params;
+      const resolvedParams = typeof params === 'function' ? await params(request) : params;
       const keyless = getKeylessCookieValue(name => request.cookies.get(name)?.value);
       const isMissingPublishableKey = !(resolvedParams.publishableKey || PUBLISHABLE_KEY || keyless?.publishableKey);
       /**


### PR DESCRIPTION
## Description

Update `ClerkMiddlewareOptionsCallback` to accept an async function for the use case where you need to go and fetch the options from an external store. I'm unsure whether this is technically a bug or a feature, because the docs imply that it's supposed to work anyway. 

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
