### PR TITLE
chore(tanstack-react-start): Make `clerkClient()` options parameter optional

### DIFF
--- a/.changeset/breezy-pillows-marry.md
+++ b/.changeset/breezy-pillows-marry.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-react-start": patch
+---
+
+Make `clerkClient()` options parameter optional

--- a/packages/tanstack-react-start/src/server/clerkClient.ts
+++ b/packages/tanstack-react-start/src/server/clerkClient.ts
@@ -1,8 +1,8 @@
-import { createClerkClient } from '@clerk/backend';
+import { type ClerkOptions, createClerkClient } from '@clerk/backend';
 
 import { commonEnvs } from './constants';
 
-const clerkClient: typeof createClerkClient = options => {
+const clerkClient = (options?: ClerkOptions) => {
   const commonEnv = commonEnvs();
   return createClerkClient({
     secretKey: commonEnv.SECRET_KEY,

--- a/packages/tanstack-react-start/src/server/clerkClient.ts
+++ b/packages/tanstack-react-start/src/server/clerkClient.ts
@@ -1,8 +1,9 @@
-import { type ClerkOptions, createClerkClient } from '@clerk/backend';
+import type { ClerkClient, ClerkOptions } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 
 import { commonEnvs } from './constants';
 
-const clerkClient = (options?: ClerkOptions) => {
+const clerkClient = (options?: ClerkOptions): ClerkClient => {
   const commonEnv = commonEnvs();
   return createClerkClient({
     secretKey: commonEnv.SECRET_KEY,


### PR DESCRIPTION
## Description

This PR updates the `clerkClient()` function to make the options parameter explicitly optional. Since the function already sets default values for all required config (secretKey, publishableKey, etc.) from env vars,

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
