### PR TITLE
fix(localizations): German "Delete account" confirmation

### DIFF
--- a/.changeset/tired-experts-dig.md
+++ b/.changeset/tired-experts-dig.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix German account deletion confirmation

--- a/.changeset/tired-experts-dig.md
+++ b/.changeset/tired-experts-dig.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/clerk-js': patch
+'@clerk/localizations': patch
 ---
 
 Fix German account deletion confirmation

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -63,7 +63,7 @@ export const deDE: LocalizationResource = {
   formFieldHintText__slug:
     'Der Slug ist eine für Menschen lesbare ID. Sie muss einzigartig sein und wird oft in URLs verwendet.',
   formFieldInputPlaceholder__backupCode: 'Sicherheitscode eingeben',
-  formFieldInputPlaceholder__confirmDeletionUserAccount: 'Account löschen',
+  formFieldInputPlaceholder__confirmDeletionUserAccount: 'Konto löschen',
   formFieldInputPlaceholder__emailAddress: 'E-Mail-Adresse eingeben',
   formFieldInputPlaceholder__emailAddress_username: 'E-Mail-Adresse oder Benutzername eingeben',
   formFieldInputPlaceholder__emailAddresses: 'example@email.com, example2@email.com',


### PR DESCRIPTION
## Description

Deleting an account is currently not possible, as the terms "Account löschen" is expected, although "Konto löschen" is requested to confirm. Details of the issue can be found in the linked issue. Note that this issue prevents Clerk from being GDPR compliant in Germany right now ⚠️.

Fixes https://github.com/clerk/javascript/issues/5623

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
