### PR TITLE
fix(backend,shared,types): Do not check for `sessionClaims` on auth state

### DIFF
--- a/.changeset/weak-hands-kiss.md
+++ b/.changeset/weak-hands-kiss.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---

--- a/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
+++ b/packages/nextjs/src/server/data/getAuthDataFromRequest.ts
@@ -78,6 +78,8 @@ export const getAuthDataFromRequestSync = (
     return getAuthObjectFromJwt(jwt, options);
   }
 
+  console.log('auth object from auth data request', { authObject });
+
   return authObject;
 };
 
@@ -132,6 +134,9 @@ export const getAuthDataFromRequestAsync = async (
 
   // Fallback to session logic (sync version) for all other cases
   const authObject = getAuthDataFromRequestSync(req, opts);
+
+  console.log('auth data from request', { authObject });
+
   return getAuthObjectForAcceptedToken({ authObject, acceptsToken });
 };
 

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -75,7 +75,8 @@ const prefixWithOrg = (value: string) => value.replace(/^(org:)*/, 'org:');
 /**
  * Checks if a user has the required organization-level authorization.
  * Verifies if the user has the specified role or permission within their organization.
- * @returns null, if unable to determine due to missing data or unspecified role/permission.
+ *
+ * @returns Null, if unable to determine due to missing data or unspecified role/permission.
  */
 const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
   const { orgId, orgRole, orgPermissions } = options;
@@ -162,7 +163,8 @@ const validateReverificationConfig = (config: ReverificationConfig | undefined |
  * Evaluates if the user meets re-verification authentication requirements.
  * Compares the user's factor verification ages against the specified maxAge.
  * Handles different verification levels (first factor, second factor, multi-factor).
- * @returns null, if requirements or verification data are missing.
+ *
+ * @returns Null, if requirements or verification data are missing.
  */
 const checkReverificationAuthorization: CheckReverificationAuthorization = (params, { factorVerificationAge }) => {
   if (!params.reverification || !factorVerificationAge) {
@@ -237,6 +239,7 @@ type AuthStateOptions = {
 /**
  * Shared utility function that centralizes auth state resolution logic,
  * preventing duplication across different packages.
+ *
  * @internal
  */
 const resolveAuthState = ({
@@ -306,7 +309,7 @@ const resolveAuthState = ({
     } as const;
   }
 
-  if (!!sessionId && !!sessionClaims && !!userId && !!orgId && !!orgRole) {
+  if (!!sessionId && !!userId && !!orgId && !!orgRole) {
     return {
       isLoaded: true,
       isSignedIn: true,
@@ -323,7 +326,7 @@ const resolveAuthState = ({
     } as const;
   }
 
-  if (!!sessionId && !!sessionClaims && !!userId && !orgId) {
+  if (!!sessionId && !!userId && !orgId) {
     return {
       isLoaded: true,
       isSignedIn: true,
@@ -341,4 +344,4 @@ const resolveAuthState = ({
   }
 };
 
-export { createCheckAuthorization, validateReverificationConfig, resolveAuthState, splitByScope };
+export { createCheckAuthorization, resolveAuthState, splitByScope, validateReverificationConfig };

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -94,7 +94,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      sessionClaims: JwtPayload;
+      sessionClaims?: JwtPayload | null;
       actor: ActClaim | null;
       orgId: null;
       orgRole: null;
@@ -108,7 +108,7 @@ export type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
-      sessionClaims: JwtPayload;
+      sessionClaims?: JwtPayload | null;
       actor: ActClaim | null;
       orgId: string;
       orgRole: OrganizationCustomRoleKey;


### PR DESCRIPTION
## Description

⚠️ Debugging weird bug with auth state - do not merge it, just using it to publish a snapshot ⚠️ 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of authentication data by making session claims optional and nullable in certain scenarios.
- **Documentation**
	- Updated JSDoc comments for clarity and consistency.
- **Style**
	- Made minor formatting adjustments and reordered export statements for improved readability.
- **Chores**
	- Added temporary logging for debugging authentication data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->