### PR TITLE
fix(clerk-js): Use `isSignedIn` to determine auth state on checkout instance creation

### DIFF
--- a/.changeset/big-sides-go.md
+++ b/.changeset/big-sides-go.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix authentication state resolution when creating checkout instance

--- a/packages/clerk-js/src/core/modules/checkout/instance.ts
+++ b/packages/clerk-js/src/core/modules/checkout/instance.ts
@@ -24,7 +24,7 @@ function createCheckoutInstance(
 ): __experimental_CheckoutInstance {
   const { for: forOrganization, planId, planPeriod } = options;
 
-  if (!clerk.user) {
+  if (!clerk.isSignedIn || !clerk.user) {
     throw new Error('Clerk: User is not authenticated');
   }
 


### PR DESCRIPTION
## Description

This PR replaces `clerk.user` with `clerk.isSignedIn` to determine auth state when creating a checkout instance. In that way, it handles `pending` sessions for after-auth flows. 

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication validation during checkout to ensure stricter user sign-in checks before allowing checkout instance creation.

* **Documentation**
  * Added a changeset describing the update and its impact on authentication state resolution during checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->