### PR TITLE
fix(repo): Unblock nightly nextjs integration tests

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -25,6 +25,7 @@ jobs:
         id: config
         uses: ./.github/actions/init
         with:
+          turbo-cache: 'local:'
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -45,7 +45,7 @@ jobs:
         run: mkdir clerk-js && cd clerk-js && pnpm init && pnpm add @clerk/clerk-js
 
       - name: Run Integration Tests
-        run: pnpm turbo test:integration:${{ matrix.test-name }} $TURBO_ARGS --only --force --no-cache
+        run: pnpm turbo test:integration:${{ matrix.test-name }} $TURBO_ARGS --only --force
         env:
           E2E_APP_CLERK_JS_DIR: ${{runner.temp}}
           E2E_CLERK_VERSION: 'latest'


### PR DESCRIPTION
## Description

Addresses issue from our nightly runs: https://github.com/clerk/javascript/actions/runs/14165884118/job/39678911621

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
