### PR TITLE
fix(backend): Consider proxyUrl in determining frontendApi URL

### DIFF
--- a/packages/backend/src/tokens/handshake.ts
+++ b/packages/backend/src/tokens/handshake.ts
@@ -134,13 +134,14 @@ export class HandshakeService {
     }
 
     const redirectUrl = this.removeDevBrowserFromURL(this.authenticateContext.clerkUrl);
-    const frontendApiNoProtocol = this.authenticateContext.frontendApi.replace(/http(s)?:\/\//, '');
 
-    const baseUrl = this.authenticateContext.proxyUrl
-      ? this.authenticateContext.proxyUrl.replace(/\/$/, '')
-      : `https://${frontendApiNoProtocol}`;
+    let baseUrl = this.authenticateContext.frontendApi.startsWith('http')
+      ? this.authenticateContext.frontendApi
+      : `https://${this.authenticateContext.frontendApi}`;
 
-    const url = new URL(`${baseUrl}/v1/client/handshake`);
+    baseUrl = baseUrl.replace(/\/+$/, '') + '/';
+
+    const url = new URL('v1/client/handshake', baseUrl);
     url.searchParams.append('redirect_url', redirectUrl?.href || '');
     url.searchParams.append('__clerk_api_version', SUPPORTED_BAPI_VERSION);
     url.searchParams.append(


### PR DESCRIPTION
## Description

Adding some additional logic to ensure that we consider the proxy_url when creating the frontendApi url. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
