### PR TITLE
fix(shared): Check for valid resource prior to initializing a payment flow

### DIFF
--- a/.changeset/bumpy-melons-grow.md
+++ b/.changeset/bumpy-melons-grow.md
@@ -1,0 +1,7 @@
+---
+'@clerk/shared': patch
+'@clerk/nextjs': patch
+'@clerk/clerk-react': patch
+---
+
+Fixes a bug which cause initialization of a payment method to never fire.

--- a/packages/shared/src/react/commerce.tsx
+++ b/packages/shared/src/react/commerce.tsx
@@ -74,18 +74,21 @@ const usePaymentSourceUtils = (forResource: ForPayerType = 'user') => {
       key: 'commerce-payment-source-initialize',
       resourceId: resource?.id,
     },
-    () =>
-      resource?.initializePaymentSource({
+    () => {
+      return resource?.initializePaymentSource({
         gateway: 'stripe',
-      }),
+      });
+    },
   );
+
   const environment = useInternalEnvironment();
 
   useEffect(() => {
+    if (!resource?.id) return;
     initializePaymentSource().catch(() => {
       // ignore errors
     });
-  }, []);
+  }, [resource?.id]);
 
   const externalGatewayId = initializedPaymentSource?.externalGatewayId;
   const externalClientSecret = initializedPaymentSource?.externalClientSecret;


### PR DESCRIPTION
## Description

This is a temporary solution. We are planning to improve this in the near future, with the introduction of a Vanilla JS api for the payment element.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where payment method initialization would not trigger as expected, ensuring smoother setup of payment sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->