### PR TITLE
fix(clerk-js): Fix multi-session navigation for hash routing

### DIFF
--- a/.changeset/warm-lies-dance.md
+++ b/.changeset/warm-lies-dance.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix multi-session navigation for hash routing

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -30,9 +30,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1580,20 +1580,30 @@ export class Clerk implements ClerkInterface {
   }
 
   public buildAfterMultiSessionSingleSignOutUrl(): string {
-    if (!this.#options.afterMultiSessionSingleSignOutUrl) {
+    if (this.#options.afterMultiSessionSingleSignOutUrl) {
+      return this.buildUrlWithAuth(this.#options.afterMultiSessionSingleSignOutUrl);
+    }
+
+    if (this.#options.signInUrl) {
       return this.buildUrlWithAuth(
         buildURL(
           {
-            base: this.#options.signInUrl
-              ? `${this.#options.signInUrl}/choose`
-              : this.environment?.displayConfig.afterSignOutOneUrl,
+            base: this.#options.signInUrl,
+            hashPath: 'choose',
           },
           { stringify: true },
         ),
       );
     }
 
-    return this.buildUrlWithAuth(this.#options.afterMultiSessionSingleSignOutUrl);
+    return this.buildUrlWithAuth(
+      buildURL(
+        {
+          base: this.environment?.displayConfig.afterSignOutOneUrl,
+        },
+        { stringify: true },
+      ),
+    );
   }
 
   public buildCreateOrganizationUrl(): string {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1600,14 +1600,7 @@ export class Clerk implements ClerkInterface {
       );
     }
 
-    return this.buildUrlWithAuth(
-      buildURL(
-        {
-          base: this.environment.displayConfig.afterSignOutOneUrl,
-        },
-        { stringify: true },
-      ),
-    );
+    return this.buildUrlWithAuth(this.environment.displayConfig.afterSignOutOneUrl);
   }
 
   public buildCreateOrganizationUrl(): string {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -30,9 +30,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1580,6 +1580,10 @@ export class Clerk implements ClerkInterface {
   }
 
   public buildAfterMultiSessionSingleSignOutUrl(): string {
+    if (!this.environment) {
+      return '';
+    }
+
     if (this.#options.afterMultiSessionSingleSignOutUrl) {
       return this.buildUrlWithAuth(this.#options.afterMultiSessionSingleSignOutUrl);
     }
@@ -1599,7 +1603,7 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(
       buildURL(
         {
-          base: this.environment?.displayConfig.afterSignOutOneUrl,
+          base: this.environment.displayConfig.afterSignOutOneUrl,
         },
         { stringify: true },
       ),

--- a/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
@@ -15,14 +15,14 @@ import { useMultisessionActions } from '../UserButton/useMultisessionActions';
 const SignInAccountSwitcherInternal = () => {
   const card = useCardState();
   const { userProfileUrl } = useEnvironment().displayConfig;
-  const { afterSignInUrl, path: signInPath } = useSignInContext();
+  const { afterSignInUrl, path: signInPath, signInUrl } = useSignInContext();
   const { navigateAfterSignOut } = useSignOutContext();
   const { handleSignOutAllClicked, handleSessionClicked, signedInSessions, handleAddAccountClicked } =
     useMultisessionActions({
       navigateAfterSignOut,
       afterSwitchSessionUrl: afterSignInUrl,
       userProfileUrl,
-      signInUrl: signInPath,
+      signInUrl: signInPath ?? signInUrl,
       user: undefined,
     });
 


### PR DESCRIPTION
## Description

- Fixes navigation on "Add account" from `SignInAccountSwitcher`:  On a hash routing, it was trying to use the route path, which was `undefined` 

https://github.com/user-attachments/assets/6fff07e3-7242-4410-bf66-b5ccaf456395

- Fixes build method for `afterMultiSessionSignOutUrl` - it was passing `/choose` as a path, but wasn't building it as a hash. 

https://github.com/user-attachments/assets/7209ebeb-c12b-40cc-b59e-4cba10702071



<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior for multi-session scenarios when using hash-based URLs.
  * Enhanced logic for determining the correct sign-in URL during account switching, ensuring better fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->