### PR TITLE
fix(clerk-js): Improve after-auth navigation within `SignIn` and `SignUp`

### DIFF
--- a/.changeset/plain-otters-joke.md
+++ b/.changeset/plain-otters-joke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Improve after-auth navigation within `SignIn` and `SignUp`

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -30,9 +30,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1322,7 +1322,6 @@ export class Clerk implements ClerkInterface {
 
     await tracker.track(async () => {
       if (!this.environment) {
-        // Typescript is not happy because since thinks this.client might have changed to undefined because the function is asynchronous.
         return;
       }
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -30,9 +30,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1318,15 +1318,28 @@ export class Clerk implements ClerkInterface {
       eventBus.emit(events.TokenUpdate, { token: null });
     }
 
-    // Only triggers navigation for internal AIO components routing or custom URLs
-    const shouldNavigateOnSetActive = this.#componentNavigationContext;
-    if (newSession?.currentTask && shouldNavigateOnSetActive) {
-      await navigateToTask(session.currentTask.key, {
-        options: this.#options,
-        environment: this.environment,
-        globalNavigate: this.navigate,
-        componentNavigationContext: this.#componentNavigationContext,
-      });
+    const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
+
+    await tracker.track(async () => {
+      if (!this.environment) {
+        // Typescript is not happy because since thinks this.client might have changed to undefined because the function is asynchronous.
+        return;
+      }
+
+      // Only triggers navigation for internal AIO components routing or custom URLs
+      const shouldNavigateOnSetActive = this.#componentNavigationContext;
+      if (newSession?.currentTask && shouldNavigateOnSetActive) {
+        await navigateToTask(session.currentTask.key, {
+          options: this.#options,
+          environment: this.environment,
+          globalNavigate: this.navigate,
+          componentNavigationContext: this.#componentNavigationContext,
+        });
+      }
+    });
+
+    if (tracker.isUnloading()) {
+      return;
     }
 
     this.#setAccessors(session);

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -1,4 +1,4 @@
-import { createContextAndHook } from '@clerk/shared/react';
+import { createContextAndHook, useClerk } from '@clerk/shared/react';
 import type { PropsWithChildren } from 'react';
 import React, { useCallback } from 'react';
 
@@ -41,6 +41,7 @@ type UseFieldOTP = <R = unknown>(params: {
 
 export const useFieldOTP: UseFieldOTP = params => {
   const card = useCardState();
+  const clerk = useClerk();
   const {
     id = 'code',
     onCodeEntryFinished: paramsOnCodeEntryFinished,
@@ -84,8 +85,10 @@ export const useFieldOTP: UseFieldOTP = params => {
     [codeControl, paramsOnResendCodeClicked],
   );
 
+  const setActiveInProgressForAfterAuth = clerk.__internal_setActiveInProgress && clerk.__internal_hasAfterAuthFlows;
+
   return {
-    isLoading: status.isLoading,
+    isLoading: status.isLoading || setActiveInProgressForAfterAuth,
     otpControl: codeControl,
     onResendCode: paramsOnResendCodeClicked ? onResendCode : undefined,
     onFakeContinue,

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -85,6 +85,8 @@ export const useFieldOTP: UseFieldOTP = params => {
     [codeControl, paramsOnResendCodeClicked],
   );
 
+  // While `setActive` is executing for after-auth navigation within `SignIn` and `SignUp`
+  // and the OTP routes keep mounted, it should still display the loading status
   const setActiveInProgressForAfterAuth = clerk.__internal_setActiveInProgress && clerk.__internal_hasAfterAuthFlows;
 
   return {

--- a/packages/clerk-js/src/ui/router/Route.tsx
+++ b/packages/clerk-js/src/ui/router/Route.tsx
@@ -30,8 +30,9 @@ const RouteGuard = ({ canActivate, children }: React.PropsWithChildren<RouteGuar
   const { navigateToFlowStart } = useNavigateToFlowStart();
   const clerk = useClerk();
 
-  const isNavigatingToTasks = clerk.__internal_setActiveInProgress && !!clerk.__internal_hasAfterAuthFlows;
-  const canActivateResult = canActivate(clerk) || isNavigatingToTasks;
+  // Do not unmount SignIn/SignUp routes while `setActive` is in-progress for after-auth tasks navigation
+  const setActiveInProgressForAfterAuth = clerk.__internal_setActiveInProgress && !!clerk.__internal_hasAfterAuthFlows;
+  const canActivateResult = canActivate(clerk) || setActiveInProgressForAfterAuth;
 
   React.useEffect(() => {
     if (!canActivateResult) {
@@ -46,7 +47,6 @@ const RouteGuard = ({ canActivate, children }: React.PropsWithChildren<RouteGuar
 
 export function Route(props: RouteProps): JSX.Element | null {
   const router = useRouter();
-  const clerk = useClerk();
 
   if (!props.children) {
     return null;
@@ -99,9 +99,6 @@ export function Route(props: RouteProps): JSX.Element | null {
         pathFromFullPath(router.fullPath).replace('/' + router.basePath, '')
       : router.flowStartPath) || router.startPath;
 
-  // Do not unmount SignIn/SignUp routes while `setActive` is in-progress for tasks navigation
-  const canActivate = props.canActivate;
-
   return (
     <RouteContext.Provider
       value={{
@@ -128,7 +125,7 @@ export function Route(props: RouteProps): JSX.Element | null {
         urlStateParam: router.urlStateParam,
       }}
     >
-      {canActivate ? <RouteGuard canActivate={canActivate}>{props.children}</RouteGuard> : props.children}
+      {props.canActivate ? <RouteGuard canActivate={props.canActivate}>{props.children}</RouteGuard> : props.children}
     </RouteContext.Provider>
   );
 }

--- a/packages/clerk-js/src/utils/componentGuards.ts
+++ b/packages/clerk-js/src/utils/componentGuards.ts
@@ -7,7 +7,7 @@ export type ComponentGuard = (
 ) => boolean;
 
 export const sessionExistsAndSingleSessionModeEnabled: ComponentGuard = (clerk, environment) => {
-  return !!(clerk.session && environment?.authConfig.singleSessionMode);
+  return !!(clerk.isSignedIn && environment?.authConfig.singleSessionMode);
 };
 
 export const noUserExists: ComponentGuard = clerk => {


### PR DESCRIPTION
## Description

- Fixes issue where OTP routes get unmounted once the session accessors get updated with a `pending` status and the client does not have an active sign-in/sign-up anymore
- Instead of unmounting, it keeps the routes with a loading status until `setActive` finishes 
- Set an unload tracker to avoid UI flickers 
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior after authentication in SignIn and SignUp components to prevent issues during page unload events.
  * Enhanced loading indicators for one-time password (OTP) fields to accurately reflect ongoing authentication processes.
  * Ensured authentication routes remain mounted during after-auth flows for smoother user experience.
  * Updated session checks to more reliably determine sign-in status in single session mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->