### PR TITLE
fix(clerk-js):  Allow modal closing after a new connected account

### DIFF
--- a/.changeset/poor-chicken-occur.md
+++ b/.changeset/poor-chicken-occur.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Added proper type checking before using the in operator to prevent errors when modal state contains non-object values

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -326,7 +326,7 @@ const Components = (props: ComponentsProps) => {
       setState(s => {
         function handleCloseModalForExperimentalUserVerification() {
           const modal = s[`${name}Modal`] || {};
-          if ('afterVerificationCancelled' in modal && notify) {
+          if (modal && typeof modal === 'object' && 'afterVerificationCancelled' in modal && notify) {
             modal.afterVerificationCancelled?.();
           }
         }


### PR DESCRIPTION
## Description

This issue causes the ClerkJS instance to break, and as a result it unloads any mounted component. 

```
hook.js:608 TypeError: Cannot use 'in' operator to search for 'afterVerificationCancelled' in true
    at clerk.browser.js:5:66006
    at ag (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:59348)
    at av (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:59806)
    at Object.useState (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:66148)
    at t.useState (clerk.browser.js:7:35861)
    at ez (clerk.browser.js:5:64614)
    at ad (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:58530)
    at ud (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:72833)
    at i (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:120293)
    at oD (framework_clerk.chips.browser_8c51a7_5.78.0.js:1:99075)
```

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal handling to prevent potential errors when closing the user verification modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->