### PR TITLE
feat(backend,shared): Move buildAccountsBaseUrl to shared utility

### DIFF
--- a/.changeset/clever-walls-shave.md
+++ b/.changeset/clever-walls-shave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Update `@clerk/shared` dependency to use new shared `buildAccountsBaseUrl` utility.

--- a/.changeset/spicy-radios-happen.md
+++ b/.changeset/spicy-radios-happen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Add shared `buildAccountsBaseUrl` utility.

--- a/packages/backend/src/createRedirect.ts
+++ b/packages/backend/src/createRedirect.ts
@@ -1,3 +1,5 @@
+import { buildAccountsBaseUrl } from '@clerk/shared/buildAccountsBaseUrl';
+
 import { constants } from './constants';
 import { errorThrower, parsePublishableKey } from './util/shared';
 
@@ -52,19 +54,6 @@ const legacyBuildUrl = (targetUrl: string, redirectUrl?: string) => {
   }
 
   return url.toString();
-};
-
-const buildAccountsBaseUrl = (frontendApi?: string) => {
-  if (!frontendApi) {
-    return '';
-  }
-
-  // convert url from FAPI to accounts for Kima and legacy (prod & dev) instances
-  const accountsBaseUrl = frontendApi
-    // staging accounts
-    .replace(/clerk\.accountsstage\./, 'accountsstage.')
-    .replace(/clerk\.accounts\.|clerk\./, 'accounts.');
-  return `https://${accountsBaseUrl}`;
 };
 
 type RedirectAdapter<RedirectReturn> = (url: string) => RedirectReturn;

--- a/packages/shared/src/__tests__/buildAccountsBaseUrl.test.ts
+++ b/packages/shared/src/__tests__/buildAccountsBaseUrl.test.ts
@@ -1,0 +1,12 @@
+import { buildAccountsBaseUrl } from '../buildAccountsBaseUrl';
+
+test.each([
+  ['', ''],
+  [undefined, ''],
+  ['one-two-three.clerk.accountsstage.dev', 'https://one-two-three.accountsstage.dev'],
+  ['one-two-three.clerk.accounts.dev', 'https://one-two-three.accounts.dev'],
+  ['clerk.accounts.example.com', 'https://accounts.example.com'],
+  ['clerk.example.com', 'https://ccounts.example.com'],
+])('buildAccountsBaseUrl(%s)', (frontendApi, accountsBaseUrl) => {
+  expect(buildAccountsBaseUrl(frontendApi)).toBe(accountsBaseUrl);
+});

--- a/packages/shared/src/__tests__/buildAccountsBaseUrl.test.ts
+++ b/packages/shared/src/__tests__/buildAccountsBaseUrl.test.ts
@@ -6,7 +6,7 @@ test.each([
   ['one-two-three.clerk.accountsstage.dev', 'https://one-two-three.accountsstage.dev'],
   ['one-two-three.clerk.accounts.dev', 'https://one-two-three.accounts.dev'],
   ['clerk.accounts.example.com', 'https://accounts.example.com'],
-  ['clerk.example.com', 'https://ccounts.example.com'],
+  ['clerk.example.com', 'https://accounts.example.com'],
 ])('buildAccountsBaseUrl(%s)', (frontendApi, accountsBaseUrl) => {
   expect(buildAccountsBaseUrl(frontendApi)).toBe(accountsBaseUrl);
 });

--- a/packages/shared/src/buildAccountsBaseUrl.ts
+++ b/packages/shared/src/buildAccountsBaseUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds a full origin string pointing to the Account Portal for the given frontend API.
+ */
+export function buildAccountsBaseUrl(frontendApi?: string): string {
+  if (!frontendApi) {
+    return '';
+  }
+
+  // convert url from FAPI to accounts for Kima and legacy (prod & dev) instances
+  const accountsBaseUrl = frontendApi
+    // staging accounts
+    .replace(/clerk\.accountsstage\./, 'accountsstage.')
+    .replace(/clerk\.accounts\.|clerk\./, 'accounts.');
+  return `https://${accountsBaseUrl}`;
+}


### PR DESCRIPTION
## Description

This PR moves the `buildAccountsBaseUrl` logic into a shared utility function within the `@clerk/shared` package so it can be reused between both `@clerk/backend` (included in this PR) and `clerk-js` (to be used in the upcoming auth with popup PR.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
