### PR TITLE
chore(backend,nextjs): Clean up request state and auth objects

### DIFF
--- a/packages/backend/src/tokens/__tests__/request.test-d.ts
+++ b/packages/backend/src/tokens/__tests__/request.test-d.ts
@@ -26,7 +26,7 @@ test('returns the correct `authenticateRequest()` return type for each accepted 
   // Array of token types
   expectTypeOf(
     authenticateRequest(request, { acceptsToken: ['session_token', 'api_key', 'machine_token'] }),
-  ).toMatchTypeOf<Promise<RequestState<'session_token' | 'api_key' | 'machine_token'>>>();
+  ).toMatchTypeOf<Promise<RequestState<'session_token' | 'api_key' | 'machine_token' | null>>>();
 
   // Any token type
   expectTypeOf(authenticateRequest(request, { acceptsToken: 'any' })).toMatchTypeOf<Promise<RequestState<TokenType>>>();

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1240,6 +1240,7 @@ describe('tokens.authenticateRequest(options)', () => {
         });
         expect(requestState.toAuth()).toBeMachineUnauthenticatedToAuth({
           tokenType,
+          isAuthenticated: false,
         });
       });
     });
@@ -1289,6 +1290,7 @@ describe('tokens.authenticateRequest(options)', () => {
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
           tokenType: 'api_key',
+          isAuthenticated: false,
         });
       });
 
@@ -1303,6 +1305,7 @@ describe('tokens.authenticateRequest(options)', () => {
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
           tokenType: 'oauth_token',
+          isAuthenticated: false,
         });
       });
 
@@ -1317,6 +1320,7 @@ describe('tokens.authenticateRequest(options)', () => {
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
           tokenType: 'machine_token',
+          isAuthenticated: false,
         });
       });
 
@@ -1331,6 +1335,7 @@ describe('tokens.authenticateRequest(options)', () => {
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
           tokenType: 'machine_token',
+          isAuthenticated: false,
         });
       });
     });
@@ -1360,12 +1365,13 @@ describe('tokens.authenticateRequest(options)', () => {
         );
 
         expect(requestState).toBeMachineUnauthenticated({
-          tokenType: 'machine_token',
+          tokenType: null,
           reason: AuthErrorReason.TokenTypeMismatch,
           message: '',
         });
         expect(requestState.toAuth()).toBeMachineUnauthenticatedToAuth({
-          tokenType: 'machine_token',
+          tokenType: null,
+          isAuthenticated: false,
         });
       });
     });

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -434,13 +434,13 @@ export const getAuthObjectFromJwt = (
  *
  * This ensures the returned object always matches the developer's intent.
  */
-export function getAuthObjectForAcceptedToken({
+export const getAuthObjectForAcceptedToken = ({
   authObject,
   acceptsToken = TokenType.SessionToken,
 }: {
   authObject: AuthObject;
   acceptsToken: AuthenticateRequestOptions['acceptsToken'];
-}): AuthObject {
+}): AuthObject => {
   // 1. any token: return as-is
   if (acceptsToken === 'any') {
     return authObject;
@@ -464,4 +464,4 @@ export function getAuthObjectForAcceptedToken({
 
   // 4. default: return as-is
   return authObject;
-}
+};

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -428,7 +428,8 @@ export const getAuthObjectFromJwt = (
  * Returns an auth object matching the requested token type(s).
  *
  * If the parsed token type does not match any in acceptsToken, returns:
- *   - an unauthenticated machine object for the first machine token type in acceptsToken (if present), or
+ *   - an invalid token auth object if the token is not in the accepted array
+ *   - an unauthenticated machine object for machine tokens, or
  *   - a signed-out session object otherwise.
  *
  * This ensures the returned object always matches the developer's intent.
@@ -440,19 +441,20 @@ export function getAuthObjectForAcceptedToken({
   authObject: AuthObject;
   acceptsToken: AuthenticateRequestOptions['acceptsToken'];
 }): AuthObject {
+  // 1. any token: return as-is
   if (acceptsToken === 'any') {
     return authObject;
   }
 
+  // 2. array of tokens: must match one of the accepted types
   if (Array.isArray(acceptsToken)) {
     if (!isTokenTypeAccepted(authObject.tokenType, acceptsToken)) {
-      // If the token is not in the accepted array, return invalid token auth object
       return invalidTokenAuthObject();
     }
     return authObject;
   }
 
-  // Single value: Intent based
+  // 3. single token: must match exactly, else return appropriate unauthenticated object
   if (!isTokenTypeAccepted(authObject.tokenType, acceptsToken)) {
     if (isMachineTokenType(acceptsToken)) {
       return unauthenticatedMachineObject(acceptsToken, authObject.debug);
@@ -460,5 +462,6 @@ export function getAuthObjectForAcceptedToken({
     return signedOutAuthObject(authObject.debug);
   }
 
+  // 4. default: return as-is
   return authObject;
 }

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -5,12 +5,14 @@ import type { TokenVerificationErrorReason } from '../errors';
 import type { AuthenticateContext } from './authenticateContext';
 import type {
   AuthenticatedMachineObject,
+  InvalidTokenAuthObject,
   SignedInAuthObject,
   SignedOutAuthObject,
   UnauthenticatedMachineObject,
 } from './authObjects';
 import {
   authenticatedMachineObject,
+  invalidTokenAuthObject,
   signedInAuthObject,
   signedOutAuthObject,
   unauthenticatedMachineObject,
@@ -27,13 +29,15 @@ export const AuthStatus = {
 
 export type AuthStatus = (typeof AuthStatus)[keyof typeof AuthStatus];
 
-type ToAuth<T extends TokenType, Authenticated extends boolean> = T extends SessionTokenType
-  ? Authenticated extends true
-    ? (opts?: PendingSessionOptions) => SignedInAuthObject
-    : () => SignedOutAuthObject
-  : Authenticated extends true
-    ? () => AuthenticatedMachineObject<Exclude<T, SessionTokenType>>
-    : () => UnauthenticatedMachineObject<Exclude<T, SessionTokenType>>;
+type ToAuth<T extends TokenType | null, Authenticated extends boolean> = T extends null
+  ? () => InvalidTokenAuthObject
+  : T extends SessionTokenType
+    ? Authenticated extends true
+      ? (opts?: PendingSessionOptions) => SignedInAuthObject
+      : () => SignedOutAuthObject
+    : Authenticated extends true
+      ? () => AuthenticatedMachineObject<Exclude<T, SessionTokenType | null>>
+      : () => UnauthenticatedMachineObject<Exclude<T, SessionTokenType | null>>;
 
 export type AuthenticatedState<T extends TokenType = SessionTokenType> = {
   status: typeof AuthStatus.SignedIn;
@@ -58,7 +62,7 @@ export type AuthenticatedState<T extends TokenType = SessionTokenType> = {
   toAuth: ToAuth<T, true>;
 };
 
-export type UnauthenticatedState<T extends TokenType = SessionTokenType> = {
+export type UnauthenticatedState<T extends TokenType | null = SessionTokenType> = {
   status: typeof AuthStatus.SignedOut;
   reason: AuthReason;
   message: string;
@@ -120,8 +124,8 @@ export type AuthErrorReason = (typeof AuthErrorReason)[keyof typeof AuthErrorRea
 
 export type AuthReason = AuthErrorReason | TokenVerificationErrorReason;
 
-export type RequestState<T extends TokenType = SessionTokenType> =
-  | AuthenticatedState<T>
+export type RequestState<T extends TokenType | null = SessionTokenType> =
+  | AuthenticatedState<T extends null ? never : T>
   | UnauthenticatedState<T>
   | (T extends SessionTokenType ? HandshakeState : never);
 
@@ -238,6 +242,29 @@ export function handshake(
     headers,
     token: null,
   });
+}
+
+export function signedOutInvalidToken(): UnauthenticatedState<null> {
+  const authObject = invalidTokenAuthObject();
+  return {
+    status: AuthStatus.SignedOut,
+    reason: AuthErrorReason.TokenTypeMismatch,
+    message: '',
+    proxyUrl: '',
+    publishableKey: '',
+    isSatellite: false,
+    domain: '',
+    signInUrl: '',
+    signUpUrl: '',
+    afterSignInUrl: '',
+    afterSignUpUrl: '',
+    isSignedIn: false,
+    isAuthenticated: false,
+    tokenType: null,
+    toAuth: () => authObject,
+    headers: new Headers(),
+    token: null,
+  };
 }
 
 const withDebugHeaders = <T extends { headers: Headers; message?: string; reason?: AuthReason; status?: AuthStatus }>(

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -477,7 +477,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/api/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer api_key_xxxxxxxxxxxxxxxxxx',
+          [constants.Headers.Authorization]: 'Bearer ak_123',
         }),
       });
 
@@ -485,7 +485,7 @@ describe('clerkMiddleware(params)', () => {
         publishableKey,
         status: AuthStatus.SignedIn,
         headers: new Headers(),
-        toAuth: () => ({ tokenType: TokenType.ApiKey, id: 'api_key_xxxxxxxxxxxxxxxxxx' }),
+        toAuth: () => ({ tokenType: TokenType.ApiKey, id: 'ak_123', isAuthenticated: true }),
       });
 
       const resp = await clerkMiddleware(async auth => {
@@ -525,7 +525,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer api_key_xxxxxxxxxxxxxxxxxx',
+          [constants.Headers.Authorization]: 'Bearer ak_123',
         }),
       });
 
@@ -552,7 +552,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer oauth_token_xxxxxxxxxxxxxxxxxx',
+          [constants.Headers.Authorization]: 'Bearer oat_123',
         }),
       });
 
@@ -658,7 +658,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/api/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer m2m_xxxxxxxxxxxxxxxxxx',
+          [constants.Headers.Authorization]: 'Bearer m2m_123',
         }),
       });
 
@@ -681,7 +681,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/api/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer api_key_xxx',
+          [constants.Headers.Authorization]: 'Bearer ak_123',
         }),
       });
 
@@ -689,7 +689,7 @@ describe('clerkMiddleware(params)', () => {
         publishableKey,
         status: AuthStatus.SignedIn,
         headers: new Headers(),
-        toAuth: () => ({ tokenType: TokenType.ApiKey, id: 'api_key_xxxxxxxxxxxxxxxxxx' }),
+        toAuth: () => ({ tokenType: TokenType.ApiKey, id: 'ak_123', isAuthenticated: true }),
       });
 
       const resp = await clerkMiddleware(async auth => {
@@ -705,7 +705,7 @@ describe('clerkMiddleware(params)', () => {
       const req = mockRequest({
         url: '/api/protected',
         headers: new Headers({
-          [constants.Headers.Authorization]: 'Bearer api_key_xxx',
+          [constants.Headers.Authorization]: 'Bearer ak_123',
         }),
       });
 

--- a/packages/nextjs/src/server/__tests__/getAuthDataFromRequest.test.ts
+++ b/packages/nextjs/src/server/__tests__/getAuthDataFromRequest.test.ts
@@ -31,6 +31,19 @@ const mockRequest = (params: MockRequestParams) => {
 
 describe('getAuthDataFromRequestAsync', () => {
   it('returns unauthenticated machine object when token type does not match', async () => {
+    vi.mocked(verifyMachineAuthToken).mockResolvedValueOnce({
+      data: undefined,
+      tokenType: 'machine_token',
+      errors: [
+        {
+          message: 'Token type mismatch',
+          code: 'token-invalid',
+          status: 401,
+          name: 'MachineTokenVerificationError',
+          getFullMessage: () => 'Token type mismatch',
+        },
+      ],
+    });
     const req = mockRequest({
       url: '/api/protected',
       headers: new Headers({
@@ -44,9 +57,23 @@ describe('getAuthDataFromRequestAsync', () => {
 
     expect(auth.tokenType).toBe('machine_token');
     expect((auth as AuthenticatedMachineObject<'machine_token'>).machineId).toBeNull();
+    expect(auth.isAuthenticated).toBe(false);
   });
 
   it('returns invalid token auth object when token type does not match any in acceptsToken array', async () => {
+    vi.mocked(verifyMachineAuthToken).mockResolvedValueOnce({
+      data: undefined,
+      tokenType: 'machine_token',
+      errors: [
+        {
+          message: 'Token type mismatch',
+          code: 'token-invalid',
+          status: 401,
+          name: 'MachineTokenVerificationError',
+          getFullMessage: () => 'Token type mismatch',
+        },
+      ],
+    });
     const req = mockRequest({
       url: '/api/protected',
       headers: new Headers({
@@ -82,6 +109,7 @@ describe('getAuthDataFromRequestAsync', () => {
 
     expect(auth.tokenType).toBe('api_key');
     expect((auth as AuthenticatedMachineObject<'api_key'>).id).toBe('ak_123');
+    expect(auth.isAuthenticated).toBe(true);
   });
 
   it('returns authenticated machine object when token type matches', async () => {
@@ -104,6 +132,7 @@ describe('getAuthDataFromRequestAsync', () => {
 
     expect(auth.tokenType).toBe('api_key');
     expect((auth as AuthenticatedMachineObject<'api_key'>).id).toBe('ak_123');
+    expect(auth.isAuthenticated).toBe(true);
   });
 
   it('falls back to session token handling', async () => {
@@ -117,6 +146,7 @@ describe('getAuthDataFromRequestAsync', () => {
     const auth = await getAuthDataFromRequestAsync(req);
     expect(auth.tokenType).toBe('session_token');
     expect((auth as SignedOutAuthObject).userId).toBeNull();
+    expect(auth.isAuthenticated).toBe(false);
   });
 });
 
@@ -135,5 +165,6 @@ describe('getAuthDataFromRequestSync', () => {
 
     expect(auth.tokenType).toBe('session_token');
     expect(auth.userId).toBeNull();
+    expect(auth.isAuthenticated).toBe(false);
   });
 });

--- a/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
+++ b/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
@@ -4,13 +4,12 @@ import {
   type AuthenticateRequestOptions,
   AuthStatus,
   constants,
+  getAuthObjectForAcceptedToken,
   getAuthObjectFromJwt,
   getMachineTokenType,
   invalidTokenAuthObject,
   isMachineTokenByPrefix,
-  isMachineTokenType,
   isTokenTypeAccepted,
-  type MachineTokenType,
   type SignedInAuthObject,
   type SignedOutAuthObject,
   signedOutAuthObject,
@@ -33,6 +32,10 @@ export type GetAuthDataFromRequestOptions = {
   acceptsToken?: AuthenticateRequestOptions['acceptsToken'];
 } & PendingSessionOptions;
 
+/**
+ * Given a request object, builds an auth object from the request data. Used in server-side environments to get access
+ * to auth data for a given request.
+ */
 export const getAuthDataFromRequestSync = (
   req: RequestLike,
   { treatPendingAsSignedOut = true, ...opts }: GetAuthDataFromRequestOptions = {},
@@ -78,10 +81,6 @@ export const getAuthDataFromRequestSync = (
 };
 
 /**
- * Note: We intentionally avoid using interface/function overloads here since these functions
- * are used internally. The complex type overloads are more valuable at the public API level
- * (like in auth.protect(), auth()) where users interact directly with the types.
- *
  * Given a request object, builds an auth object from the request data. Used in server-side environments to get access
  * to auth data for a given request.
  */
@@ -103,46 +102,25 @@ export const getAuthDataFromRequestAsync = async (
     authReason,
   };
 
-  if (bearerToken) {
-    const isMachine = isMachineTokenByPrefix(bearerToken);
-    const tokenType = isMachine ? getMachineTokenType(bearerToken) : undefined;
-
-    if (Array.isArray(acceptsToken)) {
-      if (isMachine) {
-        return handleMachineToken({
-          bearerToken,
-          tokenType: tokenType as MachineTokenType,
-          acceptsToken,
-          options,
-        });
-      }
-    } else {
-      let intendedType: TokenType | undefined;
-      if (isMachineTokenType(acceptsToken)) {
-        intendedType = acceptsToken;
-      }
-      const result = await handleIntentBased({
-        isMachine,
-        tokenType,
-        intendedType,
-        bearerToken,
-        acceptsToken,
-        options,
-      });
-      if (result) {
-        return result;
-      }
-    }
+  const hasMachineToken = bearerToken && isMachineTokenByPrefix(bearerToken);
+  if (hasMachineToken) {
+    const machineTokenType = getMachineTokenType(bearerToken);
+    const { data, errors } = await verifyMachineAuthToken(bearerToken, options);
+    const authObject = errors
+      ? unauthenticatedMachineObject(machineTokenType, options)
+      : authenticatedMachineObject(machineTokenType, bearerToken, data);
+    return getAuthObjectForAcceptedToken({ authObject, acceptsToken });
   }
 
-  if (Array.isArray(acceptsToken)) {
-    if (!isTokenTypeAccepted(TokenType.SessionToken, acceptsToken)) {
-      return invalidTokenAuthObject();
-    }
+  // If a random token is present and acceptsToken is an array that does NOT include session_token,
+  // return invalidTokenAuthObject.
+  if (bearerToken && Array.isArray(acceptsToken) && !acceptsToken.includes(TokenType.SessionToken)) {
+    return invalidTokenAuthObject();
   }
 
-  // Fall through to session logic
-  return getAuthDataFromRequestSync(req, opts);
+  // Fallback to session logic (sync version) for all other cases
+  const authObject = getAuthDataFromRequestSync(req, opts);
+  return getAuthObjectForAcceptedToken({ authObject, acceptsToken });
 };
 
 const getAuthHeaders = (req: RequestLike) => {
@@ -160,76 +138,3 @@ const getAuthHeaders = (req: RequestLike) => {
     authSignature,
   };
 };
-
-/**
- * Handles verification and response shaping for machine tokens.
- * Returns an authenticated or unauthenticated machine object based on verification and type acceptance.
- */
-async function handleMachineToken({
-  bearerToken,
-  tokenType,
-  acceptsToken,
-  options,
-}: {
-  bearerToken: string;
-  tokenType: MachineTokenType;
-  acceptsToken: AuthenticateRequestOptions['acceptsToken'];
-  options: Record<string, any>;
-}) {
-  if (Array.isArray(acceptsToken)) {
-    // If the token is not in the accepted array, return invalid token auth object
-    if (!isTokenTypeAccepted(tokenType, acceptsToken)) {
-      return invalidTokenAuthObject();
-    }
-  }
-
-  if (!isTokenTypeAccepted(tokenType, acceptsToken ?? TokenType.SessionToken)) {
-    return unauthenticatedMachineObject(tokenType, options);
-  }
-  const { data, errors } = await verifyMachineAuthToken(bearerToken, options);
-  if (errors) {
-    return unauthenticatedMachineObject(tokenType, options);
-  }
-  return authenticatedMachineObject(tokenType, bearerToken, data);
-}
-
-/**
- * Handles intent-based fallback for single-value acceptsToken.
- * Returns an unauthenticated object for the intended type, or falls back to session logic if not applicable.
- */
-async function handleIntentBased({
-  isMachine,
-  tokenType,
-  intendedType,
-  bearerToken,
-  acceptsToken,
-  options,
-}: {
-  isMachine: boolean;
-  tokenType: TokenType | undefined;
-  intendedType: TokenType | undefined;
-  bearerToken: string;
-  acceptsToken: AuthenticateRequestOptions['acceptsToken'];
-  options: Record<string, any>;
-}) {
-  if (isMachine) {
-    if (!tokenType) {
-      return signedOutAuthObject(options);
-    }
-    if (!isTokenTypeAccepted(tokenType, acceptsToken ?? TokenType.SessionToken)) {
-      if (intendedType && isMachineTokenType(intendedType)) {
-        return unauthenticatedMachineObject(intendedType, options);
-      }
-      return signedOutAuthObject(options);
-    }
-    const { data, errors } = await verifyMachineAuthToken(bearerToken, options);
-    if (errors) {
-      return unauthenticatedMachineObject(tokenType as MachineTokenType, options);
-    }
-    return authenticatedMachineObject(tokenType as MachineTokenType, bearerToken, data);
-  } else if (intendedType && isMachineTokenType(intendedType)) {
-    return unauthenticatedMachineObject(intendedType, options);
-  }
-  // else: fall through to session logic
-  return null;
-}

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -145,14 +145,10 @@ export function createProtect(opts: {
       return handleUnauthorized();
     }
 
-    if (authObject.tokenType === null) {
-      return handleUnauthorized();
-    }
-
     if (authObject.tokenType !== TokenType.SessionToken) {
       // For machine tokens, we only check if they're authenticated
       // They don't have session status or organization permissions
-      if (!authObject.id) {
+      if (!authObject.isAuthenticated) {
         return handleUnauthorized();
       }
       return authObject;


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
