### PR TITLE
chore(e2e): Remove Next.js 14 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
             next-version: '13'
           - test-name: 'nextjs'
             test-project: 'chrome'
-            next-version: '14.2.26'
+            next-version: '14'
           - test-name: 'nextjs'
             test-project: 'chrome'
             next-version: '15'


### PR DESCRIPTION
## Description

https://github.com/vercel/next.js/releases/tag/v14.2.28 was released, so we can revert the pin done in https://github.com/clerk/javascript/pull/5558

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
