### PR TITLE
fix(clerk-js): Use fractions for variable ratios

### DIFF
--- a/packages/clerk-js/src/ui/customizables/parseVariables.ts
+++ b/packages/clerk-js/src/ui/customizables/parseVariables.ts
@@ -1,8 +1,8 @@
 import type { Theme } from '@clerk/types';
 
 import { createShadowSet, generateShadow } from '../foundations/shadows';
-import { spaceScaleKeys } from '../foundations/sizes';
-import type { fontWeights } from '../foundations/typography';
+import { BORDER_RADIUS_SCALE_RATIOS, spaceScaleKeys } from '../foundations/sizes';
+import { FONT_SIZE_SCALE_RATIOS, type FontSizeKey, type fontWeights } from '../foundations/typography';
 import { colors } from '../utils/colors';
 import { colorOptionToThemedAlphaScale, colorOptionToThemedLightnessScale } from '../utils/colors/scales';
 import { createAlphaColorMixString } from '../utils/colors/utils';
@@ -119,10 +119,10 @@ export const createRadiiUnits = (theme: Theme) => {
 
   const md = borderRadius === 'none' ? '0' : borderRadius;
   return {
-    sm: `calc(${md} * 0.66)`,
+    sm: `calc(${md} * ${BORDER_RADIUS_SCALE_RATIOS.sm})`,
     md,
-    lg: `calc(${md} * 1.33)`,
-    xl: `calc(${md} * 2)`,
+    lg: `calc(${md} * ${BORDER_RADIUS_SCALE_RATIOS.lg})`,
+    xl: `calc(${md} * ${BORDER_RADIUS_SCALE_RATIOS.xl})`,
   };
 };
 
@@ -140,18 +140,6 @@ export const createSpaceScale = (theme: Theme) => {
     }),
   );
 };
-
-// Font size scale constants that match the default theme foundations
-// These ratios are used consistently across the design system
-const FONT_SIZE_SCALE_RATIOS = {
-  xs: 0.8,
-  sm: 0.9,
-  md: 1,
-  lg: 1.3,
-  xl: 1.85,
-} as const;
-
-type FontSizeKey = keyof typeof FONT_SIZE_SCALE_RATIOS;
 
 // We want to keep the same ratio between the font sizes we have for the default theme
 // This is directly related to the fontSizes object in the theme default foundations
@@ -171,11 +159,12 @@ export const createFontSizeScale = (theme: Theme): Partial<Record<FontSizeKey, s
     );
   }
 
-  // When fontSize is a string, calculate all sizes based on the base value and ratios
+  // When fontSize is a string, calculate all sizes based on the base value and fractions for precision
+  // Using fractions instead of decimal ratios to avoid floating-point precision issues
   return Object.fromEntries(
-    Object.entries(FONT_SIZE_SCALE_RATIOS).map(([key, ratio]) => [
+    Object.entries(FONT_SIZE_SCALE_RATIOS).map(([key, fraction]) => [
       key,
-      ratio === 1 ? fontSize : `calc(${fontSize} * ${ratio})`,
+      fraction === '1' ? fontSize : `calc(${fontSize} * ${fraction})`,
     ]),
   ) as Record<FontSizeKey, string>;
 };

--- a/packages/clerk-js/src/ui/foundations/sizes.ts
+++ b/packages/clerk-js/src/ui/foundations/sizes.ts
@@ -2,7 +2,6 @@ import { clerkCssVar } from '../utils/cssVariables';
 
 const SPACING_BASE_UNIT = '1rem';
 const SPACING_MULTIPLIER = 0.25; // ((num / 0.5) * 0.125)
-const BORDER_RADIUS_DEFAULT = '0.375rem';
 
 const baseSpaceUnits = Object.freeze({
   none: '0',
@@ -167,19 +166,26 @@ const sizes = Object.freeze({
   ...spaceUnits,
 } as const);
 
-const radiiDefaultVar = clerkCssVar('border-radius', BORDER_RADIUS_DEFAULT);
-
 /**
  * Border radius scale with CSS variables for theming
  */
+export const BORDER_RADIUS_SCALE_RATIOS = Object.freeze({
+  sm: '2 / 3', // 0.66
+  md: '1', // 1.0
+  lg: '4 / 3', // 1.33
+  xl: '2', // 2.0
+} as const);
+
+const radiiDefaultVar = clerkCssVar('border-radius', '0.375rem');
+
 const radii = Object.freeze({
   none: '0px',
   circle: '50%',
   avatar: clerkCssVar('border-radius-avatar', radiiDefaultVar),
-  sm: clerkCssVar('border-radius-sm', `calc(${radiiDefaultVar} * 0.666)`),
+  sm: clerkCssVar('border-radius-sm', `calc(${radiiDefaultVar} * ${BORDER_RADIUS_SCALE_RATIOS.sm})`), // Use fraction for precision
   md: clerkCssVar('border-radius-md', radiiDefaultVar),
-  lg: clerkCssVar('border-radius-lg', `calc(${radiiDefaultVar} * 1.333)`),
-  xl: clerkCssVar('border-radius-xl', `calc(${radiiDefaultVar} * 2)`),
+  lg: clerkCssVar('border-radius-lg', `calc(${radiiDefaultVar} * ${BORDER_RADIUS_SCALE_RATIOS.lg})`), // Use fraction for precision
+  xl: clerkCssVar('border-radius-xl', `calc(${radiiDefaultVar} * ${BORDER_RADIUS_SCALE_RATIOS.xl})`),
   halfHeight: '99999px',
 } as const);
 

--- a/packages/clerk-js/src/ui/foundations/typography.ts
+++ b/packages/clerk-js/src/ui/foundations/typography.ts
@@ -19,16 +19,23 @@ const letterSpacings = Object.freeze({
   normal: 'normal',
 } as const);
 
-// We want to achieve the md size to be 13px for root font size of 16px
-// This is directly related to the createFontSizeScale function in the theme
-// ref: src/ui/customizables/parseVariables.ts
+export const FONT_SIZE_SCALE_RATIOS = Object.freeze({
+  xs: '11 / 13', // 0.846154
+  sm: '12 / 13', // 0.923077
+  md: '1', // 1.0
+  lg: '17 / 13', // 1.307692
+  xl: '24 / 13', // 1.846154
+} as const);
+
+export type FontSizeKey = keyof typeof FONT_SIZE_SCALE_RATIOS;
+
 const fontSizesDefaultVar = clerkCssVar('font-size', '0.8125rem');
 const fontSizes = Object.freeze({
-  xs: clerkCssVar('font-size-xs', `calc(${fontSizesDefaultVar} * 0.8)`), // 0.6875rem
-  sm: clerkCssVar('font-size-sm', `calc(${fontSizesDefaultVar} * 0.9)`), // 0.75rem
-  md: clerkCssVar('font-size-md', fontSizesDefaultVar), // 1rem
-  lg: clerkCssVar('font-size-lg', `calc(${fontSizesDefaultVar} * 1.3)`), // 1.0625rem
-  xl: clerkCssVar('font-size-xl', `calc(${fontSizesDefaultVar} * 1.85)`), // 1.5rem
+  xs: clerkCssVar('font-size-xs', `calc(${fontSizesDefaultVar} * ${FONT_SIZE_SCALE_RATIOS.xs})`), // 0.6875rem
+  sm: clerkCssVar('font-size-sm', `calc(${fontSizesDefaultVar} * ${FONT_SIZE_SCALE_RATIOS.sm})`), // 0.75rem
+  md: clerkCssVar('font-size-md', fontSizesDefaultVar), // 0.8125rem
+  lg: clerkCssVar('font-size-lg', `calc(${fontSizesDefaultVar} * ${FONT_SIZE_SCALE_RATIOS.lg})`), // 1.0625rem
+  xl: clerkCssVar('font-size-xl', `calc(${fontSizesDefaultVar} * ${FONT_SIZE_SCALE_RATIOS.xl})`), // 1.5rem
 } as const);
 
 const fontStyles = Object.freeze({


### PR DESCRIPTION
## Description

Fixes issues highlighted in visual diffs due to floating-point precision differences.

To fix we use a fraction in CSS is more precise.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
