### PR TITLE
feat(clerk-js): Add retry if 500 errors for confirmation checkout request

### DIFF
--- a/.changeset/soft-schools-bake.md
+++ b/.changeset/soft-schools-bake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Retry confrim checkout requests if any erros with >=500 status code occur

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -437,7 +437,7 @@
     <script
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
-      data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
+      data-clerk-publishable-key="pk_test_dG9sZXJhbnQtcmVpbmRlZXItNjcuY2xlcmsuYWNjb3VudHNzdGFnZS5kZXYk"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -437,7 +437,7 @@
     <script
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
-      data-clerk-publishable-key="pk_test_dG9sZXJhbnQtcmVpbmRlZXItNjcuY2xlcmsuYWNjb3VudHNzdGFnZS5kZXYk"
+      data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -69,7 +69,7 @@ export class __experimental_CommerceCheckout extends BaseResource implements __e
           body: rest as any,
         }),
       {
-        factor: 1.55,
+        factor: 1.45,
         maxDelayBetweenRetries: 5 * 1_000,
         initialDelay: 2 * 1_000,
         jitter: false,

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -58,8 +58,8 @@ export class __experimental_CommerceCheckout extends BaseResource implements __e
     const { orgId, ...rest } = params;
 
     // Retry confirmation in case of a 500 error
-    // This will retry up to 6 times with an increasing delay
-    // It retries at 2s, 5s, ~9s, ~14s, ~19s, and ~24s after the initial attempt.
+    // This will retry up to 3 times with an increasing delay
+    // It retries at 2s, 4s, 6s and 8s
     return retry(
       () =>
         this._basePatch({
@@ -69,13 +69,13 @@ export class __experimental_CommerceCheckout extends BaseResource implements __e
           body: rest as any,
         }),
       {
-        factor: 1.45,
-        maxDelayBetweenRetries: 5 * 1_000,
+        factor: 1.1,
+        maxDelayBetweenRetries: 2 * 1_000,
         initialDelay: 2 * 1_000,
         jitter: false,
         shouldRetry(error: any, iterations: number) {
           const status = error?.status;
-          return !!status && status >= 500 && iterations <= 6;
+          return !!status && status >= 500 && iterations <= 4;
         },
       },
     );

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -74,7 +74,6 @@ export class __experimental_CommerceCheckout extends BaseResource implements __e
         initialDelay: 2 * 1_000,
         jitter: false,
         shouldRetry(error: any, iterations: number) {
-          console.error('Retrying checkout confirmation', error);
           const status = error?.status;
           return !!status && status >= 500 && iterations <= 6;
         },

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -1,3 +1,4 @@
+import { retry } from '@clerk/shared/retry';
 import type {
   __experimental_CommerceCheckoutJSON,
   __experimental_CommerceCheckoutResource,
@@ -13,7 +14,6 @@ import {
   __experimental_CommerceSubscription,
   BaseResource,
 } from './internal';
-import { retry } from '@clerk/shared/retry';
 
 export class __experimental_CommerceCheckout extends BaseResource implements __experimental_CommerceCheckoutResource {
   id!: string;


### PR DESCRIPTION
## Description

Adding retries when any errors with >=500 status code occur

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
