### PR TITLE
fix(clerk-js): Require label for Switch

### DIFF
--- a/.changeset/upset-ravens-love.md
+++ b/.changeset/upset-ravens-love.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update internal Switch component to require a label.

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -347,7 +347,7 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref
           })}
         >
           <Switch
-            checked={planPeriod === 'annual'}
+            isChecked={planPeriod === 'annual'}
             onChange={(checked: boolean) => setPlanPeriod(checked ? 'annual' : 'month')}
             label={localizationKeys('commerce.billedAnnually')}
           />

--- a/packages/clerk-js/src/ui/elements/Switch.tsx
+++ b/packages/clerk-js/src/ui/elements/Switch.tsx
@@ -5,22 +5,21 @@ import { descriptors, Flex, Text } from '../customizables';
 import { common } from '../styledSystem';
 
 interface SwitchProps {
-  checked?: boolean;
+  isChecked?: boolean;
   defaultChecked?: boolean;
   onChange?: (checked: boolean) => void;
-  disabled?: boolean;
-  'aria-label'?: string;
-  label?: string | LocalizationKey;
+  isDisabled?: boolean;
+  label: string | LocalizationKey;
 }
 
 export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
-  ({ checked: controlledChecked, defaultChecked, onChange, disabled = false, label }, ref) => {
+  ({ isChecked: controlledChecked, defaultChecked, onChange, isDisabled = false, label }, ref) => {
     const [internalChecked, setInternalChecked] = useState(!!defaultChecked);
     const isControlled = controlledChecked !== undefined;
     const checked = isControlled ? controlledChecked : internalChecked;
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (disabled) return;
+      if (isDisabled) return;
       if (!isControlled) {
         setInternalChecked(e.target.checked);
       }
@@ -45,7 +44,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
         <input
           type='checkbox'
           role='switch'
-          disabled={disabled}
+          disabled={isDisabled}
           defaultChecked={defaultChecked}
           checked={checked}
           onChange={handleChange}
@@ -65,8 +64,8 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
             backgroundColor: checked ? t.colors.$primary500 : t.colors.$neutralAlpha150,
             borderRadius: 999,
             transition: 'background-color 0.2s',
-            opacity: disabled ? 0.6 : 1,
-            cursor: disabled ? 'not-allowed' : 'pointer',
+            opacity: isDisabled ? 0.6 : 1,
+            cursor: isDisabled ? 'not-allowed' : 'pointer',
             outline: 'none',
             boxSizing: 'border-box',
             boxShadow: '0px 0px 0px 1px rgba(0, 0, 0, 0.06) inset',
@@ -89,19 +88,17 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
             })}
           />
         </Flex>
-        {label && (
-          <Text
-            as='span'
-            variant='caption'
-            colorScheme='secondary'
-            localizationKey={label}
-            sx={t => ({
-              paddingInlineStart: t.sizes.$2,
-              cursor: disabled ? 'not-allowed' : 'pointer',
-              userSelect: 'none',
-            })}
-          />
-        )}
+        <Text
+          as='span'
+          variant='caption'
+          colorScheme='secondary'
+          localizationKey={label}
+          sx={t => ({
+            paddingInlineStart: t.sizes.$2,
+            cursor: isDisabled ? 'not-allowed' : 'pointer',
+            userSelect: 'none',
+          })}
+        />
       </Flex>
     );
   },


### PR DESCRIPTION
## Description

We need to make the label for `<Switch />` required as otherwise it's not an accessible component when left out. It needs a description for people to understand what it's about.

I also added the `is` prefix to the booleans as we a) use this in other places and b) makes their purpose clearer.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
