### PR TITLE
fix(clerk-js): Reset definition list components margins

### DIFF
--- a/.changeset/eighty-suns-argue.md
+++ b/.changeset/eighty-suns-argue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ensure margin is reset on definition list components to prevent browser default styling leaking in.

--- a/packages/clerk-js/src/ui/elements/Header.tsx
+++ b/packages/clerk-js/src/ui/elements/Header.tsx
@@ -78,12 +78,18 @@ const BackLink = React.memo((props: PropsOfComponent<typeof Link>): JSX.Element 
           display: 'inline-flex',
           alignItems: 'center',
           gap: t.space.$2,
+          '&:hover': {
+            textDecoration: 'none',
+          },
         },
         sx,
       ]}
       {...rest}
     >
-      <Icon icon={ArrowLeftIcon} />
+      <Icon
+        icon={ArrowLeftIcon}
+        sx={t => ({ color: t.colors.$colorText })}
+      />
       {children}
     </Link>
   );

--- a/packages/clerk-js/src/ui/primitives/Dd.tsx
+++ b/packages/clerk-js/src/ui/primitives/Dd.tsx
@@ -10,6 +10,9 @@ export const Dd = React.forwardRef<HTMLTableCellElement, DdProps>((props, ref) =
   return (
     <Box
       as='dd'
+      css={{
+        margin: 0,
+      }}
       {...props}
       ref={ref}
     />

--- a/packages/clerk-js/src/ui/primitives/Dl.tsx
+++ b/packages/clerk-js/src/ui/primitives/Dl.tsx
@@ -10,6 +10,9 @@ export const Dl = React.forwardRef<HTMLTableCellElement, DlProps>((props, ref) =
   return (
     <Box
       as='dl'
+      css={{
+        margin: 0,
+      }}
       {...props}
       ref={ref}
     />

--- a/packages/clerk-js/src/ui/primitives/Dt.tsx
+++ b/packages/clerk-js/src/ui/primitives/Dt.tsx
@@ -10,6 +10,9 @@ export const Dt = React.forwardRef<HTMLTableCellElement, DtProps>((props, ref) =
   return (
     <Box
       as='dt'
+      css={{
+        margin: 0,
+      }}
       {...props}
       ref={ref}
     />


### PR DESCRIPTION
## Description

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-04-16 at 5 43 48 PM](https://github.com/user-attachments/assets/db812a73-c8a2-475a-ad87-fe4616833cb7) | ![Screenshot 2025-04-16 at 5 45 17 PM](https://github.com/user-attachments/assets/b1f27c27-5390-4b88-9a45-3f8de507c4e4) | 

Fixes COM-481

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
