### PR TITLE
fix(clerk-js): Add clip-path to members search to avoid overlap

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -20,7 +20,7 @@ export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
             width: '100%',
             marginLeft: 'auto',
             padding: `${t.space.$none} ${t.space.$1}`,
-            clipPath: `inset(-4px -4px -4px -4px)`,
+            clipPath: `inset(-4px -4px -${t.space.$4} -4px)`,
           })}
           gap={actionSlot ? 2 : undefined}
         >

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MembersActions.tsx
@@ -20,6 +20,7 @@ export const MembersActionsRow = ({ actionSlot }: MembersActionsRowProps) => {
             width: '100%',
             marginLeft: 'auto',
             padding: `${t.space.$none} ${t.space.$1}`,
+            clipPath: `inset(-4px -4px -4px -4px)`,
           })}
           gap={actionSlot ? 2 : undefined}
         >


### PR DESCRIPTION
## Description

Avoids the issue where the info text overlaps the table below when its being removed.

BEFORE:

https://github.com/user-attachments/assets/3ba6bba9-16cd-4110-bafc-d0d77b22a811

AFTER:

https://github.com/user-attachments/assets/265472d4-3fd3-4f30-8b8f-a3b4e8bafd31

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
