### PR TITLE
fix(nextjs): Update peerDependencies to only allow patched versions

### DIFF
--- a/.changeset/stale-students-care.md
+++ b/.changeset/stale-students-care.md
@@ -2,4 +2,4 @@
 "@clerk/nextjs": patch
 ---
 
-A security vulnerability in Next.js was disclosed on 22 MAR 2025, which allows malicious actors to bypass authorization in Middleware when targeting the x-middleware-subrequest header. With this version we update the `peerDependencies` filed of the `@clerk/nextjs` package to only allow the patched NextJS versions to be used. For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw
+A security vulnerability in Next.js was disclosed on 22 MAR 2025, which allows malicious actors to bypass authorization in Middleware when targeting the x-middleware-subrequest header. With this version, we update the `peerDependencies` field of the `@clerk/nextjs` package to only allow the patched NextJS versions to be used. For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

--- a/.changeset/stale-students-care.md
+++ b/.changeset/stale-students-care.md
@@ -2,4 +2,5 @@
 "@clerk/nextjs": patch
 ---
 
-A security vulnerability in Next.js was disclosed on 22 MAR 2025, which allows malicious actors to bypass authorization in Middleware when targeting the x-middleware-subrequest header. With this version, we update the `peerDependencies` field of the `@clerk/nextjs` package to only allow the patched NextJS versions to be used. For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw
+Developers using Clerk are not impacted by the NextJS vulnerability disclosed on 22 MAR 2025, but we still recommend upgrading to the latest NextJS version as soon as possible.
+For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

--- a/.changeset/stale-students-care.md
+++ b/.changeset/stale-students-care.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+A security vulnerability in Next.js was disclosed on 22 MAR 2025, which allows malicious actors to bypass authorization in Middleware when targeting the x-middleware-subrequest header. With this version we update the `peerDependencies` filed of the `@clerk/nextjs` package to only allow the patched NextJS versions to be used. For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -78,7 +78,7 @@
     "next": "^14.2.24"
   },
   "peerDependencies": {
-    "next": "^13.5.4 || ^14.0.3 || ^15.0.0",
+    "next": "^13.5.7 || ^14.2.25 || ^15.2.3",
     "react": "catalog:peer-react",
     "react-dom": "catalog:peer-react"
   },


### PR DESCRIPTION
For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
