### PR TITLE
fix(themes): Add dark invert style to provider icons in shadcn theme

### DIFF
--- a/.changeset/stupid-roses-call.md
+++ b/.changeset/stupid-roses-call.md
@@ -1,0 +1,5 @@
+---
+'@clerk/themes': patch
+---
+
+Fix shadcn theme provider icon rendering in dark mode for Apple, GitHub, and OKX Wallet.

--- a/packages/themes/src/themes/shadcn.ts
+++ b/packages/themes/src/themes/shadcn.ts
@@ -31,5 +31,8 @@ export const shadcn = experimental_createTheme({
         display: 'none',
       },
     },
+    providerIcon__apple: 'dark:invert',
+    providerIcon__github: 'dark:invert',
+    providerIcon__okx_wallet: 'dark:invert',
   },
 });


### PR DESCRIPTION
## Description

Applied 'dark:invert' styling to Apple, GitHub, and OKX Wallet provider icons for improved visibility in dark mode.

BEFORE

https://github.com/user-attachments/assets/15edc9c6-4e3f-4511-8a04-9b0a7172a89f

AFTER

https://github.com/user-attachments/assets/5938c90d-2bd9-4f76-b80d-5580acd7413c

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where Apple, GitHub, and OKX Wallet icons did not display correctly in dark mode when using the shadcn theme. Icons now appear properly in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->