### PR TITLE
fix(clerk-js): Transform node_modules with swc

### DIFF
--- a/.changeset/moody-owls-return.md
+++ b/.changeset/moody-owls-return.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Improve compatibility with Safari 12 by removing modern JavaScript syntax.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -5,7 +5,7 @@
     { "path": "./dist/clerk.headless.js", "maxSize": "48kB" },
     { "path": "./dist/ui-common*.js", "maxSize": "89KB" },
     { "path": "./dist/vendors*.js", "maxSize": "25KB" },
-    { "path": "./dist/coinbase*.js", "maxSize": "35.2KB" },
+    { "path": "./dist/coinbase*.js", "maxSize": "35.5KB" },
     { "path": "./dist/createorganization*.js", "maxSize": "5KB" },
     { "path": "./dist/impersonationfab*.js", "maxSize": "5KB" },
     { "path": "./dist/organizationprofile*.js", "maxSize": "12KB" },

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -173,6 +173,17 @@ const typescriptLoaderProd = () => {
         },
       },
     },
+    {
+      test: /\.m?js$/,
+      use: {
+        loader: 'builtin:swc-loader',
+        options: {
+          env: {
+            targets: packageJSON.browserslist,
+          },
+        },
+      },
+    },
   ];
 };
 


### PR DESCRIPTION
## Description

This PR fixes an issue where code within `node_modules` would not be transformed according to our `"browserslist"` configuration, which resulted in modern JS syntax being used within our bundle. By adding a new loader that does not contain the `exclude: /node_modules/` directive, we ensure that all bundled code is transformed by SWC according to our `"browserslist"` targets. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
