### PR TITLE
fix(nextjs): Make strict CSP param optional and default to false

### DIFF
--- a/.changeset/wild-cases-wash.md
+++ b/.changeset/wild-cases-wash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Default `strict` configuration option for CSP to false

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -70,7 +70,7 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
      * When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive and generates a unique nonce value to be used for script elements.
      * This helps prevent XSS attacks while allowing trusted scripts to execute.
      */
-    strict: boolean;
+    strict?: boolean;
     /**
      * Custom CSP directives to merge with Clerk's default directives
      */
@@ -211,7 +211,7 @@ export const clerkMiddleware = ((...args: unknown[]): NextMiddleware | NextMiddl
       }
       if (options.contentSecurityPolicy) {
         const { header, nonce } = createCSPHeader(
-          options.contentSecurityPolicy.strict,
+          options.contentSecurityPolicy.strict ?? false,
           (parsePublishableKey(publishableKey)?.frontendApi ?? '').replace('$', ''),
           options.contentSecurityPolicy.directives,
         );


### PR DESCRIPTION
## Description

Defaulting `strict` to false and making it optional so it does not need to be specified

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
