### PR TITLE
fix(clerk-js): Do not treat phone_number as optional if used as identifier

### DIFF
--- a/.changeset/little-wings-bathe.md
+++ b/.changeset/little-wings-bathe.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue where the combined flow wouldn't trigger if a phone number was used as an identifier while set as an optional field.

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
@@ -1,0 +1,175 @@
+import type { LoadedClerk, SignUpResource } from '@clerk/types';
+import { handleCombinedFlowTransfer, hasOptionalFields } from '../handleCombinedFlowTransfer';
+
+var mockCompleteSignUpFlow: jest.Mock;
+jest.mock('../lazy-sign-up', () => {
+  mockCompleteSignUpFlow = jest.fn();
+  return {
+    lazyCompleteSignUpFlow: () => {
+      return Promise.resolve(mockCompleteSignUpFlow);
+    },
+  };
+});
+
+const mockNavigate = jest.fn();
+const mockHandleError = jest.fn();
+
+describe('handleCombinedFlowTransfer', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should call completeSignUpFlow', async () => {
+    const mockClerk = {
+      client: {
+        signUp: {
+          create: jest.fn().mockResolvedValue({}),
+          optionalFields: [],
+        },
+      },
+    };
+
+    await handleCombinedFlowTransfer({
+      identifierAttribute: 'emailAddress',
+      identifierValue: 'test@test.com',
+      signUpMode: 'public',
+      navigate: mockNavigate,
+      handleError: mockHandleError,
+      clerk: mockClerk as unknown as LoadedClerk,
+      afterSignUpUrl: 'https://test.com',
+      passwordEnabled: false,
+    });
+
+    expect(mockCompleteSignUpFlow).toHaveBeenCalled();
+  });
+
+  it('should call completeSignUpFlow with phone number if phone number is optional field.', async () => {
+    const mockClerk = {
+      client: {
+        signUp: {
+          create: jest.fn().mockImplementation((...args) => Promise.resolve(args)),
+          optionalFields: ['phone_number'],
+        },
+      },
+    };
+
+    await handleCombinedFlowTransfer({
+      identifierAttribute: 'phoneNumber',
+      identifierValue: '+1234567890',
+      signUpMode: 'public',
+      navigate: mockNavigate,
+      handleError: mockHandleError,
+      clerk: mockClerk as unknown as LoadedClerk,
+      afterSignUpUrl: 'https://test.com',
+      passwordEnabled: false,
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockClerk.client.signUp.create).toHaveBeenCalled();
+    expect(mockCompleteSignUpFlow).toHaveBeenCalled();
+  });
+
+  it('should call navigate if password is enabled', async () => {
+    const mockClerk = {
+      client: {
+        signUp: {
+          create: jest.fn().mockImplementation((...args) => Promise.resolve(args)),
+          optionalFields: ['password'],
+        },
+      },
+    };
+
+    await handleCombinedFlowTransfer({
+      identifierAttribute: 'phoneNumber',
+      identifierValue: '+1234567890',
+      signUpMode: 'public',
+      navigate: mockNavigate,
+      handleError: mockHandleError,
+      clerk: mockClerk as unknown as LoadedClerk,
+      afterSignUpUrl: 'https://test.com',
+      passwordEnabled: true,
+    });
+
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(mockClerk.client.signUp.create).not.toHaveBeenCalled();
+    expect(mockCompleteSignUpFlow).not.toHaveBeenCalled();
+  });
+
+  it('should call navigate if identifier is username', async () => {
+    const mockClerk = {
+      client: {
+        signUp: {
+          create: jest.fn().mockImplementation((...args) => Promise.resolve(args)),
+          optionalFields: [],
+        },
+      },
+    };
+
+    await handleCombinedFlowTransfer({
+      identifierAttribute: 'username',
+      identifierValue: 'test',
+      signUpMode: 'public',
+      navigate: mockNavigate,
+      handleError: mockHandleError,
+      clerk: mockClerk as unknown as LoadedClerk,
+      afterSignUpUrl: 'https://test.com',
+      passwordEnabled: false,
+    });
+
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(mockClerk.client.signUp.create).not.toHaveBeenCalled();
+    expect(mockCompleteSignUpFlow).not.toHaveBeenCalled();
+  });
+
+  it('should call navigate if first_name is optional', async () => {
+    const mockClerk = {
+      client: {
+        signUp: {
+          create: jest.fn().mockImplementation((...args) => Promise.resolve(args)),
+          optionalFields: ['first_name'],
+        },
+      },
+    };
+
+    await handleCombinedFlowTransfer({
+      identifierAttribute: 'emailAddress',
+      identifierValue: 'test@test.com',
+      signUpMode: 'public',
+      navigate: mockNavigate,
+      handleError: mockHandleError,
+      clerk: mockClerk as unknown as LoadedClerk,
+      afterSignUpUrl: 'https://test.com',
+      passwordEnabled: false,
+    });
+
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(mockClerk.client.signUp.create).not.toHaveBeenCalled();
+    expect(mockCompleteSignUpFlow).not.toHaveBeenCalled();
+  });
+});
+
+describe('hasOptionalFields', () => {
+  it('should return true if there are optional fields', () => {
+    const signUp = {
+      optionalFields: ['legal_accepted'],
+    } as unknown as SignUpResource;
+
+    expect(hasOptionalFields(signUp, 'phoneNumber')).toBe(true);
+  });
+
+  it('should return false if the identifier attribute is phoneNumber and the optional field is phone_number', () => {
+    const signUp = {
+      optionalFields: ['phone_number'],
+    } as unknown as SignUpResource;
+
+    expect(hasOptionalFields(signUp, 'phoneNumber')).toBe(false);
+  });
+
+  it('should return false if there are no optional fields', () => {
+    const signUp = {
+      optionalFields: [],
+    } as unknown as SignUpResource;
+
+    expect(hasOptionalFields(signUp, 'phoneNumber')).toBe(false);
+  });
+});

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
@@ -1,6 +1,8 @@
 import type { LoadedClerk, SignUpResource } from '@clerk/types';
+
 import { handleCombinedFlowTransfer, hasOptionalFields } from '../handleCombinedFlowTransfer';
 
+// eslint-disable-next-line no-var -- Jest hoists mock calls to the top of the file, so var is needed.
 var mockCompleteSignUpFlow: jest.Mock;
 jest.mock('../lazy-sign-up', () => {
   mockCompleteSignUpFlow = jest.fn();


### PR DESCRIPTION
## Description

This PR fixes an issue where the combined flow wouldn't trigger correctly when invoked with a phone number while phone number was an optional field. It resolves the issue by treating phone_number as a non-optional field when a phone number identifier is used. Additionally, it adds some very, _very_ basic unit tests for the `handleCombinedFlowTransfer` function.

For context, we don't automatically convert sign ins to sign ups in the combined flow if there are possible optional fields that the user might want to complete. Before this PR, `phone_number` was an optional field. If the user tried to sign in with a phone number not associated with an account, we would consider `phone_number` an optional field, and redirect to the `create` step. This was unnecessary since the user already provided a phone number.

Fixes SDKI-1020

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
