### PR TITLE
feat(clerk-js): Remove CSS variables when modern color isn't supported

### DIFF
--- a/packages/clerk-js/src/ui/customizables/__tests__/parseVariables.spec.ts
+++ b/packages/clerk-js/src/ui/customizables/__tests__/parseVariables.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock cssSupports
+vi.mock('../../utils/cssSupports', () => ({
+  cssSupports: {
+    modernColor: vi.fn(),
+  },
+}));
+
+import { cssSupports } from '@/ui/utils/cssSupports';
+
+import { removeInvalidValues } from '../parseVariables';
+
+const mockModernColorSupport = vi.mocked(cssSupports.modernColor);
+
+describe('removeInvalidValues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockModernColorSupport.mockReturnValue(false);
+  });
+
+  it('should return the variables as-is if modern color support is present', () => {
+    mockModernColorSupport.mockReturnValue(true);
+    const variables = {
+      colorPrimary: 'var(--color-primary)',
+    };
+
+    const result = removeInvalidValues(variables);
+    expect(result).toEqual({ colorPrimary: 'var(--color-primary)' });
+  });
+
+  it('should remove invalid string values if modern color support is not present', () => {
+    mockModernColorSupport.mockReturnValue(false);
+    const variables = {
+      colorPrimary: 'var(--color-primary)',
+      colorDanger: '#ff0000',
+    };
+
+    const result = removeInvalidValues(variables);
+    expect(result).toEqual({ colorDanger: '#ff0000' });
+  });
+
+  it('should remove invalid object values if modern color support is not present', () => {
+    mockModernColorSupport.mockReturnValue(false);
+    const variables = {
+      colorPrimary: {
+        400: 'var(--color-primary-500)',
+        500: '#fff',
+      },
+      colorDanger: {
+        500: '#ff0000',
+      },
+    };
+
+    const result = removeInvalidValues(variables);
+    expect(result).toEqual({ colorDanger: { 500: '#ff0000' } });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a new function, `removeInvalidValues`, that will remove values specified with CSS variables from `appearance.variables` when modern color is not supported. It will also log a warning to the console indicating that a fallback value is being used.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
