### PR TITLE
chore(clerk-js): Move API Keys methods to its own module

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -20,7 +20,7 @@ import type {
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_UserVerificationModalProps,
-  APIKeyResource,
+  APIKeysNamespace,
   APIKeysProps,
   AuthenticateWithCoinbaseWalletParams,
   AuthenticateWithGoogleOneTapParams,
@@ -33,7 +33,6 @@ import type {
   ClientJSONSnapshot,
   ClientResource,
   CommerceBillingNamespace,
-  CreateAPIKeyParams,
   CreateOrganizationParams,
   CreateOrganizationProps,
   CredentialReturn,
@@ -41,7 +40,6 @@ import type {
   EnvironmentJSON,
   EnvironmentJSONSnapshot,
   EnvironmentResource,
-  GetAPIKeysParams,
   GoogleOneTapProps,
   HandleEmailLinkVerificationParams,
   HandleOAuthCallbackParams,
@@ -62,7 +60,6 @@ import type {
   PublicKeyCredentialWithAuthenticatorAttestationResponse,
   RedirectOptions,
   Resources,
-  RevokeAPIKeyParams,
   SDKMetadata,
   SetActiveParams,
   SignedInSessionResource,
@@ -137,9 +134,9 @@ import { eventBus, events } from './events';
 import type { FapiClient, FapiRequestCallback } from './fapiClient';
 import { createFapiClient } from './fapiClient';
 import { createClientFromJwt } from './jwt-client';
+import { APIKeys } from './modules/apiKeys';
 import { CommerceBilling } from './modules/commerce';
 import {
-  APIKey,
   BaseResource,
   Client,
   EmailLinkError,
@@ -195,6 +192,7 @@ export class Clerk implements ClerkInterface {
     environment: process.env.NODE_ENV || 'production',
   };
   private static _billing: CommerceBillingNamespace;
+  private static _apiKeys: APIKeysNamespace;
 
   public client: ClientResource | undefined;
   public session: SignedInSessionResource | null | undefined;
@@ -328,6 +326,13 @@ export class Clerk implements ClerkInterface {
       Clerk._billing = new CommerceBilling();
     }
     return Clerk._billing;
+  }
+
+  get apiKeys(): APIKeysNamespace {
+    if (!Clerk._apiKeys) {
+      Clerk._apiKeys = new APIKeys();
+    }
+    return Clerk._apiKeys;
   }
 
   public __internal_getOption<K extends keyof ClerkOptions>(key: K): ClerkOptions[K] {
@@ -2080,14 +2085,6 @@ export class Clerk implements ClerkInterface {
   public updateEnvironment(environment: EnvironmentResource): asserts this is { environment: EnvironmentResource } {
     this.environment = environment;
   }
-
-  public getApiKeys = (params?: GetAPIKeysParams): Promise<APIKeyResource[]> => APIKey.getAll(params);
-
-  public getApiKeySecret = (apiKeyID: string): Promise<string> => APIKey.getSecret(apiKeyID);
-
-  public createApiKey = (params: CreateAPIKeyParams): Promise<APIKeyResource> => APIKey.create(params);
-
-  public revokeApiKey = (params: RevokeAPIKeyParams): Promise<APIKeyResource> => APIKey.revoke(params);
 
   __internal_setCountry = (country: string | null) => {
     if (!this.__internal_country) {

--- a/packages/clerk-js/src/core/modules/apiKeys/index.ts
+++ b/packages/clerk-js/src/core/modules/apiKeys/index.ts
@@ -1,0 +1,97 @@
+import type {
+  ApiKeyJSON,
+  APIKeyResource,
+  APIKeysNamespace,
+  CreateAPIKeyParams,
+  GetAPIKeysParams,
+  RevokeAPIKeyParams,
+} from '@clerk/types';
+
+import { APIKey, BaseResource } from '../../resources/internal';
+
+export class APIKeys implements APIKeysNamespace {
+  getAll = async (params?: GetAPIKeysParams): Promise<APIKeyResource[]> => {
+    return BaseResource.clerk
+      .getFapiClient()
+      .request<{ api_keys: ApiKeyJSON[] }>({
+        method: 'GET',
+        path: '/api_keys',
+        pathPrefix: '',
+        search: {
+          subject: params?.subject ?? BaseResource.clerk.organization?.id ?? BaseResource.clerk.user?.id ?? '',
+        },
+        headers: {
+          Authorization: `Bearer ${await BaseResource.clerk.session?.getToken()}`,
+        },
+        credentials: 'same-origin',
+      })
+      .then(res => {
+        const apiKeysJSON = res.payload as unknown as { api_keys: ApiKeyJSON[] };
+        return apiKeysJSON.api_keys.map(json => new APIKey(json));
+      })
+      .catch(() => []);
+  };
+
+  getSecret = async (id: string): Promise<string> => {
+    return BaseResource.clerk
+      .getFapiClient()
+      .request<{ secret: string }>({
+        method: 'GET',
+        path: `/api_keys/${id}/secret`,
+        credentials: 'same-origin',
+        pathPrefix: '',
+        headers: {
+          Authorization: `Bearer ${await BaseResource.clerk.session?.getToken()}`,
+        },
+      })
+      .then(res => {
+        const { secret } = res.payload as unknown as { secret: string };
+        return secret;
+      })
+      .catch(() => '');
+  };
+
+  create = async (params: CreateAPIKeyParams): Promise<APIKeyResource> => {
+    const json = (
+      await BaseResource._fetch<ApiKeyJSON>({
+        path: '/api_keys',
+        method: 'POST',
+        pathPrefix: '',
+        headers: {
+          Authorization: `Bearer ${await BaseResource.clerk.session?.getToken()}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          type: params.type ?? 'api_key',
+          name: params.name,
+          subject: params.subject ?? BaseResource.clerk.organization?.id ?? BaseResource.clerk.user?.id ?? '',
+          description: params.description,
+          seconds_until_expiration: params.secondsUntilExpiration,
+        }),
+      })
+    )?.response as ApiKeyJSON;
+
+    return new APIKey(json);
+  };
+
+  revoke = async (params: RevokeAPIKeyParams): Promise<APIKeyResource> => {
+    const json = (
+      await BaseResource._fetch<ApiKeyJSON>({
+        path: `/api_keys/${params.apiKeyID}/revoke`,
+        method: 'POST',
+        pathPrefix: '',
+        headers: {
+          Authorization: `Bearer ${await BaseResource.clerk.session?.getToken()}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          revocation_reason: params.revocationReason,
+        }),
+      })
+    )?.response as ApiKeyJSON;
+
+    return new APIKey(json);
+  };
+}

--- a/packages/clerk-js/src/core/resources/internal.ts
+++ b/packages/clerk-js/src/core/resources/internal.ts
@@ -43,4 +43,4 @@ export * from './UserOrganizationInvitation';
 export * from './Verification';
 export * from './Web3Wallet';
 export * from './Waitlist';
-export * from './ApiKey';
+export * from './APIKey';

--- a/packages/clerk-js/src/ui/components/ApiKeys/ApiKeys.tsx
+++ b/packages/clerk-js/src/ui/components/ApiKeys/ApiKeys.tsx
@@ -46,7 +46,7 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
   } = useApiKeys({ subject, perPage });
   const card = useCardState();
   const { trigger: createApiKey, isMutating } = useSWRMutation(cacheKey, (_, { arg }: { arg: CreateAPIKeyParams }) =>
-    clerk.createApiKey(arg),
+    clerk.apiKeys.create(arg),
   );
   const { t } = useLocalizations();
   const clerk = useClerk();

--- a/packages/clerk-js/src/ui/components/ApiKeys/ApiKeysTable.tsx
+++ b/packages/clerk-js/src/ui/components/ApiKeys/ApiKeysTable.tsx
@@ -29,7 +29,7 @@ import { timeAgo } from '@/utils/date';
 const useApiKeySecret = ({ apiKeyID, enabled }: { apiKeyID: string; enabled: boolean }) => {
   const clerk = useClerk();
 
-  return useSWR(enabled ? ['api-key-secret', apiKeyID] : null, () => clerk.getApiKeySecret(apiKeyID));
+  return useSWR(enabled ? ['api-key-secret', apiKeyID] : null, () => clerk.apiKeys.getSecret(apiKeyID));
 };
 
 const CopySecretButton = ({ apiKeyID }: { apiKeyID: string }) => {

--- a/packages/clerk-js/src/ui/components/ApiKeys/RevokeAPIKeyConfirmationModal.tsx
+++ b/packages/clerk-js/src/ui/components/ApiKeys/RevokeAPIKeyConfirmationModal.tsx
@@ -33,7 +33,7 @@ export const RevokeAPIKeyConfirmationModal = ({
     e.preventDefault();
     if (!apiKeyId) return;
 
-    await clerk.revokeApiKey({ apiKeyID: apiKeyId });
+    await clerk.apiKeys.revoke({ apiKeyID: apiKeyId });
     void mutate({ key: 'api-keys', subject: clerk.organization?.id ?? clerk.session?.user.id });
     onClose();
   };

--- a/packages/clerk-js/src/ui/components/ApiKeys/useApiKeys.ts
+++ b/packages/clerk-js/src/ui/components/ApiKeys/useApiKeys.ts
@@ -8,7 +8,7 @@ export const useApiKeys = ({ subject, perPage = 5 }: { subject: string; perPage?
     key: 'api-keys',
     subject,
   };
-  const { data: apiKeys, isLoading, mutate } = useSWR(cacheKey, () => clerk.getApiKeys({ subject }));
+  const { data: apiKeys, isLoading, mutate } = useSWR(cacheKey, () => clerk.apiKeys.getAll({ subject }));
   const [search, setSearch] = useState('');
   const filteredApiKeys = (apiKeys ?? []).filter(key => key.name.toLowerCase().includes(search.toLowerCase()));
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -8,7 +8,7 @@ import type {
   __internal_PlanDetailsProps,
   __internal_UserVerificationModalProps,
   __internal_UserVerificationProps,
-  APIKeyResource,
+  APIKeysNamespace,
   APIKeysProps,
   AuthenticateWithCoinbaseWalletParams,
   AuthenticateWithGoogleOneTapParams,
@@ -20,11 +20,9 @@ import type {
   ClerkStatus,
   ClientResource,
   CommerceBillingNamespace,
-  CreateAPIKeyParams,
   CreateOrganizationParams,
   CreateOrganizationProps,
   DomainOrProxyUrl,
-  GetAPIKeysParams,
   GoogleOneTapProps,
   HandleEmailLinkVerificationParams,
   HandleOAuthCallbackParams,
@@ -38,7 +36,6 @@ import type {
   OrganizationSwitcherProps,
   PricingTableProps,
   RedirectOptions,
-  RevokeAPIKeyParams,
   SetActiveParams,
   SignInProps,
   SignInRedirectOptions,
@@ -104,11 +101,13 @@ type IsomorphicLoadedClerk = Without<
   | '__internal_getCachedResources'
   | '__internal_reloadInitialResources'
   | 'billing'
+  | 'apiKeys'
   | '__internal_setComponentNavigationContext'
   | '__internal_setActiveInProgress'
 > & {
   client: ClientResource | undefined;
   billing: CommerceBillingNamespace | undefined;
+  apiKeys: APIKeysNamespace | undefined;
 };
 
 export class IsomorphicClerk implements IsomorphicLoadedClerk {
@@ -700,6 +699,10 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
 
   get billing(): CommerceBillingNamespace | undefined {
     return this.clerkjs?.billing;
+  }
+
+  get apiKeys(): APIKeysNamespace | undefined {
+    return this.clerkjs?.apiKeys;
   }
 
   __unstable__setEnvironment(...args: any): void {
@@ -1331,42 +1334,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return callback() as Promise<WaitlistResource>;
     } else {
       this.premountMethodCalls.set('joinWaitlist', callback);
-    }
-  };
-
-  getApiKeys = async (params?: GetAPIKeysParams): Promise<APIKeyResource[] | void> => {
-    const callback = () => this.clerkjs?.getApiKeys(params);
-    if (this.clerkjs && this.loaded) {
-      return callback() as Promise<APIKeyResource[]>;
-    } else {
-      this.premountMethodCalls.set('getApiKeys', callback);
-    }
-  };
-
-  getApiKeySecret = async (apiKeyId: string): Promise<string | void> => {
-    const callback = () => this.clerkjs?.getApiKeySecret(apiKeyId);
-    if (this.clerkjs && this.loaded) {
-      return callback() as Promise<string>;
-    } else {
-      this.premountMethodCalls.set('getApiKeySecret', callback);
-    }
-  };
-
-  createApiKey = async (params: CreateAPIKeyParams): Promise<APIKeyResource | void> => {
-    const callback = () => this.clerkjs?.createApiKey(params);
-    if (this.clerkjs && this.loaded) {
-      return callback() as Promise<APIKeyResource>;
-    } else {
-      this.premountMethodCalls.set('createApiKey', callback);
-    }
-  };
-
-  revokeApiKey = async (params: RevokeAPIKeyParams): Promise<APIKeyResource | void> => {
-    const callback = () => this.clerkjs?.revokeApiKey(params);
-    if (this.clerkjs && this.loaded) {
-      return callback() as Promise<APIKeyResource>;
-    } else {
-      this.premountMethodCalls.set('revokeApiKey', callback);
     }
   };
 

--- a/packages/types/src/apiKeys.ts
+++ b/packages/types/src/apiKeys.ts
@@ -1,3 +1,4 @@
+import type { CreateAPIKeyParams, GetAPIKeysParams, RevokeAPIKeyParams } from './clerk';
 import type { ClerkResource } from './resource';
 
 export interface APIKeyResource extends ClerkResource {
@@ -16,4 +17,11 @@ export interface APIKeyResource extends ClerkResource {
   lastUsedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface APIKeysNamespace {
+  getAll(params?: GetAPIKeysParams): Promise<APIKeyResource[]>;
+  getSecret(id: string): Promise<string>;
+  create(params: CreateAPIKeyParams): Promise<APIKeyResource>;
+  revoke(params: RevokeAPIKeyParams): Promise<APIKeyResource>;
 }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1,4 +1,4 @@
-import type { APIKeyResource } from './apiKeys';
+import type { APIKeysNamespace } from './apiKeys';
 import type {
   APIKeysTheme,
   Appearance,
@@ -776,36 +776,9 @@ export interface Clerk {
   __internal_setActiveInProgress: boolean;
 
   /**
-   * @experimental
-   * This API is in early access and may change in future releases.
-   *
-   * Retrieves all API keys for the current user or organization.
+   * API Keys Object
    */
-  getApiKeys: (params?: GetAPIKeysParams) => Promise<APIKeyResource[]>;
-
-  /**
-   * @experimental
-   * This API is in early access and may change in future releases.
-   *
-   * Retrieves the secret for a given API key ID.
-   */
-  getApiKeySecret: (apiKeyID: string) => Promise<string>;
-
-  /**
-   * @experimental
-   * This API is in early access and may change in future releases.
-   *
-   * Creates a new API key.
-   */
-  createApiKey: (params: CreateAPIKeyParams) => Promise<APIKeyResource>;
-
-  /**
-   * @experimental
-   * This API is in early access and may change in future releases.
-   *
-   * Revokes a given API key by ID.
-   */
-  revokeApiKey: (params: RevokeAPIKeyParams) => Promise<APIKeyResource>;
+  apiKeys: APIKeysNamespace;
 }
 
 export type HandleOAuthCallbackParams = TransferableOption &


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
