### PR TITLE
feat(clerk-js): Use SameSite=none by default for development instances

### DIFF
--- a/.changeset/famous-news-judge.md
+++ b/.changeset/famous-news-judge.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Fixes an issue where cookies were not properly cleared on sign out when using non-default cookie attributes.

--- a/packages/clerk-js/src/core/auth/AuthCookieService.ts
+++ b/packages/clerk-js/src/core/auth/AuthCookieService.ts
@@ -73,8 +73,8 @@ export class AuthCookieService {
     this.refreshTokenOnFocus();
     this.startPollingForToken();
 
-    this.clientUat = createClientUatCookie(cookieSuffix);
-    this.sessionCookie = createSessionCookie(cookieSuffix);
+    this.clientUat = createClientUatCookie({ cookieSuffix, isProduction: this.instanceType === 'production' });
+    this.sessionCookie = createSessionCookie({ cookieSuffix, isProduction: this.instanceType === 'production' });
     this.activeCookie = createCookieHandler('clerk_active_context');
     this.devBrowser = createDevBrowser({
       frontendApi: clerk.frontendApi,

--- a/packages/clerk-js/src/core/auth/AuthCookieService.ts
+++ b/packages/clerk-js/src/core/auth/AuthCookieService.ts
@@ -68,6 +68,8 @@ export class AuthCookieService {
       this.setClientUatCookieForDevelopmentInstances();
     });
 
+    eventBus.on(events.UserSignOut, () => this.handleSignOut());
+
     this.refreshTokenOnFocus();
     this.startPollingForToken();
 
@@ -210,6 +212,12 @@ export class AuthCookieService {
     // Treat any other error as a noop
     // TODO(debug-logs): Once debug logs is available log this error.
     // --------
+  }
+
+  private handleSignOut() {
+    this.activeCookie.remove();
+    this.sessionCookie.remove();
+    this.setClientUatCookieForDevelopmentInstances();
   }
 
   /**

--- a/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
+++ b/packages/clerk-js/src/core/auth/cookies/__tests__/session.test.ts
@@ -71,6 +71,30 @@ describe('createSessionCookie', () => {
     expect(mockRemove).toHaveBeenCalledTimes(2);
   });
 
+  it('should remove cookies with the same attributes as set', () => {
+    const cookieHandler = createSessionCookie(mockCookieSuffix);
+    cookieHandler.set(mockToken);
+    cookieHandler.remove();
+
+    const expectedAttributes = {
+      sameSite: 'Lax',
+      secure: true,
+      partitioned: false,
+    };
+
+    expect(mockSet).toHaveBeenCalledWith(mockToken, {
+      expires: mockExpires,
+      sameSite: 'Lax',
+      secure: true,
+      partitioned: false,
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith(expectedAttributes);
+    expect(mockRemove).toHaveBeenCalledTimes(2);
+    expect(mockRemove).toHaveBeenNthCalledWith(1, expectedAttributes);
+    expect(mockRemove).toHaveBeenNthCalledWith(2, expectedAttributes);
+  });
+
   it('should get cookie value from suffixed cookie first, then fallback to non-suffixed', () => {
     mockGet.mockImplementationOnce(() => 'suffixed-value').mockImplementationOnce(() => 'non-suffixed-value');
 

--- a/packages/clerk-js/src/core/auth/cookies/clientUat.ts
+++ b/packages/clerk-js/src/core/auth/cookies/clientUat.ts
@@ -20,7 +20,13 @@ export type ClientUatCookieHandler = {
  * The cookie is used as hint from the Clerk Backend packages to identify
  * if the user is authenticated or not.
  */
-export const createClientUatCookie = (cookieSuffix: string): ClientUatCookieHandler => {
+export const createClientUatCookie = ({
+  cookieSuffix,
+  isProduction,
+}: {
+  cookieSuffix: string;
+  isProduction: boolean;
+}): ClientUatCookieHandler => {
   const clientUatCookie = createCookieHandler(CLIENT_UAT_COOKIE_NAME);
   const suffixedClientUatCookie = createCookieHandler(getSuffixedCookieName(CLIENT_UAT_COOKIE_NAME, cookieSuffix));
 
@@ -37,7 +43,13 @@ export const createClientUatCookie = (cookieSuffix: string): ClientUatCookieHand
      * Generally, this is handled by redirectWithAuth() being called and relying on the dev browser ID in the URL,
      * but if that isn't used we rely on this. In production, nothing is cross-domain and Lax is used when client_uat is set from FAPI.
      */
-    const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() ? 'None' : 'Strict';
+    const sameSite = __BUILD_VARIANT_CHIPS__
+      ? 'None'
+      : inCrossOriginIframe()
+        ? 'None'
+        : isProduction
+          ? 'Strict'
+          : 'None';
     const secure = getSecureAttribute(sameSite);
     const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
     const domain = getCookieDomain();

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -3,6 +3,7 @@ import { addYears } from '@clerk/shared/date';
 import { DEV_BROWSER_JWT_KEY } from '@clerk/shared/devBrowser';
 import { getSuffixedCookieName } from '@clerk/shared/keys';
 
+import { inCrossOriginIframe } from '../../../utils';
 import { getSecureAttribute } from '../getSecureAttribute';
 
 export type DevBrowserCookieHandler = {

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -3,13 +3,18 @@ import { addYears } from '@clerk/shared/date';
 import { DEV_BROWSER_JWT_KEY } from '@clerk/shared/devBrowser';
 import { getSuffixedCookieName } from '@clerk/shared/keys';
 
-import { inCrossOriginIframe } from '../../../utils';
 import { getSecureAttribute } from '../getSecureAttribute';
 
 export type DevBrowserCookieHandler = {
   set: (jwt: string) => void;
   get: () => string | undefined;
   remove: () => void;
+};
+
+const getCookieAttributes = (): { sameSite: string; secure: boolean } => {
+  const sameSite = 'None';
+  const secure = getSecureAttribute(sameSite);
+  return { sameSite, secure };
 };
 
 /**
@@ -26,16 +31,16 @@ export const createDevBrowserCookie = (cookieSuffix: string): DevBrowserCookieHa
 
   const set = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
-    const secure = getSecureAttribute(sameSite);
+    const { sameSite, secure } = getCookieAttributes();
 
     suffixedDevBrowserCookie.set(jwt, { expires, sameSite, secure });
     devBrowserCookie.set(jwt, { expires, sameSite, secure });
   };
 
   const remove = () => {
-    suffixedDevBrowserCookie.remove();
-    devBrowserCookie.remove();
+    const attributes = getCookieAttributes();
+    suffixedDevBrowserCookie.remove(attributes);
+    devBrowserCookie.remove(attributes);
   };
 
   return {

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -13,7 +13,7 @@ export type DevBrowserCookieHandler = {
 };
 
 const getCookieAttributes = (): { sameSite: string; secure: boolean } => {
-  const sameSite = 'None';
+  const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
   const secure = getSecureAttribute(sameSite);
   return { sameSite, secure };
 };

--- a/packages/clerk-js/src/core/auth/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/devBrowser.ts
@@ -26,7 +26,7 @@ export type CreateDevBrowserOptions = {
 };
 
 export function createDevBrowser({ cookieSuffix, frontendApi, fapiClient }: CreateDevBrowserOptions): DevBrowser {
-  const devBrowserCookie = createDevBrowserCookie(cookieSuffix);
+  const devBrowserCookie = createDevBrowserCookie({ cookieSuffix });
 
   function getDevBrowserJWT() {
     return devBrowserCookie.get();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -485,8 +485,6 @@ export class Clerk implements ClerkInterface {
 
       // Notify other tabs that user is signing out.
       eventBus.emit(events.UserSignOut, null);
-      // Clean up cookies
-      eventBus.emit(events.TokenUpdate, { token: null });
 
       this.#setTransitiveState();
 

--- a/packages/shared/src/cookie.ts
+++ b/packages/shared/src/cookie.ts
@@ -1,10 +1,17 @@
 import Cookies from 'js-cookie';
 
-type LocationAttributes = {
-  path?: string;
-  domain?: string;
-};
-
+/**
+ * Creates helper methods for dealing with a specific cookie.
+ *
+ * @example
+ * ```ts
+ * const cookie = createCookieHandler('my_cookie')
+ *
+ * cookie.set('my_value');
+ * cookie.get() // 'my_value';
+ * cookie.remove()
+ * ```
+ */
 export function createCookieHandler(cookieName: string) {
   return {
     get() {
@@ -18,10 +25,12 @@ export function createCookieHandler(cookieName: string) {
     },
     /**
      * On removing a cookie, you have to pass the exact same path/domain attributes used to set it initially
+     * > IMPORTANT! When deleting a cookie and you're not relying on the default attributes, you must pass the exact same path, domain, secure and sameSite attributes that were used to set the cookie.
+     *
      * @see https://github.com/js-cookie/js-cookie#basic-usage
      */
-    remove(locationAttributes?: LocationAttributes) {
-      Cookies.remove(cookieName, locationAttributes);
+    remove(cookieAttributes?: Cookies.CookieAttributes) {
+      Cookies.remove(cookieName, cookieAttributes);
     },
   };
 }


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

In development, we want to make sure that Clerk can work across a variety of environments, one being embedded previews in Gen AI tools (or other similar flavor of builders). When setting cookies in a cross origin iframe, we need to use `"SameSite=none`. Additionally, we want to make sure that the previews retain session state when opened in a new window ("full-screen"), so we can't rely on something like [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies).

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
