### PR TITLE
fix(clerk-js): Use a new signUp attempt on SignUpStart component when there is no ticket flow

### DIFF
--- a/.changeset/stale-boxes-attend.md
+++ b/.changeset/stale-boxes-attend.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use a new signUp attempt on SignUp component when there is no ticket flow and a phone number is provided to prevent rate-limiting issues.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -12,7 +12,7 @@
     { "path": "./dist/organizationswitcher*.js", "maxSize": "5KB" },
     { "path": "./dist/organizationlist*.js", "maxSize": "5.5KB" },
     { "path": "./dist/signin*.js", "maxSize": "12.4KB" },
-    { "path": "./dist/signup*.js", "maxSize": "6.57KB" },
+    { "path": "./dist/signup*.js", "maxSize": "6.6KB" },
     { "path": "./dist/userbutton*.js", "maxSize": "5KB" },
     { "path": "./dist/userprofile*.js", "maxSize": "15KB" },
     { "path": "./dist/userverification*.js", "maxSize": "5KB" },

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -1,4 +1,5 @@
 import { useClerk } from '@clerk/shared/react';
+import type { SignUpResource } from '@clerk/types';
 import React from 'react';
 
 import { ERROR_CODES, SIGN_UP_MODES } from '../../../core/constants';
@@ -25,7 +26,6 @@ import { determineActiveFields, emailOrPhone, getInitialActiveIdentifier, showFo
 import { SignUpRestrictedAccess } from './SignUpRestrictedAccess';
 import { SignUpSocialButtons } from './SignUpSocialButtons';
 import { completeSignUpFlow } from './util';
-import type { SignUpResource } from '@clerk/types';
 
 function SignUpStartInternal(): JSX.Element {
   const card = useCardState();

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -244,7 +244,7 @@ function SignUpStartInternal(): JSX.Element {
     const redirectUrlComplete = ctx.afterSignUpUrl || '/';
 
     let signUpAttempt: Promise<SignUpResource>;
-    if (!fields.ticket && phoneNumberProvided) {
+    if (!fields.ticket) {
       signUpAttempt = signUp.create(buildRequest(fieldsToSubmit));
     } else {
       signUpAttempt = signUp.upsert(buildRequest(fieldsToSubmit));

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -25,6 +25,7 @@ import { determineActiveFields, emailOrPhone, getInitialActiveIdentifier, showFo
 import { SignUpRestrictedAccess } from './SignUpRestrictedAccess';
 import { SignUpSocialButtons } from './SignUpSocialButtons';
 import { completeSignUpFlow } from './util';
+import type { SignUpResource } from '@clerk/types';
 
 function SignUpStartInternal(): JSX.Element {
   const card = useCardState();
@@ -242,8 +243,14 @@ function SignUpStartInternal(): JSX.Element {
     const redirectUrl = ctx.ssoCallbackUrl;
     const redirectUrlComplete = ctx.afterSignUpUrl || '/';
 
-    return signUp
-      .upsert(buildRequest(fieldsToSubmit))
+    let signUpAttempt: Promise<SignUpResource>;
+    if (!fields.ticket && phoneNumberProvided) {
+      signUpAttempt = signUp.create(buildRequest(fieldsToSubmit));
+    } else {
+      signUpAttempt = signUp.upsert(buildRequest(fieldsToSubmit));
+    }
+
+    return signUpAttempt
       .then(res =>
         completeSignUpFlow({
           signUp: res,


### PR DESCRIPTION
## Description

This PR introduces a change in the behavior introduced in #4720

Currently, we may end up rate-limited on phone number verification codes.

This PR addresses runs the `signUp.create` only when there is no ticket flow.
For all the other cases, we keep using `signUp.upsert` in order to not lose the ticket context.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
