### PR TITLE
chore(vue,shared): Move `getCurrentOrganizationMembership` helper to shared package

### DIFF
--- a/.changeset/rotten-jokes-destroy.md
+++ b/.changeset/rotten-jokes-destroy.md
@@ -1,0 +1,6 @@
+---
+"@clerk/shared": patch
+"@clerk/vue": patch
+---
+
+Previously, the `getCurrentOrganizationMembership()` function was duplicated in both `@clerk/vue` and `@clerk/shared/react`. This change moves the function to `@clerk/shared/organization`.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -116,7 +116,8 @@
     "oauth",
     "web3",
     "getEnvVariable",
-    "pathMatcher"
+    "pathMatcher",
+    "organization"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/shared/src/__tests__/organization.test.ts
+++ b/packages/shared/src/__tests__/organization.test.ts
@@ -1,0 +1,31 @@
+import type { OrganizationMembershipResource } from '@clerk/types';
+
+import { getCurrentOrganizationMembership } from '../organization';
+
+describe('getCurrentOrganizationMembership', () => {
+  const mockMemberships: OrganizationMembershipResource[] = [
+    {
+      id: 'mem_1',
+      organization: { id: 'org_1' },
+    } as OrganizationMembershipResource,
+    {
+      id: 'mem_2',
+      organization: { id: 'org_2' },
+    } as OrganizationMembershipResource,
+  ];
+
+  it('returns the correct membership for a given organization ID', () => {
+    const result = getCurrentOrganizationMembership(mockMemberships, 'org_1');
+    expect(result).toBe(mockMemberships[0]);
+  });
+
+  it('returns undefined when organization ID is not found', () => {
+    const result = getCurrentOrganizationMembership(mockMemberships, 'org_nonexistent');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when memberships array is empty', () => {
+    const result = getCurrentOrganizationMembership([], 'org_1');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/shared/src/organization.ts
+++ b/packages/shared/src/organization.ts
@@ -1,0 +1,16 @@
+import type { OrganizationMembershipResource } from '@clerk/types';
+
+/**
+ * Finds the organization membership for a given organization ID from a list of memberships
+ * @param organizationMemberships - Array of organization memberships to search through
+ * @param organizationId - ID of the organization to find the membership for
+ * @returns The matching organization membership or undefined if not found
+ */
+export function getCurrentOrganizationMembership(
+  organizationMemberships: OrganizationMembershipResource[],
+  organizationId: string,
+) {
+  return organizationMemberships.find(
+    organizationMembership => organizationMembership.organization.id === organizationId,
+  );
+}

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -11,6 +11,7 @@ import type {
   OrganizationResource,
 } from '@clerk/types';
 
+import { getCurrentOrganizationMembership } from '../../organization';
 import { eventMethodCalled } from '../../telemetry/events/method-called';
 import {
   useAssertWrappedByClerkProvider,
@@ -366,12 +367,3 @@ export const useOrganization: UseOrganization = params => {
     invitations,
   };
 };
-
-function getCurrentOrganizationMembership(
-  organizationMemberships: OrganizationMembershipResource[],
-  activeOrganizationId: string,
-) {
-  return organizationMemberships.find(
-    organizationMembership => organizationMembership.organization.id === activeOrganizationId,
-  );
-}

--- a/packages/vue/src/composables/useOrganization.ts
+++ b/packages/vue/src/composables/useOrganization.ts
@@ -1,3 +1,4 @@
+import { getCurrentOrganizationMembership } from '@clerk/shared/organization';
 import type { OrganizationMembershipResource, OrganizationResource } from '@clerk/types';
 import { computed } from 'vue';
 
@@ -85,12 +86,3 @@ export const useOrganization: UseOrganization = () => {
 
   return toComputedRefs(result);
 };
-
-function getCurrentOrganizationMembership(
-  organizationMemberships: OrganizationMembershipResource[],
-  activeOrganizationId: string,
-) {
-  return organizationMemberships.find(
-    organizationMembership => organizationMembership.organization.id === activeOrganizationId,
-  );
-}


### PR DESCRIPTION
## Description

This PR moves the duplicated `getCurrentOrganizationMembership()` function in both `@clerk/vue` and `@clerk/shared/react` to `@clerk/shared/organization`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
