### PR TITLE
fix(clerk-js): Remove logo from verification alternative methods card

### DIFF
--- a/.changeset/dirty-crabs-happen.md
+++ b/.changeset/dirty-crabs-happen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove logo from use another method verification card.

--- a/packages/clerk-js/src/ui/components/UserVerification/AlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/UserVerification/AlternativeMethods.tsx
@@ -38,7 +38,7 @@ const AlternativeMethodsList = (props: AlternativeMethodListProps) => {
     <Flow.Part part={'alternativeMethods'}>
       <Card.Root>
         <Card.Content>
-          <Header.Root showLogo>
+          <Header.Root>
             <Header.Title localizationKey={localizationKeys('reverification.alternativeMethods.title')} />
             <Header.Subtitle localizationKey={localizationKeys('reverification.alternativeMethods.subtitle')} />
           </Header.Root>


### PR DESCRIPTION
## Description

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-02-14 at 1 36 22 PM](https://github.com/user-attachments/assets/4bb1155e-fd4e-4dd2-8561-ce609930eccf) | ![Screenshot 2025-02-14 at 1 36 37 PM](https://github.com/user-attachments/assets/acb1e398-04c8-4803-b40c-60c2e0e78821) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
