### PR TITLE
fix(nextjs): Patch clerkMiddleware to reject requests with `x-middleware-subrequest`

### DIFF
--- a/.changeset/curvy-experts-occur.md
+++ b/.changeset/curvy-experts-occur.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+A security vulnerability in Next.js was disclosed on 22 MAR 2025, which allows malicious actors to bypass authorization in Middleware when targeting the x-middleware-subrequest header. With this version we patch the `clerkMiddleware` helper to reject requests that contain the `x-middleware-subrequest` header. For more details, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -246,6 +246,10 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
     };
 
     const nextMiddleware: NextMiddleware = async (request, event) => {
+      if (request.headers.get('x-middleware-subrequest')) {
+        return new NextResponse('Forbidden', { status: 403 });
+      }
+
       if (canUseKeyless) {
         return keylessMiddleware(request, event);
       }


### PR DESCRIPTION

For more info, please see https://github.com/advisories/GHSA-f82v-jwr5-mffw

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
