### PR TITLE
fix(localizations): Define that you have to enter the current password

### DIFF
--- a/.changeset/tame-clowns-brush.md
+++ b/.changeset/tame-clowns-brush.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Defines that the current password should be entered on password re-verifcation flow

--- a/packages/clerk-js/src/ui/components/UserVerification/__tests__/UVFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserVerification/__tests__/UVFactorOne.test.tsx
@@ -28,7 +28,7 @@ describe('UserVerificationFactorOne', () => {
 
     await waitFor(() => {
       getByText('Verification required');
-      getByText('Enter your password to continue');
+      getByText('Enter your current password to continue');
       getByLabelText(/^password/i);
     });
   });

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -321,7 +321,7 @@ export const bgBG: LocalizationResource = {
     },
     password: {
       actionLink: 'Use another method',
-      subtitle: 'Enter your password to continue using "{{applicationName}}"',
+      subtitle: 'Enter your current password to continue using "{{applicationName}}"',
       title: 'Enter your password',
     },
     phoneCode: {

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -322,7 +322,7 @@ export const enGB: LocalizationResource = {
     },
     password: {
       actionLink: 'Use another method',
-      subtitle: 'Enter your password to continue',
+      subtitle: 'Enter your current password to continue',
       title: 'Verification required',
     },
     phoneCode: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -311,7 +311,7 @@ export const enUS: LocalizationResource = {
     },
     password: {
       actionLink: 'Use another method',
-      subtitle: 'Enter your password to continue',
+      subtitle: 'Enter your current password to continue',
       title: 'Verification required',
     },
     phoneCode: {


### PR DESCRIPTION
## Description

This PR changes the password re-verification flow description to define that you need to enter the current password 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
