### PR TITLE
fix(backend): Update `inviterUserId` type to optional

### DIFF
--- a/.changeset/rude-pumas-jog.md
+++ b/.changeset/rude-pumas-jog.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Update `CreateOrganizationInvitationParams.inviterUserId` type to optional

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -78,7 +78,7 @@ type DeleteOrganizationMembershipParams = {
 
 type CreateOrganizationInvitationParams = {
   organizationId: string;
-  inviterUserId: string;
+  inviterUserId?: string;
   emailAddress: string;
   role: OrganizationMembershipRole;
   redirectUrl?: string;


### PR DESCRIPTION
## Description

BAPI has been updated to have `inviterUserId` as nullable/optional but we forgot to update the types here 

https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/CreateOrganizationInvitation!path=inviter_user_id&t=request
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
