### PR TITLE
chore(clerk-js,types): Handle pending sessions as signed-out in `isSignedIn` for custom flows

### DIFF
--- a/.changeset/new-showers-appear.md
+++ b/.changeset/new-showers-appear.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+By default, pending sessions are treated as signed-out on `Clerk.isSignedIn` for custom flows.

--- a/.changeset/new-showers-appear.md
+++ b/.changeset/new-showers-appear.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-By default, pending sessions are treated as signed-out on `Clerk.isSignedIn` for custom flows.
+Treat pending sessions as signed-out by default in `Clerk.isSignedIn`

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -165,6 +165,7 @@ const defaultOptions: ClerkOptions = {
   signUpFallbackRedirectUrl: undefined,
   signInForceRedirectUrl: undefined,
   signUpForceRedirectUrl: undefined,
+  treatPendingAsSignedOut: true,
 };
 
 export class Clerk implements ClerkInterface {
@@ -317,8 +318,10 @@ export class Clerk implements ClerkInterface {
   }
 
   get isSignedIn(): boolean {
+    const { treatPendingAsSignedOut } = this.#options;
+
     const hasPendingSession = this?.session?.status === 'pending';
-    if (hasPendingSession) {
+    if (treatPendingAsSignedOut && hasPendingSession) {
       return false;
     }
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -317,6 +317,11 @@ export class Clerk implements ClerkInterface {
   }
 
   get isSignedIn(): boolean {
+    const hasPendingSession = this?.session?.status === 'pending';
+    if (hasPendingSession) {
+      return false;
+    }
+
     return !!this.session;
   }
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -34,7 +34,7 @@ import type {
   SignUpFallbackRedirectUrl,
   SignUpForceRedirectUrl,
 } from './redirects';
-import type { SignedInSessionResource } from './session';
+import type { PendingSessionOptions, SignedInSessionResource } from './session';
 import type { SessionVerificationLevel } from './sessionVerification';
 import type { SignInResource } from './signIn';
 import type { SignUpResource } from './signUp';
@@ -733,7 +733,8 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
-export type ClerkOptions = ClerkOptionsNavigation &
+export type ClerkOptions = PendingSessionOptions &
+  ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -27,6 +27,13 @@ import type { SessionJSONSnapshot } from './snapshots';
 import type { TokenResource } from './token';
 import type { UserResource } from './user';
 
+export type PendingSessionOptions = {
+  /**
+   * Determines if pending sessions are considered as signed-out state. This option is set to `true` by default.
+   */
+  treatPendingAsSignedOut?: boolean;
+};
+
 type DisallowSystemPermissions<P extends string> = P extends `${OrganizationSystemPermissionPrefix}${string}`
   ? 'System permissions are not included in session claims and cannot be used on the server-side'
   : P;


### PR DESCRIPTION
## Description

Part of ORGS-621

`Clerk.isSignedIn` will return `false` by default if the `Clerk.session.status === pending`. This will make it easier for custom flows migration when force-an-org gets enabled by default on a instance: 

```js
const clerk = new Clerk(pubKey)
await clerk.load()

// Only mounts UI that relies on the user object, if the session switches to 'active'
if (clerk.isSignedIn) {
  clerk.mountUserButton(userbuttonDiv)
} else {
 // ......
}
```


<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
