### PR TITLE
feat(clerk-js): Use twMerge to merge user provided TW classNames

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -72,7 +72,8 @@
     "crypto-js": "^4.2.0",
     "dequal": "2.0.3",
     "qrcode.react": "3.1.0",
-    "regenerator-runtime": "0.13.11"
+    "regenerator-runtime": "0.13.11",
+    "tailwind-merge": "3.0.2"
   },
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "^0.4.13",

--- a/packages/clerk-js/src/ui/customizables/classGeneration.ts
+++ b/packages/clerk-js/src/ui/customizables/classGeneration.ts
@@ -1,4 +1,5 @@
 import type { Elements, ElementState } from '@clerk/types';
+import { twMerge } from 'tailwind-merge';
 
 import type { FlowMetadata } from '../elements/contexts';
 import type { ElementDescriptor, ElementId } from './elementDescriptors';
@@ -98,12 +99,13 @@ const addUserProvidedClassnames = (
   elemId: ElementId | undefined,
   state: ElementState | undefined,
 ) => {
+  let mergedCn = cn;
   for (let j = 0; j < elemDescriptors.length; j++) {
     for (let i = 0; i < parsedElements.length; i++) {
-      cn = addClassnamesFromElements(cn, parsedElements[i], elemDescriptors[j], elemId, state);
+      mergedCn = twMerge(mergedCn, addClassnamesFromElements('', parsedElements[i], elemDescriptors[j], elemId, state));
     }
   }
-  return cn; //.trimEnd();
+  return mergedCn;
 };
 
 const getElementState = (props: PropsWithState | undefined): ElementState | undefined => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       regenerator-runtime:
         specifier: 0.13.11
         version: 0.13.11
+      tailwind-merge:
+        specifier: 3.0.2
+        version: 3.0.2
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^0.4.13
@@ -2934,7 +2937,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.30':
     resolution: {integrity: sha512-V90TUJh9Ly8stYo8nwqIqNWCsYjE28GlVFWEhAFCUOp99foiQr8HSTpiiX5GIrprcPoWmlGoY+J5fQA29R4lFg==}
@@ -12790,6 +12793,9 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tailwind-merge@3.0.2:
+    resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -29672,6 +29678,8 @@ snapshots:
   system-architecture@0.1.0: {}
 
   tabbable@6.2.0: {}
+
+  tailwind-merge@3.0.2: {}
 
   tapable@2.2.1: {}
 


### PR DESCRIPTION
## Description

Currently when using TW to style elements using the appearance prop, the following example should output a blue background button for google, but results in a red background due to order of TW classes being generated.

## TODO

- [ ] Make passing in a merge function an option

## Currently:

### Input:

```ts
appearance: {
  elements: {
    button: 'bg-red-500',
    socialButtonsBlockButton__google: 'bg-blue-500'
  }
}
```

### Output:

```html
<button class="cl-socialButtonsBlockButton cl-button cl-socialButtonsBlockButton__google cl-button__google bg-red-500 bg-blue-500 🔒️ cl-internal-109vell" />
```

```css
.bg-blue-500 {...}
.bg-red-500 {...} // Take precedence due to order
```

![Screenshot 2025-02-26 at 4 22 08 PM](https://github.com/user-attachments/assets/cbdc7ef7-069d-4e26-be22-d26199356c2f)

## With twMerge

```ts
appearance: {
  elements: {
    button: 'bg-red-500',
    socialButtonsBlockButton__google: 'bg-blue-500'
  }
}
```

### Output:

```html
<button class="cl-socialButtonsBlockButton cl-button cl-socialButtonsBlockButton__google cl-button__google bg-blue-500 🔒️ cl-internal-109vell" />
```

```css
.bg-blue-500 {...}
.bg-red-500 {...} // Order doesn't matter since the red cn is stripped from the button
```

![Screenshot 2025-02-26 at 4 23 30 PM](https://github.com/user-attachments/assets/e459ebf8-c91c-4fbc-a6d4-7e91d320e663)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
