### PR TITLE
fix(clerk-js): Display "Switch to this plan" when a subscription already exists

### DIFF
--- a/.changeset/clear-trains-rhyme.md
+++ b/.changeset/clear-trains-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+For each plan inside the `<PricingTable/>` display "Switch to this plan" instead of "Get started" when a subscription already exists. 

--- a/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
@@ -4,7 +4,7 @@ import { usePlansContext } from '../../contexts';
 import { Badge, Box, Button, localizationKeys, Span, Table, Tbody, Td, Text, Th, Thead, Tr } from '../../customizables';
 
 export function SubscriptionsList() {
-  const { subscriptions, handleSelectPlan, buttonPropsForPlan } = usePlansContext();
+  const { subscriptions, handleSelectPlan, buttonPropsForPlan, shouldDisplayPlanButton } = usePlansContext();
 
   const handleSelectSubscription = (subscription: __experimental_CommerceSubscriptionResource) => {
     handleSelectPlan({
@@ -68,12 +68,14 @@ export function SubscriptionsList() {
                 textAlign: 'right',
               })}
             >
-              <Button
-                size='xs'
-                textVariant='buttonSmall'
-                onClick={() => handleSelectSubscription(subscription)}
-                {...buttonPropsForPlan({ subscription })}
-              />
+              {shouldDisplayPlanButton({ subscription }) && (
+                <Button
+                  size='xs'
+                  textVariant='buttonSmall'
+                  onClick={() => handleSelectSubscription(subscription)}
+                  {...buttonPropsForPlan({ subscription })}
+                />
+              )}
             </Td>
           </Tr>
         ))}

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -166,7 +166,10 @@ export const usePlansContext = () => {
           ? subscription.canceledAt
             ? localizationKeys('__experimental_commerce.reSubscribe')
             : localizationKeys('__experimental_commerce.manageSubscription')
-          : localizationKeys('__experimental_commerce.getStarted'),
+          : // If there are no active or grace period subscriptions, show the get started button
+            ctx.subscriptions.length > 0
+            ? localizationKeys('__experimental_commerce.switchPlan')
+            : localizationKeys('__experimental_commerce.getStarted'),
         variant: isCompact || !!subscription ? 'bordered' : 'solid',
         colorScheme: isCompact || !!subscription ? 'secondary' : 'primary',
       };

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -148,6 +148,21 @@ export const usePlansContext = () => {
     return ctx.subscriptions.length === 0;
   }, [ctx.subscriptions]);
 
+  const shouldDisplayPlanButton = useCallback(
+    ({
+      plan,
+      subscription: sub,
+    }: {
+      plan?: __experimental_CommercePlanResource;
+      subscription?: __experimental_CommerceSubscriptionResource;
+    }) => {
+      const subscription = sub ?? (plan ? activeOrUpcomingSubscription(plan) : undefined);
+
+      return !subscription || !subscription.canceledAt;
+    },
+    [activeOrUpcomingSubscription],
+  );
+
   // return the CTA button props for a plan
   const buttonPropsForPlan = useCallback(
     ({
@@ -231,5 +246,6 @@ export const usePlansContext = () => {
     isDefaultPlanImplicitlyActive,
     handleSelectPlan,
     buttonPropsForPlan,
+    shouldDisplayPlanButton,
   };
 };


### PR DESCRIPTION
## Description

<img width="669" alt="image" src="https://github.com/user-attachments/assets/0e095bd5-71b1-4b57-ae4b-ca1949952e48" />


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
