### PR TITLE
fix(nextjs): Set keyless cookie on Safari

### DIFF
--- a/.changeset/thick-beers-wave.md
+++ b/.changeset/thick-beers-wave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Resolved an issue with Keyless on Safari where users appeared to be signed out immediately after a successful sign-in.

--- a/packages/nextjs/src/app-router/keyless-actions.ts
+++ b/packages/nextjs/src/app-router/keyless-actions.ts
@@ -8,6 +8,14 @@ import { detectClerkMiddleware } from '../server/headers-utils';
 import { getKeylessCookieName, getKeylessCookieValue } from '../server/keyless';
 import { canUseKeyless } from '../utils/feature-flags';
 
+const cookieValue = {
+  // domain: 'localhost',
+  // sameSite: 'lax',
+  secure: false,
+  httpOnly: true,
+  // maxAge: 1000 * 60 * 60 * 24 * 30,
+};
+
 export async function syncKeylessConfigAction(args: AccountlessApplication & { returnUrl: string }): Promise<void> {
   const { claimUrl, publishableKey, secretKey, returnUrl } = args;
   const cookieStore = await cookies();
@@ -21,10 +29,10 @@ export async function syncKeylessConfigAction(args: AccountlessApplication & { r
     return;
   }
 
+  // const expires = new Date().setDate(new Date().getDate() + 30);
   // Set the new keys in the cookie.
   cookieStore.set(await getKeylessCookieName(), JSON.stringify({ claimUrl, publishableKey, secretKey }), {
-    secure: true,
-    httpOnly: true,
+    ...cookieValue,
   });
 
   // We cannot import `NextRequest` due to a bundling issue with server actions in Next.js 13.
@@ -65,8 +73,7 @@ export async function createOrReadKeylessAction(): Promise<null | Omit<Accountle
   const { claimUrl, publishableKey, secretKey, apiKeysUrl } = result;
 
   void (await cookies()).set(await getKeylessCookieName(), JSON.stringify({ claimUrl, publishableKey, secretKey }), {
-    secure: false,
-    httpOnly: false,
+    ...cookieValue,
   });
 
   return {


### PR DESCRIPTION
## Description

Secure cookies on localhost are not set in Safari. Switching to non-secure cookies with same-site set to `'lax'` instead.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
