### PR TITLE
fix(shared): Preserve `import.meta` without requiring ES2020 target

### DIFF
--- a/.changeset/fuzzy-radios-tease.md
+++ b/.changeset/fuzzy-radios-tease.md
@@ -1,5 +1,5 @@
 ---
-"@clerk/shared": patch
+"@clerk/shared": minor
 ---
 
 Fix compatibility with iOS 12 and older browsers while maintaining Vite support

--- a/.changeset/fuzzy-radios-tease.md
+++ b/.changeset/fuzzy-radios-tease.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix compatibility with iOS 12 and older browsers while maintaining Vite support

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -20,5 +20,5 @@
     "allowJs": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "global.d.ts"]
+  "include": ["src", "global.d.ts", "tsup.config.ts"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -20,5 +20,5 @@
     "allowJs": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "global.d.ts", "tsup.config.ts"]
+  "include": ["src", "global.d.ts"]
 }

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(overrideOptions => {
     sourcemap: true,
     dts: true,
     external: ['react', 'react-dom'],
-    esbuildPlugins: [WebWorkerMinifyPlugin as any, preserveImportMetaPlugin],
+    esbuildPlugins: [WebWorkerMinifyPlugin as any, PreserveImportMetaPlugin],
     define: {
       PACKAGE_NAME: `"${name}"`,
       PACKAGE_VERSION: `"${version}"`,
@@ -53,8 +53,8 @@ export const WebWorkerMinifyPlugin: Plugin = {
  * Preserves import.meta functionality in ESM builds while maintaining ES5 compatibility.
  * We originally used target: 'es2020' to handle this but it broke support for older browsers (e.g. iOS 12).
  */
-const preserveImportMetaPlugin: Plugin = {
-  name: 'preserve-import-meta',
+const PreserveImportMetaPlugin: Plugin = {
+  name: 'PreserveImportMetaPlugin',
   setup(build) {
     build.onEnd(result => {
       if (!result.outputFiles) return;

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -56,7 +56,7 @@ export const WebWorkerMinifyPlugin: Plugin = {
 const preserveImportMetaPlugin: Plugin = {
   name: 'preserve-import-meta',
   setup(build) {
-    build.onEnd(async result => {
+    build.onEnd(result => {
       if (!result.outputFiles) return;
 
       result.outputFiles.forEach(file => {


### PR DESCRIPTION
## Description

In #4985, we introduced a shared function that checks if environment variables exist across different platforms (Node.js, Vite, Cloudflare, etc). To support Vite's `import.meta.env`, we set the build target to `ES2020`, but this [broke support for older browsers](https://github.com/clerk/javascript/commit/f41081c563ddd2afc05b837358e0de087ae0c895#r152772163) due to ES2020 features like optional chaining.

This PR removes the added ES2020 target, but preserves the `import.meta` functionality via a plugin. The plugin removes esbuild's `var import_meta = {}` transformation and restores the original `import.meta` references in ESM builds only, while maintaining compatibility with older browsers.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
