### PR TITLE
fix(clerk-expo): Re-export `useReverification` hook

### DIFF
--- a/.changeset/fair-ways-create.md
+++ b/.changeset/fair-ways-create.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': minor
+---
+
+Re-export useReverification hook from `@clerk/clerk-react`

--- a/packages/backend/src/mock-server.ts
+++ b/packages/backend/src/mock-server.ts
@@ -19,7 +19,7 @@ export function validateHeaders<
         {
           error: 'Unauthorized',
           message: 'Missing Authorization header',
-        },
+        } as unknown as ResponseBodyType,
         { status: 401 },
       ) as ReturnType<HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>>;
     }
@@ -28,7 +28,7 @@ export function validateHeaders<
         {
           error: 'Bad request',
           message: 'Missing Clerk-API-Version header',
-        },
+        } as unknown as ResponseBodyType,
         { status: 400 },
       ) as ReturnType<HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>>;
     }
@@ -37,7 +37,7 @@ export function validateHeaders<
         {
           error: 'Bad request',
           message: 'Missing or invalid User-Agent header',
-        },
+        } as unknown as ResponseBodyType,
         { status: 400 },
       ) as ReturnType<HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>>;
     }

--- a/packages/expo/src/hooks/index.ts
+++ b/packages/expo/src/hooks/index.ts
@@ -8,6 +8,7 @@ export {
   useSignIn,
   useSignUp,
   useUser,
+  useReverification,
 } from '@clerk/clerk-react';
 
 export * from './useSSO';


### PR DESCRIPTION
## Description

Re-export `useReverification` hook from `@clerk/clerk-react`

<!-- Fixes #(issue number) -->
USER-2128

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `useReverification` hook for use in Expo projects.

- **Documentation**
  - Updated documentation to reflect the addition of the `useReverification` hook.

- **Refactor**
  - Improved type handling for error responses in backend mock server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->