### PR TITLE
fix(clerk-js): Ensure drawers render above keyless prompt

### DIFF
--- a/.changeset/lazy-laws-sniff.md
+++ b/.changeset/lazy-laws-sniff.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removes z-index from keyless prompt to prevent overlay issues with drawers.

--- a/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
+++ b/packages/clerk-js/src/ui/components/KeylessPrompt/index.tsx
@@ -156,7 +156,6 @@ const KeylessPromptInternal = (_props: KeylessPromptProps) => {
           position: 'fixed',
           bottom: '1.25rem',
           right: '1.25rem',
-          zIndex: t.zIndices.$fab,
           height: `${t.sizes.$10}`,
           minWidth: '13.4rem',
           paddingLeft: `${t.space.$3}`,


### PR DESCRIPTION
## Description

Fixes an issue where the keyless prompt was rendering above the newly added drawer component. To fix, we remove the z-index definition from the prompt. Alternatively I considered conditionally hiding the prompt when a drawer is open but the caused the initial expanded to always fire, even after it was closed once. So the z-index solution felt like the best approach.

https://github.com/user-attachments/assets/d5bffacd-9c15-46a3-b800-f947ed3fec1c

Fixes SDK-2115

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
