### PR TITLE
fix(clerk-js): Remove cancel button from free plan

### DIFF
--- a/.changeset/famous-wolves-open.md
+++ b/.changeset/famous-wolves-open.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Remove cancel subscription option when implicitly subscribed to the default free plan.

--- a/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
+++ b/packages/clerk-js/src/ui/components/Plans/PlanDetails.tsx
@@ -199,7 +199,7 @@ const PlanDetailsInternal = ({
         </Drawer.Body>
       ) : null}
 
-      {!plan.isDefault || !isDefaultPlanImplicitlyActiveOrUpcoming ? (
+      {(!plan.isDefault && !isDefaultPlanImplicitlyActiveOrUpcoming) || !subscription ? (
         <Drawer.Footer>
           {subscription ? (
             subscription.canceledAt ? (


### PR DESCRIPTION
## Description

When implicitly on the default free plan, do not show cancel subscription option.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-05-16 at 2 15 33 PM](https://github.com/user-attachments/assets/70322963-db72-423a-98fa-0e3a578f6d7a) | ![Screenshot 2025-05-16 at 2 14 15 PM](https://github.com/user-attachments/assets/569cd7a6-7680-4cd1-93e0-f06a11d2b84c) |
 
Fixes COM-823

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
