### PR TITLE
refactor(clerk-js): `<Drawer />` animation timing/easing adjustments

### DIFF
--- a/.changeset/tough-nails-explain.md
+++ b/.changeset/tough-nails-explain.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Adjust the `<Drawer />` enter/exit animations timing and easings.

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -228,6 +228,8 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
           style={transitionStyles}
           direction='col'
           sx={t => ({
+            // Apply the conditional right offset + the spread of the
+            // box shadow to ensure it is fully offscreen before unmounting
             '--transform-offset':
               strategy === 'fixed' ? `calc(100% + ${t.space.$3} + ${t.space.$8x75})` : `calc(100% + ${t.space.$8x75})`,
             willChange: 'transform',

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -168,10 +168,7 @@ const Overlay = React.forwardRef<HTMLDivElement>((_, ref) => {
       transitionProperty: 'opacity',
       transitionTimingFunction,
     },
-    duration: {
-      open: transitionTimingDuration,
-      close: transitionTimingDuration,
-    },
+    duration: transitionTimingDuration,
   });
 
   if (!isMounted) return null;
@@ -211,12 +208,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
       transitionProperty: 'transform',
       transitionTimingFunction,
     },
-    duration: isMotionSafe
-      ? {
-          open: transitionTimingDuration,
-          close: transitionTimingDuration,
-        }
-      : 0,
+    duration: isMotionSafe ? transitionTimingDuration : 0,
   });
 
   if (!isMounted) return null;

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -13,6 +13,7 @@ import {
 } from '@floating-ui/react';
 import * as React from 'react';
 
+import { transitionDurationValues, transitionTiming } from '../../ui/foundations/transitions';
 import { Box, descriptors, Flex, Heading, Icon, useAppearance } from '../customizables';
 import { usePrefersReducedMotion } from '../hooks';
 import { useScrollLock } from '../hooks/useScrollLock';
@@ -23,9 +24,6 @@ import { colors } from '../utils';
 import { IconButton } from './IconButton';
 
 type FloatingPortalProps = React.ComponentProps<typeof FloatingPortal>;
-
-const transitionTimingDuration = 500;
-const transitionTimingFunction = 'cubic-bezier(0.32, 0.72, 0, 1)';
 
 /* -------------------------------------------------------------------------------------------------
  * Drawer Context
@@ -166,9 +164,9 @@ const Overlay = React.forwardRef<HTMLDivElement>((_, ref) => {
       position: strategy,
       inset: 0,
       transitionProperty: 'opacity',
-      transitionTimingFunction,
+      transitionTimingFunction: transitionTiming.bezier,
     },
-    duration: transitionTimingDuration,
+    duration: transitionDurationValues.drawer,
   });
 
   if (!isMounted) return null;
@@ -206,9 +204,9 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
     close: { transform: `translate3d(var(--transform-offset), 0, 0)` },
     common: {
       transitionProperty: 'transform',
-      transitionTimingFunction,
+      transitionTimingFunction: transitionTiming.bezier,
     },
-    duration: isMotionSafe ? transitionTimingDuration : 0,
+    duration: isMotionSafe ? transitionDurationValues.drawer : 0,
   });
 
   if (!isMounted) return null;

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -13,7 +13,6 @@ import {
 } from '@floating-ui/react';
 import * as React from 'react';
 
-import { transitionDurationValues, transitionTiming } from '../../ui/foundations/transitions';
 import { Box, descriptors, Flex, Heading, Icon, useAppearance } from '../customizables';
 import { usePrefersReducedMotion } from '../hooks';
 import { useScrollLock } from '../hooks/useScrollLock';
@@ -24,6 +23,9 @@ import { colors } from '../utils';
 import { IconButton } from './IconButton';
 
 type FloatingPortalProps = React.ComponentProps<typeof FloatingPortal>;
+
+const transitionTimingDuration = 500;
+const transitionTimingFunction = 'cubic-bezier(0.32, 0.72, 0, 1)';
 
 /* -------------------------------------------------------------------------------------------------
  * Drawer Context
@@ -164,11 +166,11 @@ const Overlay = React.forwardRef<HTMLDivElement>((_, ref) => {
       position: strategy,
       inset: 0,
       transitionProperty: 'opacity',
-      transitionTimingFunction: transitionTiming.slowBezier,
+      transitionTimingFunction,
     },
     duration: {
-      open: transitionDurationValues.slower,
-      close: transitionDurationValues.slow,
+      open: transitionTimingDuration,
+      close: transitionTimingDuration,
     },
   });
 
@@ -202,17 +204,17 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
   const mergedRefs = useMergeRefs([ref, refs.setFloating]);
 
   const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
-    initial: { transform: 'translateX(100%)' },
-    open: { transform: 'translateX(0)' },
-    close: { transform: 'translateX(100%)' },
+    initial: { transform: `translate3d(var(--transform-offset), 0, 0)` },
+    open: { transform: 'translate3d(0, 0, 0)' },
+    close: { transform: `translate3d(var(--transform-offset), 0, 0)` },
     common: {
       transitionProperty: 'transform',
-      transitionTimingFunction: transitionTiming.slowBezier,
+      transitionTimingFunction,
     },
     duration: isMotionSafe
       ? {
-          open: transitionDurationValues.slower,
-          close: transitionDurationValues.slow,
+          open: transitionTimingDuration,
+          close: transitionTimingDuration,
         }
       : 0,
   });
@@ -234,6 +236,9 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
           style={transitionStyles}
           direction='col'
           sx={t => ({
+            '--transform-offset':
+              strategy === 'fixed' ? `calc(100% + ${t.space.$3} + ${t.space.$8x75})` : `calc(100% + ${t.space.$8x75})`,
+            willChange: 'transform',
             position: strategy,
             insetBlock: strategy === 'fixed' ? t.space.$3 : 0,
             insetInlineEnd: strategy === 'fixed' ? t.space.$3 : 0,

--- a/packages/clerk-js/src/ui/foundations/sizes.ts
+++ b/packages/clerk-js/src/ui/foundations/sizes.ts
@@ -23,6 +23,7 @@ const dynamicSpaceUnits = Object.freeze({
   '7x5': '1.875rem',
   '8': '2rem',
   '8x5': '2.125rem',
+  '8x75': '2.1875rem',
   '9': '2.25rem',
   '10': '2.5rem',
   '12': '3rem',

--- a/packages/clerk-js/src/ui/foundations/transitions.ts
+++ b/packages/clerk-js/src/ui/foundations/transitions.ts
@@ -6,6 +6,7 @@ const transitionDurationValues = Object.freeze({
   focusRing: 200,
   controls: 100,
   textField: 450,
+  drawer: 500,
 } as const);
 
 const toMs = (value: number) => `${value}ms`;
@@ -24,6 +25,7 @@ const transitionProperty = Object.freeze({
 const transitionTiming = Object.freeze({
   common: 'ease',
   easeOut: 'ease-out',
+  bezier: 'cubic-bezier(0.32, 0.72, 0, 1)',
   slowBezier: 'cubic-bezier(0.16, 1, 0.3, 1)',
 } as const);
 


### PR DESCRIPTION
## Description

Dial in the `<Drawer/>` animations.

BEFORE:

https://github.com/user-attachments/assets/d0a6b3ea-51ca-4d7a-b9f2-d3dfcd28a88d

AFTER:

https://github.com/user-attachments/assets/1640d28d-00af-4588-a6a7-a49099ee09c9

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
