### PR TITLE
fix(clerk-js): Pass metadata as variables for error localization

### DIFF
--- a/.changeset/twenty-games-repair.md
+++ b/.changeset/twenty-games-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Pass the metadata as variables for error localization

--- a/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
+++ b/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
@@ -95,7 +95,7 @@ export const useLocalizations = () => {
       return '';
     }
 
-    const metaArgsAsVariables = { identifiers: identifiers?.[0], emailAddresses: emailAddresses?.[0] };
+    const metaArgsAsVariables = { identifiers: identifiers?.join(', '), emailAddresses: emailAddresses?.join(', ') };
 
     return (
       t(localizationKeys(`unstable__errors.${code}__${paramName}` as any, metaArgsAsVariables)) ||

--- a/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
+++ b/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
@@ -89,15 +89,17 @@ export const useLocalizations = () => {
     }
 
     const { code, message, longMessage, meta } = (error || {}) as ClerkAPIError;
-    const { paramName = '' } = meta || {};
+    const { paramName = '', identifiers, emailAddresses } = meta || {};
 
     if (!code) {
       return '';
     }
 
+    const metaArgsAsVariables = { identifiers: identifiers?.[0], emailAddresses: emailAddresses?.[0] };
+
     return (
-      t(localizationKeys(`unstable__errors.${code}__${paramName}` as any)) ||
-      t(localizationKeys(`unstable__errors.${code}` as any)) ||
+      t(localizationKeys(`unstable__errors.${code}__${paramName}` as any, metaArgsAsVariables)) ||
+      t(localizationKeys(`unstable__errors.${code}` as any, metaArgsAsVariables)) ||
       longMessage ||
       message
     );


### PR DESCRIPTION
## Description

When using localization on `unstable_errors` we pass no variables, although in some cases FAPI returns values in the `meta` property. This PR allows to use the following 2 identifiers that are included in the error object coming from FAPI in the localized error message:

- `identifiers`: This is an array of identifiers
- `email_addresses`: This is an array of email addresses

Example error from FAPI:

```
{
  "code": "not_allowed_access",
  "meta": {
    "identifiers": [
      "example@gmail.com"
    ]
  },
  "message": "Access not allowed.",
  "long_message": "example@gmail.com is not allowed to access this application."
}
```

Example localization value provided by the user:
```
localization={{
  unstable__errors: {
    not_allowed_access: '{{identifiers}} is not allowed to access this page!!!!!',
  },
}}
```

Resulting in the following error:
```
example@gmail.com is not allowed to access this page!!!!!
```

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error localization to include additional metadata, allowing error messages to display more detailed and dynamic information such as identifiers and email addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->