### PR TITLE
chore(clerk-js): Add gap between no-permissions notice and pricing table

### DIFF
--- a/.changeset/fuzzy-hotels-lay.md
+++ b/.changeset/fuzzy-hotels-lay.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Added a gap between no-permissions notice and pricing table in `<OrganizationProfile/>` billing page

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
@@ -121,7 +121,10 @@ const OrganizationBillingPageInternal = withCardStateProvider(() => {
                   </Protect>
                 </Flex>
               ) : (
-                <>
+                <Flex
+                  sx={{ width: '100%', flexDirection: 'column' }}
+                  gap={4}
+                >
                   <Protect condition={has => !has({ permission: 'org:sys_billing:manage' })}>
                     <Alert
                       variant='info'
@@ -132,7 +135,7 @@ const OrganizationBillingPageInternal = withCardStateProvider(() => {
                   <PricingTableContext.Provider value={{ componentName: 'PricingTable', mode: 'modal' }}>
                     <PricingTable />
                   </PricingTableContext.Provider>
-                </>
+                </Flex>
               )}
             </TabPanel>
             <TabPanel sx={{ width: '100%' }}>


### PR DESCRIPTION
## Description

BEFORE:

![image](https://github.com/user-attachments/assets/34a54aa8-07bd-457a-b705-745deb920918)

AFTER:

![CleanShot 2025-05-06 at 20 21 37@2x](https://github.com/user-attachments/assets/b623e8b7-959a-40f1-b3e5-7e8b19526d45)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
