### PR TITLE
fix(shared): Fix memory leaks in react native environment

### DIFF
--- a/.changeset/twenty-poems-push.md
+++ b/.changeset/twenty-poems-push.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix a potential memory leak in `TelemetryCollector`

--- a/packages/shared/src/telemetry/collector.ts
+++ b/packages/shared/src/telemetry/collector.ts
@@ -229,6 +229,7 @@ export class TelemetryCollector implements TelemetryCollectorInterface {
       body: JSON.stringify({
         events: eventsToSend,
       }),
+      keepalive: true,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/packages/shared/src/telemetry/events/method-called.ts
+++ b/packages/shared/src/telemetry/events/method-called.ts
@@ -1,6 +1,7 @@
 import type { TelemetryEventRaw } from '@clerk/types';
 
 const EVENT_METHOD_CALLED = 'METHOD_CALLED';
+const EVENT_SAMPLING_RATE = 0.1;
 
 type EventMethodCalled = {
   method: string;
@@ -15,6 +16,7 @@ export function eventMethodCalled(
 ): TelemetryEventRaw<EventMethodCalled> {
   return {
     event: EVENT_METHOD_CALLED,
+    eventSamplingRate: EVENT_SAMPLING_RATE,
     payload: {
       method,
       ...payload,


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

We got a report of a memory leak in our Expo SDK, which appeared to be stemming from our telemetry code. One likely culprit is our closing over of `this.#buffer` in the fetch call, which had the possibility to retain the reference if the fetch never resolved.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential memory leak in telemetry data collection, improving resource management and application stability.

* **Tests**
  * Added a new test to ensure telemetry event batches are properly isolated, preventing event duplication or mixing between batches.

* **New Features**
  * Introduced event sampling rate metadata to telemetry events for improved data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->