### PR TITLE
chore(shared): Remove the beta warning comment from useReverification hook

### DIFF
--- a/.changeset/polite-pillows-report.md
+++ b/.changeset/polite-pillows-report.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Removes the warning comment from `useReverification`

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -146,7 +146,10 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
 }
 
 /**
- *
+ * > [!WARNING]
+ * >
+ * > Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.12.7` or later, `@clerk/clerk-react@5.25.1` or later, and `@clerk/clerk-js@5.57.1` or later.
+ * 
  * The `useReverification()` hook is used to handle a session's reverification flow. If a request requires reverification, a modal will display, prompting the user to verify their credentials. Upon successful verification, the original request will automatically retry.
  *
  * @returns The `useReverification()` hook returns an array with the "enhanced" fetcher.

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -149,7 +149,7 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
  * > [!WARNING]
  * >
  * > Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.12.7` or later, `@clerk/clerk-react@5.25.1` or later, and `@clerk/clerk-js@5.57.1` or later.
- * 
+ *
  * The `useReverification()` hook is used to handle a session's reverification flow. If a request requires reverification, a modal will display, prompting the user to verify their credentials. Upon successful verification, the original request will automatically retry.
  *
  * @returns The `useReverification()` hook returns an array with the "enhanced" fetcher.

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -146,10 +146,6 @@ function createReverificationHandler(params: CreateReverificationHandlerParams) 
 }
 
 /**
- * > [!WARNING]
- * > This feature is currently in public beta. **It is not recommended for production use.**
- * >
- * > Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.5.0` or later, `@clerk/clerk-react@5.17.0` or later, and `@clerk/clerk-js@5.35.0` or later.
  *
  * The `useReverification()` hook is used to handle a session's reverification flow. If a request requires reverification, a modal will display, prompting the user to verify their credentials. Upon successful verification, the original request will automatically retry.
  *


### PR DESCRIPTION
## Description

This PR removes the beta warning from `useReverification` hook

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
