### PR TITLE
chore(types): Mark `ver` claim as experimental

### DIFF
--- a/.changeset/smart-pianos-know.md
+++ b/.changeset/smart-pianos-know.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': patch
+---
+
+Mark `ver` claim as experimental

--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -39,6 +39,8 @@ declare global {
 
 type JWTPayloadBase = {
   /**
+   * @experimental
+   *
    * The version of the JWT payload.
    */
   ver: number | undefined;
@@ -123,6 +125,11 @@ type JWTPayloadBase = {
 
 export type VersionedJwtPayload =
   | {
+      /**
+       * @experimental
+       *
+       * The version of the JWT payload.
+       */
       ver?: never;
 
       /**
@@ -132,6 +139,11 @@ export type VersionedJwtPayload =
       org_permissions?: OrganizationCustomPermissionKey[];
     }
   | {
+      /**
+       * @experimental
+       *
+       * The version of the JWT payload.
+       */
       ver: 2;
 
       org_permissions?: never;


### PR DESCRIPTION
## Description

This PR marks the new session claim `ver` as experimental

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
