### PR TITLE
fix(vue): add check for clerk.value in UseSessionList composable

### DIFF
--- a/.changeset/seven-walls-drive.md
+++ b/.changeset/seven-walls-drive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/vue': patch
+---
+
+fix UsesessionList bug. When `clientCtx` is defined `clerk` can be `null` and throw when trying to access `clerk.value.setActive`. Added a condition to return the default values also when `clerk.value` is `null`.

--- a/packages/vue/src/composables/useSessionList.ts
+++ b/packages/vue/src/composables/useSessionList.ts
@@ -35,14 +35,14 @@ export const useSessionList: UseSessionList = () => {
   const { clerk, clientCtx } = useClerkContext();
 
   const result = computed<UseSessionListReturn>(() => {
-    if (!clientCtx.value) {
+    if (!clientCtx.value || !clerk.value) {
       return { isLoaded: false, sessions: undefined, setActive: undefined };
     }
 
     return {
       isLoaded: true,
       sessions: clientCtx.value.sessions,
-      setActive: clerk.value!.setActive,
+      setActive: clerk.value.setActive,
     };
   });
 


### PR DESCRIPTION
## Description

Fixes UsesessionList bug: when `clientCtx` is defined `clerk` can be `null` and the composable throws when trying to access `clerk.value.setActive`.
The error can be reproduced in [this project on stackblitz](https://stackblitz.com/edit/vitejs-vite-jypanyhv?file=src%2FApp.vue)
Fixed by adding a condition to return the default values also when `clerk.value` is `null`.

## Checklist

- [ x] `pnpm test` runs as expected.
- [ x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
