### PR TITLE
fix(clerk-js): Minor UI fixes for commerce

### DIFF
--- a/.changeset/icy-lemons-fall.md
+++ b/.changeset/icy-lemons-fall.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Minor UI fixes for Billing pages in `<UserProfile/>` and `<OrganizationProfile/>`.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
@@ -2,7 +2,7 @@ import {
   __experimental_PaymentSourcesContext,
   __experimental_PricingTableContext,
   InvoicesContextProvider,
-  usePlansContext,
+  useSubscriptions,
   withPlans,
 } from '../../contexts';
 import { Col, descriptors, Heading, Hr, localizationKeys } from '../../customizables';
@@ -32,8 +32,12 @@ const orgTabMap = {
 export const OrganizationBillingPage = withPlans(
   withCardStateProvider(() => {
     const card = useCardState();
-    const { subscriptions } = usePlansContext();
+    const { data: subscriptions } = useSubscriptions('org');
     const { selectedTab, handleTabChange } = useTabState(orgTabMap);
+
+    if (!Array.isArray(subscriptions?.data)) {
+      return null;
+    }
 
     return (
       <Col
@@ -61,7 +65,7 @@ export const OrganizationBillingPage = withPlans(
             <TabsList sx={t => ({ gap: t.space.$6 })}>
               <Tab
                 localizationKey={
-                  subscriptions.length > 0
+                  subscriptions.data.length > 0
                     ? localizationKeys('userProfile.__experimental_billingPage.start.headerTitle__subscriptions')
                     : localizationKeys('userProfile.__experimental_billingPage.start.headerTitle__plans')
                 }
@@ -77,7 +81,7 @@ export const OrganizationBillingPage = withPlans(
             </TabsList>
             <TabPanels>
               <TabPanel sx={{ width: '100%', flexDirection: 'column' }}>
-                {subscriptions.length > 0 && (
+                {subscriptions.data.length > 0 && (
                   <>
                     <SubscriptionsList />
                     <Hr sx={t => ({ marginBlock: t.space.$6 })} />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -68,6 +68,7 @@ export const OrganizationProfileRoutes = () => {
                 </Suspense>
               </Route>
               <Route path='invoice/:invoiceId'>
+                {/* TODO(@commerce): Should this be lazy loaded ? */}
                 <Suspense fallback={''}>
                   <InvoicesContextProvider subscriberType='org'>
                     <InvoicePage />

--- a/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
@@ -25,7 +25,7 @@ export function SubscriptionsList() {
       </Thead>
       <Tbody>
         {subscriptions.map(subscription => (
-          <Tr key={subscription.plan.id}>
+          <Tr key={subscription.id}>
             <Td>
               <Box
                 sx={t => ({
@@ -72,7 +72,7 @@ export function SubscriptionsList() {
                 size='xs'
                 textVariant='buttonSmall'
                 onClick={() => handleSelectSubscription(subscription)}
-                {...buttonPropsForPlan({ plan: subscription.plan })}
+                {...buttonPropsForPlan({ subscription })}
               />
             </Td>
           </Tr>

--- a/packages/clerk-js/src/ui/components/UserProfile/BillingPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/BillingPage.tsx
@@ -2,7 +2,7 @@ import {
   __experimental_PaymentSourcesContext,
   __experimental_PricingTableContext,
   InvoicesContextProvider,
-  usePlansContext,
+  useSubscriptions,
   withPlans,
 } from '../../contexts';
 import { Col, descriptors, Heading, Hr, localizationKeys } from '../../customizables';
@@ -32,8 +32,13 @@ const tabMap = {
 export const BillingPage = withPlans(
   withCardStateProvider(() => {
     const card = useCardState();
-    const { subscriptions } = usePlansContext();
+    const { data: subscriptions } = useSubscriptions();
+
     const { selectedTab, handleTabChange } = useTabState(tabMap);
+
+    if (!Array.isArray(subscriptions?.data)) {
+      return null;
+    }
 
     return (
       <Col
@@ -61,7 +66,7 @@ export const BillingPage = withPlans(
             <TabsList sx={t => ({ gap: t.space.$6 })}>
               <Tab
                 localizationKey={
-                  subscriptions.length > 0
+                  subscriptions.data.length > 0
                     ? localizationKeys('userProfile.__experimental_billingPage.start.headerTitle__subscriptions')
                     : localizationKeys('userProfile.__experimental_billingPage.start.headerTitle__plans')
                 }
@@ -77,7 +82,7 @@ export const BillingPage = withPlans(
             </TabsList>
             <TabPanels>
               <TabPanel sx={_ => ({ width: '100%', flexDirection: 'column' })}>
-                {subscriptions.length > 0 && (
+                {subscriptions.data.length > 0 && (
                   <>
                     <SubscriptionsList />
                     <Hr sx={t => ({ marginBlock: t.space.$6 })} />

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -66,6 +66,7 @@ export const UserProfileRoutes = () => {
                   </Suspense>
                 </Route>
                 <Route path='invoice/:invoiceId'>
+                  {/* TODO(@commerce): Should this be lazy loaded ? */}
                   <Suspense fallback={''}>
                     <InvoicesContextProvider>
                       <InvoicePage />


### PR DESCRIPTION
## Description

This PR fixes:
1. the flash from "Plans" to "Subscriptions" when subscriptions load after the first render.
2. on cancel subscription revalidate the fetched subscriptions
3. on cancel subscription close the drawer
4. avoid conflicts when opening a drawer when some of the listed subscriptions are cancelled.

https://github.com/user-attachments/assets/12a75518-d9e6-49d5-b365-28ba5b3bf3ae


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
