### PR TITLE
feat(e2e): Add ensureBapiUserExists method

### DIFF
--- a/integration/testUtils/usersService.ts
+++ b/integration/testUtils/usersService.ts
@@ -56,7 +56,7 @@ export type UserService = {
   /**
    * Creates a BAPI user if it doesn't exist, otherwise returns the existing user.
    */
-  ensureBapiUserExists: (fakeUser: FakeUser) => Promise<User>;
+  getOrCreateUser: (fakeUser: FakeUser) => Promise<User>;
   deleteIfExists: (opts: { id?: string; email?: string }) => Promise<void>;
   createFakeOrganization: (userId: string) => Promise<FakeOrganization>;
   getUser: (opts: { id?: string; email?: string }) => Promise<User | undefined>;
@@ -106,7 +106,7 @@ export const createUserService = (clerkClient: ClerkClient) => {
         skipPasswordRequirement: fakeUser.password === undefined,
       });
     },
-    ensureBapiUserExists: async fakeUser => {
+    getOrCreateUser: async fakeUser => {
       const existingUser = await self.getUser({ email: fakeUser.email });
       if (existingUser) {
         return existingUser;

--- a/integration/testUtils/usersService.ts
+++ b/integration/testUtils/usersService.ts
@@ -53,6 +53,10 @@ export type FakeOrganization = {
 export type UserService = {
   createFakeUser: (options?: FakeUserOptions) => FakeUser;
   createBapiUser: (fakeUser: FakeUser) => Promise<User>;
+  /**
+   * Creates a BAPI user if it doesn't exist, otherwise returns the existing user.
+   */
+  ensureBapiUserExists: (fakeUser: FakeUser) => Promise<User>;
   deleteIfExists: (opts: { id?: string; email?: string }) => Promise<void>;
   createFakeOrganization: (userId: string) => Promise<FakeOrganization>;
   getUser: (opts: { id?: string; email?: string }) => Promise<User | undefined>;
@@ -101,6 +105,13 @@ export const createUserService = (clerkClient: ClerkClient) => {
         username: fakeUser.username,
         skipPasswordRequirement: fakeUser.password === undefined,
       });
+    },
+    ensureBapiUserExists: async fakeUser => {
+      const existingUser = await self.getUser({ email: fakeUser.email });
+      if (existingUser) {
+        return existingUser;
+      }
+      return await self.createBapiUser(fakeUser);
     },
     deleteIfExists: async (opts: { id?: string; email?: string }) => {
       let id = opts.id;

--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -117,6 +117,8 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('oauth flo
   test('sign in modal to sign up modal to transfer respects original forceRedirectUrl', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
 
+    // The user already exists on the OAuth provider instance, but we want to make sure that the user is created on the
+    // app instance as well so that their sign up is transferred to a sign in.
     await u.services.users.ensureBapiUserExists(fakeUser);
 
     await u.page.goToRelative('/buttons');

--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -117,11 +117,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('oauth flo
   test('sign in modal to sign up modal to transfer respects original forceRedirectUrl', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
 
-    try {
-      await u.services.users.createBapiUser(fakeUser);
-    } catch {
-      // User already exists, so we don't need to create it
-    }
+    await u.services.users.ensureBapiUserExists(fakeUser);
 
     await u.page.goToRelative('/buttons');
     await u.page.waitForClerkJsLoaded();

--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -119,7 +119,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('oauth flo
 
     // The user already exists on the OAuth provider instance, but we want to make sure that the user is created on the
     // app instance as well so that their sign up is transferred to a sign in.
-    await u.services.users.ensureBapiUserExists(fakeUser);
+    await u.services.users.getOrCreateUser(fakeUser);
 
     await u.page.goToRelative('/buttons');
     await u.page.waitForClerkJsLoaded();


### PR DESCRIPTION
## Description

Adds a new `ensureBapiUserExists` for e2e tests that need to ensure the suer exists, but don't care if they're created or already exist.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
