### PR TITLE
chore(clerk-js): Hide set as default from default MFA's action menu

### DIFF
--- a/.changeset/breezy-snakes-hide.md
+++ b/.changeset/breezy-snakes-hide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide "Set as default" from the action menu of the default MFA method

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaSection.tsx
@@ -159,11 +159,10 @@ const MfaPhoneCodeMenu = ({ phone, showTOTP }: MfaPhoneCodeMenuProps) => {
 
   const actions = (
     [
-      !showTOTP
+      !showTOTP && !phone.defaultSecondFactor
         ? {
             label: localizationKeys('userProfile.start.mfaSection.phoneCode.actionLabel__setDefault'),
             onClick: () => phone.makeDefaultSecondFactor().catch(err => handleError(err, [], card.setError)),
-            isDisabled: phone.defaultSecondFactor,
           }
         : null,
       {


### PR DESCRIPTION
## Description

Aligns the MFA's default method action menu to no have the "Set as default" action menu, in order to have consistency with other sections on UP, e.g. Phone Numbers 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
