### PR TITLE
fix(clerk-js): User total due now in checkout flows instead of grand total

### DIFF
--- a/.changeset/shaky-parents-type.md
+++ b/.changeset/shaky-parents-type.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove `totals.grandTotal` from checkout flows

--- a/.changeset/shaky-parents-type.md
+++ b/.changeset/shaky-parents-type.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Remove `totals.grandTotal` from checkout flows
+Remove usage of `totals.grandTotal` from checkout flows

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
@@ -107,7 +107,7 @@ export const CheckoutComplete = ({ checkout }: { checkout: __experimental_Commer
           <LineItems.Group variant='secondary'>
             <LineItems.Title title={localizationKeys('__experimental_commerce.checkout.lineItems.title__totalPaid')} />
             <LineItems.Description
-              text={`${checkout.totals.grandTotal.currencySymbol}${checkout.totals.grandTotal.amountFormatted}`}
+              text={`${checkout.totals.totalDueNow.currencySymbol}${checkout.totals.totalDueNow.amountFormatted}`}
             />
           </LineItems.Group>
           <LineItems.Group variant='secondary'>

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -96,14 +96,8 @@ export const CheckoutForm = ({
           </LineItems.Group>
           <LineItems.Group borderTop>
             {/* TODO(@Commerce): needs localization */}
-            <LineItems.Title title={`Total${totals.totalDueNow ? ' Due Today' : ''}`} />
-            <LineItems.Description
-              text={`${
-                totals.totalDueNow
-                  ? `${totals.totalDueNow.currencySymbol}${totals.totalDueNow.amountFormatted}`
-                  : `${totals.grandTotal.currencySymbol}${totals.grandTotal.amountFormatted}`
-              }`}
-            />
+            <LineItems.Title title={`Total Due Today`} />
+            <LineItems.Description text={`${totals.totalDueNow.currencySymbol}${totals.totalDueNow.amountFormatted}`} />
           </LineItems.Group>
         </LineItems.Root>
       </Box>

--- a/packages/clerk-js/src/utils/commerce.ts
+++ b/packages/clerk-js/src/utils/commerce.ts
@@ -22,10 +22,14 @@ export const commerceTotalsFromJSON = <
   data: T,
 ) => {
   const totals = {
-    grandTotal: commerceMoneyFromJSON(data.grand_total),
     subtotal: commerceMoneyFromJSON(data.subtotal),
     taxTotal: commerceMoneyFromJSON(data.tax_total),
   };
+  if ('grandTotal' in data) {
+    // @ts-ignore
+    totals['grandTotal'] = commerceMoneyFromJSON(data.grand_total);
+  }
+
   if ('total_due_now' in data) {
     // @ts-ignore
     totals['totalDueNow'] = commerceMoneyFromJSON(data.total_due_now);


### PR DESCRIPTION
## Description

This PR changes all the usages of `grand_total` with `total_due_now`

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
