### PR TITLE
chore(clerk-js): Adjust the checkout line item rows

### DIFF
--- a/.changeset/stupid-animals-taste.md
+++ b/.changeset/stupid-animals-taste.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Adjusts the order and layout of the checkout form's line items

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
@@ -130,15 +130,6 @@ export const CheckoutComplete = ({ checkout }: { checkout: __experimental_Commer
               }
             />
           </LineItems.Group>
-          <LineItems.Group variant='tertiary'>
-            <LineItems.Title title={localizationKeys('__experimental_commerce.checkout.lineItems.title__invoiceId')} />
-            <LineItems.Description
-              text={checkout.invoice_id || '–'}
-              truncateText
-              copyText
-              copyLabel='Copy invoice ID'
-            />
-          </LineItems.Group>
         </LineItems.Root>
         <Button
           onClick={handleClose}

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -78,7 +78,7 @@ export const CheckoutForm = ({
           {showCredits && (
             <LineItems.Group variant='tertiary'>
               {/* TODO(@Commerce): needs localization */}
-              <LineItems.Title title={'Prorated credit for the remainder of your subscription.'} />
+              <LineItems.Title title={'Credit for the remainder of your current subscription.'} />
               {/* TODO(@Commerce): needs localization */}
               {/* TODO(@Commerce): Replace client-side calculation with server-side calculation once data are available in the response */}
               <LineItems.Description

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -67,13 +67,18 @@ export const CheckoutForm = ({
               suffix={`per month${planPeriod === 'annual' ? ', times 12 months' : ''}`}
             />
           </LineItems.Group>
+          <LineItems.Group
+            borderTop
+            variant='tertiary'
+          >
+            {/* TODO(@Commerce): needs localization */}
+            <LineItems.Title title='Subtotal' />
+            <LineItems.Description text={`${totals.subtotal.currencySymbol}${totals.subtotal.amountFormatted}`} />
+          </LineItems.Group>
           {showCredits && (
-            <LineItems.Group>
+            <LineItems.Group variant='tertiary'>
               {/* TODO(@Commerce): needs localization */}
-              <LineItems.Title
-                title={'Credit'}
-                description={'Prorated credit for the remainder of your subscription.'}
-              />
+              <LineItems.Title title={'Prorated credit for the remainder of your subscription.'} />
               {/* TODO(@Commerce): needs localization */}
               {/* TODO(@Commerce): Replace client-side calculation with server-side calculation once data are available in the response */}
               <LineItems.Description
@@ -81,19 +86,6 @@ export const CheckoutForm = ({
               />
             </LineItems.Group>
           )}
-          <LineItems.Group
-            borderTop
-            variant='tertiary'
-          >
-            {/* TODO(@Commerce): needs localization */}
-            <LineItems.Title title='Subtotal' />
-            <LineItems.Description text={`${totals.subtotal.currencySymbol} ${totals.subtotal.amountFormatted}`} />
-          </LineItems.Group>
-          <LineItems.Group variant='tertiary'>
-            {/* TODO(@Commerce): needs localization */}
-            <LineItems.Title title='Tax' />
-            <LineItems.Description text={`${totals.taxTotal.currencySymbol} ${totals.taxTotal.amountFormatted}`} />
-          </LineItems.Group>
           <LineItems.Group borderTop>
             {/* TODO(@Commerce): needs localization */}
             <LineItems.Title title={`Total Due Today`} />


### PR DESCRIPTION
## Description

Adjusts the layout and order of the checkout's line items. Also removes `Invoice ID` from the checkout complete page.

<img width="450" alt="Screenshot 2025-05-02 at 11 41 30 AM" src="https://github.com/user-attachments/assets/d3757a41-a2f6-43a3-9ed5-20ec8cebb798" />

https://linear.app/clerk/issue/COM-726/remove-invoice-line-from-checkout-complete-page
https://linear.app/clerk/issue/COM-713/frontend-when-switching-to-an-annual-plan-display-the-annual-total

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
