### PR TITLE
chore(clerk-js): Disable Rspack warnings

### DIFF
--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -130,6 +130,8 @@ const common = ({ mode, disableRHC = false }) => {
         },
       },
     },
+    // Disable Rspack's warnings since we use bundlewatch
+    ignoreWarnings: [/entrypoint size limit/, /asset size limit/, /Rspack performance recommendations/],
   };
 };
 


### PR DESCRIPTION
## Description

This PR disables Rspack's entrypoint and asset size warnings since we use bundlewatch instead. This clears up the terminal output when running `pnpm build`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
