### PR TITLE
fix(clerk-js): Avoid laggy ui when closing drawer after canceling subscription

### DIFF
--- a/.changeset/easy-zebras-wave.md
+++ b/.changeset/easy-zebras-wave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Avoid laggy ui when closing drawer after canceling subscription.

--- a/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionDetails.tsx
+++ b/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionDetails.tsx
@@ -21,7 +21,7 @@ import {
   Span,
   Text,
 } from '../../customizables';
-import { Alert, Avatar, Drawer, ReversibleContainer } from '../../elements';
+import { Alert, Avatar, Drawer, ReversibleContainer, useDrawerContext } from '../../elements';
 import { InformationCircle } from '../../icons';
 import { formatDate, handleError } from '../../utils';
 
@@ -34,6 +34,15 @@ export function SubscriptionDetails({
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cancelError, setCancelError] = useState<ClerkRuntimeError | ClerkAPIError | string | undefined>();
+
+  const { setIsOpen } = useDrawerContext();
+
+  const handleClose = () => {
+    if (setIsOpen) {
+      setIsOpen(false);
+    }
+  };
+
   if (!subscription) {
     return null;
   }
@@ -48,6 +57,7 @@ export function SubscriptionDetails({
       .then(() => {
         setIsSubmitting(false);
         onSubscriptionCancel?.();
+        handleClose();
       })
       .catch(error => {
         handleError(error, [], setCancelError);

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -174,7 +174,6 @@ export const usePlansContext = () => {
           onSubscriptionCancel: () => {
             ctx.revalidate();
             onSubscriptionChange?.();
-            clerk.__internal_closeSubscriptionDetails();
           },
           portalId:
             mode === 'modal'


### PR DESCRIPTION
## Description

### Before

https://github.com/user-attachments/assets/4ce90515-a501-4a93-9a75-b3a5866d0c65


### After 

https://github.com/user-attachments/assets/2faf604f-08d3-4d6d-9c3f-4800cc6f8bde


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
