### PR TITLE
chore(clerk-js,types): Split shared `CommerceTotals`

### DIFF
--- a/.changeset/nine-pets-learn.md
+++ b/.changeset/nine-pets-learn.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Split `CommerceTotals` to `CommerceCheckoutTotals` and `CommerceInvoiceTotals`.

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -1,8 +1,8 @@
 import type {
   __experimental_CommerceCheckoutJSON,
   __experimental_CommerceCheckoutResource,
+  __experimental_CommerceCheckoutTotals,
   __experimental_CommerceSubscriptionPlanPeriod,
-  __experimental_CommerceTotals,
   __experimental_ConfirmCheckoutParams,
 } from '@clerk/types';
 
@@ -24,7 +24,7 @@ export class __experimental_CommerceCheckout extends BaseResource implements __e
   planPeriod!: __experimental_CommerceSubscriptionPlanPeriod;
   status!: string;
   subscription?: __experimental_CommerceSubscription;
-  totals!: __experimental_CommerceTotals;
+  totals!: __experimental_CommerceCheckoutTotals;
 
   constructor(data: __experimental_CommerceCheckoutJSON, orgId?: string) {
     super();

--- a/packages/clerk-js/src/core/resources/CommerceInvoice.ts
+++ b/packages/clerk-js/src/core/resources/CommerceInvoice.ts
@@ -2,7 +2,7 @@ import type {
   __experimental_CommerceInvoiceJSON,
   __experimental_CommerceInvoiceResource,
   __experimental_CommerceInvoiceStatus,
-  __experimental_CommerceTotals,
+  __experimental_CommerceInvoiceTotals,
 } from '@clerk/types';
 
 import { commerceTotalsFromJSON } from '../../utils';
@@ -15,7 +15,7 @@ export class __experimental_CommerceInvoice extends BaseResource implements __ex
   paymentDueOn!: number;
   paidOn!: number;
   status!: __experimental_CommerceInvoiceStatus;
-  totals!: __experimental_CommerceTotals;
+  totals!: __experimental_CommerceInvoiceTotals;
 
   constructor(data: __experimental_CommerceInvoiceJSON) {
     super();

--- a/packages/clerk-js/src/utils/commerce.ts
+++ b/packages/clerk-js/src/utils/commerce.ts
@@ -1,8 +1,10 @@
 import type {
+  __experimental_CommerceCheckoutTotals,
+  __experimental_CommerceCheckoutTotalsJSON,
+  __experimental_CommerceInvoiceTotals,
+  __experimental_CommerceInvoiceTotalsJSON,
   __experimental_CommerceMoney,
   __experimental_CommerceMoneyJSON,
-  __experimental_CommerceTotals,
-  __experimental_CommerceTotalsJSON,
 } from '@clerk/types';
 
 export const commerceMoneyFromJSON = (data: __experimental_CommerceMoneyJSON): __experimental_CommerceMoney => {
@@ -14,11 +16,22 @@ export const commerceMoneyFromJSON = (data: __experimental_CommerceMoneyJSON): _
   };
 };
 
-export const commerceTotalsFromJSON = (data: __experimental_CommerceTotalsJSON): __experimental_CommerceTotals => {
-  return {
+export const commerceTotalsFromJSON = <
+  T extends __experimental_CommerceInvoiceTotalsJSON | __experimental_CommerceCheckoutTotalsJSON,
+>(
+  data: T,
+) => {
+  const totals = {
     grandTotal: commerceMoneyFromJSON(data.grand_total),
     subtotal: commerceMoneyFromJSON(data.subtotal),
     taxTotal: commerceMoneyFromJSON(data.tax_total),
-    totalDueNow: commerceMoneyFromJSON(data.total_due_now),
   };
+  if ('total_due_now' in data) {
+    // @ts-ignore
+    totals['totalDueNow'] = commerceMoneyFromJSON(data.total_due_now);
+  }
+
+  return totals as T extends { total_due_now: __experimental_CommerceMoneyJSON }
+    ? __experimental_CommerceCheckoutTotals
+    : __experimental_CommerceInvoiceTotals;
 };

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -114,7 +114,7 @@ export interface __experimental_CommerceInvoiceResource extends ClerkResource {
   id: string;
   planId: string;
   paymentSourceId: string;
-  totals: __experimental_CommerceTotals;
+  totals: __experimental_CommerceInvoiceTotals;
   paymentDueOn: number;
   paidOn: number;
   status: __experimental_CommerceInvoiceStatus;
@@ -142,12 +142,15 @@ export interface __experimental_CommerceMoney {
   currencySymbol: string;
 }
 
-export interface __experimental_CommerceTotals {
+export interface __experimental_CommerceCheckoutTotals {
   subtotal: __experimental_CommerceMoney;
   grandTotal: __experimental_CommerceMoney;
   taxTotal: __experimental_CommerceMoney;
   totalDueNow: __experimental_CommerceMoney;
 }
+
+export interface __experimental_CommerceInvoiceTotals
+  extends Omit<__experimental_CommerceCheckoutTotals, 'totalDueNow'> {}
 
 export type __experimental_CreateCheckoutParams = WithOptionalOrgType<{
   planId: string;
@@ -167,7 +170,7 @@ export interface __experimental_CommerceCheckoutResource extends ClerkResource {
   plan: __experimental_CommercePlanResource;
   planPeriod: __experimental_CommerceSubscriptionPlanPeriod;
   status: string;
-  totals: __experimental_CommerceTotals;
+  totals: __experimental_CommerceCheckoutTotals;
   subscription?: __experimental_CommerceSubscriptionResource;
   confirm: (params: __experimental_ConfirmCheckoutParams) => Promise<__experimental_CommerceCheckoutResource>;
 }

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -149,6 +149,7 @@ export interface __experimental_CommerceCheckoutTotals {
   totalDueNow: __experimental_CommerceMoney;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface __experimental_CommerceInvoiceTotals
   extends Omit<__experimental_CommerceCheckoutTotals, 'totalDueNow'> {}
 

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -677,6 +677,7 @@ export interface __experimental_CommerceCheckoutTotalsJSON {
   total_due_now: __experimental_CommerceMoneyJSON;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface __experimental_CommerceInvoiceTotalsJSON
   extends Omit<__experimental_CommerceCheckoutTotalsJSON, 'total_due_now'> {}
 

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -648,7 +648,7 @@ export interface __experimental_CommerceInvoiceJSON extends ClerkResourceJSON {
   payment_source_id: string;
   plan_id: string;
   status: __experimental_CommerceInvoiceStatus;
-  totals: __experimental_CommerceTotalsJSON;
+  totals: __experimental_CommerceInvoiceTotalsJSON;
 }
 
 export interface __experimental_CommerceSubscriptionJSON extends ClerkResourceJSON {
@@ -670,12 +670,15 @@ export interface __experimental_CommerceMoneyJSON {
   currency_symbol: string;
 }
 
-export interface __experimental_CommerceTotalsJSON {
+export interface __experimental_CommerceCheckoutTotalsJSON {
   grand_total: __experimental_CommerceMoneyJSON;
   subtotal: __experimental_CommerceMoneyJSON;
   tax_total: __experimental_CommerceMoneyJSON;
   total_due_now: __experimental_CommerceMoneyJSON;
 }
+
+export interface __experimental_CommerceInvoiceTotalsJSON
+  extends Omit<__experimental_CommerceCheckoutTotalsJSON, 'total_due_now'> {}
 
 export interface __experimental_CommerceCheckoutJSON extends ClerkResourceJSON {
   object: 'commerce_checkout';
@@ -688,5 +691,5 @@ export interface __experimental_CommerceCheckoutJSON extends ClerkResourceJSON {
   plan_period: __experimental_CommerceSubscriptionPlanPeriod;
   status: string;
   subscription?: __experimental_CommerceSubscriptionJSON;
-  totals: __experimental_CommerceTotalsJSON;
+  totals: __experimental_CommerceCheckoutTotalsJSON;
 }


### PR DESCRIPTION
## Description

Split `CommerceTotals` to `CommerceCheckoutTotals` and `CommerceInvoiceTotals`

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
