### PR TITLE
[USER-2344] add /oauth/authorize-with-immediate-redirect endpoint to the frontendApiRedirectPathsNoUserInput list

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/url.spec.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.spec.ts
@@ -422,6 +422,7 @@ describe('isRedirectForFAPIInitiatedFlow(frontendAp: string, redirectUrl: string
     ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/oauth/authorize', true],
     ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/v1/verify', true],
     ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/v1/tickets/accept', true],
+    ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/oauth/authorize-with-immediate-redirect', true],
     ['clerk.foo.bar-53.lcl.dev', 'https://google.com', false],
     ['clerk.foo.bar-53.lcl.dev', 'https://google.com/v1/verify', false],
   ];
@@ -441,6 +442,7 @@ describe('requiresUserInput(redirectUrl: string)', () => {
     ['https://clerk.foo.bar-53.lcl.dev/oauth/authorize', true],
     ['https://clerk.foo.bar-53.lcl.dev/v1/verify', false],
     ['https://clerk.foo.bar-53.lcl.dev/v1/tickets/accept', false],
+    ['https://clerk.foo.bar-53.lcl.dev/oauth/authorize-with-immediate-redirect', false],
     ['https://google.com', false],
     ['https://google.com/v1/verify', false],
   ];

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -337,6 +337,7 @@ const frontendApiRedirectPathsWithUserInput: string[] = [
 const frontendApiRedirectPathsNoUserInput: string[] = [
   '/v1/verify', // magic links
   '/v1/tickets/accept', // ticket flow
+  '/oauth/authorize-with-immediate-redirect', // Similiar to OAuth Authorize, but even if a user is signed out - we immediately redirect
 ];
 
 export function isRedirectForFAPIInitiatedFlow(frontendApi: string, redirectUrl: string): boolean {


### PR DESCRIPTION
Currently, to complete an oauth flow, the sign in page is usually hit. This is because the FAPI endpoint `/oauth/authorize` needs to get the user's session to complete the flow.

**However,** there are cases where FAPI's `/oauth/authorize` endpoint needs to know if the user is **not logged into clerk**. For example when handling `prompt=none` for OIDC. 

This PR adds `/oauth/authorize-with-immediate-redirect` to [frontendApiRedirectPathsNoUserInput](https://github.com/clerk/javascript/blob/7bfc9f0a110d57b4d47c7ba364f5f81a30013467/packages/clerk-js/src/utils/url.ts#L337-L340). This makes it so we can immediately redirect back to the oauth flow, but attach the client cookie or dev browser to the flow **without requiring user interaction**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing immediate OAuth redirect URLs as valid for FAPI-initiated flows.
* **Tests**
  * Expanded test coverage to include cases for immediate OAuth redirect URLs, ensuring correct behavior for user input requirements and redirect recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->