### PR TITLE
fix(clerk-js): Remove cache revalidation hooks from pending session handling

### DIFF
--- a/.changeset/full-impalas-wonder.md
+++ b/.changeset/full-impalas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove cache revalidation hooks from pending session handling. This fixes unmounting issues from `SignIn` and `SignUp` AIOs during after-auth flows.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1225,16 +1225,15 @@ export class Clerk implements ClerkInterface {
         }
       }
 
+      if (newSession?.status === 'pending') {
+        await this.#handlePendingSession(newSession);
+        return;
+      }
+
       /**
        * Hint to each framework, that the user will be signed out when `{session: null}` is provided.
        */
       await onBeforeSetActive(newSession === null ? 'sign-out' : undefined);
-
-      if (newSession?.status === 'pending') {
-        await this.#handlePendingSession(newSession);
-        await onAfterSetActive();
-        return;
-      }
 
       //1. setLastActiveSession to passed user session (add a param).
       //   Note that this will also update the session's active organization


### PR DESCRIPTION
## Description

This PR removes `onBeforeSetActive` and `onAfterSetActive` from being executed on the pending session handling within `setActive` 

This was leading to multiple issues of `SignIn` and `SignUp` getting unmounted, since the server would refetch/refresh components and leave the `session` with an `undefined` state, causing `withCoreSessionGuard` to unmount AIOs. 

We didn't have these issues outside of after-auth flows (meaning when `pending` status doesn't exist and it goes from an empty session to `active`) since `setActive` would always execute Next.js router navigation to a page outside of AIOs. 

---

**Tradeoffs**

Since those cache revalidation hooks aren't executed, it's possible that RSCs and middleware logic that relies on the pending session, doesn't get trigger once the AIO is on the `select-organization` screen. Examples could be trying to extract the `userId` with `auth({ treatPendingAsSignedOut: false })` 

We think the tradeoff is worth tho, since atm, there's no clear indication that this would make sense while using AIOs in an after-auth flow. 

If the developer wants to rely on the pending session granularly as a signed-in state on server-side logic, they can do so with custom pages by ejecting out of AIOs with `<ClerkProvider taskUrls={{ 'select-organization': '/my-server-rendered-page' />`

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues causing component unmounting in SignIn and SignUp All-In-One flows after authentication.
  * Improved session handling to prevent unmounting problems during post-authentication processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->