### PR TITLE
fix(clerk): Do not throttle touch for multisession apps

### DIFF
--- a/.changeset/rotten-trams-rush.md
+++ b/.changeset/rotten-trams-rush.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Drop throttling for multisession apps to fix edge cases when quickly switching between tabs with different sessions, in apps that have multisession support enabled.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2434,6 +2434,7 @@ export class Clerk implements ClerkInterface {
         return;
       }
 
+      // In multi-session apps, it's possible that different tabs will have different active sessions. It's critical that the tab's active session is touched in this case so the session is properly updated on the backend, and so we avoid any throttling when multi-session mode is enabled.
       const multisessionMode = this.environment && !this.environment.authConfig.singleSessionMode;
       if (!multisessionMode && this.#touchThrottledUntil > Date.now()) {
         return;

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2434,7 +2434,8 @@ export class Clerk implements ClerkInterface {
         return;
       }
 
-      if (this.#touchThrottledUntil > Date.now()) {
+      const multisessionMode = this.environment && !this.environment.authConfig.singleSessionMode;
+      if (!multisessionMode && this.#touchThrottledUntil > Date.now()) {
         return;
       }
       this.#touchThrottledUntil = Date.now() + 5_000;


### PR DESCRIPTION
## Description

This PR drops throttling for multisession apps to fix edge cases when quickly switching between tabs with different sessions, in apps that have multisession support enabled.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
