### PR TITLE
chore(repo): Update renovate script for tanstack-react-start

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1099,9 +1099,9 @@
     },
     {
       groupName: "[DEV] minor & patch dependencies",
-      groupSlug: "tanstack-start-dev-minor",
+      groupSlug: "tanstack-react-start-dev-minor",
       matchFileNames: [
-        "packages/tanstack-start/package.json",
+        "packages/tanstack-react-start/package.json",
       ],
       matchDepTypes: [
         "devDependencies",
@@ -1111,13 +1111,13 @@
         "minor",
       ],
       automerge: true,
-      semanticCommitScope: "tanstack-start",
+      semanticCommitScope: "tanstack-react-start",
     },
     {
       groupName: "[DEV] major dependencies",
-      groupSlug: "tanstack-start-dev-major",
+      groupSlug: "tanstack-react-start-dev-major",
       matchFileNames: [
-        "packages/tanstack-start/package.json",
+        "packages/tanstack-react-start/package.json",
       ],
       matchDepTypes: [
         "devDependencies",
@@ -1125,13 +1125,13 @@
       matchUpdateTypes: [
         "major",
       ],
-      semanticCommitScope: "tanstack-start",
+      semanticCommitScope: "tanstack-react-start",
     },
     {
       groupName: "minor & patch dependencies",
-      groupSlug: "tanstack-start-prod-minor",
+      groupSlug: "tanstack-react-start-prod-minor",
       matchFileNames: [
-        "packages/tanstack-start/package.json",
+        "packages/tanstack-react-start/package.json",
       ],
       matchDepTypes: [
         "dependencies",
@@ -1140,13 +1140,13 @@
         "patch",
         "minor",
       ],
-      semanticCommitScope: "tanstack-start",
+      semanticCommitScope: "tanstack-react-start",
     },
     {
       groupName: "major dependencies",
-      groupSlug: "tanstack-start-prod-major",
+      groupSlug: "tanstack-react-start-prod-major",
       matchFileNames: [
-        "packages/tanstack-start/package.json",
+        "packages/tanstack-react-start/package.json",
       ],
       matchDepTypes: [
         "dependencies",
@@ -1154,7 +1154,7 @@
       matchUpdateTypes: [
         "major",
       ],
-      semanticCommitScope: "tanstack-start",
+      semanticCommitScope: "tanstack-react-start",
     },
     {
       groupName: "[DEV] minor & patch dependencies",


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to reflect the package name change from "tanstack-start" to "tanstack-react-start" in dependency management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->