### PR TITLE
feat(clerk-js): Initiate enterprise SSO from ticket flows

### DIFF
--- a/.changeset/nasty-items-jog.md
+++ b/.changeset/nasty-items-jog.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Initiate enterprise SSO from ticket flows, such as organization invitations.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -222,6 +222,10 @@ function SignInStartInternal(): JSX.Element {
       .then(res => {
         switch (res.status) {
           case 'needs_first_factor':
+            if (res.supportedFirstFactors?.every(ff => ff.strategy === 'enterprise_sso')) {
+              return authenticateWithEnterpriseSSO();
+            }
+
             return navigate('factor-one');
           case 'needs_second_factor':
             return navigate('factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -245,6 +245,9 @@ function SignInStartInternal(): JSX.Element {
         return attemptToRecoverFromSignInError(err);
       })
       .finally(() => {
+        // Keep the card in loading state during SSO redirect to prevent UI flicker
+        // This is necessary because there's a brief delay between initiating the SSO flow
+        // and the actual redirect to the external Identity Provider
         const isRedirectingToSSOProvider = hasOnlyEnterpriseSSOFirstFactors(signIn);
         if (isRedirectingToSSOProvider) return;
 
@@ -612,11 +615,11 @@ function SignInStartInternal(): JSX.Element {
 }
 
 const hasOnlyEnterpriseSSOFirstFactors = (signIn: SignInResource): boolean => {
-  if (!signIn?.supportedFirstFactors?.length) {
+  if (!signIn.supportedFirstFactors?.length) {
     return false;
   }
 
-  return signIn.supportedFirstFactors.every(ff => ff.strategy === 'saml' || ff.strategy === 'enterprise_sso');
+  return signIn.supportedFirstFactors.every(ff => ff.strategy === 'enterprise_sso');
 };
 
 const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> }) => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -170,6 +170,9 @@ function SignUpStartInternal(): JSX.Element {
         handleError(err, [], card.setError);
       })
       .finally(() => {
+        const isRedirectingToSSOProvider = signUp.missingFields.some(mf => mf === 'saml' || mf === 'enterprise_sso');
+        if (isRedirectingToSSOProvider) return;
+
         status.setIdle();
         card.setIdle();
       });

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -119,6 +119,7 @@ function SignUpStartInternal(): JSX.Element {
   const hasEmail = !!formState.emailAddress.value;
   const isProgressiveSignUp = userSettings.signUp.progressive;
   const isLegalConsentEnabled = userSettings.signUp.legal_consent_enabled;
+  const oidcPrompt = ctx.oidcPrompt;
 
   const fields = determineActiveFields({
     attributes,
@@ -145,8 +146,13 @@ function SignUpStartInternal(): JSX.Element {
           setMissingRequirementsWithTicket(true);
         }
 
+        const redirectUrl = ctx.ssoCallbackUrl;
+        const redirectUrlComplete = ctx.afterSignUpUrl || '/';
+
         return completeSignUpFlow({
           signUp,
+          redirectUrl,
+          redirectUrlComplete,
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
           handleComplete: () => {
@@ -155,6 +161,7 @@ function SignUpStartInternal(): JSX.Element {
             return setActive({ session: signUp.createdSessionId, redirectUrl: afterSignUpUrl });
           },
           navigate,
+          oidcPrompt,
         });
       })
       .catch(err => {
@@ -302,7 +309,7 @@ function SignUpStartInternal(): JSX.Element {
           navigate,
           redirectUrl,
           redirectUrlComplete,
-          oidcPrompt: ctx.oidcPrompt,
+          oidcPrompt,
         }),
       )
       .catch(err => handleError(err, fieldsToSubmit, card.setError))

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -170,6 +170,9 @@ function SignUpStartInternal(): JSX.Element {
         handleError(err, [], card.setError);
       })
       .finally(() => {
+        // Keep the card in loading state during SSO redirect to prevent UI flicker
+        // This is necessary because there's a brief delay between initiating the SSO flow
+        // and the actual redirect to the external Identity Provider
         const isRedirectingToSSOProvider = signUp.missingFields.some(mf => mf === 'saml' || mf === 'enterprise_sso');
         if (isRedirectingToSSOProvider) return;
 


### PR DESCRIPTION
## Description

We've introduced FAPI changes to return `missing_requirements` / `needs_first_factor` when a sign-in/sign-up gets created with an org invite that is related to an active enterprise connection. 

This PR updates the ticket flows to check against those new statuses and initiate enterprise SSO redirection.

https://github.com/user-attachments/assets/460b4862-c9cb-4a12-8cad-0ab67a034b63

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
