### PR TITLE
chore(expo-passkeys): Add support for Expo 53

### DIFF
--- a/.changeset/cold-toes-rhyme.md
+++ b/.changeset/cold-toes-rhyme.md
@@ -2,4 +2,4 @@
 "@clerk/expo-passkeys": minor
 ---
 
-Add support for Expo 54
+Add support for Expo 53

--- a/.changeset/cold-toes-rhyme.md
+++ b/.changeset/cold-toes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo-passkeys": minor
+---
+
+Add support for Expo 54

--- a/packages/expo-passkeys/package.json
+++ b/packages/expo-passkeys/package.json
@@ -38,7 +38,7 @@
     "expo": "~52.0.46"
   },
   "peerDependencies": {
-    "expo": "^50 || ^51 || ^52",
+    "expo": ">=50 <54",
     "react": "catalog:peer-react",
     "react-native": "*"
   }


### PR DESCRIPTION
## Description

This is a small PR adding support to [stable Expo 53](https://expo.dev/changelog/sdk-53). No breaking changes or new features were introduced.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
