### PR TITLE
fix(clerk-js): Fix PricingTable plan button display logic

### DIFF
--- a/.changeset/violet-poets-move.md
+++ b/.changeset/violet-poets-move.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix PricingTable logic for plan button text.

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -121,12 +121,13 @@ function Card(props: CardProps) {
   const hasFeatures = plan.features.length > 0;
   const isPlanActive = subscription?.status === 'active';
   const showStatusRow = !!subscription;
+  const isEligibleForSwitchToAnnual = plan.annualMonthlyAmount > 0 && planPeriod === 'annual';
 
   const shouldShowFooter =
     !subscription ||
     subscription?.status === 'upcoming' ||
     subscription?.canceledAt ||
-    (planPeriod !== subscription?.planPeriod && !plan.isDefault);
+    (planPeriod !== subscription?.planPeriod && !plan.isDefault && isEligibleForSwitchToAnnual);
   const shouldShowFooterNotice =
     subscription?.status === 'upcoming' && (planPeriod === subscription.planPeriod || plan.isDefault);
 

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -215,6 +215,8 @@ export const usePlansContext = () => {
         _selectedPlanPeriod = 'month';
       }
 
+      const isEligibleForSwitchToAnnual = plan?.annualMonthlyAmount > 0;
+
       return {
         localizationKey: subscription
           ? subscription.canceledAt
@@ -222,10 +224,12 @@ export const usePlansContext = () => {
             : selectedPlanPeriod !== subscription.planPeriod
               ? selectedPlanPeriod === 'month'
                 ? localizationKeys('commerce.switchToMonthly')
-                : localizationKeys('commerce.switchToAnnual')
+                : isEligibleForSwitchToAnnual
+                  ? localizationKeys('commerce.switchToAnnual')
+                  : localizationKeys('commerce.manageSubscription')
               : localizationKeys('commerce.manageSubscription')
           : // If there are no active or grace period subscriptions, show the get started button
-            ctx.subscriptions.length > 0
+            ctx.subscriptions.filter(subscription => !subscription.plan.isDefault).length > 0
             ? localizationKeys('commerce.switchPlan')
             : localizationKeys('commerce.subscribe'),
         variant: isCompact ? 'bordered' : 'solid',

--- a/packages/clerk-js/src/ui/contexts/components/Plans.tsx
+++ b/packages/clerk-js/src/ui/contexts/components/Plans.tsx
@@ -215,7 +215,7 @@ export const usePlansContext = () => {
         _selectedPlanPeriod = 'month';
       }
 
-      const isEligibleForSwitchToAnnual = plan?.annualMonthlyAmount > 0;
+      const isEligibleForSwitchToAnnual = (plan?.annualMonthlyAmount ?? 0) > 0;
 
       return {
         localizationKey: subscription


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Fixes a case where the plan button was improperly showing when a plan wasn't eligible to upgrade to annual. Also fixes logic around the logic to display "Subscribe" vs. "Switch to this plan" when no subscriptions are present.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
