### PR TITLE
chore(clerk-js,types): Add drawer root descriptor

### DIFF
--- a/.changeset/mighty-forks-joke.md
+++ b/.changeset/mighty-forks-joke.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add `drawerRoot` descriptor.

--- a/.changeset/mighty-forks-joke.md
+++ b/.changeset/mighty-forks-joke.md
@@ -3,4 +3,4 @@
 '@clerk/types': patch
 ---
 
-Add `drawerRoot` descriptor.
+Add `drawerRoot` descriptor and adjust z-index approach.

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -106,6 +106,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'dividerLine',
 
   'drawerBackdrop',
+  'drawerRoot',
   'drawerContent',
   'drawerHeader',
   'drawerTitle',

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -222,7 +222,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
       outsideElementsInert
       initialFocus={refs.floating}
     >
-      <div
+      <Span
         ref={mergedRefs}
         {...getFloatingProps()}
         style={{
@@ -231,6 +231,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
           insetInline: 0,
           pointerEvents: 'none',
         }}
+        elementDescriptor={descriptors.drawerRoot}
       >
         <Flex
           elementDescriptor={descriptors.drawerContent}
@@ -260,13 +261,12 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
             borderColor: t.colors.$neutralAlpha100,
             boxShadow: t.shadows.$cardBoxShadow,
             overflow: 'hidden',
-            zIndex: t.zIndices.$modal,
             pointerEvents: 'auto',
           })}
         >
           {children}
         </Flex>
-      </div>
+      </Span>
     </FloatingFocusManager>
   );
 });

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -225,13 +225,16 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
       <Box
         ref={mergedRefs}
         {...getFloatingProps()}
-        sx={{
+        sx={t => ({
           position: strategy,
           insetBlock: 0,
           insetInline: 0,
           pointerEvents: 'none',
           isolation: 'isolate',
-        }}
+          // When drawer is within the profile components, we need to ensure it is above the drawer
+          // renders above the profile close button
+          zIndex: strategy === 'absolute' ? t.zIndices.$modal : undefined,
+        })}
         elementDescriptor={descriptors.drawerRoot}
       >
         <Flex

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -222,14 +222,15 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
       outsideElementsInert
       initialFocus={refs.floating}
     >
-      <Span
+      <Box
         ref={mergedRefs}
         {...getFloatingProps()}
-        style={{
+        sx={{
           position: strategy,
           insetBlock: 0,
           insetInline: 0,
           pointerEvents: 'none',
+          isolation: 'isolate',
         }}
         elementDescriptor={descriptors.drawerRoot}
       >
@@ -266,7 +267,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ children }, re
         >
           {children}
         </Flex>
-      </Span>
+      </Box>
     </FloatingFocusManager>
   );
 });

--- a/packages/clerk-js/src/ui/elements/Switch.tsx
+++ b/packages/clerk-js/src/ui/elements/Switch.tsx
@@ -34,6 +34,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
         align='center'
         as='label'
         sx={t => ({
+          isolation: 'isolate',
           width: 'fit-content',
           '&:has(input:focus-visible) > input + span': {
             ...common.focusRingStyles(t),

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -225,6 +225,7 @@ export type ElementsConfig = {
   dividerLine: WithOptions;
 
   drawerBackdrop: WithOptions;
+  drawerRoot: WithOptions;
   drawerContent: WithOptions;
   drawerHeader: WithOptions;
   drawerTitle: WithOptions;


### PR DESCRIPTION
## Description

- Adds descriptor to target the root content element
- Fixes z-index issues with drawer content and modal close buttons

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
