### PR TITLE
fix(clerk-js): Reset ul list styling within pricing table and plan details

### DIFF
--- a/.changeset/rare-memes-count.md
+++ b/.changeset/rare-memes-count.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix list spacing within PricingTable and PlanDetails components.

--- a/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
+++ b/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
@@ -151,6 +151,7 @@ const _PlanDetails = ({
               display: 'grid',
               rowGap: t.space.$6,
               padding: t.space.$4,
+              margin: 0,
             })}
           >
             {features.map(feature => (

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -470,6 +470,8 @@ const CardFeaturesList = React.forwardRef<HTMLDivElement, CardFeaturesListProps>
         sx={t => ({
           flex: '1',
           rowGap: isCompact ? t.space.$2 : t.space.$3,
+          margin: 0,
+          padding: 0,
         })}
       >
         {plan.features.slice(0, hasMoreFeatures ? (isCompact ? 3 : 8) : totalFeatures).map(feature => (
@@ -482,6 +484,8 @@ const CardFeaturesList = React.forwardRef<HTMLDivElement, CardFeaturesListProps>
               display: 'flex',
               alignItems: 'baseline',
               gap: t.space.$2,
+              margin: 0,
+              padding: 0,
             })}
           >
             <Icon


### PR DESCRIPTION
## Description

Noticed some unintentional spacing within staging AP.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-04-29 at 11 24 37 AM](https://github.com/user-attachments/assets/1fc7e74f-781d-4f4c-a5b8-1c04b92f8e77) | ![Screenshot 2025-04-29 at 11 24 58 AM](https://github.com/user-attachments/assets/a7da3014-5bff-4b9f-897a-44fd228754ee) | 
| ![Screenshot 2025-04-29 at 11 25 14 AM](https://github.com/user-attachments/assets/bb52e04e-aac2-4f0e-a871-2d2df112e1a4) | ![Screenshot 2025-04-29 at 11 25 35 AM](https://github.com/user-attachments/assets/f89cb3f1-a007-42fd-98ff-e27309078cd3) | 


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
