### PR TITLE
chore(nuxt): Expose `event.context.auth()` as function

### DIFF
--- a/.changeset/chatty-loops-watch.md
+++ b/.changeset/chatty-loops-watch.md
@@ -3,3 +3,18 @@
 ---
 
 Deprecate `event.context.auth` in favor of `event.context.auth()` as function
+
+```diff
+export default clerkMiddleware((event) => {
++ const { userId } = event.context.auth()
+- const { userId } = event.context.auth
+  const isAdminRoute = event.path.startsWith('/api/admin')
+
+  if (!userId && isAdminRoute) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized: User not signed in',
+    })
+  }
+})
+```

--- a/.changeset/chatty-loops-watch.md
+++ b/.changeset/chatty-loops-watch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nuxt': minor
+---
+
+Deprecate `event.context.auth` in favor of `event.context.auth()` as function

--- a/integration/templates/nuxt-node/server/api/me.js
+++ b/integration/templates/nuxt-node/server/api/me.js
@@ -1,7 +1,7 @@
 import { clerkClient } from '@clerk/nuxt/server';
 
 export default eventHandler(async event => {
-  const { userId } = event.context.auth;
+  const { userId } = event.context.auth();
 
   if (!userId) {
     throw createError({

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -104,11 +104,11 @@ export default defineNuxtModule<ModuleOptions>({
       {
         filename: 'types/clerk.d.ts',
         getContents: () => `import type { AuthObject } from '@clerk/backend';
-          interface AuthObjectHandler extends AuthObject {
-            (): AuthObject;
-          }
-
           declare module 'h3' {
+            type AuthObjectHandler = AuthObject & {
+              (): AuthObject;
+            }
+
             interface H3EventContext {
               auth: AuthObjectHandler;
             }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -26,7 +26,7 @@ export type ModuleOptions = Omit<LoadClerkJsScriptOptions, 'routerPush' | 'route
    * import { clerkMiddleware } from '@clerk/nuxt/server'
    *
    * export default clerkMiddleware((event) => {
-   *   console.log('auth', event.context.auth)
+   *   console.log('auth', event.context.auth())
    * })
    * ```
    */
@@ -99,14 +99,18 @@ export default defineNuxtModule<ModuleOptions>({
       });
     }
 
-    // Adds TS support for `event.context.auth` in event handlers
+    // Adds TS support for `event.context.auth()` in event handlers
     addTypeTemplate(
       {
         filename: 'types/clerk.d.ts',
         getContents: () => `import type { AuthObject } from '@clerk/backend';
+          interface AuthObjectHandler extends AuthObject {
+            (): AuthObject;
+          }
+
           declare module 'h3' {
             interface H3EventContext {
-              auth: AuthObject;
+              auth: AuthObjectHandler;
             }
           }
         `,

--- a/packages/nuxt/src/runtime/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nuxt/src/runtime/server/__tests__/clerkMiddleware.test.ts
@@ -42,7 +42,7 @@ describe('clerkMiddleware(params)', () => {
     app.use(clerkMiddleware());
     app.use(
       '/',
-      eventHandler(event => event.context.auth),
+      eventHandler(event => event.context.auth()),
     );
     const response = await handler(new Request(new URL('/', 'http://localhost')));
 
@@ -56,7 +56,7 @@ describe('clerkMiddleware(params)', () => {
     app.use(clerkMiddleware(MOCK_OPTIONS));
     app.use(
       '/',
-      eventHandler(event => event.context.auth),
+      eventHandler(event => event.context.auth()),
     );
     const response = await handler(new Request(new URL('/', 'http://localhost')));
 
@@ -75,7 +75,7 @@ describe('clerkMiddleware(params)', () => {
     );
     app.use(
       '/',
-      eventHandler(event => event.context.auth),
+      eventHandler(event => event.context.auth()),
     );
     const response = await handler(new Request(new URL('/', 'http://localhost')));
 
@@ -94,7 +94,7 @@ describe('clerkMiddleware(params)', () => {
     );
     app.use(
       '/',
-      eventHandler(event => event.context.auth),
+      eventHandler(event => event.context.auth()),
     );
     const response = await handler(new Request(new URL('/', 'http://localhost')));
 

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -1,7 +1,6 @@
 import type { AuthenticateRequestOptions } from '@clerk/backend/internal';
 import { AuthStatus, constants } from '@clerk/backend/internal';
 import { deprecated } from '@clerk/shared/deprecated';
-import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { EventHandler } from 'h3';
 import { createError, eventHandler, setResponseHeader } from 'h3';
 
@@ -80,14 +79,6 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
   const [handler, options] = parseHandlerAndOptions(args);
   return eventHandler(async event => {
     const clerkRequest = toWebRequest(event);
-
-    clerkClient(event).telemetry.record(
-      eventMethodCalled('clerkMiddleware', {
-        handler: Boolean(handler),
-        satellite: Boolean(options.isSatellite),
-        proxy: Boolean(options.proxyUrl),
-      }),
-    );
 
     const requestState = await clerkClient(event).authenticateRequest(clerkRequest, options);
 

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -101,7 +101,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
     const authObject = requestState.toAuth();
     const authHandler = () => authObject;
 
-    const auth = new Proxy(Object.assign(authObject, authHandler), {
+    const auth = new Proxy(Object.assign(authHandler, authObject), {
       get(target, prop: string, receiver) {
         deprecated('event.context.auth', 'Use `event.context.auth()` as a function instead.');
 

--- a/packages/nuxt/src/runtime/server/getAuth.ts
+++ b/packages/nuxt/src/runtime/server/getAuth.ts
@@ -3,9 +3,11 @@ import type { H3Event } from 'h3';
 import { moduleRegistrationRequired } from './errors';
 
 export function getAuth(event: H3Event) {
-  if (!event.context.auth) {
+  const authObject = event.context.auth();
+
+  if (!authObject) {
     throw new Error(moduleRegistrationRequired);
   }
 
-  return event.context.auth;
+  return authObject;
 }


### PR DESCRIPTION
## Description

Resolves ORGS-622

Deprecate `event.context.auth` in favor of `event.context.auth()`: 

```diff
export default clerkMiddleware((event) => {
+ const { userId } = event.context.auth()
- const { userId } = event.context.auth
  const isAdminRoute = event.path.startsWith('/api/admin')

  if (!userId && isAdminRoute) {
    throw createError({
      statusCode: 401,
      statusMessage: 'Unauthorized: User not signed in',
    })
  }
})
```

This change is needed for an upcoming feature in which options are passed to auth: `auth({ treatPendingAsSignedOn })`

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
