### PR TITLE
Following redirect url after creating an account from `/sign-in/choose`

### DIFF
--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -4,6 +4,7 @@ import type { SignedInSessionResource, UserButtonProps, UserResource } from '@cl
 import { useCardState } from '@/ui/elements/contexts';
 import { sleep } from '@/ui/utils/sleep';
 
+import { buildURL } from '../../../utils';
 import { windowNavigate } from '../../../utils/windowNavigate';
 import { useMultipleSessions } from '../../hooks/useMultipleSessions';
 import { useRouter } from '../../router';
@@ -79,7 +80,25 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
   };
 
   const handleAddAccountClicked = () => {
-    windowNavigate(opts.signInUrl || window.location.href);
+    const signInUrl = opts.signInUrl || window.location.href;
+
+    // If we have an afterSwitchSessionUrl, append it as a query parameter
+    if (opts.afterSwitchSessionUrl) {
+      const searchParams = new URLSearchParams();
+      searchParams.set('redirect_url', opts.afterSwitchSessionUrl);
+
+      const url = buildURL(
+        {
+          base: signInUrl,
+          searchParams,
+        },
+        { stringify: true },
+      );
+      windowNavigate(url);
+    } else {
+      windowNavigate(signInUrl);
+    }
+
     return sleep(2000);
   };
 


### PR DESCRIPTION
Currently if a user is on `/sign-in/choose` with a redirect_url e.g. `https://direct-flamingo-24.accounts.lclclerk.com/sign-in/choose?redirect_url=https%3A%2F%2Fdirect-flamingo-24.accounts.lclclerk.com%2Ftest`

If you select a session, it follows the redirect url after selecting a session.

However when selecting "Add Account" it will not follow the redirect url after adding the account.

This is a POC (**not to be reviewed**) to demonstrate a working-example of how we can solve this