### PR TITLE
feat(clerk-js): Add `colorModalBackdrop` variable option

### DIFF
--- a/packages/clerk-js/src/ui/customizables/parseVariables.ts
+++ b/packages/clerk-js/src/ui/customizables/parseVariables.ts
@@ -64,6 +64,7 @@ export const createColorScales = (theme: Theme) => {
     colorMuted: variables.colorMuted ? colors.toHslaString(variables.colorMuted) : undefined,
     colorRing: variables.colorRing ? colors.toHslaString(variables.colorRing) : undefined,
     colorShadow: variables.colorShadow ? colors.toHslaString(variables.colorShadow) : undefined,
+    colorModalBackdrop: variables.colorModalBackdrop ? colors.toHslaString(variables.colorModalBackdrop) : undefined,
   });
 };
 

--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -68,7 +68,7 @@ export const Modal = withFloatingTree((props: ModalProps) => {
             t => ({
               animation: `${animations.fadeIn} 150ms ${t.transitionTiming.$common}`,
               zIndex: t.zIndices.$modal,
-              backgroundColor: t.colors.$modalBackdrop,
+              backgroundColor: t.colors.$colorModalBackdrop,
               alignItems: 'flex-start',
               justifyContent: 'center',
               overflow: 'auto',

--- a/packages/clerk-js/src/ui/foundations/colors.ts
+++ b/packages/clerk-js/src/ui/foundations/colors.ts
@@ -88,7 +88,7 @@ const colorMutedForeground = clerkCssVar(
 const colors = Object.freeze({
   avatarBorder: neutralAlphaScale.neutralAlpha200,
   avatarBackground: neutralAlphaScale.neutralAlpha400,
-  modalBackdrop: neutralAlphaScale.neutralAlpha700,
+  colorModalBackdrop: clerkCssVar('color-modal-backdrop', neutralAlphaScale.neutralAlpha700),
   colorBackground: clerkCssVar('color-background', 'white'),
   colorInput: clerkCssVar('color-input', 'white'),
   colorForeground,

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -753,6 +753,11 @@ export type Variables = {
    */
   colorBorder?: CssColor;
   /**
+   * The background color of the modal backdrop.
+   * @default {@link Variables.colorNeutral} at 70% opacity
+   */
+  colorModalBackdrop?: CssColor;
+  /**
    * The default font that will be used in all components.
    * This can be the name of a custom font loaded by your code or the name of a web-safe font ((@link WebSafeFont})
    * If a specific fontFamily is not provided, the components will inherit the font of the parent element.


### PR DESCRIPTION
## Description

This PR adds `colorModalBackdrop` as a variable option

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
