### PR TITLE
fix(backend): Clear `__clerk_synced` when page is protected via middleware

### DIFF
--- a/.changeset/witty-hotels-add.md
+++ b/.changeset/witty-hotels-add.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Ensure `__clerk_synced` is removed from cross-origin return-back urls

--- a/packages/backend/src/__tests__/createRedirect.test.ts
+++ b/packages/backend/src/__tests__/createRedirect.test.ts
@@ -99,6 +99,28 @@ describe('redirect(redirectAdapter)', () => {
       );
     });
 
+    it('removes __clerk_synced when cross-origin redirect', () => {
+      const returnBackUrl = 'https://current.url:3000/path?__clerk_synced=true&q=1#hash';
+      const encodedUrl = 'https%3A%2F%2Fcurrent.url%3A3000%2Fpath%3Fq%3D1%23hash';
+      const signUpUrl = 'https://lcl.dev/sign-up';
+
+      const redirectAdapterSpy = vi.fn().mockImplementation(_url => 'redirectAdapterValue');
+      const { redirectToSignUp } = createRedirect({
+        baseUrl: 'http://www.clerk.com',
+        devBrowserToken: 'deadbeef',
+        redirectAdapter: redirectAdapterSpy,
+        publishableKey: 'pk_test_Y2xlcmsubGNsLmRldiQ',
+        sessionStatus: 'active',
+        signUpUrl,
+      });
+
+      const result = redirectToSignUp({ returnBackUrl });
+      expect(result).toBe('redirectAdapterValue');
+      expect(redirectAdapterSpy).toHaveBeenCalledWith(
+        `${signUpUrl}?redirect_url=${encodedUrl}&__clerk_db_jwt=deadbeef`,
+      );
+    });
+
     it('returns path based url with development (kima) publishableKey (with staging Clerk) but without signUpUrl to redirectToSignUp', () => {
       const redirectAdapterSpy = vi.fn().mockImplementation(_url => 'redirectAdapterValue');
       const { redirectToSignUp } = createRedirect({
@@ -318,6 +340,26 @@ describe('redirect(redirectAdapter)', () => {
       expect(result).toBe('redirectAdapterValue');
       expect(redirectAdapterSpy).toHaveBeenCalledWith(
         `https://included.katydid-92.accounts.dev/sign-up/tasks?redirect_url=${encodedUrl}&__clerk_db_jwt=deadbeef`,
+      );
+    });
+
+    it('removes __clerk_synced when cross-origin redirect', () => {
+      const returnBackUrl = 'https://current.url:3000/path?__clerk_synced=true&q=1#hash';
+      const encodedUrl = 'https%3A%2F%2Fcurrent.url%3A3000%2Fpath%3Fq%3D1%23hash';
+
+      const redirectAdapterSpy = vi.fn().mockImplementation(_url => 'redirectAdapterValue');
+      const { redirectToSignUp } = createRedirect({
+        baseUrl: 'http://www.clerk.com',
+        devBrowserToken: 'deadbeef',
+        redirectAdapter: redirectAdapterSpy,
+        publishableKey: 'pk_test_Y2xlcmsubGNsLmRldiQ',
+        sessionStatus: 'pending',
+      });
+
+      const result = redirectToSignUp({ returnBackUrl });
+      expect(result).toBe('redirectAdapterValue');
+      expect(redirectAdapterSpy).toHaveBeenCalledWith(
+        `https://accounts.lcl.dev/sign-up/tasks?redirect_url=${encodedUrl}&__clerk_db_jwt=deadbeef`,
       );
     });
   });

--- a/packages/backend/src/createRedirect.ts
+++ b/packages/backend/src/createRedirect.ts
@@ -17,12 +17,17 @@ const buildUrl = (
   const baseUrl = new URL(_baseUrl);
   const returnBackUrl = _returnBackUrl ? new URL(_returnBackUrl, baseUrl) : undefined;
   const res = new URL(_targetUrl, baseUrl);
+  const isCrossOriginRedirect = `${baseUrl.hostname}:${baseUrl.port}` !== `${res.hostname}:${res.port}`;
 
   if (returnBackUrl) {
+    if (isCrossOriginRedirect) {
+      returnBackUrl.searchParams.delete(constants.QueryParameters.ClerkSynced);
+    }
+
     res.searchParams.set('redirect_url', returnBackUrl.toString());
   }
   // For cross-origin redirects, we need to pass the dev browser token for URL session syncing
-  if (_devBrowserToken && baseUrl.hostname !== res.hostname) {
+  if (isCrossOriginRedirect && _devBrowserToken) {
     res.searchParams.set(constants.QueryParameters.DevBrowser, _devBrowserToken);
   }
   return res.toString();


### PR DESCRIPTION
## Description

The redirect to a primary domain would include would include `__clerk_synced` in the `redirect_url` when a page protected via middleware was called directly resulting in it, incorrectly, being passed back to the satellite.

This ensures that `__clerk_synced` is removed from the `redirect_url` before navigating to the primary domain.

<!-- Fixes #(issue number) -->
USER-2138

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security and privacy by removing the `__clerk_synced` parameter from cross-origin return-back URLs during redirects.

- **Tests**
  - Added new test cases to ensure the `__clerk_synced` parameter is properly removed from redirect URLs in various session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->