### PR TITLE
feat(clerk-js): Auto detect shadcn usage and inject baseTheme

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@clerk/localizations": "workspace:^",
     "@clerk/shared": "workspace:^",
+    "@clerk/themes": "workspace:^",
     "@clerk/types": "workspace:^",
     "@coinbase/wallet-sdk": "4.3.0",
     "@emotion/cache": "11.11.0",

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -86,6 +86,7 @@ import type {
 } from '@clerk/types';
 
 import type { MountComponentRenderer } from '../ui/Components';
+import { detectShadcnUsage } from '../utils/shadcnDetection';
 import {
   ALLOWED_PROTOCOLS,
   buildURL,
@@ -153,6 +154,8 @@ import {
 } from './resources/internal';
 import { navigateToTask } from './sessionTasks';
 import { warnings } from './warnings';
+
+const shadcnTheme = require('@clerk/themes').shadcn;
 
 type SetActiveHook = (intent?: 'sign-out') => void | Promise<void>;
 
@@ -2727,7 +2730,7 @@ export class Clerk implements ClerkInterface {
   };
 
   #initOptions = (options?: ClerkOptions): ClerkOptions => {
-    return {
+    const processedOptions = {
       ...defaultOptions,
       ...options,
       allowedRedirectOrigins: createAllowedRedirectOrigins(
@@ -2736,6 +2739,19 @@ export class Clerk implements ClerkInterface {
         this.instanceType,
       ),
     };
+
+    // Auto-inject shadcn theme if detected and not already set
+    if (shadcnTheme && !processedOptions.appearance?.baseTheme) {
+      const isShadcnDetected = detectShadcnUsage();
+      if (isShadcnDetected) {
+        processedOptions.appearance = {
+          baseTheme: shadcnTheme,
+          ...processedOptions.appearance,
+        };
+      }
+    }
+
+    return processedOptions;
   };
 
   /**

--- a/packages/clerk-js/src/utils/shadcnDetection.ts
+++ b/packages/clerk-js/src/utils/shadcnDetection.ts
@@ -1,0 +1,41 @@
+/**
+ * Utility function for detecting shadcn/ui usage based on CSS variables
+ */
+export function detectShadcnUsage(): boolean {
+  const shadcnCSSVariables = [
+    '--background',
+    '--foreground',
+    '--card',
+    '--card-foreground',
+    '--primary',
+    '--primary-foreground',
+    '--secondary',
+    '--secondary-foreground',
+    '--muted',
+    '--muted-foreground',
+    '--accent',
+    '--accent-foreground',
+    '--destructive',
+    '--destructive-foreground',
+    '--border',
+    '--input',
+    '--ring',
+  ];
+
+  let foundVariables = 0;
+  const totalVariables = shadcnCSSVariables.length;
+
+  // Check if CSS variables are defined in the document
+  const computedStyle = getComputedStyle(document.documentElement);
+
+  for (const variable of shadcnCSSVariables) {
+    const value = computedStyle.getPropertyValue(variable);
+    if (value && value.trim() !== '') {
+      foundVariables++;
+    }
+  }
+
+  // If we find more than 80% of the expected variables, it's likely shadcn
+  const threshold = 0.8;
+  return foundVariables >= totalVariables * threshold;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@clerk/shared':
         specifier: workspace:^
         version: link:../shared
+      '@clerk/themes':
+        specifier: workspace:^
+        version: link:../themes
       '@clerk/types':
         specifier: workspace:^
         version: link:../types
@@ -2893,7 +2896,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}


### PR DESCRIPTION
## Description

Add functionality that checks for shadcn usage in a project by looking for certain css variables being defined. If true, auto inject the shadcn theme as the baseTheme.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
