### PR TITLE
fix(clerk-js): Track usage of custom pages and custom items

### DIFF
--- a/.changeset/unlucky-doors-yawn.md
+++ b/.changeset/unlucky-doors-yawn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Track custom pages and custom items usage on `UserButton` and `UserProfile` mount.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -643,7 +643,17 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('UserProfile', props));
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted(
+        'UserProfile',
+        props,
+        props?.customPages?.length || 0 > 0
+          ? {
+              customPages: true,
+            }
+          : undefined,
+      ),
+    );
   };
 
   public unmountUserProfile = (node: HTMLDivElement): void => {
@@ -798,7 +808,21 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('UserButton', props));
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted('UserButton', props, {
+        ...(props?.customMenuItems?.length || 0 > 0
+          ? {
+              customItems: true,
+            }
+          : undefined),
+
+        ...(props?.__experimental_asStandalone
+          ? {
+              standalone: true,
+            }
+          : undefined),
+      }),
+    );
   };
 
   public unmountUserButton = (node: HTMLDivElement): void => {


### PR DESCRIPTION
## Description

Tracks usage of custom pages and custom items, and i squeezed the standalone prop as well :) 


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
