### PR TITLE
fix(testing): Fix captcha triggering issue on Cypress tests

### DIFF
--- a/.changeset/little-avocados-cheer.md
+++ b/.changeset/little-avocados-cheer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Fix captcha triggering on Cypress tests

--- a/packages/testing/src/cypress/setupClerkTestingToken.ts
+++ b/packages/testing/src/cypress/setupClerkTestingToken.ts
@@ -33,6 +33,19 @@ export const setupClerkTestingToken = (params?: SetupClerkTestingTokenParams) =>
     if (testingToken) {
       req.query[TESTING_TOKEN_PARAM] = testingToken;
     }
+
     req.continue();
+
+    req.on('response', res => {
+      // Override captcha_bypass in /v1/client
+      if (res.body?.response?.captcha_bypass === false) {
+        res.body.response.captcha_bypass = true;
+      }
+
+      // Override captcha_bypass in piggybacking
+      if (res.body?.client?.captcha_bypass === false) {
+        res.body.client.captcha_bypass = true;
+      }
+    });
   });
 };


### PR DESCRIPTION
## Description

Fixes an issue on Cypress where the captcha is triggered when Bot protection is enabled for the dev instance.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
