### PR TITLE
fix(clerk-js): Display emailAddress validation errors in `<Waitlist />` component

### DIFF
--- a/.changeset/poor-insects-yell.md
+++ b/.changeset/poor-insects-yell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Display validation error in `<Waitlist />` for email address field correctly 

--- a/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
+++ b/packages/clerk-js/src/ui/components/Waitlist/WaitlistForm.tsx
@@ -47,7 +47,7 @@ export const WaitlistForm = (props: WaitlistFormProps) => {
         return;
       })
       .catch(error => {
-        handleError(error, [], card.setError);
+        handleError(error, [formState.emailAddress], card.setError);
       })
       .finally(() => {
         status.setIdle();


### PR DESCRIPTION
## Description

In this pr we're displaying the validation fields errors in `<Waitlist />` component. Before this pr we didn't display them correctly 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

### AFTER
![Screenshot 2025-02-27 at 5 11 47 PM](https://github.com/user-attachments/assets/2c81aa93-9f7b-4a93-a96a-4ee5804e4f0c)