### PR TITLE
feat(backend,clerk-js,types): JWT versioning

### DIFF
--- a/.changeset/major-spoons-fold.md
+++ b/.changeset/major-spoons-fold.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/backend': minor
+'@clerk/types': minor
+---
+
+Introduces JWT versioning

--- a/.changeset/major-spoons-fold.md
+++ b/.changeset/major-spoons-fold.md
@@ -3,4 +3,4 @@
 '@clerk/types': minor
 ---
 
-Introduces JWT versioning
+Introduces `ver` as JWT claim to allow versioning of the session token.

--- a/.changeset/major-spoons-fold.md
+++ b/.changeset/major-spoons-fold.md
@@ -1,5 +1,4 @@
 ---
-'@clerk/clerk-js': minor
 '@clerk/backend': minor
 '@clerk/types': minor
 ---

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -27,7 +27,7 @@ export type SignedInAuthObjectOptions = CreateBackendApiOptions & {
 /**
  * @internal
  */
-export type SignedInAuthObjectProperties = {
+type SignedInAuthObjectProperties = {
   sessionClaims: JwtPayload;
   sessionId: string;
   sessionStatus: SessionStatusClaim | null;

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -100,8 +100,8 @@ export function signedInAuthObject(
     org_id: orgId,
     org_role: orgRole,
     org_slug: orgSlug,
-    org_permissions: orgPermissions,
     sub: userId,
+    org_permissions: orgPermissions,
     fva,
     sts,
   } = sessionClaims;
@@ -117,6 +117,9 @@ export function signedInAuthObject(
 
   // sts can be undefined for instances that have not opt-in
   const sessionStatus = sts ?? null;
+
+  // TODO(jwt-versioning): need to dynamically create SignedInAuthObject based on the JWT version
+  // and the claims that are present in the JWT. For now we are still on v1.
 
   return {
     actor,

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -101,7 +101,7 @@ const generateSignedInAuthObjectProperties = (claims: JwtPayload): SignedInAuthO
 
   // TODO(jwt-v2): replace this when the new claim for org permissions is added, this will not break
   // anything since the JWT v2 is not yet available
-  const orgPermissions = claims.org_permissions as OrganizationCustomPermissionKey[];
+  const orgPermissions = claims.org_permissions;
 
   return {
     sessionClaims: claims,

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -99,7 +99,7 @@ const generateSignedInAuthObjectProperties = (claims: JwtPayload): SignedInAuthO
   // sts can be undefined for instances that have not opt-in
   const sessionStatus = claims.sts ?? null;
 
-  // TODO: replace this when the new claim for org permissions is added, this will not break
+  // TODO(jwt-v2): replace this when the new claim for org permissions is added, this will not break
   // anything since the JWT v2 is not yet available
   const orgPermissions = claims.org_permissions as OrganizationCustomPermissionKey[];
 

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -101,7 +101,7 @@ const generateSignedInAuthObjectProperties = (claims: JwtPayload): SignedInAuthO
 
   // TODO: replace this when the new claim for org permissions is added, this will not break
   // anything since the JWT v2 is not yet available
-  const orgPermissions = claims.ver === undefined ? claims.org_permissions : undefined;
+  const orgPermissions = claims.org_permissions as OrganizationCustomPermissionKey[];
 
   return {
     sessionClaims: claims,

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -99,7 +99,8 @@ const generateSignedInAuthObjectProperties = (claims: JwtPayload): SignedInAuthO
   // sts can be undefined for instances that have not opt-in
   const sessionStatus = claims.sts ?? null;
 
-  // TODO: replace this when the new claim for org permissions is added
+  // TODO: replace this when the new claim for org permissions is added, this will not break
+  // anything since the JWT v2 is not yet available
   const orgPermissions = claims.ver === undefined ? claims.org_permissions : undefined;
 
   return {

--- a/packages/clerk-js/src/core/jwt-client.ts
+++ b/packages/clerk-js/src/core/jwt-client.ts
@@ -45,7 +45,7 @@ export function createClientFromJwt(jwt: string | undefined | null): Client {
 
   const { sid, sub, org_id, org_role, org_permissions, org_slug, fva } = token.jwt.claims;
 
-  // TODO: when JWT version 2 is available, we should use the new claims instead of the old ones
+  // TODO(jwt-v2): when JWT version 2 is available, we should use the new claims instead of the old ones
 
   const defaultClient = {
     object: 'client',

--- a/packages/clerk-js/src/core/jwt-client.ts
+++ b/packages/clerk-js/src/core/jwt-client.ts
@@ -45,6 +45,8 @@ export function createClientFromJwt(jwt: string | undefined | null): Client {
 
   const { sid, sub, org_id, org_role, org_permissions, org_slug, fva } = token.jwt.claims;
 
+  // TODO: when JWT version 2 is available, we should use the new claims instead of the old ones
+
   const defaultClient = {
     object: 'client',
     last_active_session_id: sid,

--- a/packages/clerk-js/src/utils/__tests__/jwt.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/jwt.test.ts
@@ -1,4 +1,15 @@
+import type { JWT } from '@clerk/types';
+
+import { encodeB64 } from '../encoders';
 import { decode } from '../jwt';
+
+const createJWTHelper = (header: JWT['header'], payload: Record<string, unknown>) => {
+  const headerB64 = encodeB64(JSON.stringify(header));
+  const payloadB64 = encodeB64(JSON.stringify(payload));
+  const signatureB64 = encodeB64('a-string-secret-at-least-256-bits-long');
+
+  return `${headerB64}.${payloadB64}.${signatureB64}`;
+};
 
 const jwt =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzB9.Z1BC47lImYvaAtluJlY-kBo0qOoAk42Xb-gNrB2SxJg';
@@ -29,5 +40,42 @@ describe('decode(token)', () => {
 
   it('throws an error when JWT is invalid', () => {
     expect(() => decode('')).toThrowError('JWT could not be decoded');
+  });
+
+  it('decodes versioned token', () => {
+    const versionedJwt = createJWTHelper(
+      {
+        alg: 'HS256',
+        typ: 'JWT',
+        kid: '',
+      },
+      {
+        exp: 1675876790,
+        data: 'foobar',
+        iat: 1675876730,
+        ver: 2,
+      },
+    );
+    const parts = versionedJwt.split('.');
+    const [header, payload, signature] = parts;
+
+    expect(decode(jwt)).toMatchObject({
+      claims: {
+        __raw: versionedJwt,
+        data: 'foobar',
+        exp: expect.any(Number),
+        iat: expect.any(Number),
+        ver: 2,
+      },
+      encoded: {
+        header,
+        payload,
+        signature,
+      },
+      header: {
+        alg: 'HS256',
+        typ: 'JWT',
+      },
+    });
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/jwt.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/jwt.test.ts
@@ -3,9 +3,6 @@ import { decode } from '../jwt';
 const jwt =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzB9.Z1BC47lImYvaAtluJlY-kBo0qOoAk42Xb-gNrB2SxJg';
 
-const versionedJwt =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzAsInZlciI6Mn0.yV1pt0f3Riy6jOwPqFOmVKa93G0lqbMLjjP5KYr94zU';
-
 describe('decode(token)', () => {
   it('decodes a JWT token', () => {
     const parts = jwt.split('.');
@@ -32,29 +29,5 @@ describe('decode(token)', () => {
 
   it('throws an error when JWT is invalid', () => {
     expect(() => decode('')).toThrowError('JWT could not be decoded');
-  });
-
-  it('decodes versioned token', () => {
-    const parts = versionedJwt.split('.');
-    const [header, payload, signature] = parts;
-
-    expect(decode(jwt)).toMatchObject({
-      claims: {
-        __raw: versionedJwt,
-        data: 'foobar',
-        exp: expect.any(Number),
-        iat: expect.any(Number),
-        ver: 2,
-      },
-      encoded: {
-        header,
-        payload,
-        signature,
-      },
-      header: {
-        alg: 'HS256',
-        typ: 'JWT',
-      },
-    });
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/jwt.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/jwt.test.ts
@@ -1,18 +1,10 @@
-import type { JWT } from '@clerk/types';
-
-import { encodeB64 } from '../encoders';
 import { decode } from '../jwt';
-
-const createJWTHelper = (header: JWT['header'], payload: Record<string, unknown>) => {
-  const headerB64 = encodeB64(JSON.stringify(header));
-  const payloadB64 = encodeB64(JSON.stringify(payload));
-  const signatureB64 = encodeB64('a-string-secret-at-least-256-bits-long');
-
-  return `${headerB64}.${payloadB64}.${signatureB64}`;
-};
 
 const jwt =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzB9.Z1BC47lImYvaAtluJlY-kBo0qOoAk42Xb-gNrB2SxJg';
+
+const versionedJwt =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzAsInZlciI6Mn0.yV1pt0f3Riy6jOwPqFOmVKa93G0lqbMLjjP5KYr94zU';
 
 describe('decode(token)', () => {
   it('decodes a JWT token', () => {
@@ -43,19 +35,6 @@ describe('decode(token)', () => {
   });
 
   it('decodes versioned token', () => {
-    const versionedJwt = createJWTHelper(
-      {
-        alg: 'HS256',
-        typ: 'JWT',
-        kid: '',
-      },
-      {
-        exp: 1675876790,
-        data: 'foobar',
-        iat: 1675876730,
-        ver: 2,
-      },
-    );
     const parts = versionedJwt.split('.');
     const [header, payload, signature] = parts;
 

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -123,7 +123,7 @@ export type JWTPayloadBase = {
 
 export type VersionedJwtPayload =
   | {
-      ver: undefined;
+      ver?: undefined;
 
       /**
        *

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -37,7 +37,12 @@ declare global {
   }
 }
 
-export interface JwtPayload extends CustomJwtSessionClaims {
+export type JWTPayloadBase = {
+  /**
+   * The version of the JWT payload.
+   */
+  ver: number | undefined;
+
   /**
    * Encoded token supporting the `getRawString` method.
    */
@@ -83,6 +88,13 @@ export interface JwtPayload extends CustomJwtSessionClaims {
   act?: ActClaim;
 
   /**
+   * Factor verification age (fva). The tuple represents the minutes that have passed since the last time a first or second factor were verified.
+   * This API is experimental and may change at any moment.
+   * @experimental
+   */
+  fva?: [fistFactorAge: number, secondFactorAge: number];
+
+  /**
    * Active organization ID.
    */
   org_id?: string;
@@ -98,18 +110,6 @@ export interface JwtPayload extends CustomJwtSessionClaims {
   org_role?: OrganizationCustomRoleKey;
 
   /**
-   * Active organization permissions
-   */
-  org_permissions?: OrganizationCustomPermissionKey[];
-
-  /**
-   * Factor verification age (fva). The tuple represents the minutes that have passed since the last time a first or second factor were verified.
-   * This API is experimental and may change at any moment.
-   * @experimental
-   */
-  fva?: [fistFactorAge: number, secondFactorAge: number];
-
-  /**
    * Session status
    */
   sts?: SessionStatusClaim;
@@ -118,7 +118,29 @@ export interface JwtPayload extends CustomJwtSessionClaims {
    * Any other JWT Claim Set member.
    */
   [propName: string]: unknown;
-}
+};
+
+export type VersionedJwtPayload =
+  | {
+      ver: undefined;
+
+      /**
+       *
+       * Active organization permissions.
+       */
+      org_permissions?: OrganizationCustomPermissionKey[];
+    }
+  | {
+      ver: 2;
+
+      /**
+       * @deprecated - TODO - replace this with new org permissions claim
+       * Active organization permissions.
+       */
+      org_permissions?: OrganizationCustomPermissionKey[];
+    };
+
+export type JwtPayload = JWTPayloadBase & CustomJwtSessionClaims & VersionedJwtPayload;
 
 /**
  * JWT Actor - [RFC8693](https://www.rfc-editor.org/rfc/rfc8693.html#name-act-actor-claim).

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -134,7 +134,7 @@ export type VersionedJwtPayload =
   | {
       ver: 2;
 
-      // TODO: include the the version 2 claims here
+      // TODO: include the version 2 claims here
     };
 
 export type JwtPayload = JWTPayloadBase & CustomJwtSessionClaims & VersionedJwtPayload;

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -47,6 +47,7 @@ export type JWTPayloadBase = {
    * Encoded token supporting the `getRawString` method.
    */
   __raw: string;
+
   /**
    * JWT Issuer - [RFC7519#section-4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1).
    */
@@ -133,11 +134,7 @@ export type VersionedJwtPayload =
   | {
       ver: 2;
 
-      /**
-       * @deprecated - TODO - replace this with new org permissions claim
-       * Active organization permissions.
-       */
-      org_permissions?: OrganizationCustomPermissionKey[];
+      // TODO: include the the version 2 claims here
     };
 
 export type JwtPayload = JWTPayloadBase & CustomJwtSessionClaims & VersionedJwtPayload;

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -123,7 +123,7 @@ type JWTPayloadBase = {
 
 export type VersionedJwtPayload =
   | {
-      ver?: undefined;
+      ver?: never;
 
       /**
        *
@@ -134,6 +134,7 @@ export type VersionedJwtPayload =
   | {
       ver: 2;
 
+      org_permissions?: never;
       // TODO: include the version 2 claims here
     };
 

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -37,7 +37,7 @@ declare global {
   }
 }
 
-export type JWTPayloadBase = {
+type JWTPayloadBase = {
   /**
    * The version of the JWT payload.
    */


### PR DESCRIPTION
## Description

This PR does some groundwork to allow versioning the JWT token, the changes are mostly type changes that are adding the base session claims that are shared between versions and also allows the ability to add claims only for specific versions.

This also adds a "generator" function that will generate the properties returned/used in `signedInAuthObject` based on the JWT version, this will allow to keep backward compatibility between the old `org_permissions` claim and the new one that will need decoding in order to be backwards compatible.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
