### PR TITLE
feat(localizations): Add waitlist values for es-MX

### DIFF
--- a/.changeset/long-toys-boil.md
+++ b/.changeset/long-toys-boil.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+feat(localizations): Add waitlist values for es-MX

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -953,16 +953,16 @@ export const esMX: LocalizationResource = {
   },
   waitlist: {
     start: {
-      actionLink: undefined,
-      actionText: undefined,
-      formButton: undefined,
-      subtitle: undefined,
-      title: undefined,
+      actionLink: 'Acceder',
+      actionText: 'Cuentas con acceso?',
+      formButton: 'Unete a la lista de espera',
+      subtitle: 'Ingresa tu correo electrónico y te avisaremos cuando tu lugar esté listo',
+      title: 'Unete a la lista de espera',
     },
     success: {
-      message: undefined,
-      subtitle: undefined,
-      title: undefined,
+      message: 'Serás redirigido pronto...',
+      subtitle: 'Nos pondremos en contacto contigo cuando tu lugar esté listo',
+      title: 'Gracias por unirte a la lista de espera!',
     },
   },
 } as const;


### PR DESCRIPTION
## Description

Just added the waitlist strings for es-MX.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Localizations added
