### PR TITLE
chore(clerk-js,types): Strict type for `CommerceCheckout.status`

### DIFF
--- a/.changeset/nasty-shirts-behave.md
+++ b/.changeset/nasty-shirts-behave.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Billing Beta] Update checkout.status type to be `'needs_confirmation' | 'completed'` instead of `string`.

--- a/packages/clerk-js/src/core/resources/CommerceCheckout.ts
+++ b/packages/clerk-js/src/core/resources/CommerceCheckout.ts
@@ -18,7 +18,7 @@ export class CommerceCheckout extends BaseResource implements CommerceCheckoutRe
   plan!: CommercePlan;
   planPeriod!: CommerceSubscriptionPlanPeriod;
   planPeriodStart!: number | undefined;
-  status!: string;
+  status!: 'needs_confirmation' | 'completed';
   totals!: CommerceCheckoutTotals;
   isImmediatePlanChange!: boolean;
 

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -1503,7 +1503,7 @@ export interface CommerceCheckoutResource extends ClerkResource {
    * <ClerkProvider clerkJsVersion="x.x.x" />
    * ```
    */
-  status: string;
+  status: 'needs_confirmation' | 'completed';
   /**
    * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
    * It is advised to pin the SDK version and the clerk-js version to a specific version to avoid breaking changes.

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -870,7 +870,7 @@ export interface CommerceCheckoutJSON extends ClerkResourceJSON {
   plan: CommercePlanJSON;
   plan_period: CommerceSubscriptionPlanPeriod;
   plan_period_start?: number;
-  status: string;
+  status: 'needs_confirmation' | 'completed';
   totals: CommerceCheckoutTotalsJSON;
   is_immediate_plan_change: boolean;
 }


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the accuracy of checkout status values by restricting them to 'needs_confirmation' or 'completed', enhancing clarity and consistency in the Billing Beta feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->