### PR TITLE
fix(clerk-js): Do not display invitation if membership is active

### DIFF
--- a/.changeset/yummy-laws-hunt.md
+++ b/.changeset/yummy-laws-hunt.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide invitation in `OrganizationSwitcher` when user is already an active member of the organization

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -168,7 +168,10 @@ const InvitationPreview = withCardStateProvider(
     };
 
     if (status === 'accepted') {
-      if (acceptedOrganization?.id && activeOrganization?.id === acceptedOrganization.id) {
+      if (
+        invitation.publicOrganizationData.id === activeOrganization?.id ||
+        (acceptedOrganization?.id && activeOrganization?.id === acceptedOrganization.id)
+      ) {
         // Hide the Accepted invitation that looks like a membership when the organization is already active
         return null;
       }


### PR DESCRIPTION
## Description

Once the after-auth navigation occurs, it invalidates the client cache, and therefore, `AcceptedInvitationsProvider` loses its state. 

This PR updates the existing render condition of `InvitationPreview` to take in account the ID of the active organization vs the invitation org ID, and if those match, then don't render it on the organization switcher. 

Also, it's not possible to invalidate organization resources before navigating away from the after-auth screen; otherwise, it'll result in a change of UI state. 

#### With fix 


https://github.com/user-attachments/assets/f68d4f31-2cf7-4178-9373-de0ba80d4602

#### 🐛 


https://github.com/user-attachments/assets/45d406c1-dd06-43f3-aef5-c6e3515b4697



<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Organization Switcher to hide invitation options for users who are already active members of an organization, preventing redundant prompts.
  * Enhanced logic to ensure accepted invitations are hidden when the invitation's organization matches the active organization, providing a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->