### PR TITLE
chore(shared): Reset back to checking `process.env` in Netlify handler

### DIFF
--- a/.changeset/itchy-ways-tell.md
+++ b/.changeset/itchy-ways-tell.md
@@ -2,4 +2,4 @@
 "@clerk/shared": patch
 ---
 
-Use shared safe environment variable access in Netlify cache handler
+Make sure `process` is defined in environment when checking if application is running on Netlify.

--- a/packages/shared/src/__tests__/netlifyCacheHandler.test.ts
+++ b/packages/shared/src/__tests__/netlifyCacheHandler.test.ts
@@ -60,4 +60,24 @@ describe('handleNetlifyCacheInDevInstance', () => {
 
     expect(requestStateHeaders.get('Location')).toBe('https://example.netlify.app');
   });
+
+  it('should ignore the URL environment variable if it is not a string', () => {
+    // @ts-expect-error - Random object
+    process.env.URL = {};
+    process.env.NETLIFY = 'true';
+
+    const requestStateHeaders = new Headers({
+      Location: 'https://example.netlify.app',
+    });
+    const locationHeader = requestStateHeaders.get('Location') || '';
+
+    handleNetlifyCacheInDevInstance({
+      locationHeader,
+      requestStateHeaders,
+      publishableKey: mockPublishableKey,
+    });
+
+    const locationUrl = new URL(requestStateHeaders.get('Location') || '');
+    expect(locationUrl.searchParams.has(CLERK_NETLIFY_CACHE_BUST_PARAM)).toBe(true);
+  });
 });

--- a/packages/shared/src/getEnvVariable.ts
+++ b/packages/shared/src/getEnvVariable.ts
@@ -46,6 +46,5 @@ export const getEnvVariable = (name: string, context?: Record<string, any>): str
   } catch {
     // This will raise an error in Cloudflare Pages
   }
-
   return '';
 };


### PR DESCRIPTION
## Description

Follow up fix PR to https://github.com/clerk/javascript/pull/6260 which uses the built-in `getEnvVariable()` which is platform agnostic. Our shared package don't like usage of `import.meta` yet:

<img width="1172" alt="Screenshot 2025-07-08 at 11 27 37 AM" src="https://github.com/user-attachments/assets/b9d0b90f-0892-43a0-957c-6cee01f55140" />

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test to ensure cache busting works correctly when environment variables are non-string values.

* **Style**
  * Removed unnecessary blank line in environment variable utility for cleaner code.

* **Chores**
  * Improved environment detection logic for Netlify runtime to enhance reliability and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->