### PR TITLE
feat(nextjs): CSP reporting mode

### DIFF
--- a/.changeset/cool-roses-scream.md
+++ b/.changeset/cool-roses-scream.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': minor
+'@clerk/nextjs': minor
+---
+
+Adding reportTo and reportOnly configuration options to the contentSecurityPolicy config for clerkMiddleware

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -50,6 +50,7 @@ const Headers = {
   CloudFrontForwardedProto: 'cloudfront-forwarded-proto',
   ContentType: 'content-type',
   ContentSecurityPolicy: 'content-security-policy',
+  ContentSecurityPolicyReportOnly: 'content-security-policy-report-only',
   EnableDebug: 'x-clerk-debug',
   ForwardedHost: 'x-forwarded-host',
   ForwardedPort: 'x-forwarded-port',
@@ -61,6 +62,7 @@ const Headers = {
   Referrer: 'referer',
   SecFetchDest: 'sec-fetch-dest',
   UserAgent: 'user-agent',
+  ReportingEndpoints: 'reporting-endpoints',
 } as const;
 
 const ContentTypes = {

--- a/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
+++ b/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
@@ -103,12 +103,16 @@ describe('CSP Header Utils', () => {
       const result = createContentSecurityPolicyHeaders(testHost, { reportTo: 'https://example.com/reports' });
 
       expect(result.headers).toHaveLength(2);
-      const [cspHeader, reportHeader] = result.headers;
-      expect(cspHeader[0]).toBe('content-security-policy');
-      expect(reportHeader[0]).toBe('reporting-endpoints');
 
+      const cspHeader = result.headers.find(([name]) => name === 'content-security-policy');
+      const reportHeader = result.headers.find(([name]) => name === 'reporting-endpoints');
+
+      expect(cspHeader).toBeDefined();
+      if (!cspHeader) throw new Error('CSP header not found');
       expect(cspHeader[1]).toContain('report-to csp-endpoint');
 
+      expect(reportHeader).toBeDefined();
+      if (!reportHeader) throw new Error('Report header not found');
       expect(reportHeader[1]).toBe('csp-endpoint="https://example.com/reports"');
     });
 

--- a/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
+++ b/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
@@ -375,5 +375,28 @@ describe('CSP Header Utils', () => {
 
       expect(result.headers[0][1]).toMatch(/^[^;]+(; [^;]+)*$/);
     });
+
+    it('should properly accumulate multiple custom directives', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, {
+        directives: {
+          'base-uri': ['value1', 'value2'],
+          'manifest-src': ['value3', 'value4'],
+        },
+      });
+
+      const directives = result.headers[0][1].split('; ');
+
+      const baseUriDirective = directives.find(d => d.startsWith('base-uri'));
+      expect(baseUriDirective).toBeDefined();
+      if (!baseUriDirective) throw new Error('base-uri directive not found');
+      expect(baseUriDirective).toContain('value1');
+      expect(baseUriDirective).toContain('value2');
+
+      const manifestSrcDirective = directives.find(d => d.startsWith('manifest-src'));
+      expect(manifestSrcDirective).toBeDefined();
+      if (!manifestSrcDirective) throw new Error('manifest-src directive not found');
+      expect(manifestSrcDirective).toContain('value3');
+      expect(manifestSrcDirective).toContain('value4');
+    });
   });
 });

--- a/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
+++ b/packages/nextjs/src/server/__tests__/content-security-policy.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createCSPHeader, generateNonce } from '../content-security-policy';
+import { createContentSecurityPolicyHeaders, generateNonce } from '../content-security-policy';
 
 describe('CSP Header Utils', () => {
   describe('generateNonce', () => {
     it('should generate a base64 nonce of correct length', () => {
       const nonce = generateNonce();
-      expect(nonce).toMatch(/^[A-Za-z0-9+/=]+$/); // Base64 pattern
+      expect(nonce).toMatch(/^[A-Za-z0-9+/=]+$/);
       expect(Buffer.from(nonce, 'base64')).toHaveLength(16);
     });
 
@@ -17,13 +17,17 @@ describe('CSP Header Utils', () => {
     });
   });
 
-  describe('createCSPHeader', () => {
+  describe('createContentSecurityPolicyHeaders', () => {
     const testHost = 'clerk.example.com';
 
-    it('should create a standard CSP header with default directives', () => {
-      const result = createCSPHeader(false, testHost);
+    it('should create standard CSP headers with default directives', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, {});
 
-      const directives = result.header.split('; ');
+      expect(result.headers).toHaveLength(1);
+      const [headerName, headerValue] = result.headers[0];
+      expect(headerName).toBe('content-security-policy');
+
+      const directives = headerValue.split('; ');
 
       expect(directives).toContainEqual("default-src 'self'");
       expect(directives).toContainEqual(
@@ -50,16 +54,18 @@ describe('CSP Header Utils', () => {
       if (process.env.NODE_ENV !== 'production') {
         expect(scriptSrc).toContain("'unsafe-eval'");
       }
-
-      expect(result.nonce).toBeUndefined();
     });
 
-    it('should create a strict-dynamic CSP header with nonce', () => {
-      const result = createCSPHeader(true, testHost);
+    it('should create strict-dynamic CSP headers with nonce', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, { strict: true });
 
-      // Extract the script-src directive and verify it contains the required values
-      const directives = result.header.split('; ');
-      const scriptSrcDirective = directives.find((d: string) => d.startsWith('script-src')) ?? '';
+      expect(result.headers).toHaveLength(2);
+      const [cspHeader, nonceHeader] = result.headers;
+      expect(cspHeader[0]).toBe('content-security-policy');
+      expect(nonceHeader[0]).toBe('x-nonce');
+
+      const directives = cspHeader[1].split('; ');
+      const scriptSrcDirective = directives.find(d => d.startsWith('script-src')) ?? '';
       expect(scriptSrcDirective).toBeDefined();
 
       const scriptSrcValues = scriptSrcDirective.replace('script-src ', '').split(' ');
@@ -68,296 +74,99 @@ describe('CSP Header Utils', () => {
       expect(scriptSrcValues).toContain("'strict-dynamic'");
       expect(scriptSrcValues.some(val => val.startsWith("'nonce-"))).toBe(true);
 
-      expect(result.nonce).toBeDefined();
-      expect(result.nonce).toMatch(/^[A-Za-z0-9+/=]+$/);
+      expect(nonceHeader[1]).toMatch(/^[A-Za-z0-9+/=]+$/);
+      expect(cspHeader[1]).toContain(`'nonce-${nonceHeader[1]}'`);
     });
 
-    it('should handle custom directives as an object', () => {
-      const customDirectives = {
-        'default-src': ['none'],
-        'img-src': ['self', 'https://example.com'],
-        'custom-directive': ['value'],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
+    it('should handle report-only mode', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, { reportOnly: true });
 
-      expect(result.header).toContain("default-src 'none'");
-      // Check for the presence of all required values in the img-src directive
-      const directives = result.header.split('; ');
+      expect(result.headers).toHaveLength(1);
+      const [headerName, headerValue] = result.headers[0];
+      expect(headerName).toBe('content-security-policy-report-only');
+
+      const directives = headerValue.split('; ');
+      expect(directives).toContainEqual("default-src 'self'");
+    });
+
+    it('should handle report-to functionality', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, { reportTo: 'https://example.com/reports' });
+
+      expect(result.headers).toHaveLength(2);
+      const [cspHeader, reportHeader] = result.headers;
+      expect(cspHeader[0]).toBe('content-security-policy');
+      expect(reportHeader[0]).toBe('reporting-endpoints');
+
+      expect(cspHeader[1]).toContain('report-to csp-endpoint');
+
+      expect(reportHeader[1]).toBe('csp-endpoint="https://example.com/reports"');
+    });
+
+    it('should handle custom directives', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, {
+        directives: {
+          'default-src': ['none'],
+          'img-src': ['self', 'https://example.com'],
+          'frame-src': ['value'],
+        },
+      });
+
+      expect(result.headers).toHaveLength(1);
+      const [headerName, headerValue] = result.headers[0];
+      expect(headerName).toBe('content-security-policy');
+
+      const directives = headerValue.split('; ');
+      expect(directives).toContainEqual("default-src 'none'");
+
       const imgSrcDirective = directives.find(d => d.startsWith('img-src'));
       expect(imgSrcDirective).toBeDefined();
       expect(imgSrcDirective).toContain("'self'");
       expect(imgSrcDirective).toContain('https://img.clerk.com');
       expect(imgSrcDirective).toContain('https://example.com');
-      expect(result.header).toContain('custom-directive value');
+
+      const frameSrcDirective = directives.find(d => d.startsWith('frame-src'));
+      expect(frameSrcDirective).toBeDefined();
+      expect(frameSrcDirective).toContain('value');
     });
 
     it('should handle development environment specific directives', () => {
-      const result = createCSPHeader(false, testHost);
-      const directives = result.header.split('; ');
+      vi.stubEnv('NODE_ENV', 'development');
+      const result = createContentSecurityPolicyHeaders(testHost, {});
+      const directives = result.headers[0][1].split('; ');
       const scriptSrcDirective = directives.find(d => d.startsWith('script-src'));
       expect(scriptSrcDirective).toBeDefined();
-      expect(scriptSrcDirective).toContain("'self'");
       expect(scriptSrcDirective).toContain("'unsafe-eval'");
-      expect(scriptSrcDirective).toContain("'unsafe-inline'");
-      expect(scriptSrcDirective).toContain('https:');
-      expect(scriptSrcDirective).toContain('http:');
-      expect(scriptSrcDirective).toContain('https://*.js.stripe.com');
-      expect(scriptSrcDirective).toContain('https://js.stripe.com');
-      expect(scriptSrcDirective).toContain('https://maps.googleapis.com');
-    });
-
-    it('preserves all original CLERK_CSP_VALUES directives with special keywords quoted', () => {
-      const result = createCSPHeader(false, testHost);
-
-      // Split the result into individual directives for precise testing
-      const directives = result.header.split('; ');
-
-      // Check each directive individually with exact matches
-      expect(directives).toContainEqual(
-        "connect-src 'self' https://clerk-telemetry.com https://*.clerk-telemetry.com https://api.stripe.com https://maps.googleapis.com clerk.example.com",
-      );
-      expect(directives).toContainEqual("default-src 'self'");
-      expect(directives).toContainEqual("form-action 'self'");
-      expect(directives).toContainEqual(
-        "frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com",
-      );
-      expect(directives).toContainEqual("img-src 'self' https://img.clerk.com");
-      expect(directives).toContainEqual("style-src 'self' 'unsafe-inline'");
-      expect(directives).toContainEqual("worker-src 'self' blob:");
-
-      // script-src varies based on NODE_ENV, so we check for common values
-      const scriptSrc = directives.find((d: string) => d.startsWith('script-src'));
-      expect(scriptSrc).toBeDefined();
-      expect(scriptSrc).toContain("'self'");
-      expect(scriptSrc).toContain('https:');
-      expect(scriptSrc).toContain('http:');
-      expect(scriptSrc).toContain("'unsafe-inline'");
-      // 'unsafe-eval' depends on NODE_ENV, so we verify conditionally
-      if (process.env.NODE_ENV !== 'production') {
-        expect(scriptSrc).toContain("'unsafe-eval'");
-      }
-    });
-
-    it('includes script-src with development-specific values when NODE_ENV is not production', () => {
-      vi.stubEnv('NODE_ENV', 'development');
-
-      const result = createCSPHeader(false, testHost);
-      const directives = result.header.split('; ');
-
-      const scriptSrc = directives.find((d: string) => d.startsWith('script-src'));
-      expect(scriptSrc).toBeDefined();
-
-      // In development, script-src should include 'unsafe-eval'
-      expect(scriptSrc).toContain("'unsafe-eval'");
-      expect(scriptSrc).toContain("'self'");
-      expect(scriptSrc).toContain('https:');
-      expect(scriptSrc).toContain('http:');
-      expect(scriptSrc).toContain("'unsafe-inline'");
-
       vi.stubEnv('NODE_ENV', 'production');
     });
 
-    it('properly converts host to clerk subdomain in CSP directives', () => {
-      const host = 'clerk.example.com';
-      const result = createCSPHeader(false, host);
+    it('should handle multiple configurations together', () => {
+      const result = createContentSecurityPolicyHeaders(testHost, {
+        strict: true,
+        reportTo: 'https://example.com/reports',
+        directives: {
+          'script-src': ['self', 'https://custom-cdn.com'],
+        },
+      });
 
-      // Split the result into individual directives for precise testing
-      const directives = result.header.split('; ');
+      expect(result.headers).toHaveLength(3);
 
-      // When full URL is provided, it should be parsed to clerk.domain.tld in all relevant directives
-      expect(directives).toContainEqual(
-        `connect-src 'self' https://clerk-telemetry.com https://*.clerk-telemetry.com https://api.stripe.com https://maps.googleapis.com clerk.example.com`,
-      );
-      expect(directives).toContainEqual(`img-src 'self' https://img.clerk.com`);
-      expect(directives).toContainEqual(
-        `frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com`,
-      );
+      const cspHeader = result.headers.find(([name]) => name === 'content-security-policy');
+      const nonceHeader = result.headers.find(([name]) => name === 'x-nonce');
+      const reportHeader = result.headers.find(([name]) => name === 'reporting-endpoints');
 
-      // Check that other directives are present but don't contain the clerk subdomain
-      expect(directives).toContainEqual(`default-src 'self'`);
-      expect(directives).toContainEqual(`form-action 'self'`);
-      expect(directives).toContainEqual(`style-src 'self' 'unsafe-inline'`);
-      expect(directives).toContainEqual(`worker-src 'self' blob:`);
-    });
+      expect(cspHeader).toBeDefined();
+      if (!cspHeader) throw new Error('CSP header not found');
+      expect(cspHeader[1]).toContain('report-to csp-endpoint');
+      expect(cspHeader[1]).toContain('https://custom-cdn.com');
+      expect(cspHeader[1]).toContain("'strict-dynamic'");
 
-    it('merges and deduplicates values for existing directives while preserving special keywords', () => {
-      const customDirectives = {
-        'script-src': ["'self'", 'new-value', 'another-value', "'unsafe-inline'", "'unsafe-eval'"],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
+      expect(nonceHeader).toBeDefined();
+      if (!nonceHeader) throw new Error('Nonce header not found');
+      expect(nonceHeader[1]).toMatch(/^[A-Za-z0-9+/=]+$/);
 
-      // The script-src directive should contain both the default values and new values, with special keywords quoted
-      const resultDirectives = result.header.split('; ');
-      const scriptSrcDirective = resultDirectives.find((d: string) => d.startsWith('script-src')) ?? '';
-      expect(scriptSrcDirective).toBeDefined();
-
-      // Verify it contains all expected values exactly once
-      const values = new Set(scriptSrcDirective.replace('script-src ', '').split(' '));
-      expect(values).toContain("'self'");
-      expect(values).toContain("'unsafe-inline'");
-      expect(values).toContain('new-value');
-      expect(values).toContain('another-value');
-    });
-
-    it('correctly adds new directives from custom directives object and preserves special keyword quoting', () => {
-      const customDirectives = {
-        'object-src': ['self', 'value1', 'value2', 'unsafe-inline'],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
-
-      // The new directive should be added
-      const directives = result.header.split('; ');
-      const newDirective = directives.find((d: string) => d.startsWith('object-src')) ?? '';
-      expect(newDirective).toBeDefined();
-
-      const newDirectiveValues = newDirective.replace('object-src ', '').split(' ');
-      expect(newDirectiveValues).toContain("'self'");
-      expect(newDirectiveValues).toContain('value1');
-      expect(newDirectiveValues).toContain('value2');
-      expect(newDirectiveValues).toContain("'unsafe-inline'");
-    });
-
-    it('produces a complete CSP header with all expected directives and special keywords quoted', () => {
-      const customDirectives = {
-        'script-src': ['new-value', 'unsafe-inline'],
-        'object-src': ['self', 'value1', 'value2'],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
-
-      // Split the result into individual directives for precise testing
-      const directives = result.header.split('; ');
-
-      // Verify all directives are present with their exact values, with special keywords quoted
-      expect(directives).toContainEqual(
-        "connect-src 'self' https://clerk-telemetry.com https://*.clerk-telemetry.com https://api.stripe.com https://maps.googleapis.com clerk.example.com",
-      );
-      expect(directives).toContainEqual("default-src 'self'");
-      expect(directives).toContainEqual("form-action 'self'");
-      expect(directives).toContainEqual(
-        "frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com",
-      );
-      expect(directives).toContainEqual("img-src 'self' https://img.clerk.com");
-      expect(directives).toContainEqual("style-src 'self' 'unsafe-inline'");
-      expect(directives).toContainEqual("worker-src 'self' blob:");
-
-      // Verify the new directive exists and has expected values
-      const newDirective = directives.find((d: string) => d.startsWith('object-src')) ?? '';
-      expect(newDirective).toBeDefined();
-
-      const newDirectiveValues = newDirective.replace('object-src ', '').split(' ');
-      expect(newDirectiveValues).toContain("'self'");
-      expect(newDirectiveValues).toContain('value1');
-      expect(newDirectiveValues).toContain('value2');
-
-      // Extract the script-src directive and check for each expected value individually
-      const scriptSrcDirective = directives.find((d: string) => d.startsWith('script-src')) ?? '';
-      expect(scriptSrcDirective).toBeDefined();
-
-      // Verify it contains all expected values regardless of order
-      const scriptSrcValues = scriptSrcDirective.replace('script-src ', '').split(' ');
-      expect(scriptSrcValues).toContain("'self'");
-      expect(scriptSrcValues).toContain("'unsafe-inline'");
-      expect(scriptSrcValues).toContain('https:');
-      expect(scriptSrcValues).toContain('http:');
-      expect(scriptSrcValues).toContain('new-value');
-
-      // Verify the header format (directives separated by semicolons)
-      expect(result.header).toMatch(/^[^;]+(; [^;]+)*$/);
-    });
-
-    it('automatically quotes special keywords in CSP directives regardless of input format', () => {
-      vi.stubEnv('NODE_ENV', 'development');
-      const customDirectives = {
-        'script-src': ['self', 'unsafe-inline', 'unsafe-eval', 'custom-domain.com'],
-        'new-directive': ['none'],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
-
-      // Verify that special keywords are always quoted in output, regardless of input format
-      const resultDirectives = result.header.split('; ');
-
-      // Verify script-src directive has properly quoted keywords
-      const scriptSrcDirective = resultDirectives.find((d: string) => d.startsWith('script-src')) ?? '';
-      expect(scriptSrcDirective).toBeDefined();
-      const scriptSrcValues = scriptSrcDirective.replace('script-src ', '').split(' ');
-      expect(scriptSrcValues).toContain("'self'");
-      expect(scriptSrcValues).toContain("'unsafe-inline'");
-      expect(scriptSrcValues).toContain("'unsafe-eval'");
-      expect(scriptSrcValues).toContain('custom-domain.com');
-      // Verify default values for standard mode
-      expect(scriptSrcValues).toContain('http:');
-      expect(scriptSrcValues).toContain('https:');
-
-      // Verify new-directive has properly quoted keywords and is the sole value
-      const newDirective = resultDirectives.find((d: string) => d.startsWith('new-directive')) ?? '';
-      expect(newDirective).toBeDefined();
-      const newDirectiveValues = newDirective.replace('new-directive ', '').split(' ');
-      expect(newDirectiveValues).toContain("'none'");
-      expect(newDirectiveValues).toHaveLength(1);
-
-      vi.stubEnv('NODE_ENV', 'production');
-    });
-
-    it('correctly merges clerk subdomain with existing CSP values', () => {
-      const customDirectives = {
-        'connect-src': ['self', 'https://api.example.com'],
-        'img-src': ['self', 'https://images.example.com'],
-        'frame-src': ['self', 'https://frames.example.com'],
-      };
-      const result = createCSPHeader(false, testHost, customDirectives);
-
-      const directives = result.header.split('; ');
-
-      // Verify clerk subdomain is added while preserving existing values
-      expect(directives).toContainEqual(
-        `connect-src 'self' https://clerk-telemetry.com https://*.clerk-telemetry.com https://api.stripe.com https://maps.googleapis.com clerk.example.com https://api.example.com`,
-      );
-      // Verify all required domains are present in the img-src directive
-      const imgSrcDirective = directives.find(d => d.startsWith('img-src')) || '';
-      expect(imgSrcDirective).toBeDefined();
-      expect(imgSrcDirective).toContain("'self'");
-      expect(imgSrcDirective).toContain('https://img.clerk.com');
-      expect(imgSrcDirective).toContain('https://images.example.com');
-      expect(directives).toContainEqual(
-        `frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com https://frames.example.com`,
-      );
-
-      // Verify other directives are present and unchanged
-      expect(directives).toContainEqual(`default-src 'self'`);
-      expect(directives).toContainEqual(`form-action 'self'`);
-      expect(directives).toContainEqual(`style-src 'self' 'unsafe-inline'`);
-      expect(directives).toContainEqual(`worker-src 'self' blob:`);
-    });
-
-    it('correctly implements strict-dynamic mode with nonce-based script-src', () => {
-      const result = createCSPHeader(true, testHost);
-      const directives = result.header.split('; ');
-
-      // Extract the script-src directive and check for specific values
-      const scriptSrcDirective = directives.find((d: string) => d.startsWith('script-src')) ?? '';
-      expect(scriptSrcDirective).toBeDefined();
-
-      // In strict-dynamic mode, script-src should contain 'strict-dynamic' and a nonce
-      const scriptSrcValues = scriptSrcDirective.replace('script-src ', '').split(' ');
-      expect(scriptSrcValues).toContain("'strict-dynamic'");
-      expect(scriptSrcValues.some(val => val.startsWith("'nonce-"))).toBe(true);
-
-      // Should not contain http: or https: in strict-dynamic mode
-      expect(scriptSrcValues).not.toContain('http:');
-      expect(scriptSrcValues).not.toContain('https:');
-
-      // Other directives should still be present
-      expect(directives).toContainEqual(
-        "connect-src 'self' https://clerk-telemetry.com https://*.clerk-telemetry.com https://api.stripe.com https://maps.googleapis.com clerk.example.com",
-      );
-      expect(directives).toContainEqual("default-src 'self'");
-      expect(directives).toContainEqual("form-action 'self'");
-      expect(directives).toContainEqual(
-        "frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com",
-      );
-      expect(directives).toContainEqual("img-src 'self' https://img.clerk.com");
-      expect(directives).toContainEqual("style-src 'self' 'unsafe-inline'");
-      expect(directives).toContainEqual("worker-src 'self' blob:");
+      expect(reportHeader).toBeDefined();
+      if (!reportHeader) throw new Error('Report header not found');
+      expect(reportHeader[1]).toBe('csp-endpoint="https://example.com/reports"');
     });
   });
 });

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -11,7 +11,7 @@ import { withLogger } from '../utils/debugLogger';
 import { canUseKeyless } from '../utils/feature-flags';
 import { clerkClient } from './clerkClient';
 import { PUBLISHABLE_KEY, SECRET_KEY, SIGN_IN_URL, SIGN_UP_URL } from './constants';
-import { createCSPHeader, type CSPDirective } from './content-security-policy';
+import { type ContentSecurityPolicyOptions, createContentSecurityPolicyHeaders } from './content-security-policy';
 import { errorThrower } from './errorThrower';
 import { getKeylessCookieValue } from './keyless';
 import { clerkMiddlewareRequestDataStorage, clerkMiddlewareRequestDataStore } from './middleware-storage';
@@ -56,7 +56,7 @@ type ClerkMiddlewareHandler = (
  * The `clerkMiddleware()` function accepts an optional object. The following options are available.
  * @interface
  */
-export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
+export interface ClerkMiddlewareOptions extends AuthenticateRequestOptions {
   /**
    * If true, additional debug information will be logged to the console.
    */
@@ -65,18 +65,8 @@ export type ClerkMiddlewareOptions = AuthenticateRequestOptions & {
   /**
    * When set, automatically injects a Content-Security-Policy header(s) compatible with Clerk.
    */
-  contentSecurityPolicy?: {
-    /**
-     * When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive and generates a unique nonce value to be used for script elements.
-     * This helps prevent XSS attacks while allowing trusted scripts to execute.
-     */
-    strict?: boolean;
-    /**
-     * Custom CSP directives to merge with Clerk's default directives
-     */
-    directives?: Partial<Record<CSPDirective, string[]>>;
-  };
-};
+  contentSecurityPolicy?: ContentSecurityPolicyOptions;
+}
 
 type ClerkMiddlewareOptionsCallback = (req: NextRequest) => ClerkMiddlewareOptions | Promise<ClerkMiddlewareOptions>;
 
@@ -210,20 +200,17 @@ export const clerkMiddleware = ((...args: unknown[]): NextMiddleware | NextMiddl
         handlerResult = handleControlFlowErrors(e, clerkRequest, request, requestState);
       }
       if (options.contentSecurityPolicy) {
-        const { header, nonce } = createCSPHeader(
-          options.contentSecurityPolicy.strict ?? false,
+        const { headers } = createContentSecurityPolicyHeaders(
           (parsePublishableKey(publishableKey)?.frontendApi ?? '').replace('$', ''),
-          options.contentSecurityPolicy.directives,
+          options.contentSecurityPolicy,
         );
 
-        setHeader(handlerResult, constants.Headers.ContentSecurityPolicy, header);
-        if (nonce) {
-          setHeader(handlerResult, constants.Headers.Nonce, nonce);
-        }
+        headers.forEach(([key, value]) => {
+          setHeader(handlerResult, key, value);
+        });
 
         logger.debug('Clerk generated CSP', () => ({
-          header,
-          nonce,
+          headers,
         }));
       }
 

--- a/packages/nextjs/src/server/content-security-policy.ts
+++ b/packages/nextjs/src/server/content-security-policy.ts
@@ -316,16 +316,13 @@ export function createContentSecurityPolicyHeaders(
 
   if (options.reportTo) {
     cspHeader += '; report-to csp-endpoint';
+    headers.push([constants.Headers.ReportingEndpoints, `csp-endpoint="${options.reportTo}"`]);
   }
 
   if (options.reportOnly) {
     headers.push([constants.Headers.ContentSecurityPolicyReportOnly, cspHeader]);
   } else {
     headers.push([constants.Headers.ContentSecurityPolicy, cspHeader]);
-  }
-
-  if (options.reportTo) {
-    headers.push([constants.Headers.ReportingEndpoints, `csp-endpoint="${options.reportTo}"`]);
   }
 
   if (nonce) {

--- a/packages/nextjs/src/server/content-security-policy.ts
+++ b/packages/nextjs/src/server/content-security-policy.ts
@@ -287,13 +287,19 @@ function buildContentSecurityPolicyDirectives(
   }
 
   if (customDirectives) {
+    const customDirectivesMap = new Map<string, Set<string>>();
     Object.entries(customDirectives).forEach(([key, values]) => {
       const valuesArray = Array.isArray(values) ? values : [values];
       if (ContentSecurityPolicyDirectiveManager.DEFAULT_DIRECTIVES[key as ContentSecurityPolicyDirective]) {
         handleExistingDirective(directives, key as ContentSecurityPolicyDirective, valuesArray);
       } else {
-        handleCustomDirective(new Map(), key, valuesArray);
+        handleCustomDirective(customDirectivesMap, key, valuesArray);
       }
+    });
+
+    // Merge all custom directives into the final directives object
+    customDirectivesMap.forEach((values, key) => {
+      directives[key as ContentSecurityPolicyDirective] = values;
     });
   }
 

--- a/packages/nextjs/src/server/content-security-policy.ts
+++ b/packages/nextjs/src/server/content-security-policy.ts
@@ -1,3 +1,5 @@
+import { constants } from '@clerk/backend/internal';
+
 /**
  * Valid CSP directives according to the CSP Level 3 specification
  */
@@ -49,14 +51,42 @@ type CSPValues = Partial<Record<CSPDirective, string[]>>;
  */
 type CSPDirectiveSet = Record<CSPDirective, Set<string>>;
 
+export interface CSPConfig {
+  /**
+   * The host to include in the CSP
+   */
+  host: string;
+  /**
+   * When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive
+   */
+  strict?: boolean;
+  /**
+   * Custom CSP directives to merge with Clerk's default directives
+   */
+  directives?: Partial<Record<CSPDirective, string[]>>;
+  /**
+   * When set to true, the Content-Security-Policy-Report-Only header will be used instead of
+   * Content-Security-Policy. This allows monitoring policy violations without blocking content.
+   */
+  reportOnly?: boolean;
+  /**
+   * Specifies a reporting endpoint for CSP violations. This value will be used in the
+   * 'report-to' directive of the Content-Security-Policy header.
+   */
+  reportTo?: string;
+}
+
 /**
  * Return type for createCSPHeader
  */
 export interface CSPHeaderResult {
-  /** The formatted CSP header string */
-  header: string;
-  /** The generated nonce, if applicable */
-  nonce?: string;
+  /**
+   * Array of formatted headers to be added to the response.
+   *
+   * Includes both standard and report-only headers when applicable.
+   * Includes nonce when strict mode is enabled.
+   */
+  headers: [string, string][];
 }
 
 class CSPDirectiveManager {
@@ -231,67 +261,99 @@ export function generateNonce(): string {
 }
 
 /**
- * Creates a merged CSP state with all necessary directives
- * @param strict - When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive
- * @param host - The host to include in CSP
- * @param customDirectives - Optional custom directives to merge with
- * @param nonce - Optional nonce for strict-dynamic mode
- * @returns Merged CSPDirectiveSet
+ * Builds a complete set of CSP directives by combining defaults with custom directives,
+ * applying special configurations like strict mode and nonce, and formatting them into a valid CSP string.
  */
-function createMergedCSP(
+function buildContentSecurityPolicyDirectives(
   strict: boolean,
   host: string,
-  customDirectives?: Record<string, string[]>,
+  customDirectives?: Partial<Record<CSPDirective, string[]>>,
   nonce?: string,
-): Record<string, Set<string>> {
-  // Initialize with default Clerk CSP values
-  const mergedCSP = CSPDirectiveManager.createDefaultDirectives();
-  mergedCSP['connect-src'].add(host);
+): string {
+  const directives = Object.entries(CSPDirectiveManager.DEFAULT_DIRECTIVES).reduce((acc, [key, values]) => {
+    acc[key as CSPDirective] = new Set(values);
+    return acc;
+  }, {} as CSPDirectiveSet);
 
-  // Handle strict-dynamic mode specific changes
+  directives['connect-src'].add(host);
+
   if (strict) {
-    mergedCSP['script-src'].delete('http:');
-    mergedCSP['script-src'].delete('https:');
-    mergedCSP['script-src'].add("'strict-dynamic'");
+    directives['script-src'].delete('http:');
+    directives['script-src'].delete('https:');
+    directives['script-src'].add("'strict-dynamic'");
     if (nonce) {
-      mergedCSP['script-src'].add(`'nonce-${nonce}'`);
+      directives['script-src'].add(`'nonce-${nonce}'`);
     }
   }
 
-  // Add custom directives if provided
-  const customDirectivesMap = new Map<string, Set<string>>();
   if (customDirectives) {
     Object.entries(customDirectives).forEach(([key, values]) => {
       const valuesArray = Array.isArray(values) ? values : [values];
       if (CSPDirectiveManager.DEFAULT_DIRECTIVES[key as CSPDirective]) {
-        handleExistingDirective(mergedCSP, key as CSPDirective, valuesArray);
+        handleExistingDirective(directives, key as CSPDirective, valuesArray);
       } else {
-        handleCustomDirective(customDirectivesMap, key, valuesArray);
+        handleCustomDirective(new Map(), key, valuesArray);
       }
     });
   }
 
-  // Combine standard directives with custom directives
-  const finalCSP: Record<string, Set<string>> = { ...mergedCSP };
-  customDirectivesMap.forEach((values, key) => {
-    finalCSP[key] = values;
-  });
+  return formatCSPHeader(directives);
+}
 
-  return finalCSP;
+export interface ContentSecurityPolicyOptions {
+  /**
+   * When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive
+   */
+  strict?: boolean;
+  /**
+   * Custom CSP directives to merge with Clerk's default directives
+   */
+  directives?: Partial<Record<CSPDirective, string[]>>;
+  /**
+   * When set to true, the Content-Security-Policy-Report-Only header will be used instead of
+   * Content-Security-Policy. This allows monitoring policy violations without blocking content.
+   */
+  reportOnly?: boolean;
+  /**
+   * Specifies a reporting endpoint for CSP violations. This value will be used in the
+   * 'report-to' directive of the Content-Security-Policy header.
+   */
+  reportTo?: string;
 }
 
 /**
- * Creates a Content Security Policy (CSP) header with the specified mode and host
- * @param strict - When set to true, enhances security by applying the `strict-dynamic` attribute to the `script-src` CSP directive
- * @param host - The host to include in the CSP (parsed from publishableKey)
- * @param customDirectives - Optional custom directives to merge with
- * @returns Object containing the formatted CSP header and nonce (if in strict-dynamic mode)
+ * Creates Content Security Policy (CSP) headers with the specified configuration
+ * @returns Object containing the formatted CSP headers
  */
-export function createCSPHeader(strict: boolean, host: string, customDirectives?: CSPValues): CSPHeaderResult {
-  const nonce = strict ? generateNonce() : undefined;
+export function createContentSecurityPolicyHeaders(
+  host: string,
+  options: ContentSecurityPolicyOptions,
+): CSPHeaderResult {
+  const headers: [string, string][] = [];
+
+  const nonce = options.strict ? generateNonce() : undefined;
+
+  let cspHeader = buildContentSecurityPolicyDirectives(options.strict ?? false, host, options.directives, nonce);
+
+  if (options.reportTo) {
+    cspHeader += '; report-to csp-endpoint';
+  }
+
+  if (options.reportOnly) {
+    headers.push([constants.Headers.ContentSecurityPolicyReportOnly, cspHeader]);
+  } else {
+    headers.push([constants.Headers.ContentSecurityPolicy, cspHeader]);
+  }
+
+  if (options.reportTo) {
+    headers.push([constants.Headers.ReportingEndpoints, `csp-endpoint="${options.reportTo}"`]);
+  }
+
+  if (nonce) {
+    headers.push([constants.Headers.Nonce, nonce]);
+  }
 
   return {
-    header: formatCSPHeader(createMergedCSP(strict, host, customDirectives, nonce)),
-    nonce,
+    headers,
   };
 }


### PR DESCRIPTION
## Description

Adding `reportTo` and `reportOnly` configuration options

Fixes: SDKI-1001

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
