### PR TITLE
fix(clerk-js, shared): Patch TelemetryCollector logic for clerk-js in browser

### DIFF
--- a/.changeset/cyan-flowers-dream.md
+++ b/.changeset/cyan-flowers-dream.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/clerk-js': patch
+---
+
+Fix TelemetryCollector logic for clerk-js in browser to properly populate sdkMetadata for telemetry events.

--- a/packages/shared/src/telemetry/collector.ts
+++ b/packages/shared/src/telemetry/collector.ts
@@ -40,11 +40,7 @@ interface WindowWithClerk extends Window {
  */
 function isWindowClerkWithMetadata(clerk: unknown): clerk is { constructor: { sdkMetadata?: SDKMetadata } } {
   return (
-    typeof clerk === 'object' &&
-    clerk !== null &&
-    'constructor' in clerk &&
-    typeof clerk.constructor === 'object' &&
-    clerk.constructor !== null
+    typeof clerk === 'object' && clerk !== null && 'constructor' in clerk && typeof clerk.constructor === 'function'
   );
 }
 


### PR DESCRIPTION
## Description

[The recent addition](https://github.com/clerk/javascript/pull/6261) of `isWindowClerkWithMetadata` prevented `sdkMetadata` from being populated properly since it would always resolve to false.

While clerk.constructor is a function and functions are considered objects, doing `typeof clerk.constructor` would resolve to `'function'` and not `'object'`.



<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where telemetry events in the browser did not correctly populate the sdkMetadata field, ensuring more accurate telemetry data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->