### PR TITLE
fix(clerk-js): Using the same identifier and strategy not triggers prepare after sign out

### DIFF
--- a/.changeset/poor-lights-look.md
+++ b/.changeset/poor-lights-look.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix sign in prepare first factor cache key

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -55,16 +55,15 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   };
 
   useFetch(
-    shouldAvoidPrepare
-      ? undefined
-      : () =>
-          signIn
-            ?.prepareFirstFactor(props.factor)
-            .then(() => props.onFactorPrepare())
-            .catch(err => handleError(err, [], card.setError)),
+    () =>
+      signIn
+        ?.prepareFirstFactor(props.factor)
+        .then(() => props.onFactorPrepare())
+        .catch(err => handleError(err, [], card.setError)),
     {
       name: 'signIn.prepareFirstFactor',
       factor: props.factor,
+      id: signIn.id,
     },
     {
       staleTime: 100,

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -55,11 +55,13 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   };
 
   useFetch(
-    () =>
-      signIn
-        ?.prepareFirstFactor(props.factor)
-        .then(() => props.onFactorPrepare())
-        .catch(err => handleError(err, [], card.setError)),
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signIn
+            ?.prepareFirstFactor(props.factor)
+            .then(() => props.onFactorPrepare())
+            .catch(err => handleError(err, [], card.setError)),
     {
       name: 'signIn.prepareFirstFactor',
       factor: props.factor,


### PR DESCRIPTION
## Description

This PR fixes a bug where the prepare first factor wasn't triggered after signing out and tried to use the same identified and strategy to sign in again.

This was a cache issue and the cache key was identical as it was just the factor, the difference was that this was a different sign in

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
