### PR TITLE
test(tanstack-react-start): Use correct test matcher for checking headers

### DIFF
--- a/integration/tests/tanstack-start/basic.test.ts
+++ b/integration/tests/tanstack-start/basic.test.ts
@@ -76,10 +76,9 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })(
       const u = createTestUtils({ app, page, context });
       const r = await u.po.signIn.goTo();
 
-      expect(r.headers()).toContain({
-        'x-clerk-auth-reason': 'session-token-and-uat-missing',
-        'x-clerk-auth-status': 'signed-out',
-      });
+      const headers = r.headers();
+      expect(headers['x-clerk-auth-reason']).toBe('session-token-and-uat-missing');
+      expect(headers['x-clerk-auth-status']).toBe('signed-out');
     });
   },
 );

--- a/integration/tests/tanstack-start/basic.test.ts
+++ b/integration/tests/tanstack-start/basic.test.ts
@@ -76,9 +76,10 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })(
       const u = createTestUtils({ app, page, context });
       const r = await u.po.signIn.goTo();
 
-      const headers = r.headers();
-      expect(headers['x-clerk-auth-reason']).toBe('session-token-and-uat-missing');
-      expect(headers['x-clerk-auth-status']).toBe('signed-out');
+      expect(r.headers()).toMatchObject({
+        'x-clerk-auth-reason': 'session-token-and-uat-missing',
+        'x-clerk-auth-status': 'signed-out',
+      });
     });
   },
 );


### PR DESCRIPTION
## Description

Use `toMatchObject()` instead of `toContain()` for header checks which allows for partial object matching. The previous one fails because `toContain()` is for arrays and strings. Failing test [here](https://github.com/clerk/javascript/actions/runs/15447324241/job/43482299028)

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
