### PR TITLE
chore(*): Improve `@default`, `@deprecated` JSDoc

### DIFF
--- a/.changeset/fast-lands-smash.md
+++ b/.changeset/fast-lands-smash.md
@@ -1,0 +1,14 @@
+---
+'@clerk/react-router': patch
+'@clerk/clerk-js': patch
+'@clerk/backend': patch
+'@clerk/shared': patch
+'@clerk/astro': patch
+'@clerk/clerk-react': patch
+'@clerk/remix': patch
+'@clerk/types': patch
+'@clerk/clerk-expo': patch
+'@clerk/vue': patch
+---
+
+Improve JSDoc comments

--- a/.typedoc/custom-plugin.mjs
+++ b/.typedoc/custom-plugin.mjs
@@ -82,10 +82,17 @@ function getCatchAllReplacements() {
     },
     {
       /**
-       * By default the markdown plugin outputs `@deprecated` with `**Deprecated**`. We want to add a full stop to it.
+       * By default, `@deprecated` is output with `**Deprecated**`. We want to add a full stop to it.
        */
       pattern: /\*\*Deprecated\*\*/g,
       replace: '**Deprecated.**',
+    },
+    {
+      /**
+       * By default, `@default` is output with "**Default** `value`". We want to capture the value and place it inside "Defaults to `value`."
+       */
+      pattern: /\*\*Default\*\* `([^`]+)`/g,
+      replace: 'Defaults to `$1`.',
     },
   ];
 }

--- a/.typedoc/custom-plugin.mjs
+++ b/.typedoc/custom-plugin.mjs
@@ -29,7 +29,7 @@ const LINK_REPLACEMENTS = [
   ['sign-up-resource', '/docs/references/javascript/sign-up'],
   ['user-resource', '/docs/references/javascript/user'],
   ['session-status-claim', '/docs/references/javascript/types/session-status'],
-  ['user-organization-invitation-resource', '/docs/references/javascript/types/organization-invitation'],
+  ['user-organization-invitation-resource', '/docs/references/javascript/types/user-organization-invitation'],
   ['organization-membership-resource', '/docs/references/javascript/types/organization-membership'],
   ['organization-suggestion-resource', '/docs/references/javascript/types/organization-suggestion'],
   ['organization-resource', '/docs/references/javascript/organization'],
@@ -62,7 +62,7 @@ function getRelativeLinkReplacements() {
   });
 }
 
-function getUnlinkedTypesReplacements() {
+function getCatchAllReplacements() {
   return [
     {
       pattern: /\(setActiveParams\)/g,
@@ -79,6 +79,13 @@ function getUnlinkedTypesReplacements() {
     {
       pattern: /\(CreateOrganizationParams\)/g,
       replace: '([CreateOrganizationParams](#create-organization-params))',
+    },
+    {
+      /**
+       * By default the markdown plugin outputs `@deprecated` with `**Deprecated**`. We want to add a full stop to it.
+       */
+      pattern: /\*\*Deprecated\*\*/g,
+      replace: '**Deprecated.**',
     },
   ];
 }
@@ -97,9 +104,9 @@ export function load(app) {
       }
     }
 
-    const unlinkedTypesReplacements = getUnlinkedTypesReplacements();
+    const catchAllReplacements = getCatchAllReplacements();
 
-    for (const { pattern, replace } of unlinkedTypesReplacements) {
+    for (const { pattern, replace } of catchAllReplacements) {
       if (output.contents) {
         output.contents = output.contents.replace(pattern, replace);
       }

--- a/.typedoc/custom-theme.mjs
+++ b/.typedoc/custom-theme.mjs
@@ -64,6 +64,63 @@ class ClerkMarkdownThemeContext extends MarkdownThemeContext {
         return output;
       },
       /**
+       * This condenses the output if only a "simple" return type + `@returns` is given.
+       * @param {import('typedoc').SignatureReflection} model
+       * @param {{ headingLevel: number }} options
+       */
+      signatureReturns: (model, options) => {
+        const defaultOutput = superPartials.signatureReturns(model, options);
+        const hasReturnsTag = model.comment?.getTag('@returns');
+
+        /**
+         * @type {any}
+         */
+        const type = model.type;
+        /**
+         * @type {import('typedoc').DeclarationReflection}
+         */
+        const typeDeclaration = type?.declaration;
+
+        /**
+         * Early return for non "simple" cases
+         */
+        if (!typeDeclaration?.signatures) {
+          if (model.type && this.helpers.hasUsefulTypeDetails(model.type)) {
+            return defaultOutput;
+          }
+        }
+        if (!hasReturnsTag) {
+          return defaultOutput;
+        }
+
+        /**
+         * Now the default output would be in this format:
+         *
+         * `Type`
+         *
+         * Contents of `@returns` tag
+         *
+         * It should be condensed to:
+         *
+         * `Type` — Contents of `@returns` tag
+         */
+
+        const o = defaultOutput.split('\n\n');
+
+        /**
+         * At this stage the output can be:
+         * - ['## Returns', '`Type`', 'Contents of `@returns` tag']
+         * - ['## Returns', '`Type`', '']
+         *
+         * We want to condense the first case by combining the second and third item with ` — `
+         */
+        if (o.length === 3 && o[2] !== '') {
+          return `${o[0]}\n\n${o[1]} — ${o[2]}`;
+        }
+
+        return defaultOutput;
+      },
+      /**
        * This hides the "Type parameters" section from the output
        * @param {import('typedoc').DeclarationReflection} model
        * @param {{ headingLevel: number }} options

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "turbo-ignore": "^2.4.4",
     "typedoc": "0.28.2",
     "typedoc-plugin-markdown": "4.6.2",
-    "typedoc-plugin-replace-text": "4.1.0",
+    "typedoc-plugin-replace-text": "4.2.0",
     "typescript": "catalog:repo",
     "typescript-eslint": "8.28.0",
     "uuid": "8.3.2",

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -73,8 +73,8 @@ export type { AstroClerkUpdateOptions, AstroClerkIntegrationParams, AstroClerkCr
 
 export type ButtonProps<Tag> = {
   /**
-   * @deprecated The 'as' prop is deprecated and will be removed in a future version.
-   * Use the default slot with the 'asChild' prop instead.
+   * @deprecated The `'as'` prop will be removed in a future version.
+   * Use the default slot with the `'asChild'` prop instead.
    * @example
    * <SignInButton asChild>
    *   <button>Sign in</button>

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -234,7 +234,7 @@ export class UserAPI extends AbstractAPI {
     });
   }
 
-  /** @deprecated Please use getUserOauthAccessToken without the `oauth_` provider prefix . */
+  /** @deprecated Use `getUserOauthAccessToken` without the `oauth_` provider prefix . */
   public async getUserOauthAccessToken(
     userId: string,
     provider: `oauth_${OAuthProvider}`,

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -54,7 +54,7 @@ type BuildRequestOptions = {
   userAgent?: string;
   /**
    * Allow requests without specifying a secret key. In most cases this should be set to `false`.
-   * Defaults to `true`.
+   * @default true
    */
   requireSecretKey?: boolean;
 };

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -108,7 +108,8 @@ export type VerifyJwtOptions = {
    */
   authorizedParties?: string[];
   /**
-   * Specifies the allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms (5 seconds).
+   * Specifies the allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token.
+   * @default 5000
    */
   clockSkewInMs?: number;
   /**

--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -90,7 +90,7 @@ export type LoadClerkJWKFromRemoteOptions = {
    */
   kid: string;
   /**
-   * @deprecated This cache TTL is deprecated and will be removed in the next major version. Specifying a cache TTL is now a no-op.
+   * @deprecated This cache TTL will be removed in the next major version. Specifying a cache TTL is a no-op.
    */
   jwksCacheTtlInMs?: number;
   /**

--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -102,11 +102,13 @@ export type LoadClerkJWKFromRemoteOptions = {
    */
   secretKey?: string;
   /**
-   * The [Clerk Backend API](https://clerk.com/docs/reference/backend-api) endpoint. Defaults to `'https://api.clerk.com'`.
+   * The [Clerk Backend API](https://clerk.com/docs/reference/backend-api) endpoint.
+   * @default 'https://api.clerk.com'
    */
   apiUrl?: string;
   /**
-   * The version passed to the Clerk API. Defaults to `'v1'`.
+   * The version passed to the Clerk API.
+   * @default 'v1'
    */
   apiVersion?: string;
 };

--- a/packages/backend/src/tokens/types.ts
+++ b/packages/backend/src/tokens/types.ts
@@ -11,7 +11,8 @@ export type AuthenticateRequestOptions = {
    */
   domain?: string;
   /**
-   * Whether the instance is a satellite domain in a multi-domain setup. Defaults to `false`.
+   * Whether the instance is a satellite domain in a multi-domain setup.
+   * @default false
    */
   isSatellite?: boolean;
   /**
@@ -27,11 +28,13 @@ export type AuthenticateRequestOptions = {
    */
   signUpUrl?: string;
   /**
-   * Full URL or path to navigate to after successful sign in. Defaults to `/`.
+   * Full URL or path to navigate to after successful sign in.
+   * @default '/'
    */
   afterSignInUrl?: string;
   /**
-   * Full URL or path to navigate to after successful sign up. Defaults to `/`.
+   * Full URL or path to navigate to after successful sign up.
+   * @default '/'
    */
   afterSignUpUrl?: string;
   /**

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -55,7 +55,7 @@ export class Client extends BaseResource implements ClientResource {
   }
 
   /**
-   * @deprecated Use `signedInSessions` instead
+   * @deprecated Use `signedInSessions()` instead.
    */
   get activeSessions(): ActiveSessionResource[] {
     return this.sessions.filter(s => s.status === 'active') as ActiveSessionResource[];

--- a/packages/expo/src/hooks/useOAuth.ts
+++ b/packages/expo/src/hooks/useOAuth.ts
@@ -25,7 +25,7 @@ export type StartOAuthFlowReturnType = {
 };
 
 /**
- * @deprecated Use `useSSO` instead
+ * @deprecated Use `useSSO()` instead.
  */
 export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
   const { strategy } = useOAuthParams || {};

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -25,7 +25,7 @@ import type { BuildClerkOptions } from './types';
 const KEY = '__clerk_client_jwt';
 
 /**
- * @deprecated Use `getClerkInstance` instead. `Clerk` will be removed in the next major version.
+ * @deprecated Use `getClerkInstance()` instead. `Clerk` will be removed in the next major version.
  */
 export let clerk: HeadlessBrowserClerk | BrowserClerk;
 let __internal_clerk: HeadlessBrowserClerk | BrowserClerk | undefined;

--- a/packages/expo/src/provider/singleton/singleton.ts
+++ b/packages/expo/src/provider/singleton/singleton.ts
@@ -3,7 +3,7 @@ import { Clerk } from '@clerk/clerk-js/headless';
 import { createClerkInstance } from './createClerkInstance';
 
 /**
- * @deprecated Use `getClerkInstance` instead. `Clerk` will be removed in the next major version.
+ * @deprecated Use `getClerkInstance()` instead. `Clerk` will be removed in the next major version.
  */
 export { clerk } from './createClerkInstance';
 

--- a/packages/expo/src/provider/singleton/singleton.web.ts
+++ b/packages/expo/src/provider/singleton/singleton.web.ts
@@ -3,7 +3,7 @@ import type { BrowserClerk, HeadlessBrowserClerk } from '@clerk/clerk-react';
 import type { BuildClerkOptions } from './types';
 
 /**
- * @deprecated Use `getClerkInstance` instead. `Clerk` will be removed in the next major version.
+ * @deprecated Use `getClerkInstance()` instead. `Clerk` will be removed in the next major version.
  */
 export const clerk = globalThis?.window?.Clerk;
 

--- a/packages/react-router/src/ssr/types.ts
+++ b/packages/react-router/src/ssr/types.ts
@@ -54,18 +54,15 @@ export type RootAuthLoaderOptions = {
    */
   secretKey?: string;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadUser?: boolean;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadSession?: boolean;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadOrganization?: boolean;
   signInUrl?: string;

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -198,7 +198,7 @@ export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<Re
 
 /**
  * @function
- * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-user-profile) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-user-profile) instead.
  */
 export const RedirectToUserProfile = withClerk(({ clerk }) => {
   React.useEffect(() => {
@@ -211,7 +211,7 @@ export const RedirectToUserProfile = withClerk(({ clerk }) => {
 
 /**
  * @function
- * @deprecated Use [`redirectToOrganizationProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-organization-profile) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToOrganizationProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-organization-profile) instead.
  */
 export const RedirectToOrganizationProfile = withClerk(({ clerk }) => {
   React.useEffect(() => {
@@ -224,7 +224,7 @@ export const RedirectToOrganizationProfile = withClerk(({ clerk }) => {
 
 /**
  * @function
- * @deprecated Use [`redirectToCreateOrganization()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-create-organization) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToCreateOrganization()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-create-organization) instead.
  */
 export const RedirectToCreateOrganization = withClerk(({ clerk }) => {
   React.useEffect(() => {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -55,7 +55,8 @@ export type ClerkProviderProps = IsomorphicClerkOptions & {
    */
   initialState?: InitialState;
   /**
-   * Indicates to silently fail the initialization process when the publishable keys is not provided, instead of throwing an error. Defaults to `false`.
+   * Indicates to silently fail the initialization process when the publishable keys is not provided, instead of throwing an error.
+   * @default false
    * @internal
    */
   __internal_bypassMissingPublishableKey?: boolean;

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -17,18 +17,15 @@ export type RootAuthLoaderOptions = {
   jwtKey?: string;
   secretKey?: string;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadUser?: boolean;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadSession?: boolean;
   /**
-   * @deprecated This option will be removed in the next major version.
-   * Use session token claims instead: https://clerk.com/docs/backend-requests/making/custom-session-token
+   * @deprecated Use [session token claims](https://clerk.com/docs/backend-requests/making/custom-session-token) instead.
    */
   loadOrganization?: boolean;
   signInUrl?: string;

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -215,7 +215,7 @@ export function isEmailLinkError(err: Error): err is EmailLinkError {
 }
 
 /**
- * @deprecated Please use `EmailLinkErrorCodeStatus` instead.
+ * @deprecated Use `EmailLinkErrorCodeStatus` instead.
  *
  * @hidden
  */

--- a/packages/shared/src/handleValueOrFn.ts
+++ b/packages/shared/src/handleValueOrFn.ts
@@ -1,6 +1,6 @@
 import { handleValueOrFn as origHandleValueOrFn } from './utils/handleValueOrFn';
 
 /**
- * @deprecated - use `handleValueOrFn` from `@clerk/shared/utils` instead
+ * @deprecated - Use `handleValueOrFn` from `@clerk/shared/utils` instead.
  */
 export const handleValueOrFn = origHandleValueOrFn;

--- a/packages/shared/src/react/hooks/useSession.ts
+++ b/packages/shared/src/react/hooks/useSession.ts
@@ -13,6 +13,8 @@ type UseSession = (options?: PendingSessionOptions) => UseSessionReturn;
  *
  * @function
  *
+ * @param [options] - An object containing options for the `useSession()` hook.
+ *
  * @example
  * ### Access the `Session` object
  *

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -89,18 +89,21 @@ export type PaginatedResourcesWithDefault<T> = {
  */
 export type PaginatedHookConfig<T> = T & {
   /**
-   * If `true`, newly fetched data will be appended to the existing list rather than replacing it. Useful for implementing infinite scroll functionality. Defaults to `false`.
+   * If `true`, newly fetched data will be appended to the existing list rather than replacing it. Useful for implementing infinite scroll functionality.
+   * @default false
    */
   infinite?: boolean;
   /**
-   * If `true`, the previous data will be kept in the cache until new data is fetched. Defaults to `false`.
+   * If `true`, the previous data will be kept in the cache until new data is fetched.
+   * @default false
    */
   keepPreviousData?: boolean;
 };
 
 export type PagesOrInfiniteConfig = PaginatedHookConfig<{
   /**
-   * If `true`, a request will be triggered. Defaults to `true`.
+   * If `true`, a request will be triggered.
+   * @default true
    */
   enabled?: boolean;
 }>;
@@ -110,11 +113,13 @@ export type PagesOrInfiniteConfig = PaginatedHookConfig<{
  */
 export type PagesOrInfiniteOptions = {
   /**
-   * A number that specifies which page to fetch. For example, if `initialPage` is set to 10, it will skip the first 9 pages and fetch the 10th page. Defaults to `1`.
+   * A number that specifies which page to fetch. For example, if `initialPage` is set to 10, it will skip the first 9 pages and fetch the 10th page.
+   * @default 1
    */
   initialPage?: number;
   /**
-   * A number that specifies the maximum number of results to return per page. Defaults to `10`.
+   * A number that specifies the maximum number of results to return per page.
+   * @default 10
    */
   pageSize?: number;
 };

--- a/packages/types/src/authConfig.ts
+++ b/packages/types/src/authConfig.ts
@@ -8,7 +8,7 @@ export interface AuthConfigResource extends ClerkResource {
   singleSessionMode: boolean;
   /**
    * Timestamp of when the instance was claimed. This only applies to applications created with the Keyless mode.
-   * Defaults to `null`.
+   * @default null
    */
   claimedAt: Date | null;
   /**

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -839,7 +839,8 @@ export type ClerkOptions = PendingSessionOptions &
     experimental?: Autocomplete<
       {
         /**
-         * Persist the Clerk client to match the user's device with a client. Defaults to `true`.
+         * Persist the Clerk client to match the user's device with a client.
+         * @default true
          */
         persistClient: boolean;
         /**

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -983,7 +983,7 @@ export type SetActiveParams = {
   organization?: OrganizationResource | string | null;
 
   /**
-   * @deprecated in favor of `redirectUrl`.
+   * @deprecated Use `redirectUrl` instead.
    *
    * Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
    */
@@ -1309,13 +1309,13 @@ export type UserButtonProps = UserButtonProfileMode & {
 
   /**
    * Full URL or path to navigate to after sign out is complete
-   * @deprecated Configure `afterSignOutUrl` as a global configuration, either in <ClerkProvider/> or in await Clerk.load()
+   * @deprecated Configure `afterSignOutUrl` as a global configuration, either in `<ClerkProvider/>` or in `await Clerk.load()`.
    */
   afterSignOutUrl?: string;
   /**
    * Full URL or path to navigate to after signing out the current user is complete.
    * This option applies to multi-session applications.
-   * @deprecated Configure `afterMultiSessionSingleSignOutUrl` as a global configuration, either in <ClerkProvider/> or in await Clerk.load()
+   * @deprecated Configure `afterMultiSessionSingleSignOutUrl` as a global configuration, either in `<ClerkProvider/>` or in `await Clerk.load()`.
    */
   afterMultiSessionSingleSignOutUrl?: string;
   /**
@@ -1388,7 +1388,7 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
     /**
      * Full URL or path to navigate to after a successful organization switch.
      * @default undefined
-     * @deprecated use `afterSelectOrganizationUrl` or `afterSelectPersonalUrl`
+     * @deprecated Use `afterSelectOrganizationUrl` or `afterSelectPersonalUrl`.
      */
     afterSwitchOrganizationUrl?: string;
     /**

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -24,7 +24,7 @@ export interface ClientResource extends ClerkResource {
   __internal_sendCaptchaToken: (params: unknown) => Promise<ClientResource>;
   __internal_toSnapshot: () => ClientJSONSnapshot;
   /**
-   * @deprecated Use `signedInSessions` instead
+   * @deprecated Use `signedInSessions` instead.
    */
   activeSessions: ActiveSessionResource[];
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -260,7 +260,7 @@ export interface UserJSON extends ClerkResourceJSON {
   enterprise_accounts: EnterpriseAccountJSON[];
   passkeys: PasskeyJSON[];
   /**
-   * @deprecated use `enterprise_accounts` instead
+   * @deprecated Use `enterprise_accounts` instead.
    */
   saml_accounts: SamlAccountJSON[];
 

--- a/packages/types/src/jwt.ts
+++ b/packages/types/src/jwt.ts
@@ -11,7 +11,7 @@ type NonEmptyArray<T> = [T, ...T[]];
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
 /**
- * @deprecated use `JwtHeader` instead
+ * @deprecated Use `JwtHeader` instead.
  */
 export interface JWTHeader {
   alg: string | Algorithm;
@@ -27,7 +27,7 @@ export interface JWTHeader {
 }
 
 /**
- * @deprecated use `JwtPayload` instead
+ * @deprecated Use `JwtPayload` instead.
  */
 export interface JWTClaims extends ClerkJWTClaims {
   /**
@@ -38,7 +38,7 @@ export interface JWTClaims extends ClerkJWTClaims {
 
 /**
  * Clerk-issued JWT payload
- * @deprecated use `JwtPayload` instead
+ * @deprecated Use `JwtPayload` instead.
  */
 export interface ClerkJWTClaims {
   /**
@@ -105,7 +105,7 @@ export interface ClerkJWTClaims {
 /**
  * JWT Actor - [RFC8693](https://www.rfc-editor.org/rfc/rfc8693.html#name-act-actor-claim).
  * @inline
- * @deprecated use `ActClaim` instead
+ * @deprecated Use `ActClaim` instead.
  */
 export interface ActJWTClaim {
   sub: string;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -433,11 +433,11 @@ type _LocalizationResource = {
         primaryButton: LocalizationValue;
         actionLabel__connectionFailed: LocalizationValue;
         /**
-         * @deprecated UserProfile now only uses `actionLabel__connectionFailed`.
+         * @deprecated Use `actionLabel__connectionFailed` instead.
          */
         actionLabel__reauthorize: LocalizationValue;
         /**
-         * @deprecated UserProfile now uses `subtitle__disconnected`.
+         * @deprecated Use `subtitle__disconnected` instead.
          */
         subtitle__reauthorize: LocalizationValue;
         subtitle__disconnected: LocalizationValue;
@@ -510,7 +510,7 @@ type _LocalizationResource = {
       formHint: LocalizationValue;
       emailCode: {
         /**
-         * @deprecated UserProfile now only uses `emailAddressPage.formHint`.
+         * @deprecated Use `emailAddressPage.formHint` instead.
          */
         formHint: LocalizationValue;
         formTitle: LocalizationValue;
@@ -520,7 +520,7 @@ type _LocalizationResource = {
       };
       emailLink: {
         /**
-         * @deprecated UserProfile now only uses `emailAddressPage.formHint`.
+         * @deprecated Use `emailAddressPage.formHint` instead.
          */
         formHint: LocalizationValue;
         formTitle: LocalizationValue;

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -71,8 +71,7 @@ export type OAuthProvider =
   | CustomOauthProvider;
 
 /**
- * @deprecated This utility will be dropped in the next major release.
- * You can import it from `@clerk/shared/oauth`.
+ * @deprecated Use `import { OAUTH_PROVIDERS } from "@clerk/shared/oauth"` instead.
  *
  * @hidden
  */

--- a/packages/types/src/pagination.ts
+++ b/packages/types/src/pagination.ts
@@ -34,11 +34,13 @@ export interface ClerkPaginatedResponse<T> {
  */
 export type ClerkPaginationParams<T = object> = {
   /**
-   * A number that specifies which page to fetch. For example, if `initialPage` is set to `10`, it will skip the first 9 pages and fetch the 10th page. Defaults to `1`.
+   * A number that specifies which page to fetch. For example, if `initialPage` is set to `10`, it will skip the first 9 pages and fetch the 10th page.
+   * @default 1
    */
   initialPage?: number;
   /**
-   * A number that specifies the maximum number of results to return per page. Defaults to `10`.
+   * A number that specifies the maximum number of results to return per page.
+   * @default 10
    */
   pageSize?: number;
 } & T;

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -101,14 +101,16 @@ export type SignUpForceRedirectUrl = {
 
 export type SignUpFallbackRedirectUrl = {
   /**
-   * The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use the [environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+   * The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. It's recommended to use the [environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+   * @default '/'
    */
   signUpFallbackRedirectUrl?: string | null;
 };
 
 export type SignInFallbackRedirectUrl = {
   /**
-   * The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use the [environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+   * The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. It's recommended to use the [environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+   * @default '/'
    */
   signInFallbackRedirectUrl?: string | null;
 };

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -16,7 +16,7 @@ export type AfterMultiSessionSingleSignOutUrl = {
 };
 
 /**
- * @deprecated This is deprecated and will be removed in a future release.
+ * @deprecated This will be removed in a future release.
  */
 export type LegacyRedirectProps = {
   /**

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -29,6 +29,7 @@ import type { UserResource } from './user';
 import type { Autocomplete } from './utils';
 
 /**
+ * Options to configure the `useSession` hook.
  * @inline
  */
 export type PendingSessionOptions = {

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -29,7 +29,6 @@ import type { UserResource } from './user';
 import type { Autocomplete } from './utils';
 
 /**
- * Options to configure the `useSession` hook.
  * @inline
  */
 export type PendingSessionOptions = {

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -80,7 +80,7 @@ export interface SignInResource extends ClerkResource {
    */
   status: SignInStatus | null;
   /**
-   * @deprecated This attribute will be removed in the next major version
+   * @deprecated This attribute will be removed in the next major version.
    */
   supportedIdentifiers: SignInIdentifier[];
   supportedFirstFactors: SignInFirstFactor[] | null;
@@ -262,7 +262,7 @@ export interface SignInJSON extends ClerkResourceJSON {
   id: string;
   status: SignInStatus;
   /**
-   * @deprecated This attribute will be removed in the next major version
+   * @deprecated This attribute will be removed in the next major version.
    */
   supported_identifiers: SignInIdentifier[];
   identifier: string;

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -192,7 +192,7 @@ export type SignUpCreateParams = Partial<
 export type SignUpUpdateParams = SignUpCreateParams;
 
 /**
- * @deprecated use `SignUpAuthenticateWithWeb3Params` instead
+ * @deprecated Use `SignUpAuthenticateWithWeb3Params` instead.
  */
 export type SignUpAuthenticateWithMetamaskParams = SignUpAuthenticateWithWeb3Params;
 

--- a/packages/types/src/strategies.ts
+++ b/packages/types/src/strategies.ts
@@ -19,6 +19,6 @@ export type OAuthStrategy = `oauth_${OAuthProvider}` | CustomOAuthStrategy;
 export type Web3Strategy = `web3_${Web3Provider}_signature`;
 
 /**
- * @deprecated Use `EnterpriseSSOStrategy` instead
+ * @deprecated Use `EnterpriseSSOStrategy` instead.
  */
 export type SamlStrategy = 'saml';

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -82,7 +82,7 @@ export interface UserResource extends ClerkResource {
   enterpriseAccounts: EnterpriseAccountResource[];
   passkeys: PasskeyResource[];
   /**
-   * @deprecated use `enterpriseAccounts` instead
+   * @deprecated Use `enterpriseAccounts` instead.
    */
   samlAccounts: SamlAccountResource[];
 

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -114,7 +114,7 @@ export interface UserSettingsJSON extends ClerkResourceJSON {
   social: OAuthProviders;
 
   /**
-   * @deprecated Use `enterprise_sso` instead
+   * @deprecated Use `enterprise_sso` instead.
    */
   saml: SamlSettings;
   enterprise_sso: EnterpriseSSOSettings;
@@ -131,7 +131,7 @@ export interface UserSettingsResource extends ClerkResource {
   social: OAuthProviders;
 
   /**
-   * @deprecated Use `enterprise_sso` instead
+   * @deprecated Use `enterprise_sso` instead.
    */
   saml: SamlSettings;
   enterpriseSSO: EnterpriseSSOSettings;

--- a/packages/types/src/web3.ts
+++ b/packages/types/src/web3.ts
@@ -13,8 +13,7 @@ export type OKXWalletWeb3Provider = 'okx_wallet';
 export type Web3Provider = MetamaskWeb3Provider | CoinbaseWalletWeb3Provider | OKXWalletWeb3Provider;
 
 /**
- * @deprecated This constant will be dropped in the next major release.
- * You can import it from `@clerk/shared/web3`.
+ * @deprecated Use `import { WEB3_PROVIDERS } from "@clerk/shared/web3"` instead.
  *
  * @hidden
  */

--- a/packages/vue/src/components/controlComponents.ts
+++ b/packages/vue/src/components/controlComponents.ts
@@ -63,7 +63,7 @@ export const RedirectToSignUp = defineComponent((props: RedirectOptions) => {
 });
 
 /**
- * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-user-profile) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-user-profile) instead.
  */
 export const RedirectToUserProfile = defineComponent(() => {
   useClerkLoaded(clerk => {
@@ -75,7 +75,7 @@ export const RedirectToUserProfile = defineComponent(() => {
 });
 
 /**
- * @deprecated Use [`redirectToOrganizationProfile()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-organization-profile) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToOrganizationProfile()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-organization-profile) instead.
  */
 export const RedirectToOrganizationProfile = defineComponent(() => {
   useClerkLoaded(clerk => {
@@ -87,7 +87,7 @@ export const RedirectToOrganizationProfile = defineComponent(() => {
 });
 
 /**
- * @deprecated Use [`redirectToCreateOrganization()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-create-organization) instead, will be removed in the next major version.
+ * @deprecated Use [`redirectToCreateOrganization()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-create-organization) instead.
  */
 export const RedirectToCreateOrganization = defineComponent(() => {
   useClerkLoaded(clerk => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,8 +281,8 @@ importers:
         specifier: 4.6.2
         version: 4.6.2(typedoc@0.28.2(typescript@5.8.3))
       typedoc-plugin-replace-text:
-        specifier: 4.1.0
-        version: 4.1.0(typedoc@0.28.2(typescript@5.8.3))
+        specifier: 4.2.0
+        version: 4.2.0(typedoc@0.28.2(typescript@5.8.3))
       typescript:
         specifier: catalog:repo
         version: 5.8.3
@@ -13531,10 +13531,10 @@ packages:
     peerDependencies:
       typedoc: 0.28.x
 
-  typedoc-plugin-replace-text@4.1.0:
-    resolution: {integrity: sha512-t/vOiGzhcK+8oVQRt6kJ19RKFN5zwQlDiXyx2eWywG7xHt0lSUcfttroGwNLIBnNEd2rLAwe5YVPhSjVoYHBag==}
+  typedoc-plugin-replace-text@4.2.0:
+    resolution: {integrity: sha512-vmhpFKg75l0CfHO7n3bdf/wwSWH6hQQxaZTqZ5HDe5Xd40tkk6jkVkP6SWhDhntSIflREQqwneflGJG3bCqPEA==}
     peerDependencies:
-      typedoc: 0.26.x || 0.27.x
+      typedoc: 0.26.x || 0.27.x || 0.28.x
 
   typedoc@0.28.2:
     resolution: {integrity: sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==}
@@ -30340,7 +30340,7 @@ snapshots:
     dependencies:
       typedoc: 0.28.2(typescript@5.8.3)
 
-  typedoc-plugin-replace-text@4.1.0(typedoc@0.28.2(typescript@5.8.3)):
+  typedoc-plugin-replace-text@4.2.0(typedoc@0.28.2(typescript@5.8.3)):
     dependencies:
       typedoc: 0.28.2(typescript@5.8.3)
 


### PR DESCRIPTION
## Description

In this PR I'm normalizing our usage of the `@default`, `@deprecated` tags. I'm also modifying the Typedoc output to sometimes adjust the `@returns` tag output.

I've checked our codebase for instances of `"Defaults to ..."` and replaced it with `@default <val>`. This way it's captured correctly and can be added in our Typedoc output in a coherent way.

Same thing with `@deprecated`. Sometimes a full stop was missing at the end, sometimes the first word wasn't capitalized. I've changed the wording to have the sentence structure of "Use X instead.".

I have also mostly removed sentences inside `@deprecated` that said "This is deprecated" since it's unnecessary so say that inside the tag. I've also sometimes removed sentences like "Will be removed in next major version" because I don't think it adds much value, it's deprecated nevertheless.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
