### PR TITLE
fix(backend): Move snakecase-keys to dev dependencies

### DIFF
--- a/.changeset/loud-feet-bathe.md
+++ b/.changeset/loud-feet-bathe.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Fix Node 18 compatibility issues with `snakecase-keys`.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -112,7 +112,6 @@
     "@clerk/shared": "workspace:^",
     "@clerk/types": "workspace:^",
     "cookie": "1.0.2",
-    "snakecase-keys": "9.0.2",
     "standardwebhooks": "^1.0.0",
     "tslib": "catalog:repo"
   },
@@ -120,6 +119,7 @@
     "@edge-runtime/vm": "5.0.0",
     "msw": "2.10.4",
     "npm-run-all": "^4.1.5",
+    "snakecase-keys": "9.0.2",
     "vitest-environment-miniflare": "2.14.4"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,9 +378,6 @@ importers:
       cookie:
         specifier: 1.0.2
         version: 1.0.2
-      snakecase-keys:
-        specifier: 9.0.2
-        version: 9.0.2
       standardwebhooks:
         specifier: ^1.0.0
         version: 1.0.0
@@ -397,6 +394,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      snakecase-keys:
+        specifier: 9.0.2
+        version: 9.0.2
       vitest-environment-miniflare:
         specifier: 2.14.4
         version: 2.14.4(vitest@3.0.5(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.10.4(@types/node@24.0.14)(typescript@5.8.3))(terser@5.43.1)(tsx@4.19.2)(yaml@2.8.0))
@@ -2898,7 +2898,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2898,7 +2898,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -13011,6 +13011,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}


### PR DESCRIPTION
## Description

Since `snakecase-keys` is bundled with `noExternal` config, it's not needed as a runtime dependency. This resolves Node.js 18 compatibility issues reported in #6419 where users encountered engine requirement errors.

Local testing with Node 18:

<img width="522" height="674" alt="Screenshot 2025-07-30 at 8 19 15 AM" src="https://github.com/user-attachments/assets/92402d60-43d6-463b-a2f8-343da6f0670f" />

with Node 20:

<img width="457" height="453" alt="Screenshot 2025-07-30 at 8 22 15 AM" src="https://github.com/user-attachments/assets/e5163d60-2ae1-4ece-947e-5b77aa207847" />

with Node 22:

<img width="589" height="573" alt="Screenshot 2025-07-30 at 8 20 45 AM" src="https://github.com/user-attachments/assets/d6508cca-4360-4ead-8f1e-2db19370e089" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with Node.js version 18 for backend utilities.
  * Adjusted package dependencies to enhance development environment management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->