### PR TITLE
feat(backend): Add support for md5_phpass and ldap_ssha hashers

### DIFF
--- a/.changeset/busy-ducks-strive.md
+++ b/.changeset/busy-ducks-strive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add support for phpass_md5 and ldap_ssha hashers

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -58,7 +58,9 @@ type PasswordHasher =
   | 'phpass'
   | 'scrypt_firebase'
   | 'scrypt_werkzeug'
-  | 'sha256';
+  | 'sha256'
+  | 'md5_phpass'
+  | 'ldap_ssha';
 
 type UserPasswordHashingParams = {
   passwordDigest: string;


### PR DESCRIPTION
## Description

Add support for `md5_phpass` and `ldap_ssha` hashers.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
