### PR TITLE
fix(shared): Offline detection with `isBrowserOnline`

### DIFF
--- a/.changeset/fuzzy-rules-perform.md
+++ b/.changeset/fuzzy-rules-perform.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Require both rtt and downlink to be zero to determine "offline" status.

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -80,7 +80,7 @@ export function isBrowserOnline(): boolean {
   const hasRtt = connection?.rtt !== 0;
   const hasDownlink = connection?.downlink !== 0;
 
-  return isNavigatorOnline && (hasRtt || hasDownlink || !connection);
+  return isNavigatorOnline && (hasRtt || hasDownlink);
 }
 
 /**


### PR DESCRIPTION
## Description

We should expect both `rtt` and `downlink` to be zero, in order to determine "offline" status

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
