### PR TITLE
chore(clerk-js): Add random jitter for session cookie pooler interval

### DIFF
--- a/packages/clerk-js/src/core/auth/SessionCookiePoller.ts
+++ b/packages/clerk-js/src/core/auth/SessionCookiePoller.ts
@@ -3,7 +3,16 @@ import { createWorkerTimers } from '@clerk/shared/workerTimers';
 import { SafeLock } from './safeLock';
 
 const REFRESH_SESSION_TOKEN_LOCK_KEY = 'clerk.lock.refreshSessionToken';
-const INTERVAL_IN_MS = 5 * 1_000;
+
+/**
+ * Returns an interval in milliseconds with random jitter.
+ * Uses a base interval of 5 seconds and adds up to 1.5 seconds of random jitter.
+ * This randomization helps prevent synchronized polling requests across multiple clients.
+ */
+const getIntervalInMs = () => {
+  const jitter = Math.random() * 1500;
+  return 5 * 1_000 + jitter;
+};
 
 export class SessionCookiePoller {
   private lock = SafeLock(REFRESH_SESSION_TOKEN_LOCK_KEY);
@@ -20,7 +29,7 @@ export class SessionCookiePoller {
     const run = async () => {
       this.initiated = true;
       await this.lock.acquireLockAndRun(cb);
-      this.timerId = this.workerTimers.setTimeout(run, INTERVAL_IN_MS);
+      this.timerId = this.workerTimers.setTimeout(run, getIntervalInMs());
     };
 
     void run();


### PR DESCRIPTION
## Description

Dynamically sets session cookie interval in milliseconds with random jitter. This helps prevent synchronized polling requests across multiple clients.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
