### PR TITLE
test(vue): Get exact selector when testing Organization Profile custom pages and links

### DIFF
--- a/integration/tests/vue/components.test.ts
+++ b/integration/tests/vue/components.test.ts
@@ -225,16 +225,19 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withCustomRoles] })('basic te
     await u.page.waitForSelector('.cl-organizationSwitcherPopoverCard', { state: 'visible' });
     await u.page.locator('.cl-button__manageOrganization').click();
 
-    // Check if custom pages and links are visible
-    await expect(u.page.getByRole('button', { name: /Terms/i })).toBeVisible();
-    await expect(u.page.getByRole('button', { name: /Homepage/i })).toBeVisible();
+    // Get the organization profile dialog
+    const dialog = u.page.getByRole('dialog');
+
+    // Check if custom pages and links are visible within the dialog
+    await expect(dialog.getByRole('button', { name: /Terms/i })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Homepage/i })).toBeVisible();
 
     // Navigate to custom page
-    await u.page.getByRole('button', { name: /Terms/i }).click();
-    await expect(u.page.getByRole('heading', { name: 'Custom Terms Page' })).toBeVisible();
+    await dialog.getByRole('button', { name: /Terms/i }).click();
+    await expect(dialog.getByRole('heading', { name: 'Custom Terms Page' })).toBeVisible();
 
     // Click custom link and check navigation
-    await u.page.getByRole('button', { name: /Homepage/i }).click();
+    await dialog.getByRole('button', { name: /Homepage/i }).click();
     await u.page.waitForAppUrl('/');
   });
 


### PR DESCRIPTION
## Description

Small PR that fixes [this failing job](https://github.com/clerk/javascript/actions/runs/13954215106/job/39061170565?pr=5399).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
