### PR TITLE
fix(astro): Construct derived state when als is empty

### DIFF
--- a/.changeset/deep-moose-slide.md
+++ b/.changeset/deep-moose-slide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': patch
+---
+
+Fixes issue with `useAuth()` erroring due to missing auth context on static output.


### PR DESCRIPTION
## Description

1. Fixes the issue in the screenshot.
2. Uses an updated `useStore` in order for authContext to not merge with `clerkContext`.
<img width="741" alt="Screenshot 2025-04-09 at 3 06 04 PM" src="https://github.com/user-attachments/assets/0a2b05fa-8f4b-4f67-adac-fa9ce51ef829" />

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
