### PR TITLE
chore(clerk-js): Extend `buildRedirectToHandshake` to accept search params

### DIFF
--- a/packages/backend/src/tokens/__tests__/handshake.test.ts
+++ b/packages/backend/src/tokens/__tests__/handshake.test.ts
@@ -179,6 +179,18 @@ describe('HandshakeService', () => {
       );
     });
 
+    it('should include additional search params when provided', () => {
+      const headers = handshakeService.buildRedirectToHandshake('test-reason', { iat_uat_delta: '100' });
+      const location = headers.get(constants.Headers.Location);
+      expect(location).toBeDefined();
+      if (!location) {
+        throw new Error('Location header is missing');
+      }
+      const url = new URL(location);
+
+      expect(url.searchParams.get('iat_uat_delta')).toBe('100');
+    });
+
     it('should use proxy URL when available', () => {
       mockAuthenticateContext.proxyUrl = 'https://my-proxy.example.com';
       // Simulate what parsePublishableKey does when proxy URL is provided

--- a/packages/backend/src/tokens/handshake.ts
+++ b/packages/backend/src/tokens/handshake.ts
@@ -125,10 +125,11 @@ export class HandshakeService {
   /**
    * Builds the redirect headers for a handshake request
    * @param reason - The reason for the handshake (e.g. 'session-token-expired')
+   * @param additionalSearchParams - Additional search params to append to the handshake URL (e.g. to help with observability)
    * @returns Headers object containing the Location header for redirect
    * @throws Error if clerkUrl is missing in authenticateContext
    */
-  buildRedirectToHandshake(reason: string): Headers {
+  buildRedirectToHandshake(reason: string, additionalSearchParams?: Record<string, string | undefined>): Headers {
     if (!this.authenticateContext?.clerkUrl) {
       throw new Error('Missing clerkUrl in authenticateContext');
     }
@@ -160,6 +161,14 @@ export class HandshakeService {
       const params = this.getOrganizationSyncQueryParams(toActivate);
       params.forEach((value, key) => {
         url.searchParams.append(key, value);
+      });
+    }
+
+    if (additionalSearchParams) {
+      Object.entries(additionalSearchParams).forEach(([key, value]) => {
+        if (typeof value !== 'undefined') {
+          url.searchParams.append(key, value);
+        }
       });
     }
 


### PR DESCRIPTION
Extend `buildRedirectToHandshake` to accept additional search parameters for improved observability

Add a query parameter for tracking delta between `session.iat` and `client_uat`


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: observability

