### PR TITLE
feat(clerk-js,types): Support switching to free plan

### DIFF
--- a/.changeset/eager-goats-vanish.md
+++ b/.changeset/eager-goats-vanish.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add support for switching to the free plan

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
@@ -79,7 +79,7 @@ export const CheckoutComplete = ({ checkout }: { checkout: __experimental_Commer
               as='h2'
               textVariant='h2'
               localizationKey={
-                checkout.subscription?.status === 'active'
+                checkout.totals.totalDueNow.amount > 0
                   ? localizationKeys('__experimental_commerce.checkout.title__paymentSuccessful')
                   : localizationKeys('__experimental_commerce.checkout.title__subscriptionSuccessful')
               }
@@ -89,7 +89,7 @@ export const CheckoutComplete = ({ checkout }: { checkout: __experimental_Commer
               colorScheme='secondary'
               sx={t => ({ textAlign: 'center', paddingInline: t.space.$8, marginBlockStart: t.space.$2 })}
               localizationKey={
-                checkout.subscription?.status === 'active'
+                checkout.totals.totalDueNow.amount > 0
                   ? localizationKeys('__experimental_commerce.checkout.description__paymentSuccessful')
                   : localizationKeys('__experimental_commerce.checkout.description__subscriptionSuccessful')
               }
@@ -113,14 +113,14 @@ export const CheckoutComplete = ({ checkout }: { checkout: __experimental_Commer
           <LineItems.Group variant='secondary'>
             <LineItems.Title
               title={
-                checkout.subscription?.status === 'active'
+                checkout.totals.totalDueNow.amount > 0
                   ? localizationKeys('__experimental_commerce.checkout.lineItems.title__paymentMethod')
                   : localizationKeys('__experimental_commerce.checkout.lineItems.title__subscriptionBegins')
               }
             />
             <LineItems.Description
               text={
-                checkout.subscription?.status === 'active'
+                checkout.totals.totalDueNow.amount > 0
                   ? checkout.paymentSource
                     ? `${capitalize(checkout.paymentSource.cardType)} ⋯ ${checkout.paymentSource.last4}`
                     : '–'

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -494,7 +494,8 @@ const CardFeaturesList = React.forwardRef<HTMLDivElement, CardFeaturesListProps>
           onClick={event => showPlanDetails(event)}
           variant='link'
           sx={t => ({
-            marginBlockStart: t.space.$2,
+            marginBlockStart: 'auto',
+            paddingBlockStart: t.space.$2,
             gap: t.space.$1,
           })}
         >

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -276,9 +276,13 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref
             ) : (
               <Badge
                 elementDescriptor={descriptors.pricingTableCardBadge}
-                localizationKey={localizationKeys('badge__startsAt', {
-                  date: subscription?.periodStart,
-                })}
+                localizationKey={
+                  subscription
+                    ? localizationKeys('badge__startsAt', {
+                        date: subscription.periodStart,
+                      })
+                    : localizationKeys('badge__upcomingPlan')
+                }
                 colorScheme={'primary'}
               />
             )}

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -22,7 +22,7 @@ import {
   Text,
   useAppearance,
 } from '../../customizables';
-import { Avatar, ReversibleContainer, SegmentedControl } from '../../elements';
+import { ReversibleContainer, SegmentedControl } from '../../elements';
 import { usePrefersReducedMotion } from '../../hooks';
 import { Check, InformationCircle, Plus } from '../../icons';
 import type { ThemableCssProp } from '../../styledSystem';
@@ -111,7 +111,7 @@ function Card(props: CardProps) {
   const totalFeatures = features.length;
   const hasFeatures = totalFeatures > 0;
 
-  const { buttonPropsForPlan } = usePlansContext();
+  const { buttonPropsForPlan, isDefaultPlanImplicitlyActiveOrUpcoming } = usePlansContext();
 
   const showPlanDetails = (event?: React.MouseEvent<HTMLElement>) => {
     const portalRoot = getClosestProfileScrollBox(mode, event);
@@ -175,7 +175,7 @@ function Card(props: CardProps) {
             />
           </Box>
         ) : null}
-        {!plan.isDefault && (
+        {(!plan.isDefault || !isDefaultPlanImplicitlyActiveOrUpcoming) && (
           <Box
             elementDescriptor={descriptors.pricingTableCardAction}
             sx={t => ({
@@ -217,7 +217,7 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref
   const prefersReducedMotion = usePrefersReducedMotion();
   const { animations: layoutAnimations } = useAppearance().parsedLayout;
   const { plan, isCompact, planPeriod, setPlanPeriod } = props;
-  const { name, avatarUrl, annualMonthlyAmount } = plan;
+  const { name, annualMonthlyAmount } = plan;
   const isMotionSafe = !prefersReducedMotion && layoutAnimations === true;
   const pricingTableCardFeePeriodNoticeAnimation: ThemableCssProp = t => ({
     transition: isMotionSafe
@@ -231,11 +231,11 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref
     return planPeriod === 'annual' ? plan.annualMonthlyAmountFormatted : plan.amountFormatted;
   }, [annualMonthlyAmount, planPeriod, plan.amountFormatted, plan.annualMonthlyAmountFormatted]);
 
-  const { activeOrUpcomingSubscription, isDefaultPlanImplicitlyActive } = usePlansContext();
+  const { activeOrUpcomingSubscription, isDefaultPlanImplicitlyActiveOrUpcoming, subscriptions } = usePlansContext();
   const subscription = activeOrUpcomingSubscription(plan);
-  const isImplicitlyActive = isDefaultPlanImplicitlyActive && plan.isDefault;
+  const isImplicitlyActiveOrUpcoming = isDefaultPlanImplicitlyActiveOrUpcoming && plan.isDefault;
 
-  const showBadge = !!subscription || isImplicitlyActive;
+  const showBadge = !!subscription || isImplicitlyActiveOrUpcoming;
 
   return (
     <Box
@@ -247,64 +247,52 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref
       })}
       data-variant={isCompact ? 'compact' : 'default'}
     >
-      {avatarUrl || showBadge ? (
-        <Box
-          elementDescriptor={descriptors.pricingTableCardAvatarBadgeContainer}
-          sx={t => ({
-            marginBlockEnd: t.space.$3,
-            display: 'flex',
-            alignItems: 'flex-start',
-            justifyContent: 'space-between',
-            flexWrap: 'wrap',
-            gap: t.space.$3,
-            float: !avatarUrl && !showBadge ? 'right' : undefined,
-          })}
-        >
-          {avatarUrl ? (
-            <Avatar
-              boxElementDescriptor={descriptors.pricingTableCardAvatar}
-              size={_ => 40}
-              title={name}
-              initials={name[0]}
-              rounded={false}
-              imageUrl={avatarUrl}
-            />
-          ) : null}
-          <ReversibleContainer reverse={!avatarUrl}>
-            {showBadge ? (
-              <Span
-                elementDescriptor={descriptors.pricingTableCardBadgeContainer}
-                sx={{
-                  flexBasis: avatarUrl ? '100%' : undefined,
-                }}
-              >
-                {isImplicitlyActive || subscription?.status === 'active' ? (
-                  <Badge
-                    elementDescriptor={descriptors.pricingTableCardBadge}
-                    localizationKey={localizationKeys('badge__currentPlan')}
-                    colorScheme={'secondary'}
-                  />
-                ) : (
-                  <Badge
-                    elementDescriptor={descriptors.pricingTableCardBadge}
-                    localizationKey={localizationKeys('badge__startsAt', {
-                      date: subscription?.periodStart,
-                    })}
-                    colorScheme={'primary'}
-                  />
-                )}
-              </Span>
-            ) : null}
-          </ReversibleContainer>
-        </Box>
-      ) : null}
-      <Heading
-        elementDescriptor={descriptors.pricingTableCardTitle}
-        as='h2'
-        textVariant={isCompact ? 'h3' : 'h2'}
+      <Box
+        elementDescriptor={descriptors.pricingTableCardBadgeTitleContainer}
+        sx={t => ({
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'row-reverse',
+          alignItems: 'baseline',
+          justifyContent: 'flex-end',
+          flexWrap: 'wrap',
+          gap: t.space.$3,
+          marginBlockEnd: t.space.$3,
+        })}
       >
-        {plan.name}
-      </Heading>
+        {showBadge ? (
+          <Span
+            elementDescriptor={descriptors.pricingTableCardBadgeContainer}
+            sx={{
+              flex: '0 0 auto',
+            }}
+          >
+            {subscription?.status === 'active' || (isImplicitlyActiveOrUpcoming && subscriptions.length === 0) ? (
+              <Badge
+                elementDescriptor={descriptors.pricingTableCardBadge}
+                localizationKey={localizationKeys('badge__currentPlan')}
+                colorScheme={'secondary'}
+              />
+            ) : (
+              <Badge
+                elementDescriptor={descriptors.pricingTableCardBadge}
+                localizationKey={localizationKeys('badge__startsAt', {
+                  date: subscription?.periodStart,
+                })}
+                colorScheme={'primary'}
+              />
+            )}
+          </Span>
+        ) : null}
+        <Heading
+          elementDescriptor={descriptors.pricingTableCardTitle}
+          as='h2'
+          textVariant={isCompact ? 'h3' : 'h2'}
+          sx={{ flex: '1 1 auto' }}
+        >
+          {name}
+        </Heading>
+      </Box>
       {!isCompact && plan.description ? (
         <Text
           elementDescriptor={descriptors.pricingTableCardDescription}

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -112,7 +112,8 @@ export const usePlansContext = () => {
 
   // should the default plan be shown as active
   const isDefaultPlanImplicitlyActiveOrUpcoming = useMemo(() => {
-    return ctx.subscriptions.length === 0;
+    // are there no subscriptions or are all subscriptions canceled
+    return ctx.subscriptions.length === 0 || !ctx.subscriptions.some(subscription => !subscription.canceledAt);
   }, [ctx.subscriptions]);
 
   const canManageSubscription = useCallback(

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -111,7 +111,7 @@ export const usePlansContext = () => {
   );
 
   // should the default plan be shown as active
-  const isDefaultPlanImplicitlyActive = useMemo(() => {
+  const isDefaultPlanImplicitlyActiveOrUpcoming = useMemo(() => {
     return ctx.subscriptions.length === 0;
   }, [ctx.subscriptions]);
 
@@ -216,7 +216,7 @@ export const usePlansContext = () => {
     ...ctx,
     componentName,
     activeOrUpcomingSubscription,
-    isDefaultPlanImplicitlyActive,
+    isDefaultPlanImplicitlyActiveOrUpcoming,
     handleSelectPlan,
     buttonPropsForPlan,
     canManageSubscription,

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -245,7 +245,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'pricingTableCardHeader',
   'pricingTableCardTitle',
   'pricingTableCardDescription',
-  'pricingTableCardAvatarBadgeContainer',
+  'pricingTableCardBadgeTitleContainer',
   'pricingTableCardAvatar',
   'pricingTableCardBadgeContainer',
   'pricingTableCardBadge',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -370,7 +370,7 @@ export type ElementsConfig = {
   pricingTable: WithOptions;
   pricingTableCard: WithOptions<string>;
   pricingTableCardHeader: WithOptions;
-  pricingTableCardAvatarBadgeContainer: WithOptions;
+  pricingTableCardBadgeTitleContainer: WithOptions;
   pricingTableCardAvatar: WithOptions;
   pricingTableCardBadgeContainer: WithOptions;
   pricingTableCardBadge: WithOptions;


### PR DESCRIPTION
## Description

Allows downgrading to the free plan through a normal checkout downgrade flow. Badges and CTAs reflect the appropriate implicit states for the free plan card.

<img width="910" alt="Screenshot 2025-05-03 at 9 18 33 AM" src="https://github.com/user-attachments/assets/4644b301-4387-4c9a-ac37-ee468d3bb566" />
<img width="441" alt="Screenshot 2025-05-03 at 9 18 44 AM" src="https://github.com/user-attachments/assets/89c3504b-1420-48c2-86ac-4b98ddbd3567" />



https://linear.app/clerk/issue/COM-725/support-checkout-flow-with-default-free-plan

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
