### PR TITLE
chore(repo): Do not use deprecated Turbo env var

### DIFF
--- a/.github/actions/init-blacksmith/action.yml
+++ b/.github/actions/init-blacksmith/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Enable Turbo?'
     required: false
     default: 'true'
+  turbo-cache:
+    description: 'Cache usage settings'
+    required: false
+    default: 'remote:rw'
   turbo-cache-dir:
     description: 'The cache dir to use for Turbo'
     required: false
@@ -24,10 +28,6 @@ inputs:
   turbo-signature:
     description: 'The signature to use for Turbo'
     required: false
-  turbo-remote-only:
-    description: 'Only use remote cache?'
-    required: false
-    default: 'true'
   turbo-team:
     description: 'The team to use for Turbo remote auth'
     required: true

--- a/.github/actions/init-blacksmith/action.yml
+++ b/.github/actions/init-blacksmith/action.yml
@@ -67,7 +67,7 @@ runs:
               ? os.availableParallelism()
               : os.cpus().length;
 
-          const { ENABLED, CACHE: 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
+          const { ENABLED, CACHE = 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
 
           const ARGS = [
             `--cache-dir=${CACHE_DIR}`,

--- a/.github/actions/init-blacksmith/action.yml
+++ b/.github/actions/init-blacksmith/action.yml
@@ -51,9 +51,9 @@ runs:
       uses: actions/github-script@v7
       env:
         # envs are required to pass inputs to the script
-        ENABLED: ${{ inputs.turbo-enabled }}
+        CACHE: ${{ inputs.turbo-cache }}
         CACHE_DIR: ${{ inputs.turbo-cache-dir }}
-        REMOTE_ONLY: ${{ inputs.turbo-remote-only }}
+        ENABLED: ${{ inputs.turbo-enabled }}
         SIGNATURE: ${{ inputs.turbo-signature }}
         SUMMARIZE: ${{ inputs.turbo-summarize }}
         TEAM: ${{ inputs.turbo-team }}
@@ -67,7 +67,7 @@ runs:
               ? os.availableParallelism()
               : os.cpus().length;
 
-          const { ENABLED, CACHE_DIR, SIGNATURE, REMOTE_ONLY, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
+          const { ENABLED, CACHE: 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
 
           const ARGS = [
             `--cache-dir=${CACHE_DIR}`,
@@ -88,9 +88,9 @@ runs:
           )
 
           if (ENABLED === 'true') {
+            core.exportVariable('TURBO_CACHE', CACHE)
             core.exportVariable('TURBO_TEAM', TEAM)
             core.exportVariable('TURBO_TOKEN', TOKEN)
-            core.exportVariable('TURBO_CACHE', 'remote:rw')
           }
 
           if (SIGNATURE && SIGNATURE !== '') {

--- a/.github/actions/init-blacksmith/action.yml
+++ b/.github/actions/init-blacksmith/action.yml
@@ -90,7 +90,7 @@ runs:
           if (ENABLED === 'true') {
             core.exportVariable('TURBO_TEAM', TEAM)
             core.exportVariable('TURBO_TOKEN', TOKEN)
-            core.exportVariable('TURBO_REMOTE_ONLY', REMOTE_ONLY)
+            core.exportVariable('TURBO_CACHE', 'remote:rw')
           }
 
           if (SIGNATURE && SIGNATURE !== '') {

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -90,7 +90,7 @@ runs:
           if (ENABLED === 'true') {
             core.exportVariable('TURBO_TEAM', TEAM)
             core.exportVariable('TURBO_TOKEN', TOKEN)
-            core.exportVariable('TURBO_REMOTE_ONLY', REMOTE_ONLY)
+            core.exportVariable('TURBO_CACHE','remote:rw')
           }
 
           if (SIGNATURE && SIGNATURE !== '') {

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -51,9 +51,9 @@ runs:
       uses: actions/github-script@v7
       env:
         # envs are required to pass inputs to the script
+        CACHE: ${{ inputs.turbo-cache }}
         ENABLED: ${{ inputs.turbo-enabled }}
         CACHE_DIR: ${{ inputs.turbo-cache-dir }}
-        REMOTE_ONLY: ${{ inputs.turbo-remote-only }}
         SIGNATURE: ${{ inputs.turbo-signature }}
         SUMMARIZE: ${{ inputs.turbo-summarize }}
         TEAM: ${{ inputs.turbo-team }}
@@ -67,7 +67,7 @@ runs:
               ? os.availableParallelism()
               : os.cpus().length;
 
-          const { ENABLED, CACHE_DIR, SIGNATURE, REMOTE_ONLY, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
+          const { ENABLED, CACHE: 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
 
           const ARGS = [
             `--cache-dir=${CACHE_DIR}`,
@@ -88,9 +88,9 @@ runs:
           )
 
           if (ENABLED === 'true') {
+            core.exportVariable('TURBO_CACHE', CACHE)
             core.exportVariable('TURBO_TEAM', TEAM)
             core.exportVariable('TURBO_TOKEN', TOKEN)
-            core.exportVariable('TURBO_CACHE','remote:rw')
           }
 
           if (SIGNATURE && SIGNATURE !== '') {

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Enable Turbo?'
     required: false
     default: 'true'
+  turbo-cache:
+    description: 'Cache usage settings'
+    required: false
+    default: 'remote:rw'
   turbo-cache-dir:
     description: 'The cache dir to use for Turbo'
     required: false
@@ -24,10 +28,6 @@ inputs:
   turbo-signature:
     description: 'The signature to use for Turbo'
     required: false
-  turbo-remote-only:
-    description: 'Only use remote cache?'
-    required: false
-    default: 'true'
   turbo-team:
     description: 'The team to use for Turbo remote auth'
     required: true

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -67,7 +67,7 @@ runs:
               ? os.availableParallelism()
               : os.cpus().length;
 
-          const { ENABLED, CACHE: 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
+          const { ENABLED, CACHE = 'remote:rw', CACHE_DIR, SIGNATURE, SUMMARIZE, TEAM, TOKEN, VERBOSE } = process.env
 
           const ARGS = [
             `--cache-dir=${CACHE_DIR}`,

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -52,8 +52,8 @@ runs:
       env:
         # envs are required to pass inputs to the script
         CACHE: ${{ inputs.turbo-cache }}
-        ENABLED: ${{ inputs.turbo-enabled }}
         CACHE_DIR: ${{ inputs.turbo-cache-dir }}
+        ENABLED: ${{ inputs.turbo-enabled }}
         SIGNATURE: ${{ inputs.turbo-signature }}
         SUMMARIZE: ${{ inputs.turbo-summarize }}
         TEAM: ${{ inputs.turbo-team }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_REMOTE_ONLY: true
+      TURBO_CACHE: remote:rw
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Description

Addressing upcoming turborepo breaking change: ` WARNING  TURBO_REMOTE_ONLY is deprecated and will be removed in a future major version. Use TURBO_CACHE=remote:rw`

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
