### PR TITLE
fix(clerk-js): Add support for the signup_rate_limit_exceeded error in OAuth flows

### DIFF
--- a/.changeset/three-olives-start.md
+++ b/.changeset/three-olives-start.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add support for the signup_rate_limit_exceeded error on OAuth flows

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -38,6 +38,7 @@ export const ERROR_CODES = {
   CAPTCHA_INVALID: 'captcha_invalid',
   FRAUD_DEVICE_BLOCKED: 'device_blocked',
   FRAUD_ACTION_BLOCKED: 'action_blocked',
+  SIGNUP_RATE_LIMIT_EXCEEDED: 'signup_rate_limit_exceeded',
 } as const;
 
 export const SIGN_IN_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username'];

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -275,6 +275,7 @@ function SignInStartInternal(): JSX.Element {
           case ERROR_CODES.CAPTCHA_INVALID:
           case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
           case ERROR_CODES.FRAUD_ACTION_BLOCKED:
+          case ERROR_CODES.SIGNUP_RATE_LIMIT_EXCEEDED:
             card.setError(error);
             break;
           default:

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -194,6 +194,7 @@ function SignUpStartInternal(): JSX.Element {
           case ERROR_CODES.CAPTCHA_INVALID:
           case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
           case ERROR_CODES.FRAUD_ACTION_BLOCKED:
+          case ERROR_CODES.SIGNUP_RATE_LIMIT_EXCEEDED:
             card.setError(error);
             break;
           default:


### PR DESCRIPTION
## Description

Adds support for the `signup_rate_limit_exceeded` error code in OAuth flows.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
