### PR TITLE
fix(shared): Restore scrollbar on re-verification completion or on canceled/closed

### DIFF
--- a/.changeset/sweet-forks-care.md
+++ b/.changeset/sweet-forks-care.md
@@ -2,4 +2,4 @@
 "@clerk/shared": patch
 ---
 
-fix(shared): Fixes restoretion of the scrollbar behaviour after re-verification it's completed or canceled/closed.
+Fixes restoration of the scrollbar behaviour after re-verification is completed or canceled/closed.

--- a/.changeset/sweet-forks-care.md
+++ b/.changeset/sweet-forks-care.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+fix(shared): Close re-verification modal after completed or canceled/closed.

--- a/.changeset/sweet-forks-care.md
+++ b/.changeset/sweet-forks-care.md
@@ -2,4 +2,4 @@
 "@clerk/shared": patch
 ---
 
-fix(shared): Close re-verification modal after completed or canceled/closed.
+fix(shared): Fixes restoretion of the scrollbar behaviour after re-verification it's completed or canceled/closed.

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -46,6 +46,7 @@ type UseReverificationOptions = {
 
 type CreateReverificationHandlerParams = UseReverificationOptions & {
   openUIComponent: Clerk['__internal_openReverification'];
+  closeUIComponent: Clerk['__internal_closeReverification'];
 };
 
 function createReverificationHandler(params: CreateReverificationHandlerParams) {
@@ -98,6 +99,8 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
           }
 
           return null;
+        } finally {
+          params.closeUIComponent?.();
         }
 
         /**
@@ -184,13 +187,14 @@ function useReverification<
   Fetcher extends (...args: any[]) => Promise<any> | undefined,
   Options extends UseReverificationOptions,
 >(fetcher: Fetcher, options?: Options): UseReverificationResult<Fetcher, Options> {
-  const { __internal_openReverification } = useClerk();
+  const { __internal_openReverification, __internal_closeReverification } = useClerk();
   const fetcherRef = useRef(fetcher);
   const optionsRef = useRef(options);
 
   const handleReverification = useMemo(() => {
     const handler = createReverificationHandler({
       openUIComponent: __internal_openReverification,
+      closeUIComponent: __internal_closeReverification,
       ...optionsRef.current,
     })(fetcherRef.current);
     return [handler] as const;


### PR DESCRIPTION
## Description

This PR fixes an issue where the re-verification modal does not restores the scrollbar behaviour after it's completed or canceled/closed.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
