### PR TITLE
fix(clerk-js): Better Stripe Elements error handling

### DIFF
--- a/.changeset/petite-sites-see.md
+++ b/.changeset/petite-sites-see.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix Stripe Elements error handling

--- a/packages/clerk-js/src/ui/components/PaymentSources/AddPaymentSource.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentSources/AddPaymentSource.tsx
@@ -246,18 +246,18 @@ const AddPaymentSourceForm = ({ children }: PropsWithChildren) => {
     card.setLoading();
     card.setError(undefined);
 
-    try {
-      const { setupIntent, error } = await stripe.confirmSetup({
-        elements,
-        confirmParams: {
-          return_url: '', // TODO(@COMMERCE): need to figure this out
-        },
-        redirect: 'if_required',
-      });
-      if (error) {
-        return; // just return, since stripe will handle the error
-      }
+    const { setupIntent, error } = await stripe.confirmSetup({
+      elements,
+      confirmParams: {
+        return_url: '', // TODO(@COMMERCE): need to figure this out
+      },
+      redirect: 'if_required',
+    });
+    if (error) {
+      return; // just return, since stripe will handle the error
+    }
 
+    try {
       await onSuccess({ stripeSetupIntent: setupIntent });
     } catch (error) {
       void handleError(error, [], card.setError);


### PR DESCRIPTION
## Description

Fixes the error handling of Stripe Elements, such that a declined card internally errors (within the Stripe element) and doesn't cause a SetupIntent revalidation.

<img width="441" alt="Screenshot 2025-06-05 at 3 35 04 PM" src="https://github.com/user-attachments/assets/0b2b2dd6-0e3d-438e-a6e3-c2555871b535" />

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
