### PR TITLE
fix(clerk-js): Skip the Client resource update on the `/v1/client/verify`

### DIFF
--- a/.changeset/six-beans-punch.md
+++ b/.changeset/six-beans-punch.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Ignore the response of the /client/verify endpoint
+Skip the Client resource update on the `/v1/client/verify` endpoint

--- a/.changeset/six-beans-punch.md
+++ b/.changeset/six-beans-punch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ignore the response of the /client/verify endpoint

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "577.51kB" },
+    { "path": "./dist/clerk.js", "maxSize": "578kB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "78.5kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "51KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "94KB" },

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -18,6 +18,7 @@ export type BaseMutateParams = {
   body?: any;
   method?: HTTPMethod;
   path?: string;
+  skipResourceUpdate?: boolean;
 };
 
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
@@ -192,15 +193,17 @@ export abstract class BaseResource {
   }
 
   protected async _baseMutate<J extends ClerkResourceJSON | null>(params: BaseMutateParams): Promise<this> {
-    const { action, body, method, path } = params;
+    const { action, body, method, path, skipResourceUpdate } = params;
     const json = await BaseResource._fetch<J>({ method, path: path || this.path(action), body });
-    return this.fromJSON((json?.response || json) as J);
+    const payload = !skipResourceUpdate ? ((json?.response || json) as J) : null;
+    return this.fromJSON(payload);
   }
 
   protected async _baseMutateBypass<J extends ClerkResourceJSON | null>(params: BaseMutateParams): Promise<this> {
-    const { action, body, method, path } = params;
+    const { action, body, method, path, skipResourceUpdate } = params;
     const json = await BaseResource._baseFetch<J>({ method, path: path || this.path(action), body });
-    return this.fromJSON((json?.response || json) as J);
+    const payload = !skipResourceUpdate ? ((json?.response || json) as J) : null;
+    return this.fromJSON(payload);
   }
 
   protected async _basePost<J extends ClerkResourceJSON | null>(params: BaseMutateParams = {}): Promise<this> {

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -118,7 +118,10 @@ export class Client extends BaseResource implements ClientResource {
   }
 
   public sendCaptchaToken(params: unknown): Promise<ClientResource> {
-    return this._basePostBypass({ body: params, path: this.path() + '/verify' });
+    // We don't want to update the Client resource after sending the captcha token
+    // because we expect an empty JSON object as a response
+    // that's why we set skipResourceUpdate to true
+    return this._basePostBypass({ body: params, path: this.path() + '/verify', skipResourceUpdate: true });
   }
 
   fromJSON(data: ClientJSON | ClientJSONSnapshot | null): this {


### PR DESCRIPTION
## Description

This PR introduces the `skipResourceUpdate` boolean property on mutating requests to FAPI.

If `true` it skips updating the resource by calling the `fromJSON` method with a `null` value.

This is only used on the `/v1/client/verify` endpoint where we expect an empty JSON object as a response (`{}`) and we want to completely ignore it.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
