### PR TITLE
chore(nextjs,clerk-react): Commerce hooks from the experimental module

### DIFF
--- a/.changeset/pretty-poets-smile.md
+++ b/.changeset/pretty-poets-smile.md
@@ -1,0 +1,17 @@
+---
+'@clerk/nextjs': minor
+'@clerk/clerk-react': minor
+---
+
+Expose commerce hooks and components under the experimental module.
+
+- PaymentElementProvider,
+- usePaymentElement,
+- PaymentElement,
+- usePaymentAttempts,
+- useStatements,
+- usePaymentMethods,
+- usePlans,
+- useSubscription,
+- CheckoutProvider,
+- useCheckout,

--- a/packages/nextjs/src/client-boundary/hooks.ts
+++ b/packages/nextjs/src/client-boundary/hooks.ts
@@ -11,11 +11,6 @@ export {
   useSignUp,
   useUser,
   useReverification,
-  __experimental_useCheckout,
-  __experimental_CheckoutProvider,
-  __experimental_usePaymentElement,
-  __experimental_PaymentElementProvider,
-  __experimental_PaymentElement,
 } from '@clerk/clerk-react';
 
 export {

--- a/packages/nextjs/src/experimental.ts
+++ b/packages/nextjs/src/experimental.ts
@@ -1,6 +1,7 @@
 'use client';
 
-export { CheckoutButton, PlanDetailsButton, SubscriptionDetailsButton } from '@clerk/clerk-react/experimental';
+export * from '@clerk/clerk-react/experimental';
+
 export type {
   __experimental_CheckoutButtonProps as CheckoutButtonProps,
   __experimental_SubscriptionDetailsButtonProps as SubscriptionDetailsButtonProps,

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -54,11 +54,6 @@ export {
   useSignUp,
   useUser,
   useReverification,
-  __experimental_usePaymentElement,
-  __experimental_PaymentElementProvider,
-  __experimental_PaymentElement,
-  __experimental_useCheckout,
-  __experimental_CheckoutProvider,
 } from './client-boundary/hooks';
 
 /**

--- a/packages/react/src/experimental.ts
+++ b/packages/react/src/experimental.ts
@@ -1,3 +1,22 @@
 export { CheckoutButton } from './components/CheckoutButton';
 export { PlanDetailsButton } from './components/PlanDetailsButton';
 export { SubscriptionDetailsButton } from './components/SubscriptionDetailsButton';
+
+export type {
+  __experimental_CheckoutButtonProps as CheckoutButtonProps,
+  __experimental_SubscriptionDetailsButtonProps as SubscriptionDetailsButtonProps,
+  __experimental_PlanDetailsButtonProps as PlanDetailsButtonProps,
+} from '@clerk/types';
+
+export {
+  __experimental_PaymentElementProvider as PaymentElementProvider,
+  __experimental_usePaymentElement as usePaymentElement,
+  __experimental_PaymentElement as PaymentElement,
+  __experimental_usePaymentAttempts as usePaymentAttempts,
+  __experimental_useStatements as useStatements,
+  __experimental_usePaymentMethods as usePaymentMethods,
+  __experimental_usePlans as usePlans,
+  __experimental_useSubscription as useSubscription,
+  __experimental_CheckoutProvider as CheckoutProvider,
+  __experimental_useCheckout as useCheckout,
+} from '@clerk/shared/react';


### PR DESCRIPTION
## Description

For nextjs re-export all experimental commerce apis from `@clerk/nextjs/experimental`

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a set of experimental commerce-related hooks and components, including payment and subscription elements, now accessible under an experimental namespace.
  * Added new types and button components for checkout, plan details, and subscription details.

* **Refactor**
  * Updated exports to provide a consolidated and stable interface for experimental payment and subscription features.
  * Adjusted export structure to re-export all experimental components from a single entry point for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->