### PR TITLE
feat(clerk-js,clerk-react,types): Navigate to next task

### DIFF
--- a/.changeset/purple-balloons-join.md
+++ b/.changeset/purple-balloons-join.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Introduce `__experimental_nextTask` method for navigating to next tasks on a after-auth flow

--- a/.changeset/purple-balloons-join.md
+++ b/.changeset/purple-balloons-join.md
@@ -1,5 +1,6 @@
 ---
 '@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
 '@clerk/types': patch
 ---
 

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -52,7 +52,7 @@ const createExpectPageObject = ({ page }: TestArgs) => {
         return !!window.Clerk?.user;
       });
     },
-    toHaveCurrentTask: async () => {
+    toHaveResolvedTask: async () => {
       return page.waitForFunction(() => {
         return !window.Clerk?.session?.currentTask;
       });

--- a/integration/testUtils/index.ts
+++ b/integration/testUtils/index.ts
@@ -7,7 +7,9 @@ import { createAppPageObject } from './appPageObject';
 import { createEmailService } from './emailService';
 import { createInvitationService } from './invitationsService';
 import { createKeylessPopoverPageObject } from './keylessPopoverPageObject';
+import { createOrganizationsService } from './organizationsService';
 import { createOrganizationSwitcherComponentPageObject } from './organizationSwitcherPageObject';
+import { createSessionTaskComponentPageObject } from './sessionTaskPageObject';
 import type { EnchancedPage, TestArgs } from './signInPageObject';
 import { createSignInComponentPageObject } from './signInPageObject';
 import { createSignUpComponentPageObject } from './signUpPageObject';
@@ -50,6 +52,11 @@ const createExpectPageObject = ({ page }: TestArgs) => {
         return !!window.Clerk?.user;
       });
     },
+    toHaveCurrentTask: async () => {
+      return page.waitForFunction(() => {
+        return !window.Clerk?.session?.currentTask;
+      });
+    },
   };
 };
 
@@ -87,6 +94,7 @@ export const createTestUtils = <
     email: createEmailService(),
     users: createUserService(clerkClient),
     invitations: createInvitationService(clerkClient),
+    organizations: createOrganizationsService(clerkClient),
     clerk: clerkClient,
   };
 
@@ -106,6 +114,7 @@ export const createTestUtils = <
     userButton: createUserButtonPageObject(testArgs),
     userVerification: createUserVerificationComponentPageObject(testArgs),
     waitlist: createWaitlistComponentPageObject(testArgs),
+    sessionTask: createSessionTaskComponentPageObject(testArgs),
     expect: createExpectPageObject(testArgs),
     clerk: createClerkUtils(testArgs),
   };

--- a/integration/testUtils/organizationsService.ts
+++ b/integration/testUtils/organizationsService.ts
@@ -1,0 +1,27 @@
+import type { ClerkClient, Organization } from '@clerk/backend';
+import { faker } from '@faker-js/faker';
+
+export type FakeOrganization = Pick<Organization, 'slug' | 'name'>;
+
+export type OrganizationService = {
+  deleteAll: () => Promise<void>;
+  createFakeOrganization: () => FakeOrganization;
+};
+
+export const createOrganizationsService = (clerkClient: ClerkClient) => {
+  const self: OrganizationService = {
+    createFakeOrganization: () => ({
+      slug: faker.helpers.slugify(faker.commerce.department()).toLowerCase(),
+      name: faker.commerce.department(),
+    }),
+    deleteAll: async () => {
+      const organizations = await clerkClient.organizations.getOrganizationList();
+
+      const bulkDeletionPromises = organizations.data.map(({ id }) => clerkClient.organizations.deleteOrganization(id));
+
+      await Promise.all(bulkDeletionPromises);
+    },
+  };
+
+  return self;
+};

--- a/integration/testUtils/organizationsService.ts
+++ b/integration/testUtils/organizationsService.ts
@@ -16,9 +16,7 @@ export const createOrganizationsService = (clerkClient: ClerkClient) => {
     }),
     deleteAll: async () => {
       const organizations = await clerkClient.organizations.getOrganizationList();
-
       const bulkDeletionPromises = organizations.data.map(({ id }) => clerkClient.organizations.deleteOrganization(id));
-
       await Promise.all(bulkDeletionPromises);
     },
   };

--- a/integration/testUtils/sessionTaskPageObject.ts
+++ b/integration/testUtils/sessionTaskPageObject.ts
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+
+import { common } from './commonPageObject';
+import type { FakeOrganization } from './organizationsService';
+import type { TestArgs } from './signInPageObject';
+
+export const createSessionTaskComponentPageObject = (testArgs: TestArgs) => {
+  const { page } = testArgs;
+
+  const self = {
+    ...common(testArgs),
+    resolveForceOrganizationSelectionTask: async (fakeOrganization: FakeOrganization) => {
+      const createOrganizationButton = page.getByRole('button', { name: /create organization/i });
+
+      await expect(createOrganizationButton).toBeVisible();
+      expect(page.url()).toContain('add-organization');
+
+      await page.locator('input[name=name]').fill(fakeOrganization.name);
+      await page.locator('input[name=slug]').fill(fakeOrganization.slug);
+
+      await createOrganizationButton.click();
+    },
+  };
+
+  return self;
+};

--- a/integration/tests/session-tasks-sign-in.test.ts
+++ b/integration/tests/session-tasks-sign-in.test.ts
@@ -40,7 +40,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
 
       // Resolves task
       await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
-      await u.po.expect.toHaveCurrentTask();
+      await u.po.expect.toHaveResolvedTask();
 
       // Navigates to after sign-in
       await u.page.waitForAppUrl('/');

--- a/integration/tests/session-tasks-sign-in.test.ts
+++ b/integration/tests/session-tasks-sign-in.test.ts
@@ -1,8 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { appConfigs } from '../presets';
 import type { FakeUser } from '../testUtils';
 import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+import type { FakeOrganization } from '../testUtils/organizationsService';
 
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
   'session tasks after sign-in flow @nextjs',
@@ -10,20 +11,26 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
     test.describe.configure({ mode: 'serial' });
 
     let fakeUser: FakeUser;
+    let fakeOrganization: FakeOrganization;
 
     test.beforeAll(async () => {
       const u = createTestUtils({ app });
       fakeUser = u.services.users.createFakeUser();
+      fakeOrganization = u.services.organizations.createFakeOrganization();
       await u.services.users.createBapiUser(fakeUser);
     });
 
     test.afterAll(async () => {
+      const u = createTestUtils({ app });
       await fakeUser.deleteIfExists();
+      await u.services.organizations.deleteAll();
       await app.teardown();
     });
 
     test('navigate to task on after sign-in', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
+
+      // Performs sign-in
       await u.po.signIn.goTo();
       await u.po.signIn.setIdentifier(fakeUser.email);
       await u.po.signIn.continue();
@@ -31,8 +38,12 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.signIn.continue();
       await u.po.expect.toBeSignedIn();
 
-      await expect(u.page.getByRole('button', { name: /create organization/i })).toBeVisible();
-      expect(page.url()).toContain('add-organization');
+      // Resolves task
+      await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
+      await u.po.expect.toHaveCurrentTask();
+
+      // Navigates to after sign-in
+      await u.page.waitForAppUrl('/');
     });
   },
 );

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -41,7 +41,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
 
       // Resolves task
       await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
-      await u.po.expect.toHaveCurrentTask();
+      await u.po.expect.toHaveResolvedTask();
 
       // Navigates to after sign-up
       await u.page.waitForAppUrl('/');

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -1,34 +1,50 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { appConfigs } from '../presets';
+import type { FakeUser } from '../testUtils';
 import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+import type { FakeOrganization } from '../testUtils/organizationsService';
 
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
   'session tasks after sign-up flow @nextjs',
   ({ app }) => {
     test.describe.configure({ mode: 'serial' });
 
-    test.afterAll(async () => {
-      await app.teardown();
-    });
+    let fakeUser: FakeUser;
+    let fakeOrganization: FakeOrganization;
 
-    test('navigate to task on after sign-up', async ({ page, context }) => {
-      const u = createTestUtils({ app, page, context });
-      const fakeUser = u.services.users.createFakeUser({
+    test.beforeAll(() => {
+      const u = createTestUtils({ app });
+      fakeUser = u.services.users.createFakeUser({
         fictionalEmail: true,
         withPhoneNumber: true,
         withUsername: true,
       });
+      fakeOrganization = u.services.organizations.createFakeOrganization();
+    });
+
+    test.afterAll(async () => {
+      const u = createTestUtils({ app });
+      await u.services.organizations.deleteAll();
+      await fakeUser.deleteIfExists();
+      await app.teardown();
+    });
+
+    test('navigate to task on after sign-up', async ({ page, context }) => {
+      // Performs sign-up
+      const u = createTestUtils({ app, page, context });
       await u.po.signUp.goTo();
       await u.po.signUp.signUpWithEmailAndPassword({
         email: fakeUser.email,
         password: fakeUser.password,
       });
 
-      await expect(u.page.getByRole('button', { name: /create organization/i })).toBeVisible();
-      expect(page.url()).toContain('add-organization');
+      // Resolves task
+      await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization);
+      await u.po.expect.toHaveCurrentTask();
 
-      await fakeUser.deleteIfExists();
+      // Navigates to after sign-up
+      await u.page.waitForAppUrl('/');
     });
   },
 );

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -2,7 +2,7 @@
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "577.51kB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "78.5kB" },
-    { "path": "./dist/clerk.headless.js", "maxSize": "51KB" },
+    { "path": "./dist/clerk.headless.js", "maxSize": "55KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "94KB" },
     { "path": "./dist/vendors*.js", "maxSize": "30KB" },
     { "path": "./dist/coinbase*.js", "maxSize": "35.5KB" },

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "577.51kB" },
+    { "path": "./dist/clerk.js", "maxSize": "580kB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "78.5kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "55KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "94KB" },

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2301,8 +2301,8 @@ describe('Clerk singleton', () => {
       it('navigates to next task', async () => {
         const sut = new Clerk(productionPublishableKey);
         await sut.load(mockedLoadOptions);
-        await sut.setActive({ session: mockResource as any as PendingSessionResource });
 
+        await sut.setActive({ session: mockResource as any as PendingSessionResource });
         await sut.__experimental_nextTask();
 
         expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/add-organization');

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2258,4 +2258,14 @@ describe('Clerk singleton', () => {
       });
     });
   });
+
+  describe('nextTask', () => {
+    describe('with pending session', () => {
+      it.todo('navigates to next task');
+    });
+
+    describe('with active session', () => {
+      it.todo('navigates to final destination url');
+    });
+  });
 });

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -519,7 +519,7 @@ describe('Clerk singleton', () => {
 
         const sut = new Clerk(productionPublishableKey);
         await sut.load();
-        await sut.setActive({ session: mockSession as ActiveSessionResource });
+        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
         expect(mockSession.touch).toHaveBeenCalled();
       });
 
@@ -530,7 +530,7 @@ describe('Clerk singleton', () => {
 
         const sut = new Clerk(productionPublishableKey);
         await sut.load({ touchSession: false });
-        await sut.setActive({ session: mockSession as ActiveSessionResource });
+        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
         await waitFor(() => {
           expect(mockSession.touch).not.toHaveBeenCalled();
           expect(mockSession.getToken).toHaveBeenCalled();
@@ -544,7 +544,7 @@ describe('Clerk singleton', () => {
 
         const executionOrder: string[] = [];
         mockSession.touch.mockImplementationOnce(() => {
-          sut.session = mockSession;
+          sut.session = mockSession as any;
           executionOrder.push('session.touch');
           return Promise.resolve();
         });
@@ -2330,16 +2330,10 @@ describe('Clerk singleton', () => {
           }),
         ),
       };
-      let eventBusSpy;
-
-      beforeEach(() => {
-        eventBusSpy = jest.spyOn(eventBus, 'dispatch');
-      });
 
       afterEach(() => {
         mockSession.remove.mockReset();
         mockSession.touch.mockReset();
-        eventBusSpy?.mockRestore();
         (window as any).__unstable__onBeforeSetActive = null;
         (window as any).__unstable__onAfterSetActive = null;
       });

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2346,9 +2346,12 @@ describe('Clerk singleton', () => {
         await sut.load(mockedLoadOptions);
         await sut.setActive({ session: mockSession as any as ActiveSessionResource });
 
-        await sut.__experimental_nextTask();
+        const redirectUrlComplete = '/welcome-to-app';
+        await sut.__experimental_nextTask({ redirectUrlComplete });
 
-        expect(mockNavigate.mock.calls[0][0]).toBe('/');
+        console.log(mockNavigate.mock.calls);
+
+        expect(mockNavigate.mock.calls[0][0]).toBe('/welcome-to-app');
       });
     });
   });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -970,12 +970,11 @@ export class Clerk implements ClerkInterface {
       session = (this.client.sessions.find(x => x.id === session) as SignedInSessionResource) || null;
     }
 
-    if (session?.status === 'pending') {
-      await this.#handlePendingSession(session);
+    let newSession = session === undefined ? this.session : session;
+    if (newSession?.status === 'pending') {
+      await this.#handlePendingSession(newSession, organization);
       return;
     }
-
-    let newSession = session === undefined ? this.session : session;
 
     // At this point, the `session` variable should contain either an `SignedInSessionResource`
     // ,`null` or `undefined`.
@@ -1064,15 +1063,35 @@ export class Clerk implements ClerkInterface {
     await onAfterSetActive();
   };
 
-  #handlePendingSession = async (session: PendingSessionResource) => {
+  #handlePendingSession = async (
+    session: PendingSessionResource,
+    organization?: string | OrganizationResource | null | undefined,
+  ) => {
     if (!this.environment) {
       return;
     }
 
+    const shouldSwitchOrganization = organization !== undefined;
+    if (shouldSwitchOrganization) {
+      const organizationIdOrSlug = typeof organization === 'string' ? organization : organization?.id;
+
+      if (isOrganizationId(organizationIdOrSlug)) {
+        session.lastActiveOrganizationId = organizationIdOrSlug || null;
+      } else {
+        const matchingOrganization = session.user.organizationMemberships.find(
+          mem => mem.organization.slug === organizationIdOrSlug,
+        );
+        session.lastActiveOrganizationId = matchingOrganization?.organization.id || null;
+      }
+    }
+
+    let newSession: SignedInSessionResource | null = session;
+
     // Handles multi-session scenario when switching between `pending` sessions
+    // and satisfying task requirements such as organization selection
     if (inActiveBrowserTab() || !this.#options.standardBrowser) {
       await this.#touchCurrentSession(session);
-      session = (this.#getSessionFromClient(session.id) as PendingSessionResource) ?? session;
+      newSession = this.#getSessionFromClient(session.id) ?? session;
     }
 
     // Syncs __session and __client_uat, in case the `pending` session
@@ -1082,16 +1101,20 @@ export class Clerk implements ClerkInterface {
       eventBus.dispatch(events.TokenUpdate, { token: null });
     }
 
-    if (session.currentTask) {
+    if (newSession?.currentTask) {
       await navigateToTask(session.currentTask, {
         globalNavigate: this.navigate,
         componentNavigationContext: this.#componentNavigationContext,
         options: this.#options,
         environment: this.environment,
       });
+
+      // Delay updating session accessors until active status transition to prevent premature component unmounting.
+      // This is particularly important when SignIn components are wrapped in SignedOut components,
+      // as early state updates could cause unwanted unmounting during the transition.
+      this.#setAccessors(session);
     }
 
-    this.#setAccessors(session);
     this.#emit();
   };
 
@@ -1111,8 +1134,12 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
+    this.#setTransitiveState();
     const defaultRedirectUrlComplete = this.client?.signUp ? this.buildAfterSignUpUrl() : this.buildAfterSignUpUrl();
     await this.navigate(redirectUrlComplete ?? defaultRedirectUrlComplete);
+
+    this.#setAccessors(session);
+    this.#emit();
   };
 
   public addListener = (listener: ListenerCallback): UnsubscribeCallback => {
@@ -2275,6 +2302,11 @@ export class Clerk implements ClerkInterface {
     }
   };
 
+  /**
+   * Temporarily clears the accessors before emitting changes to React context state.
+   * This is used during transitions like sign-out or session changes to prevent UI flickers
+   * such as unexpected unmount of control components
+   */
   #setTransitiveState = () => {
     this.session = undefined;
     this.organization = undefined;

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -44,6 +44,7 @@ import type {
   OrganizationProfileProps,
   OrganizationResource,
   OrganizationSwitcherProps,
+  PendingSessionResource,
   PublicKeyCredentialCreationOptionsWithoutExtensions,
   PublicKeyCredentialRequestOptionsWithoutExtensions,
   PublicKeyCredentialWithAuthenticatorAssertionResponse,
@@ -1069,16 +1070,15 @@ export class Clerk implements ClerkInterface {
     await onAfterSetActive();
   };
 
-  #handlePendingSession = async (session: SignedInSessionResource) => {
+  #handlePendingSession = async (session: PendingSessionResource) => {
     if (!this.environment) {
       return;
     }
 
-    // Handles multi-session scenario when switching from `active`
-    // to `pending`
+    // Handles multi-session scenario when switching between `pending` sessions
     if (inActiveBrowserTab() || !this.#options.standardBrowser) {
       await this.#touchCurrentSession(session);
-      session = this.#getSessionFromClient(session.id) ?? session;
+      session = (this.#getSessionFromClient(session.id) as PendingSessionResource) ?? session;
     }
 
     // Syncs __session and __client_uat, in case the `pending` session

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1118,9 +1118,18 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
-    this.#setTransitiveState();
+    const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
     const defaultRedirectUrlComplete = this.client?.signUp ? this.buildAfterSignUpUrl() : this.buildAfterSignUpUrl();
-    await this.navigate(redirectUrlComplete ?? defaultRedirectUrlComplete);
+
+    this.#setTransitiveState();
+
+    await tracker.track(async () => {
+      await this.navigate(redirectUrlComplete ?? defaultRedirectUrlComplete);
+    });
+
+    if (tracker.isUnloading()) {
+      return;
+    }
 
     this.#setAccessors(session);
     this.#emit();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1102,7 +1102,7 @@ export class Clerk implements ClerkInterface {
     this.#emit();
   };
 
-  public __experimental_nextTask = async ({ redirectUrlComplete }: NextTaskParams): Promise<void> => {
+  public __experimental_nextTask = async ({ redirectUrlComplete }: NextTaskParams = {}): Promise<void> => {
     if (!this.session || !this.environment) {
       return;
     }

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -971,10 +971,6 @@ export class Clerk implements ClerkInterface {
     }
 
     let newSession = session === undefined ? this.session : session;
-    if (newSession?.status === 'pending') {
-      await this.#handlePendingSession(newSession, organization);
-      return;
-    }
 
     // At this point, the `session` variable should contain either an `SignedInSessionResource`
     // ,`null` or `undefined`.
@@ -994,6 +990,11 @@ export class Clerk implements ClerkInterface {
         );
         newSession.lastActiveOrganizationId = matchingOrganization?.organization.id || null;
       }
+    }
+
+    if (newSession?.status === 'pending') {
+      await this.#handlePendingSession(newSession);
+      return;
     }
 
     if (session?.lastActiveToken) {
@@ -1063,26 +1064,9 @@ export class Clerk implements ClerkInterface {
     await onAfterSetActive();
   };
 
-  #handlePendingSession = async (
-    session: PendingSessionResource,
-    organization?: string | OrganizationResource | null | undefined,
-  ) => {
+  #handlePendingSession = async (session: PendingSessionResource) => {
     if (!this.environment) {
       return;
-    }
-
-    const shouldSwitchOrganization = organization !== undefined;
-    if (shouldSwitchOrganization) {
-      const organizationIdOrSlug = typeof organization === 'string' ? organization : organization?.id;
-
-      if (isOrganizationId(organizationIdOrSlug)) {
-        session.lastActiveOrganizationId = organizationIdOrSlug || null;
-      } else {
-        const matchingOrganization = session.user.organizationMemberships.find(
-          mem => mem.organization.slug === organizationIdOrSlug,
-        );
-        session.lastActiveOrganizationId = matchingOrganization?.organization.id || null;
-      }
     }
 
     let newSession: SignedInSessionResource | null = session;

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -1,4 +1,9 @@
-import type { ClerkOptions, EnvironmentResource, SessionTask } from '@clerk/types';
+import type {
+  __internal_ComponentNavigationContext,
+  ClerkOptions,
+  EnvironmentResource,
+  SessionTask,
+} from '@clerk/types';
 
 import { buildURL } from '../utils';
 
@@ -7,15 +12,7 @@ export const SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], string> = {
 } as const;
 
 interface NavigateToTaskOptions {
-  componentNavigationContext: {
-    navigate: (
-      to: string,
-      options?: {
-        searchParams?: URLSearchParams;
-      },
-    ) => Promise<unknown>;
-    basePath: string;
-  } | null;
+  componentNavigationContext: __internal_ComponentNavigationContext | null;
   globalNavigate: (to: string) => Promise<unknown>;
   options: ClerkOptions;
   environment: EnvironmentResource;

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -30,7 +30,7 @@ export function navigateToTask(
   const taskRoute = `/${SESSION_TASK_ROUTE_BY_KEY[task.key]}`;
 
   if (componentNavigationContext) {
-    return componentNavigationContext.navigate(`/${componentNavigationContext.basePath + taskRoute}`);
+    return componentNavigationContext.navigate(componentNavigationContext.indexPath + taskRoute);
   }
 
   const signInUrl = options['signInUrl'] || environment.displayConfig.signInUrl;

--- a/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
@@ -109,7 +109,8 @@ export const OrganizationListPage = withCardStateProvider(() => {
 });
 
 const OrganizationListFlows = ({ showListInitially }: { showListInitially: boolean }) => {
-  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug, onComplete } = useOrganizationListContext();
+  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug, __internal_onOrganizationCreated } =
+    useOrganizationListContext();
   const [isCreateOrganizationFlow, setCreateOrganizationFlow] = useState(!showListInitially);
   return (
     <>
@@ -125,7 +126,7 @@ const OrganizationListFlows = ({ showListInitially }: { showListInitially: boole
         >
           <CreateOrganizationForm
             flow='organizationList'
-            onComplete={onComplete}
+            onComplete={__internal_onOrganizationCreated}
             startPage={{ headerTitle: localizationKeys('organizationList.createOrganization') }}
             skipInvitationScreen={skipInvitationScreen}
             navigateAfterCreateOrganization={org =>

--- a/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
@@ -1,7 +1,8 @@
 import { useOrganizationList, useUser } from '@clerk/shared/react';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 import { useEnvironment, useOrganizationListContext } from '../../contexts';
+import { SessionTaskContext } from '../../contexts/components/SessionTask';
 import { Box, Col, descriptors, Flex, localizationKeys, Spinner } from '../../customizables';
 import { Action, Actions, Card, Header, useCardState, withCardStateProvider } from '../../elements';
 import { useInView } from '../../hooks';
@@ -109,9 +110,9 @@ export const OrganizationListPage = withCardStateProvider(() => {
 });
 
 const OrganizationListFlows = ({ showListInitially }: { showListInitially: boolean }) => {
-  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug, __internal_onOrganizationCreated } =
-    useOrganizationListContext();
+  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug } = useOrganizationListContext();
   const [isCreateOrganizationFlow, setCreateOrganizationFlow] = useState(!showListInitially);
+  const sessionTaskContext = useContext(SessionTaskContext);
   return (
     <>
       {!isCreateOrganizationFlow && (
@@ -126,7 +127,7 @@ const OrganizationListFlows = ({ showListInitially }: { showListInitially: boole
         >
           <CreateOrganizationForm
             flow='organizationList'
-            onComplete={__internal_onOrganizationCreated}
+            onComplete={sessionTaskContext?.nextTask}
             startPage={{ headerTitle: localizationKeys('organizationList.createOrganization') }}
             skipInvitationScreen={skipInvitationScreen}
             navigateAfterCreateOrganization={org =>

--- a/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
@@ -109,7 +109,7 @@ export const OrganizationListPage = withCardStateProvider(() => {
 });
 
 const OrganizationListFlows = ({ showListInitially }: { showListInitially: boolean }) => {
-  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug } = useOrganizationListContext();
+  const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug, onComplete } = useOrganizationListContext();
   const [isCreateOrganizationFlow, setCreateOrganizationFlow] = useState(!showListInitially);
   return (
     <>
@@ -125,6 +125,7 @@ const OrganizationListFlows = ({ showListInitially }: { showListInitially: boole
         >
           <CreateOrganizationForm
             flow='organizationList'
+            onComplete={onComplete}
             startPage={{ headerTitle: localizationKeys('organizationList.createOrganization') }}
             skipInvitationScreen={skipInvitationScreen}
             navigateAfterCreateOrganization={org =>

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
@@ -8,7 +8,7 @@ import { OrganizationListPreviewButton, sharedMainIdentifierSx } from './shared'
 
 export const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { navigateAfterSelectOrganization } = useOrganizationListContext();
+  const { navigateAfterSelectOrganization, onComplete } = useOrganizationListContext();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -19,6 +19,11 @@ export const MembershipPreview = withCardStateProvider((props: { organization: O
       await setActive({
         organization,
       });
+
+      if (onComplete) {
+        return onComplete();
+      }
+
       await navigateAfterSelectOrganization(organization);
     });
   };

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
@@ -8,7 +8,7 @@ import { OrganizationListPreviewButton, sharedMainIdentifierSx } from './shared'
 
 export const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { navigateAfterSelectOrganization, onComplete } = useOrganizationListContext();
+  const { navigateAfterSelectOrganization, __internal_onOrganizationSelected } = useOrganizationListContext();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -20,8 +20,8 @@ export const MembershipPreview = withCardStateProvider((props: { organization: O
         organization,
       });
 
-      if (onComplete) {
-        return onComplete();
+      if (__internal_onOrganizationSelected) {
+        return __internal_onOrganizationSelected();
       }
 
       await navigateAfterSelectOrganization(organization);

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
@@ -1,15 +1,18 @@
 import { useOrganizationList, useUser } from '@clerk/shared/react';
 import type { OrganizationResource } from '@clerk/types';
+import { useContext } from 'react';
 
 import { useOrganizationListContext } from '../../contexts';
+import { SessionTaskContext } from '../../contexts/components/SessionTask';
 import { OrganizationPreview, PersonalWorkspacePreview, useCardState, withCardStateProvider } from '../../elements';
 import { localizationKeys } from '../../localization';
 import { OrganizationListPreviewButton, sharedMainIdentifierSx } from './shared';
 
 export const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { navigateAfterSelectOrganization, __internal_onOrganizationSelected } = useOrganizationListContext();
+  const { navigateAfterSelectOrganization } = useOrganizationListContext();
   const { isLoaded, setActive } = useOrganizationList();
+  const sessionTaskContext = useContext(SessionTaskContext);
 
   if (!isLoaded) {
     return null;
@@ -20,8 +23,8 @@ export const MembershipPreview = withCardStateProvider((props: { organization: O
         organization,
       });
 
-      if (__internal_onOrganizationSelected) {
-        return __internal_onOrganizationSelected();
+      if (sessionTaskContext?.nextTask) {
+        return sessionTaskContext?.nextTask();
       }
 
       await navigateAfterSelectOrganization(organization);

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -1,9 +1,17 @@
-import { useClerk } from '@clerk/shared/react/index';
+import { useClerk } from '@clerk/shared/react';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { SessionTask } from '@clerk/types';
+import { useCallback, useEffect } from 'react';
 
 import { OrganizationListContext } from '../../contexts';
+import { SessionTaskContext as SessionTaskContext } from '../../contexts/components/SessionTask';
+import { useRouter } from '../../router';
 import { OrganizationList } from '../OrganizationList';
+
+interface SessionTaskProps {
+  task: SessionTask['key'];
+  redirectUrlComplete: string;
+}
 
 const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
   org: () => (
@@ -21,12 +29,30 @@ const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
 /**
  * @internal
  */
-export function SessionTask({ task }: { task: SessionTask['key'] }): React.ReactNode {
-  const clerk = useClerk();
+export function SessionTask({ task, redirectUrlComplete }: SessionTaskProps): React.ReactNode {
+  const { session, telemetry, __experimental_nextTask } = useClerk();
+  const { navigate } = useRouter();
 
-  clerk.telemetry?.record(eventComponentMounted('SessionTask', { task }));
+  useEffect(() => {
+    if (session?.currentTask) {
+      return;
+    }
+
+    void navigate(redirectUrlComplete);
+  }, [session?.currentTask, navigate, redirectUrlComplete]);
+
+  telemetry?.record(eventComponentMounted('SessionTask', { task }));
+
+  const nextTask = useCallback(
+    () => __experimental_nextTask({ redirectUrlComplete }),
+    [__experimental_nextTask, redirectUrlComplete],
+  );
 
   const Content = ContentRegistry[task];
 
-  return <Content />;
+  return (
+    <SessionTaskContext.Provider value={{ nextTask }}>
+      <Content />
+    </SessionTaskContext.Provider>
+  );
 }

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -132,7 +132,10 @@ function SignInRoutes(): JSX.Element {
               </Route>
               {signInContext.withSessionTasks && (
                 <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-                  <SessionTask task='org' />
+                  <SessionTask
+                    task='org'
+                    redirectUrlComplete={signInContext.afterSignUpUrl}
+                  />
                 </Route>
               )}
               <Route index>
@@ -146,7 +149,10 @@ function SignInRoutes(): JSX.Element {
         )}
         {signInContext.withSessionTasks && (
           <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-            <SessionTask task='org' />
+            <SessionTask
+              task='org'
+              redirectUrlComplete={signInContext.afterSignInUrl}
+            />
           </Route>
         )}
         <Route index>

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -174,7 +174,7 @@ const usePreloadSessionTask = (enabled = false) =>
 
 function SignInRoot() {
   const { __internal_setComponentNavigationContext } = useClerk();
-  const { navigate, basePath } = useRouter();
+  const { navigate, indexPath } = useRouter();
 
   const signInContext = useSignInContext();
   const normalizedSignUpContext = {
@@ -197,8 +197,8 @@ function SignInRoot() {
   usePreloadSessionTask(signInContext.withSessionTasks);
 
   React.useEffect(() => {
-    return __internal_setComponentNavigationContext?.({ basePath, navigate });
-  }, [basePath, navigate]);
+    return __internal_setComponentNavigationContext?.({ indexPath, navigate });
+  }, [indexPath, navigate]);
 
   return (
     <SignUpContext.Provider value={normalizedSignUpContext}>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -28,15 +28,15 @@ function RedirectToSignUp() {
 
 function SignUpRoutes(): JSX.Element {
   const { __internal_setComponentNavigationContext } = useClerk();
-  const { navigate, basePath } = useRouter();
+  const { navigate, indexPath } = useRouter();
   const signUpContext = useSignUpContext();
 
   // `experimental.withSessionTasks` will be removed soon in favor of checking via environment response
   usePreloadSessionTask(signUpContext.withSessionTasks);
 
   React.useEffect(() => {
-    return __internal_setComponentNavigationContext?.({ basePath, navigate });
-  }, [basePath, navigate]);
+    return __internal_setComponentNavigationContext?.({ indexPath, navigate });
+  }, [indexPath, navigate]);
 
   return (
     <Flow.Root flow='signUp'>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -91,7 +91,10 @@ function SignUpRoutes(): JSX.Element {
         </Route>
         {signUpContext.withSessionTasks && (
           <Route path={SESSION_TASK_ROUTE_BY_KEY['org']}>
-            <SessionTask task='org' />
+            <SessionTask
+              task='org'
+              redirectUrlComplete={signUpContext.afterSignUpUrl}
+            />
           </Route>
         )}
         <Route index>

--- a/packages/clerk-js/src/ui/contexts/components/SessionTask.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SessionTask.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { SessionTaskCtx } from '../../types';
+
+export const SessionTaskContext = createContext<SessionTaskCtx | null>(null);

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -112,6 +112,10 @@ export type __experimental_CheckoutCtx = __experimental_CheckoutProps & {
   setIsOpen?: (open: boolean) => void;
 };
 
+export type SessionTaskCtx = {
+  nextTask: () => void;
+};
+
 export type AvailableComponentCtx =
   | SignInCtx
   | SignUpCtx

--- a/packages/clerk-js/src/utils/beforeUnloadTracker.ts
+++ b/packages/clerk-js/src/utils/beforeUnloadTracker.ts
@@ -31,6 +31,15 @@ const createBeforeUnloadListener = () => {
   return { startListening, stopListening, isUnloading };
 };
 
+/**
+ * Creates a beforeUnload event tracker to prevent state updates and re-renders during hard
+ * navigation events.
+ *
+ * It can be wrapped around navigation-related operations to ensure they don't trigger unnecessary
+ * state updates during page transitions.
+ *
+ * @internal
+ */
 export const createBeforeUnloadTracker = (enabled = false) => {
   if (!enabled) {
     return {

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -4,7 +4,6 @@ import { handleValueOrFn } from '@clerk/shared/utils';
 import type {
   __experimental_CommerceNamespace,
   __experimental_PricingTableProps,
-  __internal_ComponentNavigationContext,
   __internal_UserVerificationModalProps,
   __internal_UserVerificationProps,
   AuthenticateWithCoinbaseWalletParams,
@@ -95,6 +94,7 @@ type IsomorphicLoadedClerk = Without<
   | '__internal_getCachedResources'
   | '__internal_reloadInitialResources'
   | '__experimental_commerce'
+  | '__internal_setComponentNavigationContext'
 > & {
   client: ClientResource | undefined;
   __experimental_commerce: __experimental_CommerceNamespace | undefined;
@@ -618,14 +618,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return this.clerkjs.__experimental_nextTask(params);
     } else {
       return Promise.reject();
-    }
-  };
-
-  __internal_setComponentNavigationContext = (params: __internal_ComponentNavigationContext) => {
-    if (this.clerkjs) {
-      return this.clerkjs.__internal_setComponentNavigationContext(params);
-    } else {
-      return undefined;
     }
   };
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -4,6 +4,7 @@ import { handleValueOrFn } from '@clerk/shared/utils';
 import type {
   __experimental_CommerceNamespace,
   __experimental_PricingTableProps,
+  __internal_ComponentNavigationContext,
   __internal_UserVerificationModalProps,
   __internal_UserVerificationProps,
   AuthenticateWithCoinbaseWalletParams,
@@ -23,6 +24,7 @@ import type {
   JoinWaitlistParams,
   ListenerCallback,
   LoadedClerk,
+  NextTaskParams,
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationResource,
@@ -93,7 +95,6 @@ type IsomorphicLoadedClerk = Without<
   | '__internal_getCachedResources'
   | '__internal_reloadInitialResources'
   | '__experimental_commerce'
-  | '__internal_setComponentNavigationContext'
 > & {
   client: ClientResource | undefined;
   __experimental_commerce: __experimental_CommerceNamespace | undefined;
@@ -609,6 +610,22 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     // Handle case where accounts has clerk-react@4 installed, but clerk-js@3 is manually loaded
     if (clerkjs && '__unstable__updateProps' in clerkjs) {
       return (clerkjs as any).__unstable__updateProps(props);
+    }
+  };
+
+  __experimental_nextTask = async (params: NextTaskParams): Promise<void> => {
+    if (this.clerkjs) {
+      return this.clerkjs.__experimental_nextTask(params);
+    } else {
+      return Promise.reject();
+    }
+  };
+
+  __internal_setComponentNavigationContext = (params: __internal_ComponentNavigationContext) => {
+    if (this.clerkjs) {
+      return this.clerkjs.__internal_setComponentNavigationContext(params);
+    } else {
+      return undefined;
     }
   };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1605,7 +1605,7 @@ export interface AuthenticateWithGoogleOneTapParams {
 
 export interface NextTaskParams {
   /**
-   * Full URL or path to navigate after successful resolving all tasks
+   * Full URL or path to navigate after successfully resolving all tasks
    * @default undefined
    */
   redirectUrlComplete?: string;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1077,13 +1077,24 @@ export type __internal_UserVerificationProps = RoutingOptions & {
 export type __internal_UserVerificationModalProps = WithoutRouting<__internal_UserVerificationProps>;
 
 export type __internal_ComponentNavigationContext = {
+  /**
+   * The `navigate` reference within the component router context
+   */
   navigate: (
     to: string,
     options?: {
       searchParams?: URLSearchParams;
     },
   ) => Promise<unknown>;
-  basePath: string;
+  /**
+   * This path represents the root route for a specific component type and is used
+   * for internal routing and navigation.
+   *
+   * @example
+   * indexPath: '/sign-in'  // When <SignIn path='/sign-in' />
+   * indexPath: '/sign-up'  // When <SignUp path='/sign-up' />
+   */
+  indexPath: string;
 };
 
 type GoogleOneTapRedirectUrlProps = SignInForceRedirectUrl & SignUpForceRedirectUrl;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -434,15 +434,7 @@ export interface Clerk {
    * be triggered from `Clerk` methods
    * @internal
    */
-  __internal_setComponentNavigationContext: (context: {
-    navigate: (
-      to: string,
-      options?: {
-        searchParams?: URLSearchParams;
-      },
-    ) => Promise<unknown>;
-    basePath: string;
-  }) => () => void;
+  __internal_setComponentNavigationContext: (context: __internal_ComponentNavigationContext) => () => void;
 
   /**
    * Set the active session and organization explicitly.
@@ -1084,6 +1076,16 @@ export type __internal_UserVerificationProps = RoutingOptions & {
 
 export type __internal_UserVerificationModalProps = WithoutRouting<__internal_UserVerificationProps>;
 
+export type __internal_ComponentNavigationContext = {
+  navigate: (
+    to: string,
+    options?: {
+      searchParams?: URLSearchParams;
+    },
+  ) => Promise<unknown>;
+  basePath: string;
+};
+
 type GoogleOneTapRedirectUrlProps = SignInForceRedirectUrl & SignUpForceRedirectUrl;
 
 export type GoogleOneTapProps = GoogleOneTapRedirectUrlProps & {
@@ -1204,11 +1206,6 @@ export type OrganizationProfileProps = RoutingOptions & {
 export type OrganizationProfileModalProps = WithoutRouting<OrganizationProfileProps>;
 
 export type CreateOrganizationProps = RoutingOptions & {
-  /**
-   * Callback function triggered after successfully creating a new organization
-   */
-  onComplete?: () => void;
-
   /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
@@ -1403,11 +1400,6 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
 
 export type OrganizationListProps = {
   /**
-   * Callback function triggered after successfully selecting a new organization
-   */
-  onComplete?: () => void;
-
-  /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
    */
@@ -1453,6 +1445,9 @@ export type OrganizationListProps = {
    * @default false
    */
   hideSlug?: boolean;
+
+  __internal_onOrganizationSelected?: () => void;
+  __internal_onOrganizationCreated?: () => void;
 };
 
 export type WaitlistProps = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -647,6 +647,14 @@ export interface Clerk {
   joinWaitlist: (params: JoinWaitlistParams) => Promise<WaitlistResource>;
 
   /**
+   * Navigates to the next task or redirects to completion URL.
+   * If the current session has pending tasks, it navigates to the next task.
+   * If all tasks are complete, it navigates to the provided completion URL.
+   * @experimental
+   */
+  __experimental_nextTask: (params: NextTaskParams) => Promise<void>;
+
+  /**
    * This is an optional function.
    * This function is used to load cached Client and Environment resources if Clerk fails to load them from the Frontend API.
    * @internal
@@ -1197,6 +1205,11 @@ export type OrganizationProfileModalProps = WithoutRouting<OrganizationProfilePr
 
 export type CreateOrganizationProps = RoutingOptions & {
   /**
+   * Callback function triggered after successfully creating a new organization
+   */
+  onComplete?: () => void;
+
+  /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
    */
@@ -1390,6 +1403,11 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
 
 export type OrganizationListProps = {
   /**
+   * Callback function triggered after successfully selecting a new organization
+   */
+  onComplete?: () => void;
+
+  /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
    */
@@ -1580,6 +1598,14 @@ export interface AuthenticateWithOKXWalletParams {
 export interface AuthenticateWithGoogleOneTapParams {
   token: string;
   legalAccepted?: boolean;
+}
+
+export interface NextTaskParams {
+  /**
+   * Full URL or path to navigate after successful resolving all tasks
+   * @default undefined
+   */
+  redirectUrlComplete?: string;
 }
 
 export interface LoadedClerk extends Clerk {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1445,9 +1445,6 @@ export type OrganizationListProps = {
    * @default false
    */
   hideSlug?: boolean;
-
-  __internal_onOrganizationSelected?: () => void;
-  __internal_onOrganizationCreated?: () => void;
 };
 
 export type WaitlistProps = {


### PR DESCRIPTION
## Description

Resolves ORGS-581

Handles navigation to next tasks on an after-auth flow. Once all tasks get completed, it navigates to the `redirectUrlComplete` option, which defaults to after sign-in/sign-up URL based on the `Clerk.client` state. 

### Developer flows 

For AIO components, there's no signature changes and it'll work out of the box 

For custom flows, `Clerk.nextTask` should be called after performing a FAPI mutation that resolves a task. Here's an example for the upcoming force MFA task:

```ts 
await fapiClient.configureTotp(...) 
await Clerk.__experimental_nextTask()
```

Building your on custom React "onboarding" components: 
```tsx
function MyFirstOnboardingPage(){ 
  const clerk = useClerk()

  const handleOrganizationSelection = async (organization: string) => {
   // Select the organization into the current session 
    await setActive({ organization })

   // Proceed with verifying if there's a next task, either navigating to it 
   // or to `redirectUrlComplete` once session transitions to active
    await clerk.__experimental_nextTask()
  }

  return <MyCustomOrganizationList onOrgSelection={handleOrgSelection} />
}

function MySecondOnboardingPage(){ 
  const clerk = useClerk()
  return <ConfigureMFA onSuccess={clerk.__experimental_nextTask} />
}
```
---- 

https://github.com/user-attachments/assets/fe55ffd7-3e33-4bad-9086-d0bfebc5f995



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
