### PR TITLE
chore(clerk-js,types): Hide personal workspace options when organization selection is enforced

### DIFF
--- a/.changeset/fresh-plums-run.md
+++ b/.changeset/fresh-plums-run.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Hide personal workspace options when organization selection is enforced

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -829,7 +829,12 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('OrganizationSwitcher', props));
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted('OrganizationSwitcher', {
+        ...props,
+        forceOrganizationSelection: this.environment?.organizationSettings.forceOrganizationSelection,
+      }),
+    );
   };
 
   public unmountOrganizationSwitcher = (node: HTMLDivElement): void => {
@@ -863,7 +868,12 @@ export class Clerk implements ClerkInterface {
       }),
     );
 
-    this.telemetry?.record(eventPrebuiltComponentMounted('OrganizationList', props));
+    this.telemetry?.record(
+      eventPrebuiltComponentMounted('OrganizationList', {
+        ...props,
+        forceOrganizationSelection: this.environment?.organizationSettings.forceOrganizationSelection,
+      }),
+    );
   };
 
   public unmountOrganizationList = (node: HTMLDivElement): void => {

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -28,7 +28,6 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
   }
 
   protected fromJSON(data: OrganizationSettingsJSON | OrganizationSettingsJSONSnapshot | null): this {
-<<<<<<< HEAD
     if (!data) {
       return this;
     }
@@ -45,25 +44,11 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
 
     this.enabled = this.withDefault(data.enabled, this.enabled);
     this.maxAllowedMemberships = this.withDefault(data.max_allowed_memberships, this.maxAllowedMemberships);
+    this.forceOrganizationSelection = this.withDefault(
+      data.force_organization_selection,
+      this.forceOrganizationSelection,
+    );
 
-=======
-    const {
-      enabled = false,
-      max_allowed_memberships = 0,
-      force_organization_selection = false,
-      actions,
-      domains,
-    } = data || {};
-    this.enabled = enabled;
-    this.maxAllowedMemberships = max_allowed_memberships;
-    this.forceOrganizationSelection = force_organization_selection;
-    this.actions = { adminDelete: actions?.admin_delete || false };
-    this.domains = {
-      enabled: domains?.enabled || false,
-      enrollmentModes: domains?.enrollment_modes || [],
-      defaultRole: domains?.default_role || null,
-    };
->>>>>>> 6413d61b9 (Add `force_organization_selection` to environment resource)
     return this;
   }
 

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -20,6 +20,7 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
   };
   enabled: boolean = false;
   maxAllowedMemberships: number = 1;
+  forceOrganizationSelection!: boolean;
 
   public constructor(data: OrganizationSettingsJSON | OrganizationSettingsJSONSnapshot | null = null) {
     super();
@@ -27,6 +28,7 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
   }
 
   protected fromJSON(data: OrganizationSettingsJSON | OrganizationSettingsJSONSnapshot | null): this {
+<<<<<<< HEAD
     if (!data) {
       return this;
     }
@@ -44,6 +46,24 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
     this.enabled = this.withDefault(data.enabled, this.enabled);
     this.maxAllowedMemberships = this.withDefault(data.max_allowed_memberships, this.maxAllowedMemberships);
 
+=======
+    const {
+      enabled = false,
+      max_allowed_memberships = 0,
+      force_organization_selection = false,
+      actions,
+      domains,
+    } = data || {};
+    this.enabled = enabled;
+    this.maxAllowedMemberships = max_allowed_memberships;
+    this.forceOrganizationSelection = force_organization_selection;
+    this.actions = { adminDelete: actions?.admin_delete || false };
+    this.domains = {
+      enabled: domains?.enabled || false,
+      enrollmentModes: domains?.enrollment_modes || [],
+      defaultRole: domains?.default_role || null,
+    };
+>>>>>>> 6413d61b9 (Add `force_organization_selection` to environment resource)
     return this;
   }
 

--- a/packages/clerk-js/src/core/resources/__tests__/Environment.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Environment.test.ts
@@ -237,6 +237,7 @@ describe('Environment', () => {
       organization_settings: {
         enabled: false,
         max_allowed_memberships: 5,
+        force_organization_selection: false,
         actions: { admin_delete: true },
         domains: { enabled: false, enrollment_modes: [], default_role: null },
       },

--- a/packages/clerk-js/src/core/resources/__tests__/__snapshots__/Environment.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__tests__/__snapshots__/Environment.test.ts.snap
@@ -581,6 +581,7 @@ Environment {
       "enrollmentModes": [],
     },
     "enabled": false,
+    "forceOrganizationSelection": false,
     "maxAllowedMemberships": 5,
     "pathRoot": "",
   },

--- a/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
@@ -185,6 +185,24 @@ describe('OrganizationList', () => {
         expect(queryByRole('button', { name: 'Join' })).not.toBeInTheDocument();
       });
     });
+
+    describe('with force organization selection setting on environment', () => {
+      it('does not show the personal account', async () => {
+        const { wrapper } = await createFixtures(f => {
+          f.withOrganizations();
+          f.withForceOrganizationSelection();
+          f.withUser({
+            email_addresses: ['test@clerk.com'],
+            organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
+          });
+        });
+        const { queryByText } = render(<OrganizationList />, { wrapper });
+
+        await waitFor(() => {
+          expect(queryByText('Personal account')).not.toBeInTheDocument();
+        });
+      });
+    });
   });
 
   describe('CreateOrganization', () => {

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -45,6 +45,19 @@ describe('OrganizationSwitcher', () => {
       expect(queryByText('Personal Workspace')).toBeNull();
       expect(getByText('No organization selected')).toBeInTheDocument();
     });
+
+    describe('with force organization selection setting on environment', () => {
+      it('does not show the personal workspace', async () => {
+        const { wrapper } = await createFixtures(f => {
+          f.withOrganizations();
+          f.withForceOrganizationSelection();
+          f.withUser({ email_addresses: ['test@clerk.com'] });
+        });
+        const { queryByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
+        await userEvent.click(getByRole('button'));
+        expect(queryByText('Personal Workspace')).toBeNull();
+      });
+    });
   });
 
   describe('OrganizationSwitcherTrigger', () => {

--- a/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTask/SessionTask.tsx
@@ -7,8 +7,12 @@ import { OrganizationList } from '../OrganizationList';
 
 const ContentRegistry: Record<SessionTask['key'], React.ComponentType> = {
   org: () => (
-    // TODO - Hide personal workspace within organization list context based on environment
-    <OrganizationListContext.Provider value={{ componentName: 'OrganizationList', hidePersonal: true }}>
+    <OrganizationListContext.Provider
+      value={{
+        componentName: 'OrganizationList',
+        skipInvitationScreen: true,
+      }}
+    >
       <OrganizationList />
     </OrganizationListContext.Provider>
   ),

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
@@ -11,7 +11,7 @@ export const OrganizationListContext = createContext<OrganizationListCtx | null>
 export const useOrganizationListContext = () => {
   const context = useContext(OrganizationListContext);
   const { navigate } = useRouter();
-  const { displayConfig } = useEnvironment();
+  const { displayConfig, organizationSettings } = useEnvironment();
 
   if (!context || context.componentName !== 'OrganizationList') {
     throw new Error('Clerk: useOrganizationListContext called outside OrganizationList.');
@@ -80,7 +80,7 @@ export const useOrganizationListContext = () => {
     afterCreateOrganizationUrl,
     skipInvitationScreen: ctx.skipInvitationScreen || false,
     hideSlug: ctx.hideSlug || false,
-    hidePersonal: ctx.hidePersonal || false,
+    hidePersonal: organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false,
     navigateAfterCreateOrganization,
     navigateAfterSelectOrganization,
     navigateAfterSelectPersonal,

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
@@ -1,5 +1,3 @@
-import { useClerk } from '@clerk/shared/react';
-import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { OrganizationResource, UserResource } from '@clerk/types';
 import { createContext, useContext } from 'react';
 
@@ -12,7 +10,6 @@ export const OrganizationListContext = createContext<OrganizationListCtx | null>
 
 export const useOrganizationListContext = () => {
   const context = useContext(OrganizationListContext);
-  const clerk = useClerk();
   const { navigate } = useRouter();
   const { displayConfig, organizationSettings } = useEnvironment();
 
@@ -77,15 +74,6 @@ export const useOrganizationListContext = () => {
   const navigateAfterSelectOrganization = (organization: OrganizationResource) =>
     navigateAfterSelectOrganizationOrPersonal({ organization });
   const navigateAfterSelectPersonal = (user: UserResource) => navigateAfterSelectOrganizationOrPersonal({ user });
-
-  const hidePersonal = organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false;
-
-  clerk?.telemetry?.record(
-    eventComponentMounted('OrganizationList', {
-      hidePersonal,
-      forceOrganizationSelection: organizationSettings.forceOrganizationSelection,
-    }),
-  );
 
   return {
     ...ctx,

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationList.ts
@@ -1,3 +1,5 @@
+import { useClerk } from '@clerk/shared/react';
+import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { OrganizationResource, UserResource } from '@clerk/types';
 import { createContext, useContext } from 'react';
 
@@ -10,6 +12,7 @@ export const OrganizationListContext = createContext<OrganizationListCtx | null>
 
 export const useOrganizationListContext = () => {
   const context = useContext(OrganizationListContext);
+  const clerk = useClerk();
   const { navigate } = useRouter();
   const { displayConfig, organizationSettings } = useEnvironment();
 
@@ -74,6 +77,15 @@ export const useOrganizationListContext = () => {
   const navigateAfterSelectOrganization = (organization: OrganizationResource) =>
     navigateAfterSelectOrganizationOrPersonal({ organization });
   const navigateAfterSelectPersonal = (user: UserResource) => navigateAfterSelectOrganizationOrPersonal({ user });
+
+  const hidePersonal = organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false;
+
+  clerk?.telemetry?.record(
+    eventComponentMounted('OrganizationList', {
+      hidePersonal,
+      forceOrganizationSelection: organizationSettings.forceOrganizationSelection,
+    }),
+  );
 
   return {
     ...ctx,

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
@@ -11,7 +11,7 @@ export const OrganizationSwitcherContext = createContext<OrganizationSwitcherCtx
 export const useOrganizationSwitcherContext = () => {
   const context = useContext(OrganizationSwitcherContext);
   const { navigate } = useRouter();
-  const { displayConfig } = useEnvironment();
+  const { displayConfig, organizationSettings } = useEnvironment();
 
   if (!context || context.componentName !== 'OrganizationSwitcher') {
     throw new Error('Clerk: useOrganizationSwitcherContext called outside OrganizationSwitcher.');
@@ -96,7 +96,7 @@ export const useOrganizationSwitcherContext = () => {
 
   return {
     ...ctx,
-    hidePersonal: ctx.hidePersonal || false,
+    hidePersonal: organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false,
     organizationProfileMode: organizationProfileMode || 'modal',
     createOrganizationMode: createOrganizationMode || 'modal',
     skipInvitationScreen: ctx.skipInvitationScreen || false,

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
@@ -1,3 +1,5 @@
+import { useClerk } from '@clerk/shared/react';
+import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { OrganizationResource, UserResource } from '@clerk/types';
 import { createContext, useContext } from 'react';
 
@@ -10,6 +12,7 @@ export const OrganizationSwitcherContext = createContext<OrganizationSwitcherCtx
 
 export const useOrganizationSwitcherContext = () => {
   const context = useContext(OrganizationSwitcherContext);
+  const clerk = useClerk();
   const { navigate } = useRouter();
   const { displayConfig, organizationSettings } = useEnvironment();
 
@@ -93,6 +96,15 @@ export const useOrganizationSwitcherContext = () => {
 
   const createOrganizationMode =
     !!ctx.createOrganizationUrl && !ctx.createOrganizationMode ? 'navigation' : ctx.createOrganizationMode;
+
+  const hidePersonal = organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false;
+
+  clerk?.telemetry?.record(
+    eventComponentMounted('OrganizationList', {
+      hidePersonal,
+      forceOrganizationSelection: organizationSettings.forceOrganizationSelection,
+    }),
+  );
 
   return {
     ...ctx,

--- a/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
+++ b/packages/clerk-js/src/ui/contexts/components/OrganizationSwitcher.ts
@@ -1,5 +1,3 @@
-import { useClerk } from '@clerk/shared/react';
-import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { OrganizationResource, UserResource } from '@clerk/types';
 import { createContext, useContext } from 'react';
 
@@ -12,7 +10,6 @@ export const OrganizationSwitcherContext = createContext<OrganizationSwitcherCtx
 
 export const useOrganizationSwitcherContext = () => {
   const context = useContext(OrganizationSwitcherContext);
-  const clerk = useClerk();
   const { navigate } = useRouter();
   const { displayConfig, organizationSettings } = useEnvironment();
 
@@ -96,15 +93,6 @@ export const useOrganizationSwitcherContext = () => {
 
   const createOrganizationMode =
     !!ctx.createOrganizationUrl && !ctx.createOrganizationMode ? 'navigation' : ctx.createOrganizationMode;
-
-  const hidePersonal = organizationSettings.forceOrganizationSelection || ctx.hidePersonal || false;
-
-  clerk?.telemetry?.record(
-    eventComponentMounted('OrganizationList', {
-      hidePersonal,
-      forceOrganizationSelection: organizationSettings.forceOrganizationSelection,
-    }),
-  );
 
   return {
     ...ctx,

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -317,13 +317,16 @@ const createOrganizationSettingsFixtureHelpers = (environment: EnvironmentJSON) 
   const withMaxAllowedMemberships = ({ max = 5 }) => {
     os.max_allowed_memberships = max;
   };
+  const withForceOrganizationSelection = () => {
+    os.force_organization_selection = true;
+  };
 
   const withOrganizationDomains = (modes?: OrganizationEnrollmentMode[], defaultRole?: string) => {
     os.domains.enabled = true;
     os.domains.enrollment_modes = modes || ['automatic_invitation', 'automatic_invitation', 'manual_invitation'];
     os.domains.default_role = defaultRole ?? null;
   };
-  return { withOrganizations, withMaxAllowedMemberships, withOrganizationDomains };
+  return { withOrganizations, withMaxAllowedMemberships, withOrganizationDomains, withForceOrganizationSelection };
 };
 
 const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -82,6 +82,7 @@ const createBaseOrganizationSettings = (): OrganizationSettingsJSON => {
   return {
     enabled: false,
     max_allowed_memberships: 5,
+    force_organization_selection: false,
     domains: {
       enabled: false,
       enrollment_modes: [],

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -8,6 +8,7 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
   object: never;
   enabled: boolean;
   max_allowed_memberships: number;
+  force_organization_selection: boolean;
   actions: {
     admin_delete: boolean;
   };
@@ -21,6 +22,7 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
 export interface OrganizationSettingsResource extends ClerkResource {
   enabled: boolean;
   maxAllowedMemberships: number;
+  forceOrganizationSelection: boolean;
   actions: {
     adminDelete: boolean;
   };


### PR DESCRIPTION
## Description

Resolves ORGS-537

Introduces `force_organization_selection` on environment settings. When enabled, all organization components should hide the "personal workspace" options. 

This is also important for the after-auth flow with `force_organization_selection`, to avoid displaying the option to select a personal account on `OrganizationList`, and to also not display "Personal Workspace" on `OrganizationSwitcher` 

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
