### PR TITLE
chore(clerk-js): Remove no manage billing permissions alert from the of start billing page

### DIFF
--- a/.changeset/red-corners-show.md
+++ b/.changeset/red-corners-show.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove no manage billing permissions alert from the of start billing page

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationBillingPage.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../contexts';
 import { Col, descriptors, Flex, localizationKeys } from '../../customizables';
 import {
-  Alert,
   Card,
   Header,
   ProfileSection,
@@ -85,13 +84,6 @@ const OrganizationBillingPageInternal = withCardStateProvider(() => {
                     paddingTop: t.space.$1,
                   })}
                 >
-                  <Protect condition={has => !has({ permission: 'org:sys_billing:manage' })}>
-                    <Alert
-                      variant='info'
-                      colorScheme='info'
-                      title={localizationKeys('organizationProfile.billingPage.alerts.noPermissionsToManageBilling')}
-                    />
-                  </Protect>
                   <SubscriptionsList />
                   <ProfileSection.ArrowButton
                     id='subscriptionsList'


### PR DESCRIPTION
## Description

BEFORE:

![CleanShot 2025-05-07 at 13 57 01@2x](https://github.com/user-attachments/assets/68facd24-1a4b-4306-93c2-26520cffc603)

AFTER:

https://github.com/user-attachments/assets/36462c51-90bf-4342-9f48-1ccbd90844a1

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
