### PR TITLE
fix(clerk-js): Reduce line truncation maxLength

### DIFF
--- a/.changeset/silly-bats-open.md
+++ b/.changeset/silly-bats-open.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue where truncated text was wraping within line items.

--- a/packages/clerk-js/src/ui/elements/LineItems.tsx
+++ b/packages/clerk-js/src/ui/elements/LineItems.tsx
@@ -229,7 +229,7 @@ function TruncatedText({ text }: { text: string }) {
         await onCopy();
       }}
     >
-      {truncateWithEndVisible(text)}
+      {truncateWithEndVisible(text, 15)}
     </Span>
   );
 }

--- a/packages/clerk-js/src/ui/utils/truncateTextWithEndVisible.ts
+++ b/packages/clerk-js/src/ui/utils/truncateTextWithEndVisible.ts
@@ -3,12 +3,12 @@
  * with an ellipsis in the middle.
  *
  * @param {string} str - The string to truncate
- * @param {number} maxLength - Maximum total length of the truncated string (including ellipsis)
- * @param {number} endChars - Number of characters to preserve at the end
+ * @param {number} maxLength - Maximum total length of the truncated string (including ellipsis). Default is 20.
+ * @param {number} endChars - Number of characters to preserve at the end. Default is 5.
  * @return {string} - Truncated string with ellipsis in the middle
  *
  * @example
- * truncateWithEndVisible('this is a very long string') // returns 'this is a ve...tring'
+ * truncateWithEndVisible('this is a very long string') // returns 'this is a ve...ring'
  * truncateWithEndVisible('test@email.com', 10) // returns 'te...e.com'
  */
 export function truncateWithEndVisible(str: string, maxLength = 20, endChars = 5): string {


### PR DESCRIPTION
## Description

![Screenshot 2025-04-14 at 9 59 48 AM](https://github.com/user-attachments/assets/367120c9-b711-46cf-8a88-ce9721c2f127)

Fixes COM-427

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
