### PR TITLE
fix(clerk-js): Correct chips entry point

### DIFF
--- a/.changeset/eighty-singers-poke.md
+++ b/.changeset/eighty-singers-poke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Correct the entry point for the clerk.chips.browser.js bundle

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -26,7 +26,7 @@ const variantToSourceFile = {
   [variants.clerkHeadless]: './src/index.headless.ts',
   [variants.clerkHeadlessBrowser]: './src/index.headless.browser.ts',
   [variants.clerkLegacyBrowser]: './src/index.legacy.browser.ts',
-  [variants.clerkCHIPS]: './src/index.chips.ts',
+  [variants.clerkCHIPS]: './src/index.chips.browser.ts',
 };
 
 /**

--- a/packages/clerk-js/src/index.chips.browser.ts
+++ b/packages/clerk-js/src/index.chips.browser.ts
@@ -1,0 +1,36 @@
+// It's crucial this is the first import,
+// otherwise chunk loading will not work
+// eslint-disable-next-line
+import './utils/setWebpackChunkPublicPath';
+
+import { Clerk } from './core/clerk';
+
+import { mountComponentRenderer } from './ui/Components';
+
+Clerk.mountComponentRenderer = mountComponentRenderer;
+
+const publishableKey =
+  document.querySelector('script[data-clerk-publishable-key]')?.getAttribute('data-clerk-publishable-key') ||
+  window.__clerk_publishable_key ||
+  '';
+
+const proxyUrl =
+  document.querySelector('script[data-clerk-proxy-url]')?.getAttribute('data-clerk-proxy-url') ||
+  window.__clerk_proxy_url ||
+  '';
+
+const domain =
+  document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
+
+// Ensure that if the script has already been injected we don't overwrite the existing Clerk instance.
+if (!window.Clerk) {
+  window.Clerk = new Clerk(publishableKey, {
+    proxyUrl,
+    // @ts-expect-error
+    domain,
+  });
+}
+
+if (module.hot) {
+  module.hot.accept();
+}

--- a/packages/clerk-js/src/index.chips.ts
+++ b/packages/clerk-js/src/index.chips.ts
@@ -1,1 +1,0 @@
-export * from './index';


### PR DESCRIPTION
## Description

Correctly build the chips.browser variant. We were using clerk.js as a base, which is not a browser variant

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
