### PR TITLE
fix(repo): Group typescript-eslint with other linting upgrades

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1501,12 +1501,13 @@
     {
       groupName: "ESLint",
       matchPackageNames: [
-        "@types/eslint",
         "@eslint/{/,}**",
+        "@types/eslint",
         "@stylistic/eslint-plugin{/,}**",
         "@types/eslint__{/,}**",
         "@typescript-eslint/{/,}**",
         "eslint{/,}**",
+        "typescript-eslint{/,}**",
       ],
     },
     {

--- a/scripts/renovate-config-generator.mjs
+++ b/scripts/renovate-config-generator.mjs
@@ -52,12 +52,13 @@ const defaultRules = [
   {
     groupName: 'ESLint',
     matchPackageNames: [
-      '@types/eslint',
       '@eslint/{/,}**',
+      '@types/eslint',
       '@stylistic/eslint-plugin{/,}**',
       '@types/eslint__{/,}**',
       '@typescript-eslint/{/,}**',
       'eslint{/,}**',
+      'typescript-eslint{/,}**',
     ],
   },
   {


### PR DESCRIPTION
## Description

Making all ESLint packages part of the same dependency upgrade group

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
