### PR TITLE
fix(clerk-js): Disambiguate redirect url options between flows

### DIFF
--- a/.changeset/cruel-baths-sleep.md
+++ b/.changeset/cruel-baths-sleep.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix an issue where `fallbackRedirectUrl` and `forceRedirectUrl` were being improperly passed from sign up to sign in and vice versa. These props will now only apply to the specific flow they were passed to initially.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "590kB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "73.88KB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "80KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "55KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "99.2KB" },
     { "path": "./dist/vendors*.js", "maxSize": "36KB" },

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -18,6 +18,7 @@ import React, { Suspense } from 'react';
 
 import { clerkUIErrorDOMElementNotFound } from '../core/errors';
 import { buildVirtualRouterUrl } from '../utils';
+import { disambiguateRedirectOptions } from '../utils/disambiguateRedirectOptions';
 import type { AppearanceCascade } from './customizables/parseAppearance';
 // NOTE: Using `./hooks` instead of `./hooks/useClerkModalStateParams` will increase the bundle size
 import { useClerkModalStateParams } from './hooks/useClerkModalStateParams';
@@ -396,7 +397,7 @@ const Components = (props: ComponentsProps) => {
       componentName={'SignInModal'}
     >
       <SignInModal {...signInModal} />
-      <SignUpModal {...signInModal} />
+      <SignUpModal {...disambiguateRedirectOptions(signInModal, 'signin')} />
       <WaitlistModal {...waitlistModal} />
     </LazyModalRenderer>
   );
@@ -412,7 +413,7 @@ const Components = (props: ComponentsProps) => {
       startPath={buildVirtualRouterUrl({ base: '/sign-up', path: urlStateParam?.path })}
       componentName={'SignUpModal'}
     >
-      <SignInModal {...signUpModal} />
+      <SignInModal {...disambiguateRedirectOptions(signUpModal, 'signup')} />
       <SignUpModal {...signUpModal} />
       <WaitlistModal {...waitlistModal} />
     </LazyModalRenderer>

--- a/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignIn.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { SessionTasks as LazySessionTasks } from '../../../ui/lazyModules/components';
 import { normalizeRoutingOptions } from '../../../utils/normalizeRoutingOptions';
 import { SignInEmailLinkFlowComplete, SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowCard';
-import type { SignUpContextType } from '../../contexts';
 import {
   SignInContext,
   SignUpContext,
@@ -17,6 +16,7 @@ import { Flow } from '../../customizables';
 import { useFetch } from '../../hooks';
 import { usePreloadTasks } from '../../hooks/usePreloadTasks';
 import { Route, Switch, useRouter, VIRTUAL_ROUTER_BASE_PATH } from '../../router';
+import type { SignUpCtx } from '../../types';
 import {
   LazySignUpContinue,
   LazySignUpSSOCallback,
@@ -173,7 +173,7 @@ function SignInRoot() {
     signInUrl: signInContext.signInUrl,
     unsafeMetadata: signInContext.unsafeMetadata,
     ...normalizeRoutingOptions({ routing: signInContext?.routing, path: signInContext?.path }),
-  } as SignUpContextType;
+  } as SignUpCtx;
 
   /**
    * Preload Sign Up when in Combined Flow.

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -66,8 +66,8 @@ export const useSignInContext = (): SignInContextType => {
     options,
     {
       ...ctx,
-      signInFallbackRedirectUrl: ctx.fallbackRedirectUrl,
-      signInForceRedirectUrl: ctx.forceRedirectUrl,
+      signInFallbackRedirectUrl: ctx.signInFallbackRedirectUrl || ctx.fallbackRedirectUrl,
+      signInForceRedirectUrl: ctx.signInForceRedirectUrl || ctx.forceRedirectUrl,
     },
     queryParams,
     mode,

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -17,7 +17,7 @@ import { useRouter } from '../../router';
 import type { SignInCtx } from '../../types';
 import { getInitialValuesFromQueryParams } from '../utils';
 
-export type SignInContextType = SignInCtx & {
+export type SignInContextType = Omit<SignInCtx, 'fallbackRedirectUrl' | 'forceRedirectUrl'> & {
   navigateAfterSignIn: () => any;
   queryParams: ParsedQueryString;
   signUpUrl: string;
@@ -72,6 +72,9 @@ export const useSignInContext = (): SignInContextType => {
     queryParams,
     mode,
   );
+
+  delete ctx.fallbackRedirectUrl;
+  delete ctx.forceRedirectUrl;
 
   const afterSignInUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignInUrl());
   const afterSignUpUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignUpUrl());

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -17,7 +17,7 @@ import { useRouter } from '../../router';
 import type { SignUpCtx } from '../../types';
 import { getInitialValuesFromQueryParams } from '../utils';
 
-export type SignUpContextType = SignUpCtx & {
+export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRedirectUrl'> & {
   navigateAfterSignUp: () => any;
   queryParams: ParsedQueryString;
   signInUrl: string;
@@ -71,6 +71,9 @@ export const useSignUpContext = (): SignUpContextType => {
     queryParams,
     mode,
   );
+
+  delete ctx.fallbackRedirectUrl;
+  delete ctx.forceRedirectUrl;
 
   const afterSignUpUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignUpUrl());
   const afterSignInUrl = clerk.buildUrlWithAuth(redirectUrls.getAfterSignInUrl());

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -65,8 +65,8 @@ export const useSignUpContext = (): SignUpContextType => {
     options,
     {
       ...ctx,
-      signUpFallbackRedirectUrl: ctx.fallbackRedirectUrl,
-      signUpForceRedirectUrl: ctx.forceRedirectUrl,
+      signUpFallbackRedirectUrl: ctx.signUpFallbackRedirectUrl || ctx.fallbackRedirectUrl,
+      signUpForceRedirectUrl: ctx.signUpForceRedirectUrl || ctx.forceRedirectUrl,
     },
     queryParams,
     mode,

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -10,7 +10,11 @@ import type {
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationSwitcherProps,
+  SignInFallbackRedirectUrl,
+  SignInForceRedirectUrl,
   SignInProps,
+  SignUpFallbackRedirectUrl,
+  SignUpForceRedirectUrl,
   SignUpProps,
   UserButtonProps,
   UserProfileProps,
@@ -50,7 +54,8 @@ type ComponentMode = 'modal' | 'mounted';
 export type SignInCtx = SignInProps & {
   componentName: 'SignIn';
   mode?: ComponentMode;
-};
+} & SignInFallbackRedirectUrl &
+  SignInForceRedirectUrl;
 
 export type UserVerificationCtx = __internal_UserVerificationProps & {
   componentName: 'UserVerification';
@@ -67,7 +72,8 @@ export type SignUpCtx = SignUpProps & {
   mode?: ComponentMode;
   emailLinkRedirectUrl?: string;
   ssoCallbackUrl?: string;
-};
+} & SignUpFallbackRedirectUrl &
+  SignUpForceRedirectUrl;
 
 export type UserButtonCtx = UserButtonProps & {
   componentName: 'UserButton';

--- a/packages/clerk-js/src/utils/disambiguateRedirectOptions.ts
+++ b/packages/clerk-js/src/utils/disambiguateRedirectOptions.ts
@@ -14,7 +14,7 @@ type DisambiguatedRedirectOptions<T extends RedirectOptions, F extends Flow> = {
 } & PrefixedRedirectOptions<F>;
 
 /**
- * Ensures redirect props have the appropriate prefix depending on the flow they were originally provided to. Used when passing props from sign up -> sign in, or vice versa
+ * Ensures redirect props have the appropriate prefix depending on the flow they were originally provided to. Used when passing props from sign up -> sign in, or vice versa, when rendering modals.
  */
 export function disambiguateRedirectOptions<T extends RedirectOptions, F extends Flow>(
   props: T | null,

--- a/packages/clerk-js/src/utils/disambiguateRedirectOptions.ts
+++ b/packages/clerk-js/src/utils/disambiguateRedirectOptions.ts
@@ -1,0 +1,43 @@
+type Flow = 'signin' | 'signup';
+
+interface RedirectOptions {
+  forceRedirectUrl?: string | null;
+  fallbackRedirectUrl?: string | null;
+}
+
+type PrefixedRedirectOptions<F extends Flow> = {
+  [K in keyof RedirectOptions as `${F extends 'signin' ? 'signIn' : 'signUp'}${Capitalize<K>}`]: RedirectOptions[K];
+};
+
+type DisambiguatedRedirectOptions<T extends RedirectOptions, F extends Flow> = {
+  [K in keyof T as K extends 'forceRedirectUrl' | 'fallbackRedirectUrl' ? never : K]: T[K];
+} & PrefixedRedirectOptions<F>;
+
+/**
+ * Ensures redirect props have the appropriate prefix depending on the flow they were originally provided to. Used when passing props from sign up -> sign in, or vice versa
+ */
+export function disambiguateRedirectOptions<T extends RedirectOptions, F extends Flow>(
+  props: T | null,
+  flow: F,
+): DisambiguatedRedirectOptions<T, F> {
+  if (!props) {
+    return {} as DisambiguatedRedirectOptions<T, F>;
+  }
+
+  const prefix = flow === 'signin' ? 'signIn' : 'signUp';
+
+  const prefixedOptions = {
+    [`${prefix}ForceRedirectUrl`]: props.forceRedirectUrl,
+    [`${prefix}FallbackRedirectUrl`]: props.fallbackRedirectUrl,
+  } as PrefixedRedirectOptions<F>;
+
+  const result = {
+    ...props,
+    ...prefixedOptions,
+  };
+
+  delete result.forceRedirectUrl;
+  delete result.fallbackRedirectUrl;
+
+  return result;
+}


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fixes an issue where `fallbackRedirectUrl` and `forceRedirectUrl` passed to a specific flow would be improperly passed to the other flow in a modal case.

Example:
```
Clerk.openSignUp({ forceRedirectUrl: '/?form=signup' }) // would apply to sign ins if user clicks sign in in the footer
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
