### PR TITLE
chore(clerk-js,types): Use is_removable flag on payment sources

### DIFF
--- a/.changeset/happy-bees-post.md
+++ b/.changeset/happy-bees-post.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Use the `is_removable` flag on a payment source to determine if it can be removed.

--- a/packages/clerk-js/src/core/resources/CommercePaymentSource.ts
+++ b/packages/clerk-js/src/core/resources/CommercePaymentSource.ts
@@ -17,6 +17,7 @@ export class CommercePaymentSource extends BaseResource implements CommercePayme
   paymentMethod!: string;
   cardType!: string;
   isDefault!: boolean;
+  isRemovable!: boolean;
   status!: CommercePaymentSourceStatus;
   walletType: string | undefined;
 
@@ -35,6 +36,7 @@ export class CommercePaymentSource extends BaseResource implements CommercePayme
     this.paymentMethod = data.payment_method;
     this.cardType = data.card_type;
     this.isDefault = data.is_default;
+    this.isRemovable = data.is_removable ?? false;
     this.status = data.status;
     this.walletType = data.wallet_type ?? undefined;
 

--- a/packages/clerk-js/src/core/resources/CommercePaymentSource.ts
+++ b/packages/clerk-js/src/core/resources/CommercePaymentSource.ts
@@ -36,7 +36,7 @@ export class CommercePaymentSource extends BaseResource implements CommercePayme
     this.paymentMethod = data.payment_method;
     this.cardType = data.card_type;
     this.isDefault = data.is_default;
-    this.isRemovable = data.is_removable ?? false;
+    this.isRemovable = data.is_removable;
     this.status = data.status;
     this.walletType = data.wallet_type ?? undefined;
 

--- a/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/PaymentSources.tsx
@@ -4,7 +4,7 @@ import type { SetupIntent } from '@stripe/stripe-js';
 import { Fragment, useCallback, useMemo, useRef } from 'react';
 
 import { RemoveResourceForm } from '../../common';
-import { usePaymentSources, useSubscriberTypeContext, useSubscriptions } from '../../contexts';
+import { usePaymentSources, useSubscriberTypeContext } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { FullHeightLoader, ProfileSection, ThreeDotsMenu, useCardState, withCardStateProvider } from '../../elements';
 import { Action } from '../../elements/Action';
@@ -174,14 +174,13 @@ const PaymentSourceMenu = ({
   const card = useCardState();
   const { organization } = useOrganization();
   const subscriberType = useSubscriberTypeContext();
-  const { data: subscriptions } = useSubscriptions();
 
   const actions = [
     {
       label: localizationKeys('userProfile.billingPage.paymentSourcesSection.actionLabel__remove'),
       isDestructive: true,
       onClick: () => open(`remove-${paymentSource.id}`),
-      isDisabled: paymentSource.isDefault && subscriptions.some(s => !s.plan.isDefault),
+      isDisabled: !paymentSource.isRemovable,
     },
   ];
 

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -96,6 +96,7 @@ export interface CommercePaymentSourceResource extends ClerkResource {
   paymentMethod: string;
   cardType: string;
   isDefault: boolean;
+  isRemovable?: boolean;
   status: CommercePaymentSourceStatus;
   walletType: string | undefined;
   remove: (params?: RemovePaymentSourceParams) => Promise<DeletedObjectResource>;

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -96,7 +96,7 @@ export interface CommercePaymentSourceResource extends ClerkResource {
   paymentMethod: string;
   cardType: string;
   isDefault: boolean;
-  isRemovable?: boolean;
+  isRemovable: boolean;
   status: CommercePaymentSourceStatus;
   walletType: string | undefined;
   remove: (params?: RemovePaymentSourceParams) => Promise<DeletedObjectResource>;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -638,7 +638,7 @@ export interface CommercePaymentSourceJSON extends ClerkResourceJSON {
   payment_method: string;
   card_type: string;
   is_default: boolean;
-  is_removable?: boolean;
+  is_removable: boolean;
   status: CommercePaymentSourceStatus;
   wallet_type: string | null;
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -638,6 +638,7 @@ export interface CommercePaymentSourceJSON extends ClerkResourceJSON {
   payment_method: string;
   card_type: string;
   is_default: boolean;
+  is_removable?: boolean;
   status: CommercePaymentSourceStatus;
   wallet_type: string | null;
 }


### PR DESCRIPTION
## Description

Uses the new `is_removable` flag on a payment source to determine whether it should be allowed to be removed from the UI

<img width="489" alt="Screenshot 2025-05-30 at 8 22 06 AM" src="https://github.com/user-attachments/assets/291a5204-2b0e-4ec9-a955-0520e4aef896" />

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
