### PR TITLE
feat(clerk-js): Handle `needs_new_password` status on sign in

### DIFF
--- a/.changeset/neat-cloths-dig.md
+++ b/.changeset/neat-cloths-dig.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Handle the `needs_new_password` sign in status when signing in via password.

--- a/.changeset/neat-cloths-dig.md
+++ b/.changeset/neat-cloths-dig.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/clerk-js': minor
+'@clerk/clerk-js': patch
 ---
 
 Handle the `needs_new_password` sign in status when signing in via password.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -76,6 +76,8 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
             return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
           case 'needs_second_factor':
             return navigate('../factor-two');
+          case 'needs_new_password':
+            return navigate('../reset-password');
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -229,6 +229,8 @@ function SignInStartInternal(): JSX.Element {
             return navigate('factor-one');
           case 'needs_second_factor':
             return navigate('factor-two');
+          case 'needs_new_password':
+            return navigate('../reset-password');
           case 'complete':
             removeClerkQueryParam('__clerk_ticket');
             return clerk.setActive({


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Handle `needs_new_password` in `SignInStart` and `SignInFactorOnePasswordCard`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users who need to set a new password during sign-in are now automatically directed to the password reset page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->