### PR TITLE
feat(clerk-js,types): Add __experimental_startPath to `openOrganizationProfile`

### DIFF
--- a/.changeset/cute-hoops-find.md
+++ b/.changeset/cute-hoops-find.md
@@ -1,0 +1,14 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Introduce `__experimental_startPath` option for `openOrganizationProfile`.
+
+Example usage:
+
+```ts
+clerk.openOrganizationProfile({
+  __experimental_startPath: '/billing',
+});
+```

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -482,7 +482,7 @@ const Components = (props: ComponentsProps) => {
       onExternalNavigate={() => componentsControls.closeModal('organizationProfile')}
       startPath={buildVirtualRouterUrl({
         base: '/organizationProfile',
-        path: urlStateParam?.path,
+        path: organizationProfileModal?.__experimental_startPath || urlStateParam?.path,
       })}
       componentName={'OrganizationProfileModal'}
       modalContainerSx={{ alignItems: 'center' }}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1302,6 +1302,11 @@ export type OrganizationProfileProps = RoutingOptions & {
    * Provide custom pages and links to be rendered inside the OrganizationProfile.
    */
   customPages?: CustomPage[];
+  /**
+   * Specify on which page the organization profile modal will open.
+   * @experimental
+   **/
+  __experimental_startPath?: string;
 };
 
 export type OrganizationProfileModalProps = WithoutRouting<OrganizationProfileProps>;


### PR DESCRIPTION
## Description

Introduce `__experimental_startPath` option to `openOrganizationProfile`.

This enables folks to open to a specific nav item.

```ts
clerk.openOrganizationProfile({
  __experimental_startPath: '/billing'
});
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
