### PR TITLE
fix(repo):  Handle errors in E2E proxy server

### DIFF
--- a/integration/scripts/proxyServer.ts
+++ b/integration/scripts/proxyServer.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import http from 'node:http';
 import type { createServer as _createServer, Server, ServerOptions } from 'node:https';
 import https from 'node:https';
@@ -14,14 +15,23 @@ type ProxyServerOptions = {
  * The server will listen on port 80 (http) or 443 (https) depending on whether SSL options are provided.
  */
 export const createProxyServer = (opts: ProxyServerOptions) => {
-  const proxy = httpProxy.createProxyServer({ xfwd: true });
   const usingSSL = !!opts.ssl;
+
+  const proxy = httpProxy.createProxyServer({
+    secure: usingSSL,
+    xfwd: true,
+  });
+
+  // We need to handle errors to avoid crashing the proxy server
+  proxy.on('error', (err: Error, req: IncomingMessage, res: ServerResponse) => {
+    console.error(`[Proxy Error]: ${req.url}`, err);
+    res.writeHead(502);
+    res.end('Proxy error');
+  });
+
   const createServer: typeof _createServer = usingSSL ? https.createServer.bind(https) : http.createServer.bind(http);
 
   return createServer(opts.ssl, (req, res) => {
-    console.log(`/n/n/n/n------------------------------------`);
-    console.log('Proxying request', req.headers.host, req.url);
-    console.log('Headers', req.headers);
     const hostHeader = req.headers.host || '';
     if (opts.targets[hostHeader]) {
       proxy.web(req, res, { target: opts.targets[hostHeader] });


### PR DESCRIPTION
## Description

Long story short... crashing the proxy server is bad. 

Long story long... 

#### Background

Our integration tests run against app servers using Next.js in dev mode, meaning Hot Module Replacement (HMR) is enabled. In some tests, we route traffic through a proxy server, which unexpectedly crashed when handling the `/_next/webpack-hmr` route.

Why? Because our proxy server wasn’t handling errors properly.

#### What Changed?

- Implemented error handling in the proxy server to prevent crashes.
- This issue started suddenly, likely because we always install the latest version of each Next.js major release in our test matrix.
- Suspicious Timing? Next.js v15.2.2 was released today, and it seems like the HMR route behavior changed. Coincidence? I think not.

#### Open Questions

- Should we be running Next.js in dev mode during tests?
- Should we pin Next.js versions instead of always using the latest major release?

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
