### PR TITLE
fix(clerk-js): Allow removal of all payment methods if no paid subs

### DIFF
--- a/.changeset/dark-tips-strive.md
+++ b/.changeset/dark-tips-strive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix logic for allowing removal of all payment methods if there are no paid subscriptions

--- a/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
@@ -184,7 +184,7 @@ const PaymentSourceMenu = ({
       label: localizationKeys('userProfile.billingPage.paymentSourcesSection.actionLabel__remove'),
       isDestructive: true,
       onClick: () => open(`remove-${paymentSource.id}`),
-      isDisabled: paymentSource.isDefault && subscriptions.filter(s => !s.plan.isDefault).length > 0,
+      isDisabled: paymentSource.isDefault && subscriptions.some(s => !s.plan.isDefault),
     },
   ];
 

--- a/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
@@ -184,7 +184,7 @@ const PaymentSourceMenu = ({
       label: localizationKeys('userProfile.billingPage.paymentSourcesSection.actionLabel__remove'),
       isDestructive: true,
       onClick: () => open(`remove-${paymentSource.id}`),
-      isDisabled: paymentSource.isDefault && subscriptions.length > 0,
+      isDisabled: paymentSource.isDefault && subscriptions.filter(s => !s.plan.isDefault).length > 0,
     },
   ];
 


### PR DESCRIPTION
## Description

Fixes the logic for allowing removal of all payment methods if there are no _paid_ subscriptions.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
