### PR TITLE
fix(clerk-js,types): Handle missing `publicUserData` in `OrganizationMembership`

### DIFF
--- a/.changeset/three-days-wash.md
+++ b/.changeset/three-days-wash.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Handle missing `publicUserData` in `OrganizationMembership`

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -17,7 +17,7 @@ import { BaseResource, Organization, PublicUserData } from './internal';
 export class OrganizationMembership extends BaseResource implements OrganizationMembershipResource {
   id!: string;
   publicMetadata: OrganizationMembershipPublicMetadata = {};
-  publicUserData!: PublicUserData;
+  publicUserData?: PublicUserData;
   organization!: Organization;
   permissions: OrganizationPermissionKey[] = [];
   role!: OrganizationCustomRoleKey;
@@ -50,14 +50,16 @@ export class OrganizationMembership extends BaseResource implements Organization
 
   destroy = async (): Promise<OrganizationMembership> => {
     // TODO: Revise the return type of _baseDelete
+    // TODO: Handle case where publicUserData is not present
     return (await this._baseDelete({
-      path: `/organizations/${this.organization.id}/memberships/${this.publicUserData.userId}`,
+      path: `/organizations/${this.organization.id}/memberships/${this.publicUserData?.userId}`,
     })) as unknown as OrganizationMembership;
   };
 
   update = async ({ role }: UpdateOrganizationMembershipParams): Promise<OrganizationMembership> => {
+    // TODO: Handle case where publicUserData is not present
     return await this._basePatch({
-      path: `/organizations/${this.organization.id}/memberships/${this.publicUserData.userId}`,
+      path: `/organizations/${this.organization.id}/memberships/${this.publicUserData?.userId}`,
       body: { role },
     });
   };
@@ -86,7 +88,7 @@ export class OrganizationMembership extends BaseResource implements Organization
       id: this.id,
       organization: this.organization.__internal_toSnapshot(),
       public_metadata: this.publicMetadata,
-      public_user_data: this.publicUserData.__internal_toSnapshot(),
+      public_user_data: this.publicUserData?.__internal_toSnapshot(),
       permissions: this.permissions,
       role: this.role,
       created_at: this.createdAt.getTime(),

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -48,7 +48,7 @@ export interface OrganizationMembershipResource extends ClerkResource {
   organization: OrganizationResource;
   permissions: OrganizationPermissionKey[];
   publicMetadata: OrganizationMembershipPublicMetadata;
-  publicUserData: PublicUserData;
+  publicUserData?: PublicUserData;
   role: OrganizationCustomRoleKey;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION


## Description

Handles missing `publicUserData` for `OrganizationMemberships` if it's `undefined`

<!-- Fixes #(issue number) -->
Fixes ECO-658
Fixes #6010 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
