### PR TITLE
refactor(clerk-js): SocialButton column distribution

### DIFF
--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -49,6 +49,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
 
   'socialButtonsRoot',
   'socialButtons',
+  'socialButtonsColumn',
   'socialButtonsIconButton',
   'socialButtonsBlockButton',
   'socialButtonsBlockButtonText',

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -93,6 +93,7 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
       elementDescriptor={descriptors.socialButtonsRoot}
     >
       <Flex
+        elementDescriptor={descriptors.socialButtons}
         wrap='wrap'
         justify='center'
         sx={t => ({
@@ -140,6 +141,8 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
           return (
             <Box
               key={strategy}
+              elementDescriptor={descriptors.socialButtonsColumn}
+              elementId={descriptors.socialButtonsProviderIcon.setId(strategyToDisplayData[strategy].id)}
               sx={t => ({
                 [mq.sm]: {
                   paddingLeft: t.sizes.$2,

--- a/packages/clerk-js/src/ui/elements/utils.ts
+++ b/packages/clerk-js/src/ui/elements/utils.ts
@@ -22,3 +22,50 @@ export function distributeStrategiesIntoRows<T>(strategies: T[], maxStrategiesPe
 
   return rows;
 }
+
+/**
+ * Calculates the number of columns given the total number of items and the maximum columns allowed per row.
+ *
+ * @param {Object} options
+ * @param {number} options.length - The total number of items.
+ * @param {number} options.max - The maximum number of columns allowed per row.
+ * @returns The calculated number of columns.
+ *
+ * Example output for item counts from 1 to 24 with `columns: 6`:
+ *
+ *  1:  [ 1 ]
+ *  2:  [ 1, 2 ]
+ *  3:  [ 1, 2, 3 ]
+ *  4:  [ 1, 2, 3, 4 ]
+ *  5:  [ 1, 2, 3, 4, 5 ]
+ *  6:  [ 1, 2, 3, 4, 5, 6 ]
+ *  7:  [ [1, 2, 3, 4], [5, 6, 7] ]
+ *  8:  [ [1, 2, 3, 4], [5, 6, 7, 8] ]
+ *  9:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9] ]
+ * 10:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10] ]
+ * 11:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11] ]
+ * 12:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12] ]
+ * 13:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13] ]
+ * 14:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14] ]
+ * 15:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11], [12, 13, 14, 15] ]
+ * 16:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [13, 14, 15, 16] ]
+ * 17:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [13, 14, 15, 16, 17] ]
+ * 18:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18] ]
+ * 19:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19] ]
+ * 20:  [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20] ]
+ * 21:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11], [12, 13, 14, 15, 16], [17, 18, 19, 20, 21] ]
+ * 22:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11], [12, 13, 14, 15, 16], [17, 18, 19, 20, 21, 22] ]
+ * 23:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [13, 14, 15, 16, 17], [18, 19, 20, 21, 22, 23] ]
+ * 24:  [ [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [13, 14, 15, 16, 17, 18], [19, 20, 21, 22, 23, 24] ]
+ *
+ * Examples:
+ * ```
+ * getColumnCount(1); // 1
+ * getColumnCount(7); // 4
+ * getColumnCount(15); // 6
+ * ```
+ */
+export function getColumnCount(length: number, max: number): number {
+  const numRows = Math.ceil(length / max);
+  return Math.ceil(length / numRows);
+}

--- a/packages/clerk-js/src/ui/styledSystem/breakpoints.tsx
+++ b/packages/clerk-js/src/ui/styledSystem/breakpoints.tsx
@@ -13,9 +13,9 @@ const deviceQueries = {
   ios: '@supports (-webkit-touch-callout: none)',
 } as const;
 
-// export const mq = Object.fromEntries(
-//   Object.entries(breakpoints).map(([k, v]) => [k, `@media (min-width: ${v})`]),
-// ) as Record<keyof typeof breakpoints, string>;
+export const mq = Object.fromEntries(
+  Object.entries(breakpoints).map(([k, v]) => [k, `@media (min-width: ${v})`]),
+) as Record<keyof typeof breakpoints, string>;
 
 export const mqu = {
   ...deviceQueries,

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -168,6 +168,7 @@ export type ElementsConfig = {
 
   socialButtonsRoot: WithOptions;
   socialButtons: WithOptions;
+  socialButtonsColumn: WithOptions;
   socialButtonsIconButton: WithOptions<OAuthProvider | Web3Provider, LoadingState>;
   socialButtonsBlockButton: WithOptions<OAuthProvider | Web3Provider, LoadingState>;
   socialButtonsBlockButtonText: WithOptions<OAuthProvider | Web3Provider>;


### PR DESCRIPTION
## Description

Fixes issue where on load the second row of the social buttons is collapsed until the calculation is computed.

Top example is the update implementation and the bottom is the current:

![Screenshot 2025-02-21 at 4 06 02 PM](https://github.com/user-attachments/assets/f9c6ada8-726a-4cb7-9428-3357cfd0baec)


https://github.com/user-attachments/assets/9419eabe-7d4e-4c7d-ba70-6f28f77e6ece

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
