### PR TITLE
refactor(backend): Use m2m tokens instead of machine tokens

### DIFF
--- a/.changeset/hot-tables-worry.md
+++ b/.changeset/hot-tables-worry.md
@@ -72,7 +72,7 @@ const clerkClient = createClerkClient({
 const authReq = await clerkClient.authenticateRequest(c.req.raw, {
   // or pass as an option here
   // machineSecretKey: process.env.CLERK_MACHINE_SECRET_KEY
-  acceptsToken: 'machine_token',
+  acceptsToken: 'm2m_token',
 })
 
 if (authReq.isAuthenticated) {

--- a/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
+++ b/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { server, validateHeaders } from '../../mock-server';
 import { createBackendApiClient } from '../factory';
 
-describe('MachineTokenAPI', () => {
+describe('M2MToken', () => {
   const m2mId = 'mt_xxxxx';
   const m2mSecret = 'mt_secret_xxxxx';
 
@@ -40,7 +40,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.create({
+      const response = await apiClient.m2mTokens.create({
         secondsUntilExpiration: 3600,
       });
 
@@ -65,7 +65,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.create({
+      const response = await apiClient.m2mTokens.create({
         machineSecretKey: 'ak_xxxxx',
         secondsUntilExpiration: 3600,
       });
@@ -102,7 +102,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const errResponse = await apiClient.machineTokens.create().catch(err => err);
+      const errResponse = await apiClient.m2mTokens.create().catch(err => err);
 
       expect(errResponse.status).toBe(401);
       expect(errResponse.errors[0].code).toBe('machine_secret_key_invalid');
@@ -143,7 +143,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.revoke({
+      const response = await apiClient.m2mTokens.revoke({
         m2mTokenId: m2mId,
         revocationReason: 'revoked by test',
       });
@@ -171,7 +171,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.revoke({
+      const response = await apiClient.m2mTokens.revoke({
         m2mTokenId: m2mId,
         revocationReason: 'revoked by test',
       });
@@ -195,7 +195,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const errResponse = await apiClient.machineTokens
+      const errResponse = await apiClient.m2mTokens
         .revoke({
           m2mTokenId: m2mId,
           revocationReason: 'revoked by test',
@@ -223,7 +223,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.verifySecret({
+      const response = await apiClient.m2mTokens.verifySecret({
         secret: m2mSecret,
       });
 
@@ -249,7 +249,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.verifySecret({
+      const response = await apiClient.m2mTokens.verifySecret({
         secret: m2mSecret,
       });
 
@@ -273,7 +273,7 @@ describe('MachineTokenAPI', () => {
         ),
       );
 
-      const errResponse = await apiClient.machineTokens
+      const errResponse = await apiClient.m2mTokens
         .verifySecret({
           secret: m2mSecret,
         })

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -325,7 +325,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.verifySecret({
+      const response = await apiClient.m2mTokens.verifySecret({
         machineSecretKey: 'ak_test_in_header_params', // this will be added to headerParams.Authorization
         secret: 'mt_secret_test',
       });
@@ -353,7 +353,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.verifySecret({
+      const response = await apiClient.m2mTokens.verifySecret({
         secret: 'mt_secret_test',
       });
       expect(response.id).toBe('mt_test');
@@ -425,7 +425,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.machineTokens.verifySecret({
+      const response = await apiClient.m2mTokens.verifySecret({
         secret: 'mt_secret_test',
       });
       expect(response.id).toBe('mt_test');

--- a/packages/backend/src/api/endpoints/M2MTokenApi.ts
+++ b/packages/backend/src/api/endpoints/M2MTokenApi.ts
@@ -1,6 +1,6 @@
-import type { ClerkBackendApiRequestOptions } from '../../api/request';
 import { joinPaths } from '../../util/path';
-import type { MachineToken } from '../resources/MachineToken';
+import type { ClerkBackendApiRequestOptions } from '../request';
+import type { M2MToken } from '../resources/M2MToken';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/m2m_tokens';
@@ -34,7 +34,7 @@ type VerifyMachineTokenParams = {
   secret: string;
 };
 
-export class MachineTokenApi extends AbstractAPI {
+export class M2MTokenApi extends AbstractAPI {
   #createRequestOptions(options: ClerkBackendApiRequestOptions, machineSecretKey?: string) {
     if (machineSecretKey) {
       return {
@@ -64,7 +64,7 @@ export class MachineTokenApi extends AbstractAPI {
       machineSecretKey,
     );
 
-    return this.request<MachineToken>(requestOptions);
+    return this.request<M2MToken>(requestOptions);
   }
 
   async revoke(params: RevokeMachineTokenParams) {
@@ -83,7 +83,7 @@ export class MachineTokenApi extends AbstractAPI {
       machineSecretKey,
     );
 
-    return this.request<MachineToken>(requestOptions);
+    return this.request<M2MToken>(requestOptions);
   }
 
   async verifySecret(params: VerifyMachineTokenParams) {
@@ -98,6 +98,6 @@ export class MachineTokenApi extends AbstractAPI {
       machineSecretKey,
     );
 
-    return this.request<MachineToken>(requestOptions);
+    return this.request<M2MToken>(requestOptions);
   }
 }

--- a/packages/backend/src/api/endpoints/index.ts
+++ b/packages/backend/src/api/endpoints/index.ts
@@ -12,7 +12,7 @@ export * from './IdPOAuthAccessTokenApi';
 export * from './InstanceApi';
 export * from './InvitationApi';
 export * from './MachineApi';
-export * from './MachineTokenApi';
+export * from './M2MTokenApi';
 export * from './JwksApi';
 export * from './JwtTemplatesApi';
 export * from './OrganizationApi';

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -13,8 +13,8 @@ import {
   InvitationAPI,
   JwksAPI,
   JwtTemplatesApi,
+  M2MTokenApi,
   MachineApi,
-  MachineTokenApi,
   OAuthApplicationsApi,
   OrganizationAPI,
   PhoneNumberAPI,
@@ -66,7 +66,7 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
     jwks: new JwksAPI(request),
     jwtTemplates: new JwtTemplatesApi(request),
     machines: new MachineApi(request),
-    machineTokens: new MachineTokenApi(
+    m2mTokens: new M2MTokenApi(
       buildRequest({
         ...options,
         skipApiVersionInUrl: true,

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -15,10 +15,10 @@ import {
   InstanceSettings,
   Invitation,
   JwtTemplate,
+  M2MToken,
   Machine,
   MachineScope,
   MachineSecretKey,
-  MachineToken,
   OauthAccessToken,
   OAuthApplication,
   Organization,
@@ -141,8 +141,8 @@ function jsonToObject(item: any): any {
       return MachineScope.fromJSON(item);
     case ObjectType.MachineSecretKey:
       return MachineSecretKey.fromJSON(item);
-    case ObjectType.MachineToken:
-      return MachineToken.fromJSON(item);
+    case ObjectType.M2MToken:
+      return M2MToken.fromJSON(item);
     case ObjectType.OauthAccessToken:
       return OauthAccessToken.fromJSON(item);
     case ObjectType.OAuthApplication:

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -37,7 +37,7 @@ export const ObjectType = {
   Machine: 'machine',
   MachineScope: 'machine_scope',
   MachineSecretKey: 'machine_secret_key',
-  MachineToken: 'machine_to_machine_token',
+  M2MToken: 'machine_to_machine_token',
   JwtTemplate: 'jwt_template',
   OauthAccessToken: 'oauth_access_token',
   IdpOAuthAccessToken: 'clerk_idp_oauth_access_token',
@@ -730,8 +730,8 @@ export interface MachineSecretKeyJSON {
   secret: string;
 }
 
-export interface MachineTokenJSON extends ClerkResourceJSON {
-  object: typeof ObjectType.MachineToken;
+export interface M2MTokenJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.M2MToken;
   secret?: string;
   subject: string;
   scopes: string[];

--- a/packages/backend/src/api/resources/M2MToken.ts
+++ b/packages/backend/src/api/resources/M2MToken.ts
@@ -1,6 +1,6 @@
-import type { MachineTokenJSON } from './JSON';
+import type { M2MTokenJSON } from './JSON';
 
-export class MachineToken {
+export class M2MToken {
   constructor(
     readonly id: string,
     readonly subject: string,
@@ -15,8 +15,8 @@ export class MachineToken {
     readonly secret?: string,
   ) {}
 
-  static fromJSON(data: MachineTokenJSON): MachineToken {
-    return new MachineToken(
+  static fromJSON(data: M2MTokenJSON): M2MToken {
+    return new M2MToken(
       data.id,
       data.subject,
       data.scopes,

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -33,7 +33,7 @@ export * from './JSON';
 export * from './Machine';
 export * from './MachineScope';
 export * from './MachineSecretKey';
-export * from './MachineToken';
+export * from './M2MToken';
 export * from './JwtTemplate';
 export * from './OauthAccessToken';
 export * from './OAuthApplication';

--- a/packages/backend/src/fixtures/machine.ts
+++ b/packages/backend/src/fixtures/machine.ts
@@ -1,7 +1,7 @@
 export const mockTokens = {
   api_key: 'ak_LCWGdaM8mv8K4PC/57IICZQXAeWfCgF30DZaFXHoGn9=',
   oauth_token: 'oat_8XOIucKvqHVr5tYP123456789abcdefghij',
-  machine_token: 'mt_8XOIucKvqHVr5tYP123456789abcdefghij',
+  m2m_token: 'mt_8XOIucKvqHVr5tYP123456789abcdefghij',
 } as const;
 
 export const mockVerificationResults = {
@@ -36,7 +36,7 @@ export const mockVerificationResults = {
     createdAt: 1744928754551,
     updatedAt: 1744928754551,
   },
-  machine_token: {
+  m2m_token: {
     id: 'm2m_ey966f1b1xf93586b2debdcadb0b3bd1',
     subject: 'mch_2vYVtestTESTtestTESTtestTESTtest',
     scopes: ['mch_1xxxxx', 'mch_2xxxxx'],
@@ -60,7 +60,7 @@ export const mockMachineAuthResponses = {
     endpoint: 'https://api.clerk.test/oauth_applications/access_tokens/verify',
     errorMessage: 'OAuth token not found',
   },
-  machine_token: {
+  m2m_token: {
     endpoint: 'https://api.clerk.test/m2m_tokens/verify',
     errorMessage: 'Machine token not found',
   },

--- a/packages/backend/src/tokens/__tests__/authObjects.test.ts
+++ b/packages/backend/src/tokens/__tests__/authObjects.test.ts
@@ -346,23 +346,23 @@ describe('authenticatedMachineObject', () => {
 
   describe('Machine Token authentication', () => {
     const debugData = { foo: 'bar' };
-    const token = mockTokens.machine_token;
-    const verificationResult = mockVerificationResults.machine_token;
+    const token = mockTokens.m2m_token;
+    const verificationResult = mockVerificationResults.m2m_token;
 
     it('getToken returns the token passed in', async () => {
-      const authObject = authenticatedMachineObject('machine_token', token, verificationResult, debugData);
+      const authObject = authenticatedMachineObject('m2m_token', token, verificationResult, debugData);
       const retrievedToken = await authObject.getToken();
       expect(retrievedToken).toBe(token);
     });
 
     it('has() always returns false', () => {
-      const authObject = authenticatedMachineObject('machine_token', token, verificationResult, debugData);
+      const authObject = authenticatedMachineObject('m2m_token', token, verificationResult, debugData);
       expect(authObject.has({})).toBe(false);
     });
 
     it('properly initializes properties', () => {
-      const authObject = authenticatedMachineObject('machine_token', token, verificationResult, debugData);
-      expect(authObject.tokenType).toBe('machine_token');
+      const authObject = authenticatedMachineObject('m2m_token', token, verificationResult, debugData);
+      expect(authObject.tokenType).toBe('m2m_token');
       expect(authObject.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
       expect(authObject.subject).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
       expect(authObject.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
@@ -373,20 +373,20 @@ describe('authenticatedMachineObject', () => {
 
 describe('unauthenticatedMachineObject', () => {
   it('properly initializes properties', () => {
-    const authObject = unauthenticatedMachineObject('machine_token');
-    expect(authObject.tokenType).toBe('machine_token');
+    const authObject = unauthenticatedMachineObject('m2m_token');
+    expect(authObject.tokenType).toBe('m2m_token');
     expect(authObject.id).toBeNull();
     expect(authObject.subject).toBeNull();
     expect(authObject.scopes).toBeNull();
   });
 
   it('has() always returns false', () => {
-    const authObject = unauthenticatedMachineObject('machine_token');
+    const authObject = unauthenticatedMachineObject('m2m_token');
     expect(authObject.has({})).toBe(false);
   });
 
   it('getToken always returns null ', async () => {
-    const authObject = unauthenticatedMachineObject('machine_token');
+    const authObject = unauthenticatedMachineObject('m2m_token');
     const retrievedToken = await authObject.getToken();
     expect(retrievedToken).toBeNull();
   });
@@ -410,7 +410,7 @@ describe('getAuthObjectForAcceptedToken', () => {
   it('returns InvalidTokenAuthObject if acceptsToken is array and token type does not match', () => {
     const result = getAuthObjectForAcceptedToken({
       authObject: machineAuth,
-      acceptsToken: ['machine_token', 'oauth_token'],
+      acceptsToken: ['m2m_token', 'oauth_token'],
     });
     expect((result as InvalidTokenAuthObject).tokenType).toBeNull();
     expect((result as InvalidTokenAuthObject).isAuthenticated).toBe(false);
@@ -429,9 +429,9 @@ describe('getAuthObjectForAcceptedToken', () => {
   });
 
   it('returns unauthenticated object for requested type if acceptsToken is a single value and does not match', () => {
-    const result = getAuthObjectForAcceptedToken({ authObject: machineAuth, acceptsToken: 'machine_token' });
-    expect((result as UnauthenticatedMachineObject<'machine_token'>).tokenType).toBe('machine_token');
-    expect((result as UnauthenticatedMachineObject<'machine_token'>).id).toBeNull();
+    const result = getAuthObjectForAcceptedToken({ authObject: machineAuth, acceptsToken: 'm2m_token' });
+    expect((result as UnauthenticatedMachineObject<'m2m_token'>).tokenType).toBe('m2m_token');
+    expect((result as UnauthenticatedMachineObject<'m2m_token'>).id).toBeNull();
   });
 });
 

--- a/packages/backend/src/tokens/__tests__/authStatus.test.ts
+++ b/packages/backend/src/tokens/__tests__/authStatus.test.ts
@@ -115,7 +115,7 @@ describe('signed-out', () => {
 
     it('returns an unauthenticated machine object with toAuth()', async () => {
       const signedOutAuthObject = signedOut({
-        tokenType: 'machine_token',
+        tokenType: 'm2m_token',
         authenticateContext: {} as AuthenticateContext,
         reason: 'auth-reason',
         message: 'auth-message',
@@ -123,7 +123,7 @@ describe('signed-out', () => {
 
       const token = await signedOutAuthObject.getToken();
       expect(token).toBeNull();
-      expect(signedOutAuthObject.tokenType).toBe('machine_token');
+      expect(signedOutAuthObject.tokenType).toBe('m2m_token');
       expect(signedOutAuthObject.id).toBeNull();
       expect(signedOutAuthObject.subject).toBeNull();
       expect(signedOutAuthObject.claims).toBeNull();

--- a/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
+++ b/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
@@ -17,15 +17,15 @@ test('infers the correct AuthObject type for each accepted token type', () => {
   // Individual token types
   expectTypeOf(getAuth(request, { acceptsToken: 'session_token' })).toMatchTypeOf<SessionAuthObject>();
   expectTypeOf(getAuth(request, { acceptsToken: 'api_key' })).toMatchTypeOf<MachineAuthObject<'api_key'>>();
-  expectTypeOf(getAuth(request, { acceptsToken: 'machine_token' })).toMatchTypeOf<MachineAuthObject<'machine_token'>>();
+  expectTypeOf(getAuth(request, { acceptsToken: 'm2m_token' })).toMatchTypeOf<MachineAuthObject<'m2m_token'>>();
   expectTypeOf(getAuth(request, { acceptsToken: 'oauth_token' })).toMatchTypeOf<MachineAuthObject<'oauth_token'>>();
 
   // Array of token types
-  expectTypeOf(getAuth(request, { acceptsToken: ['session_token', 'machine_token'] })).toMatchTypeOf<
-    SessionAuthObject | MachineAuthObject<'machine_token'> | InvalidTokenAuthObject
+  expectTypeOf(getAuth(request, { acceptsToken: ['session_token', 'm2m_token'] })).toMatchTypeOf<
+    SessionAuthObject | MachineAuthObject<'m2m_token'> | InvalidTokenAuthObject
   >();
-  expectTypeOf(getAuth(request, { acceptsToken: ['machine_token', 'oauth_token'] })).toMatchTypeOf<
-    MachineAuthObject<'machine_token' | 'oauth_token'> | InvalidTokenAuthObject
+  expectTypeOf(getAuth(request, { acceptsToken: ['m2m_token', 'oauth_token'] })).toMatchTypeOf<
+    MachineAuthObject<'m2m_token' | 'oauth_token'> | InvalidTokenAuthObject
   >();
 
   // Any token type
@@ -41,8 +41,8 @@ test('verifies discriminated union works correctly with acceptsToken: any', () =
     expectTypeOf(auth).toMatchTypeOf<SessionAuthObject>();
   } else if (auth.tokenType === 'api_key') {
     expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'api_key'>>();
-  } else if (auth.tokenType === 'machine_token') {
-    expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'machine_token'>>();
+  } else if (auth.tokenType === 'm2m_token') {
+    expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'m2m_token'>>();
   } else if (auth.tokenType === 'oauth_token') {
     expectTypeOf(auth).toMatchTypeOf<MachineAuthObject<'oauth_token'>>();
   }

--- a/packages/backend/src/tokens/__tests__/machine.test.ts
+++ b/packages/backend/src/tokens/__tests__/machine.test.ts
@@ -35,8 +35,8 @@ describe('isMachineToken', () => {
 });
 
 describe('getMachineTokenType', () => {
-  it('returns "machine_token" for tokens with M2M prefix', () => {
-    expect(getMachineTokenType(`${M2M_TOKEN_PREFIX}some-token-value`)).toBe('machine_token');
+  it('returns "m2m_token" for tokens with M2M prefix', () => {
+    expect(getMachineTokenType(`${M2M_TOKEN_PREFIX}some-token-value`)).toBe('m2m_token');
   });
 
   it('returns "oauth_token" for tokens with OAuth prefix', () => {
@@ -65,25 +65,25 @@ describe('getMachineTokenType', () => {
 describe('isTokenTypeAccepted', () => {
   it('accepts any token type', () => {
     expect(isTokenTypeAccepted('api_key', 'any')).toBe(true);
-    expect(isTokenTypeAccepted('machine_token', 'any')).toBe(true);
+    expect(isTokenTypeAccepted('m2m_token', 'any')).toBe(true);
     expect(isTokenTypeAccepted('oauth_token', 'any')).toBe(true);
     expect(isTokenTypeAccepted('session_token', 'any')).toBe(true);
   });
 
   it('accepts a list of token types', () => {
-    expect(isTokenTypeAccepted('api_key', ['api_key', 'machine_token'])).toBe(true);
-    expect(isTokenTypeAccepted('session_token', ['api_key', 'machine_token'])).toBe(false);
+    expect(isTokenTypeAccepted('api_key', ['api_key', 'm2m_token'])).toBe(true);
+    expect(isTokenTypeAccepted('session_token', ['api_key', 'm2m_token'])).toBe(false);
   });
 
   it('rejects a mismatching token type', () => {
-    expect(isTokenTypeAccepted('api_key', 'machine_token')).toBe(false);
+    expect(isTokenTypeAccepted('api_key', 'm2m_token')).toBe(false);
   });
 });
 
 describe('isMachineTokenType', () => {
   it('returns true for machine token types', () => {
     expect(isMachineTokenType('api_key')).toBe(true);
-    expect(isMachineTokenType('machine_token')).toBe(true);
+    expect(isMachineTokenType('m2m_token')).toBe(true);
     expect(isMachineTokenType('oauth_token')).toBe(true);
   });
 

--- a/packages/backend/src/tokens/__tests__/request.test-d.ts
+++ b/packages/backend/src/tokens/__tests__/request.test-d.ts
@@ -16,17 +16,17 @@ test('returns the correct `authenticateRequest()` return type for each accepted 
   expectTypeOf(authenticateRequest(request, { acceptsToken: 'api_key' })).toMatchTypeOf<
     Promise<RequestState<'api_key'>>
   >();
-  expectTypeOf(authenticateRequest(request, { acceptsToken: 'machine_token' })).toMatchTypeOf<
-    Promise<RequestState<'machine_token'>>
+  expectTypeOf(authenticateRequest(request, { acceptsToken: 'm2m_token' })).toMatchTypeOf<
+    Promise<RequestState<'m2m_token'>>
   >();
   expectTypeOf(authenticateRequest(request, { acceptsToken: 'oauth_token' })).toMatchTypeOf<
     Promise<RequestState<'oauth_token'>>
   >();
 
   // Array of token types
-  expectTypeOf(
-    authenticateRequest(request, { acceptsToken: ['session_token', 'api_key', 'machine_token'] }),
-  ).toMatchTypeOf<Promise<RequestState<'session_token' | 'api_key' | 'machine_token' | null>>>();
+  expectTypeOf(authenticateRequest(request, { acceptsToken: ['session_token', 'api_key', 'm2m_token'] })).toMatchTypeOf<
+    Promise<RequestState<'session_token' | 'api_key' | 'm2m_token' | null>>
+  >();
 
   // Any token type
   expectTypeOf(authenticateRequest(request, { acceptsToken: 'any' })).toMatchTypeOf<Promise<RequestState<TokenType>>>();

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1200,7 +1200,7 @@ describe('tokens.authenticateRequest(options)', () => {
     });
 
     // Test each token type with parameterized tests
-    const tokenTypes = [TokenType.ApiKey, TokenType.OAuthToken, TokenType.MachineToken];
+    const tokenTypes = [TokenType.ApiKey, TokenType.OAuthToken, TokenType.M2MToken];
 
     describe.each(tokenTypes)('%s Authentication', tokenType => {
       const mockToken = mockTokens[tokenType];
@@ -1244,26 +1244,26 @@ describe('tokens.authenticateRequest(options)', () => {
 
     test('accepts machine secret when verifying machine-to-machine token', async () => {
       server.use(
-        http.post(mockMachineAuthResponses.machine_token.endpoint, ({ request }) => {
+        http.post(mockMachineAuthResponses.m2m_token.endpoint, ({ request }) => {
           expect(request.headers.get('Authorization')).toBe('Bearer ak_xxxxx');
-          return HttpResponse.json(mockVerificationResults.machine_token);
+          return HttpResponse.json(mockVerificationResults.m2m_token);
         }),
       );
 
-      const request = mockRequest({ authorization: `Bearer ${mockTokens.machine_token}` });
+      const request = mockRequest({ authorization: `Bearer ${mockTokens.m2m_token}` });
       const requestState = await authenticateRequest(
         request,
-        mockOptions({ acceptsToken: 'machine_token', machineSecretKey: 'ak_xxxxx' }),
+        mockOptions({ acceptsToken: 'm2m_token', machineSecretKey: 'ak_xxxxx' }),
       );
 
       expect(requestState).toBeMachineAuthenticated();
     });
 
-    test('throws an error if acceptsToken is machine_token but machineSecretKey or secretKey is not provided', async () => {
-      const request = mockRequest({ authorization: `Bearer ${mockTokens.machine_token}` });
+    test('throws an error if acceptsToken is m2m_token but machineSecretKey or secretKey is not provided', async () => {
+      const request = mockRequest({ authorization: `Bearer ${mockTokens.m2m_token}` });
 
       await expect(
-        authenticateRequest(request, mockOptions({ acceptsToken: 'machine_token', secretKey: undefined })),
+        authenticateRequest(request, mockOptions({ acceptsToken: 'm2m_token', secretKey: undefined })),
       ).rejects.toThrow(
         'Machine token authentication requires either a Machine secret key or a Clerk secret key. ' +
           'Ensure a Clerk secret key or Machine secret key is set.',
@@ -1321,21 +1321,21 @@ describe('tokens.authenticateRequest(options)', () => {
 
       test('returns unauthenticated state when token type mismatches (OAuth token provided, M2M token expected)', async () => {
         const request = mockRequest({ authorization: `Bearer ${mockTokens.oauth_token}` });
-        const result = await authenticateRequest(request, mockOptions({ acceptsToken: 'machine_token' }));
+        const result = await authenticateRequest(request, mockOptions({ acceptsToken: 'm2m_token' }));
 
         expect(result).toBeMachineUnauthenticated({
-          tokenType: 'machine_token',
+          tokenType: 'm2m_token',
           reason: AuthErrorReason.TokenTypeMismatch,
           message: '',
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
-          tokenType: 'machine_token',
+          tokenType: 'm2m_token',
           isAuthenticated: false,
         });
       });
 
       test('returns unauthenticated state when token type mismatches (M2M token provided, API key expected)', async () => {
-        const request = mockRequest({ authorization: `Bearer ${mockTokens.machine_token}` });
+        const request = mockRequest({ authorization: `Bearer ${mockTokens.m2m_token}` });
         const result = await authenticateRequest(request, mockOptions({ acceptsToken: 'api_key' }));
 
         expect(result).toBeMachineUnauthenticated({
@@ -1351,16 +1351,16 @@ describe('tokens.authenticateRequest(options)', () => {
 
       test('returns unauthenticated state when session token is provided but machine token is expected', async () => {
         const request = mockRequestWithHeaderAuth();
-        const result = await authenticateRequest(request, mockOptions({ acceptsToken: 'machine_token' }));
+        const result = await authenticateRequest(request, mockOptions({ acceptsToken: 'm2m_token' }));
 
         expect(result).toBeMachineUnauthenticated({
-          tokenType: 'machine_token',
+          tokenType: 'm2m_token',
           reason: AuthErrorReason.TokenTypeMismatch,
           message: '',
           isAuthenticated: false,
         });
         expect(result.toAuth()).toBeMachineUnauthenticatedToAuth({
-          tokenType: 'machine_token',
+          tokenType: 'm2m_token',
           isAuthenticated: false,
         });
       });
@@ -1384,7 +1384,7 @@ describe('tokens.authenticateRequest(options)', () => {
       });
 
       test('returns unauthenticated state when token type is not in the acceptsToken array', async () => {
-        const request = mockRequest({ authorization: `Bearer ${mockTokens.machine_token}` });
+        const request = mockRequest({ authorization: `Bearer ${mockTokens.m2m_token}` });
         const requestState = await authenticateRequest(
           request,
           mockOptions({ acceptsToken: ['api_key', 'oauth_token'] }),

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { APIKey, IdPOAuthAccessToken, MachineToken } from '../../api';
+import type { APIKey, IdPOAuthAccessToken, M2MToken } from '../../api';
 import { mockJwks, mockJwt, mockJwtPayload } from '../../fixtures';
 import { mockVerificationResults } from '../../fixtures/machine';
 import { server, validateHeaders } from '../../mock-server';
@@ -104,7 +104,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
       http.post(
         'https://api.clerk.test/m2m_tokens/verify',
         validateHeaders(() => {
-          return HttpResponse.json(mockVerificationResults.machine_token);
+          return HttpResponse.json(mockVerificationResults.m2m_token);
         }),
       ),
     );
@@ -114,11 +114,11 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
       secretKey: 'a-valid-key',
     });
 
-    expect(result.tokenType).toBe('machine_token');
+    expect(result.tokenType).toBe('m2m_token');
     expect(result.data).toBeDefined();
     expect(result.errors).toBeUndefined();
 
-    const data = result.data as MachineToken;
+    const data = result.data as M2MToken;
     expect(data.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
     expect(data.subject).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
     expect(data.claims).toEqual({ foo: 'bar' });
@@ -133,7 +133,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
         'https://api.clerk.test/m2m_tokens/verify',
         validateHeaders(({ request }) => {
           expect(request.headers.get('Authorization')).toBe('Bearer ak_xxxxx');
-          return HttpResponse.json(mockVerificationResults.machine_token);
+          return HttpResponse.json(mockVerificationResults.m2m_token);
         }),
       ),
     );
@@ -144,11 +144,11 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
       machineSecretKey: 'ak_xxxxx',
     });
 
-    expect(result.tokenType).toBe('machine_token');
+    expect(result.tokenType).toBe('m2m_token');
     expect(result.data).toBeDefined();
     expect(result.errors).toBeUndefined();
 
-    const data = result.data as MachineToken;
+    const data = result.data as M2MToken;
     expect(data.id).toBe('m2m_ey966f1b1xf93586b2debdcadb0b3bd1');
     expect(data.subject).toBe('mch_2vYVtestTESTtestTESTtestTESTtest');
     expect(data.claims).toEqual({ foo: 'bar' });
@@ -241,7 +241,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
         secretKey: 'a-valid-key',
       });
 
-      expect(result.tokenType).toBe('machine_token');
+      expect(result.tokenType).toBe('m2m_token');
       expect(result.data).toBeUndefined();
       expect(result.errors).toBeDefined();
       expect(result.errors?.[0].message).toBe('Machine token not found');
@@ -262,7 +262,7 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
         secretKey: 'a-valid-key',
       });
 
-      expect(result.tokenType).toBe('machine_token');
+      expect(result.tokenType).toBe('m2m_token');
       expect(result.data).toBeUndefined();
       expect(result.errors).toBeDefined();
       expect(result.errors?.[0].message).toBe('Unexpected error');

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -11,7 +11,7 @@ import type {
   SharedSignedInAuthObjectProperties,
 } from '@clerk/types';
 
-import type { APIKey, CreateBackendApiOptions, IdPOAuthAccessToken, MachineToken } from '../api';
+import type { APIKey, CreateBackendApiOptions, IdPOAuthAccessToken, M2MToken } from '../api';
 import { createBackendApiClient } from '../api';
 import { isTokenTypeAccepted } from '../internal';
 import type { AuthenticateContext } from './authenticateContext';
@@ -95,7 +95,7 @@ type MachineObjectExtendedProperties<TAuthenticated extends boolean> = {
         | { name: string; claims: Claims | null; userId: string; orgId: null }
         | { name: string; claims: Claims | null; userId: null; orgId: string }
     : { name: null; claims: null; userId: null; orgId: null };
-  machine_token: {
+  m2m_token: {
     claims: TAuthenticated extends true ? Claims | null : null;
     machineId: TAuthenticated extends true ? string : null;
   };
@@ -279,8 +279,8 @@ export function authenticatedMachineObject<T extends MachineTokenType>(
         orgId: result.subject.startsWith('org_') ? result.subject : null,
       } as unknown as AuthenticatedMachineObject<T>;
     }
-    case TokenType.MachineToken: {
-      const result = verificationResult as MachineToken;
+    case TokenType.M2MToken: {
+      const result = verificationResult as M2MToken;
       return {
         ...baseObject,
         tokenType,
@@ -333,7 +333,7 @@ export function unauthenticatedMachineObject<T extends MachineTokenType>(
         orgId: null,
       } as unknown as UnauthenticatedMachineObject<T>;
     }
-    case TokenType.MachineToken: {
+    case TokenType.M2MToken: {
       return {
         ...baseObject,
         tokenType,

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -67,7 +67,7 @@ class AuthenticateContext implements AuthenticateContext {
     private clerkRequest: ClerkRequest,
     options: AuthenticateRequestOptions,
   ) {
-    if (options.acceptsToken === TokenType.MachineToken || options.acceptsToken === TokenType.ApiKey) {
+    if (options.acceptsToken === TokenType.M2MToken || options.acceptsToken === TokenType.ApiKey) {
       // For non-session tokens, we only want to set the header values.
       this.initHeaderValues();
     } else {

--- a/packages/backend/src/tokens/machine.ts
+++ b/packages/backend/src/tokens/machine.ts
@@ -35,7 +35,7 @@ export function isMachineTokenByPrefix(token: string): boolean {
  */
 export function getMachineTokenType(token: string): MachineTokenType {
   if (token.startsWith(M2M_TOKEN_PREFIX)) {
-    return TokenType.MachineToken;
+    return TokenType.M2MToken;
   }
 
   if (token.startsWith(OAUTH_TOKEN_PREFIX)) {
@@ -79,5 +79,5 @@ export const isTokenTypeAccepted = (
  * @returns true if the type is a machine token type
  */
 export function isMachineTokenType(type: string): type is MachineTokenType {
-  return type === TokenType.ApiKey || type === TokenType.MachineToken || type === TokenType.OAuthToken;
+  return type === TokenType.ApiKey || type === TokenType.M2MToken || type === TokenType.OAuthToken;
 }

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -154,7 +154,7 @@ export const authenticateRequest: AuthenticateRequest = (async (
   const acceptsToken = options.acceptsToken ?? TokenType.SessionToken;
 
   // machine-to-machine tokens can accept a machine secret or a secret key
-  if (acceptsToken !== TokenType.MachineToken) {
+  if (acceptsToken !== TokenType.M2MToken) {
     assertValidSecretKey(authenticateContext.secretKey);
 
     if (authenticateContext.isSatellite) {
@@ -166,8 +166,8 @@ export const authenticateRequest: AuthenticateRequest = (async (
     }
   }
 
-  // Make sure a machine secret or instance secret key is provided if acceptsToken is machine_token
-  if (acceptsToken === TokenType.MachineToken) {
+  // Make sure a machine secret or instance secret key is provided if acceptsToken is m2m_token
+  if (acceptsToken === TokenType.M2MToken) {
     assertMachineSecretOrSecretKey(authenticateContext);
   }
 
@@ -791,7 +791,7 @@ export const authenticateRequest: AuthenticateRequest = (async (
   if (
     acceptsToken === TokenType.OAuthToken ||
     acceptsToken === TokenType.ApiKey ||
-    acceptsToken === TokenType.MachineToken
+    acceptsToken === TokenType.M2MToken
   ) {
     return signedOut({
       tokenType: acceptsToken,

--- a/packages/backend/src/tokens/tokenTypes.ts
+++ b/packages/backend/src/tokens/tokenTypes.ts
@@ -1,7 +1,7 @@
 export const TokenType = {
   SessionToken: 'session_token',
   ApiKey: 'api_key',
-  MachineToken: 'machine_token',
+  M2MToken: 'm2m_token',
   OAuthToken: 'oauth_token',
 } as const;
 

--- a/packages/backend/src/tokens/types.ts
+++ b/packages/backend/src/tokens/types.ts
@@ -1,7 +1,7 @@
 import type { MatchFunction } from '@clerk/shared/pathToRegexp';
 import type { PendingSessionOptions } from '@clerk/types';
 
-import type { ApiClient, APIKey, IdPOAuthAccessToken, MachineToken } from '../api';
+import type { ApiClient, APIKey, IdPOAuthAccessToken, M2MToken } from '../api';
 import type {
   AuthenticatedMachineObject,
   AuthObject,
@@ -142,7 +142,7 @@ export type OrganizationSyncOptions = {
  */
 type Pattern = string;
 
-export type MachineAuthType = MachineToken | APIKey | IdPOAuthAccessToken;
+export type MachineAuthType = M2MToken | APIKey | IdPOAuthAccessToken;
 
 export type OrganizationSyncTargetMatchers = {
   OrganizationMatcher: MatchFunction<Partial<Record<string, string | string[]>>> | null;

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -1,7 +1,7 @@
 import { isClerkAPIResponseError } from '@clerk/shared/error';
 import type { JwtPayload } from '@clerk/types';
 
-import type { APIKey, IdPOAuthAccessToken, MachineToken } from '../api';
+import type { APIKey, IdPOAuthAccessToken, M2MToken } from '../api';
 import { createBackendApiClient } from '../api/factory';
 import {
   MachineTokenVerificationError,
@@ -203,13 +203,13 @@ function handleClerkAPIError(
 async function verifyMachineToken(
   secret: string,
   options: VerifyTokenOptions & { machineSecretKey?: string },
-): Promise<MachineTokenReturnType<MachineToken, MachineTokenVerificationError>> {
+): Promise<MachineTokenReturnType<M2MToken, MachineTokenVerificationError>> {
   try {
     const client = createBackendApiClient(options);
-    const verifiedToken = await client.machineTokens.verifySecret({ secret });
-    return { data: verifiedToken, tokenType: TokenType.MachineToken, errors: undefined };
+    const verifiedToken = await client.m2mTokens.verifySecret({ secret });
+    return { data: verifiedToken, tokenType: TokenType.M2MToken, errors: undefined };
   } catch (err: any) {
-    return handleClerkAPIError(TokenType.MachineToken, err, 'Machine token not found');
+    return handleClerkAPIError(TokenType.M2MToken, err, 'Machine token not found');
   }
 }
 

--- a/packages/fastify/src/__tests__/getAuth.test.ts
+++ b/packages/fastify/src/__tests__/getAuth.test.ts
@@ -28,11 +28,11 @@ describe('getAuth(req)', () => {
   });
 
   it('returns the actual auth object if its tokenType is included in the acceptsToken array', () => {
-    const req = { auth: { tokenType: 'machine_token', id: 'm2m_1234' } } as unknown as FastifyRequest;
-    const result = getAuth(req, { acceptsToken: ['machine_token', 'api_key'] });
-    expect(result.tokenType).toBe('machine_token');
-    expect((result as AuthenticatedMachineObject<'machine_token'>).id).toBe('m2m_1234');
-    expect((result as AuthenticatedMachineObject<'machine_token'>).subject).toBeUndefined();
+    const req = { auth: { tokenType: 'm2m_token', id: 'm2m_1234' } } as unknown as FastifyRequest;
+    const result = getAuth(req, { acceptsToken: ['m2m_token', 'api_key'] });
+    expect(result.tokenType).toBe('m2m_token');
+    expect((result as AuthenticatedMachineObject<'m2m_token'>).id).toBe('m2m_1234');
+    expect((result as AuthenticatedMachineObject<'m2m_token'>).subject).toBeUndefined();
   });
 
   it('returns an unauthenticated auth object when the tokenType does not match acceptsToken', () => {


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
