### PR TITLE
fix(clerk-js): Fix duplicate checkout calls

### DIFF
--- a/.changeset/eight-friends-fail.md
+++ b/.changeset/eight-friends-fail.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix duplicate checkout calls when clicking Get Started buttons

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -147,31 +147,29 @@ type LazyDrawerRendererProps = React.PropsWithChildren<
 
 export const LazyDrawerRenderer = (props: LazyDrawerRendererProps) => {
   return (
-    <Suspense fallback={''}>
-      <VirtualRouter startPath=''>
-        <AppearanceProvider
-          globalAppearance={props.globalAppearance}
-          appearanceKey={props.appearanceKey}
-          appearance={props.componentAppearance}
-        >
-          <FlowMetadataProvider flow={props.flowName || ('' as any)}>
-            <InternalThemeProvider>
-              <DrawerRoot
-                open={props.open}
-                onOpenChange={props.onOpenChange}
-                strategy={props.portalId ? 'absolute' : 'fixed'}
-                portalProps={{
-                  id: props.portalId ? props.portalId : undefined,
-                }}
-              >
-                <DrawerOverlay />
-                {props.children}
-              </DrawerRoot>
-            </InternalThemeProvider>
-          </FlowMetadataProvider>
-        </AppearanceProvider>
-      </VirtualRouter>
-    </Suspense>
+    <VirtualRouter startPath=''>
+      <AppearanceProvider
+        globalAppearance={props.globalAppearance}
+        appearanceKey={props.appearanceKey}
+        appearance={props.componentAppearance}
+      >
+        <FlowMetadataProvider flow={props.flowName || ('' as any)}>
+          <InternalThemeProvider>
+            <DrawerRoot
+              open={props.open}
+              onOpenChange={props.onOpenChange}
+              strategy={props.portalId ? 'absolute' : 'fixed'}
+              portalProps={{
+                id: props.portalId ? props.portalId : undefined,
+              }}
+            >
+              <DrawerOverlay />
+              <Suspense fallback={''}>{props.children}</Suspense>
+            </DrawerRoot>
+          </InternalThemeProvider>
+        </FlowMetadataProvider>
+      </AppearanceProvider>
+    </VirtualRouter>
   );
 };
 


### PR DESCRIPTION
## Description

Moves the `Suspense` boundary to only wrap the lazily loaded children in `LazyDrawerRenderer` – otherwise it was causing a double-mount that was triggering `useCheckout` twice, creating duplicate checkout API calls.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
