### PR TITLE
fix(clerk-js): Add optional `resourceId` to `useFetch` hook

### DIFF
--- a/.changeset/lucky-emus-share.md
+++ b/.changeset/lucky-emus-share.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add optional `resourceId` to `useFetch` hook

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -79,6 +79,7 @@ export const useCache = <K = any, V = any>(
  * @param fetcher If fetcher is undefined no action will be performed
  * @param params
  * @param options
+ * @param resourceId
  */
 export const useFetch = <K, T>(
   fetcher: ((...args: any) => Promise<T>) | undefined,
@@ -88,8 +89,10 @@ export const useFetch = <K, T>(
     onSuccess?: (data: T) => void;
     staleTime?: number;
   },
+  resourceId?: string,
 ) => {
-  const { subscribeCache, getCache, setCache, clearCache } = useCache<K, T>(params);
+  const cacheKey = { resourceId, params };
+  const { subscribeCache, getCache, setCache, clearCache } = useCache<typeof cacheKey, T>(cacheKey);
   const [revalidationCounter, setRevalidationCounter] = useState(0);
 
   const staleTime = options?.staleTime ?? 1000 * 60 * 2; //cache for 2 minutes by default


### PR DESCRIPTION
Currently, `useFetch` caches data using only a string-ified version of the params as a key, which very easily leads to cache collisions.

This adds an optional `resourceId` param that is used in conjunction with the params to create the cache key. This is optional and not breaking.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
