### PR TITLE
fix(backend): Derive origin from request URL

### DIFF
--- a/.changeset/tidy-windows-travel.md
+++ b/.changeset/tidy-windows-travel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fixes an issue where the Clerk SDK was improperly detecting the request's origin.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1411,7 +1411,6 @@ describe('tokens.authenticateRequest(options)', () => {
         {
           referer: 'https://satellite.com/signin',
           'sec-fetch-dest': 'document',
-          origin: 'https://primary.com',
         },
         {
           __session: mockJwt,
@@ -1441,7 +1440,6 @@ describe('tokens.authenticateRequest(options)', () => {
           referer: 'https://satellite.com/signin',
           'sec-fetch-dest': 'document',
           'sec-fetch-site': 'cross-site',
-          origin: 'https://primary.com',
         },
         {
           __session: mockJwt,
@@ -1468,9 +1466,9 @@ describe('tokens.authenticateRequest(options)', () => {
     test('does not trigger handshake when referer is same origin', async () => {
       const request = mockRequestWithCookies(
         {
+          host: 'primary.com',
           referer: 'https://primary.com/signin',
           'sec-fetch-dest': 'document',
-          origin: 'https://primary.com',
         },
         {
           __session: mockJwt,

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -174,7 +174,7 @@ class AuthenticateContext implements AuthenticateContext {
    * @returns {boolean} True if referrer exists and is from a different origin, false otherwise.
    */
   public isCrossOriginReferrer(): boolean {
-    if (!this.referrer || !this.origin) {
+    if (!this.referrer || !this.clerkUrl.origin) {
       return false;
     }
 
@@ -184,7 +184,7 @@ class AuthenticateContext implements AuthenticateContext {
       }
 
       const referrerOrigin = new URL(this.referrer).origin;
-      return referrerOrigin !== this.origin;
+      return referrerOrigin !== this.clerkUrl.origin;
     } catch {
       // Invalid referrer URL format
       return false;


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Fixes an issue where if the origin header is not present, the cross origin check would not properly execute. The origin header is actually not sent in many cases, and so I wasn't seeing this handshake case trigger when I was expecting it to. The origin that we really want is the request URL's origin, and so I've switched to using that value.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of request origin to address issues with cross-origin requests in the Clerk SDK backend.
* **Chores**
  * Updated internal documentation to reflect the patch update.
  * Adjusted test cases to better align with the updated origin detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->