### PR TITLE
feat(backend): Add Blocklist Identifiers to Backend API client

### DIFF
--- a/.changeset/fuzzy-chefs-change.md
+++ b/.changeset/fuzzy-chefs-change.md
@@ -1,0 +1,23 @@
+---
+'@clerk/backend': minor
+---
+
+Adds the Blocklist Identifier endpoints to the Backend API client.
+
+```ts
+  import { createClerkClient } from '@clerk/backend';
+
+  const clerkClient = createClerkClient(...);
+  await clerkClient.blocklistIdentifiers.getBlocklistIdentifierList();
+  await clerkClient.blocklistIdentifiers.createBlocklistIdentifier({ identifier });
+  await clerkClient.blocklistIdentifiers.deleteBlocklistIdentifier('blocklistIdentifierId');
+```
+
+Updates the ability paginate Allowlist Identifier reponses and access `identifierType` and `instanceId` from the response.
+
+```ts
+  import { createClerkClient } from '@clerk/backend';
+
+  const clerkClient = createClerkClient(...);
+  const res = await clerkClient.blocklistIdentifiers.getAllowlistIdentifierList({ limit, offset });
+```

--- a/.changeset/fuzzy-chefs-change.md
+++ b/.changeset/fuzzy-chefs-change.md
@@ -21,3 +21,5 @@ Updates the ability paginate Allowlist Identifier reponses and access `identifie
   const clerkClient = createClerkClient(...);
   const res = await clerkClient.blocklistIdentifiers.getAllowlistIdentifierList({ limit, offset });
 ```
+
+Corrects the type of the Allowlist Identifier `DeletedObject`

--- a/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts
+++ b/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts
@@ -1,3 +1,5 @@
+import type { ClerkPaginationRequest } from '@clerk/types';
+
 import { joinPaths } from '../../util/path';
 import type { AllowlistIdentifier } from '../resources/AllowlistIdentifier';
 import type { DeletedObject } from '../resources/DeletedObject';
@@ -12,11 +14,11 @@ type AllowlistIdentifierCreateParams = {
 };
 
 export class AllowlistIdentifierAPI extends AbstractAPI {
-  public async getAllowlistIdentifierList() {
+  public async getAllowlistIdentifierList(params: ClerkPaginationRequest = {}) {
     return this.request<PaginatedResourceResponse<AllowlistIdentifier[]>>({
       method: 'GET',
       path: basePath,
-      queryParams: { paginated: true },
+      queryParams: { ...params, paginated: true },
     });
   }
 

--- a/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts
+++ b/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts
@@ -1,5 +1,6 @@
 import { joinPaths } from '../../util/path';
 import type { AllowlistIdentifier } from '../resources/AllowlistIdentifier';
+import type { DeletedObject } from '../resources/DeletedObject';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import { AbstractAPI } from './AbstractApi';
 
@@ -29,7 +30,7 @@ export class AllowlistIdentifierAPI extends AbstractAPI {
 
   public async deleteAllowlistIdentifier(allowlistIdentifierId: string) {
     this.requireId(allowlistIdentifierId);
-    return this.request<AllowlistIdentifier>({
+    return this.request<DeletedObject>({
       method: 'DELETE',
       path: joinPaths(basePath, allowlistIdentifierId),
     });

--- a/packages/backend/src/api/endpoints/BlocklistIdentifierApi.ts
+++ b/packages/backend/src/api/endpoints/BlocklistIdentifierApi.ts
@@ -1,3 +1,5 @@
+import type { ClerkPaginationRequest } from '@clerk/types';
+
 import { joinPaths } from '../../util/path';
 import type { BlocklistIdentifier } from '../resources/BlocklistIdentifier';
 import type { DeletedObject } from '../resources/DeletedObject';
@@ -11,10 +13,11 @@ type BlocklistIdentifierCreateParams = {
 };
 
 export class BlocklistIdentifierAPI extends AbstractAPI {
-  public async getBlocklistIdentifierList() {
+  public async getBlocklistIdentifierList(params: ClerkPaginationRequest = {}) {
     return this.request<PaginatedResourceResponse<BlocklistIdentifier[]>>({
       method: 'GET',
       path: basePath,
+      queryParams: params,
     });
   }
 
@@ -26,7 +29,7 @@ export class BlocklistIdentifierAPI extends AbstractAPI {
     });
   }
 
-  public async deleteBlcoklistIdentifier(blocklistIdentifierId: string) {
+  public async deleteBlocklistIdentifier(blocklistIdentifierId: string) {
     this.requireId(blocklistIdentifierId);
     return this.request<DeletedObject>({
       method: 'DELETE',

--- a/packages/backend/src/api/endpoints/BlocklistIdentifierApi.ts
+++ b/packages/backend/src/api/endpoints/BlocklistIdentifierApi.ts
@@ -1,0 +1,36 @@
+import { joinPaths } from '../../util/path';
+import type { BlocklistIdentifier } from '../resources/BlocklistIdentifier';
+import type { DeletedObject } from '../resources/DeletedObject';
+import type { PaginatedResourceResponse } from '../resources/Deserializer';
+import { AbstractAPI } from './AbstractApi';
+
+const basePath = '/blocklist_identifiers';
+
+type BlocklistIdentifierCreateParams = {
+  identifier: string;
+};
+
+export class BlocklistIdentifierAPI extends AbstractAPI {
+  public async getBlocklistIdentifierList() {
+    return this.request<PaginatedResourceResponse<BlocklistIdentifier[]>>({
+      method: 'GET',
+      path: basePath,
+    });
+  }
+
+  public async createBlocklistIdentifier(params: BlocklistIdentifierCreateParams) {
+    return this.request<BlocklistIdentifier>({
+      method: 'POST',
+      path: basePath,
+      bodyParams: params,
+    });
+  }
+
+  public async deleteBlcoklistIdentifier(blocklistIdentifierId: string) {
+    this.requireId(blocklistIdentifierId);
+    return this.request<DeletedObject>({
+      method: 'DELETE',
+      path: joinPaths(basePath, blocklistIdentifierId),
+    });
+  }
+}

--- a/packages/backend/src/api/endpoints/index.ts
+++ b/packages/backend/src/api/endpoints/index.ts
@@ -1,6 +1,7 @@
 export * from './AccountlessApplicationsAPI';
 export * from './AbstractApi';
 export * from './AllowlistIdentifierApi';
+export * from './BlocklistIdentifierApi';
 export * from './ClientApi';
 export * from './DomainApi';
 export * from './EmailAddressApi';

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -1,6 +1,7 @@
 import {
   AccountlessApplicationAPI,
   AllowlistIdentifierAPI,
+  BlocklistIdentifierAPI,
   ClientAPI,
   DomainAPI,
   EmailAddressAPI,
@@ -31,6 +32,7 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
       buildRequest({ ...options, requireSecretKey: false }),
     ),
     allowlistIdentifiers: new AllowlistIdentifierAPI(request),
+    blocklistIdentifiers: new BlocklistIdentifierAPI(request),
     clients: new ClientAPI(request),
     emailAddresses: new EmailAddressAPI(request),
     invitations: new InvitationAPI(request),

--- a/packages/backend/src/api/resources/AllowlistIdentifier.ts
+++ b/packages/backend/src/api/resources/AllowlistIdentifier.ts
@@ -1,15 +1,26 @@
+import type { AllowlistIdentifierType } from './Enums';
 import type { AllowlistIdentifierJSON } from './JSON';
 
 export class AllowlistIdentifier {
   constructor(
     readonly id: string,
     readonly identifier: string,
+    readonly identifierType: AllowlistIdentifierType,
     readonly createdAt: number,
     readonly updatedAt: number,
+    readonly instanceId?: string,
     readonly invitationId?: string,
   ) {}
 
   static fromJSON(data: AllowlistIdentifierJSON): AllowlistIdentifier {
-    return new AllowlistIdentifier(data.id, data.identifier, data.created_at, data.updated_at, data.invitation_id);
+    return new AllowlistIdentifier(
+      data.id,
+      data.identifier,
+      data.identifier_type,
+      data.created_at,
+      data.updated_at,
+      data.instance_id,
+      data.invitation_id,
+    );
   }
 }

--- a/packages/backend/src/api/resources/BlocklistIdentifier.ts
+++ b/packages/backend/src/api/resources/BlocklistIdentifier.ts
@@ -1,0 +1,24 @@
+import type { BlocklistIdentifierType } from './Enums';
+import type { BlocklistIdentifierJSON } from './JSON';
+
+export class BlocklistIdentifier {
+  constructor(
+    readonly id: string,
+    readonly identifier: string,
+    readonly identifierType: BlocklistIdentifierType,
+    readonly createdAt: number,
+    readonly updatedAt: number,
+    readonly instanceId?: string,
+  ) {}
+
+  static fromJSON(data: BlocklistIdentifierJSON): BlocklistIdentifier {
+    return new BlocklistIdentifier(
+      data.id,
+      data.identifier,
+      data.identifier_type,
+      data.created_at,
+      data.updated_at,
+      data.instance_id,
+    );
+  }
+}

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -1,5 +1,6 @@
 import {
   AllowlistIdentifier,
+  BlocklistIdentifier,
   Client,
   Cookies,
   DeletedObject,
@@ -73,6 +74,8 @@ function jsonToObject(item: any): any {
       return AccountlessApplication.fromJSON(item);
     case ObjectType.AllowlistIdentifier:
       return AllowlistIdentifier.fromJSON(item);
+    case ObjectType.BlocklistIdentifier:
+      return BlocklistIdentifier.fromJSON(item);
     case ObjectType.Client:
       return Client.fromJSON(item);
     case ObjectType.Cookies:

--- a/packages/backend/src/api/resources/Enums.ts
+++ b/packages/backend/src/api/resources/Enums.ts
@@ -36,3 +36,7 @@ export type SignInStatus = 'needs_identifier' | 'needs_factor_one' | 'needs_fact
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
 
 export type InvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired';
+
+export type AllowlistIdentifierType = 'email_address' | 'phone_number' | 'web3_wallet';
+
+export type BlocklistIdentifierType = AllowlistIdentifierType;

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -1,4 +1,6 @@
 import type {
+  AllowlistIdentifierType,
+  BlocklistIdentifierType,
   InvitationStatus,
   OrganizationDomainVerificationStatus,
   OrganizationDomainVerificationStrategy,
@@ -12,6 +14,7 @@ import type {
 export const ObjectType = {
   AccountlessApplication: 'accountless_application',
   AllowlistIdentifier: 'allowlist_identifier',
+  BlocklistIdentifier: 'blocklist_identifier',
   Client: 'client',
   Cookies: 'cookies',
   Email: 'email',
@@ -73,9 +76,20 @@ export interface AccountlessApplicationJSON extends ClerkResourceJSON {
 export interface AllowlistIdentifierJSON extends ClerkResourceJSON {
   object: typeof ObjectType.AllowlistIdentifier;
   identifier: string;
+  identifier_type: AllowlistIdentifierType;
+  instance_id?: string;
+  invitation_id?: string;
   created_at: number;
   updated_at: number;
-  invitation_id?: string;
+}
+
+export interface BlocklistIdentifierJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.BlocklistIdentifier;
+  identifier: string;
+  identifier_type: BlocklistIdentifierType;
+  instance_id?: string;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface ClientJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -1,5 +1,6 @@
 export * from './AccountlessApplication';
 export * from './AllowlistIdentifier';
+export * from './BlocklistIdentifier';
 export * from './Client';
 export * from './Cookies';
 export * from './DeletedObject';

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -58,6 +58,7 @@ export type {
   ClerkResourceJSON,
   TokenJSON,
   AllowlistIdentifierJSON,
+  BlocklistIdentifierJSON,
   ClientJSON,
   EmailJSON,
   EmailAddressJSON,
@@ -96,6 +97,7 @@ export type {
 export type {
   AccountlessApplication,
   AllowlistIdentifier,
+  BlocklistIdentifier,
   Client,
   EmailAddress,
   ExternalAccount,


### PR DESCRIPTION
## Description

Adds the Blocklist Identifier endpoints to the Backend API client.

```ts
  import { createClerkClient } from '@clerk/backend';

  const clerkClient = createClerkClient(...);
  await clerkClient.blocklistIdentifiers.getBlocklistIdentifierList();
  await clerkClient.blocklistIdentifiers.createBlocklistIdentifier({ identifier });
  await clerkClient.blocklistIdentifiers.deleteBlocklistIdentifier('blocklistIdentifierId');
```

Updates the ability paginate Allowlist Identifier reponses and access `identifierType` and `instanceId` from the response.

```ts
  import { createClerkClient } from '@clerk/backend';

  const clerkClient = createClerkClient(...);
  const res = await clerkClient.blocklistIdentifiers.getAllowlistIdentifierList({ limit, offset });
```

<!-- Fixes #(issue number) -->
ECO-580

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
