### PR TITLE
fix(clerk-js): Rename the `sendCaptchaToken` to `__internal_sendCaptchaToken`

### DIFF
--- a/.changeset/eight-wombats-hunt.md
+++ b/.changeset/eight-wombats-hunt.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Rename the `sendCaptchaToken` to `__internal_sendCaptchaToken`.

--- a/packages/clerk-js/src/core/auth/CaptchaHeartbeat.ts
+++ b/packages/clerk-js/src/core/auth/CaptchaHeartbeat.ts
@@ -28,7 +28,7 @@ export class CaptchaHeartbeat {
 
     try {
       const params = await this.captchaChallenge.invisible({ action: 'heartbeat' });
-      await this.clerk.client.sendCaptchaToken(params);
+      await this.clerk.client.__internal_sendCaptchaToken(params);
     } catch {
       // Ignore unhandled errors
     }

--- a/packages/clerk-js/src/core/fraudProtection.test.ts
+++ b/packages/clerk-js/src/core/fraudProtection.test.ts
@@ -29,7 +29,7 @@ describe('FraudProtectionService', () => {
     );
 
     const mockClientInstance = {
-      sendCaptchaToken: jest.fn().mockResolvedValue({}),
+      __internal_sendCaptchaToken: jest.fn().mockResolvedValue({}),
     };
 
     mockClient = {
@@ -55,7 +55,7 @@ describe('FraudProtectionService', () => {
 
     // only one will need to call the captcha as the other will be blocked
     expect(mockManagedInModal).toHaveBeenCalledTimes(0);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(0);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(0);
     expect(fn1).toHaveBeenCalledTimes(1);
   });
 
@@ -68,7 +68,7 @@ describe('FraudProtectionService', () => {
     const fn1res = sut.execute(mockClerk, fn1);
     expect(fn1res).rejects.toEqual(unrelatedError);
     expect(mockManagedInModal).toHaveBeenCalledTimes(0);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(0);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(0);
     expect(fn1).toHaveBeenCalledTimes(1);
   });
 
@@ -88,7 +88,7 @@ describe('FraudProtectionService', () => {
 
     // only one will need to call the captcha as the other will be blocked
     expect(mockManagedInModal).toHaveBeenCalledTimes(1);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(1);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(1);
     expect(fn1).toHaveBeenCalledTimes(2);
   });
 
@@ -108,7 +108,7 @@ describe('FraudProtectionService', () => {
 
     // captcha will only be called once
     expect(mockManagedInModal).toHaveBeenCalledTimes(1);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(1);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(1);
     // but all failed requests will be retried
     expect(fn1).toHaveBeenCalledTimes(2);
     expect(fn2).toHaveBeenCalledTimes(2);
@@ -135,7 +135,7 @@ describe('FraudProtectionService', () => {
     await Promise.all([fn1res, fn2res]);
 
     expect(mockManagedInModal).toHaveBeenCalledTimes(1);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(1);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(1);
     expect(fn1).toHaveBeenCalledTimes(2);
     expect(fn2).toHaveBeenCalledTimes(1);
   });
@@ -168,7 +168,7 @@ describe('FraudProtectionService', () => {
     await Promise.all([fn2res, fn3res]);
 
     expect(mockManagedInModal).toHaveBeenCalledTimes(1);
-    expect(mockClient.getOrCreateInstance().sendCaptchaToken).toHaveBeenCalledTimes(1);
+    expect(mockClient.getOrCreateInstance().__internal_sendCaptchaToken).toHaveBeenCalledTimes(1);
 
     expect(fn1).toHaveBeenCalledTimes(2);
     expect(fn2).toHaveBeenCalledTimes(2);

--- a/packages/clerk-js/src/core/fraudProtection.ts
+++ b/packages/clerk-js/src/core/fraudProtection.ts
@@ -60,7 +60,7 @@ export class FraudProtection {
       try {
         const captchaParams: any = await this.managedChallenge(clerk);
         if (captchaParams?.captchaError !== 'modal_component_not_ready') {
-          await this.client.getOrCreateInstance().sendCaptchaToken(captchaParams);
+          await this.client.getOrCreateInstance().__internal_sendCaptchaToken(captchaParams);
           this.captchaRetryCount = 0; // Reset the retry count on success
         }
       } catch (err) {

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -117,7 +117,7 @@ export class Client extends BaseResource implements ClientResource {
       .toString();
   }
 
-  public sendCaptchaToken(params: unknown): Promise<ClientResource> {
+  public __internal_sendCaptchaToken(params: unknown): Promise<ClientResource> {
     return this._basePostBypass({ body: params, path: this.path() + '/verify' });
   }
 

--- a/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
@@ -4,7 +4,7 @@ import { createSession, createSignIn, createSignUp, createUser } from '../../tes
 import { BaseResource, Client } from '../internal';
 
 describe('Client Singleton', () => {
-  describe('sendCaptchaToken', () => {
+  describe('__internal_sendCaptchaToken', () => {
     it('sends captcha token', async () => {
       const user = createUser({ first_name: 'John', last_name: 'Doe', id: 'user_1' });
       const session = createSession({ id: 'session_1' }, user);
@@ -24,7 +24,7 @@ describe('Client Singleton', () => {
       BaseResource._baseFetch = jest.fn();
 
       const client = Client.getOrCreateInstance().fromJSON(clientObjectJSON);
-      await client.sendCaptchaToken({ captcha_token: 'test_captcha_token' });
+      await client.__internal_sendCaptchaToken({ captcha_token: 'test_captcha_token' });
       // @ts-expect-error This is a private method that we are mocking
       expect(BaseResource._baseFetch).toHaveBeenCalledWith({
         method: 'POST',
@@ -54,7 +54,7 @@ describe('Client Singleton', () => {
       BaseResource._baseFetch = jest.fn().mockResolvedValueOnce(Promise.resolve(null));
 
       const client = Client.getOrCreateInstance().fromJSON(clientObjectJSON);
-      await client.sendCaptchaToken({ captcha_token: 'test_captcha_token' });
+      await client.__internal_sendCaptchaToken({ captcha_token: 'test_captcha_token' });
       // @ts-expect-error This is a private method that we are mocking
       expect(BaseResource._baseFetch).toHaveBeenCalledWith({
         method: 'POST',

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -11,7 +11,6 @@ export interface ClientResource extends ClerkResource {
   signIn: SignInResource;
   isNew: () => boolean;
   create: () => Promise<ClientResource>;
-  sendCaptchaToken: (params: unknown) => Promise<ClientResource>;
   destroy: () => Promise<void>;
   removeSessions: () => Promise<ClientResource>;
   clearCache: () => void;
@@ -22,6 +21,7 @@ export interface ClientResource extends ClerkResource {
   cookieExpiresAt: Date | null;
   createdAt: Date | null;
   updatedAt: Date | null;
+  __internal_sendCaptchaToken: (params: unknown) => Promise<ClientResource>;
   __internal_toSnapshot: () => ClientJSONSnapshot;
   /**
    * @deprecated Use `signedInSessions` instead


### PR DESCRIPTION
## Description

Rename the `sendCaptchaToken` to `__internal_sendCaptchaToken` because it's not Public API.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
