### PR TITLE
refactor(clerk-js): Update checkout success highlight approach

### DIFF
--- a/.changeset/rotten-banks-rush.md
+++ b/.changeset/rotten-banks-rush.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Refactors checkout success highlight animation to fix an issue where background colors other that white, would not properly mask the highlight glow.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -21,7 +21,7 @@
     { "path": "./dist/waitlist*.js", "maxSize": "1.3KB" },
     { "path": "./dist/keylessPrompt*.js", "maxSize": "6.5KB" },
     { "path": "./dist/pricingTable*.js", "maxSize": "4.02KB" },
-    { "path": "./dist/checkout*.js", "maxSize": "6.45KB" },
+    { "path": "./dist/checkout*.js", "maxSize": "6.52KB" },
     { "path": "./dist/paymentSources*.js", "maxSize": "9.06KB" },
     { "path": "./dist/up-billing-page*.js", "maxSize": "3.0KB" },
     { "path": "./dist/op-billing-page*.js", "maxSize": "3.0KB" },

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
@@ -117,9 +117,12 @@ export const CheckoutComplete = ({
           ref={checkoutSuccessRootRef}
           onMouseMove={handleMouseMove}
         >
-          <svg
+          <Box
+            elementDescriptor={descriptors.checkoutSuccessRings}
+            as='svg'
+            // @ts-ignore - viewBox is a valid prop for svg
             viewBox='0 0 512 512'
-            style={{
+            sx={{
               position: 'absolute',
               inset: 0,
               pointerEvents: 'none',
@@ -185,7 +188,7 @@ export const CheckoutComplete = ({
                 />
               )}
             </g>
-          </svg>
+          </Box>
           <Box
             elementDescriptor={descriptors.checkoutSuccessBadge}
             sx={t => ({

--- a/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
+++ b/packages/clerk-js/src/ui/components/Checkout/CheckoutComplete.tsx
@@ -6,7 +6,6 @@ import { Box, Button, descriptors, Heading, localizationKeys, Span, Text } from 
 import { Drawer, LineItems, useDrawerContext } from '../../elements';
 import { transitionDurationValues, transitionTiming } from '../../foundations/transitions';
 import { useRouter } from '../../router';
-import { animations } from '../../styledSystem';
 import { formatDate } from '../../utils';
 
 const capitalize = (name: string) => name[0].toUpperCase() + name.slice(1);
@@ -22,8 +21,8 @@ export const CheckoutComplete = ({
   const router = useRouter();
   const { setIsOpen } = useDrawerContext();
   const { newSubscriptionRedirectUrl } = useCheckoutContext();
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-  const [currentPosition, setCurrentPosition] = useState({ x: 0, y: 0 });
+  const [mousePosition, setMousePosition] = useState({ x: 256, y: 256 });
+  const [currentPosition, setCurrentPosition] = useState({ x: 256, y: 256 });
   const animationRef = useRef<number | null>(null);
   const checkoutSuccessRootRef = useRef<HTMLSpanElement>(null);
   const canHover =
@@ -33,10 +32,19 @@ export const CheckoutComplete = ({
     if (!canHover) return;
     if (checkoutSuccessRootRef.current) {
       const rect = checkoutSuccessRootRef.current.getBoundingClientRect();
-      setMousePosition({
-        x: event.clientX - rect.left,
-        y: event.clientY - rect.top,
-      });
+      const domX = event.clientX - rect.left;
+      const domY = event.clientY - rect.top;
+      const domWidth = rect.width;
+
+      const svgViewBoxWidth = 512;
+
+      if (domWidth > 0) {
+        const svgX = (domX / domWidth) * svgViewBoxWidth;
+        const svgY = (domY / domWidth) * svgViewBoxWidth;
+        setMousePosition({ x: svgX, y: svgY });
+      } else {
+        setMousePosition({ x: 256, y: 256 });
+      }
     }
   };
 
@@ -72,6 +80,8 @@ export const CheckoutComplete = ({
         <Span
           elementDescriptor={descriptors.checkoutSuccessRoot}
           sx={t => ({
+            '--ring-fill': t.colors.$neutralAlpha200,
+            '--ring-highlight': t.colors.$success500,
             margin: 'auto',
             position: 'relative',
             aspectRatio: '1/1',
@@ -107,39 +117,75 @@ export const CheckoutComplete = ({
           ref={checkoutSuccessRootRef}
           onMouseMove={handleMouseMove}
         >
-          {[1, 0.75, 0.5].map((scale, index, array) => {
-            return (
-              <Ring
-                key={scale}
-                scale={scale}
-                index={array.length - 1 - index}
-                isMotionSafe={isMotionSafe}
-              />
-            );
-          })}
-          <Box
-            elementDescriptor={descriptors.checkoutSuccessHighlight}
-            sx={t => ({
-              position: 'absolute',
-              width: t.sizes.$56,
-              height: t.sizes.$56,
-              transform: 'translate(-50%, -50%)',
-              borderRadius: '50%',
-              backgroundColor: t.colors.$success500,
-              mixBlendMode: 'color',
-              filter: 'blur(20px)',
-              opacity: 0.5,
-              zIndex: 1,
-              pointerEvents: 'none',
-              ...(!canHover && {
-                display: 'none',
-              }),
-            })}
+          <svg
+            viewBox='0 0 512 512'
             style={{
-              left: currentPosition.x,
-              top: currentPosition.y,
+              position: 'absolute',
+              inset: 0,
+              pointerEvents: 'none',
             }}
-          />
+            aria-hidden
+          >
+            <defs>
+              <radialGradient id='clerk-checkout-success-gradient'>
+                <stop
+                  offset='0%'
+                  style={{
+                    stopColor: 'var(--ring-highlight)',
+                  }}
+                />
+                <stop
+                  offset='100%'
+                  stopOpacity='0'
+                  style={{
+                    stopColor: 'var(--ring-highlight)',
+                  }}
+                />
+              </radialGradient>
+              <filter id='clerk-checkout-success-blur-effect'>
+                <feGaussianBlur stdDeviation='10' />
+              </filter>
+              <mask id='clerk-checkout-success-mask'>
+                {[
+                  { r: 225, maskStart: 10, maskEnd: 90 },
+                  { r: 162.5, maskStart: 15, maskEnd: 85 },
+                  { r: 100, maskStart: 20, maskEnd: 80 },
+                ].map(({ r, maskStart, maskEnd }) => (
+                  <circle
+                    key={r}
+                    cx='256'
+                    cy='256'
+                    r={r}
+                    stroke='white'
+                    fill='none'
+                    style={{
+                      maskImage: `linear-gradient(to bottom, transparent ${maskStart}%, black, transparent ${maskEnd}%)`,
+                    }}
+                  />
+                ))}
+              </mask>
+            </defs>
+            <g mask='url(#clerk-checkout-success-mask)'>
+              <rect
+                width='512'
+                height='512'
+                style={{
+                  fill: 'var(--ring-fill)',
+                }}
+              />
+              {canHover && (
+                <rect
+                  id='movingGradientHighlight'
+                  width='256'
+                  height='256'
+                  x={currentPosition.x - 128}
+                  y={currentPosition.y - 128}
+                  fill='url(#clerk-checkout-success-gradient)'
+                  filter='url(#clerk-checkout-success-blur-effect)'
+                />
+              )}
+            </g>
+          </svg>
           <Box
             elementDescriptor={descriptors.checkoutSuccessBadge}
             sx={t => ({
@@ -341,46 +387,3 @@ export const CheckoutComplete = ({
     </>
   );
 };
-
-function Ring({
-  scale,
-  index,
-  isMotionSafe,
-}: {
-  /**
-   * Number between 0-1
-   */
-  scale: number;
-  /**
-   * Index of the ring (0-2)
-   */
-  index: number;
-  isMotionSafe: boolean;
-}) {
-  return (
-    <Span
-      elementDescriptor={descriptors.checkoutSuccessRing}
-      sx={t => ({
-        margin: 'auto',
-        gridArea: '1/1',
-        width: `${scale * 100}%`,
-        height: `${scale * 100}%`,
-        borderWidth: 1,
-        borderStyle: 'solid',
-        borderColor: t.colors.$neutralAlpha200,
-        borderRadius: t.radii.$circle,
-        maskImage: `linear-gradient(to bottom, transparent 15%, black, transparent 85%)`,
-        opacity: 0,
-        animationName: animations.fadeIn,
-        animationDuration: `${transitionDurationValues.slow}ms`,
-        animationTimingFunction: transitionTiming.bezier,
-        animationFillMode: 'forwards',
-        animationDelay: `${index * transitionDurationValues.slow}ms`,
-        ...(!isMotionSafe && {
-          animation: 'none',
-          opacity: 1,
-        }),
-      })}
-    />
-  );
-}

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -89,11 +89,10 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'checkoutFormElementsRoot',
 
   'checkoutSuccessRoot',
-  'checkoutSuccessRing',
+  'checkoutSuccessRings',
   'checkoutSuccessBadge',
   'checkoutSuccessTitle',
   'checkoutSuccessDescription',
-  'checkoutSuccessHighlight',
 
   'otpCodeField',
   'otpCodeFieldInputs',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -209,11 +209,10 @@ export type ElementsConfig = {
   checkoutFormElementsRoot: WithOptions;
 
   checkoutSuccessRoot: WithOptions;
-  checkoutSuccessRing: WithOptions;
+  checkoutSuccessRings: WithOptions;
   checkoutSuccessBadge: WithOptions;
   checkoutSuccessTitle: WithOptions;
   checkoutSuccessDescription: WithOptions;
-  checkoutSuccessHighlight: WithOptions;
 
   otpCodeField: WithOptions;
   otpCodeFieldInputs: WithOptions;


### PR DESCRIPTION
## Description

The current highlight approach uses an overlay element the uses `mix-blend-mode` to interact with the elements within the checkout success drawer. This works well for white background usage, but as soon as the user modifies to the `colorBackground` value to be a light gray or uses the dark theme for example, the blend mode does not work due to the different in colors.

This updated approach uses an SVG and mask to implement the highlight in the rings which works across any `colorBackground` usage. One downside is we lose the interaction with the checkmark element and text but I am not sure we can have an implementation that supports that where users can input any background color.

BEFORE

https://github.com/user-attachments/assets/1b64ade4-5cb4-4dd7-a0f4-61d241082973

AFTER

https://github.com/user-attachments/assets/60ab877a-43cc-4309-905e-ab0c061007b1

Fixes COM-869

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
