### PR TITLE
fix(chrome-extension): Enable support for `Metamask` & `OKX`; Mark unsupported components

### DIFF
--- a/.changeset/twelve-ducks-refuse.md
+++ b/.changeset/twelve-ducks-refuse.md
@@ -2,4 +2,4 @@
 '@clerk/chrome-extension': minor
 ---
 
-Explicitly mark `GoogleOneTap`, `PricingTable`, and `SignInWithMetamaskButton` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.
+Explicitly mark `GoogleOneTap` and `SignInWithMetamaskButton` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.

--- a/.changeset/twelve-ducks-refuse.md
+++ b/.changeset/twelve-ducks-refuse.md
@@ -2,4 +2,6 @@
 '@clerk/chrome-extension': minor
 ---
 
-Explicitly mark `GoogleOneTap` and `SignInWithMetamaskButton` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.
+- Explicitly mark `GoogleOneTap` and `SignInWithMetamaskButton` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.
+
+- Enable Metamask and OKXWallet Web3 for non-popup extensions.

--- a/.changeset/twelve-ducks-refuse.md
+++ b/.changeset/twelve-ducks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': minor
+---
+
+Explicitly mark `GoogleOneTap`, `PricingTable`, and `SignInWithMetamaskButton` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -3,7 +3,7 @@ export * from '@clerk/clerk-react';
 export type { StorageCache } from './internal/utils/storage';
 
 // The order matters since we want override @clerk/clerk-react components
-export { ClerkProvider, GoogleOneTap, PricingTable, SignInWithMetamaskButton } from './react';
+export { ClerkProvider, GoogleOneTap } from './react';
 
 // Override Clerk React error thrower to show that errors come from @clerk/chrome-extension
 import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -1,8 +1,9 @@
 export * from '@clerk/clerk-react';
+
 export type { StorageCache } from './internal/utils/storage';
 
-// The order matters since we want override @clerk/clerk-react ClerkProvider
-export { ClerkProvider } from './react';
+// The order matters since we want override @clerk/clerk-react components
+export { ClerkProvider, GoogleOneTap, PricingTable, SignInWithMetamaskButton } from './react';
 
 // Override Clerk React error thrower to show that errors come from @clerk/chrome-extension
 import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';

--- a/packages/chrome-extension/src/react/NotSupported.tsx
+++ b/packages/chrome-extension/src/react/NotSupported.tsx
@@ -2,10 +2,4 @@
  * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
  * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
  */
-export const SignInWithMetamaskButton = () => null;
-
-/**
- * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
- * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
- */
 export const GoogleOneTap = () => null;

--- a/packages/chrome-extension/src/react/NotSupported.tsx
+++ b/packages/chrome-extension/src/react/NotSupported.tsx
@@ -1,0 +1,17 @@
+/**
+ * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
+ * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
+ */
+export const PricingTable = () => null;
+
+/**
+ * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
+ * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
+ */
+export const SignInWithMetamaskButton = () => null;
+
+/**
+ * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
+ * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
+ */
+export const GoogleOneTap = () => null;

--- a/packages/chrome-extension/src/react/NotSupported.tsx
+++ b/packages/chrome-extension/src/react/NotSupported.tsx
@@ -2,12 +2,6 @@
  * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
  * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
  */
-export const PricingTable = () => null;
-
-/**
- * @deprecated This component is not supported in Browser Extensions due to Chrome's security restrictions around remotely hosted code.
- * @see https://clerk.com/docs/references/browser-extensions/browser-security-restrictions
- */
 export const SignInWithMetamaskButton = () => null;
 
 /**

--- a/packages/chrome-extension/src/react/index.ts
+++ b/packages/chrome-extension/src/react/index.ts
@@ -1,1 +1,2 @@
 export { ClerkProvider } from './ClerkProvider';
+export { GoogleOneTap, PricingTable, SignInWithMetamaskButton } from './NotSupported';

--- a/packages/chrome-extension/src/react/index.ts
+++ b/packages/chrome-extension/src/react/index.ts
@@ -1,2 +1,2 @@
 export { ClerkProvider } from './ClerkProvider';
-export { GoogleOneTap, PricingTable, SignInWithMetamaskButton } from './NotSupported';
+export { GoogleOneTap } from './NotSupported';

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1986,11 +1986,6 @@ export class Clerk implements ClerkInterface {
   };
 
   public authenticateWithMetamask = async (props: AuthenticateWithMetamaskParams = {}): Promise<void> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Metamask');
-      return;
-    }
-
     await this.authenticateWithWeb3({
       ...props,
       strategy: 'web3_metamask_signature',
@@ -1998,11 +1993,6 @@ export class Clerk implements ClerkInterface {
   };
 
   public authenticateWithCoinbaseWallet = async (props: AuthenticateWithCoinbaseWalletParams = {}): Promise<void> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Coinbase Wallet');
-      return;
-    }
-
     await this.authenticateWithWeb3({
       ...props,
       strategy: 'web3_coinbase_wallet_signature',
@@ -2010,11 +2000,6 @@ export class Clerk implements ClerkInterface {
   };
 
   public authenticateWithOKXWallet = async (props: AuthenticateWithOKXWalletParams = {}): Promise<void> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('OKX Wallet');
-      return;
-    }
-
     await this.authenticateWithWeb3({
       ...props,
       strategy: 'web3_okx_wallet_signature',
@@ -2030,11 +2015,6 @@ export class Clerk implements ClerkInterface {
     legalAccepted,
     secondFactorUrl,
   }: ClerkAuthenticateWithWeb3Params): Promise<void> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Web3');
-      return;
-    }
-
     if (!this.client || !this.environment) {
       return;
     }

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -61,7 +61,6 @@ import {
   clerkInvalidStrategy,
   clerkMissingOptionError,
   clerkMissingWebAuthnPublicKeyOptions,
-  clerkUnsupportedEnvironmentWarning,
   clerkVerifyEmailAddressCalledBeforeCreate,
   clerkVerifyPasskeyCalledBeforeCreate,
   clerkVerifyWeb3WalletCalledBeforeCreate,
@@ -274,11 +273,6 @@ export class SignIn extends BaseResource implements SignInResource {
   };
 
   public authenticateWithWeb3 = async (params: AuthenticateWithWeb3Params): Promise<SignInResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Web3');
-      return this;
-    }
-
     const { identifier, generateSignature, strategy = 'web3_metamask_signature' } = params || {};
     const provider = strategy.replace('web3_', '').replace('_signature', '') as Web3Provider;
 
@@ -325,11 +319,6 @@ export class SignIn extends BaseResource implements SignInResource {
   };
 
   public authenticateWithMetamask = async (): Promise<SignInResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Metamask');
-      return this;
-    }
-
     const identifier = await getMetamaskIdentifier();
     return this.authenticateWithWeb3({
       identifier,
@@ -339,11 +328,6 @@ export class SignIn extends BaseResource implements SignInResource {
   };
 
   public authenticateWithCoinbaseWallet = async (): Promise<SignInResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Coinbase Wallet');
-      return this;
-    }
-
     const identifier = await getCoinbaseWalletIdentifier();
     return this.authenticateWithWeb3({
       identifier,
@@ -353,11 +337,6 @@ export class SignIn extends BaseResource implements SignInResource {
   };
 
   public authenticateWithOKXWallet = async (): Promise<SignInResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('OKX Wallet');
-      return this;
-    }
-
     const identifier = await getOKXWalletIdentifier();
     return this.authenticateWithWeb3({
       identifier,

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -42,7 +42,6 @@ import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
 import {
   clerkInvalidFAPIResponse,
   clerkMissingOptionError,
-  clerkUnsupportedEnvironmentWarning,
   clerkVerifyEmailAddressCalledBeforeCreate,
   clerkVerifyWeb3WalletCalledBeforeCreate,
 } from '../errors';
@@ -183,11 +182,6 @@ export class SignUp extends BaseResource implements SignUpResource {
       legalAccepted?: boolean;
     },
   ): Promise<SignUpResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Web3');
-      return this;
-    }
-
     const {
       generateSignature,
       identifier,
@@ -237,11 +231,6 @@ export class SignUp extends BaseResource implements SignUpResource {
       legalAccepted?: boolean;
     },
   ): Promise<SignUpResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Metamask');
-      return this;
-    }
-
     const identifier = await getMetamaskIdentifier();
     return this.authenticateWithWeb3({
       identifier,
@@ -257,11 +246,6 @@ export class SignUp extends BaseResource implements SignUpResource {
       legalAccepted?: boolean;
     },
   ): Promise<SignUpResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('Coinbase Wallet');
-      return this;
-    }
-
     const identifier = await getCoinbaseWalletIdentifier();
     return this.authenticateWithWeb3({
       identifier,
@@ -277,11 +261,6 @@ export class SignUp extends BaseResource implements SignUpResource {
       legalAccepted?: boolean;
     },
   ): Promise<SignUpResource> => {
-    if (__BUILD_DISABLE_RHC__) {
-      clerkUnsupportedEnvironmentWarning('OKX Wallet');
-      return this;
-    }
-
     const identifier = await getOKXWalletIdentifier();
     return this.authenticateWithWeb3({
       identifier,

--- a/packages/clerk-js/src/utils/web3.ts
+++ b/packages/clerk-js/src/utils/web3.ts
@@ -1,5 +1,7 @@
 import type { Web3Provider } from '@clerk/types';
 
+import { clerkUnsupportedEnvironmentWarning } from '@/core/errors';
+
 import { toHex } from './hex';
 import { getInjectedWeb3Providers } from './injectedWeb3Providers';
 
@@ -75,6 +77,11 @@ export async function generateSignatureWithOKXWallet(params: GenerateSignaturePa
 
 async function getEthereumProvider(provider: Web3Provider) {
   if (provider === 'coinbase_wallet') {
+    if (__BUILD_DISABLE_RHC__) {
+      clerkUnsupportedEnvironmentWarning('Coinbase Wallet');
+      return null;
+    }
+
     const createCoinbaseWalletSDK = await import('@coinbase/wallet-sdk').then(mod => mod.createCoinbaseWalletSDK);
     const sdk = createCoinbaseWalletSDK({
       preference: {


### PR DESCRIPTION
## Description

Explicitly mark `GoogleOneTap` UI components as deprecated and unsupported (due to the requirement of Remotely Hosted Code) to help avoid confusion.

While they, technically, never worked. I plan on removing them in a future major rather than outright changing the public interface.

Enable support for `Metamask` and `OKX` while still splitting out Coinbase remotely hosted code.

<!-- Fixes #(issue number) -->
USER-2235

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deprecated the GoogleOneTap and SignInWithMetamaskButton UI components, marking them as unsupported due to security restrictions in browser extensions.
  - Re-exported multiple UI components including ClerkProvider and GoogleOneTap for improved clarity.
- **Bug Fixes**
  - Removed environment-based restrictions and warnings from Web3 authentication methods to ensure consistent behavior.
  - Added a warning and disabled Coinbase Wallet provider in unsupported environments to prevent errors.
- **Documentation**
  - Updated documentation to clarify the unsupported status of these components and provide references to relevant security guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->