### PR TITLE
feat(clerk-js): Add `cssLayerName` option to `experimental_createTheme`

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2727,9 +2727,22 @@ export class Clerk implements ClerkInterface {
   };
 
   #initOptions = (options?: ClerkOptions): ClerkOptions => {
+    // Extract baseTheme from appearance if it exists
+    let processedOptions = options ? { ...options } : {};
+    if (
+      processedOptions.appearance &&
+      typeof processedOptions.appearance === 'object' &&
+      'baseTheme' in processedOptions.appearance
+    ) {
+      processedOptions = {
+        ...processedOptions,
+        appearance: (processedOptions.appearance as any).baseTheme,
+      };
+    }
+
     return {
       ...defaultOptions,
-      ...options,
+      ...processedOptions,
       allowedRedirectOrigins: createAllowedRedirectOrigins(
         options?.allowedRedirectOrigins,
         this.frontendApi,

--- a/packages/themes/src/createTheme.ts
+++ b/packages/themes/src/createTheme.ts
@@ -9,9 +9,17 @@ interface CreateClerkThemeParams extends DeepPartial<Theme> {
    * {@link Theme.elements}
    */
   elements?: Elements | ((params: { theme: InternalTheme }) => Elements);
+  /**
+   * Optional CSS layer name for the theme
+   */
+  cssLayerName?: string;
 }
 
 export const experimental_createTheme = (appearance: Appearance<CreateClerkThemeParams>): BaseTheme => {
   // Placeholder method that might hande more transformations in the future
-  return { ...appearance, __type: 'prebuilt_appearance' };
+  return {
+    ...(appearance.cssLayerName && { cssLayerName: appearance.cssLayerName }),
+    ...appearance,
+    __type: 'prebuilt_appearance',
+  };
 };

--- a/packages/themes/src/themes/shadcn.ts
+++ b/packages/themes/src/themes/shadcn.ts
@@ -1,6 +1,7 @@
 import { experimental_createTheme } from '../createTheme';
 
 export const shadcn = experimental_createTheme({
+  cssLayerName: 'components',
   variables: {
     colorBackground: 'var(--card)',
     colorDanger: 'var(--destructive)',


### PR DESCRIPTION
## Description

This enables shipping the shadcn theme without the users needing to specify the `cssLayerName` themselves.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
