### PR TITLE
fix(clerk-js): Do not switch after-auth screens on org invites revalidation

### DIFF
--- a/.changeset/warm-parents-take.md
+++ b/.changeset/warm-parents-take.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Do not display create organization form after accepting organization invitation on after-auth flow


### PR DESCRIPTION
## Description

This PR introduces a fix to prevent after-auth screens from the "org" task from switching when organization data is revalidated, such as when invitations are accepted. 

Once the invitation gets accepted, the component is re-rendered and shows the create organization form. Instead, we want to allow the user to take the invite and then click on it. 

Previously: 

https://github.com/user-attachments/assets/0992300c-1458-45c6-9901-39fc0e9f47a7

With bug fix: 

https://github.com/user-attachments/assets/1a69b671-d134-421f-95d5-a4192fba79ec


<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the post-authentication flow to prevent the "create organization" form from appearing after accepting an organization invitation.
	- Enhanced UI stability by preventing unwanted screen transitions and flickering when selecting or creating an organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->