### PR TITLE
fix(localizations): Add ToS & privacy links

### DIFF
--- a/.changeset/tiny-snails-wonder.md
+++ b/.changeset/tiny-snails-wonder.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Adds clickable Terms of Service and Privacy Policy links to the following localizations: `be-BY`, `bg-BG`, `cs-CZ`, `es-ES`, `it-IT`, `nl-BE`, `nl-NL`, `pt-PT`, and `tr-TR`.

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -664,7 +664,8 @@ export const beBY: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Я згаджаюся з палітыкай канфідэнцыяльнасці',
         label__onlyTermsOfService: 'Я згаджаюся з умовамі выкарыстання',
-        label__termsOfServiceAndPrivacyPolicy: 'Я згаджаюся з умовамі выкарыстання і палітыкай канфідэнцыяльнасці',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Я згаджаюся з {{ termsOfServiceLink || link("умовамі выкарыстання") }} і {{ privacyPolicyLink || link("палітыкай канфідэнцыяльнасці") }}',
       },
       continue: {
         subtitle: 'Калі ласка, пагадзіцеся з умовамі, каб працягнуць.',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -660,7 +660,8 @@ export const bgBG: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Съгласен съм само с политиката за конфиденциалност',
         label__onlyTermsOfService: 'Съгласен съм само с условията за ползване',
-        label__termsOfServiceAndPrivacyPolicy: 'Съгласен съм с условията за ползване и политиката за конфиденциалност',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Съгласен съм с {{ termsOfServiceLink || link("условията за ползване") }} и {{ privacyPolicyLink || link("политиката за конфиденциалност") }}',
       },
       continue: {
         subtitle: 'Продължете, за да завършите процеса',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -658,7 +658,8 @@ export const csCZ: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Souhlasím s politikou ochrany osobních údajů',
         label__onlyTermsOfService: 'Souhlasím s podmínkami služby',
-        label__termsOfServiceAndPrivacyPolicy: 'Souhlasím s podmínkami služby a politikou ochrany osobních údajů',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Souhlasím s {{ termsOfServiceLink || link("podmínkami služby") }} a {{ privacyPolicyLink || link("politikou ochrany osobních údajů") }}',
       },
       continue: {
         subtitle: 'Pokračujte pro dokončení registrace.',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -661,7 +661,8 @@ export const esES: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'He leído y acepto la Política de Privacidad',
         label__onlyTermsOfService: 'He leído y acepto los Términos de Servicio',
-        label__termsOfServiceAndPrivacyPolicy: 'He leído y acepto los Términos de Servicio y la Política de Privacidad',
+        label__termsOfServiceAndPrivacyPolicy:
+          'He leído y acepto los {{ termsOfServiceLink || link("Términos de Servicio") }} y la {{ privacyPolicyLink || link("Política de Privacidad") }}',
       },
       continue: {
         subtitle: 'Al continuar, aceptas las condiciones mencionadas.',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -660,7 +660,8 @@ export const itIT: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Accetto la Politica sulla Privacy',
         label__onlyTermsOfService: 'Accetto i Termini di Servizio',
-        label__termsOfServiceAndPrivacyPolicy: 'Accetto i Termini di Servizio e la Politica sulla Privacy',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Accetto i {{ termsOfServiceLink || link("Termini di Servizio") }} e la {{ privacyPolicyLink || link("Politica sulla Privacy") }}',
       },
       continue: {
         subtitle: 'Per completare la registrazione, accetta i termini e la privacy policy.',

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -660,7 +660,8 @@ export const nlBE: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Ik accepteer het Privacybeleid',
         label__onlyTermsOfService: 'Ik accepteer de Algemene Voorwaarden',
-        label__termsOfServiceAndPrivacyPolicy: 'Ik accepteer de Algemene Voorwaarden en het Privacybeleid',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Ik accepteer de {{ termsOfServiceLink || link("Algemene Voorwaarden") }} en het {{ privacyPolicyLink || link("Privacybeleid") }}',
       },
       continue: {
         subtitle: 'Door verder te gaan, ga je akkoord met de bovenstaande voorwaarden.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -660,7 +660,8 @@ export const nlNL: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Ik accepteer het Privacybeleid',
         label__onlyTermsOfService: 'Ik accepteer de Algemene Voorwaarden',
-        label__termsOfServiceAndPrivacyPolicy: 'Ik accepteer de Algemene Voorwaarden en het Privacybeleid',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Ik accepteer de {{ termsOfServiceLink || link("Algemene Voorwaarden") }} en het {{ privacyPolicyLink || link("Privacybeleid") }}',
       },
       continue: {
         subtitle: 'Door verder te gaan, ga je akkoord met de bovenstaande voorwaarden.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -658,7 +658,8 @@ export const ptPT: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: 'Aceito a Política de Privacidade',
         label__onlyTermsOfService: 'Aceito os Termos de Serviço',
-        label__termsOfServiceAndPrivacyPolicy: 'Aceito os Termos de Serviço e a Política de Privacidade',
+        label__termsOfServiceAndPrivacyPolicy:
+          'Aceito os {{ termsOfServiceLink || link("Termos de Serviço") }} e a {{ privacyPolicyLink || link("Política de Privacidade") }}',
       },
       continue: {
         subtitle: 'Ao continuar, você concorda com os termos acima.',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -661,7 +661,8 @@ export const trTR: LocalizationResource = {
       checkbox: {
         label__onlyPrivacyPolicy: "Gizlilik Politikası'nı kabul ediyorum",
         label__onlyTermsOfService: "Hizmet Şartları'nı kabul ediyorum",
-        label__termsOfServiceAndPrivacyPolicy: "Hizmet Şartları ve Gizlilik Politikası'nı kabul ediyorum",
+        label__termsOfServiceAndPrivacyPolicy:
+          "{{ termsOfServiceLink || link('Hizmet Şartları') }} ve {{ privacyPolicyLink || link('Gizlilik Politikası') }}'nı kabul ediyorum",
       },
       continue: {
         subtitle: 'Devam etmek için lütfen gerekli adımları takip edin.',


### PR DESCRIPTION
## Description

Certain locales were missing clickable ToS and Privacy Policy links. This PR adds them in.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Fixes USER-2061

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clickable links for Terms of Service and Privacy Policy in the sign-up legal consent checkbox for Belarusian, Bulgarian, Czech, Spanish, Italian, Dutch (Belgium and Netherlands), Portuguese (Portugal), and Turkish localizations. This enhancement allows users to directly access legal documents from the consent label in these languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->