### PR TITLE
feat(clerk-js,shared): Refactor useReverification to support custom UIs

### DIFF
--- a/.changeset/pretty-months-wonder.md
+++ b/.changeset/pretty-months-wonder.md
@@ -1,0 +1,9 @@
+---
+'@clerk/react-router': patch
+'@clerk/clerk-js': patch
+'@clerk/nextjs': patch
+'@clerk/clerk-react': patch
+'@clerk/remix': patch
+---
+
+Export `isReverificationCancelledError` error helper

--- a/.changeset/tricky-deers-know.md
+++ b/.changeset/tricky-deers-know.md
@@ -9,15 +9,20 @@ This introducing changes to `useReverification`, the changes include removing th
 import { useReverification } from '@clerk/clerk-react'
 import { isReverificationCancelledError } from '@clerk/clerk-react/error'
 
-export function MyButton() {
-  const enhancedFetcher = useReverification(() => fetch('/api/balance'))
+type MyData = {
+  balance: number
+}
 
+export function MyButton() {
+  const fetchMyData = () => fetch('/api/balance').then(res=> res.json() as Promise<MyData>)
+  const enhancedFetcher = useReverification(fetchMyData);
+  
   const handleClick = async () => {
     try {
       const myData = await enhancedFetcher()
+      //     ^ is typed as `MyData`
     } catch (e) {
       // Handle error returned from the fetcher here
-
       // You can also handle cancellation with the following
       if (isReverificationCancelledError(err)) {
         // Handle the cancellation error here
@@ -37,8 +42,13 @@ to handle re-verification flow. When the handler is passed the default UI our AI
 import { useReverification } from '@clerk/clerk-react'
 import { isReverificationCancelledError } from '@clerk/clerk-react/error'
 
+type MyData = {
+  balance: number
+}
+
 export function MyButton() {
-  const enhancedFetcher = useReverification(() => fetch('/api/balance'), {
+  const fetchMyData = () => fetch('/api/balance').then(res=> res.json() as Promise<MyData>)
+  const enhancedFetcher = useReverification(fetchMyData, {
     onNeedsReverification: ({ complete, cancel, level }) => {
       // e.g open a modal here and handle the re-verification flow
     }
@@ -47,6 +57,7 @@ export function MyButton() {
   const handleClick = async () => {
     try {
       const myData = await enhancedFetcher()
+      //     ^ is typed as `MyData`
     } catch (e) {
       // Handle error returned from the fetcher here
 

--- a/.changeset/tricky-deers-know.md
+++ b/.changeset/tricky-deers-know.md
@@ -7,7 +7,7 @@ This introducing changes to `useReverification`, the changes include removing th
 
 ```tsx {{ filename: 'src/components/MyButton.tsx' }}
 import { useReverification } from '@clerk/clerk-react'
-import { isClerkRuntimeError } from '@clerk/clerk-react/error'
+import { isReverificationCancelledError } from '@clerk/clerk-react/error'
 
 export function MyButton() {
   const enhancedFetcher = useReverification(() => fetch('/api/balance'))
@@ -15,14 +15,11 @@ export function MyButton() {
   const handleClick = async () => {
     try {
       const myData = await enhancedFetcher()
-      // If `myData` is null, the user canceled the reverification process
-      // You can choose how your app responds. This example returns null.
-      if (!myData) return
     } catch (e) {
-      // Handle error returned from the fetcher
+      // Handle error returned from the fetcher here
 
       // You can also handle cancellation with the following
-      if (isClerkRuntimeError(err) && err.code === 'reverification_cancelled') {
+      if (isReverificationCancelledError(err)) {
         // Handle the cancellation error here
       }
     }
@@ -37,8 +34,8 @@ to handle re-verification flow. When the handler is passed the default UI our AI
 
 
 ```tsx {{ filename: 'src/components/MyButtonCustom.tsx' }}
-import { useReverification } from '@clerk/react'
-import { isClerkRuntimeError } from '@clerk/react/error'
+import { useReverification } from '@clerk/clerk-react'
+import { isReverificationCancelledError } from '@clerk/clerk-react/error'
 
 export function MyButton() {
   const enhancedFetcher = useReverification(() => fetch('/api/balance'), {
@@ -50,11 +47,13 @@ export function MyButton() {
   const handleClick = async () => {
     try {
       const myData = await enhancedFetcher()
-      // If `myData` is null, the user canceled the reverification process
-      // You can choose how your app responds. This example returns null.
-      if (!myData) return
     } catch (e) {
-      // Handle error returned from the fetcher
+      // Handle error returned from the fetcher here
+
+      // You can also handle cancellation with the following
+      if (isReverificationCancelledError(err)) {
+        // Handle the cancellation error here
+      }
     }
   }
 

--- a/.changeset/tricky-deers-know.md
+++ b/.changeset/tricky-deers-know.md
@@ -6,8 +6,8 @@
 This introducing changes to `useReverification`, the changes include removing the array and returning the fetcher directly and also the dropping the options `throwOnCancel` and `onCancel` in favour of always throwing the cancellation error.
 
 ```tsx {{ filename: 'src/components/MyButton.tsx' }}
-import { useReverification } from '@clerk/react'
-import { isClerkRuntimeError } from '@clerk/react/error'
+import { useReverification } from '@clerk/clerk-react'
+import { isClerkRuntimeError } from '@clerk/clerk-react/error'
 
 export function MyButton() {
   const enhancedFetcher = useReverification(() => fetch('/api/balance'))

--- a/.changeset/tricky-deers-know.md
+++ b/.changeset/tricky-deers-know.md
@@ -1,0 +1,63 @@
+---
+'@clerk/shared': minor
+'@clerk/clerk-js': patch
+---
+
+This introducing changes to `useReverification`, the changes include removing the array and returning the fetcher directly and also the dropping the options `throwOnCancel` and `onCancel` in favour of always throwing the cancellation error.
+
+```tsx {{ filename: 'src/components/MyButton.tsx' }}
+import { useReverification } from '@clerk/react'
+import { isClerkRuntimeError } from '@clerk/react/error'
+
+export function MyButton() {
+  const enhancedFetcher = useReverification(() => fetch('/api/balance'))
+
+  const handleClick = async () => {
+    try {
+      const myData = await enhancedFetcher()
+      // If `myData` is null, the user canceled the reverification process
+      // You can choose how your app responds. This example returns null.
+      if (!myData) return
+    } catch (e) {
+      // Handle error returned from the fetcher
+
+      // You can also handle cancellation with the following
+      if (isClerkRuntimeError(err) && err.code === 'reverification_cancelled') {
+        // Handle the cancellation error here
+      }
+    }
+  }
+
+  return <button onClick={handleClick}>Update User</button>
+}
+```
+
+These changes are also adding a new handler in options called `onNeedsReverification`, which can be used to create a custom UI
+to handle re-verification flow. When the handler is passed the default UI our AIO components provide will not be triggered so you will have to create and handle the re-verification process.
+
+
+```tsx {{ filename: 'src/components/MyButtonCustom.tsx' }}
+import { useReverification } from '@clerk/react'
+import { isClerkRuntimeError } from '@clerk/react/error'
+
+export function MyButton() {
+  const enhancedFetcher = useReverification(() => fetch('/api/balance'), {
+    onNeedsReverification: ({ complete, cancel, level }) => {
+      // e.g open a modal here and handle the re-verification flow
+    }
+  })
+
+  const handleClick = async () => {
+    try {
+      const myData = await enhancedFetcher()
+      // If `myData` is null, the user canceled the reverification process
+      // You can choose how your app responds. This example returns null.
+      if (!myData) return
+    } catch (e) {
+      // Handle error returned from the fetcher
+    }
+  }
+
+  return <button onClick={handleClick}>Update User</button>
+}
+```

--- a/integration/templates/next-app-router/src/app/(reverification)/action-with-use-reverification/page.tsx
+++ b/integration/templates/next-app-router/src/app/(reverification)/action-with-use-reverification/page.tsx
@@ -4,7 +4,7 @@ import { useReverification } from '@clerk/nextjs';
 import { logUserIdActionReverification } from '@/app/(reverification)/actions';
 
 function Page() {
-  const [logUserWithReverification] = useReverification(logUserIdActionReverification);
+  const logUserWithReverification = useReverification(logUserIdActionReverification);
   const [pending, startTransition] = useTransition();
   const [res, setRes] = useState(null);
 

--- a/integration/tests/reverification.test.ts
+++ b/integration/tests/reverification.test.ts
@@ -144,11 +144,8 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
       await u.page.getByRole('button', { name: /^add$/i }).click();
 
       await u.po.userVerification.waitForMounted();
-
       await u.po.userVerification.closeReverificationModal();
-
       await u.po.userVerification.waitForClosed();
-      await u.po.userProfile.enterTestOtpCode();
 
       await expect(u.page.locator('.cl-profileSectionItem__emailAddresses')).not.toContainText(newFakeEmail);
     });

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "580kB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "78.5kB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "78.6kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "55KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "94KB" },
     { "path": "./dist/vendors*.js", "maxSize": "30KB" },

--- a/packages/clerk-js/src/ui/common/RemoveResourceForm.tsx
+++ b/packages/clerk-js/src/ui/common/RemoveResourceForm.tsx
@@ -17,7 +17,7 @@ type RemoveFormProps = FormProps & {
 export const RemoveResourceForm = withCardStateProvider((props: RemoveFormProps) => {
   const { title, messageLine1, messageLine2, deleteResource, onSuccess, onReset } = props;
   const card = useCardState();
-  const [deleteWithReverification] = useReverification(deleteResource);
+  const deleteWithReverification = useReverification(deleteResource);
 
   const handleSubmit = async () => {
     try {

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -61,12 +61,9 @@ const DeviceItem = ({ session }: { session: SessionWithActivitiesResource }) => 
       return;
     }
     status.setLoading();
-    return (
-      revokeSession()
-        // TODO-STEPUP: Properly handler the response with a setCardError
-        .catch(err => handleError(err, [], status.setError))
-        .finally(() => status.setIdle())
-    );
+    return revokeSession()
+      .catch(err => handleError(err, [], status.setError))
+      .finally(() => status.setIdle());
   };
 
   return (

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -6,7 +6,7 @@ import { FullHeightLoader, ProfileSection, ThreeDotsMenu } from '../../elements'
 import { useFetch, useLoadingStatus } from '../../hooks';
 import { DeviceLaptop, DeviceMobile } from '../../icons';
 import { mqu, type PropsOfComponent } from '../../styledSystem';
-import { getRelativeToNowDateKey } from '../../utils';
+import { getRelativeToNowDateKey, handleError } from '../../utils';
 import { currentSessionFirst } from './utils';
 
 export const ActiveDevicesSection = () => {
@@ -54,7 +54,7 @@ const isSignedInStatus = (status: string): status is SignedInSessionResource['st
 const DeviceItem = ({ session }: { session: SessionWithActivitiesResource }) => {
   const isCurrent = useSession().session?.id === session.id;
   const status = useLoadingStatus();
-  const [revokeSession] = useReverification(session.revoke.bind(session));
+  const revokeSession = useReverification(session.revoke.bind(session));
 
   const revoke = async () => {
     if (isCurrent || !session) {
@@ -64,7 +64,7 @@ const DeviceItem = ({ session }: { session: SessionWithActivitiesResource }) => 
     return (
       revokeSession()
         // TODO-STEPUP: Properly handler the response with a setCardError
-        .catch(() => {})
+        .catch(err => handleError(err, [], status.setError))
         .finally(() => status.setIdle())
     );
   };
@@ -76,15 +76,14 @@ const DeviceItem = ({ session }: { session: SessionWithActivitiesResource }) => 
       elementId={isCurrent ? descriptors.activeDeviceListItem.setId('current') : undefined}
       sx={{
         alignItems: 'flex-start',
+        opacity: status.isLoading ? 0.5 : 1,
       }}
+      isDisabled={status.isLoading}
     >
-      {status.isLoading && <FullHeightLoader />}
-      {!status.isLoading && (
-        <>
-          <DeviceInfo session={session} />
-          {!isCurrent && <ActiveDeviceMenu revoke={revoke} />}
-        </>
-      )}
+      <>
+        <DeviceInfo session={session} />
+        {!isCurrent && <ActiveDeviceMenu revoke={revoke} />}
+      </>
     </ProfileSection.Item>
   );
 };

--- a/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
@@ -28,7 +28,7 @@ export const AddAuthenticatorApp = withCardStateProvider((props: AddAuthenticato
   const { title, onSuccess, onReset } = props;
   const { user } = useUser();
   const card = useCardState();
-  const [createTOTP] = useReverification(() => user?.createTOTP());
+  const createTOTP = useReverification(() => user?.createTOTP());
   const { close } = useActionContext();
   const [totp, setTOTP] = React.useState<TOTPResource | undefined>(undefined);
   const [displayFormat, setDisplayFormat] = React.useState<DisplayFormat>('qr');

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsMenu.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsMenu.tsx
@@ -19,7 +19,7 @@ const ConnectMenuButton = (props: { strategy: OAuthStrategy; onClick?: () => voi
   const { additionalOAuthScopes, componentName, mode } = useUserProfileContext();
   const isModal = mode === 'modal';
 
-  const [createExternalAccount] = useReverification(() => {
+  const createExternalAccount = useReverification(() => {
     const socialProvider = strategy.replace('oauth_', '') as OAuthProvider;
     const redirectUrl = isModal
       ? appendModalState({ url: window.location.href, componentName, socialProvider: socialProvider })

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -104,7 +104,7 @@ const ConnectedAccount = ({ account }: { account: ExternalAccountResource }) => 
       })
     : window.location.href;
 
-  const [createExternalAccount] = useReverification(() =>
+  const createExternalAccount = useReverification(() =>
     user?.createExternalAccount({
       strategy: account.verification!.strategy as OAuthStrategy,
       redirectUrl,

--- a/packages/clerk-js/src/ui/components/UserProfile/DeleteUserForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/DeleteUserForm.tsx
@@ -16,7 +16,7 @@ export const DeleteUserForm = withCardStateProvider((props: DeleteUserFormProps)
   const { t } = useLocalizations();
   const { otherSessions } = useMultipleSessions({ user });
   const { setActive } = useClerk();
-  const [deleteUserWithReverification] = useReverification(() => user?.delete());
+  const deleteUserWithReverification = useReverification(() => user?.delete());
 
   const confirmationField = useFormControl('deleteConfirmation', '', {
     type: 'text',

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailForm.tsx
@@ -21,7 +21,7 @@ export const EmailForm = withCardStateProvider((props: EmailFormProps) => {
   const { user } = useUser();
   const environment = useEnvironment();
 
-  const [createEmailAddress] = useReverification((email: string) => user?.createEmailAddress({ email }));
+  const createEmailAddress = useReverification((email: string) => user?.createEmailAddress({ email }));
 
   const emailAddressRef = React.useRef<EmailAddressResource | undefined>(user?.emailAddresses.find(a => a.id === id));
   const strategy = getEmailAddressVerificationStrategy(emailAddressRef.current, environment);

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailsSection.tsx
@@ -111,7 +111,7 @@ const EmailMenu = ({ email }: { email: EmailAddressResource }) => {
   const emailId = email.id;
   const isPrimary = user?.primaryEmailAddressId === emailId;
   const isVerified = email.verification.status === 'verified';
-  const [setPrimary] = useReverification(() => {
+  const setPrimary = useReverification(() => {
     return user?.update({ primaryEmailAddressId: emailId });
   });
 

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeCreateForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeCreateForm.tsx
@@ -1,4 +1,4 @@
-import { isClerkRuntimeError } from '@clerk/shared/error';
+import { isReverificationCancelledError } from '@clerk/shared/error';
 import { useReverification, useUser } from '@clerk/shared/react';
 import type { BackupCodeResource } from '@clerk/types';
 import React from 'react';
@@ -31,7 +31,7 @@ export const MfaBackupCodeCreateForm = withCardStateProvider((props: MfaBackupCo
     void createBackupCode()
       .then(backupCode => setBackupCode(backupCode))
       .catch(err => {
-        if (isClerkRuntimeError(err) && err.code === 'reverification_cancelled') {
+        if (isReverificationCancelledError(err)) {
           return onReset();
         }
 

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodeScreen.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodeScreen.tsx
@@ -88,7 +88,7 @@ const EnableMFAButtonForPhone = (
 ) => {
   const { phone, onSuccess, onUnverifiedPhoneClick, resourceRef } = props;
   const card = useCardState();
-  const [setReservedForSecondFactor] = useReverification(() => phone.setReservedForSecondFactor({ reserved: true }));
+  const setReservedForSecondFactor = useReverification(() => phone.setReservedForSecondFactor({ reserved: true }));
 
   const { country } = getCountryFromPhoneString(phone.phoneNumber);
   const formattedPhone = stringToFormattedPhoneString(phone.phoneNumber);
@@ -134,7 +134,7 @@ export const MFAVerifyPhone = (props: MFAVerifyPhoneProps) => {
   const { title, onSuccess, resourceRef, onReset } = props;
   const card = useCardState();
   const phone = resourceRef.current;
-  const [setReservedForSecondFactor] = useReverification(() => phone?.setReservedForSecondFactor({ reserved: true }));
+  const setReservedForSecondFactor = useReverification(() => phone?.setReservedForSecondFactor({ reserved: true }));
 
   const enableMfa = async () => {
     card.setLoading(phone?.id);

--- a/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasskeySection.tsx
@@ -201,7 +201,7 @@ const AddPasskeyButton = ({ onClick }: { onClick?: () => void }) => {
   const card = useCardState();
   const { isSatellite } = useClerk();
   const { user } = useUser();
-  const [createPasskey] = useReverification(() => user?.createPasskey());
+  const createPasskey = useReverification(() => user?.createPasskey());
 
   const handleCreatePasskey = async () => {
     onClick?.();

--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordForm.tsx
@@ -37,7 +37,7 @@ type PasswordFormProps = FormProps;
 export const PasswordForm = withCardStateProvider((props: PasswordFormProps) => {
   const { onSuccess, onReset } = props;
   const { user } = useUser();
-  const [updatePasswordWithReverification] = useReverification(
+  const updatePasswordWithReverification = useReverification(
     (user: UserResource, opts: Parameters<UserResource['updatePassword']>) => user.updatePassword(...opts),
   );
 

--- a/packages/clerk-js/src/ui/components/UserProfile/PhoneForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhoneForm.tsx
@@ -49,7 +49,7 @@ export const AddPhone = (props: AddPhoneProps) => {
   const { title, onSuccess, onReset, onUseExistingNumberClick, resourceRef } = props;
   const card = useCardState();
   const { user } = useUser();
-  const [createPhoneNumber] = useReverification(
+  const createPhoneNumber = useReverification(
     (user: UserResource, opt: Parameters<UserResource['createPhoneNumber']>[0]) => user.createPhoneNumber(opt),
   );
 

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
@@ -12,7 +12,7 @@ export const UsernameForm = withCardStateProvider((props: UsernameFormProps) => 
   const { onSuccess, onReset } = props;
   const { user } = useUser();
 
-  const [updateUsername] = useReverification((username: string) => user?.update({ username }));
+  const updateUsername = useReverification((username: string) => user?.update({ username }));
 
   const { userSettings } = useEnvironment();
   const card = useCardState();

--- a/packages/clerk-js/src/ui/components/UserProfile/Web3Form.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/Web3Form.tsx
@@ -1,4 +1,4 @@
-import { useUser } from '@clerk/shared/react';
+import { useReverification, useUser } from '@clerk/shared/react';
 import type { Web3Provider, Web3Strategy } from '@clerk/types';
 
 import { generateWeb3Signature, getWeb3Identifier } from '../../../utils/web3';
@@ -17,6 +17,9 @@ export const AddWeb3WalletActionMenu = withCardStateProvider(({ onClick }: { onC
   const unconnectedStrategies = enabledStrategies.filter(strategy => {
     return !connectedStrategies.includes(strategy);
   });
+  const createWeb3Wallet = useReverification((identifier: string) =>
+    user?.createWeb3Wallet({ web3Wallet: identifier }),
+  );
 
   const connect = async (strategy: Web3Strategy) => {
     const provider = strategy.replace('web3_', '').replace('_signature', '') as Web3Provider;
@@ -30,11 +33,11 @@ export const AddWeb3WalletActionMenu = withCardStateProvider(({ onClick }: { onC
         throw new Error('user is not defined');
       }
 
-      let web3Wallet = await user.createWeb3Wallet({ web3Wallet: identifier });
-      web3Wallet = await web3Wallet.prepareVerification({ strategy });
-      const message = web3Wallet.verification.message as string;
+      let web3Wallet = await createWeb3Wallet(identifier);
+      web3Wallet = await web3Wallet?.prepareVerification({ strategy });
+      const message = web3Wallet?.verification.message as string;
       const signature = await generateWeb3Signature({ identifier, nonce: message, provider });
-      await web3Wallet.attemptVerification({ signature });
+      await web3Wallet?.attemptVerification({ signature });
       card.setIdle();
     } catch (err) {
       card.setIdle();

--- a/packages/clerk-js/src/ui/components/UserProfile/Web3Section.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/Web3Section.tsx
@@ -116,7 +116,7 @@ const Web3WalletMenu = ({ walletId }: { walletId: string }) => {
   const { open } = useActionContext();
   const { user } = useUser();
   const isPrimary = user?.primaryWeb3WalletId === walletId;
-  const [setPrimary] = useReverification(() => {
+  const setPrimary = useReverification(() => {
     return user?.update({ primaryWeb3WalletId: walletId });
   });
 

--- a/packages/nextjs/src/client-boundary/hooks.ts
+++ b/packages/nextjs/src/client-boundary/hooks.ts
@@ -19,6 +19,7 @@ export {
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
+  isReverificationCancelledError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,
 } from '@clerk/clerk-react/errors';

--- a/packages/nextjs/src/errors.ts
+++ b/packages/nextjs/src/errors.ts
@@ -2,6 +2,7 @@ export {
   isClerkRuntimeError,
   isEmailLinkError,
   isKnownError,
+  isReverificationCancelledError,
   isMetamaskError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,

--- a/packages/react-router/src/errors.ts
+++ b/packages/react-router/src/errors.ts
@@ -3,6 +3,7 @@ export {
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
+  isReverificationCancelledError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,
 } from '@clerk/clerk-react/errors';

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -4,6 +4,7 @@ export {
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
+  isReverificationCancelledError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,
 } from '@clerk/shared/error';

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -3,6 +3,7 @@ export {
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
+  isReverificationCancelledError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,
 } from '@clerk/clerk-react/errors';

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -63,6 +63,10 @@ export function isClerkRuntimeError(err: any): err is ClerkRuntimeError {
   return 'clerkRuntimeError' in err;
 }
 
+export function isReverificationCancelledError(err: any) {
+  return isClerkRuntimeError(err) && err.code === 'reverification_cancelled';
+}
+
 export function isMetamaskError(err: any): err is MetamaskError {
   return 'code' in err && [4001, 32602, 32603].includes(err.code) && 'message' in err;
 }

--- a/packages/shared/src/react/__tests__/useReverification.test.ts
+++ b/packages/shared/src/react/__tests__/useReverification.test.ts
@@ -27,7 +27,7 @@ type Fetcher = typeof fetcherWithHelper;
 
 describe('useReverification type tests', () => {
   it('allow pass through types', () => {
-    type UseReverificationWithFetcher = typeof useReverification<typeof fetcher, object>;
+    type UseReverificationWithFetcher = typeof useReverification<typeof fetcher>;
     type VerifiedFetcher = ReturnType<UseReverificationWithFetcher>;
     expectTypeOf(fetcher).toEqualTypeOf<VerifiedFetcher>();
   });

--- a/packages/shared/src/react/__tests__/useReverification.test.ts
+++ b/packages/shared/src/react/__tests__/useReverification.test.ts
@@ -28,31 +28,13 @@ type Fetcher = typeof fetcherWithHelper;
 describe('useReverification type tests', () => {
   it('allow pass through types', () => {
     type UseReverificationWithFetcher = typeof useReverification<typeof fetcher, object>;
-    type VerifiedFetcher = ReturnType<UseReverificationWithFetcher>[0];
+    type VerifiedFetcher = ReturnType<UseReverificationWithFetcher>;
     expectTypeOf(fetcher).toEqualTypeOf<VerifiedFetcher>();
   });
 
-  it('returned callback with clerk error excluded and possible null in case of cancelled flow', () => {
-    type UseReverificationWithFetcherHelper = typeof useReverification<typeof fetcherWithHelper, object>;
-    type VerifiedFetcherHelper = ReturnType<UseReverificationWithFetcherHelper>[0];
-
-    expectTypeOf(fetcherWithHelper).not.toEqualTypeOf<VerifiedFetcherHelper>();
-
-    expectTypeOf<Parameters<Fetcher>>().toEqualTypeOf<Parameters<VerifiedFetcherHelper>>();
-    expectTypeOf<ReturnType<Fetcher>>().not.toEqualTypeOf<ReturnType<VerifiedFetcherHelper>>();
-    expectTypeOf<ExcludeClerkError<Awaited<ReturnType<Fetcher>>> | null>().toEqualTypeOf<
-      Awaited<ReturnType<VerifiedFetcherHelper>>
-    >();
-  });
-
-  it('returned callback with clerk error excluded but without null since we throw', () => {
-    type UseReverificationWithFetcherHelperThrow = typeof useReverification<
-      typeof fetcherWithHelper,
-      {
-        throwOnCancel: true;
-      }
-    >;
-    type VerifiedFetcherHelperThrow = ReturnType<UseReverificationWithFetcherHelperThrow>[0];
+  it('returned callback with clerk error excluded', () => {
+    type UseReverificationWithFetcherHelperThrow = typeof useReverification<typeof fetcherWithHelper>;
+    type VerifiedFetcherHelperThrow = ReturnType<UseReverificationWithFetcherHelperThrow>;
     expectTypeOf(fetcherWithHelper).not.toEqualTypeOf<VerifiedFetcherHelperThrow>();
     expectTypeOf<ExcludeClerkError<Awaited<ReturnType<Fetcher>>>>().toEqualTypeOf<
       Awaited<ReturnType<VerifiedFetcherHelperThrow>>

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -166,12 +166,18 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  * import { useReverification } from '@clerk/clerk-react'
  * import { isReverificationCancelledError } from '@clerk/clerk-react/error'
  *
+ * type MyData = {
+ *   balance: number
+ * }
+ * 
  * export function MyButton() {
- *   const enhancedFetcher = useReverification(() => fetch('/api/balance'))
+ *   const fetchMyData = () => fetch('/api/balance').then(res=> res.json() as Promise<MyData>)
+ *   const enhancedFetcher = useReverification(fetchMyData);
  *
  *   const handleClick = async () => {
  *     try {
  *       const myData = await enhancedFetcher()
+ *       //     ^ is types as `MyData`    
  *     } catch (e) {
  *       // Handle error returned from the fetcher here
  *

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -169,7 +169,7 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  * type MyData = {
  *   balance: number
  * }
- * 
+ *
  * export function MyButton() {
  *   const fetchMyData = () => fetch('/api/balance').then(res=> res.json() as Promise<MyData>)
  *   const enhancedFetcher = useReverification(fetchMyData);
@@ -177,7 +177,7 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  *   const handleClick = async () => {
  *     try {
  *       const myData = await enhancedFetcher()
- *       //     ^ is types as `MyData`    
+ *       //     ^ is types as `MyData`
  *     } catch (e) {
  *       // Handle error returned from the fetcher here
  *

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -155,7 +155,7 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  * In the following example, `myFetcher` would be a function in your backend that fetches data from the route that requires reverification. See the [guide on how to require reverification](https://clerk.com/docs/guides/reverification) for more information.
  *
  * ```tsx {{ filename: 'src/components/MyButton.tsx' }}
- * import { useReverification } from '@clerk/react'
+ * import { useReverification } from '@clerk/clerk-react'
  *
  * export function MyButton() {
  *   const enhancedFetcher = useReverification(myFetcher)

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -62,7 +62,7 @@ type UseReverificationResult<Fetcher extends (...args: any[]) => Promise<any> | 
  */
 type UseReverification = <
   Fetcher extends (...args: any[]) => Promise<any> | undefined,
-  Options extends UseReverificationOptions,
+  Options extends UseReverificationOptions = UseReverificationOptions,
 >(
   fetcher: Fetcher,
   options?: Options,

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -161,15 +161,22 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  *
  * ```tsx {{ filename: 'src/components/MyButton.tsx' }}
  * import { useReverification } from '@clerk/clerk-react'
+ * import { isReverificationCancelledError } from '@clerk/clerk-react/error'
  *
  * export function MyButton() {
- *   const enhancedFetcher = useReverification(myFetcher)
+ *   const enhancedFetcher = useReverification(() => fetch('/api/balance'))
  *
  *   const handleClick = async () => {
- *     const myData = await enhancedFetcher()
- *     // If `myData` is null, the user canceled the reverification process
- *     // You can choose how your app responds. This example returns null.
- *     if (!myData) return
+ *     try {
+ *       const myData = await enhancedFetcher()
+ *     } catch (e) {
+ *       // Handle error returned from the fetcher here
+ *
+ *       // You can also handle cancellation with the following
+ *       if (isReverificationCancelledError(err)) {
+ *         // Handle the cancellation error here
+ *       }
+ *     }
  *   }
  *
  *   return <button onClick={handleClick}>Update User</button>

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -31,6 +31,15 @@ async function resolveResult<T>(result: Promise<T> | T): Promise<T | ReturnType<
 type ExcludeClerkError<T> = T extends { clerk_error: any } ? never : T;
 
 /**
+ * @interface
+ */
+type NeedsReverificationParameters = {
+  cancel: () => void;
+  complete: () => void;
+  level: SessionVerificationLevel | undefined;
+};
+
+/**
  * The optional options object.
  * @interface
  */
@@ -43,11 +52,7 @@ type UseReverificationOptions = {
    * @param level - The level returned with the reverification hint.
    *
    */
-  onNeedsReverification?: (properties: {
-    cancel: () => void;
-    complete: () => void;
-    level: SessionVerificationLevel | undefined;
-  }) => void;
+  onNeedsReverification?: (properties: NeedsReverificationParameters) => void;
 };
 
 /**

--- a/packages/tanstack-start/src/errors.ts
+++ b/packages/tanstack-start/src/errors.ts
@@ -7,6 +7,7 @@ export {
   isEmailLinkError,
   isKnownError,
   isMetamaskError,
+  isReverificationCancelledError,
   EmailLinkErrorCode,
   EmailLinkErrorCodeStatus,
 } from '@clerk/clerk-react/errors';


### PR DESCRIPTION
## Description
This PR refactors `useReverification` to allow it to be used both for AIO and custom UI's.

This refactor will introduce breaking changes to `useReverification` as now it will not return an array but instead will return the fetcher, an also the `throwOnCancel` and `onCancel` options are dropped and all errors even canceling will be thrown.

```tsx
import { useReverification } from '@clerk/clerk-react'
import { isReverificationCancelledError } from '@clerk/clerk-react/errors'

export function MyButton() {
  const enhancedFetcher = useReverification(() => fetch('/api/fetcher'))

  const handleClick = async () => {
    try {
      const myData = await enhancedFetcher()
    } catch (e) {
      // Handle if user cancels the reverification process
      if (isReverificationCancelledError(e)) {
        console.error('User cancelled reverification', e.code)
      }
    }
  }

  return <button onClick={handleClick}>Update user</button>
}
```

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
