### PR TITLE
feat(clerk-js): Handle pwned password in SignInStart first party submit

### DIFF
--- a/.changeset/wise-stingrays-protect.md
+++ b/.changeset/wise-stingrays-protect.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Handle pwned password error during sign in instant password submit.

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -18,6 +18,7 @@ export const CLERK_SATELLITE_URL = '__clerk_satellite_url';
 export const ERROR_CODES = {
   FORM_IDENTIFIER_NOT_FOUND: 'form_identifier_not_found',
   FORM_PASSWORD_INCORRECT: 'form_password_incorrect',
+  FORM_PASSWORD_PWNED: 'form_password_pwned',
   INVALID_STRATEGY_FOR_USER: 'strategy_for_user_invalid',
   NOT_ALLOWED_TO_SIGN_UP: 'not_allowed_to_sign_up',
   OAUTH_ACCESS_DENIED: 'oauth_access_denied',

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -343,7 +343,9 @@ export function _SignInStart(): JSX.Element {
     }
     const instantPasswordError: ClerkAPIError = e.errors.find(
       (e: ClerkAPIError) =>
-        e.code === ERROR_CODES.INVALID_STRATEGY_FOR_USER || e.code === ERROR_CODES.FORM_PASSWORD_INCORRECT,
+        e.code === ERROR_CODES.INVALID_STRATEGY_FOR_USER ||
+        e.code === ERROR_CODES.FORM_PASSWORD_INCORRECT ||
+        e.code === ERROR_CODES.FORM_PASSWORD_PWNED,
     );
 
     const alreadySignedInError: ClerkAPIError = e.errors.find(

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -428,6 +428,58 @@ describe('SignInStart', () => {
     });
   });
 
+  describe('Submitting form via instant password autofill', () => {
+    const ERROR_CODES = ['strategy_for_user_invalid', 'form_password_incorrect', 'form_password_pwned'];
+    ERROR_CODES.forEach(code => {
+      it(`calls sign in with identifier again with only the email if the api respondes with the error ${code}`, async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPassword({ required: true });
+        });
+
+        const errJSON = {
+          code,
+          long_message: '',
+          message: '',
+          meta: { param_name: 'password' },
+        };
+
+        fixtures.signIn.create.mockRejectedValueOnce(
+          new ClerkAPIResponseError('Error', {
+            data: [errJSON],
+            status: 422,
+          }),
+        );
+
+        const { userEvent, container } = render(<SignInStart />, { wrapper });
+
+        const emailField = screen.getByLabelText(/email address/i);
+        await userEvent.type(emailField, 'hello@clerk.com');
+
+        // We can't find the instantPasswordField in the screen so we must query it by id
+        const instantPasswordField = container.querySelector('#password-field') as Element;
+        expect(instantPasswordField).not.toBeNull();
+        fireEvent.change(instantPasswordField, { target: { value: 'some-password' } });
+
+        const form = container.querySelector('form') as Element;
+        expect(instantPasswordField).not.toBeNull();
+        fireEvent.submit(form);
+
+        await waitFor(() => {
+          expect(fixtures.signIn.create).toHaveBeenCalledWith({
+            identifier: 'hello@clerk.com',
+            password: 'some-password',
+            strategy: 'password',
+          });
+
+          expect(fixtures.signIn.create).toHaveBeenCalledWith({
+            identifier: 'hello@clerk.com',
+          });
+        });
+      });
+    });
+  });
+
   describe('ticket flow', () => {
     it('calls the appropriate resource function upon detecting the ticket', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
@@ -493,58 +545,6 @@ describe('SignInStart', () => {
         '',
         expect.not.stringContaining('__clerk_ticket'),
       );
-    });
-  });
-
-  describe('Submitting form via instant password autofill', () => {
-    const ERROR_CODES = ['strategy_for_user_invalid', 'form_password_incorrect', 'form_password_pwned'];
-    ERROR_CODES.forEach(code => {
-      it(`calls sign in with identifier again with only the email if the api respondes with the error ${code}`, async () => {
-        const { wrapper, fixtures } = await createFixtures(f => {
-          f.withEmailAddress();
-          f.withPassword({ required: true });
-        });
-
-        const errJSON = {
-          code,
-          long_message: '',
-          message: '',
-          meta: { param_name: 'password' },
-        };
-
-        fixtures.signIn.create.mockRejectedValueOnce(
-          new ClerkAPIResponseError('Error', {
-            data: [errJSON],
-            status: 422,
-          }),
-        );
-
-        const { userEvent, container } = render(<SignInStart />, { wrapper });
-
-        const emailField = screen.getByLabelText(/email address/i);
-        await userEvent.type(emailField, 'hello@clerk.com');
-
-        // We can't find the instantPasswordField in the screen so we must query it by id
-        const instantPasswordField = container.querySelector('#password-field') as Element;
-        expect(instantPasswordField).not.toBeNull();
-        fireEvent.change(instantPasswordField, { target: { value: 'some-password' } });
-
-        const form = container.querySelector('form') as Element;
-        expect(instantPasswordField).not.toBeNull();
-        fireEvent.submit(form);
-
-        await waitFor(() => {
-          expect(fixtures.signIn.create).toHaveBeenCalledWith({
-            identifier: 'hello@clerk.com',
-            password: 'some-password',
-            strategy: 'password',
-          });
-
-          expect(fixtures.signIn.create).toHaveBeenCalledWith({
-            identifier: 'hello@clerk.com',
-          });
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
## Description

Consider form_password_pwned error as an instant password error. This will lead to the sign in beeing created again without the password field beeing submitted this time.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
