### PR TITLE
fix(shared): Reverse permissions array on `parsePermissions` to match bitmask correctly

### DIFF
--- a/.changeset/fluffy-teeth-decide.md
+++ b/.changeset/fluffy-teeth-decide.md
@@ -2,4 +2,4 @@
 '@clerk/shared': patch
 ---
 
-Bug fix: Remove padding when parsing permissions from the JWT v2 format.
+Bug fix: Reverse permissions array on `parsePermissions` to match bitmask correctly.

--- a/.changeset/fluffy-teeth-decide.md
+++ b/.changeset/fluffy-teeth-decide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Bug fix: Remove padding when parsing permissions from the JWT v2 format.

--- a/packages/shared/src/__tests__/jwtPayloadParser.test.ts
+++ b/packages/shared/src/__tests__/jwtPayloadParser.test.ts
@@ -183,6 +183,61 @@ describe('JWTPayloadToAuthObjectProperties', () => {
       ['org:memberships:read', 'org:memberships:manage'].sort(),
     );
   });
+
+  test('org permissions are constructed correctly case 2', () => {
+    const { sessionClaims: v2Claims, ...signedInAuthObject } = JWTPayloadToAuthObjectProperties({
+      ...baseClaims,
+      v: 2,
+      fea: 'o:billing,o:email,o:fraud,o:instance,o:staging_plans',
+      o: {
+        id: 'org_id',
+        rol: 'admin',
+        slg: 'org_slug',
+        per: 'manage,read',
+        fpm: '3,3,3,3,1',
+      },
+    });
+
+    expect(signedInAuthObject.orgPermissions?.sort()).toEqual(
+      [
+        'org:billing:manage',
+        'org:billing:read',
+        'org:email:manage',
+        'org:email:read',
+        'org:fraud:manage',
+        'org:fraud:read',
+        'org:instance:manage',
+        'org:instance:read',
+        'org:staging_plans:manage',
+      ].sort(),
+    );
+  });
+
+  test('org permissions are constructed correctly case 3', () => {
+    const { sessionClaims: v2Claims, ...signedInAuthObject } = JWTPayloadToAuthObjectProperties({
+      ...baseClaims,
+      v: 2,
+      fea: 'o:repositories,o:projects',
+      o: {
+        id: 'org_id',
+        rol: 'admin',
+        slg: 'org_slug',
+        per: 'read,create,update,delete,revoke',
+        fpm: '7,21',
+      },
+    });
+
+    expect(signedInAuthObject.orgPermissions?.sort()).toEqual(
+      [
+        'org:repositories:read',
+        'org:repositories:create',
+        'org:repositories:update',
+        'org:projects:read',
+        'org:projects:update',
+        'org:projects:revoke',
+      ].sort(),
+    );
+  });
 });
 
 describe('splitByScope ', () => {

--- a/packages/shared/src/__tests__/jwtPayloadParser.test.ts
+++ b/packages/shared/src/__tests__/jwtPayloadParser.test.ts
@@ -38,7 +38,7 @@ describe('JWTPayloadToAuthObjectProperties', () => {
       o: {
         id: 'org_xxxxxxx',
         rol: 'admin',
-        slg: '/test',
+        slg: 'org_test',
         per: 'read,manage',
         fpm: '3',
       },
@@ -48,32 +48,8 @@ describe('JWTPayloadToAuthObjectProperties', () => {
       ...baseClaims,
       org_id: 'org_xxxxxxx',
       org_role: 'org:admin',
-      org_slug: '/test',
-      org_permissions: ['org:impersonation:read', 'org:impersonation:manage'],
-    });
-    expect(signedInAuthObjectV1).toEqual(signedInAuthObjectV2);
-  });
-
-  test('produced auth object is the same for v1 and v2', () => {
-    const { sessionClaims: v2Claims, ...signedInAuthObjectV2 } = JWTPayloadToAuthObjectProperties({
-      ...baseClaims,
-      v: 2,
-      fea: 'o:impersonation',
-      o: {
-        id: 'org_xxxxxxx',
-        rol: 'admin',
-        slg: '/test',
-        per: 'read,manage',
-        fpm: '3',
-      },
-    });
-
-    const { sessionClaims: v1Claims, ...signedInAuthObjectV1 } = JWTPayloadToAuthObjectProperties({
-      ...baseClaims,
-      org_id: 'org_xxxxxxx',
-      org_role: 'org:admin',
-      org_slug: '/test',
-      org_permissions: ['org:impersonation:read', 'org:impersonation:manage'],
+      org_slug: 'org_test',
+      org_permissions: ['org:impersonation:manage', 'org:impersonation:read'],
     });
     expect(signedInAuthObjectV1).toEqual(signedInAuthObjectV2);
   });
@@ -86,9 +62,9 @@ describe('JWTPayloadToAuthObjectProperties', () => {
       o: {
         id: 'org_xxxxxxx',
         rol: 'admin',
-        slg: '/test',
+        slg: 'org_test',
         per: 'read,manage',
-        fpm: '2,3',
+        fpm: '1,3',
       },
     });
 
@@ -107,7 +83,7 @@ describe('JWTPayloadToAuthObjectProperties', () => {
         rol: 'admin',
         slg: 'org_slug',
         per: 'read,manage',
-        fpm: '2,3',
+        fpm: '1,3',
       },
     });
 
@@ -126,7 +102,7 @@ describe('JWTPayloadToAuthObjectProperties', () => {
         rol: 'admin',
         slg: 'org_slug',
         per: 'read,manage',
-        fpm: '2,3,2',
+        fpm: '1,3,1',
       },
     });
 
@@ -218,6 +194,51 @@ describe('JWTPayloadToAuthObjectProperties', () => {
       ...baseClaims,
       v: 2,
       fea: 'o:repositories,o:projects',
+      o: {
+        id: 'org_id',
+        rol: 'admin',
+        slg: 'org_slug',
+        per: 'read,create,update,delete,revoke',
+        fpm: '7,21',
+      },
+    });
+
+    expect(signedInAuthObject.orgPermissions?.sort()).toEqual(
+      [
+        'org:repositories:read',
+        'org:repositories:create',
+        'org:repositories:update',
+        'org:projects:read',
+        'org:projects:update',
+        'org:projects:revoke',
+      ].sort(),
+    );
+  });
+
+  test('org permissions are constructed correctly case 4', () => {
+    const { sessionClaims: v2Claims, ...signedInAuthObject } = JWTPayloadToAuthObjectProperties({
+      ...baseClaims,
+      v: 2,
+      fea: 'o:repositories,o:projects,o:webhooks,o:impersonation',
+      o: {
+        id: 'org_id',
+        rol: 'admin',
+        slg: 'org_slug',
+        per: 'read,manage',
+        fpm: '1,2,3',
+      },
+    });
+
+    expect(signedInAuthObject.orgPermissions?.sort()).toEqual(
+      ['org:repositories:read', 'org:projects:manage', 'org:webhooks:read', 'org:webhooks:manage'].sort(),
+    );
+  });
+
+  test('org permissions are constructed correctly case 5', () => {
+    const { sessionClaims: v2Claims, ...signedInAuthObject } = JWTPayloadToAuthObjectProperties({
+      ...baseClaims,
+      v: 2,
+      fea: 'o:repositories,uo:projects,u:goldprofileborder',
       o: {
         id: 'org_id',
         rol: 'admin',

--- a/packages/shared/src/jwtPayloadParser.ts
+++ b/packages/shared/src/jwtPayloadParser.ts
@@ -12,7 +12,10 @@ export const parsePermissions = ({ per, fpm }: { per?: string; fpm?: string }) =
     return { permissions: [], featurePermissionMap: [] };
   }
 
-  const permissions = per.split(',').map(p => p.trim());
+  const permissions = per
+    .split(',')
+    .map(p => p.trim())
+    .reverse();
 
   // TODO: make this more efficient
   const featurePermissionMap = fpm
@@ -21,6 +24,7 @@ export const parsePermissions = ({ per, fpm }: { per?: string; fpm?: string }) =
     .map((permission: number) =>
       permission
         .toString(2)
+        .padStart(permissions.length, '0')
         .split('')
         .map(bit => Number.parseInt(bit, 10)),
     )

--- a/packages/shared/src/jwtPayloadParser.ts
+++ b/packages/shared/src/jwtPayloadParser.ts
@@ -21,7 +21,6 @@ export const parsePermissions = ({ per, fpm }: { per?: string; fpm?: string }) =
     .map((permission: number) =>
       permission
         .toString(2)
-        .padStart(permissions.length, '0')
         .split('')
         .map(bit => Number.parseInt(bit, 10)),
     )


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
