### PR TITLE
fix(clerk-js): Fix Turnstile console warning when locale is used

### DIFF
--- a/.changeset/smart-chefs-fail.md
+++ b/.changeset/smart-chefs-fail.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix Turnstile console warning when locale is used

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -18,7 +18,7 @@ export const CaptchaElement = () => {
   const { locale } = useLocalizations();
   const captchaTheme = parsedCaptcha?.theme;
   const captchaSize = parsedCaptcha?.size;
-  const captchaLanguage = parsedCaptcha?.language || locale;
+  const captchaLanguage = parsedCaptcha?.language || locale?.toLowerCase();
 
   useEffect(() => {
     if (!elementRef.current) return;


### PR DESCRIPTION
## Description

Fixes the following Turnstile console warning:

```
[Cloudflare Turnstile] Language en-US is not supported, falling back to: en-us.
```

It was already falling back to the correct language, e.g. falling back to `es-es` if `es-ES` was passed.
However it expects the language code to be in lowercase.

Supported values here: https://developers.cloudflare.com/turnstile/reference/supported-languages/


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
