### PR TITLE
fix(clerk-js): Emit captcha errors if the turnstile fails to execute

### DIFF
--- a/.changeset/tough-crabs-sit.md
+++ b/.changeset/tough-crabs-sit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Emit captcha errors if the turnstile fails to execute

--- a/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
+++ b/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
@@ -25,11 +25,11 @@ export class CaptchaChallenge {
         if (e.captchaError) {
           return { captchaError: e.captchaError };
         }
-        return undefined;
+        return { captchaError: e?.message || e };
       });
     }
 
-    return undefined;
+    return { captchaError: 'invisible_captcha_unsupported' };
   }
 
   /**
@@ -55,11 +55,11 @@ export class CaptchaChallenge {
         if (e.captchaError) {
           return { captchaError: e.captchaError };
         }
-        return undefined;
+        return { captchaError: e?.message || e };
       });
     }
 
-    return {};
+    return { captchaError: 'captcha_unsupported' };
   }
 
   /**

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -134,11 +134,15 @@ async function loadCaptchaFromCloudflareURL() {
 }
 
 function getCaptchaAttibutesFromElemenet(element: HTMLElement): CaptchaAttributes {
-  const theme = (element.getAttribute('data-cl-theme') as RenderOptions['theme']) || undefined;
-  const language = (element.getAttribute('data-cl-language') as RenderOptions['language']) || undefined;
-  const size = (element.getAttribute('data-cl-size') as RenderOptions['size']) || undefined;
+  try {
+    const theme = (element.getAttribute('data-cl-theme') as RenderOptions['theme']) || undefined;
+    const language = (element.getAttribute('data-cl-language') as RenderOptions['language']) || undefined;
+    const size = (element.getAttribute('data-cl-size') as RenderOptions['size']) || undefined;
 
-  return { theme, language, size };
+    return { theme, language, size };
+  } catch {
+    return { theme: undefined, language: undefined, size: undefined };
+  }
 }
 
 /*


### PR DESCRIPTION
## Description

Sends the `captcha_error` property if turnstile throws error.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
