### PR TITLE
fix(backend): Rename constant to match value

### DIFF
--- a/.changeset/chubby-geese-arrive.md
+++ b/.changeset/chubby-geese-arrive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Renaming DEFAULT_CLOCK_SKEW_IN_SECONDS to DEFAULT_CLOCK_SKEW_IN_MS which is the actual value

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -17,7 +17,7 @@ import {
 import { importKey } from './cryptoKeys';
 import type { JwtReturnType } from './types';
 
-const DEFAULT_CLOCK_SKEW_IN_SECONDS = 5 * 1000;
+const DEFAULT_CLOCK_SKEW_IN_MS = 5 * 1000;
 
 export async function hasValidSignature(jwt: Jwt, key: JsonWebKey | string): Promise<JwtReturnType<boolean, Error>> {
   const { header, signature, raw } = jwt;
@@ -126,7 +126,7 @@ export async function verifyJwt(
   options: VerifyJwtOptions,
 ): Promise<JwtReturnType<JwtPayload, TokenVerificationError>> {
   const { audience, authorizedParties, clockSkewInMs, key } = options;
-  const clockSkew = clockSkewInMs || DEFAULT_CLOCK_SKEW_IN_SECONDS;
+  const clockSkew = clockSkewInMs || DEFAULT_CLOCK_SKEW_IN_MS;
 
   const { data: decoded, errors } = decodeJwt(token);
   if (errors) {


### PR DESCRIPTION
## Description

Renaming `DEFAULT_CLOCK_SKEW_IN_SECONDS` to `DEFAULT_CLOCK_SKEW_IN_MS` which is the actual value

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
