### PR TITLE
chore(nextjs): Remove telemetry event from `clerkMiddleware()`

### DIFF
--- a/.changeset/spotty-schools-juggle.md
+++ b/.changeset/spotty-schools-juggle.md
@@ -1,5 +1,7 @@
 ---
 '@clerk/nextjs': patch
+'@clerk/astro': patch
+'@clerk/nuxt': patch
 ---
 
 Remove telemtry event from `clerkMiddleware()`.

--- a/.changeset/spotty-schools-juggle.md
+++ b/.changeset/spotty-schools-juggle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Remove telemtry event from `clerkMiddleware()`.

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -3,7 +3,6 @@ import type { AuthenticateRequestOptions, ClerkRequest, RedirectFun, RequestStat
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
 import { isDevelopmentFromPublishableKey, isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
-import { eventMethodCalled } from '@clerk/shared/telemetry';
 import { handleValueOrFn } from '@clerk/shared/utils';
 import type { APIContext } from 'astro';
 
@@ -67,14 +66,6 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
     }
 
     const clerkRequest = createClerkRequest(context.request);
-
-    clerkClient(context).telemetry.record(
-      eventMethodCalled('clerkMiddleware', {
-        handler: Boolean(handler),
-        satellite: Boolean(options.isSatellite),
-        proxy: Boolean(options.proxyUrl),
-      }),
-    );
 
     const requestState = await clerkClient(context).authenticateRequest(
       clerkRequest,

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -1,7 +1,6 @@
 import type { AuthObject, ClerkClient } from '@clerk/backend';
 import type { AuthenticateRequestOptions, ClerkRequest, RedirectFun, RequestState } from '@clerk/backend/internal';
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
-import { eventMethodCalled } from '@clerk/shared/telemetry';
 import { notFound as nextjsNotFound } from 'next/navigation';
 import type { NextMiddleware, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -127,14 +126,6 @@ export const clerkMiddleware = ((...args: unknown[]): NextMiddleware | NextMiddl
       // Propagates the request data to be accessed on the server application runtime from helpers such as `clerkClient`
       clerkMiddlewareRequestDataStore.set('requestData', options);
       const resolvedClerkClient = await clerkClient();
-
-      resolvedClerkClient.telemetry.record(
-        eventMethodCalled('clerkMiddleware', {
-          handler: Boolean(handler),
-          satellite: Boolean(options.isSatellite),
-          proxy: Boolean(options.proxyUrl),
-        }),
-      );
 
       if (options.debug) {
         logger.enable();

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -1,6 +1,5 @@
 import type { AuthenticateRequestOptions } from '@clerk/backend/internal';
 import { AuthStatus, constants } from '@clerk/backend/internal';
-import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { EventHandler } from 'h3';
 import { createError, eventHandler, setResponseHeader } from 'h3';
 
@@ -79,14 +78,6 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
   const [handler, options] = parseHandlerAndOptions(args);
   return eventHandler(async event => {
     const clerkRequest = toWebRequest(event);
-
-    clerkClient(event).telemetry.record(
-      eventMethodCalled('clerkMiddleware', {
-        handler: Boolean(handler),
-        satellite: Boolean(options.isSatellite),
-        proxy: Boolean(options.proxyUrl),
-      }),
-    );
 
     const requestState = await clerkClient(event).authenticateRequest(clerkRequest, options);
 


### PR DESCRIPTION
## Description

Removes the `METHOD_CALLED` telemetry event from `clerkMiddleware()` as it's being fired more than intended. We can revisit in the future, but due to the reliance on the async `clerkClient()`, we can't just move it back to the middleware factory method.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
