### PR TITLE
fix(clerk-js): Fix PricingTable spacing within profile components

### DIFF
--- a/.changeset/clever-parts-build.md
+++ b/.changeset/clever-parts-build.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue within profile components where the ProfileBox was removed when mounting the pricing table component causing padding issues.

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
@@ -13,7 +13,7 @@ import { FreePlanRow } from './FreePlanRow';
 import { PricingTableDefault } from './PricingTableDefault';
 import { PricingTableMatrix } from './PricingTableMatrix';
 
-const PricingTable = (props: __experimental_PricingTableProps) => {
+const PricingTableRoot = (props: __experimental_PricingTableProps) => {
   const clerk = useClerk();
   const { mode = 'mounted' } = usePricingTableContext();
   const subscriberType = useSubscriberTypeContext();
@@ -72,6 +72,23 @@ const PricingTable = (props: __experimental_PricingTableProps) => {
       )}
     </Flow.Root>
   );
+};
+
+// When used in a modal, we need to wrap the root in a div to avoid layout issues
+// within UserProfile and OrganizationProfile.
+const PricingTableModal = (props: __experimental_PricingTableProps) => {
+  return (
+    // TODO: Used by InvisibleRootBox, can we simplify?
+    <div>
+      <PricingTableRoot {...props} />
+    </div>
+  );
+};
+
+const PricingTable = (props: __experimental_PricingTableProps) => {
+  const { mode = 'mounted' } = usePricingTableContext();
+
+  return mode === 'modal' ? <PricingTableModal {...props} /> : <PricingTableRoot {...props} />;
 };
 
 export const __experimental_PricingTable = PricingTable;


### PR DESCRIPTION
## Description

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-04-30 at 5 41 16 PM](https://github.com/user-attachments/assets/235c9502-e978-4a8c-965c-2026bedfadce) | ![Screenshot 2025-04-30 at 5 40 39 PM](https://github.com/user-attachments/assets/f556b4c7-82f8-4b60-be58-d74ba1c02371) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
