### PR TITLE
fix(clerk-js): Lazily load BillingPage in UserProfile

### DIFF
--- a/.changeset/breezy-walls-tease.md
+++ b/.changeset/breezy-walls-tease.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Lazy-loads the BillingPage within the UserProfile

--- a/.changeset/breezy-walls-tease.md
+++ b/.changeset/breezy-walls-tease.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Lazy-loads the BillingPage within the UserProfile
+Lazy-loads experimental `BillingPage` within `UserProfile`, preventing unnecessary code from loading.

--- a/.changeset/breezy-walls-tease.md
+++ b/.changeset/breezy-walls-tease.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Lazy-loads experimental `BillingPage` within `UserProfile`, preventing unnecessary code from loading.
+Lazy-loads experimental components within `UserProfile`, preventing unnecessary code from loading.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "577.51kB" },
+    { "path": "./dist/clerk.js", "maxSize": "577.65kB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "78.5kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "51KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "94KB" },

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -20,6 +20,7 @@
     { "path": "./dist/waitlist*.js", "maxSize": "1.3KB" },
     { "path": "./dist/keylessPrompt*.js", "maxSize": "5.9KB" },
     { "path": "./dist/pricingTable*.js", "maxSize": "3.5KB" },
-    { "path": "./dist/checkout*.js", "maxSize": "8.8KB" }
+    { "path": "./dist/checkout*.js", "maxSize": "8.8KB" },
+    { "path": "./dist/up-billing-page*.js", "maxSize": "1KB" }
   ]
 }

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -1,9 +1,10 @@
+import { lazy, Suspense } from 'react';
+
 import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
 import { USER_PROFILE_NAVBAR_ROUTE_ID } from '../../constants';
 import { useOptions, useUserProfileContext } from '../../contexts';
 import { Route, Switch } from '../../router';
 import { AccountPage } from './AccountPage';
-import { BillingPage } from './BillingPage';
 import { SecurityPage } from './SecurityPage';
 
 export const UserProfileRoutes = () => {
@@ -13,6 +14,12 @@ export const UserProfileRoutes = () => {
   const isAccountPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT;
   const isSecurityPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY;
   const isBillingPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.BILLING;
+
+  const BillingPage = lazy(() =>
+    import('./BillingPage').then(module => ({
+      default: module.BillingPage,
+    })),
+  );
 
   const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
     const shouldFirstCustomItemBeOnRoot = !isAccountPageRoot && !isSecurityPageRoot && index === 0;
@@ -52,7 +59,9 @@ export const UserProfileRoutes = () => {
           <Route path={isBillingPageRoot ? undefined : 'billing'}>
             <Switch>
               <Route index>
-                <BillingPage />
+                <Suspense fallback={''}>
+                  <BillingPage />
+                </Suspense>
               </Route>
             </Switch>
           </Route>

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -16,7 +16,7 @@ export const UserProfileRoutes = () => {
   const isBillingPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.BILLING;
 
   const BillingPage = lazy(() =>
-    import('./BillingPage').then(module => ({
+    import(/* webpackChunkName: "up-billing-page"*/ './BillingPage').then(module => ({
       default: module.BillingPage,
     })),
   );


### PR DESCRIPTION
## Description

Lazy load BillingPage only when commerce is enabled, to avoid unnecessary loading of Stripe.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
