### PR TITLE
fix(clerk-js): Update shortDate modifier to include year for future dates

### DIFF
--- a/.changeset/ten-taxes-float.md
+++ b/.changeset/ten-taxes-float.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update shortDate modifier to include year for future dates.

--- a/packages/clerk-js/src/ui/localization/localizationModifiers.ts
+++ b/packages/clerk-js/src/ui/localization/localizationModifiers.ts
@@ -19,11 +19,17 @@ const weekday = (val: Date | string | number, locale?: string, weekday?: 'long' 
   }
 };
 
+/**
+ * Returns a short date string if the current year is the same as the date's year,
+ * otherwise returns a long date string.
+ */
 const shortDate = (val: Date | string | number, locale?: string) => {
+  const date = normalizeDate(val);
   try {
     return new Intl.DateTimeFormat(locale || 'en-US', {
       month: 'short',
       day: 'numeric',
+      ...(date.getFullYear() !== new Date().getFullYear() ? { year: 'numeric' } : {}),
     }).format(normalizeDate(val));
   } catch (e) {
     console.warn(e);


### PR DESCRIPTION
## Description

Usually when only the year is missing the current year is inferred.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
