### PR TITLE
fix(*): Update some package.json conditional exports

### DIFF
--- a/.changeset/olive-elephants-share.md
+++ b/.changeset/olive-elephants-share.md
@@ -1,0 +1,11 @@
+---
+'@clerk/agent-toolkit': patch
+'@clerk/react-router': patch
+'@clerk/astro': patch
+'@clerk/nuxt': patch
+'@clerk/vue': patch
+---
+
+The [`exports` map](https://nodejs.org/api/packages.html#conditional-exports) inside `package.json` has been slightly adjusted to allow for [`require(esm)`](https://joyeecheung.github.io/blog/2024/03/18/require-esm-in-node-js/) to work correctly. The `"import"` conditions have been changed to `"default"`.
+
+You shouldn't see any change in behavior/functionality on your end.

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -19,11 +19,11 @@
   "exports": {
     "./langchain": {
       "types": "./dist/langchain/index.d.ts",
-      "import": "./dist/langchain/index.js"
+      "default": "./dist/langchain/index.js"
     },
     "./ai-sdk": {
       "types": "./dist/ai-sdk/index.d.ts",
-      "import": "./dist/ai-sdk/index.js"
+      "default": "./dist/ai-sdk/index.js"
     }
   },
   "files": [

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -37,23 +37,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",
-      "import": "./dist/react/index.js"
+      "default": "./dist/react/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "default": "./dist/client/index.js"
     },
     "./internal": {
       "types": "./dist/internal/index.d.ts",
-      "import": "./dist/internal/index.js"
+      "default": "./dist/internal/index.js"
     },
     "./server": {
       "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js"
+      "default": "./dist/server/index.js"
     },
     "./env": "./env.d.ts",
     "./components": "./components/index.ts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -28,23 +28,23 @@
   "exports": {
     ".": {
       "types": "./dist/module.d.ts",
-      "import": "./dist/module.js"
+      "default": "./dist/module.js"
     },
     "./server": {
       "types": "./dist/runtime/server/index.d.ts",
-      "import": "./dist/runtime/server/index.js"
+      "default": "./dist/runtime/server/index.js"
     },
     "./components": {
       "types": "./dist/runtime/components/index.d.ts",
-      "import": "./dist/runtime/components/index.js"
+      "default": "./dist/runtime/components/index.js"
     },
     "./composables": {
       "types": "./dist/runtime/composables/index.d.ts",
-      "import": "./dist/runtime/composables/index.js"
+      "default": "./dist/runtime/composables/index.js"
     },
     "./errors": {
       "types": "./dist/runtime/errors.d.ts",
-      "import": "./dist/runtime/errors.js"
+      "default": "./dist/runtime/errors.js"
     }
   },
   "main": "./dist/module.js",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -28,19 +28,19 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./ssr.server": {
       "types": "./dist/ssr/index.d.ts",
-      "import": "./dist/ssr/index.js"
+      "default": "./dist/ssr/index.js"
     },
     "./api.server": {
       "types": "./dist/api/index.d.ts",
-      "import": "./dist/api/index.js"
+      "default": "./dist/api/index.js"
     },
     "./errors": {
       "types": "./dist/errors.d.ts",
-      "import": "./dist/errors.js"
+      "default": "./dist/errors.js"
     }
   },
   "main": "dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,15 +28,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
-      "import": "./dist/internal.js"
+      "default": "./dist/internal.js"
     },
     "./errors": {
       "types": "./dist/errors.d.ts",
-      "import": "./dist/errors.js"
+      "default": "./dist/errors.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
## Description

We should update some packages to allow for require(esm) to work correctly.

https://joyeecheung.github.io/blog/2024/03/18/require-esm-in-node-js/

We should use this everywhere for ESM-only packages:

```json
"type": "module",
"exports": {
    "types": "./index.d.ts",
    "default": "./index.js"
},
```

Then ESM will be correctly resolved. Because as per https://nodejs.org/api/packages.html#conditional-exports it says:

> "import" - matches when the package is loaded via import or import()

So with our current setup the `require()` won't work.

> "default" - the generic fallback that always matches.

Good 👍 

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
