### PR TITLE
fix(clerk-js): Force SameSite=none for chips

### DIFF
--- a/.changeset/hungry-foxes-sell.md
+++ b/.changeset/hungry-foxes-sell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Forcing \_\_session cookie to have SameSite=none attribute in the CHIPS build variant

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -29,7 +29,7 @@ export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler 
 
   const set = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : (inCrossOriginIframe() ? 'None' : 'Lax');
+    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() ? 'None' : 'Lax';
     const secure = getSecureAttribute(sameSite);
     const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
 

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -29,9 +29,9 @@ export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler 
 
   const set = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
+    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() ? 'None' : 'Lax';
     const secure = getSecureAttribute(sameSite);
-    const partitioned = __BUILD_VARIANT_CHIPS__ && secure && sameSite === 'None';
+    const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
 
     // If setting Partitioned to true, remove the existing session cookies.
     // This is to avoid conflicts with the same cookie name without Partitioned attribute.

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -29,7 +29,7 @@ export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler 
 
   const set = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() ? 'None' : 'Lax';
+    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : (inCrossOriginIframe() ? 'None' : 'Lax');
     const secure = getSecureAttribute(sameSite);
     const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
 


### PR DESCRIPTION
## Description

Staying standards compliant, and forcing SameSite=none for partitioned cookies

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
