### PR TITLE
feat(clerk-js): Add commerce support for Apple Pay

### DIFF
--- a/.changeset/big-chairs-smile.md
+++ b/.changeset/big-chairs-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Adds support for Apple Pay to `AddPaymentSource` component, and removes the unusable "collapsed" state.

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -6,7 +6,7 @@ import type {
   ClerkAPIError,
   ClerkRuntimeError,
 } from '@clerk/types';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Box, Button, Col, descriptors, Flex, Form, Icon, localizationKeys, Text } from '../../customizables';
 import { Alert, Disclosure, Divider, Drawer, LineItems, Select, SelectButton, SelectOptionList } from '../../elements';
@@ -98,10 +98,6 @@ const CheckoutFormElements = ({
   const { data } = useFetch(__experimental_commerce?.getPaymentSources, 'commerce-payment-sources');
   const { data: paymentSources } = data || { data: [] };
 
-  const didExpandStripePaymentMethods = useCallback(() => {
-    setOpenAccountFundsDropDown(false);
-  }, []);
-
   const confirmCheckout = async ({ paymentSourceId }: { paymentSourceId: string }) => {
     return checkout
       .confirm({ paymentSourceId })
@@ -183,7 +179,6 @@ const CheckoutFormElements = ({
           <AddPaymentSource
             checkout={checkout}
             onSuccess={onAddPaymentSourceSuccess}
-            onExpand={didExpandStripePaymentMethods}
             submitLabel={localizationKeys(
               'userProfile.__experimental_billingPage.paymentSourcesSection.formButtonPrimary__pay',
               {


### PR DESCRIPTION
## Description

Adds support for Apple Pay to `AddPaymentSource` component, and removes the unusable "collapsed" state.

<img width="578" alt="Screenshot 2025-04-01 at 8 19 11 PM" src="https://github.com/user-attachments/assets/fd1e79f5-dc84-41e9-ba7b-820681ab2ef2" />
<img width="651" alt="Screenshot 2025-04-01 at 8 25 50 PM" src="https://github.com/user-attachments/assets/c2d612b6-eba0-4f32-92ec-92084397fab4" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
