### PR TITLE
fix(dev-cli): Improve reliability by cleaning turbo daemon

### DIFF
--- a/.changeset/fresh-baboons-spend.md
+++ b/.changeset/fresh-baboons-spend.md
@@ -1,0 +1,5 @@
+---
+'@clerk/dev-cli': patch
+---
+
+Improve reliability by cleaning the turborepo daemon before starting watch task.

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ scripts/.env
 # typedoc
 .typedoc/docs
 .typedoc/docs.json
+tsup.config.bundled_*


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
