### PR TITLE
fix(clerk-js): Add missing PlansContextProvider to PricingTable

### DIFF
--- a/.changeset/red-bears-wink.md
+++ b/.changeset/red-bears-wink.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix: add missing context to PricingTable

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -15,6 +15,7 @@ import {
   OrganizationListContext,
   OrganizationProfileContext,
   OrganizationSwitcherContext,
+  PlansContextProvider,
   SignInContext,
   SignUpContext,
   UserButtonContext,
@@ -87,11 +88,13 @@ export function ComponentContextProvider({
       );
     case 'PricingTable':
       return (
-        <__experimental_PricingTableContext.Provider
-          value={{ componentName, ...(props as __experimental_PricingTableProps) }}
-        >
-          {children}
-        </__experimental_PricingTableContext.Provider>
+        <PlansContextProvider>
+          <__experimental_PricingTableContext.Provider
+            value={{ componentName, ...(props as __experimental_PricingTableProps) }}
+          >
+            {children}
+          </__experimental_PricingTableContext.Provider>
+        </PlansContextProvider>
       );
     case 'Checkout':
       return (


### PR DESCRIPTION
## Description

Add missing `PlansContextProvider` to standalone `PricingTable`

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
