### PR TITLE
fix(clerk-js): Remove extra legal consent checkbox

### DIFF
--- a/.changeset/afraid-cats-study.md
+++ b/.changeset/afraid-cats-study.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removes legal consent checkbox from sign-up start card when only social or web3 strategies are enabled.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -8,9 +8,7 @@ import { SignInContext, useCoreSignUp, useEnvironment, useSignUpContext } from '
 import { descriptors, Flex, Flow, localizationKeys, useAppearance, useLocalizations } from '../../customizables';
 import {
   Card,
-  Form,
   Header,
-  LegalCheckbox,
   LoadingCard,
   SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
@@ -320,14 +318,6 @@ function _SignUpStart(): JSX.Element {
                 />
               )}
             </SocialButtonsReversibleContainerWithDivider>
-            {!shouldShowForm && isLegalConsentEnabled && (
-              <Form.ControlRow elementId='legalAccepted'>
-                <LegalCheckbox
-                  {...formState.legalAccepted.props}
-                  isRequired={fields.legalAccepted?.required}
-                />
-              </Form.ControlRow>
-            )}
             {!shouldShowForm && <CaptchaElement />}
           </Flex>
         </Card.Content>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -8,7 +8,9 @@ import { SignInContext, useCoreSignUp, useEnvironment, useSignUpContext } from '
 import { descriptors, Flex, Flow, localizationKeys, useAppearance, useLocalizations } from '../../customizables';
 import {
   Card,
+  Form,
   Header,
+  LegalCheckbox,
   LoadingCard,
   SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
@@ -318,6 +320,14 @@ function _SignUpStart(): JSX.Element {
                 />
               )}
             </SocialButtonsReversibleContainerWithDivider>
+            {!shouldShowForm && isLegalConsentEnabled && (
+              <Form.ControlRow elementId='legalAccepted'>
+                <LegalCheckbox
+                  {...formState.legalAccepted.props}
+                  isRequired={fields.legalAccepted?.required}
+                />
+              </Form.ControlRow>
+            )}
             {!shouldShowForm && <CaptchaElement />}
           </Flex>
         </Card.Content>


### PR DESCRIPTION
## Description

Removes legal consent checkbox from sign-up start card when only social or web3 strategies are enabled.

Fixes SDKI-904

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
