### PR TITLE
chore(shared): Set a timeout when loading Clerk from an inline script.

### DIFF
--- a/.changeset/cyan-planes-double.md
+++ b/.changeset/cyan-planes-double.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix infinite pending loading when an inline script fails before event listeners are set by adding a timeout.


### PR DESCRIPTION
## Description

The inline script might fail before the event listeners are attached which causes an infinite pending state. Instead, we would like to retry fetching the script and/or throw an error.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
