### PR TITLE
POC - Navigating to task after `#emit`

### DIFF
--- a/.changeset/funny-cobras-jog.md
+++ b/.changeset/funny-cobras-jog.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Navigate after task resolution

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -54,7 +54,7 @@ const createExpectPageObject = ({ page }: TestArgs) => {
     },
     toHaveResolvedTasks: async () => {
       return page.waitForFunction(() => {
-        return !window.Clerk?.session.currentTask;
+        return !window.Clerk?.session?.currentTask;
       });
     },
   };

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -7,18 +7,20 @@ import { createAppPageObject } from './appPageObject';
 import { createEmailService } from './emailService';
 import { createInvitationService } from './invitationsService';
 import { createKeylessPopoverPageObject } from './keylessPopoverPageObject';
+import { createOrganizationsService } from './organizationsService';
 import { createOrganizationSwitcherComponentPageObject } from './organizationSwitcherPageObject';
+import { createSessionTaskComponentPageObject } from './sessionTaskPageObject';
 import type { EnchancedPage, TestArgs } from './signInPageObject';
 import { createSignInComponentPageObject } from './signInPageObject';
 import { createSignUpComponentPageObject } from './signUpPageObject';
 import { createUserButtonPageObject } from './userButtonPageObject';
 import { createUserProfileComponentPageObject } from './userProfilePageObject';
-import type { FakeOrganization, FakeUser } from './usersService';
+import type { FakeUser, FakeUserOrganization } from './usersService';
 import { createUserService } from './usersService';
 import { createUserVerificationComponentPageObject } from './userVerificationPageObject';
 import { createWaitlistComponentPageObject } from './waitlistPageObject';
 
-export type { FakeUser, FakeOrganization };
+export type { FakeUser, FakeUserOrganization as FakeOrganization };
 const createClerkClient = (app: Application) => {
   return backendCreateClerkClient({
     apiUrl: app.env.privateVariables.get('CLERK_API_URL'),
@@ -48,6 +50,11 @@ const createExpectPageObject = ({ page }: TestArgs) => {
     toBeSignedIn: async () => {
       return page.waitForFunction(() => {
         return !!window.Clerk?.user;
+      });
+    },
+    toHaveResolvedTasks: async () => {
+      return page.waitForFunction(() => {
+        return !window.Clerk?.session.currentTask;
       });
     },
   };
@@ -82,6 +89,7 @@ export const createTestUtils = <
     email: createEmailService(),
     users: createUserService(clerkClient),
     invitations: createInvitationService(clerkClient),
+    organizations: createOrganizationsService(clerkClient),
     clerk: clerkClient,
   };
 
@@ -101,6 +109,7 @@ export const createTestUtils = <
     userButton: createUserButtonPageObject(testArgs),
     userVerification: createUserVerificationComponentPageObject(testArgs),
     waitlist: createWaitlistComponentPageObject(testArgs),
+    sessionTask: createSessionTaskComponentPageObject(testArgs),
     expect: createExpectPageObject(testArgs),
     clerk: createClerkUtils(testArgs),
   };

--- a/integration/testUtils/organizationsService.ts
+++ b/integration/testUtils/organizationsService.ts
@@ -1,0 +1,27 @@
+import type { ClerkClient, Organization } from '@clerk/backend';
+import { faker } from '@faker-js/faker';
+
+export type FakeOrganization = Pick<Organization, 'slug' | 'name'>;
+
+export type OrganizationService = {
+  deleteAll: () => Promise<void>;
+  createFakeOrganization: () => FakeOrganization;
+};
+
+export const createOrganizationsService = (clerkClient: ClerkClient) => {
+  const self: OrganizationService = {
+    createFakeOrganization: () => ({
+      slug: faker.helpers.slugify(faker.commerce.department()).toLowerCase(),
+      name: faker.commerce.department(),
+    }),
+    deleteAll: async () => {
+      const organizations = await clerkClient.organizations.getOrganizationList();
+
+      const bulkDeletionPromises = organizations.data.map(({ id }) => clerkClient.organizations.deleteOrganization(id));
+
+      await Promise.all(bulkDeletionPromises);
+    },
+  };
+
+  return self;
+};

--- a/integration/testUtils/sessionTaskPageObject.ts
+++ b/integration/testUtils/sessionTaskPageObject.ts
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+
+import { common } from './commonPageObject';
+import type { FakeOrganization } from './organizationsService';
+import type { TestArgs } from './signInPageObject';
+
+export const createSessionTaskComponentPageObject = (testArgs: TestArgs) => {
+  const { page } = testArgs;
+
+  const self = {
+    ...common(testArgs),
+    resolveForceOrganizationSelectionTask: async (fakeOrganization: FakeOrganization) => {
+      const createOrganizationButton = page.getByRole('button', { name: /create organization/i });
+
+      await expect(createOrganizationButton).toBeVisible();
+      expect(page.url()).toContain('add-organization');
+
+      await page.locator('input[name=name]').fill(fakeOrganization.name);
+      await page.locator('input[name=slug]').fill(fakeOrganization.slug);
+
+      await createOrganizationButton.click();
+    },
+  };
+
+  return self;
+};

--- a/integration/testUtils/usersService.ts
+++ b/integration/testUtils/usersService.ts
@@ -44,7 +44,7 @@ export type FakeUser = {
   deleteIfExists: () => Promise<void>;
 };
 
-export type FakeOrganization = {
+export type FakeUserOrganization = {
   name: string;
   organization: { id: string };
   delete: () => Promise<Organization>;
@@ -54,7 +54,7 @@ export type UserService = {
   createFakeUser: (options?: FakeUserOptions) => FakeUser;
   createBapiUser: (fakeUser: FakeUser) => Promise<User>;
   deleteIfExists: (opts: { id?: string; email?: string }) => Promise<void>;
-  createFakeOrganization: (userId: string) => Promise<FakeOrganization>;
+  createFakeOrganization: (userId: string) => Promise<FakeUserOrganization>;
   getUser: (opts: { id?: string; email?: string }) => Promise<User | undefined>;
 };
 
@@ -150,7 +150,7 @@ export const createUserService = (clerkClient: ClerkClient) => {
         name,
         organization,
         delete: () => clerkClient.organizations.deleteOrganization(organization.id),
-      } satisfies FakeOrganization;
+      } satisfies FakeUserOrganization;
     },
   };
 

--- a/integration/tests/session-tasks-sign-in.test.ts
+++ b/integration/tests/session-tasks-sign-in.test.ts
@@ -1,8 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { appConfigs } from '../presets';
 import type { FakeUser } from '../testUtils';
 import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+import type { FakeOrganization } from '../testUtils/organizationsService';
 
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
   'session tasks after sign-in flow @nextjs',
@@ -10,20 +11,26 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
     test.describe.configure({ mode: 'serial' });
 
     let fakeUser: FakeUser;
+    let fakeOrganization: FakeOrganization;
 
     test.beforeAll(async () => {
       const u = createTestUtils({ app });
       fakeUser = u.services.users.createFakeUser();
+      fakeOrganization = u.services.organizations.createFakeOrganization();
       await u.services.users.createBapiUser(fakeUser);
     });
 
     test.afterAll(async () => {
+      const u = createTestUtils({ app });
       await fakeUser.deleteIfExists();
+      await u.services.organizations.deleteAll();
       await app.teardown();
     });
 
     test('navigate to task on after sign-in', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
+
+      // Performs sign-in
       await u.po.signIn.goTo();
       await u.po.signIn.setIdentifier(fakeUser.email);
       await u.po.signIn.continue();
@@ -31,8 +38,12 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.signIn.continue();
       await u.po.expect.toBeSignedIn();
 
-      await expect(u.page.getByRole('button', { name: /create organization/i })).toBeVisible();
-      expect(page.url()).toContain('add-organization');
+      // Resolves task
+      await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
+      await u.po.expect.toHaveResolvedTasks();
+
+      // Navigates to after sign-in
+      await u.page.waitForAppUrl('/');
     });
   },
 );

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -43,7 +43,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
       await u.po.expect.toHaveResolvedTasks();
 
-      // Navigates to after sign-in
+      // Navigates to after sign-up
       await u.page.waitForAppUrl('/');
     });
   },

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -1,9 +1,7 @@
 import { useClerk } from '@clerk/shared/react/index';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { SessionTask } from '@clerk/types';
-import { useEffect } from 'react';
 
-import { useRouter } from '../../../ui/router';
 import { OrganizationListContext } from '../../contexts';
 import { OrganizationList } from '../OrganizationList';
 
@@ -12,16 +10,19 @@ interface SessionTaskProps {
   redirectUrlComplete: string;
 }
 
-const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
-  org: () => (
+const ContentRegistry: Record<
+  SessionTask['key'],
+  React.ComponentType<Pick<SessionTaskProps, 'redirectUrlComplete'>>
+> = {
+  org: ({ redirectUrlComplete }) => (
     // TODO - Hide personal workspace within organization list context based on environment
     <OrganizationListContext.Provider
       value={{
         componentName: 'OrganizationList',
         hidePersonal: true,
         skipInvitationScreen: true,
-        afterSelectOrganizationUrl: undefined,
-        afterCreateOrganizationUrl: undefined,
+        afterSelectOrganizationUrl: redirectUrlComplete,
+        afterCreateOrganizationUrl: redirectUrlComplete,
       }}
     >
       <OrganizationList />
@@ -34,19 +35,10 @@ const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
  */
 export function SessionTask({ task, redirectUrlComplete }: SessionTaskProps): React.ReactNode {
   const clerk = useClerk();
-  const { navigate } = useRouter();
-
-  useEffect(() => {
-    if (clerk.session?.currentTask) {
-      return;
-    }
-
-    void navigate(redirectUrlComplete);
-  }, [clerk.session?.currentTask, navigate, redirectUrlComplete]);
 
   clerk.telemetry?.record(eventComponentMounted('SessionTask', { task }));
 
   const Content = ContentRegistry[task];
 
-  return <Content />;
+  return <Content redirectUrlComplete={redirectUrlComplete} />;
 }

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -12,18 +12,16 @@ interface SessionTaskProps {
   redirectUrlComplete: string;
 }
 
-const ContentRegistry: Record<
-  SessionTask['key'],
-  React.ComponentType<Pick<SessionTaskProps, 'redirectUrlComplete'>>
-> = {
-  org: ({ redirectUrlComplete }) => (
+const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
+  org: () => (
     // TODO - Hide personal workspace within organization list context based on environment
     <OrganizationListContext.Provider
       value={{
         componentName: 'OrganizationList',
         hidePersonal: true,
-        afterSelectOrganizationUrl: redirectUrlComplete,
-        afterCreateOrganizationUrl: redirectUrlComplete,
+        skipInvitationScreen: true,
+        afterSelectOrganizationUrl: undefined,
+        afterCreateOrganizationUrl: undefined,
       }}
     >
       <OrganizationList />
@@ -39,14 +37,16 @@ export function SessionTask({ task, redirectUrlComplete }: SessionTaskProps): Re
   const { navigate } = useRouter();
 
   useEffect(() => {
-    if (!clerk.session?.currentTask) {
-      void navigate(redirectUrlComplete);
+    if (clerk.session?.currentTask) {
+      return;
     }
+
+    void navigate(redirectUrlComplete);
   }, [clerk.session?.currentTask, navigate, redirectUrlComplete]);
 
   clerk.telemetry?.record(eventComponentMounted('SessionTask', { task }));
 
   const Content = ContentRegistry[task];
 
-  return <Content redirectUrlComplete={redirectUrlComplete} />;
+  return <Content />;
 }

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -5,10 +5,25 @@ import type { SessionTask } from '@clerk/types';
 import { OrganizationListContext } from '../../contexts';
 import { OrganizationList } from '../OrganizationList';
 
-const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
-  org: () => (
+interface SessionTaskProps {
+  task: SessionTask['key'];
+  redirectUrlComplete: string;
+}
+
+const ContentRegistry: Record<
+  SessionTask['key'],
+  React.ComponentType<Pick<SessionTaskProps, 'redirectUrlComplete'>>
+> = {
+  org: ({ redirectUrlComplete }) => (
     // TODO - Hide personal workspace within organization list context based on environment
-    <OrganizationListContext.Provider value={{ componentName: 'OrganizationList', hidePersonal: true }}>
+    <OrganizationListContext.Provider
+      value={{
+        componentName: 'OrganizationList',
+        hidePersonal: true,
+        afterSelectOrganizationUrl: redirectUrlComplete,
+        afterCreateOrganizationUrl: redirectUrlComplete,
+      }}
+    >
       <OrganizationList />
     </OrganizationListContext.Provider>
   ),
@@ -17,12 +32,12 @@ const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
 /**
  * @internal
  */
-export function SessionTask({ task }: { task: SessionTask['key'] }): React.ReactNode {
+export function SessionTask({ task, redirectUrlComplete }: SessionTaskProps): React.ReactNode {
   const clerk = useClerk();
 
   clerk.telemetry?.record(eventComponentMounted('SessionTask', { task }));
 
   const Content = ContentRegistry[task];
 
-  return <Content />;
+  return <Content redirectUrlComplete={redirectUrlComplete} />;
 }

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -1,7 +1,9 @@
 import { useClerk } from '@clerk/shared/react/index';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { SessionTask } from '@clerk/types';
+import { useEffect } from 'react';
 
+import { useRouter } from '../../../ui/router';
 import { OrganizationListContext } from '../../contexts';
 import { OrganizationList } from '../OrganizationList';
 
@@ -34,6 +36,13 @@ const ContentRegistry: Record<
  */
 export function SessionTask({ task, redirectUrlComplete }: SessionTaskProps): React.ReactNode {
   const clerk = useClerk();
+  const { navigate } = useRouter();
+
+  useEffect(() => {
+    if (!clerk.session?.currentTask) {
+      void navigate(redirectUrlComplete);
+    }
+  }, [clerk.session?.currentTask, navigate, redirectUrlComplete]);
 
   clerk.telemetry?.record(eventComponentMounted('SessionTask', { task }));
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -132,7 +132,10 @@ function SignInRoutes(): JSX.Element {
               </Route>
               {signInContext.withSessionTasks && (
                 <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-                  <SessionTask task='org' />
+                  <SessionTask
+                    task='org'
+                    redirectUrlComplete={signInContext.afterSignUpUrl}
+                  />
                 </Route>
               )}
               <Route index>
@@ -146,7 +149,10 @@ function SignInRoutes(): JSX.Element {
         )}
         {signInContext.withSessionTasks && (
           <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-            <SessionTask task='org' />
+            <SessionTask
+              task='org'
+              redirectUrlComplete={signInContext.afterSignInUrl}
+            />
           </Route>
         )}
         <Route index>

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
@@ -77,6 +77,8 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
               queryParams.set('createdSessionId', res.createdSessionId);
               return navigate(`../reset-password-success?${queryParams.toString()}`);
             }
+            // Nowadays, the `redirectUrl` is bypassed if the session provided is pending
+            // #handlePendingSession is earlier executed within `setActive` which navigates to the tasks flow
             return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -2,7 +2,6 @@ import { useClerk } from '@clerk/shared/react';
 import type { SignUpModalProps, SignUpProps } from '@clerk/types';
 import React from 'react';
 
-import { SESSION_TASK_ROUTE_BY_KEY } from '../../../core/sessionTasks';
 import { SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowCard';
 import { SignUpContext, useSignUpContext, withCoreSessionSwitchGuard } from '../../contexts';
 import { Flow } from '../../customizables';
@@ -90,9 +89,10 @@ function SignUpRoutes(): JSX.Element {
           </Route>
         </Route>
         {signUpContext.withSessionTasks && (
-          <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-            <SessionTask task='org' />
-          </Route>
+          <SessionTask
+            task='org'
+            redirectUrlComplete={signUpContext.afterSignUpUrl}
+          />
         )}
         <Route index>
           <SignUpStart />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -2,6 +2,7 @@ import { useClerk } from '@clerk/shared/react';
 import type { SignUpModalProps, SignUpProps } from '@clerk/types';
 import React from 'react';
 
+import { SESSION_TASK_ROUTE_BY_KEY } from '../../../core/sessionTasks';
 import { SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowCard';
 import { SignUpContext, useSignUpContext, withCoreSessionSwitchGuard } from '../../contexts';
 import { Flow } from '../../customizables';
@@ -89,10 +90,12 @@ function SignUpRoutes(): JSX.Element {
           </Route>
         </Route>
         {signUpContext.withSessionTasks && (
-          <SessionTask
-            task='org'
-            redirectUrlComplete={signUpContext.afterSignUpUrl}
-          />
+          <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
+            <SessionTask
+              task='org'
+              redirectUrlComplete={signUpContext.afterSignUpUrl}
+            />
+          </Route>
         )}
         <Route index>
           <SignUpStart />

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -441,6 +441,8 @@ export interface Clerk {
     basePath: string;
   }) => () => void;
 
+  completeTask: () => Promise<void>;
+
   /**
    * Set the active session and organization explicitly.
    *


### PR DESCRIPTION
**⚠️ Experimental branch to showcase a different implementation approach compared to https://github.com/clerk/javascript/pull/5343**

Issues with this approach:
- `#emit` runs which updates the React session context to have the `active` status. The `SignIn` re-renders and executes `withAfterSignIn` guard that logs the warning and triggers navigation to `afterSignInUrl`
- Also due to the above, you can see a whole flicker of re-painting on the component -> I'd expect this behavior to be even worse on multi-session apps with the `MultisessionAppSupport`

https://github.com/user-attachments/assets/c26148d8-9a6b-4d23-957a-f54a0097e4f4

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
