### PR TITLE
feat(nuxt): Introduce `getAuth()` helper

### DIFF
--- a/.changeset/spicy-turtles-tease.md
+++ b/.changeset/spicy-turtles-tease.md
@@ -1,0 +1,18 @@
+---
+"@clerk/nuxt": minor
+---
+
+Introduce `getAuth()` helper to retrieve authentication state from the event object.
+
+Example:
+
+```ts
+export default eventHandler((event) => {
+  const { userId } = getAuth(event);
+
+  if (!userId) {
+    // User is not authenticated
+  }
+});
+```
+

--- a/.changeset/spicy-turtles-tease.md
+++ b/.changeset/spicy-turtles-tease.md
@@ -2,7 +2,7 @@
 "@clerk/nuxt": minor
 ---
 
-Introduce `getAuth()` helper to retrieve authentication state from the event object.
+Introduce `getAuth()` helper to retrieve authentication state from the [event](https://h3.unjs.io/guide/event) object.
 
 Example:
 

--- a/.changeset/spicy-turtles-tease.md
+++ b/.changeset/spicy-turtles-tease.md
@@ -7,6 +7,8 @@ Introduce `getAuth()` helper to retrieve authentication state from the event obj
 Example:
 
 ```ts
+import { getAuth } from '@clerk/nuxt/server';
+
 export default eventHandler((event) => {
   const { userId } = getAuth(event);
 

--- a/integration/tests/nuxt/middleware.test.ts
+++ b/integration/tests/nuxt/middleware.test.ts
@@ -24,10 +24,10 @@ test.describe('custom middleware @nuxt', () => {
       )
       .addFile(
         'server/middleware/clerk.js',
-        () => `import { clerkMiddleware, createRouteMatcher } from '@clerk/nuxt/server';
+        () => `import { clerkMiddleware, createRouteMatcher, getAuth } from '@clerk/nuxt/server';
 
         export default clerkMiddleware((event) => {
-          const { userId } = event.context.auth
+          const { userId } = getAuth(event);
           const isProtectedRoute = createRouteMatcher(['/api/me']);
 
           if (!userId && isProtectedRoute(event)) {

--- a/packages/nuxt/src/runtime/server/errors.ts
+++ b/packages/nuxt/src/runtime/server/errors.ts
@@ -1,0 +1,16 @@
+const createErrorMessage = (msg: string) => {
+  return `🔒 Clerk: ${msg.trim()}
+  
+  For more info, check out the docs: https://clerk.com/docs,
+  or come say hi in our discord server: https://clerk.com/discord
+  `;
+};
+
+export const moduleRegistrationRequired =
+  createErrorMessage(`The "@clerk/nuxt" module should be registered before using "getAuth".
+Example:
+
+export default defineNuxtConfig({
+  modules: ['@clerk/nuxt'],
+})
+`);

--- a/packages/nuxt/src/runtime/server/getAuth.ts
+++ b/packages/nuxt/src/runtime/server/getAuth.ts
@@ -1,0 +1,11 @@
+import type { H3Event } from 'h3';
+
+import { moduleRegistrationRequired } from './errors';
+
+export function getAuth(event: H3Event) {
+  if (!event.context.auth) {
+    throw new Error(moduleRegistrationRequired);
+  }
+
+  return event.context.auth;
+}

--- a/packages/nuxt/src/runtime/server/index.ts
+++ b/packages/nuxt/src/runtime/server/index.ts
@@ -2,3 +2,4 @@ export * from '@clerk/backend';
 export { clerkClient } from './clerkClient';
 export { clerkMiddleware } from './clerkMiddleware';
 export { createRouteMatcher } from './routeMatcher';
+export { getAuth } from './getAuth';


### PR DESCRIPTION
## Description

This PR introduces a `getAuth()` helper to our Nuxt SDK similar to our other SDKs ([Next.js](https://clerk.com/docs/references/nextjs/get-auth)) that retrieves the current auth state.

Example:

```ts
import { getAuth } from '@clerk/nuxt/server';

export default eventHandler((event) => {
  const { userId } = getAuth(event);

  if (!userId) {
    // User is not authenticated
  }
});
```

Resolves ECO-405

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
