### PR TITLE
fix(clerk-js): Render long message for submitError within CheckoutForm

### DIFF
--- a/.changeset/spotty-pugs-laugh.md
+++ b/.changeset/spotty-pugs-laugh.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Render long message for submitError within CheckoutForm
+Render long message for `submitError` within `CheckoutForm`

--- a/.changeset/spotty-pugs-laugh.md
+++ b/.changeset/spotty-pugs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Render long message for submitError within CheckoutForm

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutForm.tsx
@@ -335,7 +335,11 @@ const ExistingPaymentSourceForm = ({
             animation: `${animations.textInBig} ${t.transitionDuration.$slow}`,
           })}
         >
-          {typeof submitError === 'string' ? submitError : submitError.message}
+          {typeof submitError === 'string'
+            ? submitError
+            : 'longMessage' in submitError
+              ? submitError.longMessage || submitError.message
+              : submitError.message}
         </Alert>
       )}
       <Button


### PR DESCRIPTION
## Description

![Screenshot 2025-05-06 at 1 35 56 PM](https://github.com/user-attachments/assets/b1441f15-fa83-491e-93b5-56ad25aab5ee)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
