### PR TITLE
Revert "feat(clerk-js): Switch to `subscription_items` endpoints"

### DIFF
--- a/.changeset/beige-aliens-wish.md
+++ b/.changeset/beige-aliens-wish.md
@@ -1,5 +1,0 @@
----
-'@clerk/clerk-js': patch
----
-
-Internal only: switch to `/subscription_items` endpoints

--- a/.changeset/great-memes-nail.md
+++ b/.changeset/great-memes-nail.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/clerk-js': patch
 ---
-
-Rollback changes to subscription endpoints for now

--- a/.changeset/great-memes-nail.md
+++ b/.changeset/great-memes-nail.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Rollback changes to subscription endpoints for now

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "608.92kB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "70.16KB" },
+    { "path": "./dist/clerk.js", "maxSize": "608.91kB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "70.15KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "113KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "53.06KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "108.36KB" },

--- a/packages/clerk-js/src/core/modules/commerce/CommerceBilling.ts
+++ b/packages/clerk-js/src/core/modules/commerce/CommerceBilling.ts
@@ -45,7 +45,7 @@ export class CommerceBilling implements CommerceBillingNamespace {
     const { orgId, ...rest } = params;
 
     return await BaseResource._fetch({
-      path: orgId ? `/organizations/${orgId}/commerce/subscription_items` : `/me/commerce/subscription_items`,
+      path: orgId ? `/organizations/${orgId}/commerce/subscriptions` : `/me/commerce/subscriptions`,
       method: 'GET',
       search: convertPageToOffsetSearchParams(rest),
     }).then(res => {

--- a/packages/clerk-js/src/core/resources/CommerceSubscription.ts
+++ b/packages/clerk-js/src/core/resources/CommerceSubscription.ts
@@ -52,8 +52,8 @@ export class CommerceSubscription extends BaseResource implements CommerceSubscr
     const json = (
       await BaseResource._fetch({
         path: orgId
-          ? `/organizations/${orgId}/commerce/subscription_items/${this.id}`
-          : `/me/commerce/subscription_items/${this.id}`,
+          ? `/organizations/${orgId}/commerce/subscriptions/${this.id}`
+          : `/me/commerce/subscriptions/${this.id}`,
         method: 'DELETE',
       })
     )?.response as unknown as DeletedObjectJSON;

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -237,7 +237,7 @@ export class Organization extends BaseResource implements OrganizationResource {
     getSubscriptionsParams?: GetSubscriptionsParams,
   ): Promise<ClerkPaginatedResponse<CommerceSubscriptionResource>> => {
     return await BaseResource._fetch({
-      path: `/organizations/${this.id}/commerce/subscription_items`,
+      path: `/organizations/${this.id}/commerce/subscriptions`,
       method: 'GET',
       search: convertPageToOffsetSearchParams(getSubscriptionsParams),
     }).then(res => {


### PR DESCRIPTION
Reverts clerk/javascript#6137

Reverting for now as we align on a rollout strategy to turn existing `subscriptions` into `subscription items`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated subscription management endpoints to improve consistency and reliability when viewing and canceling subscriptions.
- **Chores**
  - Removed an internal patch and added an empty changeset file. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->