### PR TITLE
feat(clerk-js): Send to preferred phone code channel by country

### DIFF
--- a/.changeset/four-lamps-drive.md
+++ b/.changeset/four-lamps-drive.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Add support for country-specific alternative phone code channels

--- a/packages/clerk-js/src/core/resources/AuthConfig.ts
+++ b/packages/clerk-js/src/core/resources/AuthConfig.ts
@@ -1,4 +1,4 @@
-import type { AuthConfigJSON, AuthConfigJSONSnapshot, AuthConfigResource } from '@clerk/types';
+import type { AuthConfigJSON, AuthConfigJSONSnapshot, AuthConfigResource, PhoneCodeChannel } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
 import { BaseResource } from './internal';
@@ -7,6 +7,7 @@ export class AuthConfig extends BaseResource implements AuthConfigResource {
   claimedAt: Date | null = null;
   reverification: boolean = false;
   singleSessionMode: boolean = false;
+  preferredChannels: Record<string, PhoneCodeChannel> | null = null;
 
   public constructor(data: Partial<AuthConfigJSON> | null = null) {
     super();
@@ -21,6 +22,7 @@ export class AuthConfig extends BaseResource implements AuthConfigResource {
     this.claimedAt = this.withDefault(data.claimed_at ? unixEpochToDate(data.claimed_at) : null, this.claimedAt);
     this.reverification = this.withDefault(data.reverification, this.reverification);
     this.singleSessionMode = this.withDefault(data.single_session_mode, this.singleSessionMode);
+    this.preferredChannels = this.withDefault(data.preferred_channels, this.preferredChannels);
     return this;
   }
 

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -28,6 +28,9 @@ const factorKey = (factor: SignInFactor | null | undefined) => {
   if ('phoneNumberId' in factor) {
     key += factor.phoneNumberId;
   }
+  if ('channel' in factor) {
+    key += factor.channel;
+  }
   return key;
 };
 
@@ -39,7 +42,7 @@ function SignInFactorOneInternal(): JSX.Element {
   const card = useCardState();
   const { supportedFirstFactors, firstFactorVerification } = useCoreSignIn();
 
-  const alternativePhoneCodeChannel = firstFactorVerification.channel;
+  const phoneCodeChannel = firstFactorVerification.channel;
 
   const lastPreparedFactorKeyRef = React.useRef('');
   const [{ currentFactor }, setFactor] = React.useState<{
@@ -159,8 +162,9 @@ function SignInFactorOneInternal(): JSX.Element {
         <SignInFactorOnePhoneCodeCard
           factorAlreadyPrepared={lastPreparedFactorKeyRef.current === factorKey(currentFactor)}
           onFactorPrepare={handleFactorPrepare}
-          factor={{ ...currentFactor, channel: alternativePhoneCodeChannel }}
+          factor={{ ...currentFactor, channel: phoneCodeChannel }}
           onShowAlternativeMethodsClicked={toggleAllStrategies}
+          onChangePhoneCodeChannel={selectFactor}
         />
       );
     case 'email_link':

--- a/packages/clerk-js/src/ui/components/SignIn/utils.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/utils.ts
@@ -1,9 +1,16 @@
 import { titleize } from '@clerk/shared/underscore';
 import { isWebAuthnSupported } from '@clerk/shared/webauthn';
-import type { PreferredSignInStrategy, SignInFactor, SignInResource, SignInStrategy } from '@clerk/types';
-import type { FormControlState } from 'ui/utils';
+import type {
+  PhoneCodeChannel,
+  PreferredSignInStrategy,
+  SignInFactor,
+  SignInResource,
+  SignInStrategy,
+} from '@clerk/types';
 
 import { PREFERRED_SIGN_IN_STRATEGIES } from '../../common/constants';
+import { type FormControlState } from '../../utils';
+import { getPreferredPhoneCodeChannelByCountry } from '../../utils';
 import { otpPrefFactorComparator, passwordPrefFactorComparator } from '../../utils/factorSorting';
 
 const factorForIdentifier = (i: string | null) => (f: SignInFactor) => {
@@ -122,3 +129,33 @@ export function getSignUpAttributeFromIdentifier(identifier: FormControlState<'i
 
   return 'username';
 }
+
+export const getPreferredAlternativePhoneChannel = (
+  fields: Array<FormControlState<string>>,
+  preferredChannels: Record<string, PhoneCodeChannel> | null,
+  phoneNumberFieldName: 'identifier' | 'phoneNumber',
+): PhoneCodeChannel | null => {
+  // If preferred channels are not set, we don't expect to have a preferred phone code provider
+  if (!preferredChannels) {
+    return null;
+  }
+  const strategy = fields.find(f => f.id === 'strategy')?.value;
+  // If the strategy is missing, it could be implied from the identifier being a phone number
+  if (!!strategy && strategy !== 'phone_code') {
+    return null;
+  }
+  const phoneNumber = fields.find(f => f.id === phoneNumberFieldName)?.value;
+  // If identifier is missing or if it does not start with '+' (meaning that it's not a phone number), then it's not a phone_code strategy
+  if (!phoneNumber || !phoneNumber?.startsWith('+')) {
+    return null;
+  }
+  const preferredChannel: PhoneCodeChannel | null = getPreferredPhoneCodeChannelByCountry(
+    phoneNumber,
+    preferredChannels,
+  );
+  // If the preferred channel is sms, we don't expect to have a preferred phone code provider
+  if (preferredChannel === 'sms') {
+    return null;
+  }
+  return preferredChannel;
+};

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -1,8 +1,9 @@
 import { getAlternativePhoneCodeProviderData } from '@clerk/shared/alternativePhoneCode';
+import { useState } from 'react';
 
 import { useCoreSignUp } from '../../contexts';
 import { Flow, localizationKeys } from '../../customizables';
-import { useCardState, withCardStateProvider } from '../../elements';
+import { LoadingCard, useCardState, withCardStateProvider } from '../../elements';
 import { useFetch } from '../../hooks';
 import { handleError } from '../../utils';
 import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
@@ -10,6 +11,8 @@ import { SignUpVerificationCodeForm } from './SignUpVerificationCodeForm';
 export const SignUpPhoneCodeCard = withCardStateProvider(() => {
   const signUp = useCoreSignUp();
   const card = useCardState();
+  const [isLoading, setIsLoading] = useState(false);
+  const [userSelectedFallbackToSMS, setUserSelectedFallbackToSMS] = useState(false);
   const channel = signUp.verifications.phoneNumber.channel;
 
   const phoneVerificationStatus = signUp.verifications.phoneNumber.status;
@@ -29,7 +32,7 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
   useFetch(
     // If an alternative phone code provider is used, we skip the prepare step
     // because the verification is already created on the Start screen
-    shouldAvoidPrepare || isAlternativePhoneCodeProvider
+    shouldAvoidPrepare || isAlternativePhoneCodeProvider || userSelectedFallbackToSMS
       ? undefined
       : () =>
           signUp
@@ -58,6 +61,20 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     resendButtonKey = localizationKeys('signUp.alternativePhoneCodeProvider.resendButton');
   }
 
+  const prepareWithSMS = () => {
+    setIsLoading(true);
+    card.setError(undefined);
+    void signUp
+      .preparePhoneNumberVerification({ strategy: 'phone_code', channel: 'sms' })
+      .then(() => setUserSelectedFallbackToSMS(true))
+      .catch(err => handleError(err, [], card.setError))
+      .finally(() => setIsLoading(false));
+  };
+
+  if (isLoading) {
+    return <LoadingCard />;
+  }
+
   return (
     <Flow.Part part='phoneCode'>
       <SignUpVerificationCodeForm
@@ -67,6 +84,13 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
         prepare={prepare}
         attempt={attempt}
         safeIdentifier={signUp.phoneNumber}
+        alternativeMethodsLabel={
+          isAlternativePhoneCodeProvider
+            ? localizationKeys('footerActionLink__alternativePhoneCodeProvider')
+            : undefined
+        }
+        onShowAlternativeMethodsClicked={isAlternativePhoneCodeProvider ? prepareWithSMS : undefined}
+        showAlternativeMethods={isAlternativePhoneCodeProvider ? true : undefined}
       />
     </Flow.Part>
   );

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -21,6 +21,7 @@ import { useLoadingStatus } from '../../hooks';
 import { useRouter } from '../../router';
 import type { FormControlState } from '../../utils';
 import { buildRequest, createPasswordError, createUsernameError, handleError, useFormControl } from '../../utils';
+import { getPreferredAlternativePhoneChannel } from '../SignIn/utils';
 import { SignUpAlternativePhoneCodePhoneNumberCard } from './SignUpAlternativePhoneCodePhoneNumberCard';
 import { SignUpForm } from './SignUpForm';
 import type { ActiveIdentifier } from './signUpFormHelpers';
@@ -35,7 +36,7 @@ function SignUpStartInternal(): JSX.Element {
   const status = useLoadingStatus();
   const signUp = useCoreSignUp();
   const { showOptionalFields } = useAppearance().parsedLayout;
-  const { userSettings } = useEnvironment();
+  const { userSettings, authConfig } = useEnvironment();
   const { navigate } = useRouter();
   const { attributes } = userSettings;
   const { setActive } = useClerk();
@@ -208,8 +209,6 @@ function SignUpStartInternal(): JSX.Element {
     setActiveCommIdentifierType(type);
   };
 
-  const alternativePhoneCodeProviderFields: FormControlState[] = [];
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -236,8 +235,30 @@ function SignUpStartInternal(): JSX.Element {
       } as any);
     }
 
-    if (alternativePhoneCodeProviderFields.length) {
-      fieldsToSubmit.push(...alternativePhoneCodeProviderFields);
+    // If the user has already selected an alternative phone code provider, we use that.
+    const preferredAlternativePhoneChannel =
+      alternativePhoneCodeProvider?.channel ||
+      getPreferredAlternativePhoneChannel(fieldsToSubmit, authConfig.preferredChannels, 'phoneNumber');
+    if (preferredAlternativePhoneChannel) {
+      // We need to send the alternative phone code provider channel in the sign up request
+      // together with the phone_code strategy, in order for FAPI to create a Verification upon this first request.
+      const noop = () => {};
+      fieldsToSubmit.push({
+        id: 'strategy',
+        value: 'phone_code',
+        clearFeedback: noop,
+        setValue: noop,
+        onChange: noop,
+        setError: noop,
+      } as any);
+      fieldsToSubmit.push({
+        id: 'channel',
+        value: preferredAlternativePhoneChannel,
+        clearFeedback: noop,
+        setValue: noop,
+        onChange: noop,
+        setError: noop,
+      } as any);
     }
 
     // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
@@ -278,30 +299,6 @@ function SignUpStartInternal(): JSX.Element {
       )
       .catch(err => handleError(err, fieldsToSubmit, card.setError))
       .finally(() => card.setIdle());
-  };
-
-  // We need to send the alternative phone code provider channel in the sign up request
-  // together with the phone_code strategy, in order for FAPI to create a Verification upon this first request.
-  const handleAlternativePhoneCodeSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    const noop = () => {};
-    alternativePhoneCodeProviderFields.push({
-      id: 'strategy',
-      value: 'phone_code',
-      clearFeedback: noop,
-      setValue: noop,
-      onChange: noop,
-      setError: noop,
-    } as any);
-    alternativePhoneCodeProviderFields.push({
-      id: 'channel',
-      value: alternativePhoneCodeProvider?.channel,
-      clearFeedback: noop,
-      setValue: noop,
-      onChange: noop,
-      setError: noop,
-    } as any);
-
-    return handleSubmit(e);
   };
 
   if (status.isLoading) {
@@ -394,7 +391,7 @@ function SignUpStartInternal(): JSX.Element {
         </Card.Root>
       ) : (
         <SignUpAlternativePhoneCodePhoneNumberCard
-          handleSubmit={handleAlternativePhoneCodeSubmit}
+          handleSubmit={handleSubmit}
           fields={fields}
           formState={formState}
           onUseAnotherMethod={onAlternativePhoneCodeUseAnotherMethod}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -16,6 +16,9 @@ type SignInFactorOneCodeFormProps = {
   prepare: () => Promise<SignUpResource | void> | undefined;
   attempt: (code: string) => Promise<SignUpResource>;
   safeIdentifier?: string | undefined | null;
+  alternativeMethodsLabel?: LocalizationKey;
+  onShowAlternativeMethodsClicked?: React.MouseEventHandler;
+  showAlternativeMethods?: boolean;
 };
 
 export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) => {
@@ -56,6 +59,9 @@ export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) 
       onResendCodeClicked={props.prepare}
       safeIdentifier={props.safeIdentifier}
       onIdentityPreviewEditClicked={goBack}
+      alternativeMethodsLabel={props.alternativeMethodsLabel}
+      onShowAlternativeMethodsClicked={props.onShowAlternativeMethodsClicked}
+      showAlternativeMethods={props.showAlternativeMethods}
     />
   );
 };

--- a/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
@@ -16,6 +16,7 @@ export type VerificationCodeCardProps = {
   inputLabel?: LocalizationKey;
   safeIdentifier?: string | undefined | null;
   resendButton?: LocalizationKey;
+  alternativeMethodsLabel?: LocalizationKey;
   profileImageUrl?: string;
   onCodeEntryFinishedAction: (
     code: string,
@@ -75,7 +76,9 @@ export const VerificationCodeCard = (props: PropsWithChildren<VerificationCodeCa
             {showAlternativeMethods && props.onShowAlternativeMethodsClicked && (
               <Card.Action elementId='alternativeMethods'>
                 <Card.ActionLink
-                  localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}
+                  localizationKey={
+                    props.alternativeMethodsLabel ?? localizationKeys('footerActionLink__useAnotherMethod')
+                  }
                   onClick={props.onShowAlternativeMethodsClicked}
                 />
               </Card.Action>

--- a/packages/clerk-js/src/ui/utils/phoneUtils.ts
+++ b/packages/clerk-js/src/ui/utils/phoneUtils.ts
@@ -1,3 +1,5 @@
+import type { PhoneCodeChannel } from '@clerk/types';
+
 import type { CountryEntry, CountryIso } from '../elements/PhoneInput/countryCodeData';
 import { CodeToCountriesMap, IsoToCountryMap, SubAreaCodeSets } from '../elements/PhoneInput/countryCodeData';
 
@@ -127,4 +129,15 @@ export function getCountryFromPhoneString(phone: string): { number: string; coun
   const number = phoneWithCode.slice(country?.code.length || 0);
 
   return { number, country };
+}
+
+export function getPreferredPhoneCodeChannelByCountry(
+  phoneNumber: string,
+  preferredChannels: Record<string, PhoneCodeChannel>,
+): PhoneCodeChannel | null {
+  if (!preferredChannels) {
+    return null;
+  }
+  const { country } = getCountryFromPhoneString(phoneNumber);
+  return preferredChannels[country.iso.toUpperCase()] || null;
 }

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -111,6 +111,7 @@ export const enUS: LocalizationResource = {
   },
   dividerText: 'or',
   footerActionLink__useAnotherMethod: 'Use another method',
+  footerActionLink__alternativePhoneCodeProvider: 'Send code via SMS instead',
   footerPageLink__help: 'Help',
   footerPageLink__privacy: 'Privacy',
   footerPageLink__terms: 'Terms',

--- a/packages/types/src/authConfig.ts
+++ b/packages/types/src/authConfig.ts
@@ -1,3 +1,5 @@
+import type { PhoneCodeChannel } from 'phoneCodeChannel';
+
 import type { ClerkResource } from './resource';
 import type { AuthConfigJSONSnapshot } from './snapshots';
 
@@ -15,5 +17,9 @@ export interface AuthConfigResource extends ClerkResource {
    * Whether Reverification is enabled at the instance level.
    */
   reverification: boolean;
+  /**
+   * Preferred channels for phone code providers.
+   */
+  preferredChannels: Record<string, PhoneCodeChannel> | null;
   __internal_toSnapshot: () => AuthConfigJSONSnapshot;
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -305,6 +305,7 @@ export interface AuthConfigJSON extends ClerkResourceJSON {
   single_session_mode: boolean;
   claimed_at: number | null;
   reverification: boolean;
+  preferred_channels?: Record<string, PhoneCodeChannel>;
 }
 
 export interface VerificationJSON extends ClerkResourceJSON {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -79,6 +79,7 @@ type _LocalizationResource = {
   signInEnterPasswordTitle: LocalizationValue;
   backButton: LocalizationValue;
   footerActionLink__useAnotherMethod: LocalizationValue;
+  footerActionLink__alternativePhoneCodeProvider: LocalizationValue;
   badge__primary: LocalizationValue;
   badge__thisDevice: LocalizationValue;
   badge__userDevice: LocalizationValue;


### PR DESCRIPTION
## Description

This PR:

- Adds a button to fallback to SMS channel when being in the WhatsApp flow.
- Adds support for the `auth_config.preferred_channels` map, to support different phone code provider per country.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
