### PR TITLE
fix(clerk-js): Do not trigger after-auth navigation from `useMultisessionActions`

### DIFF
--- a/.changeset/deep-poems-sneeze.md
+++ b/.changeset/deep-poems-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Do not trigger after-auth navigation outside of AIOs

--- a/.changeset/deep-poems-sneeze.md
+++ b/.changeset/deep-poems-sneeze.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Do not trigger after-auth navigation outside of AIOs
+Do not trigger after-auth navigation from `useMultisessionActions`

--- a/.changeset/deep-poems-sneeze.md
+++ b/.changeset/deep-poems-sneeze.md
@@ -1,5 +1,7 @@
 ---
 '@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+'@clerk/types': minor
 ---
 
 Do not trigger after-auth navigation from `useMultisessionActions`

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -29,9 +29,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1348,15 +1348,16 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
-    const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
-    const defaultRedirectUrlComplete = this.client?.signUp ? this.buildAfterSignUpUrl() : this.buildAfterSignInUrl();
+    if (redirectUrlComplete) {
+      const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
 
-    await tracker.track(async () => {
-      await this.navigate(redirectUrlComplete ?? defaultRedirectUrlComplete);
-    });
+      await tracker.track(async () => {
+        await this.navigate(redirectUrlComplete);
+      });
 
-    if (tracker.isUnloading()) {
-      return;
+      if (tracker.isUnloading()) {
+        return;
+      }
     }
   };
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -19,6 +19,7 @@ import type {
   __experimental_CheckoutOptions,
   __internal_CheckoutProps,
   __internal_ComponentNavigationContext,
+  __internal_NavigateToTaskIfAvailableParams,
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_SubscriptionDetailsProps,
@@ -29,9 +30,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -50,7 +51,6 @@ import type {
   JoinWaitlistParams,
   ListenerCallback,
   NavigateOptions,
-  NextTaskParams,
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationResource,
@@ -1332,7 +1332,9 @@ export class Clerk implements ClerkInterface {
     this.#emit();
   };
 
-  public __internal_navigateToTaskIfAvailable = async ({ redirectUrlComplete }: NextTaskParams = {}): Promise<void> => {
+  public __internal_navigateToTaskIfAvailable = async ({
+    redirectUrlComplete,
+  }: __internal_NavigateToTaskIfAvailableParams = {}): Promise<void> => {
     const session = this.session;
     if (!session || !this.environment) {
       return;

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -4,6 +4,7 @@ import { loadClerkJsScript } from '@clerk/shared/loadClerkJsScript';
 import { handleValueOrFn } from '@clerk/shared/utils';
 import type {
   __internal_CheckoutProps,
+  __internal_NavigateToTaskIfAvailableParams,
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_SubscriptionDetailsProps,
@@ -30,7 +31,6 @@ import type {
   JoinWaitlistParams,
   ListenerCallback,
   LoadedClerk,
-  NextTaskParams,
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationResource,
@@ -731,7 +731,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
-  __internal_navigateToTaskIfAvailable = async (params?: NextTaskParams): Promise<void> => {
+  __internal_navigateToTaskIfAvailable = async (params?: __internal_NavigateToTaskIfAvailableParams): Promise<void> => {
     if (this.clerkjs) {
       return this.clerkjs.__internal_navigateToTaskIfAvailable(params);
     } else {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -2003,6 +2003,17 @@ export interface AuthenticateWithGoogleOneTapParams {
   legalAccepted?: boolean;
 }
 
+/**
+ * @deprecated Use `__internal_NavigateToTaskIfAvailableParams` instead
+ */
+export interface NextTaskParams {
+  /**
+   * Full URL or path to navigate to after successfully resolving all tasks
+   * @default undefined
+   */
+  redirectUrlComplete?: string;
+}
+
 export interface __internal_NavigateToTaskIfAvailableParams {
   /**
    * Full URL or path to navigate to after successfully resolving all tasks

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -815,12 +815,10 @@ export interface Clerk {
   joinWaitlist: (params: JoinWaitlistParams) => Promise<WaitlistResource>;
 
   /**
-   * Navigates to the next task or redirects to completion URL.
-   * If the current session has pending tasks, it navigates to the next task.
-   * If all tasks are complete, it navigates to the provided completion URL or defaults to the origin redirect URL (either from sign-in or sign-up).
+   * Navigates to the current task or redirects to `redirectUrlComplete` once the session is `active`.
    * @internal
    */
-  __internal_navigateToTaskIfAvailable: (params?: NextTaskParams) => Promise<void>;
+  __internal_navigateToTaskIfAvailable: (params?: __internal_NavigateToTaskIfAvailableParams) => Promise<void>;
 
   /**
    * This is an optional function.
@@ -2005,7 +2003,7 @@ export interface AuthenticateWithGoogleOneTapParams {
   legalAccepted?: boolean;
 }
 
-export interface NextTaskParams {
+export interface __internal_NavigateToTaskIfAvailableParams {
   /**
    * Full URL or path to navigate to after successfully resolving all tasks
    * @default undefined

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -2003,17 +2003,6 @@ export interface AuthenticateWithGoogleOneTapParams {
   legalAccepted?: boolean;
 }
 
-/**
- * @deprecated Use `__internal_NavigateToTaskIfAvailableParams` instead
- */
-export interface NextTaskParams {
-  /**
-   * Full URL or path to navigate to after successfully resolving all tasks
-   * @default undefined
-   */
-  redirectUrlComplete?: string;
-}
-
 export interface __internal_NavigateToTaskIfAvailableParams {
   /**
    * Full URL or path to navigate to after successfully resolving all tasks


### PR DESCRIPTION
## Description

This previous [PR](https://github.com/clerk/javascript/pull/6319/files) introduced calling `__internal_navigateToTaskIfAvailable` after `setActive` when switching sessions via `useMultisessionActions`

This after-auth navigation must only be done if `__internal_navigateToTaskIfAvailable` is called with a `redirectUrlComplete`, which is passed from AIOs: 
https://github.com/clerk/javascript/blob/7f341dc7ed4982324e6dae59e803f42e794f2e2f/packages/clerk-js/src/ui/components/SessionTasks/index.tsx#L84-L87

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic navigation after authentication unless a valid redirect URL is provided, improving navigation control post-login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->