### PR TITLE
feat(backend): Add webhooks endpoints to the Backend API client

### DIFF
--- a/.changeset/nice-candles-send.md
+++ b/.changeset/nice-candles-send.md
@@ -1,0 +1,14 @@
+---
+'@clerk/backend': minor
+---
+
+Adds webhooks endpoints to the Backend API client.
+
+```ts
+  import { createClerkClient } from '@clerk/backend';
+
+  const clerkClient = createClerkClient(...);
+  await clerkClient.webhooks.createSvixApp();
+  await clerkClient.webhooks.generateSvixAuthURL();
+  await clerkClient.webhooks.deleteSvixApp();
+```

--- a/packages/backend/src/api/endpoints/WebhookApi.ts
+++ b/packages/backend/src/api/endpoints/WebhookApi.ts
@@ -1,0 +1,28 @@
+import { joinPaths } from '../../util/path';
+import type { WebhooksSvixJSON } from '../resources/JSON';
+import { AbstractAPI } from './AbstractApi';
+
+const basePath = '/webhooks';
+
+export class WebhookAPI extends AbstractAPI {
+  public async createSvixApp() {
+    return this.request<WebhooksSvixJSON>({
+      method: 'POST',
+      path: joinPaths(basePath, 'svix'),
+    });
+  }
+
+  public async generateSvixAuthURL() {
+    return this.request<WebhooksSvixJSON>({
+      method: 'POST',
+      path: joinPaths(basePath, 'svix_url'),
+    });
+  }
+
+  public async deleteSvixApp() {
+    return this.request<void>({
+      method: 'DELETE',
+      path: joinPaths(basePath, 'svix'),
+    });
+  }
+}

--- a/packages/backend/src/api/endpoints/index.ts
+++ b/packages/backend/src/api/endpoints/index.ts
@@ -16,3 +16,4 @@ export * from './SignInTokenApi';
 export * from './UserApi';
 export * from './SamlConnectionApi';
 export * from './TestingTokenApi';
+export * from './WebhookApi';

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -16,6 +16,7 @@ import {
   SignInTokenAPI,
   TestingTokenAPI,
   UserAPI,
+  WebhookAPI,
 } from './endpoints';
 import { buildRequest } from './request';
 
@@ -46,5 +47,6 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
     domains: new DomainAPI(request),
     samlConnections: new SamlConnectionAPI(request),
     testingTokens: new TestingTokenAPI(request),
+    webhooks: new WebhookAPI(request),
   };
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -524,3 +524,7 @@ export interface SamlAccountConnectionJSON extends ClerkResourceJSON {
   created_at: number;
   updated_at: number;
 }
+
+export interface WebhooksSvixJSON {
+  svix_url: string;
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -88,6 +88,7 @@ export type {
   DeletedObjectJSON,
   PaginatedResponseJSON,
   TestingTokenJSON,
+  WebhooksSvixJSON,
 } from './api/resources/JSON';
 
 /**


### PR DESCRIPTION
## Description

Adds webhooks endpoints to the Backend API client.

```ts
  import { createClerkClient } from '@clerk/backend';

  const clerkClient = createClerkClient(...);
  await clerkClient.webhooks.createSvixApp();
  await clerkClient.webhooks.generateSvixAuthURL();
  await clerkClient.webhooks.deleteSvixApp();
```

<!-- Fixes #(issue number) -->

ECO-593

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
