### PR TITLE
feat(clerk-js,localizations): Switching monthly to annual for existing subscription

### DIFF
--- a/.changeset/sad-teeth-argue.md
+++ b/.changeset/sad-teeth-argue.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Allow switching from an existing monthly subscription to an annual subscription for the same plan

--- a/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
+++ b/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
@@ -15,6 +15,7 @@ import {
   Badge,
   Box,
   Button,
+  Col,
   descriptors,
   Flex,
   Heading,
@@ -89,12 +90,16 @@ const _PlanDetails = ({
       });
   };
 
-  const openCheckout = () => {
+  type OpenCheckoutProps = {
+    planPeriod?: __experimental_CommerceSubscriptionPlanPeriod;
+  };
+
+  const openCheckout = (props?: OpenCheckoutProps) => {
     handleClose();
 
     // if the plan doesn't support annual, use monthly
-    let _planPeriod = planPeriod;
-    if (planPeriod === 'annual' && plan.annualMonthlyAmount === 0) {
+    let _planPeriod = props?.planPeriod || planPeriod;
+    if (_planPeriod === 'annual' && plan.annualMonthlyAmount === 0) {
       _planPeriod = 'month';
     }
 
@@ -210,24 +215,36 @@ const _PlanDetails = ({
                 block
                 textVariant='buttonLarge'
                 {...buttonPropsForPlan({ plan })}
-                onClick={openCheckout}
+                onClick={() => openCheckout()}
               />
             ) : (
-              <Button
-                block
-                variant='bordered'
-                colorScheme='secondary'
-                textVariant='buttonLarge'
-                onClick={() => setShowConfirmation(true)}
-                localizationKey={localizationKeys('__experimental_commerce.cancelSubscription')}
-              />
+              <Col gap={4}>
+                {!!subscription && subscription.planPeriod === 'month' && plan.annualMonthlyAmount > 0 ? (
+                  <Button
+                    block
+                    variant='bordered'
+                    colorScheme='secondary'
+                    textVariant='buttonLarge'
+                    onClick={() => openCheckout({ planPeriod: 'annual' })}
+                    localizationKey={localizationKeys('__experimental_commerce.switchToAnnual')}
+                  />
+                ) : null}
+                <Button
+                  block
+                  variant='bordered'
+                  colorScheme='danger'
+                  textVariant='buttonLarge'
+                  onClick={() => setShowConfirmation(true)}
+                  localizationKey={localizationKeys('__experimental_commerce.cancelSubscription')}
+                />
+              </Col>
             )
           ) : (
             <Button
               block
               textVariant='buttonLarge'
               {...buttonPropsForPlan({ plan })}
-              onClick={openCheckout}
+              onClick={() => openCheckout()}
             />
           )}
         </Drawer.Footer>
@@ -481,19 +498,7 @@ const Header = React.forwardRef<HTMLDivElement, HeaderProps>((props, ref) => {
         </Flex>
       ) : null}
 
-      {!!subscription && (
-        <Text
-          elementDescriptor={descriptors.planDetailCaption}
-          variant={'caption'}
-          localizationKey={captionForSubscription(subscription)}
-          colorScheme='secondary'
-          sx={t => ({
-            marginTop: t.space.$3,
-          })}
-        />
-      )}
-
-      {!subscription && plan.annualMonthlyAmount > 0 ? (
+      {!subscription || (subscription.planPeriod === 'month' && plan.annualMonthlyAmount > 0) ? (
         <Box
           elementDescriptor={descriptors.planDetailPeriodToggle}
           sx={t => ({
@@ -519,6 +524,18 @@ const Header = React.forwardRef<HTMLDivElement, HeaderProps>((props, ref) => {
           </SegmentedControl.Root>
         </Box>
       ) : null}
+
+      {!!subscription && (
+        <Text
+          elementDescriptor={descriptors.planDetailCaption}
+          variant={'caption'}
+          localizationKey={captionForSubscription(subscription)}
+          colorScheme='secondary'
+          sx={t => ({
+            marginTop: t.space.$3,
+          })}
+        />
+      )}
     </Box>
   );
 });

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -29,6 +29,7 @@ export const enUS: LocalizationResource = {
     month: 'Month',
     reSubscribe: 'Re-subscribe',
     switchPlan: 'Switch to this plan',
+    switchToAnnual: 'Switch to annual',
     defaultFreePlanActive: "You're currently on the Free plan",
     availableFeatures: 'Available features',
     viewFeatures: 'View features',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -114,6 +114,7 @@ type _LocalizationResource = {
     keepSubscription: LocalizationValue;
     reSubscribe: LocalizationValue;
     switchPlan: LocalizationValue;
+    switchToAnnual: LocalizationValue;
     billedAnnually: LocalizationValue;
     accountFunds: LocalizationValue;
     defaultFreePlanActive: LocalizationValue;


### PR DESCRIPTION
## Description

Adds the ability within `PlanDetails` to switch from an existing monthly subscription to an annual subscription for the same plan.

<img width="526" alt="Screenshot 2025-05-03 at 10 41 43 AM" src="https://github.com/user-attachments/assets/e38af951-4fdf-4dcc-9f01-685a37fd453a" />

https://linear.app/clerk/issue/COM-686/add-ability-to-change-plan-period-for-existing-subscription

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
