### PR TITLE
fix(clerk-expo): Add console error for disabled Native API

### DIFF
--- a/.changeset/eight-paws-add.md
+++ b/.changeset/eight-paws-add.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Add a console error if the Native API is disabled for the instance.

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -168,11 +168,19 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
         }
       });
 
+      let nativeApiErrorShown = false;
       // @ts-expect-error - This is an internal API
       __internal_clerk.__unstable__onAfterResponse(async (_: FapiRequestInit, response: FapiResponse<unknown>) => {
         const authHeader = response.headers.get('authorization');
         if (authHeader) {
           await saveToken(KEY, authHeader);
+        }
+
+        if (!nativeApiErrorShown && response.payload?.errors?.[0]?.code === 'native_api_disabled') {
+          console.error(
+            'Clerk: The Native API is disabled for this instance.\nGo to Clerk Dashboard > Configure > Native applications to enable it.',
+          );
+          nativeApiErrorShown = true;
         }
       });
     }

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -178,7 +178,7 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
 
         if (!nativeApiErrorShown && response.payload?.errors?.[0]?.code === 'native_api_disabled') {
           console.error(
-            'Clerk: The Native API is disabled for this instance.\nGo to Clerk Dashboard > Configure > Native applications to enable it.',
+            'The Native API is disabled for this instance.\nGo to Clerk Dashboard > Configure > Native applications to enable it.\nOr, navigate here: https://dashboard.clerk.com/last-active?path=native-applications',
           );
           nativeApiErrorShown = true;
         }


### PR DESCRIPTION
## Description

Adds a console error message on Expo app if the Native API toggle is disabled on Clerk Dashboard.

Screenshot:
<img width="727" alt="Screenshot 2025-03-17 at 14 17 24" src="https://github.com/user-attachments/assets/3d39adb3-0b8d-461d-a207-3aecb65ce029" />



## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
