### PR TITLE
fix(clerk-js): Add explicit check for `withSignUp` being false

### DIFF
--- a/.changeset/serious-mice-approve.md
+++ b/.changeset/serious-mice-approve.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+When a user passes `withSignUp={false}` we should opt out of combined flow even when `signUpUrl` is undefined.

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -45,7 +45,8 @@ export const useSignInContext = (): SignInContextType => {
 
   const isCombinedFlow =
     (signUpMode !== 'restricted' &&
-      Boolean(!options.signUpUrl && options.signInUrl && !isAbsoluteUrl(options.signInUrl))) ||
+      Boolean(!options.signUpUrl && options.signInUrl && !isAbsoluteUrl(options.signInUrl)) &&
+      context.withSignUp !== false) ||
     context.withSignUp ||
     false;
 


### PR DESCRIPTION
## Description

When a user passes `withSignUp={false}` we should opt out of combined flow even when `signUpUrl` is undefined.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
