### PR TITLE
fix(clerk-js): Retry checkout confirm if there is another checkout already in progress

### DIFF
--- a/.changeset/eighty-windows-grow.md
+++ b/.changeset/eighty-windows-grow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Retry checkout confirmation if there is another checkout in progress


### PR DESCRIPTION
## Description

This PR adds the logic to retry the checkout confirmation request if there is another checkout already in progress

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
