### PR TITLE
fix(nextjs): Update `clerkMiddleware` request callback to accept an async function

### DIFF
--- a/.changeset/fast-teachers-attack.md
+++ b/.changeset/fast-teachers-attack.md
@@ -2,7 +2,7 @@
 '@clerk/nextjs': patch
 ---
 
-Update `clerkMiddleware` request callback to also accept an asynchronous function
+Update `clerkMiddleware` request callback to accept an asynchronous function
 
 ```ts
 export default clerkMiddleware(

--- a/.changeset/fast-teachers-attack.md
+++ b/.changeset/fast-teachers-attack.md
@@ -2,4 +2,16 @@
 '@clerk/nextjs': patch
 ---
 
-Update ClerkMiddlewareOptionsCallback to also accept an async function
+Update `clerkMiddleware` request callback to also accept an asynchronous function
+
+```ts
+export default clerkMiddleware(
+  (auth, req) => {
+    // Add your middleware checks
+  },
+  async (req) => {
+    const options = await getOptions(req)
+    return options;
+  },
+)
+```

--- a/.changeset/fast-teachers-attack.md
+++ b/.changeset/fast-teachers-attack.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Update ClerkMiddlewareOptionsCallback to also accept an async function

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -238,31 +238,67 @@ describe('clerkMiddleware(params)', () => {
     expect(decryptedData).toEqual(options);
   });
 
-  it('allows access to request object to dynamically define options', async () => {
-    const options = {
-      secretKey: 'sk_test_xxxxxxxxxxxxxxxxxx',
-      publishableKey: 'pk_test_xxxxxxxxxxxxx',
-      signInUrl: '/foo',
-      signUpUrl: '/bar',
-    };
-    const resp = await clerkMiddleware(
-      () => {
-        return NextResponse.next();
-      },
-      req => ({
-        ...options,
-        domain: req.nextUrl.host,
-      }),
-    )(mockRequest({ url: '/sign-in' }), {} as NextFetchEvent);
-    expect(resp?.status).toEqual(200);
+  describe('allows access to request object to define options via callback', () => {
+    it('with synchronously callback', async () => {
+      const options = {
+        secretKey: 'sk_test_xxxxxxxxxxxxxxxxxx',
+        publishableKey: 'pk_test_xxxxxxxxxxxxx',
+        signInUrl: '/foo',
+        signUpUrl: '/bar',
+      };
+      const resp = await clerkMiddleware(
+        () => {
+          return NextResponse.next();
+        },
+        req => ({
+          ...options,
+          domain: req.nextUrl.host,
+        }),
+      )(mockRequest({ url: '/sign-in' }), {} as NextFetchEvent);
+      expect(resp?.status).toEqual(200);
 
-    const requestData = resp?.headers.get('x-middleware-request-x-clerk-request-data');
-    assert.ok(requestData);
+      const requestData = resp?.headers.get('x-middleware-request-x-clerk-request-data');
+      assert.ok(requestData);
 
-    const decryptedData = decryptClerkRequestData(requestData);
+      const decryptedData = decryptClerkRequestData(requestData);
 
-    expect(resp?.headers.get('x-middleware-request-x-clerk-request-data')).toBeDefined();
-    expect(decryptedData).toEqual({ ...options, domain: 'www.clerk.com' });
+      expect(resp?.headers.get('x-middleware-request-x-clerk-request-data')).toBeDefined();
+      expect(decryptedData).toEqual({ ...options, domain: 'www.clerk.com' });
+    });
+
+    it('with asynchronously callback', async () => {
+      const options = {
+        secretKey: 'sk_test_xxxxxxxxxxxxxxxxxx',
+        publishableKey: 'pk_test_xxxxxxxxxxxxx',
+        signInUrl: '/foo',
+        signUpUrl: '/bar',
+      };
+
+      const mockFetchOptionsExternalStore = (_req: NextRequest) => Promise.resolve(options);
+
+      const resp = await clerkMiddleware(
+        () => {
+          return NextResponse.next();
+        },
+        async req => {
+          const resolvedOptions = await mockFetchOptionsExternalStore(req);
+
+          return {
+            ...resolvedOptions,
+            domain: req.nextUrl.host,
+          };
+        },
+      )(mockRequest({ url: '/sign-in' }), {} as NextFetchEvent);
+      expect(resp?.status).toEqual(200);
+
+      const requestData = resp?.headers.get('x-middleware-request-x-clerk-request-data');
+      assert.ok(requestData);
+
+      const decryptedData = decryptClerkRequestData(requestData);
+
+      expect(resp?.headers.get('x-middleware-request-x-clerk-request-data')).toBeDefined();
+      expect(decryptedData).toEqual({ ...options, domain: 'www.clerk.com' });
+    });
   });
 
   describe('auth().redirectToSignIn()', () => {

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -239,7 +239,7 @@ describe('clerkMiddleware(params)', () => {
   });
 
   describe('allows access to request object to define options via callback', () => {
-    it('with synchronously callback', async () => {
+    it('with synchronous callback', async () => {
       const options = {
         secretKey: 'sk_test_xxxxxxxxxxxxxxxxxx',
         publishableKey: 'pk_test_xxxxxxxxxxxxx',
@@ -266,7 +266,7 @@ describe('clerkMiddleware(params)', () => {
       expect(decryptedData).toEqual({ ...options, domain: 'www.clerk.com' });
     });
 
-    it('with asynchronously callback', async () => {
+    it('with asynchronous callback', async () => {
       const options = {
         secretKey: 'sk_test_xxxxxxxxxxxxxxxxxx',
         publishableKey: 'pk_test_xxxxxxxxxxxxx',

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -59,7 +59,7 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
   debug?: boolean;
 };
 
-type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions;
+type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions | Promise<ClerkMiddlewareOptions>;
 
 /**
  * Middleware for Next.js that handles authentication and authorization with Clerk.
@@ -102,7 +102,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
   return clerkMiddlewareRequestDataStorage.run(clerkMiddlewareRequestDataStore, () => {
     const baseNextMiddleware: NextMiddleware = withLogger('clerkMiddleware', logger => async (request, event) => {
       // Handles the case where `options` is a callback function to dynamically access `NextRequest`
-      const resolvedParams = typeof params === 'function' ? params(request) : params;
+      const resolvedParams = typeof params === 'function' ? await params(request) : params;
 
       const keyless = getKeylessCookieValue(name => request.cookies.get(name)?.value);
 
@@ -223,7 +223,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
         return returnBackFromKeylessSync(request);
       }
 
-      const resolvedParams = typeof params === 'function' ? params(request) : params;
+      const resolvedParams = typeof params === 'function' ? await params(request) : params;
       const keyless = getKeylessCookieValue(name => request.cookies.get(name)?.value);
       const isMissingPublishableKey = !(resolvedParams.publishableKey || PUBLISHABLE_KEY || keyless?.publishableKey);
       /**


### PR DESCRIPTION
## Description

Update `ClerkMiddlewareOptionsCallback` to accept an async function for the use case where you need to go and fetch the options from an external store. I'm unsure whether this is technically a bug or a feature, because the docs imply that it's supposed to work anyway. 

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
