### PR TITLE
fix(clerk-js): Create client from jwt only on network errors or 5xx

### DIFF
--- a/.changeset/small-ads-rescue.md
+++ b/.changeset/small-ads-rescue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update the resiliency logic for failed client attempts to allow the creation of a dev browser.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2094,7 +2094,11 @@ export class Clerk implements ClerkInterface {
             .fetch()
             .then(res => this.updateClient(res))
             .catch(async e => {
-              if (isClerkAPIResponseError(e) && e.errors[0].code === 'requires_captcha') {
+              /**
+               * Only handle non 4xx errors, like 5xx errors and network errors.
+               */
+              if (is4xxError(e)) {
+                // bubble it up
                 throw e;
               }
 
@@ -2125,7 +2129,7 @@ export class Clerk implements ClerkInterface {
         if (clientResult.status === 'rejected') {
           const e = clientResult.reason;
 
-          if (isClerkAPIResponseError(e) && e.errors[0].code === 'requires_captcha') {
+          if (isError(e, 'requires_captcha')) {
             if (envResult.status === 'rejected') {
               await initEnvironmentPromise;
             }


### PR DESCRIPTION
## Description

Update the resiliency logic for failed client attempts to allow the creation of a dev browser.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
