### PR TITLE
fix(shared): Prevent stale closures in useReverification hook

### DIFF
--- a/.changeset/slick-llamas-sneeze.md
+++ b/.changeset/slick-llamas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Bugfix: prevent stale closures in useReverification hook

--- a/packages/shared/customJSDOMEnvironment.ts
+++ b/packages/shared/customJSDOMEnvironment.ts
@@ -1,0 +1,9 @@
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+export default class CustomJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    this.global.Response = Response;
+  }
+}

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -6,7 +6,7 @@ const config = {
   displayName: name.replace('@clerk', ''),
   injectGlobals: true,
 
-  testEnvironment: 'jsdom',
+  testEnvironment: './customJSDOMEnvironment.ts',
   roots: ['<rootDir>/src'],
   setupFiles: ['./jest.setup.ts'],
 

--- a/packages/shared/src/react/__tests__/useReverification.test.ts
+++ b/packages/shared/src/react/__tests__/useReverification.test.ts
@@ -1,7 +1,18 @@
+import { act, renderHook } from '@testing-library/react';
 import { expectTypeOf } from 'expect-type';
 
 import { reverificationError } from '../../authorization-errors';
-import type { useReverification } from '../hooks/useReverification';
+import { useReverification as useReverificationImp } from '../hooks/useReverification';
+
+jest.mock('../hooks/useClerk', () => {
+  const mockClerk = {
+    __internal_openReverification: jest.fn(),
+    telemetry: { record: jest.fn() },
+  };
+  return {
+    useClerk: () => mockClerk,
+  };
+});
 
 type ExcludeClerkError<T> = T extends { clerk_error: any } ? never : T;
 
@@ -27,17 +38,54 @@ type Fetcher = typeof fetcherWithHelper;
 
 describe('useReverification type tests', () => {
   it('allow pass through types', () => {
-    type UseReverificationWithFetcher = typeof useReverification<typeof fetcher>;
+    type UseReverificationWithFetcher = typeof useReverificationImp<typeof fetcher>;
     type VerifiedFetcher = ReturnType<UseReverificationWithFetcher>;
     expectTypeOf(fetcher).toEqualTypeOf<VerifiedFetcher>();
   });
 
   it('returned callback with clerk error excluded', () => {
-    type UseReverificationWithFetcherHelperThrow = typeof useReverification<typeof fetcherWithHelper>;
+    type UseReverificationWithFetcherHelperThrow = typeof useReverificationImp<typeof fetcherWithHelper>;
     type VerifiedFetcherHelperThrow = ReturnType<UseReverificationWithFetcherHelperThrow>;
     expectTypeOf(fetcherWithHelper).not.toEqualTypeOf<VerifiedFetcherHelperThrow>();
     expectTypeOf<ExcludeClerkError<Awaited<ReturnType<Fetcher>>>>().toEqualTypeOf<
       Awaited<ReturnType<VerifiedFetcherHelperThrow>>
     >();
+  });
+});
+describe('useReverification', () => {
+  const mockFetcherInner = jest.fn().mockResolvedValue({ ok: true });
+
+  beforeEach(() => {
+    mockFetcherInner.mockClear();
+  });
+
+  it('returns a stable function reference across re-renders when fetcher is stable', () => {
+    const stableFetcher = jest.fn().mockResolvedValue({ data: 'test' });
+    const { result, rerender } = renderHook(() => useReverificationImp(stableFetcher));
+    const firstResult = result.current;
+
+    rerender();
+
+    const secondResult = result.current;
+
+    expect(secondResult).toBe(firstResult);
+  });
+
+  it('keeps the same handler even when an inline fetcher changes on every render', async () => {
+    const fetchSpy = jest.fn(async v => ({ v }));
+    const { result, rerender } = renderHook(({ value }) => useReverificationImp(() => fetchSpy(value)), {
+      initialProps: { value: 'A' },
+    });
+    const firstHandler = result.current;
+
+    rerender({ value: 'B' });
+    const secondHandler = result.current;
+
+    expect(secondHandler).toBe(firstHandler);
+
+    await act(async () => {
+      await secondHandler();
+    });
+    expect(fetchSpy).toHaveBeenCalledWith('B');
   });
 });

--- a/packages/shared/src/react/hooks/useReverification.ts
+++ b/packages/shared/src/react/hooks/useReverification.ts
@@ -1,5 +1,5 @@
 import type { Clerk, SessionVerificationLevel } from '@clerk/types';
-import { useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { validateReverificationConfig } from '../../authorization';
 import { isReverificationHint, reverificationError } from '../../authorization-errors';
@@ -204,20 +204,21 @@ export const useReverification: UseReverification = (fetcher, options) => {
     }),
   );
 
-  const handleReverification = useMemo(() => {
-    const handler = createReverificationHandler({
-      openUIComponent: __internal_openReverification,
-      telemetry,
-      ...optionsRef.current,
-    })(fetcherRef.current);
-    return handler;
-  }, [__internal_openReverification, fetcherRef.current, optionsRef.current]);
-
   // Keep fetcher and options ref in sync
   useSafeLayoutEffect(() => {
     fetcherRef.current = fetcher;
     optionsRef.current = options;
   });
 
-  return handleReverification;
+  return useCallback(
+    (...args) => {
+      const handler = createReverificationHandler({
+        openUIComponent: __internal_openReverification,
+        telemetry,
+        ...optionsRef.current,
+      })(fetcherRef.current);
+      return handler(...args);
+    },
+    [__internal_openReverification, telemetry],
+  );
 };


### PR DESCRIPTION
## Description

Addresses a stale closure bug within the `useReverification` hook and improves the stability of our test environment.

The primary issue was that the hook could capture an initial version of the fetcher function and would not use the updated version on subsequent re-renders.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Jest testing environment to provide global access to the `Response` API during tests.

* **Bug Fixes**
  * Improved the stability and correctness of the `useReverification` hook by updating its internal logic for handler creation and invocation.

* **Tests**
  * Added new tests to verify the runtime behavior and function identity stability of the `useReverification` hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->