### PR TITLE
fix(clerk-js): Fix turnstile language fallback warning on captcha modal

### DIFF
--- a/.changeset/shiny-olives-worry.md
+++ b/.changeset/shiny-olives-worry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix turnstile language fallback warning on captcha modal.

--- a/packages/clerk-js/src/ui/components/BlankCaptchaModal/index.tsx
+++ b/packages/clerk-js/src/ui/components/BlankCaptchaModal/index.tsx
@@ -7,7 +7,9 @@ const BlankCard = withCardStateProvider(() => {
   const { locale } = useLocalizations();
   const captchaTheme = parsedCaptcha?.theme;
   const captchaSize = parsedCaptcha?.size;
-  const captchaLanguage = parsedCaptcha?.language || locale;
+  // Turnstile expects the language to be lowercase, so we convert it here (e.g. 'en-US' -> 'en-us')
+  // Supported languages: https://developers.cloudflare.com/turnstile/reference/supported-languages
+  const captchaLanguage = parsedCaptcha?.language || locale?.toLowerCase();
 
   return (
     <Card.Root>


### PR DESCRIPTION
## Description

Fixes the following warning message when captcha modal is triggered:

```
[Cloudflare Turnstile] Language en-US is not supported, falling back to: en-us.
```

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
