### PR TITLE
chore(backend): Improve subject handling for machine auth objects

### DIFF
--- a/.changeset/mean-items-retire.md
+++ b/.changeset/mean-items-retire.md
@@ -1,0 +1,36 @@
+---
+"@clerk/backend": minor
+---
+
+Improve `subject` property handling for machine auth objects.
+
+Usage:
+
+```ts
+import { createClerkClient } from '@clerk/backend'
+
+const clerkClient = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+})
+
+const requestState = await clerkClient.authenticateRequest(request, {
+  acceptsToken: 'any',
+})
+
+const authObject = requestState.toAuth()
+
+switch (authObject.tokenType) {
+  case 'api_key':
+    // authObject.userId
+    // authObject.orgId
+    break;
+  case 'machine_token':
+    // authObject.machineId
+    break;
+  case 'oauth_token':
+    // authObject.userId
+    // authObject.clientId
+    break;
+}
+```

--- a/packages/backend/src/api/endpoints/IdPOAuthAccessTokenApi.ts
+++ b/packages/backend/src/api/endpoints/IdPOAuthAccessTokenApi.ts
@@ -5,11 +5,11 @@ import { AbstractAPI } from './AbstractApi';
 const basePath = '/oauth_applications/access_tokens';
 
 export class IdPOAuthAccessTokenApi extends AbstractAPI {
-  async verifySecret(secret: string) {
+  async verifySecret(accessToken: string) {
     return this.request<IdPOAuthAccessToken>({
       method: 'POST',
       path: joinPaths(basePath, 'verify'),
-      bodyParams: { secret },
+      bodyParams: { access_token: accessToken },
     });
   }
 }

--- a/packages/backend/src/api/endpoints/IdPOAuthAccessTokenApi.ts
+++ b/packages/backend/src/api/endpoints/IdPOAuthAccessTokenApi.ts
@@ -5,7 +5,7 @@ import { AbstractAPI } from './AbstractApi';
 const basePath = '/oauth_applications/access_tokens';
 
 export class IdPOAuthAccessTokenApi extends AbstractAPI {
-  async verifySecret(accessToken: string) {
+  async verifyAccessToken(accessToken: string) {
     return this.request<IdPOAuthAccessToken>({
       method: 'POST',
       path: joinPaths(basePath, 'verify'),

--- a/packages/backend/src/fixtures/machine.ts
+++ b/packages/backend/src/fixtures/machine.ts
@@ -1,7 +1,7 @@
 export const mockTokens = {
   api_key: 'ak_LCWGdaM8mv8K4PC/57IICZQXAeWfCgF30DZaFXHoGn9=',
   oauth_token: 'oat_8XOIucKvqHVr5tYP123456789abcdefghij',
-  machine_token: 'mt_8XOIucKvqHVr5tYP123456789abcdefghij',
+  machine_token: 'm2m_8XOIucKvqHVr5tYP123456789abcdefghij',
 } as const;
 
 export const mockVerificationResults = {
@@ -37,7 +37,7 @@ export const mockVerificationResults = {
     updatedAt: 1744928754551,
   },
   machine_token: {
-    id: 'mt_ey966f1b1xf93586b2debdcadb0b3bd1',
+    id: 'm2m_ey966f1b1xf93586b2debdcadb0b3bd1',
     name: 'my-machine-token',
     subject: 'user_2vYVtestTESTtestTESTtestTESTtest',
     scopes: ['read:foo', 'write:bar'],

--- a/packages/backend/src/fixtures/machine.ts
+++ b/packages/backend/src/fixtures/machine.ts
@@ -39,7 +39,7 @@ export const mockVerificationResults = {
   machine_token: {
     id: 'm2m_ey966f1b1xf93586b2debdcadb0b3bd1',
     name: 'my-machine-token',
-    subject: 'user_2vYVtestTESTtestTESTtestTESTtest',
+    subject: 'mch_2vYVtestTESTtestTESTtestTESTtest',
     scopes: ['read:foo', 'write:bar'],
     claims: { foo: 'bar' },
     revoked: false,

--- a/packages/backend/src/fixtures/machine.ts
+++ b/packages/backend/src/fixtures/machine.ts
@@ -1,7 +1,7 @@
 export const mockTokens = {
   api_key: 'ak_LCWGdaM8mv8K4PC/57IICZQXAeWfCgF30DZaFXHoGn9=',
   oauth_token: 'oat_8XOIucKvqHVr5tYP123456789abcdefghij',
-  machine_token: 'm2m_8XOIucKvqHVr5tYP123456789abcdefghij',
+  machine_token: 'mt_8XOIucKvqHVr5tYP123456789abcdefghij',
 } as const;
 
 export const mockVerificationResults = {

--- a/packages/backend/src/tokens/__tests__/authObjects.test.ts
+++ b/packages/backend/src/tokens/__tests__/authObjects.test.ts
@@ -280,13 +280,34 @@ describe('authenticatedMachineObject', () => {
       expect(authObject.has({})).toBe(false);
     });
 
-    it('properly initializes properties', () => {
+    it('properly initializes properties (user)', () => {
       const authObject = authenticatedMachineObject('api_key', token, verificationResult, debugData);
       expect(authObject.tokenType).toBe('api_key');
-      expect(authObject.name).toBe('my-api-key');
+      expect(authObject.id).toBe('ak_ey966f1b1xf93586b2debdcadb0b3bd1');
       expect(authObject.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
       expect(authObject.scopes).toEqual(['read:foo', 'write:bar']);
       expect(authObject.claims).toEqual({ foo: 'bar' });
+      expect(authObject.userId).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
+      expect(authObject.orgId).toBeNull();
+    });
+
+    it('properly initializes properties (org)', () => {
+      const authObject = authenticatedMachineObject(
+        'api_key',
+        token,
+        {
+          ...verificationResult,
+          subject: 'org_2vYVtestTESTtestTESTtestTESTtest',
+        },
+        debugData,
+      );
+      expect(authObject.tokenType).toBe('api_key');
+      expect(authObject.id).toBe('ak_ey966f1b1xf93586b2debdcadb0b3bd1');
+      expect(authObject.subject).toBe('org_2vYVtestTESTtestTESTtestTESTtest');
+      expect(authObject.scopes).toEqual(['read:foo', 'write:bar']);
+      expect(authObject.claims).toEqual({ foo: 'bar' });
+      expect(authObject.userId).toBeNull();
+      expect(authObject.orgId).toBe('org_2vYVtestTESTtestTESTtestTESTtest');
     });
   });
 
@@ -308,8 +329,11 @@ describe('authenticatedMachineObject', () => {
     it('properly initializes properties', () => {
       const authObject = authenticatedMachineObject('oauth_token', token, verificationResult, debugData);
       expect(authObject.tokenType).toBe('oauth_token');
+      expect(authObject.id).toBe('oat_2VTWUzvGC5UhdJCNx6xG1D98edc');
       expect(authObject.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
       expect(authObject.scopes).toEqual(['read:foo', 'write:bar']);
+      expect(authObject.userId).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
+      expect(authObject.clientId).toBe('client_2VTWUzvGC5UhdJCNx6xG1D98edc');
     });
   });
 
@@ -332,10 +356,11 @@ describe('authenticatedMachineObject', () => {
     it('properly initializes properties', () => {
       const authObject = authenticatedMachineObject('machine_token', token, verificationResult, debugData);
       expect(authObject.tokenType).toBe('machine_token');
-      expect(authObject.name).toBe('my-machine-token');
-      expect(authObject.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
+      expect(authObject.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
+      expect(authObject.subject).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
       expect(authObject.scopes).toEqual(['read:foo', 'write:bar']);
       expect(authObject.claims).toEqual({ foo: 'bar' });
+      expect(authObject.machineId).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
     });
   });
 });

--- a/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
+++ b/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, expectTypeOf, test } from 'vitest';
+import { expectTypeOf, test } from 'vitest';
 
 import type { AuthObject } from '../authObjects';
 import type { GetAuthFn, MachineAuthObject, SessionAuthObject } from '../types';
@@ -32,76 +32,18 @@ test('infers the correct AuthObject type for each accepted token type', () => {
   expectTypeOf(getAuth(request, { acceptsToken: 'any' })).toMatchTypeOf<AuthObject>();
 });
 
-test('verifies correct properties exist for each token type', () => {
-  const request = new Request('https://example.com');
-
-  // Session token should have userId
-  const sessionAuth = getAuth(request, { acceptsToken: 'session_token' });
-  expectTypeOf(sessionAuth.userId).toMatchTypeOf<string | null>();
-
-  // All machine tokens should have id and subject
-  const apiKeyAuth = getAuth(request, { acceptsToken: 'api_key' });
-  const machineTokenAuth = getAuth(request, { acceptsToken: 'machine_token' });
-  const oauthTokenAuth = getAuth(request, { acceptsToken: 'oauth_token' });
-
-  expectTypeOf(apiKeyAuth.id).toMatchTypeOf<string | null>();
-  expectTypeOf(machineTokenAuth.id).toMatchTypeOf<string | null>();
-  expectTypeOf(oauthTokenAuth.id).toMatchTypeOf<string | null>();
-  expectTypeOf(apiKeyAuth.subject).toMatchTypeOf<string | null>();
-  expectTypeOf(machineTokenAuth.subject).toMatchTypeOf<string | null>();
-  expectTypeOf(oauthTokenAuth.subject).toMatchTypeOf<string | null>();
-
-  // Only api_key and machine_token should have name and claims
-  expectTypeOf(apiKeyAuth.name).toMatchTypeOf<string | null>();
-  expectTypeOf(apiKeyAuth.claims).toMatchTypeOf<Record<string, any> | null>();
-
-  expectTypeOf(machineTokenAuth.name).toMatchTypeOf<string | null>();
-  expectTypeOf(machineTokenAuth.claims).toMatchTypeOf<Record<string, any> | null>();
-
-  // oauth_token should NOT have name and claims
-  // @ts-expect-error oauth_token does not have name property
-  assertType<string | null>(oauthTokenAuth.name);
-  // @ts-expect-error oauth_token does not have claims property
-  assertType<Record<string, any> | null>(oauthTokenAuth.claims);
-});
-
 test('verifies discriminated union works correctly with acceptsToken: any', () => {
   const request = new Request('https://example.com');
 
   const auth = getAuth(request, { acceptsToken: 'any' });
 
   if (auth.tokenType === 'session_token') {
-    // Should be SessionAuthObject - has userId
-    expectTypeOf(auth.userId).toMatchTypeOf<string | null>();
-    // Should NOT have machine token properties
-    // @ts-expect-error session_token does not have id property
-    assertType<string | null>(auth.id);
+    expectTypeOf(auth).toMatchTypeOf<SessionAuthObject>();
   } else if (auth.tokenType === 'api_key') {
-    // Should be AuthenticatedMachineObject<'api_key'> - has id, name, claims
-    expectTypeOf(auth.id).toMatchTypeOf<string | null>();
-    expectTypeOf(auth.name).toMatchTypeOf<string | null>();
-    expectTypeOf(auth.claims).toMatchTypeOf<Record<string, any> | null>();
-    // Should NOT have session token properties
-    // @ts-expect-error api_key does not have userId property
-    assertType<string | null>(auth.userId);
+    expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'api_key'>>();
   } else if (auth.tokenType === 'machine_token') {
-    // Should be AuthenticatedMachineObject<'machine_token'> - has id, name, claims
-    expectTypeOf(auth.id).toMatchTypeOf<string | null>();
-    expectTypeOf(auth.name).toMatchTypeOf<string | null>();
-    expectTypeOf(auth.claims).toMatchTypeOf<Record<string, any> | null>();
-    // Should NOT have session token properties
-    // @ts-expect-error machine_token does not have userId property
-    assertType<string | null>(auth.userId);
+    expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'machine_token'>>();
   } else if (auth.tokenType === 'oauth_token') {
-    // Should be AuthenticatedMachineObject<'oauth_token'> - has id but NOT name/claims
-    expectTypeOf(auth.id).toMatchTypeOf<string | null>();
-    // Should NOT have name or claims
-    // @ts-expect-error oauth_token does not have name property
-    assertType<string | null>(auth.name);
-    // @ts-expect-error oauth_token does not have claims property
-    assertType<Record<string, any> | null>(auth.claims);
-    // Should NOT have session token properties
-    // @ts-expect-error oauth_token does not have userId property
-    assertType<string | null>(auth.userId);
+    expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'oauth_token'>>();
   }
 });

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -98,7 +98,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
   });
 
   it('verifies provided Machine token', async () => {
-    const token = 'm2m_8XOIucKvqHVr5tYP123456789abcdefghij';
+    const token = 'mt_8XOIucKvqHVr5tYP123456789abcdefghij';
 
     server.use(
       http.post(
@@ -199,7 +199,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
 
   describe('handles API errors for M2M tokens', () => {
     it('handles invalid token', async () => {
-      const token = 'm2m_invalid_token';
+      const token = 'mt_invalid_token';
 
       server.use(
         http.post('https://api.clerk.test/m2m_tokens/verify', () => {
@@ -220,7 +220,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
     });
 
     it('handles unexpected error', async () => {
-      const token = 'm2m_ey966f1b1xf93586b2debdcadb0b3bd1';
+      const token = 'mt_ey966f1b1xf93586b2debdcadb0b3bd1';
 
       server.use(
         http.post('https://api.clerk.test/m2m_tokens/verify', () => {

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -98,7 +98,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
   });
 
   it('verifies provided Machine token', async () => {
-    const token = 'mt_8XOIucKvqHVr5tYP123456789abcdefghij';
+    const token = 'm2m_8XOIucKvqHVr5tYP123456789abcdefghij';
 
     server.use(
       http.post(
@@ -119,7 +119,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
     expect(result.errors).toBeUndefined();
 
     const data = result.data as MachineToken;
-    expect(data.id).toBe('mt_ey966f1b1xf93586b2debdcadb0b3bd1');
+    expect(data.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
     expect(data.name).toBe('my-machine-token');
     expect(data.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
     expect(data.scopes).toEqual(['read:foo', 'write:bar']);
@@ -199,7 +199,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
 
   describe('handles API errors for M2M tokens', () => {
     it('handles invalid token', async () => {
-      const token = 'mt_invalid_token';
+      const token = 'm2m_invalid_token';
 
       server.use(
         http.post('https://api.clerk.test/m2m_tokens/verify', () => {
@@ -220,7 +220,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
     });
 
     it('handles unexpected error', async () => {
-      const token = 'mt_ey966f1b1xf93586b2debdcadb0b3bd1';
+      const token = 'm2m_ey966f1b1xf93586b2debdcadb0b3bd1';
 
       server.use(
         http.post('https://api.clerk.test/m2m_tokens/verify', () => {

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -121,7 +121,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
     const data = result.data as MachineToken;
     expect(data.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
     expect(data.name).toBe('my-machine-token');
-    expect(data.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
+    expect(data.subject).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
     expect(data.scopes).toEqual(['read:foo', 'write:bar']);
     expect(data.claims).toEqual({ foo: 'bar' });
   });

--- a/packages/backend/src/tokens/machine.ts
+++ b/packages/backend/src/tokens/machine.ts
@@ -2,7 +2,7 @@ import type { AuthenticateRequestOptions } from '../tokens/types';
 import type { MachineTokenType } from './tokenTypes';
 import { TokenType } from './tokenTypes';
 
-export const M2M_TOKEN_PREFIX = 'm2m_';
+export const M2M_TOKEN_PREFIX = 'mt_';
 export const OAUTH_TOKEN_PREFIX = 'oat_';
 export const API_KEY_PREFIX = 'ak_';
 

--- a/packages/backend/src/tokens/machine.ts
+++ b/packages/backend/src/tokens/machine.ts
@@ -2,7 +2,7 @@ import type { AuthenticateRequestOptions } from '../tokens/types';
 import type { MachineTokenType } from './tokenTypes';
 import { TokenType } from './tokenTypes';
 
-export const M2M_TOKEN_PREFIX = 'mt_';
+export const M2M_TOKEN_PREFIX = 'm2m_';
 export const OAUTH_TOKEN_PREFIX = 'oat_';
 export const API_KEY_PREFIX = 'ak_';
 

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -214,12 +214,12 @@ async function verifyMachineToken(
 }
 
 async function verifyOAuthToken(
-  secret: string,
+  accessToken: string,
   options: VerifyTokenOptions,
 ): Promise<MachineTokenReturnType<IdPOAuthAccessToken, MachineTokenVerificationError>> {
   try {
     const client = createBackendApiClient(options);
-    const verifiedToken = await client.idPOAuthAccessToken.verifySecret(secret);
+    const verifiedToken = await client.idPOAuthAccessToken.verifyAccessToken(accessToken);
     return { data: verifiedToken, tokenType: TokenType.OAuthToken, errors: undefined };
   } catch (err: any) {
     return handleClerkAPIError(TokenType.OAuthToken, err, 'OAuth token not found');

--- a/packages/express/src/__tests__/getAuth.test.ts
+++ b/packages/express/src/__tests__/getAuth.test.ts
@@ -29,10 +29,10 @@ describe('getAuth', () => {
   });
 
   it('returns the actual auth object if its tokenType is included in the acceptsToken array', () => {
-    const req = mockRequestWithAuth({ tokenType: 'machine_token', id: 'mt_1234' });
+    const req = mockRequestWithAuth({ tokenType: 'machine_token', id: 'm2m_1234' });
     const result = getAuth(req, { acceptsToken: ['machine_token', 'api_key'] });
     expect(result.tokenType).toBe('machine_token');
-    expect(result.id).toBe('mt_1234');
+    expect(result.id).toBe('m2m_1234');
     expect(result.subject).toBeUndefined();
   });
 

--- a/packages/express/src/__tests__/getAuth.test.ts
+++ b/packages/express/src/__tests__/getAuth.test.ts
@@ -21,11 +21,12 @@ describe('getAuth', () => {
   });
 
   it('returns the actual auth object when its tokenType matches acceptsToken', () => {
-    const req = mockRequestWithAuth({ tokenType: 'api_key', id: 'ak_1234', subject: 'api_key_1234' });
+    const req = mockRequestWithAuth({ tokenType: 'api_key', id: 'ak_1234', userId: 'user_12345', orgId: null });
     const result = getAuth(req, { acceptsToken: 'api_key' });
     expect(result.tokenType).toBe('api_key');
     expect(result.id).toBe('ak_1234');
-    expect(result.subject).toBe('api_key_1234');
+    expect(result.userId).toBe('user_12345');
+    expect(result.orgId).toBeNull();
   });
 
   it('returns the actual auth object if its tokenType is included in the acceptsToken array', () => {
@@ -41,7 +42,7 @@ describe('getAuth', () => {
     const result = getAuth(req, { acceptsToken: 'api_key' });
     expect(result.tokenType).toBe('session_token'); // reflects the actual token found
     // Properties specific to authenticated objects should be null or undefined
-    // @ts-expect-error - userId is not a property of the unauthenticated object
     expect(result.userId).toBeNull();
+    expect(result.orgId).toBeNull();
   });
 });

--- a/packages/fastify/src/__tests__/getAuth.test.ts
+++ b/packages/fastify/src/__tests__/getAuth.test.ts
@@ -16,11 +16,14 @@ describe('getAuth(req)', () => {
   });
 
   it('returns the actual auth object when its tokenType matches acceptsToken', () => {
-    const req = { auth: { tokenType: 'api_key', id: 'ak_1234', subject: 'api_key_1234' } } as unknown as FastifyRequest;
+    const req = {
+      auth: { tokenType: 'api_key', id: 'ak_1234', userId: 'user_12345', orgId: null },
+    } as unknown as FastifyRequest;
     const result = getAuth(req, { acceptsToken: 'api_key' });
     expect(result.tokenType).toBe('api_key');
     expect(result.id).toBe('ak_1234');
-    expect(result.subject).toBe('api_key_1234');
+    expect(result.userId).toBe('user_12345');
+    expect(result.orgId).toBeNull();
   });
 
   it('returns the actual auth object if its tokenType is included in the acceptsToken array', () => {
@@ -35,8 +38,7 @@ describe('getAuth(req)', () => {
     const req = { auth: { tokenType: 'session_token', userId: 'user_12345' } } as unknown as FastifyRequest;
     const result = getAuth(req, { acceptsToken: 'api_key' });
     expect(result.tokenType).toBe('session_token'); // reflects the actual token found
-    // Properties specific to authenticated objects should be null or undefined
-    // @ts-expect-error - userId is not a property of the unauthenticated object
     expect(result.userId).toBeNull();
+    expect(result.orgId).toBeNull();
   });
 });

--- a/packages/fastify/src/__tests__/getAuth.test.ts
+++ b/packages/fastify/src/__tests__/getAuth.test.ts
@@ -24,10 +24,10 @@ describe('getAuth(req)', () => {
   });
 
   it('returns the actual auth object if its tokenType is included in the acceptsToken array', () => {
-    const req = { auth: { tokenType: 'machine_token', id: 'mt_1234' } } as unknown as FastifyRequest;
+    const req = { auth: { tokenType: 'machine_token', id: 'm2m_1234' } } as unknown as FastifyRequest;
     const result = getAuth(req, { acceptsToken: ['machine_token', 'api_key'] });
     expect(result.tokenType).toBe('machine_token');
-    expect(result.id).toBe('mt_1234');
+    expect(result.id).toBe('m2m_1234');
     expect(result.subject).toBeUndefined();
   });
 

--- a/packages/nextjs/src/server/__tests__/getAuthDataFromRequest.test.ts
+++ b/packages/nextjs/src/server/__tests__/getAuthDataFromRequest.test.ts
@@ -48,7 +48,7 @@ describe('getAuthDataFromRequestAsync', () => {
 
   it('returns authenticated machine object when token type matches', async () => {
     vi.mocked(verifyMachineAuthToken).mockResolvedValueOnce({
-      data: { id: 'ak_123' } as any,
+      data: { id: 'ak_123', subject: 'user_12345' } as any,
       tokenType: 'api_key',
       errors: undefined,
     });


### PR DESCRIPTION
## Description

This PR improves the `subject` property handling for machine auth objects. Specifically:

- For `api_keys`, added a `userId` and `orgId`
- For `machine_token`, added a `machineId`
- For `oauth_token`, added a `userId` and the `clientId` for convenience.

Resolves USER-2118

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for machine authentication objects, providing clearer identification properties such as userId, orgId, machineId, and clientId for different token types (API keys, machine tokens, and OAuth tokens).

- **Bug Fixes**
  - Improved consistency in token and subject prefixes for machine tokens.
  - Renamed method and parameter for OAuth token verification to better reflect usage.

- **Tests**
  - Updated and expanded test cases to reflect new identifier properties and adjusted expected values for machine token IDs.
  - Simplified type assertions in tests for authentication objects.

- **Documentation**
  - Added usage examples and improved documentation for handling machine authentication objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->