### PR TITLE
fix(clerk-js): Pass full statement id as value

### DIFF
--- a/.changeset/poor-results-lay.md
+++ b/.changeset/poor-results-lay.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Pass the full statement id to the list item to ensure the full value is copied to clipboard.

--- a/packages/clerk-js/src/ui/components/Statements/StatementPage.tsx
+++ b/packages/clerk-js/src/ui/components/Statements/StatementPage.tsx
@@ -3,7 +3,6 @@ import { Box, descriptors, Spinner, Text } from '../../customizables';
 import { Header } from '../../elements';
 import { Plus, RotateLeftRight } from '../../icons';
 import { useRouter } from '../../router';
-import { truncateWithEndVisible } from '../../utils/truncateTextWithEndVisible';
 import { Statement } from './Statement';
 
 export const StatementPage = () => {
@@ -82,7 +81,7 @@ export const StatementPage = () => {
                             : `Subscribed and paid for ${item.subscription.plan.name} ${item.subscription.planPeriod} plan`
                         }
                         labelIcon={item.chargeType === 'recurring' ? RotateLeftRight : Plus}
-                        value={truncateWithEndVisible(item.id)}
+                        value={item.id}
                         valueTruncated
                         valueCopyable
                       />


### PR DESCRIPTION
## Description

Pass the full statement id into `SectionContentDetailsListItem` as internally it handles truncation and ensures the full value is copied to the clipboard.

Fixes COM-857

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
