### PR TITLE
fix(localizations): Add jaJP translations in User Profile Update

### DIFF
--- a/.changeset/fluffy-jeans-care.md
+++ b/.changeset/fluffy-jeans-care.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add ja-JP translations in `<UserProfile/>`.

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -1189,7 +1189,7 @@ export const jaJP: LocalizationResource = {
         title: '電話番号',
       },
       profileSection: {
-        primaryButton: undefined,
+        primaryButton: 'プロフィールを更新',
         title: 'プロフィール',
       },
       usernameSection: {

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -425,7 +425,7 @@ export const jaJP: LocalizationResource = {
       headerTitle__general: '一般',
       headerTitle__members: 'メンバー',
       profileSection: {
-        primaryButton: undefined,
+        primaryButton: 'プロフィールを更新',
         title: '組織プロフィール',
         uploadAction__title: 'ロゴ',
       },


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Add jaJP localization for user profile update button


## Summary

Added Japanese translation for the **Update Profile** button in the User Profile component.

Although it's only a two-line change, this fixes the issue where the **Update Profile** button disappears when using the `jaJP` locale.

## Detail

There was a bug where the **Update Profile** button would not render when the `jaJP` locale was applied. ([Reproduction](https://github.com/tsume-ha/clerk-react-jp-user-management))  
This was caused by the Japanese text for **Update Profile** being `undefined`.  
As a native speaker, I added the missing Japanese translation for the **Update Profile** button, fixing the issue so that it displays correctly under the `jaJP` locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing Japanese translations for the primary button in two profile sections, ensuring the button now displays "プロフィールを更新" ("Update Profile").
* **New Features**
  * Added Japanese language support for the user profile interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->