### PR TITLE
chore(clerk-js): Add temporary API keys limit query for pagination compatibility

### DIFF
--- a/.changeset/tired-lines-rhyme.md
+++ b/.changeset/tired-lines-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Added temporary patch for API keys pagination compatibility

--- a/packages/clerk-js/src/core/modules/apiKeys/index.ts
+++ b/packages/clerk-js/src/core/modules/apiKeys/index.ts
@@ -43,6 +43,7 @@ export class APIKeys implements APIKeysNamespace {
         path: '/api_keys',
         search: {
           subject: params?.subject ?? BaseResource.clerk.organization?.id ?? BaseResource.clerk.user?.id ?? '',
+          // TODO: (rob) Remove when server-side pagination is implemented.
           limit: '100',
         },
       })

--- a/packages/clerk-js/src/core/modules/apiKeys/index.ts
+++ b/packages/clerk-js/src/core/modules/apiKeys/index.ts
@@ -43,6 +43,7 @@ export class APIKeys implements APIKeysNamespace {
         path: '/api_keys',
         search: {
           subject: params?.subject ?? BaseResource.clerk.organization?.id ?? BaseResource.clerk.user?.id ?? '',
+          limit: '100',
         },
       })
       .then(res => {


### PR DESCRIPTION
## Description

[This workers PR](https://github.com/clerk/cloudflare-workers/pull/1158) introduces pagination for fetching "Opaque Tokens" and updates API Key endpoints to support pagination. This is technically a breaking change as API Key endpoints previously returned all API Keys without pagination.

This PR adds a temporary compatibility patch for the API Keys component to work with the upcoming pagination changes.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key fetching to address pagination compatibility issues by limiting results to 100 per request.
* **Chores**
  * Updated documentation to reflect the temporary fix for API keys pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->