### PR TITLE
fix(clerk-js): Rollback drawer suspense change

### DIFF
--- a/.changeset/mean-impalas-reply.md
+++ b/.changeset/mean-impalas-reply.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Rollback change to lazy-loading suspense wrapper

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -147,29 +147,31 @@ type LazyDrawerRendererProps = React.PropsWithChildren<
 
 export const LazyDrawerRenderer = (props: LazyDrawerRendererProps) => {
   return (
-    <VirtualRouter startPath=''>
-      <AppearanceProvider
-        globalAppearance={props.globalAppearance}
-        appearanceKey={props.appearanceKey}
-        appearance={props.componentAppearance}
-      >
-        <FlowMetadataProvider flow={props.flowName || ('' as any)}>
-          <InternalThemeProvider>
-            <DrawerRoot
-              open={props.open}
-              onOpenChange={props.onOpenChange}
-              strategy={props.portalId ? 'absolute' : 'fixed'}
-              portalProps={{
-                id: props.portalId ? props.portalId : undefined,
-              }}
-            >
-              <DrawerOverlay />
-              <Suspense fallback={''}>{props.children}</Suspense>
-            </DrawerRoot>
-          </InternalThemeProvider>
-        </FlowMetadataProvider>
-      </AppearanceProvider>
-    </VirtualRouter>
+    <Suspense fallback={''}>
+      <VirtualRouter startPath=''>
+        <AppearanceProvider
+          globalAppearance={props.globalAppearance}
+          appearanceKey={props.appearanceKey}
+          appearance={props.componentAppearance}
+        >
+          <FlowMetadataProvider flow={props.flowName || ('' as any)}>
+            <InternalThemeProvider>
+              <DrawerRoot
+                open={props.open}
+                onOpenChange={props.onOpenChange}
+                strategy={props.portalId ? 'absolute' : 'fixed'}
+                portalProps={{
+                  id: props.portalId ? props.portalId : undefined,
+                }}
+              >
+                <DrawerOverlay />
+                {props.children}
+              </DrawerRoot>
+            </InternalThemeProvider>
+          </FlowMetadataProvider>
+        </AppearanceProvider>
+      </VirtualRouter>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
## Description

Fixes inconsistent issue with mounting Checkout drawer by rolling back the Suspense wrapper placement change.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
