### PR TITLE
fix(clerk-js): Ensure drawer works corrrectly in safari

### DIFF
--- a/.changeset/icy-papers-hunt.md
+++ b/.changeset/icy-papers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix drawer positioning issues experienced in safari

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -217,38 +217,46 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
       outsideElementsInert
       initialFocus={refs.floating}
     >
-      <Flex
+      <div
         ref={mergedRefs}
-        elementDescriptor={descriptors.drawerContent}
         {...getFloatingProps()}
-        style={transitionStyles}
-        direction='col'
-        sx={t => ({
-          // Apply the conditional right offset + the spread of the
-          // box shadow to ensure it is fully offscreen before unmounting
-          '--transform-offset':
-            strategy === 'fixed' ? `calc(100% + ${t.space.$3} + ${t.space.$8x75})` : `calc(100% + ${t.space.$8x75})`,
-          willChange: 'transform',
+        style={{
           position: strategy,
-          insetBlock: strategy === 'fixed' ? t.space.$3 : 0,
-          insetInlineEnd: strategy === 'fixed' ? t.space.$3 : 0,
-          outline: 0,
-          width: t.sizes.$100,
-          backgroundColor: t.colors.$colorBackground,
-          borderStartStartRadius: t.radii.$xl,
-          borderEndStartRadius: t.radii.$xl,
-          borderEndEndRadius: strategy === 'fixed' ? t.radii.$xl : 0,
-          borderStartEndRadius: strategy === 'fixed' ? t.radii.$xl : 0,
-          borderWidth: t.borderWidths.$normal,
-          borderStyle: t.borderStyles.$solid,
-          borderColor: t.colors.$neutralAlpha100,
-          boxShadow: t.shadows.$cardBoxShadow,
-          overflow: 'hidden',
-          zIndex: t.zIndices.$modal,
-        })}
+          insetBlock: 0,
+          insetInlineEnd: 0,
+        }}
       >
-        {children}
-      </Flex>
+        <Flex
+          elementDescriptor={descriptors.drawerContent}
+          style={transitionStyles}
+          direction='col'
+          sx={t => ({
+            // Apply the conditional right offset + the spread of the
+            // box shadow to ensure it is fully offscreen before unmounting
+            '--transform-offset':
+              strategy === 'fixed' ? `calc(100% + ${t.space.$3} + ${t.space.$8x75})` : `calc(100% + ${t.space.$8x75})`,
+            willChange: 'transform',
+            position: strategy,
+            insetBlock: strategy === 'fixed' ? t.space.$3 : 0,
+            insetInlineEnd: strategy === 'fixed' ? t.space.$3 : 0,
+            outline: 0,
+            width: t.sizes.$100,
+            backgroundColor: t.colors.$colorBackground,
+            borderStartStartRadius: t.radii.$xl,
+            borderEndStartRadius: t.radii.$xl,
+            borderEndEndRadius: strategy === 'fixed' ? t.radii.$xl : 0,
+            borderStartEndRadius: strategy === 'fixed' ? t.radii.$xl : 0,
+            borderWidth: t.borderWidths.$normal,
+            borderStyle: t.borderStyles.$solid,
+            borderColor: t.colors.$neutralAlpha100,
+            boxShadow: t.shadows.$cardBoxShadow,
+            overflow: 'hidden',
+            zIndex: t.zIndices.$modal,
+          })}
+        >
+          {children}
+        </Flex>
+      </div>
     </FloatingFocusManager>
   );
 });


### PR DESCRIPTION
## Description

Fixes a bug surfaced in Safari where the Drawer positioning was incorrectly being calculated causing the drawer to shift the content within the profile scroll boxes.

BEFORE:

https://github.com/user-attachments/assets/b82f8590-e5a3-469e-9989-c675a5a9e70e

AFTER:


https://github.com/user-attachments/assets/9951b73b-ad4e-495e-aa2f-0e4af04051a8

Fixes COM-749

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
