### PR TITLE
chore(e2e): Fix flaky tests for multi-session with tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,9 +301,6 @@ jobs:
             next-version: '14'
           - test-name: 'nextjs'
             test-project: 'chrome'
-            next-version: '14.2.25'
-          - test-name: 'nextjs'
-            test-project: 'chrome'
             next-version: '15'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,9 @@ jobs:
             next-version: '14'
           - test-name: 'nextjs'
             test-project: 'chrome'
+            next-version: '14.2.25'
+          - test-name: 'nextjs'
+            test-project: 'chrome'
             next-version: '15'
 
     steps:

--- a/integration/tests/session-tasks-multi-session.test.ts
+++ b/integration/tests/session-tasks-multi-session.test.ts
@@ -30,14 +30,14 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await app.teardown();
     });
 
-    test.afterEach(async ({ page, context }) => {
-      const u = createTestUtils({ app, page, context });
-      await u.page.signOut();
-      await u.page.context().clearCookies();
-    });
-
     test('when switching sessions, navigate to task', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
+
+      // TODO -> Figure out why test is flaky on Next.js 14
+      if (u.nextJsVersion === '14') {
+        test.skip();
+        return;
+      }
 
       // Performs sign-in
       await u.po.signIn.goTo();
@@ -95,6 +95,9 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
 
       // Navigates to after sign-in
       await u.page.waitForAppUrl('/');
+
+      await u.page.signOut();
+      await u.page.context().clearCookies();
     });
   },
 );

--- a/integration/tests/session-tasks-multi-session.test.ts
+++ b/integration/tests/session-tasks-multi-session.test.ts
@@ -36,7 +36,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.page.context().clearCookies();
     });
 
-    test.skip('when switching sessions, navigate to task', async ({ page, context }) => {
+    test('when switching sessions, navigate to task', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
 
       // Performs sign-in
@@ -82,9 +82,13 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.userButton.waitForPopover();
       await u.po.userButton.toHaveVisibleMenuItems([/Manage account/i, /Sign out$/i]);
       await u.po.userButton.switchAccount(user2.email);
+      await u.po.userButton.waitForPopoverClosed();
+
+      // Wait for sign-in component to be mounted after switching accounts
+      await u.po.signIn.waitForMounted();
+      await page.waitForURL(/tasks/);
 
       // Resolve task
-      await u.po.signIn.waitForMounted();
       const fakeOrganization2 = u.services.organizations.createFakeOrganization();
       await u.po.sessionTask.resolveForceOrganizationSelectionTask(fakeOrganization2);
       await u.po.expect.toHaveResolvedTask();


### PR DESCRIPTION
## Description

This PR temporarily skips the multi-session test for Next.js 14. I don't know the root cause yet, due to not having been able to run Cypress locally with debug mode against Next.js 14. 

We made tests on a Next.js 14 app using the latest `@clerk/nextjs` and the feature works correctly. 

For Next.js 15: Tests were flaky before due to a race condition where we were awaiting for the `SignIn` component to be mounted, by the time the client-side navigation to the`/tasks` route was happening. 

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of session-switching navigation tests by adding explicit waits for UI state and navigation changes.
  * Activated a previously skipped test with adjustments for compatibility across different Next.js versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->