### PR TITLE
fix(astro): Introduce `protect-fallback` slot to avoid server islands conflict

### DIFF
--- a/integration/templates/astro-node/src/pages/server-islands.astro
+++ b/integration/templates/astro-node/src/pages/server-islands.astro
@@ -1,0 +1,20 @@
+---
+import { Protect } from "@clerk/astro/components";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Page is only accessible by members">
+  <div class="w-full flex justify-center flex-col">
+    <Protect server:islands role="admin">
+      <p slot="fallback">Loading</p>
+      <Fragment slot="protect-fallback">
+        <h1 class="text-2xl text-center">Not an admin</h1>
+        <a
+          class="text-sm text-center text-gray-100 transition hover:text-gray-400"
+          href="/only-members">Go to Members Page</a
+        >
+      </Fragment>
+      <h1 class="text-2xl text-center">I'm an admin</h1>
+    </Protect>
+  </div>
+</Layout>

--- a/packages/astro/src/astro-components/control/Protect.astro
+++ b/packages/astro/src/astro-components/control/Protect.astro
@@ -31,5 +31,6 @@ const ProtectComponent = isStaticOutput(isStatic) ? ProtectCSR : ProtectSSR;
 
 <ProtectComponent {...props}>
   <slot />
+  <slot name="protect-fallback" slot="protect-fallback" />
   <slot name="fallback" slot="fallback" />
 </ProtectComponent>

--- a/packages/astro/src/astro-components/control/ProtectSSR.astro
+++ b/packages/astro/src/astro-components/control/ProtectSSR.astro
@@ -9,6 +9,13 @@ const isUnauthorized =
   (typeof Astro.props.condition === "function" &&
     !Astro.props.condition(has)) ||
   ((Astro.props.role || Astro.props.permission) && !has(Astro.props));
+
+// Note: Astro server islands also use a "fallback" slot for loading states
+// See: https://docs.astro.build/en/guides/server-islands/#server-island-fallback-content
+// We use "protect-fallback" as our preferred slot name to avoid conflicts
+const fallbackSlot = Astro.slots.has('protect-fallback') 
+  ? 'protect-fallback' 
+  : 'fallback';
 ---
 
-{isUnauthorized ? <slot name="fallback" /> : <slot />}
+{isUnauthorized ? <slot name={fallbackSlot} /> : <slot />}


### PR DESCRIPTION
## Description

We have a naming conflict between our Astro SDK`<Protect >` component and the Astro server islands [fallback content slot](https://docs.astro.build/en/guides/server-islands/#server-island-fallback-content).

The `fallback` slot from our `<Protect >` component is intended to render content when a user is unauthorized while the `fallback` slot for server islands is used to show a loading content for example.

To resolve this, we've introduced a new `protect-fallback` slot while maintaining backwards compatibility with the original `fallback` slot.

![Screenshot 2025-02-18 at 7 44 20 AM](https://github.com/user-attachments/assets/3b60636b-612f-4cac-a04c-96bb2f28a3b5)

Example:

```html
<Protect server:islands role="admin">
  <p slot="fallback">Loading</p>
  <Fragment slot="protect-fallback">
    <h1>Not an admin</h1>
    <a href="/members">Go to Members Page</a>
  </Fragment>
  <h1>I'm an admin</h1>
</Protect>
```

ECO-419

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
