### PR TITLE
fix(clerk-js): Only lock scroll when Drawer is using fixed strategy

### DIFF
--- a/.changeset/plain-keys-visit.md
+++ b/.changeset/plain-keys-visit.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Only lock scroll when Drawer is using fixed strategy

--- a/packages/clerk-js/src/ui/elements/Drawer.tsx
+++ b/packages/clerk-js/src/ui/elements/Drawer.tsx
@@ -1,4 +1,4 @@
-import { useSafeLayoutEffect } from '@clerk/shared/react';
+import { useSafeLayoutEffect } from '@clerk/shared/react/index';
 import type { UseDismissProps, UseFloatingOptions, UseRoleProps } from '@floating-ui/react';
 import {
   FloatingFocusManager,
@@ -16,8 +16,7 @@ import * as React from 'react';
 import { transitionDurationValues, transitionTiming } from '../../ui/foundations/transitions';
 import type { LocalizationKey } from '../customizables';
 import { Box, descriptors, Flex, Heading, Icon, Span, useAppearance } from '../customizables';
-import { useDirection, usePrefersReducedMotion } from '../hooks';
-import { useScrollLock } from '../hooks/useScrollLock';
+import { useDirection, usePrefersReducedMotion, useScrollLock } from '../hooks';
 import { Close as CloseIcon } from '../icons';
 import type { ThemableCssProp } from '../styledSystem';
 import { common } from '../styledSystem';
@@ -131,15 +130,18 @@ export const FloatingOverlay = React.forwardRef(function FloatingOverlay(
   props: React.ComponentPropsWithoutRef<typeof Box>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
+  const { strategy } = useDrawerContext();
   const { disableScrollLock, enableScrollLock } = useScrollLock();
 
   useSafeLayoutEffect(() => {
+    if (strategy !== 'fixed') {
+      return;
+    }
     enableScrollLock();
-
     return () => {
       disableScrollLock();
     };
-  }, []);
+  }, [strategy, disableScrollLock, enableScrollLock]);
 
   return (
     <Box


### PR DESCRIPTION
## Description

This PR updates the scroll lock functionality for the Drawer to only lock when we are using the fixed strategy. When Drawers are used in the profile components where the strategy is absolute, we don't want to lock scroll as that can prevent folks from seeing the full profile component.

Resolves COM-799

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
