### PR TITLE
fix(clerk-js): Preserve active organization when attempting to switch to personal workspace

### DIFF
--- a/.changeset/dark-cougars-burn.md
+++ b/.changeset/dark-cougars-burn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Maintain current active organization when `setActive({ organization: null })` is called with force organization selection enabled

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -537,6 +537,87 @@ describe('Clerk singleton', () => {
         });
       });
     });
+
+    describe('with force organization selection enabled', () => {
+      const mockSession = {
+        id: '1',
+        remove: jest.fn(),
+        status: 'active',
+        user: {},
+        touch: jest.fn(() => Promise.resolve()),
+        getToken: jest.fn(),
+        lastActiveToken: { getRawString: () => 'mocked-token' },
+      };
+
+      beforeEach(() => {
+        mockEnvironmentFetch.mockReturnValue(
+          Promise.resolve({
+            userSettings: mockUserSettings,
+            displayConfig: mockDisplayConfig,
+            isSingleSession: () => false,
+            isProduction: () => false,
+            isDevelopmentOrStaging: () => true,
+            organizationSettings: {
+              forceOrganizationSelection: true,
+            },
+          }),
+        );
+      });
+
+      afterEach(() => {
+        mockSession.remove.mockReset();
+        mockSession.touch.mockReset();
+        mockEnvironmentFetch.mockReset();
+
+        // cleanup global window pollution
+        (window as any).__unstable__onBeforeSetActive = null;
+        (window as any).__unstable__onAfterSetActive = null;
+      });
+
+      it('does not update session to personal workspace', async () => {
+        const mockSessionWithOrganization = {
+          id: '1',
+          status: 'active',
+          user: {
+            organizationMemberships: [
+              {
+                id: 'orgmem_id',
+                organization: {
+                  id: 'org_id',
+                  slug: 'some-org-slug',
+                },
+              },
+            ],
+          },
+          touch: jest.fn(),
+          getToken: jest.fn(),
+        };
+
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSessionWithOrganization] }));
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+
+        mockSessionWithOrganization.touch.mockImplementationOnce(() => {
+          sut.session = mockSessionWithOrganization as any;
+          return Promise.resolve();
+        });
+        mockSessionWithOrganization.getToken.mockImplementation(() => 'mocked-token');
+
+        await sut.setActive({ organization: 'some-org-slug' });
+
+        await waitFor(() => {
+          expect(mockSessionWithOrganization.touch).toHaveBeenCalled();
+          expect(mockSessionWithOrganization.getToken).toHaveBeenCalled();
+          expect((mockSessionWithOrganization as any as ActiveSessionResource)?.lastActiveOrganizationId).toEqual(
+            'org_id',
+          );
+          expect(sut.session).toMatchObject(mockSessionWithOrganization);
+        });
+
+        await sut.setActive({ organization: null });
+        expect(sut.session).toMatchObject(mockSessionWithOrganization);
+      });
+    });
   });
 
   describe('.load()', () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1071,10 +1071,6 @@ export class Clerk implements ClerkInterface {
         );
       }
 
-      if (organization === null && this.environment?.organizationSettings?.forceOrganizationSelection) {
-        throw new Error('setActive requires an organization parameter when organization selection is forced.');
-      }
-
       const onBeforeSetActive: SetActiveHook =
         typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
           ? window.__unstable__onBeforeSetActive
@@ -1107,7 +1103,16 @@ export class Clerk implements ClerkInterface {
           const matchingOrganization = newSession.user.organizationMemberships.find(
             mem => mem.organization.slug === organizationIdOrSlug,
           );
-          newSession.lastActiveOrganizationId = matchingOrganization?.organization.id || null;
+
+          const newLastActiveOrganizationId = matchingOrganization?.organization.id || null;
+          const isPersonalWorkspace = newLastActiveOrganizationId === null;
+
+          // Do not update in-memory to personal workspace if force organization selection is enabled
+          if (this.environment?.organizationSettings?.forceOrganizationSelection && isPersonalWorkspace) {
+            return;
+          }
+
+          newSession.lastActiveOrganizationId = newLastActiveOrganizationId;
         }
       }
 


### PR DESCRIPTION
## Description

Related to https://github.com/clerk/javascript/pull/6073 

Instead of throwing an error, this PR maintains the latest active organization ID and does not update the session to the personal workspace. 

Important to note that this only applies to the `Clerk.session` singleton, as FAPI has already been updated on `/tokens` and `/touch` to also handle it in a idempotent way.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of organization selection when force organization selection is enabled, ensuring the active organization is not cleared if set to null.  
- **Tests**
  - Added tests to verify correct behavior when changing the active organization with force organization selection enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->