### PR TITLE
fix(clerk-js,chrome-extension): Externalize StripeJS (Non-RHC only)

### DIFF
--- a/.changeset/open-papers-cross.md
+++ b/.changeset/open-papers-cross.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ensure Stripe dependencies aren't bundled for non-RHC environments

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -72,7 +72,7 @@ const common = ({ mode, disableRHC = false }) => {
      * Necessary to prevent the Stripe dependencies from being bundled into
      * SDKs such as Browser Extensions.
      */
-    externals: disableRHC ? ['@stripe/stripe-js'] : undefined,
+    externals: disableRHC ? ['@stripe/stripe-js', '@stripe/react-stripe-js'] : undefined,
     optimization: {
       splitChunks: {
         cacheGroups: {

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -67,6 +67,12 @@ const common = ({ mode, disableRHC = false }) => {
     output: {
       chunkFilename: `[name]_[fullhash:6]_${packageJSON.version}.js`,
     },
+    /**
+     * Remove the Stripe dependencies from the bundle, if RHC is disabled.
+     * Necessary to prevent the Stripe dependencies from being bundled into
+     * SDKs such as Browser Extensions.
+     */
+    externals: disableRHC ? ['@stripe/stripe-js'] : undefined,
     optimization: {
       splitChunks: {
         cacheGroups: {

--- a/packages/clerk-js/src/ui/components/PaymentSources/AddPaymentSource.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/AddPaymentSource.tsx
@@ -75,16 +75,18 @@ export const AddPaymentSource = (props: AddPaymentSourceProps) => {
 
   useEffect(() => {
     if (!stripePromiseRef.current && externalGatewayId && __experimental_commerceSettings.stripePublishableKey) {
-      if (!__BUILD_DISABLE_RHC__) {
-        stripePromiseRef.current = loadStripe(__experimental_commerceSettings.stripePublishableKey, {
-          stripeAccount: externalGatewayId,
-        });
-        void stripePromiseRef.current.then(stripeInstance => {
-          setStripe(stripeInstance);
-        });
-      } else {
+      if (__BUILD_DISABLE_RHC__) {
         clerkUnsupportedEnvironmentWarning('Stripe');
+        return;
       }
+
+      stripePromiseRef.current = loadStripe(__experimental_commerceSettings.stripePublishableKey, {
+        stripeAccount: externalGatewayId,
+      });
+
+      void stripePromiseRef.current.then(stripeInstance => {
+        setStripe(stripeInstance);
+      });
     }
   }, [externalGatewayId, __experimental_commerceSettings]);
 

--- a/scripts/search-for-rhc.mjs
+++ b/scripts/search-for-rhc.mjs
@@ -27,7 +27,7 @@ await Promise.allSettled([
   asyncSearchRHC('Turnstile', 'cloudflare.com/turnstile/v0/api.js'),
   asyncSearchRHC('clerk-js Hotloading', '/npm/@clerk/clerk-js'),
   asyncSearchRHC('Google One Tap', 'accounts.google.com/gsi/client'),
-  asyncSearchRHC('Stripe', 'loadStripe('),
+  asyncSearchRHC('Stripe', 'js.stripe.com'),
 ]).then(results => {
   const errors = results.filter(result => result.status === 'rejected').map(result => result.reason.message);
 


### PR DESCRIPTION
## Description

Ensure Stripe dependencies aren't bundled/chunked for non-RHC environments

<!-- Fixes #(issue number) -->

ECO-595

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
