### PR TITLE
fix(clerk-js): Use the same cache key for payment sources across checkout and profiles

### DIFF
--- a/.changeset/dull-peaches-camp.md
+++ b/.changeset/dull-peaches-camp.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Use the same cache key for payment sources across checkout and profiles.

--- a/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
@@ -92,7 +92,7 @@ const PaymentSources = (_: __experimental_PaymentSourcesProps) => {
     __experimental_commerce?.getPaymentSources,
     { ...(subscriberType === 'org' ? { orgId: organization?.id } : {}) },
     undefined,
-    'commerce-user-payment-sources',
+    'commerce-payment-sources',
   );
   const { data: paymentSources } = data || { data: [] };
 


### PR DESCRIPTION
## Description

Using the same cache key allows for existing data to be displayed, improving unnecessary layout shifts.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
