### PR TITLE
feat(backend): Include expiresAt in OauthAccessToken resource

### DIFF
--- a/.changeset/red-rivers-call.md
+++ b/.changeset/red-rivers-call.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Include expiresAt in OAuth access token resource

--- a/.changeset/red-rivers-call.md
+++ b/.changeset/red-rivers-call.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-Include expiresAt in OAuth access token resource
+Include `expiresAt` in OAuth access token resource

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -289,6 +289,7 @@ export interface OauthAccessTokenJSON {
   scopes?: string[];
   // Only set in OAuth 1.0 tokens
   token_secret?: string;
+  expires_at?: number;
 }
 
 export interface OAuthApplicationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/OauthAccessToken.ts
+++ b/packages/backend/src/api/resources/OauthAccessToken.ts
@@ -9,6 +9,7 @@ export class OauthAccessToken {
     readonly label: string,
     readonly scopes?: string[],
     readonly tokenSecret?: string,
+    readonly expiresAt?: number,
   ) {}
 
   static fromJSON(data: OauthAccessTokenJSON) {
@@ -20,6 +21,7 @@ export class OauthAccessToken {
       data.label || '',
       data.scopes,
       data.token_secret,
+      data.expires_at,
     );
   }
 }


### PR DESCRIPTION
## Description

Include expiresAt in OauthAccessToken resource.

https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetOAuthAccessToken!c=200&path=expires_at&t=response

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
