### PR TITLE
chore(clerk-js): Trigger navigation to tasks on `setActive` for internal routing only 

### DIFF
--- a/.changeset/salty-zebras-matter.md
+++ b/.changeset/salty-zebras-matter.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Trigger navigation to tasks on `setActive` for internal routing only

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -536,36 +536,6 @@ describe('Clerk singleton', () => {
           expect(mockSession.getToken).toHaveBeenCalled();
         });
       });
-
-      it('navigates to task and set accessors with touched session', async () => {
-        mockClientFetch.mockReturnValue(Promise.resolve({ sessions: [mockSession], signedInSessions: [mockSession] }));
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load();
-
-        const executionOrder: string[] = [];
-        mockSession.touch.mockImplementationOnce(() => {
-          sut.session = mockSession as any;
-          executionOrder.push('session.touch');
-          return Promise.resolve();
-        });
-        mockSession.getToken.mockImplementation(() => {
-          executionOrder.push('set cookie');
-          return 'mocked-token';
-        });
-        sut.navigate = jest.fn().mockImplementationOnce(() => {
-          executionOrder.push('navigate');
-          return Promise.resolve();
-        });
-
-        await sut.setActive({ session: mockSession.id });
-
-        await waitFor(() => {
-          expect(executionOrder).toEqual(['session.touch', 'set cookie', 'navigate']);
-          expect(mockSession.touch).toHaveBeenCalled();
-          expect(mockSession.getToken).toHaveBeenCalled();
-          expect(sut.session).toMatchObject(mockSession);
-        });
-      });
     });
   });
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1123,20 +1123,17 @@ export class Clerk implements ClerkInterface {
       eventBus.dispatch(events.TokenUpdate, { token: null });
     }
 
-    if (newSession?.currentTask) {
+    // Only triggers navigation for internal routing, in order to not affect custom flows
+    if (newSession?.currentTask && this.#componentNavigationContext) {
       await navigateToTask(session.currentTask.key, {
-        globalNavigate: this.navigate,
-        componentNavigationContext: this.#componentNavigationContext,
         options: this.#options,
         environment: this.environment,
+        globalNavigate: this.navigate,
+        componentNavigationContext: this.#componentNavigationContext,
       });
-
-      // Delay updating session accessors until active status transition to prevent premature component unmounting.
-      // This is particularly important when SignIn components are wrapped in SignedOut components,
-      // as early state updates could cause unwanted unmounting during the transition.
-      this.#setAccessors(session);
     }
 
+    this.#setAccessors(session);
     this.#emit();
   };
 


### PR DESCRIPTION
## Description

### Summary

- Do not trigger navigation to tasks on `setActive` if it's called from outside UI components 
- Do not delay emitting state, this was a wrong workaround to avoid UI updating on session updates, eg: `SignIn` rendered inside `SignedOut`, which got fixed now that `SignedOut` treats pending sessions as signed out by default https://github.com/clerk/javascript/pull/5512

### For custom flows 

```ts
await setActive({ session })
const task = clerk.currentTask; 
mountTaskComponentIfAny(task)
```

Or use `clerk.__experimental_nextTask` for orchestrating navigation:
```ts
await setActive({ session })
await clerk.__experimental_nextTask({ redirectUrlComplete: afterTasksUrl })
```

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
