### PR TITLE
feat(clerk-js): Track fapi requests triggered by UI components

### DIFF
--- a/.changeset/fresh-pears-brake.md
+++ b/.changeset/fresh-pears-brake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Track fapi requests triggered by UI components.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -101,6 +101,7 @@ import {
   windowNavigate,
 } from '../utils';
 import { assertNoLegacyProp } from '../utils/assertNoLegacyProp';
+import { usageByUIComponents } from '../utils/detect-ui-caller';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
 import { RedirectUrls } from '../utils/redirectUrls';
 import { AuthCookieService } from './auth/AuthCookieService';
@@ -323,6 +324,9 @@ export class Clerk implements ClerkInterface {
       getSessionId: () => {
         return this.session?.id;
       },
+      isTriggeredByUI: () => {
+        return usageByUIComponents.get();
+      },
       proxyUrl: this.proxyUrl,
     });
     // This line is used for the piggy-backing mechanism
@@ -375,6 +379,8 @@ export class Clerk implements ClerkInterface {
     if (!this.client || this.client.sessions.length === 0) {
       return;
     }
+
+    console.log('EHEHEH', usageByUIComponents.get());
 
     const onBeforeSetActive: SetActiveHook =
       typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
@@ -1027,6 +1033,7 @@ export class Clerk implements ClerkInterface {
     const unsubscribe = () => {
       this.#navigationListeners = this.#navigationListeners.filter(l => l !== listener);
     };
+    console.log('too unsubscribe', unsubscribe);
     return unsubscribe;
   };
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -380,8 +380,6 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
-    console.log('EHEHEH', usageByUIComponents.get());
-
     const onBeforeSetActive: SetActiveHook =
       typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
         ? window.__unstable__onBeforeSetActive
@@ -1033,7 +1031,6 @@ export class Clerk implements ClerkInterface {
     const unsubscribe = () => {
       this.#navigationListeners = this.#navigationListeners.filter(l => l !== listener);
     };
-    console.log('too unsubscribe', unsubscribe);
     return unsubscribe;
   };
 

--- a/packages/clerk-js/src/ui/contexts/CoreClerkContextWrapper.tsx
+++ b/packages/clerk-js/src/ui/contexts/CoreClerkContextWrapper.tsx
@@ -8,6 +8,7 @@ import {
 import type { Clerk, LoadedClerk, Resources } from '@clerk/types';
 import React from 'react';
 
+import { makeUICaller } from '../../utils/detect-ui-caller';
 import { assertClerkSingletonExists } from './utils';
 
 type CoreClerkContextWrapperProps = {
@@ -35,10 +36,11 @@ export function CoreClerkContextWrapper(props: CoreClerkContextWrapperProps): JS
   }, []);
 
   const { client, session, user, organization } = state;
-  const clerkCtx = React.useMemo(() => ({ value: clerk }), []);
-  const clientCtx = React.useMemo(() => ({ value: client }), [client]);
-  const sessionCtx = React.useMemo(() => ({ value: session }), [session]);
-  const userCtx = React.useMemo(() => ({ value: user }), [user]);
+  const clerkCtx = React.useMemo(() => ({ value: makeUICaller(clerk) }), []);
+  const clientCtx = React.useMemo(() => ({ value: makeUICaller(client) }), [client]);
+  const sessionCtx = React.useMemo(() => ({ value: makeUICaller(session) }), [session]);
+  const userCtx = React.useMemo(() => ({ value: makeUICaller(user) }), [user]);
+
   const organizationCtx = React.useMemo(
     () => ({
       value: { organization: organization },

--- a/packages/clerk-js/src/utils/detect-ui-caller.ts
+++ b/packages/clerk-js/src/utils/detect-ui-caller.ts
@@ -20,6 +20,7 @@ const isThenable = (value: unknown): value is Promise<unknown> => {
 
 export const makeUICaller = <T>(resource: T): T => {
   if (!resource) return null as T;
+  // return resource
   const resourceProxy = new Proxy(resource, {
     get(target, prop) {
       // @ts-expect-error

--- a/packages/clerk-js/src/utils/detect-ui-caller.ts
+++ b/packages/clerk-js/src/utils/detect-ui-caller.ts
@@ -1,0 +1,48 @@
+function createStore(initialUsages: number) {
+  let state = initialUsages;
+
+  return {
+    get: () => state > 0,
+    increment: () => {
+      state++;
+    },
+    decrease: () => {
+      state = Math.max(state - 1, 0);
+    },
+  };
+}
+
+export const usageByUIComponents = createStore(0);
+
+const isThenable = (value: unknown): value is Promise<unknown> => {
+  return !!value && typeof (value as any).then === 'function';
+};
+
+export const makeUICaller = <T>(resource: T): T => {
+  if (!resource) return null as T;
+  const resourceProxy = new Proxy(resource, {
+    get(target, prop) {
+      // @ts-expect-error
+      const value = target[prop];
+      if (typeof value === 'function') {
+        // @ts-expect-error
+        return function (...args) {
+          usageByUIComponents.increment();
+          const result = value.apply(target, args);
+          if (isThenable(result)) {
+            return result.finally(() => usageByUIComponents.decrease());
+          }
+          usageByUIComponents.decrease();
+          return result;
+        };
+      }
+
+      // Allows for nested objects to be proxied (e.g. `client.signIn.create()`)
+      if (typeof value === 'object') {
+        return makeUICaller(value);
+      }
+      return value;
+    },
+  });
+  return resourceProxy;
+};


### PR DESCRIPTION
## Description

This PR decorates all requests towards the Frontend API with a new query param `_clerk_ui_triggered=true` which indicates that the request originated from our UI components.

The solution proposed by this PR, uses a proxy to wrap all resources (e.g. user and client) before passing them to their respective react context. The proxy will detect any function usage and will flag it as "used by UI", so that fapiClient can use this to attach the new query param. This solution allows to not make any changes to public API or affect the implementation of our resources.

**Attention:** This solution does not guarantee that the detection will work every time since it uses a stack to determine if the request should be flagged as "used by UI". If a request from a custom flow fires while there is at least one pending request triggered by a UI component, the former will be wrongly flagged as "used by UI".  This is acceptable because we are using the query param for analytics, and such errors will not affect the performance or the behaviour of the application.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
