### PR TITLE
fix(clerk-js): Translate username error in username form

### DIFF
--- a/.changeset/slick-windows-listen.md
+++ b/.changeset/slick-windows-listen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes issue where min/max username lengths errors were not properly interpolated within profile component.

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernameForm.tsx
@@ -1,10 +1,10 @@
 import { useReverification, useUser } from '@clerk/shared/react';
 
 import { useEnvironment } from '../../contexts';
-import { localizationKeys } from '../../customizables';
+import { localizationKeys, useLocalizations } from '../../customizables';
 import type { FormProps } from '../../elements';
 import { Form, FormButtons, FormContainer, useCardState, withCardStateProvider } from '../../elements';
-import { handleError, useFormControl } from '../../utils';
+import { createUsernameError, handleError, useFormControl } from '../../utils';
 
 type UsernameFormProps = FormProps;
 
@@ -16,10 +16,13 @@ export const UsernameForm = withCardStateProvider((props: UsernameFormProps) => 
 
   const { userSettings } = useEnvironment();
   const card = useCardState();
+  const { t, locale } = useLocalizations();
+  const { usernameSettings } = userSettings;
   const usernameField = useFormControl('username', user?.username || '', {
     type: 'text',
     label: localizationKeys('formFieldLabel__username'),
     placeholder: localizationKeys('formFieldInputPlaceholder__username'),
+    buildErrorMessage: errors => createUsernameError(errors, { t, locale, usernameSettings }),
   });
 
   if (!user) {


### PR DESCRIPTION
## Description

Fixes issue where min/max username lengths errors were not properly interpolated within profile component.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2025-05-16 at 2 58 17 PM](https://github.com/user-attachments/assets/7064c7b9-13fe-4590-8bb5-c4160610612e) | ![Screenshot 2025-05-16 at 2 57 53 PM](https://github.com/user-attachments/assets/225ae361-7f32-4087-b380-b98253d5545d) | 

Fixes SDK-2110

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
