### PR TITLE
fix(backend): Ability to convert bodyParam keys recursively

### DIFF
--- a/.changeset/silver-singers-train.md
+++ b/.changeset/silver-singers-train.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix SAML Connection `attributeMapping` keys not being converted from camelCase to snake_case.

--- a/packages/backend/src/api/__tests__/SamlConnectionApi.test.ts
+++ b/packages/backend/src/api/__tests__/SamlConnectionApi.test.ts
@@ -10,36 +10,36 @@ describe('SamlConnectionAPI', () => {
     secretKey: 'deadbeef',
   });
 
+  const mockSamlConnectionResponse = {
+    object: 'saml_connection',
+    id: 'samlc_123',
+    name: 'Test Connection',
+    provider: 'saml_custom',
+    domain: 'test.example.com',
+    organization_id: 'org_123',
+    created_at: 1672531200000,
+    updated_at: 1672531200000,
+    active: true,
+    sync_user_attributes: false,
+    allow_subdomains: false,
+    allow_idp_initiated: false,
+    idp_entity_id: 'entity_123',
+    idp_sso_url: 'https://idp.example.com/sso',
+    idp_certificate: 'cert_data',
+    idp_metadata_url: null,
+    idp_metadata: null,
+    attribute_mapping: {
+      user_id: 'userId',
+      email_address: 'email',
+      first_name: 'firstName',
+      last_name: 'lastName',
+    },
+  };
+
   describe('getSamlConnectionList', () => {
     it('successfully fetches SAML connections with all parameters', async () => {
       const mockSamlConnectionsResponse = {
-        data: [
-          {
-            object: 'saml_connection',
-            id: 'samlc_123',
-            name: 'Test Connection',
-            provider: 'saml_custom',
-            domain: 'test.example.com',
-            organization_id: 'org_123',
-            created_at: 1672531200000,
-            updated_at: 1672531200000,
-            active: true,
-            sync_user_attributes: false,
-            allow_subdomains: false,
-            allow_idp_initiated: false,
-            idp_entity_id: 'entity_123',
-            idp_sso_url: 'https://idp.example.com/sso',
-            idp_certificate: 'cert_data',
-            idp_metadata_url: null,
-            idp_metadata: null,
-            attribute_mapping: {
-              user_id: 'userId',
-              email_address: 'email',
-              first_name: 'firstName',
-              last_name: 'lastName',
-            },
-          },
-        ],
+        data: [mockSamlConnectionResponse],
         total_count: 1,
       };
 
@@ -71,6 +71,117 @@ describe('SamlConnectionAPI', () => {
       expect(response.data[0].name).toBe('Test Connection');
       expect(response.data[0].organizationId).toBe('org_123');
       expect(response.totalCount).toBe(1);
+    });
+  });
+
+  describe('createSamlConnection', () => {
+    it('successfully creates a SAML connection', async () => {
+      server.use(
+        http.post(
+          'https://api.clerk.test/v1/saml_connections',
+          validateHeaders(async ({ request }) => {
+            const body = await request.json();
+
+            expect(body).toEqual({
+              name: 'Test Connection',
+              provider: 'saml_custom',
+              domain: 'test.example.com',
+              attribute_mapping: {
+                user_id: 'userId',
+                email_address: 'email',
+                first_name: 'firstName',
+                last_name: 'lastName',
+              },
+            });
+
+            return HttpResponse.json(mockSamlConnectionResponse);
+          }),
+        ),
+      );
+
+      const response = await apiClient.samlConnections.createSamlConnection({
+        name: 'Test Connection',
+        provider: 'saml_custom',
+        domain: 'test.example.com',
+        attributeMapping: {
+          userId: 'userId',
+          emailAddress: 'email',
+          firstName: 'firstName',
+          lastName: 'lastName',
+        },
+      });
+
+      expect(response.id).toBe('samlc_123');
+      expect(response.name).toBe('Test Connection');
+      expect(response.organizationId).toBe('org_123');
+    });
+  });
+
+  describe('updateSamlConnection', () => {
+    it('successfully updates a SAML connection', async () => {
+      server.use(
+        http.patch(
+          'https://api.clerk.test/v1/saml_connections/samlc_123',
+          validateHeaders(async ({ request }) => {
+            const body = await request.json();
+
+            expect(body).toEqual({
+              name: 'Test Connection',
+              provider: 'saml_custom',
+              domain: 'test.example.com',
+              organization_id: 'org_123',
+              idp_entity_id: 'entity_123',
+              idp_sso_url: 'https://idp.example.com/sso',
+              idp_certificate: 'cert_data',
+              attribute_mapping: {
+                user_id: 'userId2',
+                email_address: 'email2',
+                first_name: 'firstName2',
+                last_name: 'lastName2',
+              },
+            });
+
+            return HttpResponse.json({
+              ...mockSamlConnectionResponse,
+              idp_entity_id: 'entity_123',
+              idp_sso_url: 'https://idp.example.com/sso',
+              idp_certificate: 'cert_data',
+              attribute_mapping: {
+                user_id: 'userId2',
+                email_address: 'email2',
+                first_name: 'firstName2',
+                last_name: 'lastName2',
+              },
+            });
+          }),
+        ),
+      );
+
+      const response = await apiClient.samlConnections.updateSamlConnection('samlc_123', {
+        name: 'Test Connection',
+        provider: 'saml_custom',
+        domain: 'test.example.com',
+        organizationId: 'org_123',
+        idpEntityId: 'entity_123',
+        idpSsoUrl: 'https://idp.example.com/sso',
+        idpCertificate: 'cert_data',
+        attributeMapping: {
+          userId: 'userId2',
+          emailAddress: 'email2',
+          firstName: 'firstName2',
+          lastName: 'lastName2',
+        },
+      });
+
+      expect(response.id).toBe('samlc_123');
+      expect(response.name).toBe('Test Connection');
+      expect(response.organizationId).toBe('org_123');
+      expect(response.attributeMapping).toEqual({
+        userId: 'userId2',
+        emailAddress: 'email2',
+        firstName: 'firstName2',
+        lastName: 'lastName2',
+      });
     });
   });
 });

--- a/packages/backend/src/api/endpoints/SamlConnectionApi.ts
+++ b/packages/backend/src/api/endpoints/SamlConnectionApi.ts
@@ -82,6 +82,9 @@ export class SamlConnectionAPI extends AbstractAPI {
       method: 'POST',
       path: basePath,
       bodyParams: params,
+      options: {
+        deepSnakecaseBodyParamKeys: true,
+      },
     });
   }
 
@@ -100,6 +103,9 @@ export class SamlConnectionAPI extends AbstractAPI {
       method: 'PATCH',
       path: joinPaths(basePath, samlConnectionId),
       bodyParams: params,
+      options: {
+        deepSnakecaseBodyParamKeys: true,
+      },
     });
   }
   public async deleteSamlConnection(samlConnectionId: string) {


### PR DESCRIPTION
## Description

Adds the ability to convert bodyParam keys recursively by adding `options.deepSnakecaseBodyParamKeys`.

I didn't default to `deep: true` to ensure that there weren't any regressions.

<!-- Fixes #(issue number) -->
USER-2475

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where SAML Connection attribute mapping keys were not properly converted to snake_case, ensuring correct formatting in API requests.

* **Tests**
  * Added and improved tests for creating and updating SAML Connections, including validation of request payloads and response handling.

* **Refactor**
  * Enhanced request handling to support deep snake_case conversion of body parameters, improving consistency in API communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->