### PR TITLE
chore(vue,nuxt): Add satellite application types

### DIFF
--- a/.changeset/four-mangos-punch.md
+++ b/.changeset/four-mangos-punch.md
@@ -3,4 +3,4 @@
 "@clerk/vue": patch
 ---
 
-Add missing `isSatellite` prop in Vue and Nuxt SDKs
+Add `isSatellite` prop type in Vue and Nuxt SDKs

--- a/.changeset/four-mangos-punch.md
+++ b/.changeset/four-mangos-punch.md
@@ -1,0 +1,6 @@
+---
+"@clerk/nuxt": patch
+"@clerk/vue": patch
+---
+
+Add missing `isSatellite` prop in Vue and Nuxt SDKs

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,4 +1,5 @@
-import type { LoadClerkJsScriptOptions } from '@clerk/shared/loadClerkJsScript';
+import type { Without } from '@clerk/types';
+import type { PluginOptions } from '@clerk/vue';
 import {
   addComponent,
   addImports,
@@ -11,7 +12,7 @@ import {
   updateRuntimeConfig,
 } from '@nuxt/kit';
 
-export type ModuleOptions = Omit<LoadClerkJsScriptOptions, 'routerPush' | 'routerReplace' | 'publishableKey'> & {
+export type ModuleOptions = Without<PluginOptions, 'routerPush' | 'routerReplace'> & {
   publishableKey?: string;
   /**
    * Skip the automatic server middleware registration. When enabled, you'll need to
@@ -63,6 +64,7 @@ export default defineNuxtModule<ModuleOptions>({
           clerkJSUrl: options.clerkJSUrl,
           clerkJSVariant: options.clerkJSVariant,
           clerkJSVersion: options.clerkJSVersion,
+          isSatellite: options.isSatellite,
           // Backend specific variables that are safe to share.
           // We want them to be overridable like the other public keys (e.g NUXT_PUBLIC_CLERK_PROXY_URL)
           proxyUrl: options.proxyUrl,

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -12,7 +12,7 @@ import {
   updateRuntimeConfig,
 } from '@nuxt/kit';
 
-export type ModuleOptions = Without<PluginOptions, 'routerPush' | 'routerReplace'> & {
+export type ModuleOptions = Without<PluginOptions, 'routerPush' | 'routerReplace' | 'publishableKey'> & {
   publishableKey?: string;
   /**
    * Skip the automatic server middleware registration. When enabled, you'll need to

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,13 +1,13 @@
 import { inBrowser } from '@clerk/shared/browser';
 import { deriveState } from '@clerk/shared/deriveState';
 import { loadClerkJsScript, type LoadClerkJsScriptOptions } from '@clerk/shared/loadClerkJsScript';
-import type { Clerk, ClientResource, Resources } from '@clerk/types';
+import type { Clerk, ClientResource, MultiDomainAndOrProxy, Resources, Without } from '@clerk/types';
 import type { Plugin } from 'vue';
 import { computed, ref, shallowRef, triggerRef } from 'vue';
 
 import { ClerkInjectionKey } from './keys';
 
-export type PluginOptions = LoadClerkJsScriptOptions;
+export type PluginOptions = Without<LoadClerkJsScriptOptions, 'domain' | 'proxyUrl'> & MultiDomainAndOrProxy;
 
 const SDK_METADATA = {
   name: PACKAGE_NAME,
@@ -48,10 +48,10 @@ export const clerkPlugin: Plugin<[PluginOptions]> = {
       organization: undefined,
     });
 
-    const options: LoadClerkJsScriptOptions = {
+    const options = {
       ...pluginOptions,
       sdkMetadata: pluginOptions.sdkMetadata || SDK_METADATA,
-    };
+    } as LoadClerkJsScriptOptions;
 
     // We need this check for SSR apps like Nuxt as it will try to run this code on the server
     // and loadClerkJsScript contains browser-specific code


### PR DESCRIPTION
## Description

This PR updates the Vue plugin and Nuxt module option types to accept a `isSatellite` prop. We also add a default `undefined` `isSatellite` value to the Nuxt module so it can be overridden by `NUXT_PUBLIC_CLERK_IS_SATELLITE` env var.

Related discord thread - https://discord.com/channels/856971667393609759/1021521740800733244/threads/1371557423038599190

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
