### PR TITLE
fix(clerk-js): Show error message when account is locked

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2216,7 +2216,6 @@ export class Clerk implements ClerkInterface {
 
   __internal_navigateWithError(to: string, err: ClerkAPIError) {
     this.__internal_last_error = err;
-    eventBus.emit(events.ErrorUserLocked, null);
     return this.navigate(to);
   }
 

--- a/packages/clerk-js/src/core/events.ts
+++ b/packages/clerk-js/src/core/events.ts
@@ -6,7 +6,6 @@ export const events = {
   UserSignOut: 'user:signOut',
   EnvironmentUpdate: 'environment:update',
   SessionTokenResolved: 'session:tokenResolved',
-  ErrorUserLocked: 'error:user_locked',
 } as const;
 
 type TokenUpdatePayload = { token: TokenResource | null };
@@ -16,7 +15,6 @@ type InternalEvents = {
   [events.UserSignOut]: null;
   [events.EnvironmentUpdate]: null;
   [events.SessionTokenResolved]: null;
-  [events.ErrorUserLocked]: null;
 };
 
 export const eventBus = createEventBus<InternalEvents>();

--- a/packages/clerk-js/src/ui/elements/contexts/index.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/index.tsx
@@ -3,9 +3,8 @@ import type { ClerkAPIError, ClerkRuntimeError } from '@clerk/types';
 import { FloatingTree, useFloatingParentNodeId } from '@floating-ui/react';
 import React from 'react';
 
-import { useSafeState } from '@/ui/hooks';
+import { useRouter } from '@/ui/router';
 
-import { eventBus, events } from '../../../core/events';
 import { useLocalizations } from '../../customizables';
 
 type Status = 'idle' | 'loading' | 'error';
@@ -20,30 +19,21 @@ const [CardStateCtx, _useCardState] = createContextAndHook<CardStateCtxValue>('C
 
 export const CardStateProvider = (props: React.PropsWithChildren<any>) => {
   const { translateError } = useLocalizations();
+  const router = useRouter();
 
-  const [state, setState] = useSafeState<State>({
+  const [state, setState] = React.useState<State>(() => ({
     status: 'idle',
     metadata: undefined,
-    error: undefined,
-  });
+    error: translateError(window?.Clerk?.__internal_last_error || undefined),
+  }));
 
   React.useEffect(() => {
-    const initialError = window?.Clerk?.__internal_last_error;
-    if (initialError) {
-      setState(s => ({ ...s, error: translateError(initialError) }));
+    const error = window?.Clerk?.__internal_last_error;
+
+    if (error) {
+      setState(s => ({ ...s, error: translateError(error) }));
     }
-
-    const handler = () => {
-      const error = window?.Clerk?.__internal_last_error;
-      if (error) {
-        setState(s => ({ ...s, error: translateError(error) }));
-      }
-    };
-
-    eventBus.on(events.ErrorUserLocked, handler);
-
-    return () => eventBus.off(events.ErrorUserLocked, handler);
-  }, [translateError, setState]);
+  }, [translateError, setState, router.currentPath]);
 
   const value = React.useMemo(() => ({ value: { state, setState } }), [state, setState]);
   return <CardStateCtx.Provider value={value}>{props.children}</CardStateCtx.Provider>;


### PR DESCRIPTION
## Description

Adds missing error message when an account is locked in hash routing mode. ([USER-2175](https://linear.app/clerk/issue/USER-2175/error-message-not-updating-for-locked-account-in-signin-component))

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->








| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/396d0a8c-2efc-469f-b8ad-e32e6d46bdaa.mp4">  | <video src="https://github.com/user-attachments/assets/be6dace4-7f44-41fd-ab67-462a9c347307.mp4">|

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a missing error message for users whose accounts are locked while using hash routing mode, ensuring clear feedback in this scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->