### PR TITLE
fix(clerk-js): Update `usePrefersReducedMotion` initial value

### DIFF
--- a/.changeset/tiny-lands-retire.md
+++ b/.changeset/tiny-lands-retire.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Bug fix: Drawers would always act as prefered-reduced-motion was turned on on the first render.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -4,7 +4,7 @@
     { "path": "./dist/clerk.browser.js", "maxSize": "70.16KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "113KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "53.06KB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "108.54KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "108.56KB" },
     { "path": "./dist/vendors*.js", "maxSize": "40.2KB" },
     { "path": "./dist/coinbase*.js", "maxSize": "38KB" },
     { "path": "./dist/createorganization*.js", "maxSize": "5KB" },

--- a/packages/clerk-js/src/ui/hooks/usePrefersReducedMotion.ts
+++ b/packages/clerk-js/src/ui/hooks/usePrefersReducedMotion.ts
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react';
 
 const mediaQueryNoPreference = '(prefers-reduced-motion: no-preference)';
 
-export function usePrefersReducedMotion() {
-  // Get the correct initial value instead of defaulting to true
-  const getInitialValue = () => {
-    if (typeof window === 'undefined') return true; // SSR fallback
-    return !window.matchMedia(mediaQueryNoPreference).matches;
-  };
+// Get the correct initial value instead of defaulting to true
+const getInitialValue = () => {
+  if (typeof window === 'undefined') return true; // SSR fallback
+  return !window.matchMedia(mediaQueryNoPreference).matches;
+};
 
+export function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(getInitialValue);
 
   useEffect(() => {

--- a/packages/clerk-js/src/ui/hooks/usePrefersReducedMotion.ts
+++ b/packages/clerk-js/src/ui/hooks/usePrefersReducedMotion.ts
@@ -3,7 +3,13 @@ import { useEffect, useState } from 'react';
 const mediaQueryNoPreference = '(prefers-reduced-motion: no-preference)';
 
 export function usePrefersReducedMotion() {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(true);
+  // Get the correct initial value instead of defaulting to true
+  const getInitialValue = () => {
+    if (typeof window === 'undefined') return true; // SSR fallback
+    return !window.matchMedia(mediaQueryNoPreference).matches;
+  };
+
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(getInitialValue);
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQueryNoPreference);


### PR DESCRIPTION
## Description

Fixes an issue where the `<Drawer />` component initial enter animation wasn't firing correctly due to `prefersReducedMotion` defaulting to true on first render.

## Reduced motion = false

BEFORE

https://github.com/user-attachments/assets/5eb312a0-722f-48b5-a9f6-d3de5eb1e406

AFTER

https://github.com/user-attachments/assets/48423e0c-6f5c-4c0a-95fd-aca009268c82

## Reduced motion = true

> [!NOTE]  
> No difference here, just showing that it still correctly respects prefersReducedMotion setting.

BEFORE

https://github.com/user-attachments/assets/9655b68e-20e3-4d01-9f7a-71732802f67e

AFTER

https://github.com/user-attachments/assets/0098b578-cab7-4034-ac4b-9ee16d93739c

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of user motion preferences, ensuring animations and motion settings better reflect individual accessibility settings, especially during initial load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->