### PR TITLE
fix(clerk-js): Handle invalid_plan_change error with custom UI

### DIFF
--- a/.changeset/pink-bats-share.md
+++ b/.changeset/pink-bats-share.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Handle `invalid_plan_change` error with custom UI

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -21,7 +21,7 @@
     { "path": "./dist/waitlist*.js", "maxSize": "1.3KB" },
     { "path": "./dist/keylessPrompt*.js", "maxSize": "6.5KB" },
     { "path": "./dist/pricingTable*.js", "maxSize": "4.02KB" },
-    { "path": "./dist/checkout*.js", "maxSize": "5.79KB" },
+    { "path": "./dist/checkout*.js", "maxSize": "5.95KB" },
     { "path": "./dist/paymentSources*.js", "maxSize": "9.06KB" },
     { "path": "./dist/up-billing-page*.js", "maxSize": "3.0KB" },
     { "path": "./dist/op-billing-page*.js", "maxSize": "3.0KB" },

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
@@ -153,8 +153,8 @@ export const CheckoutPage = (props: __internal_CheckoutProps) => {
         })}
       >
         <Alert
-          variant='info'
-          colorScheme='info'
+          variant='danger'
+          colorScheme='danger'
         >
           {errors ? translateError(errors[0]) : 'There was a problem, please try again later.'}
         </Alert>

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutPage.tsx
@@ -119,7 +119,6 @@ export const CheckoutPage = (props: __internal_CheckoutProps) => {
                   title={plan.name}
                   description={planPeriod === 'annual' ? localizationKeys('commerce.billedAnnually') : undefined}
                 />
-                {/* TODO(@Commerce): needs localization */}
                 <LineItems.Description
                   prefix={planPeriod === 'annual' ? 'x12' : undefined}
                   text={`${plan.currencySymbol}${planPeriod === 'month' ? plan.amountFormatted : plan.annualMonthlyAmountFormatted}`}

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -31,8 +31,20 @@ export const useSubscriptions = (subscriberType?: CommerceSubscriberType) => {
   );
 };
 
-export const PlansContextProvider = ({ children }: PropsWithChildren) => {
+export const usePlans = (subscriberType?: CommerceSubscriberType) => {
   const { billing } = useClerk();
+
+  return useFetch(
+    billing.getPlans,
+    {
+      subscriberType,
+    },
+    undefined,
+    'commerce-plans',
+  );
+};
+
+export const PlansContextProvider = ({ children }: PropsWithChildren) => {
   const { organization } = useOrganization();
   const { user, isSignedIn } = useUser();
   const subscriberType = useSubscriberTypeContext();
@@ -44,11 +56,7 @@ export const PlansContextProvider = ({ children }: PropsWithChildren) => {
     revalidate: revalidateSubscriptions,
   } = useSubscriptions(subscriberType);
 
-  const {
-    data: plans,
-    isLoading: isLoadingPlans,
-    revalidate: revalidatePlans,
-  } = useFetch(billing.getPlans, { subscriberType }, undefined, 'commerce-plans');
+  const { data: plans, isLoading: isLoadingPlans, revalidate: revalidatePlans } = usePlans(subscriberType);
 
   // Revalidates the next time the hooks gets mounted
   const { revalidate: revalidateStatements } = useFetch(


### PR DESCRIPTION
## Description

When trying to switch from an annual plan to a monthly plan that has lower price FAPI returns an error, this PR handles that error and displays a custom UI

BEFORE:

![CleanShot 2025-05-06 at 22 09 36@2x](https://github.com/user-attachments/assets/c09a5040-7ea6-489a-93b9-418a24b1972e)

AFTER:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/154a06f7-756c-4eae-9931-33db6c5bc148" />

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
