### PR TITLE
fix(clerk-js): Remove navbar icon shift in safari

### DIFF
--- a/.changeset/stupid-gifts-juggle.md
+++ b/.changeset/stupid-gifts-juggle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes issue in Safari where navigating between profile tabs caused the navbar icons to shift unexpectedly.

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -290,7 +290,10 @@ const NavButton = (props: NavButtonProps) => {
         elementDescriptor={iconElementDescriptor}
         elementId={iconElementId}
         icon={icon}
-        sx={{ opacity: isActive ? 1 : 0.7 }}
+        sx={{
+          opacity: isActive ? 1 : 0.7,
+          transform: 'translateZ(0)',
+        }}
       />
       {children}
     </Button>

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -292,6 +292,7 @@ const NavButton = (props: NavButtonProps) => {
         icon={icon}
         sx={{
           opacity: isActive ? 1 : 0.7,
+          // Fixes a bug in Safari where the icon shifts when navigating between routes.
           transform: 'translateZ(0)',
         }}
       />


### PR DESCRIPTION
## Description

Fixes issue in Safari where navigating between tabs in the profile components, cause the icon to shift unexpectedly.

BEFORE

https://github.com/user-attachments/assets/9ad7ffac-cf73-4640-85d1-c3f4445a8880


AFTER

https://github.com/user-attachments/assets/1c50ccfc-9c6f-4e97-b7a6-a28e61d70e79

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
