### PR TITLE
fix(clerk-js): Emit a TokenUpdate event on Session.touch()

### DIFF
--- a/.changeset/wide-bags-mate.md
+++ b/.changeset/wide-bags-mate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes a scenario where the session token would not immediately update after a call to `Clerk.session.touch()`.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "610kB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "70.16KB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "70.2KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "113KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "53.06KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "108.4KB" },

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -84,6 +84,13 @@ export class Session extends BaseResource implements SessionResource {
     return this._basePost({
       action: 'touch',
       body: { active_organization_id: this.lastActiveOrganizationId },
+    }).then(res => {
+      console.log('touch', res);
+      // touch() will potentially change the session state, and so we need to ensure we emit the updated token that comes back in the response. This avoids potential issues where the session cookie is out of sync with the current session state.
+      if (res.lastActiveToken) {
+        eventBus.emit(events.TokenUpdate, { token: res.lastActiveToken });
+      }
+      return res;
     });
   };
 
@@ -302,6 +309,8 @@ export class Session extends BaseResource implements SessionResource {
     if (data.public_user_data) {
       this.publicUserData = new PublicUserData(data.public_user_data);
     }
+
+    console.log('last_active_token', data);
 
     this.lastActiveToken = data.last_active_token ? new Token(data.last_active_token) : null;
 

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -85,7 +85,6 @@ export class Session extends BaseResource implements SessionResource {
       action: 'touch',
       body: { active_organization_id: this.lastActiveOrganizationId },
     }).then(res => {
-      console.log('touch', res);
       // touch() will potentially change the session state, and so we need to ensure we emit the updated token that comes back in the response. This avoids potential issues where the session cookie is out of sync with the current session state.
       if (res.lastActiveToken) {
         eventBus.emit(events.TokenUpdate, { token: res.lastActiveToken });
@@ -309,8 +308,6 @@ export class Session extends BaseResource implements SessionResource {
     if (data.public_user_data) {
       this.publicUserData = new PublicUserData(data.public_user_data);
     }
-
-    console.log('last_active_token', data);
 
     this.lastActiveToken = data.last_active_token ? new Token(data.last_active_token) : null;
 

--- a/packages/clerk-js/src/core/resources/__tests__/Session.spec.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Session.spec.ts
@@ -264,7 +264,7 @@ describe('Session', () => {
       BaseResource.clerk = null as any;
     });
 
-    it.only('dispatches token:update event on touch', async () => {
+    it('dispatches token:update event on touch', async () => {
       const mockToken = { object: 'token', jwt: mockJwt };
       const session = new Session({
         status: 'active',


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Emits a `TokenUpdate` event on a successful `Session.touch()` event. This addresses a potential race condition scenario where the active session is switched, but the session token does not update immediately, causing some requests to potentially fire with the "old" session token in parallel.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the session token did not update immediately after invoking the session touch action, ensuring the token now reflects the latest state right away.

- **Tests**
  - Added tests to verify that the session token update event is triggered correctly after the session touch action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->