### PR TITLE
feat(backend): Add additional fields to SamlConnectionListParams type

### DIFF
--- a/.changeset/itchy-rings-spend.md
+++ b/.changeset/itchy-rings-spend.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add `query`, `orderBy`, and `organizationId` to the `SamlConnectionListParams` type.

--- a/packages/backend/src/api/__tests__/SamlConnectionApi.test.ts
+++ b/packages/backend/src/api/__tests__/SamlConnectionApi.test.ts
@@ -1,0 +1,72 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server, validateHeaders } from '../../mock-server';
+import { createBackendApiClient } from '../factory';
+
+describe('SamlConnectionAPI', () => {
+  const apiClient = createBackendApiClient({
+    apiUrl: 'https://api.clerk.test',
+    secretKey: 'deadbeef',
+  });
+
+  describe('getSamlConnectionList', () => {
+    it('successfully fetches SAML connections with all parameters', async () => {
+      const mockSamlConnectionsResponse = [
+        {
+          object: 'saml_connection',
+          id: 'samlc_123',
+          name: 'Test Connection',
+          provider: 'saml_custom',
+          domain: 'test.example.com',
+          organization_id: 'org_123',
+          created_at: 1672531200000,
+          updated_at: 1672531200000,
+          active: true,
+          sync_user_attributes: false,
+          allow_subdomains: false,
+          allow_idp_initiated: false,
+          idp_entity_id: 'entity_123',
+          idp_sso_url: 'https://idp.example.com/sso',
+          idp_certificate: 'cert_data',
+          idp_metadata_url: null,
+          idp_metadata: null,
+          attribute_mapping: {
+            user_id: 'userId',
+            email_address: 'email',
+            first_name: 'firstName',
+            last_name: 'lastName',
+          },
+        },
+      ];
+
+      server.use(
+        http.get(
+          'https://api.clerk.test/v1/saml_connections',
+          validateHeaders(({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('query')).toBe('test');
+            expect(url.searchParams.get('order_by')).toBe('+created_at');
+            expect(url.searchParams.get('limit')).toBe('5');
+            expect(url.searchParams.get('offset')).toBe('10');
+            expect(url.searchParams.getAll('organization_id')).toEqual(['+org_123', '-org_456']);
+            return HttpResponse.json({ data: mockSamlConnectionsResponse });
+          }),
+        ),
+      );
+
+      const response = await apiClient.samlConnections.getSamlConnectionList({
+        query: 'test',
+        orderBy: '+created_at',
+        organizationId: ['+org_123', '-org_456'],
+        limit: 5,
+        offset: 10,
+      });
+
+      expect(response).toHaveLength(1);
+      expect(response[0].id).toBe('samlc_123');
+      expect(response[0].name).toBe('Test Connection');
+      expect(response[0].organizationId).toBe('org_123');
+    });
+  });
+});

--- a/packages/backend/src/api/endpoints/SamlConnectionApi.ts
+++ b/packages/backend/src/api/endpoints/SamlConnectionApi.ts
@@ -3,13 +3,18 @@ import type { SamlIdpSlug } from '@clerk/types';
 import { joinPaths } from '../../util/path';
 import type { SamlConnection } from '../resources';
 import { AbstractAPI } from './AbstractApi';
+import type { WithSign } from './util-types';
 
 const basePath = '/saml_connections';
 
 type SamlConnectionListParams = {
   limit?: number;
   offset?: number;
+  query?: string;
+  orderBy?: WithSign<'phone_number' | 'email_address' | 'created_at' | 'first_name' | 'last_name' | 'username'>;
+  organizationId?: WithSign<string>[];
 };
+
 type CreateSamlConnectionParams = {
   name: string;
   provider: SamlIdpSlug;


### PR DESCRIPTION
## Description
 
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

This adds `query`, `orderBy`, and `organizationId` to the `SamlConnectionListParams` type.

Documentation for these params: https://clerk.com/docs/reference/backend-api/tag/SAML-Connections

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SAML connection listing with new options to filter by search query, sort results, and scope results to specific organizations.

* **Tests**
  * Added tests to verify correct handling of the new filtering, sorting, and scoping parameters when listing SAML connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->