### PR TITLE
chore(shared): Mark error utilities as internal

### DIFF
--- a/.changeset/new-taxes-fry.md
+++ b/.changeset/new-taxes-fry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Mark error utilities as internal.

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -4,27 +4,54 @@ import type {
   ClerkAPIResponseError as ClerkAPIResponseErrorInterface,
 } from '@clerk/types';
 
+/**
+ * Checks if the provided error object is an unauthorized error.
+ *
+ * @internal
+ *
+ * @deprecated This is no longer used, and will be removed in the next major version.
+ */
 export function isUnauthorizedError(e: any): boolean {
   const status = e?.status;
   const code = e?.errors?.[0]?.code;
   return code === 'authentication_invalid' && status === 401;
 }
 
+/**
+ * Checks if the provided error object is a captcha error.
+ *
+ * @internal
+ */
 export function isCaptchaError(e: ClerkAPIResponseError): boolean {
   return ['captcha_invalid', 'captcha_not_enabled', 'captcha_missing_token'].includes(e.errors[0].code);
 }
 
+/**
+ * Checks if the provided error is a 4xx error.
+ *
+ * @internal
+ */
 export function is4xxError(e: any): boolean {
   const status = e?.status;
   return !!status && status >= 400 && status < 500;
 }
 
+/**
+ * Checks if the provided error is a network error.
+ *
+ * @internal
+ */
 export function isNetworkError(e: any): boolean {
   // TODO: revise during error handling epic
   const message = (`${e.message}${e.name}` || '').toLowerCase().replace(/\s+/g, '');
   return message.includes('networkerror');
 }
 
+/**
+ * Options for creating a ClerkAPIResponseError.
+ *
+ * @internal
+ */
 interface ClerkAPIResponseOptions {
   data: ClerkAPIErrorJSON[];
   status: number;
@@ -40,10 +67,20 @@ export interface MetamaskError extends Error {
   data?: unknown;
 }
 
+/**
+ * Checks if the provided error is either a ClerkAPIResponseError, a ClerkRuntimeError, or a MetamaskError.
+ *
+ * @internal
+ */
 export function isKnownError(error: any): error is ClerkAPIResponseError | ClerkRuntimeError | MetamaskError {
   return isClerkAPIResponseError(error) || isMetamaskError(error) || isClerkRuntimeError(error);
 }
 
+/**
+ * Checks if the provided error is a ClerkAPIResponseError.
+ *
+ * @internal
+ */
 export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError {
   return 'clerkError' in err;
 }
@@ -68,26 +105,56 @@ export function isClerkRuntimeError(err: any): err is ClerkRuntimeError {
   return 'clerkRuntimeError' in err;
 }
 
+/**
+ * Checks if the provided error is a Clerk runtime error indicating a reverification was cancelled.
+ *
+ * @internal
+ */
 export function isReverificationCancelledError(err: any) {
   return isClerkRuntimeError(err) && err.code === 'reverification_cancelled';
 }
 
+/**
+ * Checks if the provided error is a Metamask error.
+ *
+ * @internal
+ */
 export function isMetamaskError(err: any): err is MetamaskError {
   return 'code' in err && [4001, 32602, 32603].includes(err.code) && 'message' in err;
 }
 
+/**
+ * Checks if the provided error is clerk api response error indicating a user is locked.
+ *
+ * @internal
+ */
 export function isUserLockedError(err: any) {
   return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'user_locked';
 }
 
+/**
+ * Checks if the provided error is a clerk api response error indicating a password was pwned.
+ *
+ * @internal
+ */
 export function isPasswordPwnedError(err: any) {
   return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'form_password_pwned';
 }
 
+/**
+ * Parses an array of ClerkAPIErrorJSON objects into an array of ClerkAPIError objects.
+ *
+ * @internal
+ */
 export function parseErrors(data: ClerkAPIErrorJSON[] = []): ClerkAPIError[] {
   return data.length > 0 ? data.map(parseError) : [];
 }
 
+/**
+ * Parses a ClerkAPIErrorJSON object into a ClerkAPIError object.
+ *
+ * @internal
+ */
 export function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
   return {
     code: error.code,
@@ -104,6 +171,11 @@ export function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
   };
 }
 
+/**
+ * Converts a ClerkAPIError object into a ClerkAPIErrorJSON object.
+ *
+ * @internal
+ */
 export function errorToJSON(error: ClerkAPIError | null): ClerkAPIErrorJSON {
   return {
     code: error?.code || '',
@@ -217,6 +289,11 @@ export class EmailLinkError extends Error {
   }
 }
 
+/**
+ * Checks if the provided error is an EmailLinkError.
+ *
+ * @internal
+ */
 export function isEmailLinkError(err: Error): err is EmailLinkError {
   return err.name === 'EmailLinkError';
 }
@@ -275,9 +352,19 @@ export interface ErrorThrower {
   throw(message: string): never;
 }
 
+/**
+ * Builds an error thrower.
+ *
+ * @internal
+ */
 export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerOptions): ErrorThrower {
   let pkg = packageName;
 
+  /**
+   * Builds a message from a raw message and replacements.
+   *
+   * @internal
+   */
   function buildMessage(rawMessage: string, replacements?: Record<string, string | number>) {
     if (!replacements) {
       return `${pkg}: ${rawMessage}`;


### PR DESCRIPTION
## Description

Marking them with `@internal` prevens typedocs from being generated.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for error handling utilities with detailed descriptions, usage notes, and internal-use annotations.
  * Deprecated status of certain error types is now clearly documented.
  * No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->