### PR TITLE
fix(backend): Ensure `SAMLConnection` API responses are explicitly deserialized

### DIFF
--- a/.changeset/weak-kings-ring.md
+++ b/.changeset/weak-kings-ring.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Ensure SAMLConnection API responses are explicitly deserialized

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -22,6 +22,7 @@ import {
   PhoneNumber,
   ProxyCheck,
   RedirectUrl,
+  SamlConnection,
   Session,
   SignInToken,
   SignUpAttempt,
@@ -125,6 +126,8 @@ function jsonToObject(item: any): any {
       return ProxyCheck.fromJSON(item);
     case ObjectType.RedirectUrl:
       return RedirectUrl.fromJSON(item);
+    case ObjectType.SamlConnection:
+      return SamlConnection.fromJSON(item);
     case ObjectType.SignInToken:
       return SignInToken.fromJSON(item);
     case ObjectType.SignUpAttempt:

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -45,6 +45,7 @@ export const ObjectType = {
   ProxyCheck: 'proxy_check',
   RedirectUrl: 'redirect_url',
   SamlAccount: 'saml_account',
+  SamlConnection: 'saml_connection',
   Session: 'session',
   SignInAttempt: 'sign_in_attempt',
   SignInToken: 'sign_in_token',
@@ -603,6 +604,7 @@ export interface PaginatedResponseJSON {
 }
 
 export interface SamlConnectionJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.SamlConnection;
   name: string;
   domain: string;
   organization_id: string | null;


### PR DESCRIPTION
## Description

`SAMLConnection` responses weren't being deserialized. This PR fixes that.

<!-- Fixes #(issue number) -->

ECO-656

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
