### PR TITLE
chore(astro): Introduce `treatPendingAsSignedOut` option to server-side utilities

### DIFF
--- a/.changeset/sixty-carpets-stare.md
+++ b/.changeset/sixty-carpets-stare.md
@@ -1,10 +1,18 @@
 ---
-'@clerk/astro': patch
+'@clerk/astro': minor
 ---
 
 Introduce `treatPendingAsSignedOut` option to `getAuth` and `auth` from `clerkMiddleware`
 
+By default, `treatPendingAsSignedOut` is set to `true`, which means pending sessions are treated as signed-out. You can set this option to `false` to treat pending sessions as authenticated.
+
 ```ts
+// `pending` sessions will be treated as signed-out by default
+const { userId } = getAuth(req, locals)
+```
+
+```ts
+// Both `active` and `pending` sessions will be treated as authenticated when `treatPendingAsSignedOut` is false
 const { userId } = getAuth(req, locals, { treatPendingAsSignedOut: false })
 ```
 

--- a/.changeset/sixty-carpets-stare.md
+++ b/.changeset/sixty-carpets-stare.md
@@ -1,0 +1,20 @@
+---
+'@clerk/astro': patch
+---
+
+Introduce `treatPendingAsSignedOut` option to `getAuth` and `auth` from `clerkMiddleware`
+
+```ts
+const { userId } = getAuth(req, locals, { treatPendingAsSignedOut: false })
+```
+
+```ts
+clerkMiddleware((auth, context) => {
+  const { redirectToSignIn, userId } = auth({ treatPendingAsSignedOut: false })
+
+  // Both `active` and `pending` sessions will be treated as authenticated when `treatPendingAsSignedOut` is false
+  if (!userId && isProtectedRoute(context.request)) {
+    return redirectToSignIn()
+  }
+})
+```

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -5,6 +5,7 @@ import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
 import { handleNetlifyCacheInDevInstance } from '@clerk/shared/netlifyCacheHandler';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
 import { handleValueOrFn } from '@clerk/shared/utils';
+import type { PendingSessionOptions } from '@clerk/types';
 import type { APIContext } from 'astro';
 
 import { authAsyncStorage } from '#async-local-storage';
@@ -244,8 +245,8 @@ function decorateAstroLocal(clerkRequest: ClerkRequest, context: APIContext, req
   context.locals.authStatus = status;
   context.locals.authMessage = message;
   context.locals.authReason = reason;
-  context.locals.auth = () => {
-    const authObject = getAuth(clerkRequest, context.locals);
+  context.locals.auth = ({ treatPendingAsSignedOut }: PendingSessionOptions = {}) => {
+    const authObject = getAuth(clerkRequest, context.locals, { treatPendingAsSignedOut });
 
     const clerkUrl = clerkRequest.clerkUrl;
 

--- a/packages/astro/src/server/get-auth.ts
+++ b/packages/astro/src/server/get-auth.ts
@@ -1,6 +1,7 @@
 import type { AuthObject } from '@clerk/backend';
 import { AuthStatus, signedInAuthObject, signedOutAuthObject } from '@clerk/backend/internal';
 import { decodeJwt } from '@clerk/backend/jwt';
+import type { PendingSessionOptions } from '@clerk/types';
 import type { APIContext } from 'astro';
 
 import { getSafeEnv } from './get-safe-env';
@@ -9,7 +10,11 @@ import { getAuthKeyFromRequest } from './utils';
 export type GetAuthReturn = AuthObject;
 
 export const createGetAuth = ({ noAuthStatusMessage }: { noAuthStatusMessage: string }) => {
-  return (req: Request, locals: APIContext['locals'], opts?: { secretKey?: string }): GetAuthReturn => {
+  return (
+    req: Request,
+    locals: APIContext['locals'],
+    { treatPendingAsSignedOut = true, ...opts }: { secretKey?: string } & PendingSessionOptions = {},
+  ): GetAuthReturn => {
     // When the auth status is set, we trust that the middleware has already run
     // Then, we don't have to re-verify the JWT here,
     // we can just strip out the claims manually.
@@ -31,13 +36,21 @@ export const createGetAuth = ({ noAuthStatusMessage }: { noAuthStatusMessage: st
       authReason,
     };
 
+    let authObject;
+
     if (authStatus !== AuthStatus.SignedIn) {
-      return signedOutAuthObject(options);
+      authObject = signedOutAuthObject(options);
     }
 
     const jwt = decodeJwt(authToken as string);
-    // @ts-expect-error - TODO: Align types
-    return signedInAuthObject(options, jwt.raw.text, jwt.payload);
+    // @ts-expect-error -- Restrict parameter type of options to only list what's needed
+    authObject = signedInAuthObject(options, jwt.raw.text, jwt.payload);
+
+    if (treatPendingAsSignedOut && authObject.sessionStatus === 'pending') {
+      authObject = signedOutAuthObject(options);
+    }
+
+    return authObject;
   };
 };
 

--- a/packages/astro/src/server/get-auth.ts
+++ b/packages/astro/src/server/get-auth.ts
@@ -36,18 +36,16 @@ export const createGetAuth = ({ noAuthStatusMessage }: { noAuthStatusMessage: st
       authReason,
     };
 
-    let authObject;
-
     if (authStatus !== AuthStatus.SignedIn) {
-      authObject = signedOutAuthObject(options);
+      return signedOutAuthObject(options);
     }
 
     const jwt = decodeJwt(authToken as string);
-    // @ts-expect-error -- Restrict parameter type of options to only list what's needed
-    authObject = signedInAuthObject(options, jwt.raw.text, jwt.payload);
+    // @ts-expect-error - TODO: Align types
+    const authObject = signedInAuthObject(options, jwt.raw.text, jwt.payload);
 
     if (treatPendingAsSignedOut && authObject.sessionStatus === 'pending') {
-      authObject = signedOutAuthObject(options);
+      return signedOutAuthObject(options);
     }
 
     return authObject;


### PR DESCRIPTION
## Description

Allow passing `treatPendingAsSignedOut` to `auth`, `getAuth`, and server-side control components.

```ts
const { userId } = getAuth(req, { treatPendingAsSignedOut: false })
```

```ts
clerkMiddleware((auth, context) => {
  const { redirectToSignIn, userId } = auth({ treatPendingAsSignedOut: false })

  // Both `active` and `pending` sessions will be treated as authenticated when `treatPendingAsSignedOut` is false
  if (!userId && isProtectedRoute(context.request)) {
    return redirectToSignIn()
  }
})
```


## Checklist

- [X] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
