### PR TITLE
test(e2e): Add tests for transfer sign up with legal consent

### DIFF
--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -42,6 +42,11 @@ export const createLongRunningApps = () => {
       config: next.appRouter,
       env: envs.withSessionTasks,
     },
+    {
+      id: 'next.appRouter.withLegalConsent',
+      config: next.appRouter,
+      env: envs.withLegalConsent,
+    },
     { id: 'quickstart.next.appRouter', config: next.appRouterQuickstart, env: envs.withEmailCodesQuickstart },
     { id: 'elements.next.appRouter', config: elements.nextAppRouter, env: envs.withEmailCodes },
     { id: 'astro.node.withCustomRoles', config: astro.node, env: envs.withCustomRoles },

--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -142,3 +142,81 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('oauth flo
     });
   });
 });
+
+testAgainstRunningApps({ withEnv: [appConfigs.envs.withLegalConsent] })(
+  'oauth flows with legal consent @nextjs',
+  ({ app }) => {
+    test.describe.configure({ mode: 'serial' });
+
+    let fakeUser: FakeUser;
+
+    test.beforeAll(async () => {
+      // Create a clerkClient for the OAuth provider instance.
+      const client = createClerkClient({
+        secretKey: instanceKeys.get('oauth-provider').sk,
+        publishableKey: instanceKeys.get('oauth-provider').pk,
+      });
+      const users = createUserService(client);
+      fakeUser = users.createFakeUser({
+        withUsername: true,
+      });
+      // Create the user on the OAuth provider instance so we do not need to sign up twice.
+      await users.createBapiUser(fakeUser);
+    });
+
+    test.afterAll(async () => {
+      const u = createTestUtils({ app });
+      // Delete the user on the OAuth provider instance.
+      await fakeUser.deleteIfExists();
+      // Delete the user on the app instance.
+      await u.services.users.deleteIfExists({ email: fakeUser.email });
+      await app.teardown();
+    });
+
+    test('sign up via transfer with custom oauth provider', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+      await u.po.signIn.goTo();
+
+      await u.page.getByRole('button', { name: 'E2E OAuth Provider' }).click();
+      await u.page.getByText('Sign in to oauth-provider').waitFor();
+
+      await u.po.signIn.setIdentifier(fakeUser.email);
+      await u.po.signIn.continue();
+      await u.po.signIn.enterTestOtpCode();
+
+      await u.page.getByText('Legal consent').waitFor();
+      await u.page.getByLabel(/I agree to the/).check();
+      await u.po.signIn.continue();
+
+      // We can't use our `expect.toBeSignedIn` first because that would result in `true` on the OAuth provider instance.
+      // We want to assert that we're signed in on our app instance, which will render the text 'SignedIn'.
+      await u.page.getByText('SignedIn').waitFor();
+      await u.po.expect.toBeSignedIn();
+    });
+
+    test('sign up via transfer modal', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+      await u.services.users.deleteIfExists({ email: fakeUser.email });
+
+      await u.page.goToRelative('/buttons');
+      await u.page.waitForClerkJsLoaded();
+      await u.po.expect.toBeSignedOut();
+
+      await u.page.getByText('Sign in button (force)').click();
+
+      await u.po.signIn.waitForModal();
+      await u.page.getByRole('button', { name: 'E2E OAuth Provider' }).click();
+      await u.page.getByText('Sign in to oauth-provider').waitFor();
+
+      await u.po.signIn.setIdentifier(fakeUser.email);
+      await u.po.signIn.continue();
+      await u.po.signIn.enterTestOtpCode();
+
+      await u.page.getByText('Legal consent').waitFor();
+      await u.page.getByLabel(/I agree to the/).check();
+      await u.po.signIn.continue();
+
+      await u.page.waitForAppUrl('/protected');
+    });
+  },
+);

--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -184,7 +184,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withLegalConsent] })(
       await u.po.signIn.continue();
       await u.po.signIn.enterTestOtpCode();
 
-      await u.page.getByText('Legal consent').waitFor();
+      await u.page.getByRole('heading', { name: 'Legal consent' }).waitFor();
       await u.page.getByLabel(/I agree to the/).check();
       await u.po.signIn.continue();
 
@@ -212,7 +212,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withLegalConsent] })(
       await u.po.signIn.continue();
       await u.po.signIn.enterTestOtpCode();
 
-      await u.page.getByText('Legal consent').waitFor();
+      await u.page.getByRole('heading', { name: 'Legal consent' }).waitFor();
       await u.page.getByLabel(/I agree to the/).check();
       await u.po.signIn.continue();
 


### PR DESCRIPTION
## Description

This PR adds tests for sign in transferred to sign up on an instance with legal consent required, both via the mounted component and via the modal.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
