### PR TITLE
Default keychainAccessible to AFTER_FIRST_UNLOCK in createResourceCacheStore

### DIFF
--- a/.changeset/slow-hats-drum.md
+++ b/.changeset/slow-hats-drum.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': minor
+---
+
+Default token cache `SecureStore` implementation `keychainAccessible` to `AFTER_FIRST_UNLOCK` createResourceCacheStore to align with createTokenCache - The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user. This may be useful if you need to access the item when the device is locked.

--- a/packages/expo/src/resource-cache/__tests__/secure-store.test.ts
+++ b/packages/expo/src/resource-cache/__tests__/secure-store.test.ts
@@ -29,6 +29,7 @@ vi.mock('expo-secure-store', () => {
     setItemAsync: mocks.setItemAsync,
     getItemAsync: mocks.getItemAsync,
     deleteItemAsync: mocks.deleteItemAsync,
+    AFTER_FIRST_UNLOCK: 0,
   };
 });
 

--- a/packages/expo/src/resource-cache/resource-cache.ts
+++ b/packages/expo/src/resource-cache/resource-cache.ts
@@ -31,9 +31,18 @@ export const createResourceCacheStore = (): IStorage => {
   let queue: KeyValuePair[] = [];
   let isProcessing = false;
 
-  const setItem = SecureStore.setItemAsync;
-  const getItem = SecureStore.getItemAsync;
-  const deleteItem = SecureStore.deleteItemAsync;
+  const secureStoreOpts: SecureStore.SecureStoreOptions = {
+    /**
+     * The data in the keychain item cannot be accessed after a restart until the
+     * device has been unlocked once by the user.
+     *
+     * This may be useful if you need to access the item when the phone is locked.
+     */
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+  };
+  const setItem = (key: string, value: string) => SecureStore.setItemAsync(key, value, secureStoreOpts);
+  const getItem = (key: string) => SecureStore.getItemAsync(key, secureStoreOpts);
+  const deleteItem = (key: string) => SecureStore.deleteItemAsync(key, secureStoreOpts);
 
   const set = (key: string, value: string): Promise<void> => {
     queue.push({ key, value });


### PR DESCRIPTION
## Description
Allows for the ResourceCacheStore to be accessed from within background jobs, by default.

This aligns directly with https://github.com/clerk/javascript/pull/6025 where it allows for the token to be accessed from within background jobs, by default.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
