### PR TITLE
fix(clerk-js): Add `payer_type` param default to plans call

### DIFF
--- a/.changeset/cool-mugs-drop.md
+++ b/.changeset/cool-mugs-drop.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix: add default param to plans call

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -13,7 +13,7 @@ type PlansContextProviderProps = {
 const PlansContext = createContext<__experimental_PlansCtx | null>(null);
 
 export const PlansContextProvider = ({
-  subscriberType,
+  subscriberType = 'user',
   children,
 }: PlansContextProviderProps & {
   children: ReactNode;


### PR DESCRIPTION
## Description

Fix commerce plans call by adding default `payer_type`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
