### PR TITLE
chore(clerk-js): Update qrcode.react to 4.2.0

### DIFF
--- a/.changeset/stale-waves-rhyme.md
+++ b/.changeset/stale-waves-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update dependency qrcode.react from 3.1.0 to 4.2.0. This fixes peer dependency warnings with React 19.

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -73,7 +73,7 @@
     "core-js": "3.41.0",
     "crypto-js": "^4.2.0",
     "dequal": "2.0.3",
-    "qrcode.react": "3.1.0",
+    "qrcode.react": "4.2.0",
     "regenerator-runtime": "0.13.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,8 +486,8 @@ importers:
         specifier: 2.0.3
         version: 2.0.3
       qrcode.react:
-        specifier: 3.1.0
-        version: 3.1.0(react@18.3.1)
+        specifier: 4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: catalog:peer-react
         version: 18.3.1
@@ -11867,10 +11867,10 @@ packages:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
 
-  qrcode.react@3.1.0:
-    resolution: {integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==}
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -28457,7 +28457,7 @@ snapshots:
 
   qrcode-terminal@0.11.0: {}
 
-  qrcode.react@3.1.0(react@18.3.1):
+  qrcode.react@4.2.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
## Description

This updates https://github.com/zpao/qrcode.react from 3.1.0 to 4.2.0 as 4.2.0 includes React 19 as a peerDep. The changelog for 4.0.0 is at https://github.com/zpao/qrcode.react/blob/trunk/CHANGELOG.md#400---2024-08-27. The breaking changes don't affect us as we already used the named import and didn't use the `style` prop.

Fixes ECO-621
Fixes https://github.com/clerk/javascript/issues/5752

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
