### PR TITLE
fix(dev-cli): Prevent import of lockfile when none is present

### DIFF
--- a/.changeset/itchy-pigs-learn.md
+++ b/.changeset/itchy-pigs-learn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/dev-cli': patch
+---
+
+Fix issue where `clerk-dev` would attempt to import a lockfile even when one was not present.

--- a/packages/dev-cli/src/commands/setup.js
+++ b/packages/dev-cli/src/commands/setup.js
@@ -135,7 +135,7 @@ function hasSupportedLockfile() {
 async function importPackageLock() {
   return new Promise((resolve, reject) => {
     if (!hasSupportedLockfile()) {
-      resolve();
+      return resolve();
     }
     console.log('Supported non-pnpm lockfile detected, importing with `pnpm import`...');
 


### PR DESCRIPTION
## Description

This PR fixes an issue with `clerk-dev` where we would attempt to import a lock file even when one was not present. This was due to the `importPackageLock` function continuing to execute even after `resolve()` was called.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
