### PR TITLE
chore(repo): Pin version of pkg-pr-new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,5 +420,11 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
+      - name: Debug Environment
+        run: |
+          echo "PKG_PR_NEW_VERSION: ${{ env.PKG_PR_NEW_VERSION }}"
+          echo "All env vars:"
+          env | sort
+
       - name: Publish with pkg-pr-new
         run: pnpm run build && pnpx pkg-pr-new@${{ env.PKG_PR_NEW_VERSION }} publish --compact --pnpm './packages/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,4 +420,4 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Publish with pkg-pr-new
-        run: pnpm run build && pnpx pkg-pr-new@${{ vars.PKG_PR_NEW_VERSION || 'latest' }} publish --compact --pnpm './packages/*'
+        run: pnpm run build && pnpx pkg-pr-new@${{ vars.PKG_PR_NEW_VERSION || '0.0.49' }} publish --compact --pnpm './packages/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,6 @@ jobs:
 
     env:
       TURBO_SUMMARIZE: false
-      PKG_PR_NEW_VERSION: latest
 
     steps:
       - name: Checkout repository
@@ -420,11 +419,5 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
-      - name: Debug Environment
-        run: |
-          echo "PKG_PR_NEW_VERSION: ${{ env.PKG_PR_NEW_VERSION }}"
-          echo "All env vars:"
-          env | sort
-
       - name: Publish with pkg-pr-new
-        run: pnpm run build && pnpx pkg-pr-new@${{ env.PKG_PR_NEW_VERSION }} publish --compact --pnpm './packages/*'
+        run: pnpm run build && pnpx pkg-pr-new@${{ vars.PKG_PR_NEW_VERSION || 'latest' }} publish --compact --pnpm './packages/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,4 +420,4 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Publish with pkg-pr-new
-        run: pnpm run build && pnpx pkg-pr-new publish --compact --pnpm './packages/*'
+        run: pnpm run build && pnpx pkg-pr-new@${{env.PKG_PR_NEW_VERSION || 'latest'}} publish --compact --pnpm './packages/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,7 @@ jobs:
 
     env:
       TURBO_SUMMARIZE: false
+      PKG_PR_NEW_VERSION: latest
 
     steps:
       - name: Checkout repository
@@ -420,4 +421,4 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Publish with pkg-pr-new
-        run: pnpm run build && pnpx pkg-pr-new@${{env.PKG_PR_NEW_VERSION || 'latest'}} publish --compact --pnpm './packages/*'
+        run: pnpm run build && pnpx pkg-pr-new@${{ env.PKG_PR_NEW_VERSION }} publish --compact --pnpm './packages/*'


### PR DESCRIPTION
## Description

Pinning version of `pr-pkg-new` in CI

<img width="580" alt="Screenshot 2025-05-15 at 6 56 52 PM" src="https://github.com/user-attachments/assets/2a82cda7-640c-4bef-aaf3-f9d6ce8a7638" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
