### PR TITLE
fix(backend): Handle Basic auth gracefully

### DIFF
--- a/.changeset/ninety-bugs-jam.md
+++ b/.changeset/ninety-bugs-jam.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': patch
+'@clerk/nextjs': patch
+---
+
+Handle Basic auth gracefully

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -455,6 +455,30 @@ describe('tokens.authenticateRequest(options)', () => {
   // HTTP Authorization exists
   //
 
+  test('does not throw error with missing auth scheme from Authorization header', async () => {
+    server.use(
+      http.get('https://api.clerk.test/v1/jwks', () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    await expect(
+      authenticateRequest(mockRequestWithHeaderAuth({ authorization: mockInvalidSignatureJwt }), mockOptions()),
+    ).resolves.not.toThrow();
+  });
+
+  test('does not throw error with Basic auth scheme from Authorization header', async () => {
+    server.use(
+      http.get('https://api.clerk.test/v1/jwks', () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    await expect(
+      authenticateRequest(mockRequestWithHeaderAuth({ authorization: 'Basic dXNlcjpwYXNzd29yZA==' }), mockOptions()),
+    ).resolves.not.toThrow();
+  });
+
   test('returns signed out state if jwk fails to load from remote', async () => {
     server.use(
       http.get('https://api.clerk.test/v1/jwks', () => {

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -250,7 +250,7 @@ const mockOptions = (options?) => {
 };
 
 const mockRequestWithHeaderAuth = (headers?, requestUrl?) => {
-  return mockRequest({ authorization: mockJwt, ...headers }, requestUrl);
+  return mockRequest({ authorization: `Bearer ${mockJwt}`, ...headers }, requestUrl);
 };
 
 const mockRequestWithCookies = (headers?, cookies = {}, requestUrl?) => {
@@ -545,7 +545,7 @@ describe('tokens.authenticateRequest(options)', () => {
 
     const requestState = await authenticateRequest(
       mockRequestWithHeaderAuth({
-        authorization: mockInvalidSignatureJwt,
+        authorization: `Bearer ${mockInvalidSignatureJwt}`,
       }),
       mockOptions(),
     );
@@ -560,7 +560,7 @@ describe('tokens.authenticateRequest(options)', () => {
 
   test('headerToken: returns signed out state when an malformed token [1y.1n]', async () => {
     const requestState = await authenticateRequest(
-      mockRequestWithHeaderAuth({ authorization: 'test_header_token' }),
+      mockRequestWithHeaderAuth({ authorization: 'Bearer test_header_token' }),
       mockOptions(),
     );
 

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -171,7 +171,7 @@ class AuthenticateContext implements AuthenticateContext {
   }
 
   private initHeaderValues() {
-    this.sessionTokenInHeader = this.stripAuthorizationHeader(this.getHeader(constants.Headers.Authorization));
+    this.sessionTokenInHeader = this.parseAuthorizationHeader(this.getHeader(constants.Headers.Authorization));
     this.origin = this.getHeader(constants.Headers.Origin);
     this.host = this.getHeader(constants.Headers.Host);
     this.forwardedHost = this.getHeader(constants.Headers.ForwardedHost);
@@ -200,10 +200,6 @@ class AuthenticateContext implements AuthenticateContext {
     this.handshakeRedirectLoopCounter = Number(this.getCookie(constants.Cookies.RedirectCount)) || 0;
   }
 
-  private stripAuthorizationHeader(authValue: string | undefined | null): string | undefined {
-    return authValue?.replace('Bearer ', '');
-  }
-
   private getQueryParam(name: string) {
     return this.clerkRequest.clerkUrl.searchParams.get(name);
   }
@@ -225,6 +221,18 @@ class AuthenticateContext implements AuthenticateContext {
       return this.getSuffixedCookie(cookieName);
     }
     return this.getCookie(cookieName);
+  }
+
+  private parseAuthorizationHeader(authorizationHeader: string | undefined | null): string | undefined {
+    if (!authorizationHeader) {
+      return undefined;
+    }
+
+    if (authorizationHeader.startsWith('Bearer ')) {
+      return authorizationHeader.slice('Bearer '.length);
+    }
+
+    return undefined;
   }
 
   private tokenHasIssuer(token: string): boolean {

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -224,15 +224,7 @@ class AuthenticateContext implements AuthenticateContext {
   }
 
   private parseAuthorizationHeader(authorizationHeader: string | undefined | null): string | undefined {
-    if (!authorizationHeader) {
-      return undefined;
-    }
-
-    if (authorizationHeader.startsWith('Bearer ')) {
-      return authorizationHeader.slice('Bearer '.length);
-    }
-
-    return undefined;
+    return authorizationHeader?.startsWith('Bearer ') ? authorizationHeader.slice(7) : undefined;
   }
 
   private tokenHasIssuer(token: string): boolean {

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -224,7 +224,23 @@ class AuthenticateContext implements AuthenticateContext {
   }
 
   private parseAuthorizationHeader(authorizationHeader: string | undefined | null): string | undefined {
-    return authorizationHeader?.startsWith('Bearer ') ? authorizationHeader.slice(7) : undefined;
+    if (!authorizationHeader) {
+      return undefined;
+    }
+
+    const [scheme, token] = authorizationHeader.split(' ', 2);
+
+    if (!token) {
+      // No scheme specified, treat the entire value as the token
+      return scheme;
+    }
+
+    if (scheme === 'Bearer') {
+      return token;
+    }
+
+    // Skip all other schemes
+    return undefined;
   }
 
   private tokenHasIssuer(token: string): boolean {

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -144,6 +144,11 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
       logger.debug('options', options);
       logger.debug('url', () => clerkRequest.toJSON());
 
+      const authHeader = request.headers.get('authorization');
+      if (authHeader && authHeader.startsWith('Basic ')) {
+        logger.debug('Basic Auth detected');
+      }
+
       const requestState = await resolvedClerkClient.authenticateRequest(
         clerkRequest,
         createAuthenticateRequestOptions(clerkRequest, options),


### PR DESCRIPTION
## Description

Handle cases where we get Authorization header with basic auth, like `Basic ....` instead of `Bearer ....`

Right now we would throw an error since we assume any authorization header contains a `Bearer` token.

Also switched from `.replace` to `.slice` for perf since we know the string will begin with `Basic ` or `Bearer ` 

Fixes: SDKI-896

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
