### PR TITLE
chore(backend): Change telemetry sampling rate from 1 to 0.1

### DIFF
--- a/.changeset/blue-owls-beam.md
+++ b/.changeset/blue-owls-beam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Change sampling rate of telemetry events to 0.1.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -34,6 +34,7 @@ export function createClerkClient(options: ClerkOptions): ClerkClient {
     ...options.telemetry,
     publishableKey: opts.publishableKey,
     secretKey: opts.secretKey,
+    samplingRate: 0.1,
     ...(opts.sdkMetadata ? { sdk: opts.sdkMetadata.name, sdkVersion: opts.sdkMetadata.version } : {}),
   });
 


### PR DESCRIPTION
## Description

This affects all BE sdks that rely in `@clerk/backend` for example it throttles the logging of `clerkMiddleware` usage in `@clerk/nextjs`.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
