### PR TITLE
fix(clerk-js): Ensure withSignUp is collected in telemetry

### DIFF
--- a/.changeset/good-olives-unite.md
+++ b/.changeset/good-olives-unite.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': minor
+'@clerk/clerk-js': patch
+---
+
+Support passing additional properties to `eventPrebuiltComponentMounted()`, and ensure `withSignUp` is collected on `SignIn` mount.

--- a/.changeset/good-olives-unite.md
+++ b/.changeset/good-olives-unite.md
@@ -1,6 +1,7 @@
 ---
 '@clerk/shared': minor
 '@clerk/clerk-js': patch
+'@clerk/types': patch
 ---
 
 Support passing additional properties to `eventPrebuiltComponentMounted()`, and ensure `withSignUp` is collected on `SignIn` mount.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -581,10 +581,15 @@ export class Clerk implements ClerkInterface {
       }),
     );
     this.telemetry?.record(
-      eventPrebuiltComponentMounted('SignIn', {
-        ...props,
-        withSignUp: props?.withSignUp ?? this.#isCombinedSignInOrUpFlow(),
-      }),
+      eventPrebuiltComponentMounted(
+        'SignIn',
+        {
+          ...props,
+        },
+        {
+          withSignUp: props?.withSignUp ?? this.#isCombinedSignInOrUpFlow(),
+        },
+      ),
     );
   };
 

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -3,6 +3,8 @@ import type { TelemetryEventRaw } from '@clerk/types';
 const EVENT_COMPONENT_MOUNTED = 'COMPONENT_MOUNTED';
 const EVENT_SAMPLING_RATE = 0.1;
 
+type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+
 type ComponentMountedBase = {
   component: string;
 };
@@ -15,7 +17,7 @@ type EventPrebuiltComponentMounted = ComponentMountedBase & {
 };
 
 type EventComponentMounted = ComponentMountedBase & {
-  [key: string]: boolean | string;
+  [key: string]: JSONValue;
 };
 
 /**
@@ -23,6 +25,7 @@ type EventComponentMounted = ComponentMountedBase & {
  *
  * @param component - The name of the component.
  * @param props - The props passed to the component. Will be filtered to a known list of props.
+ * @param additionalPayload - Additional data to send with the event.
  *
  * @example
  * telemetry.record(eventPrebuiltComponentMounted('SignUp', props));
@@ -30,6 +33,7 @@ type EventComponentMounted = ComponentMountedBase & {
 export function eventPrebuiltComponentMounted(
   component: string,
   props?: Record<string, any>,
+  additionalPayload?: Record<string, JSONValue>,
 ): TelemetryEventRaw<EventPrebuiltComponentMounted> {
   return {
     event: EVENT_COMPONENT_MOUNTED,
@@ -40,6 +44,7 @@ export function eventPrebuiltComponentMounted(
       baseTheme: Boolean(props?.appearance?.baseTheme),
       elements: Boolean(props?.appearance?.elements),
       variables: Boolean(props?.appearance?.variables),
+      ...additionalPayload,
     },
   };
 }

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -3,8 +3,6 @@ import type { TelemetryEventRaw } from '@clerk/types';
 const EVENT_COMPONENT_MOUNTED = 'COMPONENT_MOUNTED';
 const EVENT_SAMPLING_RATE = 0.1;
 
-type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
-
 type ComponentMountedBase = {
   component: string;
 };
@@ -16,9 +14,7 @@ type EventPrebuiltComponentMounted = ComponentMountedBase & {
   baseTheme: boolean;
 };
 
-type EventComponentMounted = ComponentMountedBase & {
-  [key: string]: JSONValue;
-};
+type EventComponentMounted = ComponentMountedBase & TelemetryEventRaw['payload'];
 
 /**
  * Helper function for `telemetry.record()`. Create a consistent event object for when a prebuilt (AIO) component is mounted.
@@ -33,7 +29,7 @@ type EventComponentMounted = ComponentMountedBase & {
 export function eventPrebuiltComponentMounted(
   component: string,
   props?: Record<string, any>,
-  additionalPayload?: Record<string, JSONValue>,
+  additionalPayload?: TelemetryEventRaw['payload'],
 ): TelemetryEventRaw<EventPrebuiltComponentMounted> {
   return {
     event: EVENT_COMPONENT_MOUNTED,
@@ -62,7 +58,7 @@ export function eventPrebuiltComponentMounted(
  */
 export function eventComponentMounted(
   component: string,
-  props: Record<string, string | boolean> = {},
+  props: TelemetryEventRaw['payload'] = {},
 ): TelemetryEventRaw<EventComponentMounted> {
   return {
     event: EVENT_COMPONENT_MOUNTED,

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,5 +1,7 @@
 import type { InstanceType } from 'instance';
 
+type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+
 /**
  * @internal
  */
@@ -29,7 +31,7 @@ export type TelemetryEvent = {
    * SDK Version
    */
   sdkv?: string;
-  payload: Record<string, string | number | boolean>;
+  payload: Record<string, JSONValue>;
 };
 
 /**


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Support passing additional payload values to `eventPrebuiltComponentMounted()`. This ensures we are actually recording `withSignUp`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
