### PR TITLE
chore(vue): Make plugin installation type-safe

### DIFF
--- a/.changeset/modern-rings-relax.md
+++ b/.changeset/modern-rings-relax.md
@@ -1,5 +1,6 @@
 ---
 "@clerk/vue": patch
+"@clerk/nuxt": patch
 ---
 
 Improved type-safety in Vue plugin installation.

--- a/.changeset/modern-rings-relax.md
+++ b/.changeset/modern-rings-relax.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Improved type-safety in Vue plugin installation.

--- a/packages/nuxt/src/global.d.ts
+++ b/packages/nuxt/src/global.d.ts
@@ -1,2 +1,21 @@
-declare const PACKAGE_NAME: string;
-declare const PACKAGE_VERSION: string;
+import type { PluginOptions } from '@clerk/vue';
+
+declare global {
+  const PACKAGE_NAME: string;
+  const PACKAGE_VERSION: string;
+}
+
+// See https://nuxt.com/docs/guide/going-further/runtime-config#typing-runtime-config
+declare module 'nuxt/schema' {
+  interface RuntimeConfig {
+    clerk: {
+      secretKey?: string;
+      jwtKey?: string;
+    };
+  }
+  interface PublicRuntimeConfig {
+    clerk: PluginOptions;
+  }
+}
+
+export {};

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -11,7 +11,8 @@ import {
   updateRuntimeConfig,
 } from '@nuxt/kit';
 
-export type ModuleOptions = Omit<LoadClerkJsScriptOptions, 'routerPush' | 'routerReplace'> & {
+export type ModuleOptions = Omit<LoadClerkJsScriptOptions, 'routerPush' | 'routerReplace' | 'publishableKey'> & {
+  publishableKey?: string;
   /**
    * Skip the automatic server middleware registration. When enabled, you'll need to
    * register the middleware manually in your application.

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -1,10 +1,17 @@
 import { setClerkJsLoadingErrorPackageName } from '@clerk/shared/loadClerkJsScript';
+import type { PluginOptions } from '@clerk/vue';
 import { clerkPlugin } from '@clerk/vue';
 import { setErrorThrowerOptions } from '@clerk/vue/internal';
 import { defineNuxtPlugin, navigateTo, useRuntimeConfig, useState } from 'nuxt/app';
 
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });
 setClerkJsLoadingErrorPackageName(PACKAGE_NAME);
+
+declare module 'nuxt/schema' {
+  interface PublicRuntimeConfig {
+    clerk: PluginOptions;
+  }
+}
 
 export default defineNuxtPlugin(nuxtApp => {
   // SSR-friendly shared state
@@ -15,8 +22,9 @@ export default defineNuxtPlugin(nuxtApp => {
     initialState.value = nuxtApp.ssrContext?.event.context.__clerk_initial_state;
   }
 
+  const runtimeConfig = useRuntimeConfig();
   nuxtApp.vueApp.use(clerkPlugin, {
-    ...(useRuntimeConfig().public.clerk ?? {}),
+    ...(runtimeConfig.public.clerk ?? {}),
     routerPush: (to: string) => navigateTo(to),
     routerReplace: (to: string) => navigateTo(to, { replace: true }),
     initialState: initialState.value,

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -1,17 +1,10 @@
 import { setClerkJsLoadingErrorPackageName } from '@clerk/shared/loadClerkJsScript';
-import type { PluginOptions } from '@clerk/vue';
 import { clerkPlugin } from '@clerk/vue';
 import { setErrorThrowerOptions } from '@clerk/vue/internal';
 import { defineNuxtPlugin, navigateTo, useRuntimeConfig, useState } from 'nuxt/app';
 
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });
 setClerkJsLoadingErrorPackageName(PACKAGE_NAME);
-
-declare module 'nuxt/schema' {
-  interface PublicRuntimeConfig {
-    clerk: PluginOptions;
-  }
-}
 
 export default defineNuxtPlugin(nuxtApp => {
   // SSR-friendly shared state

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,7 +5,7 @@ import { setErrorThrowerOptions } from './errors/errorThrower';
 export * from './components';
 export * from './composables';
 
-export { clerkPlugin } from './plugin';
+export { clerkPlugin, type PluginOptions } from './plugin';
 export { updateClerkOptions } from './utils';
 
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -27,8 +27,8 @@ export type PluginOptions = LoadClerkJsScriptOptions;
  * app.mount('#app')
  * ```
  */
-export const clerkPlugin: Plugin = {
-  install(app, options: PluginOptions) {
+export const clerkPlugin: Plugin<[PluginOptions]> = {
+  install(app, options) {
     // @ts-expect-error: Internal property for SSR frameworks like Nuxt
     const { initialState } = options;
 


### PR DESCRIPTION
## Description

Small PR that makes Vue Clerk plugin installation type-safe

<img width="678" alt="Screenshot 2025-03-26 at 8 56 56 AM" src="https://github.com/user-attachments/assets/7a2f1f30-eaaf-40a8-bc80-e7222e70679b" />

https://github.com/user-attachments/assets/d1295443-ee4e-4765-9c12-42b399ef61c8

Resolves ECO-518

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
