### PR TITLE
fix(clerk-js): PlanDetails heading spacing

### DIFF
--- a/.changeset/fresh-lamps-serve.md
+++ b/.changeset/fresh-lamps-serve.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes incorrect heading spacing within PlanDetails drawer header

--- a/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
+++ b/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
@@ -382,7 +382,7 @@ const Header = React.forwardRef<HTMLDivElement, HeaderProps>((props, ref) => {
       ) : null}
       <Box
         sx={t => ({
-          paddingBlockEnd: t.space.$10,
+          paddingInlineEnd: t.space.$10,
         })}
       >
         <Flex


### PR DESCRIPTION
## Description

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-05-13 at 6 28 59 PM](https://github.com/user-attachments/assets/50461209-1e93-45a1-9294-8d513e530ba4) | ![Screenshot 2025-05-13 at 6 28 37 PM](https://github.com/user-attachments/assets/4f5c7e24-aa91-4a2a-b080-f9cf24c839f3) | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
