### PR TITLE
feat(clerk-js): Expose CSS variables for clerk appearance variables

### DIFF
--- a/packages/clerk-js/src/ui/components/PaymentAttempts/PaymentAttemptPage.tsx
+++ b/packages/clerk-js/src/ui/components/PaymentAttempts/PaymentAttemptPage.tsx
@@ -228,7 +228,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
         borderRadius: t.radii.$sm,
         '&:focus-visible': {
           outline: '2px solid',
-          outlineColor: t.colors.$neutralAlpha200,
+          outlineColor: t.colors.$colorRing,
         },
       })}
       focusRing={false}

--- a/packages/clerk-js/src/ui/components/Statements/Statement.tsx
+++ b/packages/clerk-js/src/ui/components/Statements/Statement.tsx
@@ -428,7 +428,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
         borderRadius: t.radii.$sm,
         '&:focus-visible': {
           outline: '2px solid',
-          outlineColor: t.colors.$neutralAlpha200,
+          outlineColor: t.colors.$colorRing,
         },
       })}
       focusRing={false}

--- a/packages/clerk-js/src/ui/customizables/parseVariables.ts
+++ b/packages/clerk-js/src/ui/customizables/parseVariables.ts
@@ -55,6 +55,7 @@ export const createColorScales = (theme: Theme) => {
       : colors.toHslaString(variables.colorInputBackground),
     colorShimmer: colors.toHslaString(variables.colorShimmer),
     colorMuted: variables.colorMuted ? colors.toHslaString(variables.colorMuted) : undefined,
+    colorRing: variables.colorRing ? colors.toHslaString(variables.colorRing) : undefined,
   });
 };
 

--- a/packages/clerk-js/src/ui/elements/LineItems.tsx
+++ b/packages/clerk-js/src/ui/elements/LineItems.tsx
@@ -267,7 +267,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
         borderRadius: t.radii.$sm,
         '&:focus-visible': {
           outline: '2px solid',
-          outlineColor: t.colors.$neutralAlpha200,
+          outlineColor: t.colors.$colorRing,
         },
       })}
       focusRing={false}

--- a/packages/clerk-js/src/ui/foundations/colors.ts
+++ b/packages/clerk-js/src/ui/foundations/colors.ts
@@ -86,6 +86,7 @@ const colors = Object.freeze({
   colorForeground,
   colorMutedForeground,
   colorMuted: undefined,
+  colorRing: clerkCssVar('color-ring', neutralAlphaScale.neutralAlpha200),
   colorInputForeground: clerkCssVar('color-input-foreground', '#131316'),
   colorPrimaryForeground: clerkCssVar('color-primary-foreground', 'white'),
   colorShimmer: clerkCssVar('color-shimmer', 'rgba(255, 255, 255, 0.36)'),

--- a/packages/clerk-js/src/ui/polishedAppearance.ts
+++ b/packages/clerk-js/src/ui/polishedAppearance.ts
@@ -68,7 +68,7 @@ const inputStyles = (theme: InternalTheme) => ({
     idle2: theme.colors.$neutralAlpha100,
     hover1: theme.colors.$neutralAlpha300,
     hover2: theme.colors.$neutralAlpha150,
-    focus: theme.colors.$neutralAlpha150,
+    focus: theme.colors.$colorRing,
   }),
   '&[data-feedback="error"]': inputShadowStyles(theme, {
     idle1: theme.colors.$dangerAlpha400,
@@ -121,7 +121,7 @@ export const polishedAppearance: Appearance = {
             '&:focus': {
               boxShadow: [
                 BUTTON_SOLID_SHADOW(theme.colors.$primary500),
-                theme.shadows.$focusRing.replace('{{color}}', theme.colors.$neutralAlpha200),
+                theme.shadows.$focusRing.replace('{{color}}', theme.colors.$colorRing),
               ].toString(),
             },
           },
@@ -141,7 +141,7 @@ export const polishedAppearance: Appearance = {
           '&:focus': {
             boxShadow: [
               BUTTON_OUTLINE_SHADOW(theme.colors.$neutralAlpha100),
-              theme.shadows.$focusRing.replace('{{color}}', theme.colors.$neutralAlpha200),
+              theme.shadows.$focusRing.replace('{{color}}', theme.colors.$colorRing),
             ].toString(),
           },
         },
@@ -151,7 +151,7 @@ export const polishedAppearance: Appearance = {
           '&:focus': {
             boxShadow: [
               BUTTON_OUTLINE_SHADOW(theme.colors.$neutralAlpha100),
-              theme.shadows.$focusRing.replace('{{color}}', theme.colors.$neutralAlpha200),
+              theme.shadows.$focusRing.replace('{{color}}', theme.colors.$colorRing),
             ].toString(),
           },
         },

--- a/packages/clerk-js/src/ui/styledSystem/common.ts
+++ b/packages/clerk-js/src/ui/styledSystem/common.ts
@@ -137,7 +137,7 @@ const focusRingStyles = (t: InternalTheme) => {
   return {
     '&::-moz-focus-inner': { border: '0' },
     WebkitTapHighlightColor: 'transparent',
-    boxShadow: t.shadows.$focusRing.replace('{{color}}', t.colors.$neutralAlpha200),
+    boxShadow: t.shadows.$focusRing.replace('{{color}}', t.colors.$colorRing),
     transitionProperty: t.transitionProperty.$common,
     transitionTimingFunction: t.transitionTiming.$common,
     transitionDuration: t.transitionDuration.$focusRing,

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -718,6 +718,11 @@ export type Variables = {
    */
   colorShimmer?: CssColor;
   /**
+   * The color of the ring when and interactive element is focused.
+   * @default 'rgba(255, 255, 255, 0.36)'
+   */
+  colorRing?: CssColor;
+  /**
    * The default font that will be used in all components.
    * This can be the name of a custom font loaded by your code or the name of a web-safe font ((@link WebSafeFont})
    * If a specific fontFamily is not provided, the components will inherit the font of the parent element.

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -718,8 +718,8 @@ export type Variables = {
    */
   colorShimmer?: CssColor;
   /**
-   * The color of the ring when and interactive element is focused.
-   * @default 'rgba(255, 255, 255, 0.36)'
+   * The color of the ring when an interactive element is focused.
+   * @default {@link Variables.colorNeutral} at 15% opacity
    */
   colorRing?: CssColor;
   /**


### PR DESCRIPTION
## Description

Adds `colorRing` variable option. When specified overrides the default ring outline color `neutralAlpha200`.

https://github.com/user-attachments/assets/f06ebc19-7478-4a72-92ab-f58bdeca1bc6

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
