### PR TITLE
fix(nextjs): Propagate `treatPendingAsSignedOut` to `auth` from `clerkMiddleware`

### DIFF
--- a/.changeset/tricky-planets-cry.md
+++ b/.changeset/tricky-planets-cry.md
@@ -1,0 +1,19 @@
+---
+'@clerk/nextjs': patch
+---
+
+Propagate `treatPendingAsSignedOut` to `auth` from `clerkMiddleware`
+
+```ts
+export default clerkMiddleware(async (auth, req) => {
+  // If the session has a `pending` status, `userId` will be `null` by default, treated as a signed-out state
+  const { userId } = await auth()
+})
+```
+
+```ts
+export default clerkMiddleware(async (auth, req) => {
+  // If the session has a `pending` status, `userId` will be defined, treated as a signed-in state
+  const { userId } = await auth({ treatPendingAsSignedOut: false })
+})
+```


### PR DESCRIPTION
## Description

Previously, the `treatPendingAsSignedOut` wasn't being propagated to the `clerkMiddleware` handler. This PR fixes it by resolving the auth object on the handler itself using that option. 

```ts
export default clerkMiddleware((auth, req) => {
  // If the session has a `pending` status, `userId` will be `null` by default, treated as a signed-out state
  const { userId } = await auth()
})
```

```ts
export default clerkMiddleware((auth, req) => {
  // If the session has a `pending` status, `userId` will be defined, treated as a signed-in state
  const { userId } = await auth({ treatPendingAsSignedOut: false })
})
```

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added examples and improved documentation for handling pending sessions with the authentication middleware, clarifying how to control whether pending sessions are treated as signed in or signed out.

* **New Features**
  * Introduced an option to explicitly control how pending authentication sessions are interpreted in middleware, allowing more flexible session handling for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->