### PR TITLE
chore(clerk-js): Prefer popup for `v0.dev` domain

### DIFF
--- a/.changeset/evil-jobs-boil.md
+++ b/.changeset/evil-jobs-boil.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add `.v0.dev` as prefered origin for oauth flows with popup.

--- a/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
+++ b/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
@@ -1,4 +1,10 @@
-const POPUP_PREFERRED_ORIGINS = ['.lovable.app', '.lovableproject.com', '.webcontainer-api.io', '.vusercontent.net'];
+const POPUP_PREFERRED_ORIGINS = [
+  '.lovable.app',
+  '.lovableproject.com',
+  '.webcontainer-api.io',
+  '.vusercontent.net',
+  '.v0.dev',
+];
 
 /**
  * Returns `true` if the current origin is one that is typically embedded via an iframe, which would benefit from the


### PR DESCRIPTION
## Description
Adds `v0.dev` as a domain that prefer the popup oauth flow.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for popup flows on additional domains ending with ".v0.dev".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->