### PR TITLE
chore(clerk-js,backend): Update the supported API version to 2025-04-10

### DIFF
--- a/.changeset/metal-meals-cover.md
+++ b/.changeset/metal-meals-cover.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/backend': patch
+---
+
+Update the supported API version to `2025-04-10`

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -3,7 +3,7 @@ export const API_VERSION = 'v1';
 
 export const USER_AGENT = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
 export const MAX_CACHE_LAST_UPDATED_AT_SECONDS = 5 * 60;
-export const SUPPORTED_BAPI_VERSION = '2024-10-01';
+export const SUPPORTED_BAPI_VERSION = '2025-04-10';
 
 const Attributes = {
   AuthToken: '__clerkAuthToken',

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -50,4 +50,4 @@ export const SIGN_UP_MODES: Record<string, SignUpModes> = {
 };
 
 // This is the currently supported version of the Frontend API
-export const SUPPORTED_FAPI_VERSION = '2024-10-01';
+export const SUPPORTED_FAPI_VERSION = '2025-04-10';


### PR DESCRIPTION
## Description

This PR updates both FAPI and BAPI to the latest stable version `2025-04-10`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
