### PR TITLE
fix(nextjs,shared): Listen for hotloaded clerk-js script failing to download

### DIFF
--- a/.changeset/olive-shrimps-dress.md
+++ b/.changeset/olive-shrimps-dress.md
@@ -1,0 +1,6 @@
+---
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+---
+
+Listen for hotloaded clerk-js script failing to download.

--- a/packages/shared/global.d.ts
+++ b/packages/shared/global.d.ts
@@ -10,3 +10,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  __clerk_script_promise?: Promise<unknown> | null | undefined;
+}

--- a/packages/shared/src/loadClerkJsScript.ts
+++ b/packages/shared/src/loadClerkJsScript.ts
@@ -61,11 +61,13 @@ const loadClerkJsScript = async (opts?: LoadClerkJsScriptOptions) => {
       });
     });
 
-    const loaded = await Promise.race([
-      attemptExisting,
-      // @ts-ignore
-      window.__clerk_script_promise,
-    ])
+    const promisesToRace = [attemptExisting];
+
+    if (typeof window?.__clerk_script_promise?.then === 'function') {
+      promisesToRace.push(window?.__clerk_script_promise);
+    }
+
+    const loaded = await Promise.race(promisesToRace)
       .then(() => true)
       .catch(msg => {
         if (msg) {


### PR DESCRIPTION
## Description

Replaces #5509 and unblocks #5476
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
