### PR TITLE
fix(repo): More robust hasMajorChangeset check

### DIFF
--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -57,7 +57,7 @@ jobs:
 
                 // Only check for "major" in the YAML frontmatter section (between --- markers)
                 // This avoids false positives from descriptive text mentioning "major"
-                const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+                const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\s*$/m);
                 if (frontmatterMatch) {
                   const frontmatter = frontmatterMatch[1];
                   if (/:\s*["']?major["']?/.test(frontmatter)) {


### PR DESCRIPTION
## Description

https://github.com/clerk/javascript/pull/6275 is incorrectly getting flagged as including a `major` bump due to usage of `major` within the changeset description. This PR updates the check to only check within the frontmatter.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved detection accuracy for major version bumps in workflow automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->