### PR TITLE
fix(clerk-js): Handle two factor redirect when authenticate with web3

### DIFF
--- a/.changeset/new-plants-lick.md
+++ b/.changeset/new-plants-lick.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Handle two factor redirect when authenticate with web3 and multifactor has been enabled

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1901,11 +1901,20 @@ export class Clerk implements ClerkInterface {
       }
     }
 
-    if (signInOrSignUp.createdSessionId) {
-      await this.setActive({
-        session: signInOrSignUp.createdSessionId,
-        redirectUrl,
-      });
+    switch (signInOrSignUp.status) {
+      case 'needs_second_factor':
+        await navigate('factor-two');
+        break;
+      case 'complete':
+        if (signInOrSignUp.createdSessionId) {
+          await this.setActive({
+            session: signInOrSignUp.createdSessionId,
+            redirectUrl,
+          });
+        }
+        break;
+      default:
+        return;
     }
   };
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1851,6 +1851,7 @@ export class Clerk implements ClerkInterface {
     unsafeMetadata,
     strategy,
     legalAccepted,
+    secondFactorUrl,
   }: ClerkAuthenticateWithWeb3Params): Promise<void> => {
     if (__BUILD_DISABLE_RHC__) {
       clerkUnsupportedEnvironmentWarning('Web3');
@@ -1860,6 +1861,9 @@ export class Clerk implements ClerkInterface {
     if (!this.client || !this.environment) {
       return;
     }
+
+    const { displayConfig } = this.environment;
+
     const provider = strategy.replace('web3_', '').replace('_signature', '') as Web3Provider;
     const identifier = await getWeb3Identifier({ provider });
     const generateSignature =
@@ -1869,8 +1873,23 @@ export class Clerk implements ClerkInterface {
           ? generateSignatureWithCoinbaseWallet
           : generateSignatureWithOKXWallet;
 
-    const navigate = (to: string) =>
+    const makeNavigate = (to: string) => () =>
       customNavigate && typeof customNavigate === 'function' ? customNavigate(to) : this.navigate(to);
+
+    const navigateToFactorTwo = makeNavigate(
+      secondFactorUrl || buildURL({ base: displayConfig.signInUrl, hashPath: '/factor-two' }, { stringify: true }),
+    );
+
+    const navigateToContinueSignUp = makeNavigate(
+      signUpContinueUrl ||
+        buildURL(
+          {
+            base: displayConfig.signUpUrl,
+            hashPath: '/continue',
+          },
+          { stringify: true },
+        ),
+    );
 
     let signInOrSignUp: SignInResource | SignUpResource;
     try {
@@ -1894,7 +1913,7 @@ export class Clerk implements ClerkInterface {
           signInOrSignUp.status === 'missing_requirements' &&
           signInOrSignUp.verifications.web3Wallet.status === 'verified'
         ) {
-          await navigate(signUpContinueUrl);
+          await navigateToContinueSignUp();
         }
       } else {
         throw err;
@@ -1903,7 +1922,7 @@ export class Clerk implements ClerkInterface {
 
     switch (signInOrSignUp.status) {
       case 'needs_second_factor':
-        await navigate('factor-two');
+        await navigateToFactorTwo();
         break;
       case 'complete':
         if (signInOrSignUp.createdSessionId) {

--- a/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
@@ -54,6 +54,7 @@ export const SignInSocialButtons = React.memo((props: SocialButtonsProps) => {
             redirectUrl: redirectUrlComplete,
             signUpContinueUrl: ctx.isCombinedFlow ? 'create/continue' : ctx.signUpContinueUrl,
             strategy,
+            secondFactorUrl: 'factor-two',
           })
           .catch(err => web3CallbackErrorHandler(err, card.setError));
       }}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1612,6 +1612,7 @@ export interface ClerkAuthenticateWithWeb3Params {
   unsafeMetadata?: SignUpUnsafeMetadata;
   strategy: Web3Strategy;
   legalAccepted?: boolean;
+  secondFactorUrl?: string;
 }
 
 export type JoinWaitlistParams = {


### PR DESCRIPTION
## Description

In this pr we're handling the redirect to `two-factor` when user try to login with web3 and has enabled the `Multi-factor authentication`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

### BEFORE

https://github.com/user-attachments/assets/07f2ab5b-ca62-4da5-a0b1-9a7324aea80d

### AFTER

https://github.com/user-attachments/assets/5b05234c-6499-4a0f-bc09-849d175a8202

