### PR TITLE
fix(clerk-react): Add details to `UserButton.*` error message

### DIFF
--- a/.changeset/shaky-crabs-show.md
+++ b/.changeset/shaky-crabs-show.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Add details to `<UserButton.*>` error messages indicating that the components must be used within client components.

--- a/packages/react/src/errors/messages.ts
+++ b/packages/react/src/errors/messages.ts
@@ -42,9 +42,6 @@ export const incompatibleRoutingWithPathProvidedError = (componentName: string) 
 
 export const userButtonIgnoredComponent = `<UserButton /> can only accept <UserButton.UserProfilePage />, <UserButton.UserProfileLink /> and <UserButton.MenuItems /> as its children. Any other provided component will be ignored. Additionally, please ensure that the component is rendered in a client component.`;
 
-export const mustBeContainedInClientComponentError = (componentName: string) =>
-  `The <${componentName}/> component must be used in a client component.`;
-
 export const customMenuItemsIgnoredComponent =
   '<UserButton.MenuItems /> component can only accept <UserButton.Action /> and <UserButton.Link /> as its children. Any other provided component will be ignored. Additionally, please ensure that the component is rendered in a client component.';
 

--- a/packages/react/src/errors/messages.ts
+++ b/packages/react/src/errors/messages.ts
@@ -23,7 +23,7 @@ export const organizationProfileLinkRenderedError =
   '<OrganizationProfile.Link /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
 
 export const customPagesIgnoredComponent = (componentName: string) =>
-  `<${componentName} /> can only accept <${componentName}.Page /> and <${componentName}.Link /> as its children. Any other provided component will be ignored.`;
+  `<${componentName} /> can only accept <${componentName}.Page /> and <${componentName}.Link /> as its children. Any other provided component will be ignored. Additionally, please ensure that the component is rendered in a client component.`;
 
 export const customPageWrongProps = (componentName: string) =>
   `Missing props. <${componentName}.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.`;
@@ -40,10 +40,13 @@ export const noPathProvidedError = (componentName: string) =>
 export const incompatibleRoutingWithPathProvidedError = (componentName: string) =>
   `The \`path\` prop will only be respected when the Clerk component uses path-based routing. To resolve this error, pass \`routing='path'\` to the <${componentName}/> component, or drop the \`path\` prop to switch to hash-based routing. For more details please refer to our docs: https://clerk.com/docs`;
 
-export const userButtonIgnoredComponent = `<UserButton /> can only accept <UserButton.UserProfilePage />, <UserButton.UserProfileLink /> and <UserButton.MenuItems /> as its children. Any other provided component will be ignored.`;
+export const userButtonIgnoredComponent = `<UserButton /> can only accept <UserButton.UserProfilePage />, <UserButton.UserProfileLink /> and <UserButton.MenuItems /> as its children. Any other provided component will be ignored. Additionally, please ensure that the component is rendered in a client component.`;
+
+export const mustBeContainedInClientComponentError = (componentName: string) =>
+  `The <${componentName}/> component must be used in a client component.`;
 
 export const customMenuItemsIgnoredComponent =
-  '<UserButton.MenuItems /> component can only accept <UserButton.Action /> and <UserButton.Link /> as its children. Any other provided component will be ignored.';
+  '<UserButton.MenuItems /> component can only accept <UserButton.Action /> and <UserButton.Link /> as its children. Any other provided component will be ignored. Additionally, please ensure that the component is rendered in a client component.';
 
 export const userButtonMenuItemsRenderedError =
   '<UserButton.MenuItems /> component needs to be a direct child of `<UserButton />`.';


### PR DESCRIPTION
## Description


There are error messages which pop-up when using `<UserButton.*>` stating that only specific components may be used as children. This error will also pop-up when the component tree is correct but is contained within a server component.

This PR is a quick-fix to add client component details to the error message in an effort to unblock developers who may find themselves in this state.

<!-- Fixes #(issue number) -->
Fixes ECO-617

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
