### PR TITLE
chore(backend): Add explicit config for api version handling in url

### DIFF
--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -43,36 +43,34 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
     ),
     actorTokens: new ActorTokenAPI(request),
     allowlistIdentifiers: new AllowlistIdentifierAPI(request),
+    apiKeys: new APIKeysAPI(
+      buildRequest({
+        ...options,
+        skipApiVersionInUrl: true,
+      }),
+    ),
     betaFeatures: new BetaFeaturesAPI(request),
     blocklistIdentifiers: new BlocklistIdentifierAPI(request),
     clients: new ClientAPI(request),
     domains: new DomainAPI(request),
     emailAddresses: new EmailAddressAPI(request),
-    instance: new InstanceAPI(request),
-    invitations: new InvitationAPI(request),
-    // Using "/" instead of an actual version since they're bapi-proxy endpoints.
-    // bapi-proxy connects directly to C1 without URL versioning,
-    // while API versioning is handled through the Clerk-API-Version header.
-    machineTokens: new MachineTokensApi(
-      buildRequest({
-        ...options,
-        apiVersion: '/',
-      }),
-    ),
     idPOAuthAccessToken: new IdPOAuthAccessTokenApi(
       buildRequest({
         ...options,
-        apiVersion: '/',
+        skipApiVersionInUrl: true,
       }),
     ),
-    apiKeys: new APIKeysAPI(
-      buildRequest({
-        ...options,
-        apiVersion: '/',
-      }),
-    ),
+    instance: new InstanceAPI(request),
+    invitations: new InvitationAPI(request),
     jwks: new JwksAPI(request),
     jwtTemplates: new JwtTemplatesApi(request),
+    machineTokens: new MachineTokensApi(
+      buildRequest({
+        ...options,
+        skipApiVersionInUrl: true,
+        requireSecretKey: false,
+      }),
+    ),
     oauthApplications: new OAuthApplicationsApi(request),
     organizations: new OrganizationAPI(request),
     phoneNumbers: new PhoneNumberAPI(request),

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -68,7 +68,6 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
       buildRequest({
         ...options,
         skipApiVersionInUrl: true,
-        requireSecretKey: false,
       }),
     ),
     oauthApplications: new OAuthApplicationsApi(request),

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -57,6 +57,15 @@ type BuildRequestOptions = {
    * @default true
    */
   requireSecretKey?: boolean;
+  /**
+   * If true, omits the API version from the request URL path.
+   * This is required for bapi-proxy endpoints, which do not use versioning in the URL.
+   *
+   * Note: API versioning for these endpoints is instead handled via the `Clerk-API-Version` HTTP header.
+   *
+   * @default false
+   */
+  skipApiVersionInUrl?: boolean;
 };
 
 export function buildRequest(options: BuildRequestOptions) {
@@ -67,6 +76,7 @@ export function buildRequest(options: BuildRequestOptions) {
       apiUrl = API_URL,
       apiVersion = API_VERSION,
       userAgent = USER_AGENT,
+      skipApiVersionInUrl = false,
     } = options;
     const { path, method, queryParams, headerParams, bodyParams, formData } = requestOptions;
 
@@ -74,7 +84,7 @@ export function buildRequest(options: BuildRequestOptions) {
       assertValidSecretKey(secretKey);
     }
 
-    const url = joinPaths(apiUrl, apiVersion, path);
+    const url = skipApiVersionInUrl ? joinPaths(apiUrl, path) : joinPaths(apiUrl, apiVersion, path);
 
     // Build final URL with search parameters
     const finalUrl = new URL(url);


### PR DESCRIPTION
## Description

Currently, we use a magic value (`"/"`) for apiVersion to remove the version segment from the final URL. This approach is not clear or self-explanatory.

This PR introduces an explicit configuration option to the backend API request builder. This is internal and to control whether the API version segment is included in the request URL path. BAPI proxy requests does not have versioning in the url and use the `Clerk-API-Version` header instead.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
