### PR TITLE
fix(clerk-js): Fix an issue where the captcha would appear after an OAuth error

### DIFF
--- a/.changeset/poor-swans-refuse.md
+++ b/.changeset/poor-swans-refuse.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix an issue where the captcha would appear after receiving an OAuth error

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -86,7 +86,9 @@ export class SignUp extends BaseResource implements SignUpResource {
   create = async (_params: SignUpCreateParams): Promise<SignUpResource> => {
     let params: Record<string, unknown> = _params;
     const shouldSkipCaptcha = params?.__internal_skipCaptcha;
-    delete params?.__internal_skipCaptcha;
+    if (params?.__internal_skipCaptcha) {
+      delete params?.__internal_skipCaptcha;
+    }
 
     if (
       !__BUILD_DISABLE_RHC__ &&

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -85,12 +85,14 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   create = async (_params: SignUpCreateParams): Promise<SignUpResource> => {
     let params: Record<string, unknown> = _params;
+    const shouldSkipCaptcha = params?.__internal_skipCaptcha;
+    delete params?.__internal_skipCaptcha;
 
     if (
       !__BUILD_DISABLE_RHC__ &&
       !this.clientBypass() &&
       !this.shouldBypassCaptchaForAttempt(params) &&
-      !params?.__internal_skipCaptcha
+      !shouldSkipCaptcha
     ) {
       const captchaChallenge = new CaptchaChallenge(SignUp.clerk);
       const captchaParams = await captchaChallenge.managedOrInvisible({ action: 'signup' });

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -86,7 +86,12 @@ export class SignUp extends BaseResource implements SignUpResource {
   create = async (_params: SignUpCreateParams): Promise<SignUpResource> => {
     let params: Record<string, unknown> = _params;
 
-    if (!__BUILD_DISABLE_RHC__ && !this.clientBypass() && !this.shouldBypassCaptchaForAttempt(params)) {
+    if (
+      !__BUILD_DISABLE_RHC__ &&
+      !this.clientBypass() &&
+      !this.shouldBypassCaptchaForAttempt(params) &&
+      !params?.__internal_skipCaptcha
+    ) {
       const captchaChallenge = new CaptchaChallenge(SignUp.clerk);
       const captchaParams = await captchaChallenge.managedOrInvisible({ action: 'signup' });
       if (!captchaParams) {

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -85,6 +85,10 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   create = async (_params: SignUpCreateParams): Promise<SignUpResource> => {
     let params: Record<string, unknown> = _params;
+
+    // This is only used in SignUpStart in order to skip the captcha
+    // challenge when we fire the create request to clear the error.
+    // It's a temporary solution until we have a better way to handle this.
     const shouldSkipCaptcha = params?.__internal_skipCaptcha;
     if (params?.__internal_skipCaptcha) {
       delete params?.__internal_skipCaptcha;

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -186,9 +186,13 @@ function SignUpStartInternal(): JSX.Element {
 
         // TODO: This is a hack to reset the sign in attempt so that the oauth error
         // does not persist on full page reloads.
-        // We will revise this strategy as part of the Clerk DX epic.
-        // @ts-ignore We want to skip triggering the captcha on this sign up attempt
-        void (await signUp.create({ __internal_skipCaptcha: true }));
+        // We are going to revise this in the near future.
+        try {
+          // @ts-ignore We want to skip triggering the captcha on this sign up attempt
+          void (await signUp.create({ __internal_skipCaptcha: true }));
+        } catch {
+          // Mute the 400 error from FAPI
+        }
       }
     }
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -187,7 +187,8 @@ function SignUpStartInternal(): JSX.Element {
         // TODO: This is a hack to reset the sign in attempt so that the oauth error
         // does not persist on full page reloads.
         // We will revise this strategy as part of the Clerk DX epic.
-        void (await signUp.create({}));
+        // @ts-ignore We want to skip triggering the captcha on this sign up attempt
+        void (await signUp.create({ __internal_skipCaptcha: true }));
       }
     }
 


### PR DESCRIPTION
## Description

There is an edge case where you can end up with an OAuth error and a captcha that practically should not be there. This is because we call the `signUp.create` to clear the error message, but it triggers the turnstile check.

In this specific scenario we want to skip calling the Turnstile script as it's useless.

#### Screenshot of the buggy behavior:
![Screenshot 2025-04-10 at 18 51 30](https://github.com/user-attachments/assets/035088b8-062f-478f-82cc-09599220e3cd)


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
