### PR TITLE
fix(clerk-js): Use the credit amount from FAPI for credit proration checkout flow

### DIFF
--- a/.changeset/fuzzy-donkeys-post.md
+++ b/.changeset/fuzzy-donkeys-post.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Use the `total.proration.credit` to show the proration credit on checkout flow

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -437,7 +437,7 @@
     <script
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
-      data-clerk-publishable-key="pk_test_Z2FtZS1tYWdwaWUtMTkuY2xlcmsuYWNjb3VudHNzdGFnZS5kZXYk"
+      data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -437,7 +437,7 @@
     <script
       type="text/javascript"
       src="/<%= htmlRspackPlugin.files.js[0] %>"
-      data-clerk-publishable-key="pk_test_dG91Y2hlZC1sYWR5YmlyZC0yMy5jbGVyay5hY2NvdW50cy5kZXYk"
+      data-clerk-publishable-key="pk_test_Z2FtZS1tYWdwaWUtMTkuY2xlcmsuYWNjb3VudHNzdGFnZS5kZXYk"
     ></script>
     <script
       type="text/javascript"

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -31,9 +31,8 @@ export const CheckoutForm = ({
   onCheckoutComplete: (checkout: __experimental_CommerceCheckoutResource) => void;
 }) => {
   const { plan, planPeriod, totals, isImmediatePlanChange } = checkout;
-
-  const adjustmentAmount = (totals.proration?.days || 0) * (totals.proration?.ratePerDay.amount || 0);
-  const showAdjustment = totals.totalDueNow.amount > 0 && adjustmentAmount > 0;
+  const showAdjustment =
+    totals.totalDueNow.amount > 0 && totals.proration?.credit?.amount && totals.proration.credit.amount > 0;
   const showDowngradeInfo = !isImmediatePlanChange;
 
   return (
@@ -78,7 +77,7 @@ export const CheckoutForm = ({
               {/* TODO(@Commerce): needs localization */}
               {/* TODO(@Commerce): Replace client-side calculation with server-side calculation once data are available in the response */}
               <LineItems.Description
-                text={`- ${totals.proration?.totalProration.currencySymbol}${adjustmentAmount / 100}`}
+                text={`- ${totals.proration?.credit.currencySymbol}${totals.proration?.credit.amountFormatted}`}
               />
             </LineItems.Group>
           )}

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -71,7 +71,7 @@ export const CheckoutForm = ({
             <LineItems.Group>
               {/* TODO(@Commerce): needs localization */}
               <LineItems.Title
-                title={'Adjustment'}
+                title={'Credit'}
                 description={'Prorated credit for the remainder of your subscription.'}
               />
               {/* TODO(@Commerce): needs localization */}

--- a/packages/clerk-js/src/utils/commerce.ts
+++ b/packages/clerk-js/src/utils/commerce.ts
@@ -39,6 +39,8 @@ export const commerceTotalsFromJSON = <
       ratePerDay: commerceMoneyFromJSON(data.proration.rate_per_day),
       // @ts-ignore
       totalProration: commerceMoneyFromJSON(data.proration.total_proration),
+      // @ts-ignore
+      credit: commerceMoneyFromJSON(data.proration.credit),
     };
   }
 

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -151,6 +151,7 @@ export interface __experimental_CommerceCheckoutTotals {
     days: number;
     ratePerDay: __experimental_CommerceMoney;
     totalProration: __experimental_CommerceMoney;
+    credit: __experimental_CommerceMoney;
   };
 }
 


### PR DESCRIPTION
## Description

Use the `totals.proration.credit` for showing the proration credit in the checkout flows

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
