### PR TITLE
fix(backend): Missing invitation status `expired`

### DIFF
--- a/.changeset/calm-files-confess.md
+++ b/.changeset/calm-files-confess.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Added invitation status `expired`

--- a/packages/backend/src/api/resources/Enums.ts
+++ b/packages/backend/src/api/resources/Enums.ts
@@ -35,4 +35,4 @@ export type SignInStatus = 'needs_identifier' | 'needs_factor_one' | 'needs_fact
 
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
 
-export type InvitationStatus = 'pending' | 'accepted' | 'revoked';
+export type InvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired';


### PR DESCRIPTION
## Description

Adds status `expired` to `InvitationStatus`

I'm receiving this status on the API but the typings are missing it

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
