### PR TITLE
chore(backend): Add scoping and secret key retrieval to machines BAPI

### DIFF
--- a/.changeset/five-jokes-clap.md
+++ b/.changeset/five-jokes-clap.md
@@ -1,0 +1,16 @@
+---
+"@clerk/backend": patch
+---
+
+Adds scoping and secret key retrieval to machines BAPI methods:
+
+```ts
+// Creates a new machine scope
+clerkClient.machines.createScope('machine_id', 'to_machine'id)
+
+// Deletes a machine scope
+clerkClient.machines.deleteScope('machine_id', 'other_machine'id)
+
+// Retrieve a secret key
+clerkClient.machines.getSecretKey('machine_id')
+```

--- a/.changeset/five-jokes-clap.md
+++ b/.changeset/five-jokes-clap.md
@@ -6,10 +6,10 @@ Adds scoping and secret key retrieval to machines BAPI methods:
 
 ```ts
 // Creates a new machine scope
-clerkClient.machines.createScope('machine_id', 'to_machine'id)
+clerkClient.machines.createScope('machine_id', 'to_machine_id')
 
 // Deletes a machine scope
-clerkClient.machines.deleteScope('machine_id', 'other_machine'id)
+clerkClient.machines.deleteScope('machine_id', 'other_machine_id')
 
 // Retrieve a secret key
 clerkClient.machines.getSecretKey('machine_id')

--- a/packages/backend/src/api/__tests__/MachineApi.test.ts
+++ b/packages/backend/src/api/__tests__/MachineApi.test.ts
@@ -1,0 +1,204 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server, validateHeaders } from '../../mock-server';
+import { createBackendApiClient } from '../factory';
+
+describe('MachineAPI', () => {
+  const apiClient = createBackendApiClient({
+    apiUrl: 'https://api.clerk.test',
+    secretKey: 'deadbeef',
+  });
+
+  const machineId = 'machine_123';
+  const otherMachineId = 'machine_456';
+
+  const mockSecondMachine = {
+    object: 'machine',
+    id: otherMachineId,
+    name: 'Second Machine',
+    instance_id: 'inst_456',
+    created_at: 1640995200,
+    updated_at: 1640995200,
+  };
+
+  const mockMachine = {
+    object: 'machine',
+    id: machineId,
+    name: 'Test Machine',
+    instance_id: 'inst_123',
+    created_at: 1640995200,
+    updated_at: 1640995200,
+    scoped_machines: [mockSecondMachine],
+  };
+
+  const mockMachineScope = {
+    object: 'machine_scope',
+    from_machine_id: machineId,
+    to_machine_id: otherMachineId,
+    created_at: 1640995200,
+  };
+
+  const mockMachineSecretKey = {
+    secret: 'ak_test_...',
+  };
+
+  const mockPaginatedResponse = {
+    data: [mockMachine],
+    total_count: 1,
+  };
+
+  it('fetches a machine by ID', async () => {
+    server.use(
+      http.get(
+        `https://api.clerk.test/v1/machines/${machineId}`,
+        validateHeaders(() => {
+          return HttpResponse.json(mockMachine);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.get(machineId);
+
+    expect(response.id).toBe(machineId);
+    expect(response.name).toBe('Test Machine');
+  });
+
+  it('fetches machines list with query parameters', async () => {
+    server.use(
+      http.get(
+        'https://api.clerk.test/v1/machines',
+        validateHeaders(({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('limit')).toBe('10');
+          expect(url.searchParams.get('offset')).toBe('5');
+          expect(url.searchParams.get('query')).toBe('test');
+          return HttpResponse.json(mockPaginatedResponse);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.list({
+      limit: 10,
+      offset: 5,
+      query: 'test',
+    });
+
+    expect(response.data).toHaveLength(1);
+    expect(response.totalCount).toBe(1);
+  });
+
+  it('creates a machine with scoped machines', async () => {
+    const createParams = {
+      name: 'New Machine',
+      scoped_machines: [otherMachineId],
+      default_token_ttl: 7200,
+    };
+
+    server.use(
+      http.post(
+        'https://api.clerk.test/v1/machines',
+        validateHeaders(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual(createParams);
+          return HttpResponse.json(mockMachine);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.create(createParams);
+
+    expect(response.id).toBe(machineId);
+    expect(response.name).toBe('Test Machine');
+    expect(response.scopedMachines).toHaveLength(1);
+    expect(response.scopedMachines[0].id).toBe(otherMachineId);
+    expect(response.scopedMachines[0].name).toBe('Second Machine');
+  });
+
+  it('updates a machine with partial parameters', async () => {
+    const updateParams = {
+      machineId,
+      name: 'Updated Machine',
+    };
+
+    server.use(
+      http.patch(
+        `https://api.clerk.test/v1/machines/${machineId}`,
+        validateHeaders(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual({ name: 'Updated Machine' });
+          return HttpResponse.json(mockMachine);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.update(updateParams);
+
+    expect(response.id).toBe(machineId);
+    expect(response.name).toBe('Test Machine');
+  });
+
+  it('deletes a machine', async () => {
+    server.use(
+      http.delete(
+        `https://api.clerk.test/v1/machines/${machineId}`,
+        validateHeaders(() => {
+          return HttpResponse.json(mockMachine);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.delete(machineId);
+
+    expect(response.id).toBe(machineId);
+  });
+
+  it('fetches machine secret key', async () => {
+    server.use(
+      http.get(
+        `https://api.clerk.test/v1/machines/${machineId}/secret_key`,
+        validateHeaders(() => {
+          return HttpResponse.json(mockMachineSecretKey);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.getSecretKey(machineId);
+
+    expect(response.secret).toBe('ak_test_...');
+  });
+
+  it('creates a machine scope', async () => {
+    server.use(
+      http.post(
+        `https://api.clerk.test/v1/machines/${machineId}/scopes`,
+        validateHeaders(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual({ to_machine_id: otherMachineId });
+          return HttpResponse.json(mockMachineScope);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.createScope(machineId, otherMachineId);
+
+    expect(response.fromMachineId).toBe(machineId);
+    expect(response.toMachineId).toBe(otherMachineId);
+  });
+
+  it('deletes a machine scope', async () => {
+    server.use(
+      http.delete(
+        `https://api.clerk.test/v1/machines/${machineId}/scopes/${otherMachineId}`,
+        validateHeaders(() => {
+          return HttpResponse.json(mockMachineScope);
+        }),
+      ),
+    );
+
+    const response = await apiClient.machines.deleteScope(machineId, otherMachineId);
+
+    expect(response.fromMachineId).toBe(machineId);
+    expect(response.toMachineId).toBe(otherMachineId);
+  });
+});

--- a/packages/backend/src/api/endpoints/MachineApi.ts
+++ b/packages/backend/src/api/endpoints/MachineApi.ts
@@ -6,7 +6,18 @@ import { AbstractAPI } from './AbstractApi';
 const basePath = '/machines';
 
 type CreateMachineParams = {
+  /**
+   * The name of the machine.
+   */
   name: string;
+  /**
+   * Array of machine IDs that this machine will have access to.
+   */
+  scopedMachines?: string[];
+  /**
+   * The default time-to-live (TTL) in seconds for tokens created by this machine.
+   */
+  defaultTokenTtl?: number;
 };
 
 type UpdateMachineParams = {

--- a/packages/backend/src/api/endpoints/MachineApi.ts
+++ b/packages/backend/src/api/endpoints/MachineApi.ts
@@ -2,6 +2,7 @@ import { joinPaths } from '../../util/path';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import type { Machine } from '../resources/Machine';
 import type { MachineScope } from '../resources/MachineScope';
+import type { MachineSecretKey } from '../resources/MachineSecretKey';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/machines';
@@ -82,6 +83,14 @@ export class MachineApi extends AbstractAPI {
     return this.request<Machine>({
       method: 'DELETE',
       path: joinPaths(basePath, machineId),
+    });
+  }
+
+  async getSecretKey(machineId: string) {
+    this.requireId(machineId);
+    return this.request<MachineSecretKey>({
+      method: 'GET',
+      path: joinPaths(basePath, machineId, 'secret_key'),
     });
   }
 

--- a/packages/backend/src/api/endpoints/MachineApi.ts
+++ b/packages/backend/src/api/endpoints/MachineApi.ts
@@ -1,6 +1,7 @@
 import { joinPaths } from '../../util/path';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import type { Machine } from '../resources/Machine';
+import type { MachineScope } from '../resources/MachineScope';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/machines';
@@ -28,7 +29,7 @@ type UpdateMachineParams = {
   /**
    * The name of the machine.
    */
-  name: string;
+  name?: string;
   /**
    * The default time-to-live (TTL) in seconds for tokens created by this machine.
    */
@@ -81,6 +82,37 @@ export class MachineApi extends AbstractAPI {
     return this.request<Machine>({
       method: 'DELETE',
       path: joinPaths(basePath, machineId),
+    });
+  }
+
+  /**
+   * Creates a new machine scope, allowing the specified machine to access another machine.
+   *
+   * @param machineId - The ID of the machine that will have access to another machine.
+   * @param toMachineId - The ID of the machine that will be scoped to the current machine.
+   */
+  async createScope(machineId: string, toMachineId: string) {
+    this.requireId(machineId);
+    return this.request<MachineScope>({
+      method: 'POST',
+      path: joinPaths(basePath, machineId, 'scopes'),
+      bodyParams: {
+        toMachineId,
+      },
+    });
+  }
+
+  /**
+   * Deletes a machine scope, removing access from one machine to another.
+   *
+   * @param machineId - The ID of the machine that has access to another machine.
+   * @param otherMachineId - The ID of the machine that is being accessed.
+   */
+  async deleteScope(machineId: string, otherMachineId: string) {
+    this.requireId(machineId);
+    return this.request<MachineScope>({
+      method: 'DELETE',
+      path: joinPaths(basePath, machineId, 'scopes', otherMachineId),
     });
   }
 }

--- a/packages/backend/src/api/endpoints/MachineApi.ts
+++ b/packages/backend/src/api/endpoints/MachineApi.ts
@@ -21,8 +21,18 @@ type CreateMachineParams = {
 };
 
 type UpdateMachineParams = {
+  /**
+   * The ID of the machine to update.
+   */
   machineId: string;
+  /**
+   * The name of the machine.
+   */
   name: string;
+  /**
+   * The default time-to-live (TTL) in seconds for tokens created by this machine.
+   */
+  defaultTokenTtl?: number;
 };
 
 type GetMachineListParams = {

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -17,6 +17,7 @@ import {
   JwtTemplate,
   Machine,
   MachineScope,
+  MachineSecretKey,
   MachineToken,
   OauthAccessToken,
   OAuthApplication,
@@ -138,6 +139,8 @@ function jsonToObject(item: any): any {
       return Machine.fromJSON(item);
     case ObjectType.MachineScope:
       return MachineScope.fromJSON(item);
+    case ObjectType.MachineSecretKey:
+      return MachineSecretKey.fromJSON(item);
     case ObjectType.MachineToken:
       return MachineToken.fromJSON(item);
     case ObjectType.OauthAccessToken:

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -16,6 +16,7 @@ import {
   Invitation,
   JwtTemplate,
   Machine,
+  MachineScope,
   MachineToken,
   OauthAccessToken,
   OAuthApplication,
@@ -135,6 +136,8 @@ function jsonToObject(item: any): any {
       return JwtTemplate.fromJSON(item);
     case ObjectType.Machine:
       return Machine.fromJSON(item);
+    case ObjectType.MachineScope:
+      return MachineScope.fromJSON(item);
     case ObjectType.MachineToken:
       return MachineToken.fromJSON(item);
     case ObjectType.OauthAccessToken:

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -35,6 +35,7 @@ export const ObjectType = {
   InstanceSettings: 'instance_settings',
   Invitation: 'invitation',
   Machine: 'machine',
+  MachineScope: 'machine_scope',
   MachineToken: 'machine_to_machine_token',
   JwtTemplate: 'jwt_template',
   OauthAccessToken: 'oauth_access_token',
@@ -710,6 +711,14 @@ export interface MachineJSON extends ClerkResourceJSON {
   instance_id: string;
   created_at: number;
   updated_at: number;
+}
+
+export interface MachineScopeJSON {
+  object: typeof ObjectType.MachineScope;
+  from_machine_id: string;
+  to_machine_id: string;
+  created_at?: number;
+  deleted?: boolean;
 }
 
 export interface MachineTokenJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -36,6 +36,7 @@ export const ObjectType = {
   Invitation: 'invitation',
   Machine: 'machine',
   MachineScope: 'machine_scope',
+  MachineSecretKey: 'machine_secret_key',
   MachineToken: 'machine_to_machine_token',
   JwtTemplate: 'jwt_template',
   OauthAccessToken: 'oauth_access_token',
@@ -719,6 +720,11 @@ export interface MachineScopeJSON {
   to_machine_id: string;
   created_at?: number;
   deleted?: boolean;
+}
+
+export interface MachineSecretKeyJSON {
+  object: typeof ObjectType.MachineSecretKey;
+  secret: string;
 }
 
 export interface MachineTokenJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -712,6 +712,8 @@ export interface MachineJSON extends ClerkResourceJSON {
   instance_id: string;
   created_at: number;
   updated_at: number;
+  default_token_ttl: number;
+  scoped_machines: MachineJSON[];
 }
 
 export interface MachineScopeJSON {

--- a/packages/backend/src/api/resources/Machine.ts
+++ b/packages/backend/src/api/resources/Machine.ts
@@ -7,9 +7,30 @@ export class Machine {
     readonly instanceId: string,
     readonly createdAt: number,
     readonly updatedAt: number,
+    readonly scopedMachines: Machine[],
+    readonly defaultTokenTtl: number,
   ) {}
 
   static fromJSON(data: MachineJSON): Machine {
-    return new Machine(data.id, data.name, data.instance_id, data.created_at, data.updated_at);
+    return new Machine(
+      data.id,
+      data.name,
+      data.instance_id,
+      data.created_at,
+      data.updated_at,
+      data.scoped_machines.map(
+        m =>
+          new Machine(
+            m.id,
+            m.name,
+            m.instance_id,
+            m.created_at,
+            m.updated_at,
+            [], // Nested machines don't have scoped_machines
+            m.default_token_ttl,
+          ),
+      ),
+      data.default_token_ttl,
+    );
   }
 }

--- a/packages/backend/src/api/resources/MachineScope.ts
+++ b/packages/backend/src/api/resources/MachineScope.ts
@@ -1,0 +1,14 @@
+import type { MachineScopeJSON } from './JSON';
+
+export class MachineScope {
+  constructor(
+    readonly fromMachineId: string,
+    readonly toMachineId: string,
+    readonly createdAt?: number,
+    readonly deleted?: boolean,
+  ) {}
+
+  static fromJSON(data: MachineScopeJSON): MachineScope {
+    return new MachineScope(data.from_machine_id, data.to_machine_id, data.created_at, data.deleted);
+  }
+}

--- a/packages/backend/src/api/resources/MachineSecretKey.ts
+++ b/packages/backend/src/api/resources/MachineSecretKey.ts
@@ -1,0 +1,9 @@
+import type { MachineSecretKeyJSON } from './JSON';
+
+export class MachineSecretKey {
+  constructor(readonly secret: string) {}
+
+  static fromJSON(data: MachineSecretKeyJSON): MachineSecretKey {
+    return new MachineSecretKey(data.secret);
+  }
+}

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -31,6 +31,7 @@ export * from './InstanceSettings';
 export * from './Invitation';
 export * from './JSON';
 export * from './Machine';
+export * from './MachineScope';
 export * from './MachineToken';
 export * from './JwtTemplate';
 export * from './OauthAccessToken';

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -32,6 +32,7 @@ export * from './Invitation';
 export * from './JSON';
 export * from './Machine';
 export * from './MachineScope';
+export * from './MachineSecretKey';
 export * from './MachineToken';
 export * from './JwtTemplate';
 export * from './OauthAccessToken';


### PR DESCRIPTION
## Description

This PR adds machine scope [creation](https://clerk.com/docs/reference/backend-api/tag/machines/post/machines/%7Bmachine_id%7D/scopes), [deletion](https://clerk.com/docs/reference/backend-api/tag/machines/delete/machines/%7Bmachine_id%7D/scopes/%7Bother_machine_id%7D) and machine [secret key retrieval](https://clerk.com/docs/reference/backend-api/tag/machines/get/machines/%7Bmachine_id%7D/secret_key) to `machines` BAPI

Resolves USER-2474

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to create and delete machine scopes, enabling management of authorization between machines.
  * Introduced functionality to retrieve secret keys associated with machines.
  * Enhanced machine creation and update options with additional parameters for scoped machines and token time-to-live.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->