### PR TITLE
fix(clerk-js): PlanCard whitespace when ctaPostion is top

### DIFF
--- a/.changeset/ten-forks-shout.md
+++ b/.changeset/ten-forks-shout.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removes white space from PlanCard when the ctaPosition is top and there are no features

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -193,7 +193,7 @@ function Card(props: CardProps) {
           gap: 0,
         }}
       >
-        {!collapseFeatures ? (
+        {(ctaPosition === 'bottom' && !collapseFeatures) || (ctaPosition === 'top' && hasFeatures) ? (
           <Box
             elementDescriptor={descriptors.pricingTableCardFeatures}
             sx={t => ({


### PR DESCRIPTION
## Description

BEFORE

![Screenshot 2025-05-08 at 9 59 11 AM](https://github.com/user-attachments/assets/f38f4763-32d5-48ff-b72d-4fbfeac99bf1)

AFTER

![Screenshot 2025-05-08 at 9 58 44 AM](https://github.com/user-attachments/assets/77597599-dd4c-497b-bdc3-71486fe31f96)

Fixes COM-776

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
