### PR TITLE
feat(clerk-expo): Default token cache `SecureStore` implementation `keychainAccessible` to `AFTER_FIRST_UNLOCK`

### DIFF
--- a/.changeset/pretty-parks-arrive.md
+++ b/.changeset/pretty-parks-arrive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': minor
+---
+
+Default token cache `SecureStore` implementation `keychainAccessible` to `AFTER_FIRST_UNLOCK` - The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user. This may be useful if you need to access the item when the device is locked.

--- a/packages/expo/src/token-cache/index.ts
+++ b/packages/expo/src/token-cache/index.ts
@@ -7,18 +7,28 @@ import { isNative } from '../utils';
  * Create a token cache using Expo's SecureStore
  */
 const createTokenCache = (): TokenCache => {
+  const secureStoreOpts: SecureStore.SecureStoreOptions = {
+    /**
+     * The data in the keychain item cannot be accessed after a restart until the
+     * device has been unlocked once by the user.
+     *
+     * This may be useful if you need to access the item when the phone is locked.
+     */
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+  };
+
   return {
     getToken: async (key: string) => {
       try {
-        const item = await SecureStore.getItemAsync(key);
+        const item = await SecureStore.getItemAsync(key, secureStoreOpts);
         return item;
       } catch {
-        await SecureStore.deleteItemAsync(key);
+        await SecureStore.deleteItemAsync(key, secureStoreOpts);
         return null;
       }
     },
     saveToken: (key: string, token: string) => {
-      return SecureStore.setItemAsync(key, token);
+      return SecureStore.setItemAsync(key, token, secureStoreOpts);
     },
   };
 };


### PR DESCRIPTION
## Description

Allows for the token to be accessed from within background jobs, by default.

> [Unlikely to be breaking, but we will need to test in a number of scenarios.]

<!-- Fixes #(issue number) -->

FIXES ECO-661

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
