### PR TITLE
feat(backend, clerk-js,clerk-react,shared,types): Add feature param to has

### DIFF
--- a/.changeset/curvy-teeth-watch.md
+++ b/.changeset/curvy-teeth-watch.md
@@ -1,0 +1,9 @@
+---
+'@clerk/backend': patch
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Add feature param to has

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -146,7 +146,13 @@ export function signedInAuthObject(
     orgPermissions,
     factorVerificationAge,
     getToken,
-    has: createCheckAuthorization({ orgId, orgRole, orgPermissions, userId, factorVerificationAge }),
+    has: createCheckAuthorization({
+      orgId,
+      orgRole,
+      orgPermissions,
+      userId,
+      factorVerificationAge,
+    }),
     debug: createDebug({ ...authenticateContext, sessionToken }),
   };
 }

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -43,6 +43,7 @@ type SignedInAuthObjectProperties = {
    * [fistFactorAge, secondFactorAge]
    */
   factorVerificationAge: [firstFactorAge: number, secondFactorAge: number] | null;
+  __experimental_features?: string | null;
 };
 
 /**
@@ -114,6 +115,7 @@ const generateSignedInAuthObjectProperties = (claims: JwtPayload): SignedInAuthO
     orgSlug: claims.org_slug,
     orgPermissions,
     factorVerificationAge,
+    __experimental_features: claims.fea,
   };
 };
 
@@ -125,8 +127,18 @@ export function signedInAuthObject(
   sessionToken: string,
   sessionClaims: JwtPayload,
 ): SignedInAuthObject {
-  const { actor, sessionId, sessionStatus, userId, orgId, orgRole, orgSlug, orgPermissions, factorVerificationAge } =
-    generateSignedInAuthObjectProperties(sessionClaims);
+  const {
+    actor,
+    sessionId,
+    sessionStatus,
+    userId,
+    orgId,
+    orgRole,
+    orgSlug,
+    orgPermissions,
+    factorVerificationAge,
+    __experimental_features,
+  } = generateSignedInAuthObjectProperties(sessionClaims);
   const apiClient = createBackendApiClient(authenticateContext);
   const getToken = createGetToken({
     sessionId,
@@ -145,6 +157,7 @@ export function signedInAuthObject(
     orgSlug,
     orgPermissions,
     factorVerificationAge,
+    __experimental_features,
     getToken,
     has: createCheckAuthorization({
       orgId,
@@ -152,6 +165,7 @@ export function signedInAuthObject(
       orgPermissions,
       userId,
       factorVerificationAge,
+      __experimental_features,
     }),
     debug: createDebug({ ...authenticateContext, sessionToken }),
   };

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -115,7 +115,8 @@ export class Session extends BaseResource implements SessionResource {
       orgId: activeMembership?.id,
       orgRole: activeMembership?.role,
       orgPermissions: activeMembership?.permissions,
-      features: '',
+      // TODO: retrieve features
+      __experimental_features: 'testfeature',
     })(params);
   };
 

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -115,6 +115,7 @@ export class Session extends BaseResource implements SessionResource {
       orgId: activeMembership?.id,
       orgRole: activeMembership?.role,
       orgPermissions: activeMembership?.permissions,
+      features: '',
     })(params);
   };
 

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -1,6 +1,7 @@
 import { deprecated } from '@clerk/shared/deprecated';
 import type {
   CheckAuthorizationWithCustomPermissions,
+  FeatureKey,
   HandleOAuthCallbackParams,
   OrganizationCustomPermissionKey,
   OrganizationCustomRoleKey,
@@ -61,21 +62,31 @@ export type ProtectProps = React.PropsWithChildren<
         condition?: never;
         role: OrganizationCustomRoleKey;
         permission?: never;
+        __experimental_feature?: never;
       }
     | {
         condition?: never;
         role?: never;
         permission: OrganizationCustomPermissionKey;
+        __experimental_feature?: never;
       }
     | {
         condition: (has: CheckAuthorizationWithCustomPermissions) => boolean;
         role?: never;
         permission?: never;
+        __experimental_feature?: never;
       }
     | {
         condition?: never;
         role?: never;
         permission?: never;
+        __experimental_feature: FeatureKey;
+      }
+    | {
+        condition?: never;
+        role?: never;
+        permission?: never;
+        __experimental_feature?: never;
       }
   ) & {
     fallback?: React.ReactNode;
@@ -89,8 +100,10 @@ export type ProtectProps = React.PropsWithChildren<
  * ```
  * <Protect permission="a_permission_key" />
  * <Protect role="a_role_key" />
+ * <Protect __experimental_feature"a_feature_key" />
  * <Protect condition={(has) => has({permission:"a_permission_key"})} />
  * <Protect condition={(has) => has({role:"a_role_key"})} />
+ * <Protect condition={(has) => has({__experimental_feature:"a_feature_key"})} />
  * <Protect fallback={<p>Unauthorized</p>} />
  * ```
  */
@@ -127,7 +140,7 @@ export const Protect = ({ children, fallback, treatPendingAsSignedOut, ...restAu
     return unauthorized;
   }
 
-  if (restAuthorizedParams.role || restAuthorizedParams.permission) {
+  if (restAuthorizedParams.role || restAuthorizedParams.permission || restAuthorizedParams.__experimental_feature) {
     if (has(restAuthorizedParams)) {
       return authorized;
     }

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -157,7 +157,8 @@ export function useDerivedAuth(
         orgRole,
         orgPermissions,
         factorVerificationAge,
-        features: '',
+        // TODO: get features from authObject
+        // features: 'testfeature',
       })(params);
     },
     [has, userId, orgId, orgRole, orgPermissions, factorVerificationAge],

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -157,6 +157,7 @@ export function useDerivedAuth(
         orgRole,
         orgPermissions,
         factorVerificationAge,
+        features: '',
       })(params);
     },
     [has, userId, orgId, orgRole, orgPermissions, factorVerificationAge],

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -144,7 +144,17 @@ export function useDerivedAuth(
   authObject: any,
   { treatPendingAsSignedOut = true }: PendingSessionOptions = {},
 ): UseAuthReturn {
-  const { userId, orgId, orgRole, has, signOut, getToken, orgPermissions, factorVerificationAge } = authObject ?? {};
+  const {
+    userId,
+    orgId,
+    orgRole,
+    has,
+    signOut,
+    getToken,
+    orgPermissions,
+    factorVerificationAge,
+    __experimental_features,
+  } = authObject ?? {};
 
   const derivedHas = useCallback(
     (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => {
@@ -157,11 +167,10 @@ export function useDerivedAuth(
         orgRole,
         orgPermissions,
         factorVerificationAge,
-        // TODO: get features from authObject
-        // features: 'testfeature',
+        __experimental_features,
       })(params);
     },
-    [has, userId, orgId, orgRole, orgPermissions, factorVerificationAge],
+    [has, userId, orgId, orgRole, orgPermissions, factorVerificationAge, __experimental_features],
   );
 
   const payload = resolveAuthState({

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -20,7 +20,7 @@ type AuthorizationOptions = {
   orgRole: string | null | undefined;
   orgPermissions: string[] | null | undefined;
   factorVerificationAge: [number, number] | null;
-  features: string | null | undefined;
+  __experimental_features?: string | null;
 };
 
 type CheckOrgAuthorization = (
@@ -30,7 +30,7 @@ type CheckOrgAuthorization = (
 
 type CheckFeatureAuthorization = (
   params: { __experimental_feature?: string },
-  { features }: AuthorizationOptions,
+  { __experimental_features }: AuthorizationOptions,
 ) => boolean | null;
 
 type CheckReverificationAuthorization = (
@@ -93,18 +93,18 @@ const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
 
 const checkFeatureAuthorization: CheckFeatureAuthorization = (param, options) => {
   const { __experimental_feature: feature } = param;
-  const { features } = options;
+  const { __experimental_features } = options;
 
   if (!feature) {
     return null;
   }
 
-  if (!features) {
+  if (!__experimental_features) {
     return null;
   }
 
-  if (typeof features === 'string') {
-    return features.split(',').includes(feature);
+  if (typeof __experimental_features === 'string') {
+    return __experimental_features.split(',').includes(feature);
   }
 
   return null;
@@ -205,6 +205,7 @@ type AuthStateOptions = {
     orgRole?: OrganizationCustomRoleKey | null;
     orgSlug?: string | null;
     orgPermissions?: OrganizationCustomPermissionKey[] | null;
+    __experimental_features?: string | null;
     getToken: GetToken;
     signOut: SignOut;
     has: (params: Parameters<CheckAuthorizationWithCustomPermissions>[0]) => boolean;

--- a/packages/types/src/authorization.ts
+++ b/packages/types/src/authorization.ts
@@ -1,0 +1,34 @@
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface ClerkAuthorization {}
+}
+
+interface AuthorizationKeysBase {
+  role: string;
+  permission: string;
+  __experimental_feature: string;
+}
+
+interface AuthorizationKeysPlaceholder {
+  role: unknown;
+  permission: unknown;
+  __experimental_feature: unknown;
+}
+
+export type RoleKey = ClerkAuthorization extends AuthorizationKeysPlaceholder
+  ? ClerkAuthorization['role'] extends string
+    ? ClerkAuthorization['role']
+    : AuthorizationKeysBase['role']
+  : AuthorizationKeysBase['role'];
+
+export type PermissionKey = ClerkAuthorization extends AuthorizationKeysPlaceholder
+  ? ClerkAuthorization['permission'] extends string
+    ? ClerkAuthorization['permission']
+    : AuthorizationKeysBase['permission']
+  : AuthorizationKeysBase['permission'];
+
+export type FeatureKey = ClerkAuthorization extends AuthorizationKeysPlaceholder
+  ? ClerkAuthorization['__experimental_feature'] extends string
+    ? ClerkAuthorization['__experimental_feature']
+    : AuthorizationKeysBase['__experimental_feature']
+  : AuthorizationKeysBase['__experimental_feature'];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export * from './appearance';
 export * from './elementIds';
 export * from './attributes';
 export * from './authConfig';
+export * from './authorization';
 export * from './backupCode';
 export * from './clerk';
 export * from './client';

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -116,15 +116,15 @@ type JWTPayloadBase = {
   sts?: SessionStatusClaim;
 
   /**
-   * Feature claims this represent features, you can have multiple features in the same claim. e.g.: "impersonation,emails"
-   * @experimental
-   */
-  fea?: string | null;
-
-  /**
    * Any other JWT Claim Set member.
    */
   [propName: string]: unknown;
+
+  /**
+   * Feature claims, you can have multiple features in the same claim. e.g.: "impersonation,emails"
+   * @experimental
+   */
+  fea?: string | null;
 };
 
 export type VersionedJwtPayload =
@@ -132,7 +132,6 @@ export type VersionedJwtPayload =
       ver?: never;
 
       /**
-       *
        * Active organization permissions.
        */
       org_permissions?: OrganizationCustomPermissionKey[];

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -116,6 +116,12 @@ type JWTPayloadBase = {
   sts?: SessionStatusClaim;
 
   /**
+   * Feature claims this represent features, you can have multiple features in the same claim. e.g.: "impersonation,emails"
+   * @experimental
+   */
+  fea?: string | null;
+
+  /**
    * Any other JWT Claim Set member.
    */
   [propName: string]: unknown;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -50,14 +50,21 @@ type WithReverification<T> = T & {
 
 export type CheckAuthorizationParamsWithCustomPermissions = WithReverification<
   | {
+      role?: never;
+      permission?: never;
+      __experimental_feature: string;
+    }
+  | {
       role: OrganizationCustomRoleKey;
       permission?: never;
+      __experimental_feature?: never;
     }
   | {
       role?: never;
       permission: OrganizationCustomPermissionKey;
+      __experimental_feature?: never;
     }
-  | { role?: never; permission?: never }
+  | { role?: never; permission?: never; __experimental_feature?: never }
 >;
 
 export type CheckAuthorization = CheckAuthorizationFn<CheckAuthorizationParams>;
@@ -88,14 +95,21 @@ export type CheckAuthorizationFromSessionClaims = <P extends OrganizationCustomP
 
 export type CheckAuthorizationParamsFromSessionClaims<P extends OrganizationCustomPermissionKey> = WithReverification<
   | {
+      role?: never;
+      permission?: never;
+      __experimental_feature: string;
+    }
+  | {
       role: OrganizationCustomRoleKey;
       permission?: never;
+      __experimental_feature?: never;
     }
   | {
       role?: never;
       permission: DisallowSystemPermissions<P>;
+      __experimental_feature?: never;
     }
-  | { role?: never; permission?: never }
+  | { role?: never; permission?: never; __experimental_feature?: never }
 >;
 
 /**

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -1,3 +1,4 @@
+import type { FeatureKey } from './authorization';
 import type {
   BackupCodeAttempt,
   EmailCodeAttempt,
@@ -50,11 +51,6 @@ type WithReverification<T> = T & {
 
 export type CheckAuthorizationParamsWithCustomPermissions = WithReverification<
   | {
-      role?: never;
-      permission?: never;
-      __experimental_feature: string;
-    }
-  | {
       role: OrganizationCustomRoleKey;
       permission?: never;
       __experimental_feature?: never;
@@ -63,6 +59,11 @@ export type CheckAuthorizationParamsWithCustomPermissions = WithReverification<
       role?: never;
       permission: OrganizationCustomPermissionKey;
       __experimental_feature?: never;
+    }
+  | {
+      role?: never;
+      permission?: never;
+      __experimental_feature: FeatureKey;
     }
   | { role?: never; permission?: never; __experimental_feature?: never }
 >;
@@ -95,11 +96,6 @@ export type CheckAuthorizationFromSessionClaims = <P extends OrganizationCustomP
 
 export type CheckAuthorizationParamsFromSessionClaims<P extends OrganizationCustomPermissionKey> = WithReverification<
   | {
-      role?: never;
-      permission?: never;
-      __experimental_feature: string;
-    }
-  | {
       role: OrganizationCustomRoleKey;
       permission?: never;
       __experimental_feature?: never;
@@ -108,6 +104,11 @@ export type CheckAuthorizationParamsFromSessionClaims<P extends OrganizationCust
       role?: never;
       permission: DisallowSystemPermissions<P>;
       __experimental_feature?: never;
+    }
+  | {
+      role?: never;
+      permission?: never;
+      __experimental_feature: FeatureKey;
     }
   | { role?: never; permission?: never; __experimental_feature?: never }
 >;


### PR DESCRIPTION
## Description

Add `__experimental_feature` param to `has` function:

```ts
const { has } = await auth()

const hasFeature = has({ __experimental_feature: 'testfeature' })
```

Resolves [COM-203](https://linear.app/clerk/issue/COM-203/sdk-support-features-in-has).

TODO: 
- testing
- fill in features claims in `Session` and `useAuth`
- improving checking roles, permissions and reverifications with feature.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

