### PR TITLE
chore(repo): Modify Typedoc union type output

### DIFF
--- a/.typedoc/custom-theme.mjs
+++ b/.typedoc/custom-theme.mjs
@@ -345,6 +345,28 @@ class ClerkMarkdownThemeContext extends MarkdownThemeContext {
 
         return md.join('\n\n');
       },
+      /**
+       * Copied from default theme / source code. This modifies the output of union types by wrapping everything in a single `<code>foo | bar</code>` tag instead of doing `<code>foo</code>` | `<code>bar</code>`
+       * https://github.com/typedoc2md/typedoc-plugin-markdown/blob/5d7c3c7fb816b6b009f3425cf284c95400f53929/packages/typedoc-plugin-markdown/src/theme/context/partials/type.union.ts
+       * @param {import('typedoc').UnionType} model
+       */
+      unionType: model => {
+        const useCodeBlocks = this.options.getValue('useCodeBlocks');
+        const typesOut = model.types.map(unionType => {
+          // So, .someType adds the backticks to the string and we don't want to deal with modifying that partial. So just remove any backticks in the next step again :shrug:
+          const defaultResult = this.partials.someType(unionType, { forceCollapse: true });
+
+          // Remove any backticks
+          return defaultResult.replace(/`/g, '');
+        });
+
+        const shouldFormat = useCodeBlocks && (typesOut?.join('').length > 70 || typesOut?.join('').includes('\n'));
+
+        const md = typesOut.join(shouldFormat ? `\n  \\| ` : ` \\| `);
+        const result = shouldFormat ? `\n  \\| ` + md : md;
+
+        return `<code>${result}</code>`;
+      },
     };
   }
 }


### PR DESCRIPTION
## Description

By default the Typedoc markdown plugin returns a union in such a format:

```md
`foo` | `bar`

`foo` | [`Foo`](bar)
```

We want to have it instead like this:

```md
`foo | bar`

`foo | [Foo](bar)`
```

Fixes https://linear.app/clerk/issue/ECO-519/wrap-union-types-in-one-code-block

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
