### PR TITLE
fix(backend): Remove `Authorization` header when `secretKey` is not required

### DIFF
--- a/.changeset/tricky-hats-sort.md
+++ b/.changeset/tricky-hats-sort.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Bug fix: Properly remove `Authorization` header on requests that don't require a secret key.

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -97,9 +97,7 @@ export function buildRequest(options: BuildRequestOptions) {
     };
 
     if (secretKey) {
-      Object.assign(headers, {
-        Authorization: `Bearer ${secretKey}`,
-      });
+      headers.Authorization = `Bearer ${secretKey}`,
     }
 
     let res: Response | undefined;

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -57,6 +57,7 @@ type BuildRequestOptions = {
    */
   requireSecretKey?: boolean;
 };
+
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
     const {
@@ -97,7 +98,7 @@ export function buildRequest(options: BuildRequestOptions) {
     };
 
     if (secretKey) {
-      headers.Authorization = `Bearer ${secretKey}`,
+      headers.Authorization = `Bearer ${secretKey}`;
     }
 
     let res: Response | undefined;

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -91,11 +91,16 @@ export function buildRequest(options: BuildRequestOptions) {
 
     // Build headers
     const headers: Record<string, any> = {
-      Authorization: `Bearer ${secretKey}`,
       'Clerk-API-Version': SUPPORTED_BAPI_VERSION,
       'User-Agent': userAgent,
       ...headerParams,
     };
+
+    if (secretKey) {
+      Object.assign(headers, {
+        Authorization: `Bearer ${secretKey}`,
+      });
+    }
 
     let res: Response | undefined;
     try {


### PR DESCRIPTION
## Description

Properly remove authorization header when `requireSecretKey: false`  and `secretKey` does not exist.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
