### PR TITLE
chore(clerk-js): Add v0 preview domain to popup preferred list

### DIFF
--- a/.changeset/old-roses-wave.md
+++ b/.changeset/old-roses-wave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+add v0 preview domain to opt-in to pop-up auth flow

--- a/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
+++ b/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
@@ -1,4 +1,4 @@
-const POPUP_PREFERRED_ORIGINS = ['.lovable.app', '.lovableproject.com', '.webcontainer-api.io'];
+const POPUP_PREFERRED_ORIGINS = ['.lovable.app', '.lovableproject.com', '.webcontainer-api.io', '.vusercontent.net'];
 
 /**
  * Returns `true` if the current origin is one that is typically embedded via an iframe, which would benefit from the


### PR DESCRIPTION
## Description

Adds v0's preview domain (`vusercontent.net`) to the list of domains where we prefer the popup oauth flow. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
