### PR TITLE
fix(clerk-js): Only refresh when auth with popup is called

### DIFF
--- a/.changeset/curly-carrots-invite.md
+++ b/.changeset/curly-carrots-invite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Only refresh signIn and signUp resources during an SSO callback if the authentication was performed via a popup.

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -51,3 +51,5 @@ export const SIGN_UP_MODES: Record<string, SignUpModes> = {
 
 // This is the currently supported version of the Frontend API
 export const SUPPORTED_FAPI_VERSION = '2024-10-01';
+
+export const SESSION_STORAGE_AUTH_WITH_POPUP_KEY = 'hasUsedAuthenticateWithPopup';

--- a/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInSocialButtons.tsx
@@ -1,6 +1,7 @@
 import { useClerk } from '@clerk/shared/react';
 import React from 'react';
 
+import { SESSION_STORAGE_AUTH_WITH_POPUP_KEY } from '../../../core/constants';
 import { buildSSOCallbackURL } from '../../common/redirects';
 import { useCoreSignIn, useSignInContext } from '../../contexts';
 import { useEnvironment } from '../../contexts/EnvironmentContext';
@@ -37,6 +38,12 @@ export const SignInSocialButtons = React.memo((props: SocialButtonsProps) => {
               card.setIdle();
             }
           }, 500);
+
+          try {
+            window.sessionStorage.setItem(SESSION_STORAGE_AUTH_WITH_POPUP_KEY, 'true');
+          } catch {
+            // It's okay if sessionStorage is disabled since we will treat the failure to read the value as it being true.
+          }
 
           return signIn
             .authenticateWithPopup({ strategy, redirectUrl, redirectUrlComplete, popup })

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
@@ -2,6 +2,7 @@ import { useClerk } from '@clerk/shared/react';
 import type { OAuthStrategy } from '@clerk/types';
 import React from 'react';
 
+import { SESSION_STORAGE_AUTH_WITH_POPUP_KEY } from '../../../core/constants';
 import { useCoreSignUp, useSignUpContext } from '../../contexts';
 import { useCardState } from '../../elements';
 import type { SocialButtonsProps } from '../../elements/SocialButtons';
@@ -38,6 +39,12 @@ export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) 
               card.setIdle();
             }
           }, 500);
+
+          try {
+            window.sessionStorage.setItem(SESSION_STORAGE_AUTH_WITH_POPUP_KEY, 'true');
+          } catch {
+            // It's okay if sessionStorage is disabled since we will treat the failure to read the value as it being true.
+          }
 
           return signUp
             .authenticateWithPopup({


### PR DESCRIPTION
## Description

This PR uses `sessionStorage` to set a flag indicating that `authenticateWithPopup` was used to initiate an SSO connection, which likely means that the `signIn` and `signUp` resources need to be reloaded before handling the redirect.

This reduces the instances of a `405 Method Not Allowed` response from FAPI which is returned when we attempt to refresh a resource that we haven't acted upon. For example, if we're attempting to sign in, calling `signUp.reload()` will cause an HTTP 405 error. By only performing this reload when `authenticateWithPopup` has been called, we reduce the instance of 405 errors in our logs and within customer applications.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
