### PR TITLE
fix(clerk-js): Drawer portal location fix in User/OrgProfile

### DIFF
--- a/.changeset/happy-doors-stare.md
+++ b/.changeset/happy-doors-stare.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix drawer location in UserProfile and OrgProfile

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
@@ -1,5 +1,4 @@
 import type { __experimental_CheckoutProps, __experimental_CommerceCheckoutResource } from '@clerk/types';
-import { useEffect } from 'react';
 
 import { Alert, Spinner } from '../../customizables';
 import { useCheckout } from '../../hooks';
@@ -15,11 +14,8 @@ export const CheckoutPage = (props: __experimental_CheckoutProps) => {
     subscriberType,
   });
 
-  useEffect(() => {
-    return invalidate;
-  }, []);
-
   const onCheckoutComplete = (newCheckout: __experimental_CommerceCheckoutResource) => {
+    invalidate(); // invalidate the initial checkout on complete
     updateCheckout(newCheckout);
     onSubscriptionComplete?.();
   };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
@@ -2,6 +2,7 @@ import { useOrganization } from '@clerk/shared/react';
 import type { OrganizationProfileModalProps, OrganizationProfileProps } from '@clerk/types';
 import React from 'react';
 
+import { ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
 import { OrganizationProfileContext, withCoreUserGuard } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
 import { NavbarMenuButtonRow, ProfileCard, withCardStateProvider } from '../../elements';
@@ -38,7 +39,10 @@ const AuthenticatedRoutes = withCoreUserGuard(() => {
     >
       <OrganizationProfileNavbar contentRef={contentRef}>
         <NavbarMenuButtonRow navbarTitleLocalizationKey={localizationKeys('organizationProfile.navbar.title')} />
-        <ProfileCard.Content contentRef={contentRef}>
+        <ProfileCard.Content
+          contentRef={contentRef}
+          scrollBoxId={ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID}
+        >
           <OrganizationProfileRoutes />
         </ProfileCard.Content>
       </OrganizationProfileNavbar>

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
@@ -6,7 +6,7 @@ import type {
 } from '@clerk/types';
 import { useState } from 'react';
 
-import { PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
+import { ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID, USER_PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
 import { usePlansContext, usePricingTableContext } from '../../contexts';
 import { PricingTableDefault } from './PricingTableDefault';
 import { PricingTableMatrix } from './PricingTableMatrix';
@@ -32,7 +32,12 @@ const PricingTable = (props: __experimental_PricingTableProps) => {
         subscription,
         subscriberType,
         onSubscriptionCancel: onSubscriptionChange,
-        portalId: mode === 'modal' ? PROFILE_CARD_SCROLLBOX_ID : undefined,
+        portalId:
+          mode === 'modal'
+            ? subscriberType === 'user'
+              ? USER_PROFILE_CARD_SCROLLBOX_ID
+              : ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID
+            : undefined,
       });
     } else {
       clerk.__internal_openCheckout({
@@ -40,7 +45,12 @@ const PricingTable = (props: __experimental_PricingTableProps) => {
         planPeriod,
         subscriberType,
         onSubscriptionComplete: onSubscriptionChange,
-        portalId: mode === 'modal' ? PROFILE_CARD_SCROLLBOX_ID : undefined,
+        portalId:
+          mode === 'modal'
+            ? subscriberType === 'user'
+              ? USER_PROFILE_CARD_SCROLLBOX_ID
+              : ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID
+            : undefined,
       });
     }
   };

--- a/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
@@ -1,11 +1,11 @@
 import { useClerk } from '@clerk/shared/react';
 
-import { PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
+import { ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID, USER_PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
 import { usePlansContext } from '../../contexts';
 import { Badge, Box, Button, localizationKeys, Span, Table, Tbody, Td, Text, Th, Thead, Tr } from '../../customizables';
 
 export function SubscriptionsList() {
-  const { subscriptions, revalidate } = usePlansContext();
+  const { subscriptions, subscriberType, revalidate } = usePlansContext();
   const clerk = useClerk();
   return (
     <Table tableHeadVisuallyHidden>
@@ -70,7 +70,10 @@ export function SubscriptionsList() {
                   clerk.__internal_openSubscriptionDetails({
                     subscription,
                     onSubscriptionCancel: () => revalidate(),
-                    portalId: PROFILE_CARD_SCROLLBOX_ID,
+                    portalId:
+                      subscriberType === 'user'
+                        ? USER_PROFILE_CARD_SCROLLBOX_ID
+                        : ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID,
                   })
                 }
                 localizationKey={localizationKeys(

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfile.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfile.tsx
@@ -1,6 +1,7 @@
 import type { UserProfileModalProps, UserProfileProps } from '@clerk/types';
 import React from 'react';
 
+import { USER_PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
 import { UserProfileContext, withCoreUserGuard } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
 import { NavbarMenuButtonRow, ProfileCard, withCardStateProvider } from '../../elements';
@@ -34,7 +35,10 @@ const AuthenticatedRoutes = withCoreUserGuard(() => {
     <ProfileCard.Root>
       <UserProfileNavbar contentRef={contentRef}>
         <NavbarMenuButtonRow navbarTitleLocalizationKey={localizationKeys('userProfile.navbar.title')} />
-        <ProfileCard.Content contentRef={contentRef}>
+        <ProfileCard.Content
+          contentRef={contentRef}
+          scrollBoxId={USER_PROFILE_CARD_SCROLLBOX_ID}
+        >
           <UserProfileRoutes />
         </ProfileCard.Content>
       </UserProfileNavbar>

--- a/packages/clerk-js/src/ui/constants.ts
+++ b/packages/clerk-js/src/ui/constants.ts
@@ -15,4 +15,5 @@ export const USER_BUTTON_ITEM_ID = {
   SIGN_OUT: 'signOut',
 };
 
-export const PROFILE_CARD_SCROLLBOX_ID = 'clerk-profileCardScrollBox';
+export const USER_PROFILE_CARD_SCROLLBOX_ID = 'clerk-userProfileCardScrollBox';
+export const ORGANIZATION_PROFILE_CARD_SCROLLBOX_ID = 'clerk-organizationProfileCardScrollBox';

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -253,7 +253,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
   );
 });
 
-Overlay.displayName = 'Drawer.Content';
+Content.displayName = 'Drawer.Content';
 
 /* -------------------------------------------------------------------------------------------------
  * Drawer.Header

--- a/packages/clerk-js/src/ui/elements/ProfileCard/ProfileCardContent.tsx
+++ b/packages/clerk-js/src/ui/elements/ProfileCard/ProfileCardContent.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
-import { PROFILE_CARD_SCROLLBOX_ID } from '../../constants';
 import { Col, descriptors } from '../../customizables';
 import { useRouter } from '../../router';
 import { common, mqu } from '../../styledSystem';
 
-type ProfileCardContentProps = React.PropsWithChildren<{ contentRef?: React.RefObject<HTMLDivElement> }>;
+type ProfileCardContentProps = React.PropsWithChildren<{
+  contentRef?: React.RefObject<HTMLDivElement>;
+  scrollBoxId?: string;
+}>;
 export const ProfileCardContent = (props: ProfileCardContentProps) => {
-  const { contentRef, children } = props;
+  const { contentRef, children, scrollBoxId } = props;
   const router = useRouter();
   const scrollPosRef = React.useRef(0);
 
@@ -43,7 +45,7 @@ export const ProfileCardContent = (props: ProfileCardContentProps) => {
         borderColor: t.colors.$neutralAlpha50,
         boxShadow: t.shadows.$cardContentShadow,
       })}
-      id={PROFILE_CARD_SCROLLBOX_ID}
+      id={scrollBoxId}
     >
       <Col
         elementDescriptor={descriptors.pageScrollBox}

--- a/packages/clerk-js/src/ui/lazyModules/providers.tsx
+++ b/packages/clerk-js/src/ui/lazyModules/providers.tsx
@@ -165,7 +165,7 @@ export const LazyDrawerRenderer = (props: LazyDrawerRendererProps) => {
                 }}
               >
                 <DrawerOverlay />
-                {props.children}
+                <Suspense fallback={''}>{props.children}</Suspense>
               </DrawerRoot>
             </InternalThemeProvider>
           </FlowMetadataProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3445,82 +3445,66 @@ packages:
   '@miniflare/cache@2.14.4':
     resolution: {integrity: sha512-ayzdjhcj+4mjydbNK7ZGDpIXNliDbQY4GPcY2KrYw0v1OSUdj5kZUkygD09fqoGRfAks0d91VelkyRsAXX8FQA==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/core@2.14.4':
     resolution: {integrity: sha512-FMmZcC1f54YpF4pDWPtdQPIO8NXfgUxCoR9uyrhxKJdZu7M6n8QKopPVNuaxR40jcsdxb7yKoQoFWnHfzJD9GQ==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/d1@2.14.4':
     resolution: {integrity: sha512-pMBVq9XWxTDdm+RRCkfXZP+bREjPg1JC8s8C0JTovA9OGmLQXqGTnFxIaS9vf1d8k3uSUGhDzPTzHr0/AUW1gA==}
     engines: {node: '>=16.7'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/durable-objects@2.14.4':
     resolution: {integrity: sha512-+JrmHP6gHHrjxV8S3axVw5lGHLgqmAGdcO/1HJUPswAyJEd3Ah2YnKhpo+bNmV4RKJCtEq9A2hbtVjBTD2YzwA==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/html-rewriter@2.14.4':
     resolution: {integrity: sha512-GB/vZn7oLbnhw+815SGF+HU5EZqSxbhIa3mu2L5MzZ2q5VOD5NHC833qG8c2GzDPhIaZ99ITY+ZJmbR4d+4aNQ==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/kv@2.14.4':
     resolution: {integrity: sha512-QlERH0Z+klwLg0xw+/gm2yC34Nnr/I0GcQ+ASYqXeIXBwjqOtMBa3YVQnocaD+BPy/6TUtSpOAShHsEj76R2uw==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/queues@2.14.4':
     resolution: {integrity: sha512-aXQ5Ik8Iq1KGMBzGenmd6Js/jJgqyYvjom95/N9GptCGpiVWE5F0XqC1SL5rCwURbHN+aWY191o8XOFyY2nCUA==}
     engines: {node: '>=16.7'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/r2@2.14.4':
     resolution: {integrity: sha512-4ctiZWh7Ty7LB3brUjmbRiGMqwyDZgABYaczDtUidblo2DxX4JZPnJ/ZAyxMPNJif32kOJhcg6arC2hEthR9Sw==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/runner-vm@2.14.4':
     resolution: {integrity: sha512-Nog0bB9SVhPbZAkTWfO4lpLAUsBXKEjlb4y+y66FJw77mPlmPlVdpjElCvmf8T3VN/pqh83kvELGM+/fucMf4g==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/shared-test-environment@2.14.4':
     resolution: {integrity: sha512-FdU2/8wEd00vIu+MfofLiHcfZWz+uCbE2VTL85KpyYfBsNGAbgRtzFMpOXdoXLqQfRu6MBiRwWpb2FbMrBzi7g==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/shared@2.14.4':
     resolution: {integrity: sha512-upl4RSB3hyCnITOFmRZjJj4A72GmkVrtfZTilkdq5Qe5TTlzsjVeDJp7AuNUM9bM8vswRo+N5jOiot6O4PVwwQ==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/sites@2.14.4':
     resolution: {integrity: sha512-O5npWopi+fw9W9Ki0gy99nuBbgDva/iXy8PDC4dAXDB/pz45nISDqldabk0rL2t4W2+lY6LXKzdOw+qJO1GQTA==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/storage-file@2.14.4':
     resolution: {integrity: sha512-JxcmX0hXf4cB0cC9+s6ZsgYCq+rpyUKRPCGzaFwymWWplrO3EjPVxKCcMxG44jsdgsII6EZihYUN2J14wwCT7A==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/storage-memory@2.14.4':
     resolution: {integrity: sha512-9jB5BqNkMZ3SFjbPFeiVkLi1BuSahMhc/W1Y9H0W89qFDrrD+z7EgRgDtHTG1ZRyi9gIlNtt9qhkO1B6W2qb2A==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/watcher@2.14.4':
     resolution: {integrity: sha512-PYn05ET2USfBAeXF6NZfWl0O32KVyE8ncQ/ngysrh3hoIV7l3qGGH7ubeFx+D8VWQ682qYhwGygUzQv2j1tGGg==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@miniflare/web-sockets@2.14.4':
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
 
   '@modelcontextprotocol/sdk@1.7.0':
     resolution: {integrity: sha512-IYPe/FLpvF3IZrd/f5p5ffmWhMc3aEMuM2wGJASDqC2Ge7qatVCdbfPx3n/5xFeb19xN0j/911M2AaFuircsWA==}
@@ -8291,6 +8275,7 @@ packages:
 
   formidable@2.1.2:
     resolution: {integrity: sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==}
+    deprecated: 'ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE! v1 is DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects'
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -14031,7 +14016,6 @@ packages:
   vitest-environment-miniflare@2.14.4:
     resolution: {integrity: sha512-DzwQWdY42sVYR6aUndw9FdCtl/i0oh3NkbkQpw+xq5aYQw5eiJn5kwnKaKQEWaoBe8Cso71X2i1EJGvi1jZ2xw==}
     engines: {node: '>=16.13'}
-    deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
     peerDependencies:
       vitest: '>=0.23.0'
 


### PR DESCRIPTION
## Description

Fixes issue where Checkout and SubscriptionDetails drawers would portal to the wrong UserProfile / OrgProfile, when both were mounted.

Also tidies up the invalidation timing of created checkout objects in the Checkout component.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
