### PR TITLE
feat(clerk-js): PlanCard redirect to sign in when not signed in

### DIFF
--- a/.changeset/serious-badgers-lie.md
+++ b/.changeset/serious-badgers-lie.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+When a C2 is not signed-in, redirect them to sign-in from the `<PlanCard />`.

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -291,7 +291,6 @@
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
       data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
-      data-clerk-publishable-key="pk_test_cmlnaHQta2luZ2Zpc2gtNTEuY2xlcmsuYWNjb3VudHMubGNsY2xlcmsuY29tJA"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -291,6 +291,7 @@
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
       data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
+      data-clerk-publishable-key="pk_test_cmlnaHQta2luZ2Zpc2gtNTEuY2xlcmsuYWNjb3VudHMubGNsY2xlcmsuY29tJA"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/src/ui/components/PricingTable/PlanCard.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PlanCard.tsx
@@ -1,3 +1,4 @@
+import { useClerk } from '@clerk/shared/react';
 import type { __experimental_CommercePlanResource, __experimental_PricingTableProps } from '@clerk/types';
 import * as React from 'react';
 
@@ -32,6 +33,7 @@ interface PlanCardProps {
 }
 
 export function PlanCard(props: PlanCardProps) {
+  const clerk = useClerk();
   const { plan, period, setPeriod, onSelect, props: pricingTableProps, isCompact = false } = props;
   const { ctaPosition = 'top', collapseFeatures = false } = pricingTableProps;
   const [showAllFeatures, setShowAllFeatures] = React.useState(false);
@@ -309,7 +311,13 @@ export function PlanCard(props: PlanCardProps) {
                 ? localizationKeys('__experimental_commerce.manageMembership')
                 : localizationKeys('__experimental_commerce.getStarted')
             }
-            onClick={() => onSelect(plan)}
+            onClick={() => {
+              if (clerk.isSignedIn) {
+                onSelect(plan);
+              } else {
+                void clerk.redirectToSignIn();
+              }
+            }}
           />
         </Box>
       </ReversibleContainer>


### PR DESCRIPTION
## Description

When a C2 is not signed-in, redirect them to sign-in from the `<PlanCard />`

Resolves COM-147

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
