### PR TITLE
fix(clerk-js): Add Partitioned to __client_uat in CHIPS build

### DIFF
--- a/.changeset/giant-owls-cut.md
+++ b/.changeset/giant-owls-cut.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Adding Partitioned attribute to \_\_client_uat cookie in CHIPS build variant

--- a/packages/clerk-js/src/core/auth/cookies/__tests__/clientUat.test.ts
+++ b/packages/clerk-js/src/core/auth/cookies/__tests__/clientUat.test.ts
@@ -1,0 +1,127 @@
+import { createClientUatCookie } from '../clientUat';
+import { createCookieHandler } from '@clerk/shared/cookie';
+import { addYears } from '@clerk/shared/date';
+import { inCrossOriginIframe } from '../../../../utils';
+import { getCookieDomain } from '../../getCookieDomain';
+import { getSecureAttribute } from '../../getSecureAttribute';
+
+// Mock dependencies
+jest.mock('@clerk/shared/cookie');
+jest.mock('@clerk/shared/date');
+jest.mock('../../../../utils');
+jest.mock('../../getCookieDomain');
+jest.mock('../../getSecureAttribute');
+
+describe('createClientUatCookie', () => {
+  const mockCookieSuffix = 'test-suffix';
+  const mockExpires = new Date('2024-12-31');
+  const mockDomain = 'test.domain';
+  const mockSet = jest.fn();
+  const mockRemove = jest.fn();
+  const mockGet = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReset();
+    (addYears as jest.Mock).mockReturnValue(mockExpires);
+    (inCrossOriginIframe as jest.Mock).mockReturnValue(false);
+    (getCookieDomain as jest.Mock).mockReturnValue(mockDomain);
+    (getSecureAttribute as jest.Mock).mockReturnValue(true);
+    (createCookieHandler as jest.Mock).mockImplementation(() => ({
+      set: mockSet,
+      remove: mockRemove,
+      get: mockGet,
+    }));
+  });
+
+  it('should create both suffixed and non-suffixed cookie handlers', () => {
+    createClientUatCookie(mockCookieSuffix);
+    expect(createCookieHandler).toHaveBeenCalledTimes(2);
+    expect(createCookieHandler).toHaveBeenCalledWith('__client_uat');
+    expect(createCookieHandler).toHaveBeenCalledWith('__client_uat_test-suffix');
+  });
+
+  it('should set cookies with correct parameters in non-cross-origin context', () => {
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    cookieHandler.set({
+      id: 'test-client',
+      updatedAt: new Date('2024-01-01'),
+      signedInSessions: ['session1'],
+    });
+
+    expect(mockSet).toHaveBeenCalledTimes(2);
+    expect(mockSet).toHaveBeenCalledWith('1704067200', {
+      domain: mockDomain,
+      expires: mockExpires,
+      sameSite: 'Strict',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should set cookies with None sameSite in cross-origin context', () => {
+    (inCrossOriginIframe as jest.Mock).mockReturnValue(true);
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    cookieHandler.set({
+      id: 'test-client',
+      updatedAt: new Date('2024-01-01'),
+      signedInSessions: ['session1'],
+    });
+
+    expect(mockSet).toHaveBeenCalledWith('1704067200', {
+      domain: mockDomain,
+      expires: mockExpires,
+      sameSite: 'None',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should set value to 0 when client is undefined', () => {
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    cookieHandler.set(undefined);
+
+    expect(mockSet).toHaveBeenCalledWith('0', {
+      domain: mockDomain,
+      expires: mockExpires,
+      sameSite: 'Strict',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should set value to 0 when client has no signed in sessions', () => {
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    cookieHandler.set({
+      id: 'test-client',
+      updatedAt: new Date('2024-01-01'),
+      signedInSessions: [],
+    });
+
+    expect(mockSet).toHaveBeenCalledWith('0', {
+      domain: mockDomain,
+      expires: mockExpires,
+      sameSite: 'Strict',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should get cookie value from suffixed cookie first, then fallback to non-suffixed', () => {
+    mockGet.mockImplementationOnce(() => '1234567890').mockImplementationOnce(() => '9876543210');
+
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    const result = cookieHandler.get();
+
+    expect(result).toBe(1234567890);
+  });
+
+  it('should return 0 when no cookie value is present', () => {
+    mockGet.mockImplementationOnce(() => undefined).mockImplementationOnce(() => undefined);
+
+    const cookieHandler = createClientUatCookie(mockCookieSuffix);
+    const result = cookieHandler.get();
+
+    expect(result).toBe(0);
+  });
+});

--- a/packages/clerk-js/src/core/auth/cookies/__tests__/clientUat.test.ts
+++ b/packages/clerk-js/src/core/auth/cookies/__tests__/clientUat.test.ts
@@ -1,11 +1,11 @@
-import { createClientUatCookie } from '../clientUat';
 import { createCookieHandler } from '@clerk/shared/cookie';
 import { addYears } from '@clerk/shared/date';
+
 import { inCrossOriginIframe } from '../../../../utils';
 import { getCookieDomain } from '../../getCookieDomain';
 import { getSecureAttribute } from '../../getSecureAttribute';
+import { createClientUatCookie } from '../clientUat';
 
-// Mock dependencies
 jest.mock('@clerk/shared/cookie');
 jest.mock('@clerk/shared/date');
 jest.mock('../../../../utils');

--- a/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
+++ b/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
@@ -1,0 +1,91 @@
+import { createSessionCookie } from '../session';
+import { createCookieHandler } from '@clerk/shared/cookie';
+import { addYears } from '@clerk/shared/date';
+import { inCrossOriginIframe } from '../../../../utils';
+import { getSecureAttribute } from '../../getSecureAttribute';
+
+// Mock dependencies
+jest.mock('@clerk/shared/cookie');
+jest.mock('@clerk/shared/date');
+jest.mock('../../../../utils');
+jest.mock('../../getSecureAttribute');
+
+describe('createSessionCookie', () => {
+  const mockCookieSuffix = 'test-suffix';
+  const mockToken = 'test-token';
+  const mockExpires = new Date('2024-12-31');
+  const mockSet = jest.fn();
+  const mockRemove = jest.fn();
+  const mockGet = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReset();
+    (addYears as jest.Mock).mockReturnValue(mockExpires);
+    (inCrossOriginIframe as jest.Mock).mockReturnValue(false);
+    (getSecureAttribute as jest.Mock).mockReturnValue(true);
+    (createCookieHandler as jest.Mock).mockImplementation(() => ({
+      set: mockSet,
+      remove: mockRemove,
+      get: mockGet,
+    }));
+  });
+
+  it('should create both suffixed and non-suffixed cookie handlers', () => {
+    createSessionCookie(mockCookieSuffix);
+    expect(createCookieHandler).toHaveBeenCalledTimes(2);
+    expect(createCookieHandler).toHaveBeenCalledWith('__session');
+    expect(createCookieHandler).toHaveBeenCalledWith('__session_test-suffix');
+  });
+
+  it('should set cookies with correct parameters in non-cross-origin context', () => {
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    cookieHandler.set(mockToken);
+
+    expect(mockSet).toHaveBeenCalledTimes(2);
+    expect(mockSet).toHaveBeenCalledWith(mockToken, {
+      expires: mockExpires,
+      sameSite: 'Lax',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should set cookies with None sameSite in cross-origin context', () => {
+    (inCrossOriginIframe as jest.Mock).mockReturnValue(true);
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    cookieHandler.set(mockToken);
+
+    expect(mockSet).toHaveBeenCalledWith(mockToken, {
+      expires: mockExpires,
+      sameSite: 'None',
+      secure: true,
+      partitioned: false,
+    });
+  });
+
+  it('should remove both cookies when remove is called', () => {
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    cookieHandler.remove();
+
+    expect(mockRemove).toHaveBeenCalledTimes(2);
+  });
+
+  it('should get cookie value from suffixed cookie first, then fallback to non-suffixed', () => {
+    mockGet.mockImplementationOnce(() => 'suffixed-value').mockImplementationOnce(() => 'non-suffixed-value');
+
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    const result = cookieHandler.get();
+
+    expect(result).toBe('suffixed-value');
+  });
+
+  it('should fallback to non-suffixed cookie when suffixed cookie is not present', () => {
+    mockGet.mockImplementationOnce(() => undefined).mockImplementationOnce(() => 'non-suffixed-value');
+
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    const result = cookieHandler.get();
+
+    expect(result).toBe('non-suffixed-value');
+  });
+});

--- a/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
+++ b/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
@@ -1,10 +1,10 @@
-import { createSessionCookie } from '../session';
 import { createCookieHandler } from '@clerk/shared/cookie';
 import { addYears } from '@clerk/shared/date';
+
 import { inCrossOriginIframe } from '../../../../utils';
 import { getSecureAttribute } from '../../getSecureAttribute';
+import { createSessionCookie } from '../session';
 
-// Mock dependencies
 jest.mock('@clerk/shared/cookie');
 jest.mock('@clerk/shared/date');
 jest.mock('../../../../utils');

--- a/packages/clerk-js/src/core/auth/cookies/clientUat.ts
+++ b/packages/clerk-js/src/core/auth/cookies/clientUat.ts
@@ -37,8 +37,9 @@ export const createClientUatCookie = (cookieSuffix: string): ClientUatCookieHand
      * Generally, this is handled by redirectWithAuth() being called and relying on the dev browser ID in the URL,
      * but if that isn't used we rely on this. In production, nothing is cross-domain and Lax is used when client_uat is set from FAPI.
      */
-    const sameSite = inCrossOriginIframe() ? 'None' : 'Strict';
+    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() ? 'None' : 'Strict';
     const secure = getSecureAttribute(sameSite);
+    const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
     const domain = getCookieDomain();
 
     // '0' indicates the user is signed out
@@ -53,8 +54,8 @@ export const createClientUatCookie = (cookieSuffix: string): ClientUatCookieHand
     suffixedClientUatCookie.remove();
     clientUatCookie.remove();
 
-    suffixedClientUatCookie.set(val, { expires, sameSite, domain, secure });
-    clientUatCookie.set(val, { expires, sameSite, domain, secure });
+    suffixedClientUatCookie.set(val, { domain, expires, partitioned, sameSite, secure });
+    clientUatCookie.set(val, { domain, expires, partitioned, sameSite, secure });
   };
 
   return {


### PR DESCRIPTION
## Description

Looks like this was missed in the initial change to send the Partitioned attribute for the `__session` cookie

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
