### PR TITLE
chore(types): Deprecate old jwt types

### DIFF
--- a/.changeset/thick-bags-promise.md
+++ b/.changeset/thick-bags-promise.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/astro': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+'@clerk/vue': minor
+---
+
+Deprecate out of date jwt types in favour of existing that are up-to-date.

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -1,5 +1,5 @@
 import type {
-  ActJWTClaim,
+  ActClaim,
   CheckAuthorizationWithCustomPermissions,
   Clerk,
   GetToken,
@@ -85,7 +85,7 @@ type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      actor: ActJWTClaim | null;
+      actor: ActClaim | null;
       orgId: null;
       orgRole: null;
       orgSlug: null;
@@ -98,7 +98,7 @@ type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      actor: ActJWTClaim | null;
+      actor: ActClaim | null;
       orgId: string;
       orgRole: OrganizationCustomRoleKey;
       orgSlug: string | null;

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -3,7 +3,7 @@ import { ClerkWebAuthnError, is4xxError } from '@clerk/shared/error';
 import { retry } from '@clerk/shared/retry';
 import { isWebAuthnSupported as isWebAuthnSupportedOnWindow } from '@clerk/shared/webauthn';
 import type {
-  ActJWTClaim,
+  ActClaim,
   CheckAuthorization,
   EmailCodeConfig,
   GetToken,
@@ -45,7 +45,7 @@ export class Session extends BaseResource implements SessionResource {
   lastActiveAt!: Date;
   lastActiveToken!: TokenResource | null;
   lastActiveOrganizationId!: string | null;
-  actor!: ActJWTClaim | null;
+  actor!: ActClaim | null;
   user!: UserResource | null;
   publicUserData!: PublicUserData;
   factorVerificationAge: [number, number] | null = null;

--- a/packages/clerk-js/src/core/resources/SessionWithActivities.ts
+++ b/packages/clerk-js/src/core/resources/SessionWithActivities.ts
@@ -1,5 +1,5 @@
 import type {
-  ActJWTClaim,
+  ActClaim,
   SessionActivity,
   SessionActivityJSON,
   SessionWithActivitiesJSON,
@@ -28,7 +28,7 @@ export class SessionWithActivities extends BaseResource implements SessionWithAc
   expireAt!: Date;
   lastActiveAt!: Date;
   latestActivity!: SessionActivity;
-  actor!: ActJWTClaim | null;
+  actor!: ActClaim | null;
 
   constructor(data: SessionWithActivitiesJSON, pathRoot: string) {
     super();

--- a/packages/clerk-js/src/utils/jwt.ts
+++ b/packages/clerk-js/src/utils/jwt.ts
@@ -1,4 +1,4 @@
-import type { JWT, JWTClaims } from '@clerk/types';
+import type { JWT, JwtPayload } from '@clerk/types';
 
 import { urlDecodeB64 } from './encoders';
 
@@ -11,7 +11,7 @@ export function decode(token: string): JWT {
   }
 
   const payloadJSON = JSON.parse(urlDecodeB64(payload));
-  const claims = { __raw: token } as JWTClaims;
+  const claims = { __raw: token } as JwtPayload;
 
   Object.keys(payloadJSON).forEach(k => {
     claims[k] = payloadJSON[k];

--- a/packages/react/src/contexts/AuthContext.ts
+++ b/packages/react/src/contexts/AuthContext.ts
@@ -1,10 +1,10 @@
 import { createContextAndHook } from '@clerk/shared/react';
-import type { ActJWTClaim, OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from '@clerk/types';
+import type { ActClaim, OrganizationCustomPermissionKey, OrganizationCustomRoleKey } from '@clerk/types';
 
 export type AuthContextValue = {
   userId: string | null | undefined;
   sessionId: string | null | undefined;
-  actor: ActJWTClaim | null | undefined;
+  actor: ActClaim | null | undefined;
   orgId: string | null | undefined;
   orgRole: OrganizationCustomRoleKey | null | undefined;
   orgSlug: string | null | undefined;

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -2,7 +2,7 @@ import type { OrganizationCustomRoleKey } from 'organizationMembership';
 import type { SignInResource } from 'signIn';
 
 import type { SetActive, SignOut } from './clerk';
-import type { ActJWTClaim } from './jwt';
+import type { ActClaim } from './jwtv2';
 import type {
   CheckAuthorizationWithCustomPermissions,
   GetToken,
@@ -83,7 +83,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      actor: ActJWTClaim | null;
+      actor: ActClaim | null;
       orgId: null;
       orgRole: null;
       orgSlug: null;
@@ -96,7 +96,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      actor: ActJWTClaim | null;
+      actor: ActClaim | null;
       orgId: string;
       orgRole: OrganizationCustomRoleKey;
       orgSlug: string | null;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -5,7 +5,7 @@
 import type { __experimental_CommerceSettingsJSON } from './commerceSettings';
 import type { DisplayConfigJSON } from './displayConfig';
 import type { EnterpriseProtocol, EnterpriseProvider } from './enterpriseAccount';
-import type { ActJWTClaim } from './jwt';
+import type { ActClaim } from './jwtv2';
 import type { OAuthProvider } from './oauth';
 import type { OrganizationDomainVerificationStatus, OrganizationEnrollmentMode } from './organizationDomain';
 import type { OrganizationInvitationStatus } from './organizationInvitation';
@@ -118,7 +118,7 @@ export interface SessionJSON extends ClerkResourceJSON {
   last_active_at: number;
   last_active_token: TokenJSON;
   last_active_organization_id: string | null;
-  actor: ActJWTClaim | null;
+  actor: ActClaim | null;
   tasks: Array<SessionTask> | null;
   user: UserJSON;
   public_user_data: PublicUserDataJSON;

--- a/packages/types/src/jwt.ts
+++ b/packages/types/src/jwt.ts
@@ -1,14 +1,18 @@
+import type { ActClaim, JwtHeader, JwtPayload } from './jwtv2';
 import type { OrganizationCustomRoleKey } from './organizationMembership';
 
 export interface JWT {
   encoded: { header: string; payload: string; signature: string };
-  header: JWTHeader;
-  claims: JWTClaims;
+  header: JwtHeader;
+  claims: JwtPayload;
 }
 
 type NonEmptyArray<T> = [T, ...T[]];
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
+/**
+ * @deprecated use `JwtHeader` instead
+ */
 export interface JWTHeader {
   alg: string | Algorithm;
   typ?: string;
@@ -22,6 +26,9 @@ export interface JWTHeader {
   x5c?: string | string[];
 }
 
+/**
+ * @deprecated use `JwtPayload` instead
+ */
 export interface JWTClaims extends ClerkJWTClaims {
   /**
    * Encoded token supporting the `getRawString` method.
@@ -29,7 +36,10 @@ export interface JWTClaims extends ClerkJWTClaims {
   __raw: string;
 }
 
-/* Clerk-issued JWT payload */
+/**
+ * Clerk-issued JWT payload
+ * @deprecated use `JwtPayload` instead
+ */
 export interface ClerkJWTClaims {
   /**
    * JWT Issuer - [RFC7519#section-4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1).
@@ -69,7 +79,7 @@ export interface ClerkJWTClaims {
   /**
    * JWT Actor - [RFC8693](https://www.rfc-editor.org/rfc/rfc8693.html#name-act-actor-claim).
    */
-  act?: ActJWTClaim;
+  act?: ActClaim;
 
   /**
    * Active organization id.
@@ -95,10 +105,15 @@ export interface ClerkJWTClaims {
 /**
  * JWT Actor - [RFC8693](https://www.rfc-editor.org/rfc/rfc8693.html#name-act-actor-claim).
  * @inline
+ * @deprecated use `ActClaim` instead
  */
 export interface ActJWTClaim {
   sub: string;
+
   [x: string]: unknown;
 }
 
+/**
+ * @deprecated This type will be removed in the next major version.
+ */
 export type OrganizationsJWTClaim = Record<string, OrganizationCustomRoleKey>;

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -119,6 +119,5 @@ export interface JwtPayload extends CustomJwtSessionClaims {
  */
 export interface ActClaim {
   sub: string;
-
   [x: string]: unknown;
 }

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -10,7 +10,7 @@ import type {
   PhoneCodeSecondFactorConfig,
   TOTPAttempt,
 } from './factors';
-import type { ActJWTClaim } from './jwt';
+import type { ActClaim } from './jwtv2';
 import type {
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
@@ -122,7 +122,7 @@ export interface SessionResource extends ClerkResource {
   lastActiveToken: TokenResource | null;
   lastActiveOrganizationId: string | null;
   lastActiveAt: Date;
-  actor: ActJWTClaim | null;
+  actor: ActClaim | null;
   tasks: Array<SessionTask> | null;
   currentTask?: SessionTask;
   /**
@@ -190,7 +190,7 @@ export interface SessionWithActivitiesResource extends ClerkResource {
   abandonAt: Date;
   lastActiveAt: Date;
   latestActivity: SessionActivity;
-  actor: ActJWTClaim | null;
+  actor: ActClaim | null;
 
   revoke: () => Promise<SessionWithActivitiesResource>;
 }

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,5 +1,5 @@
 import type {
-  ActJWTClaim,
+  ActClaim,
   Clerk,
   ClerkOptions,
   ClientResource,
@@ -19,7 +19,7 @@ export interface VueClerkInjectionKeyType {
   authCtx: ComputedRef<{
     userId: string | null | undefined;
     sessionId: string | null | undefined;
-    actor: ActJWTClaim | null | undefined;
+    actor: ActClaim | null | undefined;
     orgId: string | null | undefined;
     orgRole: OrganizationCustomRoleKey | null | undefined;
     orgSlug: string | null | undefined;


### PR DESCRIPTION
## Description

These types were duplicated and the new updated ones exist inside `jwtv2.ts`. This PR marks the out of date types as deprecated in favour of the one that are up to date.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
