### PR TITLE
fix(backend,types): Append `expired` status to invitation types

### DIFF
--- a/.changeset/cute-ghosts-decide.md
+++ b/.changeset/cute-ghosts-decide.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': patch
+'@clerk/types': patch
+---
+
+Append expired status to invitation types

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -2,6 +2,7 @@ import type { ClerkPaginationRequest } from '@clerk/types';
 
 import { joinPaths } from '../../util/path';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
+import type { InvitationStatus } from '../resources/Enums';
 import type { Invitation } from '../resources/Invitation';
 import { AbstractAPI } from './AbstractApi';
 
@@ -17,7 +18,7 @@ type CreateParams = {
 
 type GetInvitationListParams = ClerkPaginationRequest<{
   /**
-   * Filters invitations based on their status(accepted, pending, revoked).
+   * Filters invitations based on their status.
    *
    * @example
    * Get all revoked invitations
@@ -27,7 +28,7 @@ type GetInvitationListParams = ClerkPaginationRequest<{
    * await clerkClient.invitations.getInvitationList({ status: 'revoked' })
    * ```
    */
-  status?: 'accepted' | 'pending' | 'revoked';
+  status?: InvitationStatus;
   /**
    * Filters invitations based on `email_address` or `id`.
    *

--- a/packages/backend/src/api/resources/Enums.ts
+++ b/packages/backend/src/api/resources/Enums.ts
@@ -21,7 +21,7 @@ export type OAuthProvider =
 
 export type OAuthStrategy = `oauth_${OAuthProvider}`;
 
-export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';
+export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired';
 
 export type OrganizationDomainVerificationStatus = 'unverified' | 'verified';
 

--- a/packages/types/src/organizationInvitation.ts
+++ b/packages/types/src/organizationInvitation.ts
@@ -35,4 +35,4 @@ export interface OrganizationInvitationResource extends ClerkResource {
 /**
  * @inline
  */
-export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';
+export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired';


### PR DESCRIPTION
## Description

Appends `expired` to invitation status types

<!-- Fixes #(issue number) -->
Fixes ECO-604

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
