### PR TITLE
chore(shared,vue,nextjs,astro,clerk-react): Update `useAuth` to handle pending session as signed-out

### DIFF
--- a/.changeset/common-teams-do.md
+++ b/.changeset/common-teams-do.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': minor
+---
+
+Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `useAuth({ treatPendingAsSignedOut: false })` or `clerk({ treatPendingAsSignedOut: false })`

--- a/.changeset/early-boats-help.md
+++ b/.changeset/early-boats-help.md
@@ -1,0 +1,5 @@
+---
+'@clerk/vue': minor
+---
+
+Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `useAuth({ treatPendingAsSignedOut: false })` or `app.use(clerkPlugin, { treatPendingAsSignedOut: false })`

--- a/.changeset/modern-paws-mate.md
+++ b/.changeset/modern-paws-mate.md
@@ -6,4 +6,4 @@
 '@clerk/vue': patch
 ---
 
-Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `treatPendingAsSignedOut: false`
+Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `useAuth({ treatPendingAsSignedOut: false })` or `<ClerkProvider treatPendingAsSignedOut={false} />`

--- a/.changeset/modern-paws-mate.md
+++ b/.changeset/modern-paws-mate.md
@@ -1,9 +1,7 @@
 ---
 '@clerk/nextjs': patch
 '@clerk/shared': patch
-'@clerk/astro': patch
 '@clerk/clerk-react': patch
-'@clerk/vue': patch
 ---
 
 Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `useAuth({ treatPendingAsSignedOut: false })` or `<ClerkProvider treatPendingAsSignedOut={false} />`

--- a/.changeset/modern-paws-mate.md
+++ b/.changeset/modern-paws-mate.md
@@ -1,0 +1,9 @@
+---
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/astro': patch
+'@clerk/clerk-react': patch
+'@clerk/vue': patch
+---
+
+Update `useAuth` to handle pending sessions as signed-out by default, with opt-out via `treatPendingAsSignedOut: false`

--- a/packages/astro/src/env.d.ts
+++ b/packages/astro/src/env.d.ts
@@ -18,6 +18,7 @@ interface InternalEnv {
   readonly PUBLIC_CLERK_SIGN_UP_URL?: string;
   readonly PUBLIC_CLERK_TELEMETRY_DISABLED?: string;
   readonly PUBLIC_CLERK_TELEMETRY_DEBUG?: string;
+  readonly PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT?: string;
 }
 
 interface ImportMeta {

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -19,7 +19,15 @@ type HotloadAstroClerkIntegrationParams = AstroClerkIntegrationParams & {
 
 function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() {
   return (params?: Params): AstroIntegration => {
-    const { proxyUrl, isSatellite, domain, signInUrl, signUpUrl, enableEnvSchema = true } = params || {};
+    const {
+      proxyUrl,
+      isSatellite,
+      domain,
+      signInUrl,
+      signUpUrl,
+      enableEnvSchema = true,
+      treatPendingAsSignedOut,
+    } = params || {};
 
     // These are not provided when the "bundled" integration is used
     const clerkJSUrl = (params as any)?.clerkJSUrl as string | undefined;
@@ -57,6 +65,7 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
                 /**
                  * Convert the integration params to environment variable in order for it to be readable from the server
                  */
+                ...buildEnvVarFromOption(treatPendingAsSignedOut, 'PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT'),
                 ...buildEnvVarFromOption(signInUrl, 'PUBLIC_CLERK_SIGN_IN_URL'),
                 ...buildEnvVarFromOption(signUpUrl, 'PUBLIC_CLERK_SIGN_UP_URL'),
                 ...buildEnvVarFromOption(isSatellite, 'PUBLIC_CLERK_IS_SATELLITE'),

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -125,8 +125,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       has,
     },
     options: {
-      treatPendingAsSignedOut:
-        treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut') ?? true,
+      treatPendingAsSignedOut: treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut'),
     },
   });
 

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -125,7 +125,8 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       has,
     },
     options: {
-      treatPendingAsSignedOut: treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut'),
+      treatPendingAsSignedOut:
+        treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut') ?? true,
     },
   });
 

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -12,7 +12,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 import { authAsyncStorage } from '#async-local-storage';
 
-import { $authStore, $clerkStore } from '../stores/external';
+import { $authStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
 
 /**
@@ -85,8 +85,6 @@ type UseAuth = (options?: PendingSessionOptions) => UseAuthReturn;
 export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
   const authContext = useStore($authStore);
 
-  const clerk = useStore($clerkStore);
-
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
 
@@ -125,7 +123,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       has,
     },
     options: {
-      treatPendingAsSignedOut: treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut'),
+      treatPendingAsSignedOut,
     },
   });
 

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -116,7 +116,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
   );
 
   const payload = resolveAuthState({
-    authContext: {
+    authObject: {
       ...authContext,
       getToken,
       signOut,

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -1,21 +1,19 @@
+import { resolveAuthState } from '@clerk/shared/authorization';
 import type {
-  ActClaim,
   CheckAuthorizationWithCustomPermissions,
   Clerk,
   GetToken,
-  OrganizationCustomRoleKey,
+  PendingSessionOptions,
   SignOut,
+  UseAuthReturn,
 } from '@clerk/types';
 import type { Store, StoreValue } from 'nanostores';
 import { useCallback, useSyncExternalStore } from 'react';
 
 import { authAsyncStorage } from '#async-local-storage';
 
-import { $authStore } from '../stores/external';
+import { $authStore, $clerkStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
-
-type CheckAuthorizationSignedOut = undefined;
-type CheckAuthorizationWithoutOrgOrUser = (params?: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => false;
 
 /**
  * @internal
@@ -54,61 +52,7 @@ const createSignOut = () => {
   };
 };
 
-type UseAuthReturn =
-  | {
-      isLoaded: false;
-      isSignedIn: undefined;
-      userId: undefined;
-      sessionId: undefined;
-      actor: undefined;
-      orgId: undefined;
-      orgRole: undefined;
-      orgSlug: undefined;
-      has: CheckAuthorizationSignedOut;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: false;
-      userId: null;
-      sessionId: null;
-      actor: null;
-      orgId: null;
-      orgRole: null;
-      orgSlug: null;
-      has: CheckAuthorizationWithoutOrgOrUser;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: true;
-      userId: string;
-      sessionId: string;
-      actor: ActClaim | null;
-      orgId: null;
-      orgRole: null;
-      orgSlug: null;
-      has: CheckAuthorizationWithoutOrgOrUser;
-      signOut: SignOut;
-      getToken: GetToken;
-    }
-  | {
-      isLoaded: true;
-      isSignedIn: true;
-      userId: string;
-      sessionId: string;
-      actor: ActClaim | null;
-      orgId: string;
-      orgRole: OrganizationCustomRoleKey;
-      orgSlug: string | null;
-      has: CheckAuthorizationWithCustomPermissions;
-      signOut: SignOut;
-      getToken: GetToken;
-    };
-
-type UseAuth = () => UseAuthReturn;
+type UseAuth = (options?: PendingSessionOptions) => UseAuthReturn;
 
 /**
  * Returns the current auth state, the user and session ids and the `getToken`
@@ -138,11 +82,15 @@ type UseAuth = () => UseAuthReturn;
  *   return <div>...</div>
  * }
  */
-export const useAuth: UseAuth = () => {
-  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions } = useStore($authStore);
+export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
+  const authContext = useStore($authStore);
+
+  const clerk = useStore($clerkStore);
 
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
+
+  const { userId, orgId, orgRole, orgPermissions } = authContext;
 
   const has = useCallback(
     (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
@@ -169,71 +117,23 @@ export const useAuth: UseAuth = () => {
     [orgId, orgRole, userId, orgPermissions],
   );
 
-  if (sessionId === undefined && userId === undefined) {
-    return {
-      isLoaded: false,
-      isSignedIn: undefined,
-      sessionId,
-      userId,
-      actor: undefined,
-      orgId: undefined,
-      orgRole: undefined,
-      orgSlug: undefined,
-      has: undefined,
-      signOut,
+  const payload = resolveAuthState({
+    authContext: {
+      ...authContext,
       getToken,
-    };
-  }
-
-  if (sessionId === null && userId === null) {
-    return {
-      isLoaded: true,
-      isSignedIn: false,
-      sessionId,
-      userId,
-      actor: null,
-      orgId: null,
-      orgRole: null,
-      orgSlug: null,
-      has: () => false,
       signOut,
-      getToken,
-    };
-  }
-
-  if (!!sessionId && !!userId && !!orgId && !!orgRole) {
-    return {
-      isLoaded: true,
-      isSignedIn: true,
-      sessionId,
-      userId,
-      actor: actor || null,
-      orgId,
-      orgRole,
-      orgSlug: orgSlug || null,
       has,
-      signOut,
-      getToken,
-    };
+    },
+    options: {
+      treatPendingAsSignedOut: treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut'),
+    },
+  });
+
+  if (!payload) {
+    throw new Error('Invalid state. Feel free to submit a bug or reach out to support');
   }
 
-  if (!!sessionId && !!userId && !orgId) {
-    return {
-      isLoaded: true,
-      isSignedIn: true,
-      sessionId,
-      userId,
-      actor: actor || null,
-      orgId: null,
-      orgRole: null,
-      orgSlug: null,
-      has: () => false,
-      signOut,
-      getToken,
-    };
-  }
-
-  throw new Error('Invalid state. Feel free to submit a bug or reach out to support');
+  return payload;
 };
 
 /**

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -12,7 +12,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 import { authAsyncStorage } from '#async-local-storage';
 
-import { $authStore } from '../stores/external';
+import { $authStore, $clerkStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
 
 /**
@@ -84,6 +84,7 @@ type UseAuth = (options?: PendingSessionOptions) => UseAuthReturn;
  */
 export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
   const authContext = useStore($authStore);
+  const clerkContext = useStore($clerkStore);
 
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
@@ -123,7 +124,8 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       has,
     },
     options: {
-      treatPendingAsSignedOut,
+      treatPendingAsSignedOut:
+        treatPendingAsSignedOut ?? clerkContext?.__internal_getOption?.('treatPendingAsSignedOut'),
     },
   });
 

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -125,7 +125,10 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
     },
     options: {
       treatPendingAsSignedOut:
-        treatPendingAsSignedOut ?? clerkContext?.__internal_getOption?.('treatPendingAsSignedOut'),
+        // Fallback from option provided via SSR / CSR contexts
+        treatPendingAsSignedOut ??
+        clerkContext?.__internal_getOption?.('treatPendingAsSignedOut') ??
+        import.meta.env.PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT,
     },
   });
 

--- a/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
+++ b/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
@@ -54,7 +54,7 @@ export function PromisifiedAuthProvider({
  * }
  * ```
  */
-export function usePromisifiedAuth() {
+export function usePromisifiedAuth(options: Parameters<typeof useAuth>[0]) {
   const isPagesRouter = useRouter();
   const valueFromContext = React.useContext(PromisifiedAuthContext);
 
@@ -68,12 +68,12 @@ export function usePromisifiedAuth() {
   if (typeof window === 'undefined') {
     // Pages router should always use useAuth as it is able to grab initial auth state from context during SSR.
     if (isPagesRouter) {
-      return useAuth();
+      return useAuth(options);
     }
 
     // We don't need to deal with Clerk being loaded here
-    return useDerivedAuth(resolvedData);
+    return useDerivedAuth({ ...resolvedData, ...options });
   } else {
-    return useAuth(resolvedData);
+    return useAuth({ ...resolvedData, ...options });
   }
 }

--- a/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
+++ b/packages/nextjs/src/client-boundary/PromisifiedAuthProvider.tsx
@@ -54,7 +54,7 @@ export function PromisifiedAuthProvider({
  * }
  * ```
  */
-export function usePromisifiedAuth(options: Parameters<typeof useAuth>[0]) {
+export function usePromisifiedAuth(options: Parameters<typeof useAuth>[0] = {}) {
   const isPagesRouter = useRouter();
   const valueFromContext = React.useContext(PromisifiedAuthContext);
 
@@ -64,7 +64,6 @@ export function usePromisifiedAuth(options: Parameters<typeof useAuth>[0]) {
   }
 
   // At this point we should have a usable auth object
-
   if (typeof window === 'undefined') {
     // Pages router should always use useAuth as it is able to grab initial auth state from context during SSR.
     if (isPagesRouter) {

--- a/packages/react/src/hooks/__tests__/useAuth.test.tsx
+++ b/packages/react/src/hooks/__tests__/useAuth.test.tsx
@@ -130,7 +130,7 @@ describe('useDerivedAuth', () => {
     expect(current.has?.({ permission: 'test' })).toBe(false);
   });
 
-  it('with `treatPendingAsSignedOut` option, returns signed in state when session has pending status', () => {
+  it('with `treatPendingAsSignedOut: true` option, returns signed out state when session has pending status', () => {
     const authObject = {
       sessionId: 'session123',
       sessionStatus: 'pending',
@@ -146,6 +146,35 @@ describe('useDerivedAuth', () => {
     const {
       result: { current },
     } = renderHook(() => useDerivedAuth(authObject, { treatPendingAsSignedOut: true }));
+
+    expect(current.isLoaded).toBe(true);
+    expect(current.isSignedIn).toBe(false);
+    expect(current.sessionId).toBeNull();
+    expect(current.userId).toBeNull();
+    expect(current.actor).toBeNull();
+    expect(current.orgId).toBeNull();
+    expect(current.orgRole).toBeNull();
+    expect(current.orgSlug).toBeNull();
+    expect(current.has).toBeInstanceOf(Function);
+    expect(current.has?.({ permission: 'test' })).toBe(false);
+  });
+
+  it('with `treatPendingAsSignedOut: false` option, returns signed in state when session has pending status', () => {
+    const authObject = {
+      sessionId: 'session123',
+      sessionStatus: 'pending',
+      userId: 'user123',
+      actor: 'actor123',
+      orgId: 'org123',
+      orgRole: 'admin',
+      orgSlug: 'my-org',
+      signOut: vi.fn(),
+      getToken: vi.fn(),
+    };
+
+    const {
+      result: { current },
+    } = renderHook(() => useDerivedAuth(authObject, { treatPendingAsSignedOut: false }));
 
     expect(current.isLoaded).toBe(true);
     expect(current.isSignedIn).toBe(true);

--- a/packages/react/src/hooks/__tests__/useAuth.test.tsx
+++ b/packages/react/src/hooks/__tests__/useAuth.test.tsx
@@ -101,6 +101,65 @@ describe('useDerivedAuth', () => {
     expect(current.has?.({ permission: 'test' })).toBe(false);
   });
 
+  it('returns signed out state when session has pending status by default', () => {
+    const authObject = {
+      sessionId: 'session123',
+      sessionStatus: 'pending',
+      userId: 'user123',
+      actor: 'actor123',
+      orgId: 'org123',
+      orgRole: 'admin',
+      orgSlug: 'my-org',
+      signOut: vi.fn(),
+      getToken: vi.fn(),
+    };
+
+    const {
+      result: { current },
+    } = renderHook(() => useDerivedAuth(authObject));
+
+    expect(current.isLoaded).toBe(true);
+    expect(current.isSignedIn).toBe(false);
+    expect(current.sessionId).toBeNull();
+    expect(current.userId).toBeNull();
+    expect(current.actor).toBeNull();
+    expect(current.orgId).toBeNull();
+    expect(current.orgRole).toBeNull();
+    expect(current.orgSlug).toBeNull();
+    expect(current.has).toBeInstanceOf(Function);
+    expect(current.has?.({ permission: 'test' })).toBe(false);
+  });
+
+  it('with `treatPendingAsSignedOut` option, returns signed in state when session has pending status', () => {
+    const authObject = {
+      sessionId: 'session123',
+      sessionStatus: 'pending',
+      userId: 'user123',
+      actor: 'actor123',
+      orgId: 'org123',
+      orgRole: 'admin',
+      orgSlug: 'my-org',
+      signOut: vi.fn(),
+      getToken: vi.fn(),
+    };
+
+    const {
+      result: { current },
+    } = renderHook(() => useDerivedAuth(authObject, { treatPendingAsSignedOut: true }));
+
+    expect(current.isLoaded).toBe(true);
+    expect(current.isSignedIn).toBe(true);
+    expect(current.sessionId).toBe('session123');
+    expect(current.userId).toBe('user123');
+    expect(current.actor).toBe('actor123');
+    expect(current.orgId).toBe('org123');
+    expect(current.orgRole).toBe('admin');
+    expect(current.orgSlug).toBe('my-org');
+    expect(typeof current.has).toBe('function');
+    expect(current.signOut).toBe(authObject.signOut);
+    expect(current.getToken).toBe(authObject.getToken);
+  });
+
   it('returns signed in with org context when sessionId, userId, orgId, and orgRole are present', () => {
     const authObject = {
       sessionId: 'session123',

--- a/packages/react/src/hooks/__tests__/useAuth.type.test.ts
+++ b/packages/react/src/hooks/__tests__/useAuth.type.test.ts
@@ -1,7 +1,9 @@
+import type { PendingSessionOptions } from '@clerk/types';
 import { describe, expectTypeOf, it } from 'vitest';
 
 import type { useAuth } from '../useAuth';
 
+type UseAuthParameters = Parameters<typeof useAuth>[0];
 type HasFunction = Exclude<ReturnType<typeof useAuth>['has'], undefined>;
 type ParamsOfHas = Parameters<HasFunction>[0];
 
@@ -109,6 +111,20 @@ describe('useAuth type tests', () => {
           afterMinutes: 10,
         },
       } as const).not.toMatchTypeOf<ParamsOfHas>();
+    });
+  });
+
+  describe('with parameters', () => {
+    it('allows passing any auth state object', () => {
+      expectTypeOf({ orgId: null }).toMatchTypeOf<UseAuthParameters>();
+    });
+
+    it('do not allow invalid option types', () => {
+      const invalidValue = 5;
+      expectTypeOf({ treatPendingAsSignedOut: invalidValue } satisfies Record<
+        keyof PendingSessionOptions,
+        any
+      >).toMatchTypeOf<UseAuthParameters>();
     });
   });
 });

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -173,7 +173,7 @@ export function useDerivedAuth(authObject: any, options: PendingSessionOptions =
       has: derivedHas,
     },
     options: {
-      treatPendingAsSignedOut: treatPendingAsSignedOut ?? options.treatPendingAsSignedOut,
+      treatPendingAsSignedOut: treatPendingAsSignedOut ?? options.treatPendingAsSignedOut ?? true,
     },
   });
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,5 +1,4 @@
 import { createCheckAuthorization, resolveAuthState } from '@clerk/shared/authorization';
-import { useOptionsContext } from '@clerk/shared/react';
 import type {
   CheckAuthorizationWithCustomPermissions,
   GetToken,
@@ -144,8 +143,9 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
  * ```
  */
 export function useDerivedAuth(authObject: any, options: PendingSessionOptions = {}): UseAuthReturn {
-  const optionsContext = useOptionsContext();
-  const treatPendingAsSignedOut = options.treatPendingAsSignedOut ?? optionsContext?.treatPendingAsSignedOut;
+  const clerk = useIsomorphicClerkContext();
+  const treatPendingAsSignedOut =
+    options.treatPendingAsSignedOut ?? clerk.__internal_getOption('treatPendingAsSignedOut') ?? true;
 
   const { userId, orgId, orgRole, has, signOut, getToken, orgPermissions, factorVerificationAge } = authObject ?? {};
 
@@ -173,7 +173,7 @@ export function useDerivedAuth(authObject: any, options: PendingSessionOptions =
       has: derivedHas,
     },
     options: {
-      treatPendingAsSignedOut: treatPendingAsSignedOut ?? options.treatPendingAsSignedOut ?? true,
+      treatPendingAsSignedOut,
     },
   });
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -145,7 +145,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
 export function useDerivedAuth(authObject: any, options: PendingSessionOptions = {}): UseAuthReturn {
   const clerk = useIsomorphicClerkContext();
   const treatPendingAsSignedOut =
-    options.treatPendingAsSignedOut ?? clerk.__internal_getOption('treatPendingAsSignedOut') ?? true;
+    options.treatPendingAsSignedOut ?? clerk.__internal_getOption('treatPendingAsSignedOut');
 
   const { userId, orgId, orgRole, has, signOut, getToken, orgPermissions, factorVerificationAge } = authObject ?? {};
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -17,7 +17,8 @@ import { useAssertWrappedByClerkProvider } from './useAssertWrappedByClerkProvid
 import { createGetToken, createSignOut } from './utils';
 
 type Nullish<T> = T | undefined | null;
-type UseAuthOptions = Nullish<Record<string, any> | PendingSessionOptions>;
+type InitialAuthState = Record<string, any>;
+type UseAuthOptions = Nullish<InitialAuthState | PendingSessionOptions>;
 
 /**
  * The `useAuth()` hook provides access to the current user's authentication state and methods to manage the active session.
@@ -94,9 +95,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
     authContext = initialAuthState != null ? initialAuthState : {};
   }
 
-  const { sessionId, userId, actor, orgId, orgRole, orgSlug, orgPermissions, factorVerificationAge } = authContext;
   const isomorphicClerk = useIsomorphicClerkContext();
-
   const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
   const signOut: SignOut = useCallback(createSignOut(isomorphicClerk), [isomorphicClerk]);
 
@@ -104,18 +103,14 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
 
   return useDerivedAuth(
     {
-      sessionId,
-      userId,
-      actor,
-      orgId,
-      orgSlug,
-      orgRole,
+      ...authContext,
       getToken,
       signOut,
-      orgPermissions,
-      factorVerificationAge,
     },
-    { treatPendingAsSignedOut },
+    {
+      treatPendingAsSignedOut:
+        treatPendingAsSignedOut ?? isomorphicClerk.__internal_getOption('treatPendingAsSignedOut'),
+    },
   );
 };
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -181,5 +181,5 @@ export function useDerivedAuth(authObject: any, options: PendingSessionOptions =
     return errorThrower.throw(invalidStateError);
   }
 
-  return errorThrower.throw(invalidStateError);
+  return payload;
 }

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -87,6 +87,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
   const initialAuthState = rest as any;
 
   const authContextFromHook = useAuthContext();
+
   let authContext = authContextFromHook;
 
   if (authContext.sessionId === undefined && authContext.userId === undefined) {
@@ -112,7 +113,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
       orgPermissions,
       factorVerificationAge,
     },
-    { treatPendingAsSignedOut },
+    { treatPendingAsSignedOut: treatPendingAsSignedOut },
   );
 };
 
@@ -142,11 +143,10 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
  * } = useDerivedAuth(authObject);
  * ```
  */
-export function useDerivedAuth(authObject: any, options: PendingSessionOptions = {}): UseAuthReturn {
-  const clerk = useIsomorphicClerkContext();
-  const treatPendingAsSignedOut =
-    options.treatPendingAsSignedOut ?? clerk.__internal_getOption('treatPendingAsSignedOut');
-
+export function useDerivedAuth(
+  authObject: any,
+  { treatPendingAsSignedOut = true }: PendingSessionOptions = {},
+): UseAuthReturn {
   const { userId, orgId, orgRole, has, signOut, getToken, orgPermissions, factorVerificationAge } = authObject ?? {};
 
   const derivedHas = useCallback(

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { createCheckAuthorization, resolveAuthState } from '@clerk/shared/authorization';
+import { useOptionsContext } from '@clerk/shared/react';
 import type {
   CheckAuthorizationWithCustomPermissions,
   GetToken,
@@ -143,9 +144,8 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
  * ```
  */
 export function useDerivedAuth(authObject: any, options: PendingSessionOptions = {}): UseAuthReturn {
-  const clerk = useIsomorphicClerkContext();
-  const treatPendingAsSignedOut =
-    options.treatPendingAsSignedOut ?? clerk.__internal_getOption('treatPendingAsSignedOut');
+  const optionsContext = useOptionsContext();
+  const treatPendingAsSignedOut = options.treatPendingAsSignedOut ?? optionsContext?.treatPendingAsSignedOut;
 
   const { userId, orgId, orgRole, has, signOut, getToken, orgPermissions, factorVerificationAge } = authObject ?? {};
 
@@ -173,7 +173,7 @@ export function useDerivedAuth(authObject: any, options: PendingSessionOptions =
       has: derivedHas,
     },
     options: {
-      treatPendingAsSignedOut: treatPendingAsSignedOut ?? clerk?.__internal_getOption('treatPendingAsSignedOut'),
+      treatPendingAsSignedOut: treatPendingAsSignedOut ?? options.treatPendingAsSignedOut,
     },
   });
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { createCheckAuthorization, resolveAuthState } from '@clerk/shared/authorization';
+import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type {
   CheckAuthorizationWithCustomPermissions,
   GetToken,
@@ -98,6 +99,8 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
 
   const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
   const signOut: SignOut = useCallback(createSignOut(isomorphicClerk), [isomorphicClerk]);
+
+  isomorphicClerk.telemetry?.record(eventMethodCalled('useAuth', { treatPendingAsSignedOut }));
 
   return useDerivedAuth(
     {

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -109,7 +109,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
     },
     {
       treatPendingAsSignedOut:
-        treatPendingAsSignedOut ?? isomorphicClerk.__internal_getOption('treatPendingAsSignedOut'),
+        treatPendingAsSignedOut ?? isomorphicClerk.__internal_getOption?.('treatPendingAsSignedOut'),
     },
   );
 };

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -87,7 +87,6 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
   const initialAuthState = rest as any;
 
   const authContextFromHook = useAuthContext();
-
   let authContext = authContextFromHook;
 
   if (authContext.sessionId === undefined && authContext.userId === undefined) {
@@ -113,7 +112,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
       orgPermissions,
       factorVerificationAge,
     },
-    { treatPendingAsSignedOut: treatPendingAsSignedOut },
+    { treatPendingAsSignedOut },
   );
 };
 
@@ -162,11 +161,11 @@ export function useDerivedAuth(
         factorVerificationAge,
       })(params);
     },
-    [userId, factorVerificationAge, orgId, orgRole, orgPermissions],
+    [has, userId, orgId, orgRole, orgPermissions, factorVerificationAge],
   );
 
   const payload = resolveAuthState({
-    authContext: {
+    authObject: {
       ...authObject,
       getToken,
       signOut,

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -197,8 +197,13 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     return this.#proxyUrl || '';
   }
 
+  /**
+   * Accesses private options from the `Clerk` instance and defaults to
+   * `IsomorphicClerk` options when in SSR context.
+   *  @internal
+   */
   public __internal_getOption<K extends keyof ClerkOptions>(key: K): ClerkOptions[K] | undefined {
-    return this.clerkjs?.__internal_getOption(key);
+    return this.clerkjs?.__internal_getOption ? this.clerkjs?.__internal_getOption(key) : this.options[key];
   }
 
   constructor(options: IsomorphicClerkOptions) {

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -189,7 +189,7 @@ type AuthStateOptions = {
  */
 const resolveAuthState = ({
   authContext: { sessionId, sessionStatus, userId, actor, orgId, orgRole, orgSlug, signOut, getToken, has },
-  options: { treatPendingAsSignedOut },
+  options: { treatPendingAsSignedOut = true },
 }: AuthStateOptions): UseAuthReturn | undefined => {
   if (sessionId === undefined && userId === undefined) {
     return {

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -10,6 +10,7 @@ import type {
   SessionVerificationLevel,
   SessionVerificationTypes,
   SignOut,
+  UseAuthReturn,
 } from '@clerk/types';
 
 type TypesToConfig = Record<SessionVerificationTypes, Exclude<ReverificationConfig, SessionVerificationTypes>>;
@@ -186,10 +187,10 @@ type AuthStateOptions = {
  * preventing duplication across different packages
  * @internal
  */
-export const resolveAuthState = ({
+const resolveAuthState = ({
   authContext: { sessionId, sessionStatus, userId, actor, orgId, orgRole, orgSlug, signOut, getToken, has },
   options: { treatPendingAsSignedOut },
-}: AuthStateOptions) => {
+}: AuthStateOptions): UseAuthReturn | undefined => {
   if (sessionId === undefined && userId === undefined) {
     return {
       isLoaded: false,
@@ -203,7 +204,7 @@ export const resolveAuthState = ({
       has: undefined,
       signOut,
       getToken,
-    };
+    } as const;
   }
 
   if (sessionId === null && userId === null) {
@@ -219,15 +220,15 @@ export const resolveAuthState = ({
       has: () => false,
       signOut,
       getToken,
-    };
+    } as const;
   }
 
   if (treatPendingAsSignedOut && sessionStatus === 'pending') {
     return {
       isLoaded: true,
       isSignedIn: false,
-      sessionId,
-      userId,
+      sessionId: null,
+      userId: null,
       actor: null,
       orgId: null,
       orgRole: null,
@@ -235,7 +236,7 @@ export const resolveAuthState = ({
       has: () => false,
       signOut,
       getToken,
-    };
+    } as const;
   }
 
   if (!!sessionId && !!userId && !!orgId && !!orgRole) {
@@ -251,7 +252,7 @@ export const resolveAuthState = ({
       has,
       signOut,
       getToken,
-    };
+    } as const;
   }
 
   if (!!sessionId && !!userId && !orgId) {
@@ -267,8 +268,8 @@ export const resolveAuthState = ({
       has: () => false,
       signOut,
       getToken,
-    };
+    } as const;
   }
 };
 
-export { createCheckAuthorization, validateReverificationConfig };
+export { createCheckAuthorization, validateReverificationConfig, resolveAuthState };

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -166,7 +166,7 @@ const createCheckAuthorization = (options: AuthorizationOptions): CheckAuthoriza
 };
 
 type AuthStateOptions = {
-  authContext: {
+  authObject: {
     userId?: string | null;
     sessionId?: string | null;
     sessionStatus?: SessionStatusClaim | null;
@@ -188,7 +188,7 @@ type AuthStateOptions = {
  * @internal
  */
 const resolveAuthState = ({
-  authContext: { sessionId, sessionStatus, userId, actor, orgId, orgRole, orgSlug, signOut, getToken, has },
+  authObject: { sessionId, sessionStatus, userId, actor, orgId, orgRole, orgSlug, signOut, getToken, has },
   options: { treatPendingAsSignedOut = true },
 }: AuthStateOptions): UseAuthReturn | undefined => {
   if (sessionId === undefined && userId === undefined) {
@@ -265,7 +265,7 @@ const resolveAuthState = ({
       orgId: null,
       orgRole: null,
       orgSlug: null,
-      has: () => false,
+      has,
       signOut,
       getToken,
     } as const;

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -80,8 +80,8 @@ type UseAuth = (options?: PendingSessionOptions) => ToComputedRefs<UseAuthReturn
  *   </div>
  * </template>
  */
-export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
-  const { clerk, authCtx, treatPendingAsSignedOut } = useClerkContext();
+export const useAuth: UseAuth = (options = {}) => {
+  const { clerk, authCtx, ...contextOptions } = useClerkContext();
 
   const getToken: GetToken = createGetToken(clerk);
   const signOut: SignOut = createSignOut(clerk);
@@ -116,8 +116,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
         has,
       },
       options: {
-        treatPendingAsSignedOut:
-          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
+        treatPendingAsSignedOut: options.treatPendingAsSignedOut ?? contextOptions.treatPendingAsSignedOut,
       },
     });
 

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -81,7 +81,7 @@ type UseAuth = (options?: PendingSessionOptions) => ToComputedRefs<UseAuthReturn
  * </template>
  */
 export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
-  const { clerk, authCtx } = useClerkContext();
+  const { clerk, authCtx, treatPendingAsSignedOut } = useClerkContext();
 
   const getToken: GetToken = createGetToken(clerk);
   const signOut: SignOut = createSignOut(clerk);
@@ -116,7 +116,8 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
         has,
       },
       options: {
-        treatPendingAsSignedOut,
+        treatPendingAsSignedOut:
+          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
       },
     });
 

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -117,7 +117,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       },
       options: {
         treatPendingAsSignedOut:
-          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
+          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut') ?? true,
       },
     });
 

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -125,7 +125,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       return errorThrower.throw(invalidStateError);
     }
 
-    return errorThrower.throw(invalidStateError);
+    return payload;
   });
 
   return toComputedRefs(result);

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -109,7 +109,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
     };
 
     const payload = resolveAuthState({
-      authContext: {
+      authObject: {
         ...authCtx.value,
         getToken,
         signOut,

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -116,8 +116,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
         has,
       },
       options: {
-        treatPendingAsSignedOut:
-          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
+        treatPendingAsSignedOut,
       },
     });
 

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -117,7 +117,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       },
       options: {
         treatPendingAsSignedOut:
-          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut') ?? true,
+          treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
       },
     });
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -3,7 +3,7 @@ import { deriveState } from '@clerk/shared/deriveState';
 import { loadClerkJsScript, type LoadClerkJsScriptOptions } from '@clerk/shared/loadClerkJsScript';
 import type { Clerk, ClientResource, Resources } from '@clerk/types';
 import type { Plugin } from 'vue';
-import { computed, ref, shallowRef, shallowRef, triggerRef } from 'vue';
+import { computed, ref, shallowRef, triggerRef } from 'vue';
 
 import { ClerkInjectionKey } from './keys';
 
@@ -84,7 +84,7 @@ export const clerkPlugin: Plugin<[PluginOptions]> = {
       userCtx,
       organizationCtx,
       treatPendingAsSignedOut:
-        options.treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
+        options.treatPendingAsSignedOut ?? clerk.value?.__internal_getOption?.('treatPendingAsSignedOut'),
     });
   },
 };

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -3,7 +3,7 @@ import { deriveState } from '@clerk/shared/deriveState';
 import { loadClerkJsScript, type LoadClerkJsScriptOptions } from '@clerk/shared/loadClerkJsScript';
 import type { Clerk, ClientResource, Resources } from '@clerk/types';
 import type { Plugin } from 'vue';
-import { computed, ref, shallowRef, triggerRef } from 'vue';
+import { computed, ref, shallowRef, shallowRef, triggerRef } from 'vue';
 
 import { ClerkInjectionKey } from './keys';
 
@@ -83,6 +83,8 @@ export const clerkPlugin: Plugin<[PluginOptions]> = {
       sessionCtx,
       userCtx,
       organizationCtx,
+      treatPendingAsSignedOut:
+        options.treatPendingAsSignedOut ?? clerk.value?.__internal_getOption('treatPendingAsSignedOut'),
     });
   },
 };

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -31,6 +31,7 @@ export interface VueClerkInjectionKeyType {
   sessionCtx: ComputedRef<SignedInSessionResource | null | undefined>;
   userCtx: ComputedRef<UserResource | null | undefined>;
   organizationCtx: ComputedRef<OrganizationResource | null | undefined>;
+  treatPendingAsSignedOut?: boolean;
 }
 
 // Copied from `@clerk/clerk-react`


### PR DESCRIPTION
## Description

Part of ORGS-621 

Allows to pass `treatPendingAsSignedOut` as an option to `useAuth` - refer to the following behavior when a session has a pending status:

```ts
// userId is undefined, since pending is treat as signed-out state (default behavior)
const { userId } = useAuth() 

// userId is defined, since pending is treat as signed-out state (opt-in behavior)
const { userId } = useAuth({ treatPendingAsSignedOut: true })
```

Globally changing the default: 
```tsx
<ClerkProvider treatPendingAsSignedOut={false} />
```

--- 

Example from Nuxt route middleware: 

```ts
const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])

export default defineNuxtRouteMiddleware((to) => {
  const { userId } = useAuth()

  // If the user has a pending session, they aren't allowed to access
  // the protected route and are redirected to the sign-in page
  // If the sign-in page renders `SignIn`, then it'll redirect to `/tasks` internal route on component mount
  if (!userId.value && isProtectedRoute(to)) {
    return navigateTo('/sign-in')
  }
})
```

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
