### PR TITLE
feat(clerk-js): Track usage of UI modals

### DIFF
--- a/.changeset/poor-cobras-sin.md
+++ b/.changeset/poor-cobras-sin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Track usage of modal UI Components as part of telemetry.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -404,11 +404,12 @@ export class Clerk implements ClerkInterface {
   };
 
   public openGoogleOneTap = (props?: GoogleOneTapProps): void => {
-    // TODO: add telemetry
     this.assertComponentsReady(this.#componentControls);
     void this.#componentControls
       .ensureMounted({ preloadHint: 'GoogleOneTap' })
       .then(controls => controls.openModal('googleOneTap', props || {}));
+
+    this.telemetry?.record(eventPrebuiltComponentMounted(`GoogleOneTap`, props));
   };
 
   public closeGoogleOneTap = (): void => {
@@ -429,6 +430,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'SignIn' })
       .then(controls => controls.openModal('signIn', props || {}));
+
+    this.#recordSignInUsage(props, 'Modal');
   };
 
   public closeSignIn = (): void => {
@@ -449,6 +452,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'UserVerification' })
       .then(controls => controls.openModal('userVerification', props || {}));
+
+    this.telemetry?.record(eventPrebuiltComponentMounted(`UserVerification`, props));
   };
 
   public __internal_closeReverification = (): void => {
@@ -483,6 +488,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'SignUp' })
       .then(controls => controls.openModal('signUp', props || {}));
+
+    this.#recordSignUpUsage(props, 'Modal');
   };
 
   public closeSignUp = (): void => {
@@ -503,6 +510,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'UserProfile' })
       .then(controls => controls.openModal('userProfile', props || {}));
+
+    this.#recordUserProfileUsage(props, 'Modal');
   };
 
   public closeUserProfile = (): void => {
@@ -531,6 +540,7 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'OrganizationProfile' })
       .then(controls => controls.openModal('organizationProfile', props || {}));
+    this.#recordOrganizationProfileUsage(props, 'Modal');
   };
 
   public closeOrganizationProfile = (): void => {
@@ -551,6 +561,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'CreateOrganization' })
       .then(controls => controls.openModal('createOrganization', props || {}));
+
+    this.#recordCreateOrganizationUsage(props, 'Modal');
   };
 
   public closeCreateOrganization = (): void => {
@@ -563,6 +575,8 @@ export class Clerk implements ClerkInterface {
     void this.#componentControls
       .ensureMounted({ preloadHint: 'Waitlist' })
       .then(controls => controls.openModal('waitlist', props || {}));
+
+    this.#recordWaitlistUsage(props, 'Modal');
   };
 
   public closeWaitlist = (): void => {
@@ -580,17 +594,7 @@ export class Clerk implements ClerkInterface {
         props,
       }),
     );
-    this.telemetry?.record(
-      eventPrebuiltComponentMounted(
-        'SignIn',
-        {
-          ...props,
-        },
-        {
-          withSignUp: props?.withSignUp ?? this.#isCombinedSignInOrUpFlow(),
-        },
-      ),
-    );
+    this.#recordSignInUsage(props);
   };
 
   public unmountSignIn = (node: HTMLDivElement): void => {
@@ -612,7 +616,7 @@ export class Clerk implements ClerkInterface {
         props,
       }),
     );
-    this.telemetry?.record(eventPrebuiltComponentMounted('SignUp', props));
+    this.#recordSignUpUsage(props);
   };
 
   public unmountSignUp = (node: HTMLDivElement): void => {
@@ -643,17 +647,7 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(
-      eventPrebuiltComponentMounted(
-        'UserProfile',
-        props,
-        props?.customPages?.length || 0 > 0
-          ? {
-              customPages: true,
-            }
-          : undefined,
-      ),
-    );
+    this.#recordUserProfileUsage(props);
   };
 
   public unmountUserProfile = (node: HTMLDivElement): void => {
@@ -693,7 +687,7 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('OrganizationProfile', props));
+    this.#recordOrganizationProfileUsage(props);
   };
 
   public unmountOrganizationProfile = (node: HTMLDivElement) => {
@@ -724,7 +718,7 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('CreateOrganization', props));
+    this.#recordCreateOrganizationUsage(props);
   };
 
   public unmountCreateOrganization = (node: HTMLDivElement) => {
@@ -841,7 +835,7 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('Waitlist', props));
+    this.#recordWaitlistUsage(props);
   };
 
   public unmountWaitlist = (node: HTMLDivElement): void => {
@@ -2246,4 +2240,42 @@ export class Clerk implements ClerkInterface {
 
     return allowedProtocols;
   }
+
+  #recordSignInUsage = (props?: SignInProps, mode?: 'Modal') => {
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted(`SignIn${mode || ''}`, props, {
+        withSignUp: props?.withSignUp ?? this.#isCombinedSignInOrUpFlow(),
+      }),
+    );
+  };
+
+  #recordSignUpUsage = (props?: SignUpProps, mode?: 'Modal') => {
+    this.telemetry?.record(eventPrebuiltComponentMounted(`SignUp${mode || ''}`, props));
+  };
+
+  #recordUserProfileUsage = (props?: UserProfileProps, mode?: 'Modal') => {
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted(
+        `UserProfile${mode || ''}`,
+        props,
+        props?.customPages?.length || 0 > 0
+          ? {
+              customPages: true,
+            }
+          : undefined,
+      ),
+    );
+  };
+
+  #recordOrganizationProfileUsage = (props?: OrganizationProfileProps, mode?: 'Modal') => {
+    this.telemetry?.record(eventPrebuiltComponentMounted(`OrganizationProfile${mode || ''}`, props));
+  };
+
+  #recordCreateOrganizationUsage = (props?: OrganizationProfileProps, mode?: 'Modal') => {
+    this.telemetry?.record(eventPrebuiltComponentMounted(`CreateOrganization${mode || ''}`, props));
+  };
+
+  #recordWaitlistUsage = (props?: WaitlistProps, mode?: 'Modal') => {
+    this.telemetry?.record(eventPrebuiltComponentMounted(`Waitlist${mode || ''}`, props));
+  };
 }

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -1,13 +1,14 @@
 import type { TelemetryEventRaw } from '@clerk/types';
 
 const EVENT_COMPONENT_MOUNTED = 'COMPONENT_MOUNTED';
+const EVENT_COMPONENT_OPENED = 'COMPONENT_OPENED';
 const EVENT_SAMPLING_RATE = 0.1;
 
 type ComponentMountedBase = {
   component: string;
 };
 
-type EventPrebuiltComponentMounted = ComponentMountedBase & {
+type EventPrebuiltComponent = ComponentMountedBase & {
   appearanceProp: boolean;
   elements: boolean;
   variables: boolean;
@@ -15,6 +16,27 @@ type EventPrebuiltComponentMounted = ComponentMountedBase & {
 };
 
 type EventComponentMounted = ComponentMountedBase & TelemetryEventRaw['payload'];
+
+function createPrebuiltComponentEvent(event: typeof EVENT_COMPONENT_MOUNTED | typeof EVENT_COMPONENT_OPENED) {
+  return function (
+    component: string,
+    props?: Record<string, any>,
+    additionalPayload?: TelemetryEventRaw['payload'],
+  ): TelemetryEventRaw<EventPrebuiltComponent> {
+    return {
+      event,
+      eventSamplingRate: EVENT_SAMPLING_RATE,
+      payload: {
+        component,
+        appearanceProp: Boolean(props?.appearance),
+        baseTheme: Boolean(props?.appearance?.baseTheme),
+        elements: Boolean(props?.appearance?.elements),
+        variables: Boolean(props?.appearance?.variables),
+        ...additionalPayload,
+      },
+    };
+  };
+}
 
 /**
  * Helper function for `telemetry.record()`. Create a consistent event object for when a prebuilt (AIO) component is mounted.
@@ -30,19 +52,26 @@ export function eventPrebuiltComponentMounted(
   component: string,
   props?: Record<string, any>,
   additionalPayload?: TelemetryEventRaw['payload'],
-): TelemetryEventRaw<EventPrebuiltComponentMounted> {
-  return {
-    event: EVENT_COMPONENT_MOUNTED,
-    eventSamplingRate: EVENT_SAMPLING_RATE,
-    payload: {
-      component,
-      appearanceProp: Boolean(props?.appearance),
-      baseTheme: Boolean(props?.appearance?.baseTheme),
-      elements: Boolean(props?.appearance?.elements),
-      variables: Boolean(props?.appearance?.variables),
-      ...additionalPayload,
-    },
-  };
+): TelemetryEventRaw<EventPrebuiltComponent> {
+  return createPrebuiltComponentEvent(EVENT_COMPONENT_MOUNTED)(component, props, additionalPayload);
+}
+
+/**
+ * Helper function for `telemetry.record()`. Create a consistent event object for when a prebuilt (AIO) component is mounted.
+ *
+ * @param component - The name of the component.
+ * @param props - The props passed to the component. Will be filtered to a known list of props.
+ * @param additionalPayload - Additional data to send with the event.
+ *
+ * @example
+ * telemetry.record(eventPrebuiltComponentOpened('GoogleOneTap', props));
+ */
+export function eventPrebuiltComponentOpened(
+  component: string,
+  props?: Record<string, any>,
+  additionalPayload?: TelemetryEventRaw['payload'],
+): TelemetryEventRaw<EventPrebuiltComponent> {
+  return createPrebuiltComponentEvent(EVENT_COMPONENT_OPENED)(component, props, additionalPayload);
 }
 
 /**

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -57,7 +57,7 @@ export function eventPrebuiltComponentMounted(
 }
 
 /**
- * Helper function for `telemetry.record()`. Create a consistent event object for when a prebuilt (AIO) component is mounted.
+ * Helper function for `telemetry.record()`. Create a consistent event object for when a prebuilt (AIO) component is opened as a modal.
  *
  * @param component - The name of the component.
  * @param props - The props passed to the component. Will be filtered to a known list of props.


### PR DESCRIPTION
## Description

This PR allows for telemetry data to be collected when the following components render
- GoogleOneTap (only modal)
- UserVerification (only modal)
- SignIn as modal
- SignUp as modal
- UserProfile as modal
- OrganizationProfile as modal
- CreateOrganization as modal
- Waitlist as Modal

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
