### PR TITLE
fix(clerk-js): add nonce to captcha script element

### DIFF
--- a/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
+++ b/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
@@ -12,14 +12,14 @@ export class CaptchaChallenge {
    * always use the fallback key.
    */
   public async invisible(opts?: Partial<CaptchaOptions>) {
-    const { captchaSiteKey, canUseCaptcha, captchaPublicKeyInvisible } = retrieveCaptchaInfo(this.clerk);
+    const { captchaSiteKey, canUseCaptcha, captchaPublicKeyInvisible, nonce } = retrieveCaptchaInfo(this.clerk);
 
     if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       const captchaResult = await getCaptchaToken({
         action: opts?.action,
         captchaProvider: 'turnstile',
         invisibleSiteKey: captchaPublicKeyInvisible,
-        nonce: opts?.nonce,
+        nonce: opts?.nonce || nonce || undefined,
         siteKey: captchaPublicKeyInvisible,
         widgetType: 'invisible',
       }).catch(e => {
@@ -43,13 +43,14 @@ export class CaptchaChallenge {
    * Managed challenged start as non-interactive and escalate to interactive if necessary.
    */
   public async managedOrInvisible(opts?: Partial<CaptchaOptions>) {
-    const { captchaSiteKey, canUseCaptcha, captchaWidgetType, captchaProvider, captchaPublicKeyInvisible } =
+    const { captchaSiteKey, canUseCaptcha, captchaWidgetType, captchaProvider, captchaPublicKeyInvisible, nonce } =
       retrieveCaptchaInfo(this.clerk);
 
     if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       const captchaResult = await getCaptchaToken({
         captchaProvider,
         invisibleSiteKey: captchaPublicKeyInvisible,
+        nonce: nonce || undefined,
         siteKey: captchaSiteKey,
         widgetType: captchaWidgetType,
         ...opts,

--- a/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
+++ b/packages/clerk-js/src/utils/captcha/CaptchaChallenge.ts
@@ -16,11 +16,12 @@ export class CaptchaChallenge {
 
     if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       const captchaResult = await getCaptchaToken({
-        siteKey: captchaPublicKeyInvisible,
-        invisibleSiteKey: captchaPublicKeyInvisible,
-        widgetType: 'invisible',
-        captchaProvider: 'turnstile',
         action: opts?.action,
+        captchaProvider: 'turnstile',
+        invisibleSiteKey: captchaPublicKeyInvisible,
+        nonce: opts?.nonce,
+        siteKey: captchaPublicKeyInvisible,
+        widgetType: 'invisible',
       }).catch(e => {
         if (e.captchaError) {
           return { captchaError: e.captchaError };
@@ -47,10 +48,10 @@ export class CaptchaChallenge {
 
     if (canUseCaptcha && captchaSiteKey && captchaPublicKeyInvisible) {
       const captchaResult = await getCaptchaToken({
+        captchaProvider,
+        invisibleSiteKey: captchaPublicKeyInvisible,
         siteKey: captchaSiteKey,
         widgetType: captchaWidgetType,
-        invisibleSiteKey: captchaPublicKeyInvisible,
-        captchaProvider,
         ...opts,
       }).catch(e => {
         if (e.captchaError) {

--- a/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
+++ b/packages/clerk-js/src/utils/captcha/retrieveCaptchaInfo.ts
@@ -4,11 +4,15 @@ export const retrieveCaptchaInfo = (clerk: Clerk) => {
   const _environment = clerk.__unstable__environment;
   const captchaProvider = _environment ? _environment.displayConfig.captchaProvider : 'turnstile';
 
+  // Access nonce via internal options - casting to any since nonce is in IsomorphicClerkOptions but not ClerkOptions
+  const nonce = (clerk as any).__internal_getOption?.('nonce') as string | undefined;
+
   return {
     captchaSiteKey: _environment ? _environment.displayConfig.captchaPublicKey : null,
     captchaWidgetType: _environment ? _environment.displayConfig.captchaWidgetType : null,
     captchaProvider,
     captchaPublicKeyInvisible: _environment ? _environment.displayConfig.captchaPublicKeyInvisible : null,
     canUseCaptcha: _environment ? _environment.userSettings.signUp.captcha_enabled && clerk.isStandardBrowser : null,
+    nonce: nonce || undefined,
   };
 };

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -26,9 +26,9 @@ export const shouldRetryTurnstileErrorCode = (errorCode: string) => {
   return !!codesWithRetries.find(w => errorCode.startsWith(w));
 };
 
-async function loadCaptcha() {
+async function loadCaptcha(nonce?: string) {
   if (!window.turnstile) {
-    await loadCaptchaFromCloudflareURL().catch(() => {
+    await loadCaptchaFromCloudflareURL(nonce).catch(() => {
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw { captchaError: 'captcha_script_failed_to_load' };
     });
@@ -36,13 +36,13 @@ async function loadCaptcha() {
   return window.turnstile;
 }
 
-async function loadCaptchaFromCloudflareURL() {
+async function loadCaptchaFromCloudflareURL(nonce?: string) {
   try {
     if (__BUILD_DISABLE_RHC__) {
       return Promise.reject(new Error('Captcha not supported in this environment'));
     }
 
-    return await loadScript(CLOUDFLARE_TURNSTILE_ORIGINAL_URL, { defer: true });
+    return await loadScript(CLOUDFLARE_TURNSTILE_ORIGINAL_URL, { defer: true, nonce });
   } catch (err) {
     console.warn(
       'Clerk: Failed to load the CAPTCHA script from Cloudflare. If you see a CSP error in your browser, please add the necessary CSP rules to your app. Visit https://clerk.com/docs/security/clerk-csp for more information.',
@@ -71,9 +71,9 @@ function getCaptchaAttibutesFromElemenet(element: HTMLElement): CaptchaAttribute
  *  not exist, the invisibleSiteKey is used as a fallback and the widget is rendered in a hidden div at the bottom of the body.
  */
 export const getTurnstileToken = async (opts: CaptchaOptions) => {
-  const { siteKey, widgetType, invisibleSiteKey } = opts;
+  const { siteKey, widgetType, invisibleSiteKey, nonce } = opts;
   const { modalContainerQuerySelector, modalWrapperQuerySelector, closeModal, openModal } = opts;
-  const captcha: Turnstile.Turnstile = await loadCaptcha();
+  const captcha: Turnstile.Turnstile = await loadCaptcha(nonce);
   const errorCodes: (string | number)[] = [];
 
   let captchaToken = '';

--- a/packages/clerk-js/src/utils/captcha/types.ts
+++ b/packages/clerk-js/src/utils/captcha/types.ts
@@ -1,15 +1,16 @@
 import type { CaptchaProvider, CaptchaWidgetType } from '@clerk/types';
 
 export type CaptchaOptions = {
-  siteKey: string;
-  widgetType: CaptchaWidgetType;
-  invisibleSiteKey: string;
+  action?: 'verify' | 'signup' | 'heartbeat';
   captchaProvider: CaptchaProvider;
+  closeModal?: () => Promise<unknown>;
+  invisibleSiteKey: string;
   modalContainerQuerySelector?: string;
   modalWrapperQuerySelector?: string;
+  nonce?: string;
   openModal?: () => Promise<unknown>;
-  closeModal?: () => Promise<unknown>;
-  action?: 'verify' | 'signup' | 'heartbeat';
+  siteKey: string;
+  widgetType: CaptchaWidgetType;
 };
 
 export type GetCaptchaTokenReturn = {


### PR DESCRIPTION
## Description

Adds Content Security Policy (CSP) nonce support to the Cloudflare Turnstile 
script loading to prevent CSP violations in applications using nonce-based 
CSP policies.

Changes:
- Add optional nonce field to CaptchaOptions type 
- Thread nonce parameter through turnstile loading chain
- Extract nonce from Clerk options in retrieveCaptchaInfo()
- Pass nonce to loadScript() for proper CSP compliance

The nonce is automatically retrieved from the Clerk instance options when 
available (e.g., from Next.js CSP headers), maintaining backward compatibility
with existing implementations.

Fixes CSP violations when using Turnstile with strict-dynamic policies.

Fixes: USER-2295

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
