### PR TITLE
fix(clerk-js): Fix `<CheckoutForm />` select positioning and option text color

### DIFF
--- a/.changeset/chatty-lobsters-approve.md
+++ b/.changeset/chatty-lobsters-approve.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix `<CheckoutForm />` select positioning and option text color.

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -191,6 +191,7 @@ const PaymentSourceMethods = ({
             const paymentSource = paymentSources.find(source => source.id === option.value);
             setSelectedPaymentSource(paymentSource);
           }}
+          portal
         >
           {/*Store value inside an input in order to be accessible as form data*/}
           <input
@@ -217,7 +218,12 @@ const PaymentSourceMethods = ({
               </Flex>
             )}
           </SelectButton>
-          <SelectOptionList />
+          <SelectOptionList
+            sx={t => ({
+              paddingBlock: t.space.$1,
+              color: t.colors.$colorText,
+            })}
+          />
         </Select>
         <Button
           type='submit'


### PR DESCRIPTION
## Description

Use portal to fix positioning:

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-03-14 at 3 36 04 PM](https://github.com/user-attachments/assets/578237fd-7ab4-4f37-9c00-91cd9223388b) | ![Screenshot 2025-03-14 at 3 35 41 PM](https://github.com/user-attachments/assets/6791a194-c1a3-4914-855b-2a2684f32295) | 

Add text color to ensure select options render correctly for diff themes:

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-03-14 at 3 36 27 PM](https://github.com/user-attachments/assets/34b76556-8239-46ca-a7be-efea6f4471b1) | ![Screenshot 2025-03-14 at 3 35 12 PM](https://github.com/user-attachments/assets/2fec7d51-4488-4f5a-8a38-ef4253555344) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
