### PR TITLE
fix(clerk-js): Ensure setActive emits previous token for onBeforeSetActive

### DIFF
--- a/.changeset/crazy-readers-flow.md
+++ b/.changeset/crazy-readers-flow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix an issue where clerk-js was incorrectly emitting the new session's token during session switching. This impacts some applications that rely on Clerk's multi-session behavior.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1094,8 +1094,8 @@ export class Clerk implements ClerkInterface {
         return;
       }
 
-      if (session?.lastActiveToken) {
-        eventBus.emit(events.TokenUpdate, { token: session.lastActiveToken });
+      if (this.session?.lastActiveToken) {
+        eventBus.emit(events.TokenUpdate, { token: this.session.lastActiveToken });
       }
 
       /**


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Currently, we are updating the session token with the new session's token during a session switch, causing the invalidate cache call in `onBeforeSetActive()` to use the new token. Conceptually, this is wrong. We expect this call to be made with the current (previous) session's token before the new session is actually switched to.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
