### PR TITLE
fix(clerk-js): Add support for 2 new OAuth error codes

### DIFF
--- a/.changeset/tough-cameras-lie.md
+++ b/.changeset/tough-cameras-lie.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add support for 2 new OAuth error codes

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -36,6 +36,8 @@ export const ERROR_CODES = {
   INVITATION_ACCOUNT_NOT_EXISTS: 'invitation_account_not_exists',
   ORGANIZATION_MEMBERSHIP_QUOTA_EXCEEDED_FOR_SSO: 'organization_membership_quota_exceeded_for_sso',
   CAPTCHA_INVALID: 'captcha_invalid',
+  FRAUD_DEVICE_BLOCKED: 'device_blocked',
+  FRAUD_ACTION_BLOCKED: 'action_blocked',
 } as const;
 
 export const SIGN_IN_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username'];

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -241,6 +241,9 @@ function SignInStartInternal(): JSX.Element {
           case ERROR_CODES.ENTERPRISE_SSO_HOSTED_DOMAIN_MISMATCH:
           case ERROR_CODES.SAML_EMAIL_ADDRESS_DOMAIN_MISMATCH:
           case ERROR_CODES.ORGANIZATION_MEMBERSHIP_QUOTA_EXCEEDED_FOR_SSO:
+          case ERROR_CODES.CAPTCHA_INVALID:
+          case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
+          case ERROR_CODES.FRAUD_ACTION_BLOCKED:
             card.setError(error);
             break;
           default:

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -177,6 +177,8 @@ function SignUpStartInternal(): JSX.Element {
           case ERROR_CODES.SAML_EMAIL_ADDRESS_DOMAIN_MISMATCH:
           case ERROR_CODES.ORGANIZATION_MEMBERSHIP_QUOTA_EXCEEDED_FOR_SSO:
           case ERROR_CODES.CAPTCHA_INVALID:
+          case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
+          case ERROR_CODES.FRAUD_ACTION_BLOCKED:
             card.setError(error);
             break;
           default:


### PR DESCRIPTION
## Description

Add support for the 2 new error codes on OAuth flows:

- `device_blocked`
- `action_blocked`

This affects the message that is being shown on the UI component.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
