### PR TITLE
feat(clerk-js): Add signInMode to PricingTable

### DIFF
--- a/.changeset/little-lizards-hammer.md
+++ b/.changeset/little-lizards-hammer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add `signInMode` prop to `PricingTable` for configuring sign in behavior

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTable.tsx
@@ -9,7 +9,7 @@ import { PricingTableMatrix } from './PricingTableMatrix';
 
 const PricingTableRoot = (props: PricingTableProps) => {
   const clerk = useClerk();
-  const { mode = 'mounted' } = usePricingTableContext();
+  const { mode = 'mounted', signInMode = 'redirect' } = usePricingTableContext();
   const isCompact = mode === 'modal';
   const { data: subscriptions } = useSubscriptions();
   const { data: plans } = usePlans();
@@ -42,6 +42,9 @@ const PricingTableRoot = (props: PricingTableProps) => {
 
   const selectPlan = (plan: CommercePlanResource, event?: React.MouseEvent<HTMLElement>) => {
     if (!clerk.isSignedIn) {
+      if (signInMode === 'modal') {
+        return clerk.openSignIn();
+      }
       return clerk.redirectToSignIn();
     }
 

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -54,6 +54,7 @@ export type AvailableComponentProps =
   | APIKeysProps;
 
 type ComponentMode = 'modal' | 'mounted';
+type SignInMode = 'modal' | 'redirect';
 
 export type SignInCtx = SignInProps & {
   componentName: 'SignIn';
@@ -116,6 +117,7 @@ export type WaitlistCtx = WaitlistProps & {
 export type PricingTableCtx = PricingTableProps & {
   componentName: 'PricingTable';
   mode?: ComponentMode;
+  signInMode?: SignInMode;
 };
 
 export type APIKeysCtx = APIKeysProps & {


### PR DESCRIPTION
## Description

Adds `signInMode` ('redirect' or 'modal', defaults to 'redirect') to `<PricingTable />` to allow configuring the sign in UX for unauthenticated end-users.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
