### PR TITLE
fix(clerk-js): Browser back/forward nav for tabs

### DIFF
--- a/.changeset/all-doors-sing.md
+++ b/.changeset/all-doors-sing.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix browser back / forward navigation for tabs

--- a/packages/clerk-js/src/ui/hooks/useTabState.ts
+++ b/packages/clerk-js/src/ui/hooks/useTabState.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 
 import { useRouter } from '../router';
 
@@ -15,7 +15,15 @@ export const useTabState = (tabMap: TabMap, defaultTab = 0) => {
     return tabIndex ? parseInt(tabIndex, 10) : defaultTab;
   };
 
-  const [selectedTab, setSelectedTab] = React.useState(getInitialTab());
+  const [selectedTab, setSelectedTab] = useState(getInitialTab());
+
+  // Listen for URL changes (browser back/forward)
+  useEffect(() => {
+    const currentTab = getInitialTab();
+    if (currentTab !== selectedTab) {
+      setSelectedTab(currentTab);
+    }
+  }, [router.queryParams.tab, selectedTab]);
 
   const handleTabChange = (index: number) => {
     setSelectedTab(index);

--- a/packages/clerk-js/src/ui/hooks/useTabState.ts
+++ b/packages/clerk-js/src/ui/hooks/useTabState.ts
@@ -23,7 +23,7 @@ export const useTabState = (tabMap: TabMap, defaultTab = 0) => {
     if (currentTab !== selectedTab) {
       setSelectedTab(currentTab);
     }
-  }, [router.queryParams.tab, selectedTab]);
+  }, [router.queryParams.tab]);
 
   const handleTabChange = (index: number) => {
     setSelectedTab(index);


### PR DESCRIPTION
## Description

Fixes issue where the browser back and forward navigation wasn't working when using tabs within components.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation to ensure correct behavior when using browser back and forward buttons. Tabs now stay in sync with browser navigation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->