### PR TITLE
chore(vue): Remove `treatPendingAsSignedOut` from `useSession`

### DIFF
--- a/.changeset/sixty-dogs-film.md
+++ b/.changeset/sixty-dogs-film.md
@@ -1,0 +1,5 @@
+---
+'@clerk/vue': patch
+---
+
+Remove `treatPendingAsSignedOut` from `useSession` and always return pending session

--- a/packages/vue/src/composables/useSession.ts
+++ b/packages/vue/src/composables/useSession.ts
@@ -1,11 +1,11 @@
-import type { PendingSessionOptions, UseSessionReturn } from '@clerk/types';
+import type { UseSessionReturn } from '@clerk/types';
 import { computed } from 'vue';
 
 import type { ToComputedRefs } from '../utils';
 import { toComputedRefs } from '../utils';
 import { useClerkContext } from './useClerkContext';
 
-type UseSession = (options?: PendingSessionOptions) => ToComputedRefs<UseSessionReturn>;
+type UseSession = () => ToComputedRefs<UseSessionReturn>;
 
 /**
  * Returns the current [`Session`](https://clerk.com/docs/references/javascript/session) object which provides
@@ -32,23 +32,20 @@ type UseSession = (options?: PendingSessionOptions) => ToComputedRefs<UseSession
  *   </div>
  * </template>
  */
-export const useSession: UseSession = (options = {}) => {
-  const { sessionCtx, ...clerkContext } = useClerkContext();
+export const useSession: UseSession = () => {
+  const { sessionCtx, clerk } = useClerkContext();
 
   const result = computed<UseSessionReturn>(() => {
     if (sessionCtx.value === undefined) {
       return { isLoaded: false, isSignedIn: undefined, session: undefined };
     }
 
-    const pendingAsSignedOut =
-      sessionCtx.value?.status === 'pending' &&
-      (options.treatPendingAsSignedOut ?? clerkContext.treatPendingAsSignedOut);
-    const isSignedOut = sessionCtx.value === null || pendingAsSignedOut;
+    const isSignedOut = sessionCtx.value === null;
     if (isSignedOut) {
       return { isLoaded: true, isSignedIn: false, session: null };
     }
 
-    return { isLoaded: true, isSignedIn: true, session: sessionCtx.value };
+    return { isLoaded: true, isSignedIn: !!clerk.value?.isSignedIn, session: sessionCtx.value };
   });
 
   return toComputedRefs(result);


### PR DESCRIPTION
## Description


Leftover from https://github.com/clerk/javascript/pull/6432 - we've applied this change on the React hook but forgot to apply to Vue

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified session state handling by removing the option to treat pending sessions as signed out.
  * Session status now consistently reflects a pending state when applicable, improving sign-in status accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->