### PR TITLE
chore(backend): Add optional secret property in api key response

### DIFF
--- a/.changeset/hungry-chairs-shake.md
+++ b/.changeset/hungry-chairs-shake.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add optional `secret` property in API key response

--- a/packages/backend/src/api/resources/APIKey.ts
+++ b/packages/backend/src/api/resources/APIKey.ts
@@ -17,6 +17,7 @@ export class APIKey {
     readonly lastUsedAt: number | null,
     readonly createdAt: number,
     readonly updatedAt: number,
+    readonly secret?: string,
   ) {}
 
   static fromJSON(data: APIKeyJSON) {
@@ -36,6 +37,7 @@ export class APIKey {
       data.last_used_at,
       data.created_at,
       data.updated_at,
+      data.secret,
     );
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -718,6 +718,7 @@ export interface APIKeyJSON extends ClerkResourceJSON {
   object: typeof ObjectType.ApiKey;
   type: string;
   name: string;
+  secret?: string;
   subject: string;
   scopes: string[];
   claims: Record<string, any> | null;


### PR DESCRIPTION
## Description

This PR adds a `secret` property to the API key response which is only available in the `create` method:

```ts
const resp = await clerkClient.apiKeys.create({})

resp.secret === 'ak_xxxxxx'
```

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key responses may now include an optional secret property, providing additional information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->