### PR TITLE
chore(repo): Notify generated-typedoc of new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,13 @@ jobs:
                 ref: 'main',
                 inputs: { version: nextjsVersion }
               })
+
+              github.rest.actions.createWorkflowDispatch({
+                owner: 'clerk',
+                repo: 'generated-typedoc',
+                workflow_id: 'update-docs.yml',
+                ref: 'main',
+              })
             } else{
               core.warning("Changeset in pre-mode should not prepare a ClerkJS production release")
             }


### PR DESCRIPTION
## Description

We want to get https://github.com/clerk/generated-typedoc/ updated once a new release is out (so that documentation only gets updated once it's live). The repository has a GitHub action (https://github.com/clerk/generated-typedoc/blob/main/.github/workflows/update-docs.yml) to update its contents through a PR.

This PR adds a trigger for this workflow once the release has happened.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
