### PR TITLE
fix(clerk-js): Fix lazy-loading of `BillingPage` within `UserProfile`

### DIFF
--- a/.changeset/common-melons-camp.md
+++ b/.changeset/common-melons-camp.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix lazy-loading of `BillingPage` in `UserProfile`

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -7,6 +7,12 @@ import { Route, Switch } from '../../router';
 import { AccountPage } from './AccountPage';
 import { SecurityPage } from './SecurityPage';
 
+const BillingPage = lazy(() =>
+  import(/* webpackChunkName: "up-billing-page"*/ './BillingPage').then(module => ({
+    default: module.BillingPage,
+  })),
+);
+
 export const UserProfileRoutes = () => {
   const { pages } = useUserProfileContext();
   const { experimental } = useOptions();
@@ -14,12 +20,6 @@ export const UserProfileRoutes = () => {
   const isAccountPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT;
   const isSecurityPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY;
   const isBillingPageRoot = pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.BILLING;
-
-  const BillingPage = lazy(() =>
-    import(/* webpackChunkName: "up-billing-page"*/ './BillingPage').then(module => ({
-      default: module.BillingPage,
-    })),
-  );
 
   const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
     const shouldFirstCustomItemBeOnRoot = !isAccountPageRoot && !isSecurityPageRoot && index === 0;


### PR DESCRIPTION
## Description

Quick fix to move the lazily-loaded `BillingPage` out of the component body to prevent re-renders.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
