### PR TITLE
fix(clerk-js): Ensure window.Clerk is only ever assigned once

### DIFF
--- a/.changeset/late-cheetahs-raise.md
+++ b/.changeset/late-cheetahs-raise.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix an edge case where `window.Clerk` is re-assigned if the Clerk script is injected multiple times.

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -24,11 +24,14 @@ const proxyUrl =
 const domain =
   document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
 
-window.Clerk = new Clerk(publishableKey, {
-  proxyUrl,
-  // @ts-expect-error
-  domain,
-});
+// Ensure that if the script has already been injected we don't overwrite the existing Clerk instance.
+if (!window.Clerk) {
+  window.Clerk = new Clerk(publishableKey, {
+    proxyUrl,
+    // @ts-expect-error
+    domain,
+  });
+}
 
 if (module.hot) {
   module.hot.accept();

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -20,11 +20,13 @@ const proxyUrl =
 const domain =
   document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
 
-window.Clerk = new Clerk(publishableKey, {
-  proxyUrl,
-  // @ts-expect-error
-  domain,
-});
+if (!window.Clerk) {
+  window.Clerk = new Clerk(publishableKey, {
+    proxyUrl,
+    // @ts-expect-error
+    domain,
+  });
+}
 
 if (module.hot) {
   module.hot.accept();


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
In scenarios where the clerk-js script is injected multiple times, it's possible that `window.Clerk` can be re-assigned while Clerk is loading, causing Clerk to get stuck in a state where it never gets marked as "loaded". Adding this check ensures that even if the script is re-injected, we don't re-assign the original `window.Clerk`.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
