### PR TITLE
chore(backend): Add `taskUrls` as `clerkMiddleware` option

### DIFF
--- a/packages/backend/src/tokens/types.ts
+++ b/packages/backend/src/tokens/types.ts
@@ -1,5 +1,5 @@
 import type { MatchFunction } from '@clerk/shared/pathToRegexp';
-import type { PendingSessionOptions } from '@clerk/types';
+import type { PendingSessionOptions, SessionTask } from '@clerk/types';
 
 import type { ApiClient, APIKey, IdPOAuthAccessToken, MachineToken } from '../api';
 import type {
@@ -67,6 +67,13 @@ export type AuthenticateRequestOptions = {
    * @default 'session_token'
    */
   acceptsToken?: TokenType | TokenType[] | 'any';
+  /**
+   * Customize the URL paths users are redirected to after sign-in or sign-up when specific
+   * session tasks need to be completed.
+   *
+   * @default undefined - Uses Clerk's default task flow URLs
+   */
+  taskUrls?: Record<SessionTask['key'], string>;
 } & VerifyTokenOptions;
 
 /**


### PR DESCRIPTION
## Description

Introduces `taskUrls` as `clerkMiddleware` option to redirect to pages, where `TaskSelectOrganization` gets rendered, on `auth.protect()`

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
