### PR TITLE
fix(clerk-js): Add custom implementation of Promise.allSettled for es6 compat

### DIFF
--- a/.changeset/ripe-books-unite.md
+++ b/.changeset/ripe-books-unite.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Create a utility that implements `Promise.allSettled` with ES6/ES2015 compatibility.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -11,7 +11,7 @@ import {
   TelemetryCollector,
 } from '@clerk/shared/telemetry';
 import { addClerkPrefix, isAbsoluteUrl, stripScheme } from '@clerk/shared/url';
-import { handleValueOrFn, noop } from '@clerk/shared/utils';
+import { allSettled, handleValueOrFn, noop } from '@clerk/shared/utils';
 import type {
   __experimental_CommerceNamespace,
   __experimental_PricingTableProps,
@@ -2181,7 +2181,7 @@ export class Clerk implements ClerkInterface {
           }
         };
 
-        const [envResult, clientResult] = await Promise.allSettled([initEnvironmentPromise, initClient()]);
+        const [envResult, clientResult] = await allSettled([initEnvironmentPromise, initClient()]);
 
         if (clientResult.status === 'rejected') {
           const e = clientResult.reason;

--- a/packages/shared/src/utils/allSettled.ts
+++ b/packages/shared/src/utils/allSettled.ts
@@ -1,0 +1,14 @@
+/**
+ * A ES6 compatible utility that implements `Promise.allSettled`
+ */
+export function allSettled<T>(
+  iterable: Iterable<Promise<T>>,
+): Promise<({ status: 'fulfilled'; value: T } | { status: 'rejected'; reason: any })[]> {
+  const promises = Array.from(iterable).map(p =>
+    p.then(
+      value => ({ status: 'fulfilled', value }) as const,
+      reason => ({ status: 'rejected', reason }) as const,
+    ),
+  );
+  return Promise.all(promises);
+}

--- a/packages/shared/src/utils/createDeferredPromise.ts
+++ b/packages/shared/src/utils/createDeferredPromise.ts
@@ -5,7 +5,7 @@ type Callback = (val?: any) => void;
 /**
  * Create a promise that can be resolved or rejected from
  * outside the Promise constructor callback
- * @internal
+ * A ES6 compatible utility that implements `Promise.withResolvers`
  */
 export const createDeferredPromise = () => {
   let resolve: Callback = noop;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './createDeferredPromise';
+export * from './allSettled';
 export { isStaging } from './instance';
 export { logErrorInDevMode } from './logErrorInDevMode';
 export { noop } from './noop';


### PR DESCRIPTION
## Description

Create a utility that implements `Promise.allSettled` with ES6/ES2015 compatibility.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
