### PR TITLE
feat(clerk-js): Introduce `navigate` for `setActive`

### DIFF
--- a/.changeset/mighty-ducks-occur.md
+++ b/.changeset/mighty-ducks-occur.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove sending `redirect_url_complete` as `redirect_url` for SSO with after-auth flows

--- a/.changeset/mighty-ducks-occur.md
+++ b/.changeset/mighty-ducks-occur.md
@@ -1,5 +1,0 @@
----
-'@clerk/clerk-js': patch
----
-
-Remove sending `redirect_url_complete` as `redirect_url` for SSO with after-auth flows

--- a/.changeset/rich-donuts-agree.md
+++ b/.changeset/rich-donuts-agree.md
@@ -17,7 +17,7 @@ await clerk.setActive({
       return;
     }
 
-    await navigate('/dashboard')
+    await router.push('/dashboard')
   }
 });
 ```

--- a/.changeset/rich-donuts-agree.md
+++ b/.changeset/rich-donuts-agree.md
@@ -12,9 +12,8 @@ await clerk.setActive({
   session,
   navigate: async ({ session }) => {
     const currentTask = session.currentTask;
-
     if (currentTask) {
-      await router.push('/onboarding/choose-organization')
+      await router.push(`/onboarding/${currentTask.key}`)
       return;
     }
 

--- a/.changeset/rich-donuts-agree.md
+++ b/.changeset/rich-donuts-agree.md
@@ -11,9 +11,14 @@ It's useful for handling pending session tasks for after-auth flows:
 await clerk.setActive({
   session,
   navigate: async ({ session }) => {
-    if (session.currentTask.key === 'choose-organization') {
+    const currentTask = session.currentTask;
+
+    if (currentTask) {
       await router.push('/onboarding/choose-organization')
+      return;
     }
+
+    await navigate('/dashboard')
   }
 });
 ```

--- a/.changeset/rich-donuts-agree.md
+++ b/.changeset/rich-donuts-agree.md
@@ -1,0 +1,19 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add `navigate` parameter to `clerk.setActive()` for custom navigation before the session and/or organization is set.
+
+It's useful for handling pending session tasks for after-auth flows:
+
+```typescript
+await clerk.setActive({
+  session,
+  navigate: async ({ session }) => {
+    if (session.currentTask.key === 'choose-organization') {
+      await router.push('/onboarding/choose-organization')
+    }
+  }
+});
+```

--- a/.changeset/warm-rocks-flow.md
+++ b/.changeset/warm-rocks-flow.md
@@ -1,0 +1,12 @@
+---
+'@clerk/tanstack-react-start': minor
+'@clerk/react-router': minor
+'@clerk/clerk-js': minor
+'@clerk/nextjs': minor
+'@clerk/clerk-react': minor
+'@clerk/remix': minor
+'@clerk/types': minor
+'@clerk/vue': minor
+---
+
+Remove `RedirectToTask` control component

--- a/.changeset/warm-rocks-flow.md
+++ b/.changeset/warm-rocks-flow.md
@@ -4,7 +4,6 @@
 '@clerk/nextjs': minor
 '@clerk/clerk-react': minor
 '@clerk/remix': minor
-'@clerk/types': minor
 '@clerk/vue': minor
 ---
 

--- a/.changeset/warm-rocks-flow.md
+++ b/.changeset/warm-rocks-flow.md
@@ -1,7 +1,6 @@
 ---
 '@clerk/tanstack-react-start': minor
 '@clerk/react-router': minor
-'@clerk/clerk-js': minor
 '@clerk/nextjs': minor
 '@clerk/clerk-react': minor
 '@clerk/remix': minor
@@ -9,4 +8,4 @@
 '@clerk/vue': minor
 ---
 
-Remove `RedirectToTask` control component
+Rename `RedirectToTask` control component to `RedirectToTasks`

--- a/integration/tests/session-tasks-sign-in.test.ts
+++ b/integration/tests/session-tasks-sign-in.test.ts
@@ -83,7 +83,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.signIn.enterTestOtpCode();
 
       // Resolves task
-      await u.po.signIn.waitForMounted();
+      await u.po.signUp.waitForMounted();
       const fakeOrganization = Object.assign(u.services.organizations.createFakeOrganization(), {
         slug: u.services.organizations.createFakeOrganization().slug + '-with-sign-in-sso',
       });

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -23,7 +23,10 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
     test.afterAll(async () => {
       const u = createTestUtils({ app });
       await u.services.organizations.deleteAll();
+      // Delete the user on the OAuth provider instance.
       await fakeUser.deleteIfExists();
+      // Delete the user on the app instance.
+      await u.services.users.deleteIfExists({ email: fakeUser.email });
       await app.teardown();
     });
 

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -41,8 +41,6 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       });
       const users = createUserService(client);
       await users.deleteIfExists({ email: fakeUserForOAuth.email });
-      // Delete OAuth user from `with-session-tasks` instance
-      await u.services.users.deleteIfExists({ email: fakeUserForOAuth.email });
 
       await app.teardown();
     });

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -1,19 +1,28 @@
+import { createClerkClient } from '@clerk/backend';
 import { expect, test } from '@playwright/test';
 
 import { appConfigs } from '../presets';
+import { instanceKeys } from '../presets/envs';
 import type { FakeUser } from '../testUtils';
 import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+import { createUserService } from '../testUtils/usersService';
 
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
   'session tasks after sign-up flow @nextjs',
   ({ app }) => {
     test.describe.configure({ mode: 'serial' });
 
-    let fakeUser: FakeUser;
+    let regularFakeUser: FakeUser;
+    let fakeUserForOAuth: FakeUser;
 
     test.beforeEach(() => {
       const u = createTestUtils({ app });
-      fakeUser = u.services.users.createFakeUser({
+      regularFakeUser = u.services.users.createFakeUser({
+        fictionalEmail: true,
+        withPhoneNumber: true,
+        withUsername: true,
+      });
+      fakeUserForOAuth = u.services.users.createFakeUser({
         fictionalEmail: true,
         withPhoneNumber: true,
         withUsername: true,
@@ -23,10 +32,18 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
     test.afterAll(async () => {
       const u = createTestUtils({ app });
       await u.services.organizations.deleteAll();
-      // Delete the user on the OAuth provider instance.
-      await fakeUser.deleteIfExists();
-      // Delete the user on the app instance.
-      await u.services.users.deleteIfExists({ email: fakeUser.email });
+      await regularFakeUser.deleteIfExists();
+
+      // Delete user from OAuth provider instance
+      const client = createClerkClient({
+        secretKey: instanceKeys.get('oauth-provider').sk,
+        publishableKey: instanceKeys.get('oauth-provider').pk,
+      });
+      const users = createUserService(client);
+      await users.deleteIfExists({ email: fakeUserForOAuth.email });
+      // Delete OAuth user from `with-session-tasks` instance
+      await u.services.users.deleteIfExists({ email: fakeUserForOAuth.email });
+
       await app.teardown();
     });
 
@@ -41,8 +58,8 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       const u = createTestUtils({ app, page, context });
       await u.po.signUp.goTo();
       await u.po.signUp.signUpWithEmailAndPassword({
-        email: fakeUser.email,
-        password: fakeUser.password,
+        email: regularFakeUser.email,
+        password: regularFakeUser.password,
       });
       await u.po.expect.toBeSignedIn();
 
@@ -71,7 +88,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.signIn.getGoToSignUp().click();
 
       await u.po.signUp.waitForMounted();
-      await u.po.signUp.setEmailAddress(fakeUser.email);
+      await u.po.signUp.setEmailAddress(fakeUserForOAuth.email);
       await u.po.signUp.continue();
       await u.po.signUp.enterTestOtpCode();
 

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -73,7 +73,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
       await u.po.signUp.enterTestOtpCode();
 
       // Resolves task
-      await u.po.signIn.waitForMounted();
+      await u.po.signUp.waitForMounted();
       const fakeOrganization = Object.assign(u.services.organizations.createFakeOrganization(), {
         slug: u.services.organizations.createFakeOrganization().slug + '-with-sign-in-sso',
       });

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "622.25KB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "76KB" },
+    { "path": "./dist/clerk.js", "maxSize": "625KB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "78KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "117KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "61KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "113KB" },

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -3,7 +3,7 @@
     { "path": "./dist/clerk.js", "maxSize": "622.25KB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "76KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "117KB" },
-    { "path": "./dist/clerk.headless*.js", "maxSize": "58KB" },
+    { "path": "./dist/clerk.headless*.js", "maxSize": "61KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "113KB" },
     { "path": "./dist/ui-common*.legacy.*.js", "maxSize": "118KB" },
     { "path": "./dist/vendors*.js", "maxSize": "40.2KB" },

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2471,7 +2471,6 @@ describe('Clerk singleton', () => {
         await sut.load(mockedLoadOptions);
 
         await sut.setActive({ session: mockResource as any as PendingSessionResource });
-        await sut.__internal_navigateToTaskIfAvailable();
 
         expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/tasks/choose-organization');
       });
@@ -2486,7 +2485,6 @@ describe('Clerk singleton', () => {
         });
 
         await sut.setActive({ session: mockResource as any as PendingSessionResource });
-        await sut.__internal_navigateToTaskIfAvailable();
 
         expect(mockNavigate.mock.calls[0][0]).toBe('/onboarding/choose-organization');
       });
@@ -2535,7 +2533,6 @@ describe('Clerk singleton', () => {
         await sut.setActive({ session: mockSession as any as ActiveSessionResource });
 
         const redirectUrlComplete = '/welcome-to-app';
-        await sut.__internal_navigateToTaskIfAvailable({ redirectUrlComplete });
 
         console.log(mockNavigate.mock.calls);
 

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -1033,7 +1033,7 @@ describe('Clerk singleton', () => {
         await sut.handleRedirectCallback();
 
         await waitFor(() => {
-          expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/tasks/choose-organization');
+          expect(mockNavigate.mock.calls[0][0]).toBe('/sign-up#/tasks/choose-organization');
         });
       });
     });

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -444,6 +444,18 @@ describe('Clerk singleton', () => {
         expect(sut.navigate).toHaveBeenCalledWith('/redirect-url-path');
       });
 
+      it('calls `navigate`', async () => {
+        mockSession.touch.mockReturnValue(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+        const navigate = jest.fn();
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+        await sut.setActive({ session: mockSession as any as PendingSessionResource, navigate });
+        expect(mockSession.touch).toHaveBeenCalled();
+        expect(navigate).toHaveBeenCalled();
+      });
+
       mockNativeRuntime(() => {
         it('calls session.touch in a non-standard browser', async () => {
           mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
@@ -484,7 +496,7 @@ describe('Clerk singleton', () => {
         getToken: jest.fn(),
         lastActiveToken: { getRawString: () => 'mocked-token' },
         tasks: [{ key: 'choose-organization' }],
-        currentTask: { key: 'choose-organization', __internal_getUrl: () => 'https://sut/tasks/choose-organization' },
+        currentTask: { key: 'choose-organization' },
         reload: jest.fn(() =>
           Promise.resolve({
             id: '1',
@@ -493,7 +505,6 @@ describe('Clerk singleton', () => {
             tasks: [{ key: 'choose-organization' }],
             currentTask: {
               key: 'choose-organization',
-              __internal_getUrl: () => 'https://sut/tasks/choose-organization',
             },
           }),
         ),
@@ -524,33 +535,7 @@ describe('Clerk singleton', () => {
         expect(mockSession.touch).toHaveBeenCalled();
       });
 
-      it('calls `onPendingSession` from clerk options', async () => {
-        mockSession.touch.mockReturnValue(Promise.resolve());
-        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
-        const onPendingSession = jest.fn();
-
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load({
-          onPendingSession,
-        });
-        await sut.setActive({ session: mockSession as any as PendingSessionResource });
-        expect(mockSession.touch).toHaveBeenCalled();
-        expect(onPendingSession).toHaveBeenCalled();
-      });
-
-      it('calls `onPendingSession` as argument', async () => {
-        mockSession.touch.mockReturnValue(Promise.resolve());
-        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
-        const onPendingSession = jest.fn();
-
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load();
-        await sut.setActive({ session: mockSession as any as PendingSessionResource, onPendingSession });
-        expect(mockSession.touch).toHaveBeenCalled();
-        expect(onPendingSession).toHaveBeenCalled();
-      });
-
-      it('if `onPendingSession` is not defined, navigate to `taskUrl` option', async () => {
+      it('navigate to `taskUrl` option', async () => {
         mockSession.touch.mockReturnValue(Promise.resolve());
         mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
 
@@ -564,6 +549,18 @@ describe('Clerk singleton', () => {
         await sut.setActive({ session: mockSession as any as PendingSessionResource });
         expect(mockSession.touch).toHaveBeenCalled();
         expect(sut.navigate).toHaveBeenCalledWith('/choose-organization');
+      });
+
+      it('calls `navigate`', async () => {
+        mockSession.touch.mockReturnValue(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+        const navigate = jest.fn();
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+        await sut.setActive({ session: mockSession as any as PendingSessionResource, navigate });
+        expect(mockSession.touch).toHaveBeenCalled();
+        expect(navigate).toHaveBeenCalled();
       });
     });
 
@@ -972,7 +969,7 @@ describe('Clerk singleton', () => {
           status: 'pending',
           user: {},
           tasks: [{ key: 'choose-organization' }],
-          currentTask: { key: 'choose-organization', __internal_getUrl: () => 'https://sut/tasks/choose-organization' },
+          currentTask: { key: 'choose-organization' },
           lastActiveToken: { getRawString: () => 'mocked-token' },
         };
 

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -535,6 +535,32 @@ describe('Clerk singleton', () => {
         expect(mockSession.touch).toHaveBeenCalled();
       });
 
+      it('does not call __unstable__onBeforeSetActive before session.touch', async () => {
+        mockSession.touch.mockReturnValueOnce(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+
+        const onBeforeSetActive = jest.fn();
+        (window as any).__unstable__onBeforeSetActive = onBeforeSetActive;
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
+        expect(onBeforeSetActive).not.toHaveBeenCalled();
+      });
+
+      it('does not call __unstable__onAfterSetActive after session.touch', async () => {
+        mockSession.touch.mockReturnValueOnce(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+
+        const onAfterSetActive = jest.fn();
+        (window as any).__unstable__onAfterSetActive = onAfterSetActive;
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
+        expect(onAfterSetActive).not.toHaveBeenCalled();
+      });
+
       it('navigate to `taskUrl` option', async () => {
         mockSession.touch.mockReturnValue(Promise.resolve());
         mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -474,6 +474,7 @@ describe('Clerk singleton', () => {
       });
     });
 
+    // TODO -> Refactor tests
     describe('with `pending` session status', () => {
       const mockSession = {
         id: '1',
@@ -525,6 +526,7 @@ describe('Clerk singleton', () => {
       });
     });
 
+    // TODO -> Refactor tests
     describe('with force organization selection enabled', () => {
       const mockSession = {
         id: '1',

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -1503,7 +1503,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           sessions: [mockSession],
-          signedInSessions: [],
+          signedInSessions: [mockSession],
           signIn: new SignIn(null),
           signUp: new SignUp({
             status: 'missing_requirements',
@@ -1543,7 +1543,7 @@ describe('Clerk singleton', () => {
       const mockSession = {
         id: sessionId,
         remove: jest.fn(),
-        status,
+        status: 'active',
         user: {},
         touch: jest.fn(() => Promise.resolve()),
         getToken: jest.fn(),
@@ -1564,7 +1564,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           sessions: [mockSession],
-          signedInSessions: [],
+          signedInSessions: [mockSession],
           signIn: new SignIn(null),
           signUp: new SignUp({
             status: 'missing_requirements',

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -474,7 +474,6 @@ describe('Clerk singleton', () => {
       });
     });
 
-    // TODO -> Refactor tests
     describe('with `pending` session status', () => {
       const mockSession = {
         id: '1',
@@ -521,12 +520,53 @@ describe('Clerk singleton', () => {
 
         const sut = new Clerk(productionPublishableKey);
         await sut.load();
-        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
+        await sut.setActive({ session: mockSession as any as PendingSessionResource });
         expect(mockSession.touch).toHaveBeenCalled();
+      });
+
+      it('calls `onPendingSession` from clerk options', async () => {
+        mockSession.touch.mockReturnValue(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+        const onPendingSession = jest.fn();
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load({
+          onPendingSession,
+        });
+        await sut.setActive({ session: mockSession as any as PendingSessionResource });
+        expect(mockSession.touch).toHaveBeenCalled();
+        expect(onPendingSession).toHaveBeenCalled();
+      });
+
+      it('calls `onPendingSession` as argument', async () => {
+        mockSession.touch.mockReturnValue(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+        const onPendingSession = jest.fn();
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+        await sut.setActive({ session: mockSession as any as PendingSessionResource, onPendingSession });
+        expect(mockSession.touch).toHaveBeenCalled();
+        expect(onPendingSession).toHaveBeenCalled();
+      });
+
+      it('if `onPendingSession` is not defined, navigate to `taskUrl` option', async () => {
+        mockSession.touch.mockReturnValue(Promise.resolve());
+        mockClientFetch.mockReturnValue(Promise.resolve({ signedInSessions: [mockSession] }));
+
+        const sut = new Clerk(productionPublishableKey);
+        sut.navigate = jest.fn();
+        await sut.load({
+          taskUrls: {
+            'choose-organization': '/choose-organization',
+          },
+        });
+        await sut.setActive({ session: mockSession as any as PendingSessionResource });
+        expect(mockSession.touch).toHaveBeenCalled();
+        expect(sut.navigate).toHaveBeenCalledWith('/choose-organization');
       });
     });
 
-    // TODO -> Refactor tests
     describe('with force organization selection enabled', () => {
       const mockSession = {
         id: '1',
@@ -909,7 +949,7 @@ describe('Clerk singleton', () => {
       mockEnvironmentFetch.mockReset();
     });
 
-    describe('with after-auth flows', () => {
+    describe('with pending session', () => {
       beforeEach(() => {
         mockClientFetch.mockReset();
         mockEnvironmentFetch.mockReturnValue(
@@ -926,7 +966,7 @@ describe('Clerk singleton', () => {
         );
       });
 
-      it('redirects to pending task', async () => {
+      it('navigates to task', async () => {
         const mockSession = {
           id: '1',
           status: 'pending',
@@ -956,7 +996,6 @@ describe('Clerk singleton', () => {
           }),
         );
 
-        const mockSetActive = jest.fn();
         const mockSignUpCreate = jest
           .fn()
           .mockReturnValue(Promise.resolve({ status: 'complete', createdSessionId: '123' }));
@@ -967,58 +1006,11 @@ describe('Clerk singleton', () => {
           fail('we should always have a client');
         }
         sut.client.signUp.create = mockSignUpCreate;
-        sut.setActive = mockSetActive;
 
         await sut.handleRedirectCallback();
 
         await waitFor(() => {
           expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/tasks/choose-organization');
-        });
-      });
-
-      it('redirects to after sign-in URL when task has been resolved', async () => {
-        const mockSession = {
-          id: '1',
-          status: 'active',
-          user: {},
-          lastActiveToken: { getRawString: () => 'mocked-token' },
-        };
-
-        const mockResource = {
-          ...mockSession,
-          remove: jest.fn(),
-          touch: jest.fn(() => Promise.resolve()),
-          getToken: jest.fn(),
-          reload: jest.fn(() => Promise.resolve(mockSession)),
-        };
-
-        mockResource.touch.mockReturnValueOnce(Promise.resolve());
-        mockClientFetch.mockReturnValue(
-          Promise.resolve({
-            signedInSessions: [mockResource],
-            signIn: new SignIn(null),
-            signUp: new SignUp(null),
-            isEligibleForTouch: () => false,
-          }),
-        );
-
-        const mockSetActive = jest.fn();
-        const mockSignUpCreate = jest
-          .fn()
-          .mockReturnValue(Promise.resolve({ status: 'complete', createdSessionId: '123' }));
-
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load(mockedLoadOptions);
-        if (!sut.client) {
-          fail('we should always have a client');
-        }
-        sut.client.signUp.create = mockSignUpCreate;
-        sut.setActive = mockSetActive;
-
-        await sut.handleRedirectCallback();
-
-        await waitFor(() => {
-          expect(mockNavigate.mock.calls[0][0]).toBe('/');
         });
       });
     });
@@ -2430,115 +2422,6 @@ describe('Clerk singleton', () => {
       expect(BaseResource._fetch).toHaveBeenCalledWith({
         method: 'GET',
         path: '/organizations/org_id',
-      });
-    });
-  });
-
-  describe('navigateToTask', () => {
-    describe('with `pending` session status', () => {
-      const mockSession = {
-        id: '1',
-        status: 'pending',
-        user: {},
-        tasks: [{ key: 'choose-organization' }],
-        currentTask: { key: 'choose-organization', __internal_getUrl: () => 'https://sut/tasks/choose-organization' },
-        lastActiveToken: { getRawString: () => 'mocked-token' },
-      };
-
-      const mockResource = {
-        ...mockSession,
-        remove: jest.fn(),
-        touch: jest.fn(() => Promise.resolve()),
-        getToken: jest.fn(),
-        reload: jest.fn(() => Promise.resolve(mockSession)),
-      };
-
-      beforeEach(() => {
-        mockResource.touch.mockReturnValueOnce(Promise.resolve());
-        mockClientFetch.mockReturnValue(
-          Promise.resolve({
-            signedInSessions: [mockResource],
-            isEligibleForTouch: () => false,
-          }),
-        );
-      });
-
-      afterEach(() => {
-        mockResource.remove.mockReset();
-        mockResource.touch.mockReset();
-      });
-
-      it('navigates to next task with default internal routing for AIOs', async () => {
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load(mockedLoadOptions);
-
-        await sut.setActive({ session: mockResource as any as PendingSessionResource });
-
-        expect(mockNavigate.mock.calls[0][0]).toBe('/sign-in#/tasks/choose-organization');
-      });
-
-      it('navigates to next task with custom routing from clerk options', async () => {
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load({
-          ...mockedLoadOptions,
-          taskUrls: {
-            'choose-organization': '/onboarding/choose-organization',
-          },
-        });
-
-        await sut.setActive({ session: mockResource as any as PendingSessionResource });
-
-        expect(mockNavigate.mock.calls[0][0]).toBe('/onboarding/choose-organization');
-      });
-    });
-
-    describe('with `active` session status', () => {
-      const mockSession = {
-        id: '1',
-        remove: jest.fn(),
-        status: 'active',
-        user: {},
-        touch: jest.fn(() => Promise.resolve()),
-        getToken: jest.fn(),
-        lastActiveToken: { getRawString: () => 'mocked-token' },
-        reload: jest.fn(() =>
-          Promise.resolve({
-            id: '1',
-            remove: jest.fn(),
-            status: 'active',
-            user: {},
-            touch: jest.fn(() => Promise.resolve()),
-            getToken: jest.fn(),
-            lastActiveToken: { getRawString: () => 'mocked-token' },
-          }),
-        ),
-      };
-
-      afterEach(() => {
-        mockSession.remove.mockReset();
-        mockSession.touch.mockReset();
-        (window as any).__unstable__onBeforeSetActive = null;
-        (window as any).__unstable__onAfterSetActive = null;
-      });
-
-      it('navigates to redirect url on completion', async () => {
-        mockSession.touch.mockReturnValue(Promise.resolve());
-        mockClientFetch.mockReturnValue(
-          Promise.resolve({
-            signedInSessions: [mockSession],
-            isEligibleForTouch: () => false,
-          }),
-        );
-
-        const sut = new Clerk(productionPublishableKey);
-        await sut.load(mockedLoadOptions);
-        await sut.setActive({ session: mockSession as any as ActiveSessionResource });
-
-        const redirectUrlComplete = '/welcome-to-app';
-
-        console.log(mockNavigate.mock.calls);
-
-        expect(mockNavigate.mock.calls[0][0]).toBe('/welcome-to-app');
       });
     });
   });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -428,10 +428,6 @@ export class Clerk implements ClerkInterface {
     });
 
     assertNoLegacyProp(this.#options);
-
-    if (this.__internal_hasAfterAuthFlows) {
-      warnNoTaskOptions(this.#options);
-    }
 
     if (this.#options.sdkMetadata) {
       Clerk.sdkMetadata = this.#options.sdkMetadata;
@@ -1268,6 +1264,10 @@ export class Clerk implements ClerkInterface {
       }
 
       if (newSession?.status === 'pending') {
+        warnNoTaskOptions({
+          ...this.#options,
+          onPendingSession: this.#options['onPendingSession'] ?? onPendingSession,
+        });
         await this.#handlePendingSession(newSession, onPendingSession);
         return;
       }
@@ -1362,7 +1362,7 @@ export class Clerk implements ClerkInterface {
     if (currentSession.status === 'pending') {
       const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
 
-      const onPendingSessionHook = this.#options['onPendingSession'] ?? onPendingSession;
+      const onPendingSessionHook = onPendingSession ?? this.#options['onPendingSession'];
       const taskUrls = this.#options['taskUrls'];
 
       await tracker.track(async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1755,8 +1755,6 @@ export class Clerk implements ClerkInterface {
       navigate: (to: string) => Promise<unknown>;
     },
   ): Promise<unknown> => {
-    debugger;
-
     if (!this.loaded || !this.environment || !this.client) {
       return;
     }
@@ -2006,10 +2004,7 @@ export class Clerk implements ClerkInterface {
     }
 
     if (this.session?.currentTask) {
-      await navigateIfTaskExists(this.session, {
-        baseUrl: params.signInUrl ?? displayConfig.signInUrl,
-        navigate: this.navigate,
-      });
+      await this.redirectToTasks();
       return;
     }
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1267,7 +1267,7 @@ export class Clerk implements ClerkInterface {
       }
 
       // Do not revalidate server cache for pending sessions to avoid unmount of `SignIn/SignUp` AIOs when navigating to task
-      if (!sessionIsPending) {
+      if (newSession?.status !== 'pending') {
         /**
          * Hint to each framework, that the user will be signed out when `{session: null}` is provided.
          */

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1997,6 +1997,14 @@ export class Clerk implements ClerkInterface {
       return navigateToNextStepSignUp({ missingFields: signUp.missingFields });
     }
 
+    if (this.session?.currentTask) {
+      await navigateIfTaskExists(this.session, {
+        baseUrl: params.signInUrl ?? displayConfig.signInUrl,
+        navigate: this.navigate,
+      });
+      return;
+    }
+
     return navigateToSignIn();
   };
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -151,7 +151,11 @@ import {
   Organization,
   Waitlist,
 } from './resources/internal';
-import { navigateIfTaskExists, warnMissingPendingTaskHandlers } from './sessionTasks';
+import {
+  INTERNAL_SESSION_TASK_ROUTE_BY_KEY,
+  navigateIfTaskExists,
+  warnMissingPendingTaskHandlers,
+} from './sessionTasks';
 import { State } from './state';
 import { warnings } from './warnings';
 
@@ -1560,6 +1564,28 @@ export class Clerk implements ClerkInterface {
     return this.buildUrlWithAuth(this.environment.displayConfig.organizationProfileUrl);
   }
 
+  public buildTasksUrl(): string {
+    const currentTask = this.session?.currentTask;
+    if (!currentTask) {
+      return '';
+    }
+
+    const customTaskUrl = this.#options.taskUrls?.[currentTask.key];
+    if (customTaskUrl) {
+      return customTaskUrl;
+    }
+
+    return buildURL(
+      {
+        base: this.buildSignInUrl(),
+        hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`,
+      },
+      {
+        stringify: true,
+      },
+    );
+  }
+
   #redirectToSatellite = async (): Promise<unknown> => {
     if (!inBrowser()) {
       return;
@@ -1646,6 +1672,13 @@ export class Clerk implements ClerkInterface {
   public redirectToWaitlist = async (): Promise<unknown> => {
     if (inBrowser()) {
       return this.navigate(this.buildWaitlistUrl());
+    }
+    return;
+  };
+
+  public redirectToTasks = async (): Promise<unknown> => {
+    if (inBrowser()) {
+      return this.navigate(this.buildTasksUrl());
     }
     return;
   };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -151,7 +151,7 @@ import {
   Organization,
   Waitlist,
 } from './resources/internal';
-import { navigateIfTaskExists } from './sessionTasks';
+import { navigateIfTaskExists, warnMissingPendingTaskHandlers } from './sessionTasks';
 import { State } from './state';
 import { warnings } from './warnings';
 
@@ -1230,6 +1230,10 @@ export class Clerk implements ClerkInterface {
 
       let newSession = session === undefined ? this.session : session;
       const sessionIsPending = newSession?.status === 'pending';
+
+      if (sessionIsPending) {
+        warnMissingPendingTaskHandlers(params);
+      }
 
       // At this point, the `session` variable should contain either an `SignedInSessionResource`
       // ,`null` or `undefined`.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1319,7 +1319,10 @@ export class Clerk implements ClerkInterface {
           }
 
           if (taskUrl) {
-            await this.navigate(taskUrl);
+            const taskUrlWithRedirect = redirectUrl
+              ? buildURL({ base: taskUrl, hashSearchParams: { redirectUrl } }, { stringify: true })
+              : taskUrl;
+            await this.navigate(taskUrlWithRedirect);
             return;
           }
 
@@ -2350,8 +2353,8 @@ export class Clerk implements ClerkInterface {
     this.#authService = await AuthCookieService.create(
       this,
       this.#fapiClient,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.#instanceType!,
+
+      this.#instanceType,
       this.#publicEventBus,
     );
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -119,7 +119,7 @@ import {
   stripOrigin,
   windowNavigate,
 } from '../utils';
-import { assertNoLegacyProp } from '../utils/assertNoLegacyProp';
+import { assertNoLegacyProp, warnNoTaskOptions } from '../utils/assertNoLegacyProp';
 import { CLERK_ENVIRONMENT_STORAGE_ENTRY, SafeLocalStorage } from '../utils/localStorage';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
 import { RedirectUrls } from '../utils/redirectUrls';
@@ -428,6 +428,10 @@ export class Clerk implements ClerkInterface {
     });
 
     assertNoLegacyProp(this.#options);
+
+    if (this.__internal_hasAfterAuthFlows) {
+      warnNoTaskOptions(this.#options);
+    }
 
     if (this.#options.sdkMetadata) {
       Clerk.sdkMetadata = this.#options.sdkMetadata;

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1929,6 +1929,7 @@ export class Clerk implements ClerkInterface {
       return this.setActive({
         session: su.sessionId,
         redirectUrl: redirectUrls.getAfterSignUpUrl(),
+        onPendingSession,
       });
     }
 
@@ -1953,6 +1954,7 @@ export class Clerk implements ClerkInterface {
         return this.setActive({
           session: sessionId,
           redirectUrl: redirectUrls.getAfterSignInUrl(),
+          onPendingSession,
         });
       }
     }

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1361,7 +1361,7 @@ export class Clerk implements ClerkInterface {
       this.#emit();
 
       // Do not revalidate server cache for pending sessions to avoid unmount of `SignIn/SignUp` AIOs when navigating to task
-      if (!sessionIsPending) {
+      if (!sessionIsPending || newSession?.status === 'active') {
         await onAfterSetActive();
       }
     } finally {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -151,7 +151,7 @@ import {
   Organization,
   Waitlist,
 } from './resources/internal';
-import { navigateToTask } from './sessionTasks';
+import { navigateIfTaskExists } from './sessionTasks';
 import { State } from './state';
 import { warnings } from './warnings';
 
@@ -1822,7 +1822,7 @@ export class Clerk implements ClerkInterface {
     };
 
     const setActiveNavigate: SetActiveNavigate = async ({ session }) => {
-      await navigateToTask(session, {
+      await navigateIfTaskExists(session, {
         baseUrl: displayConfig.signInUrl,
         navigate: this.navigate,
       });
@@ -2125,7 +2125,7 @@ export class Clerk implements ClerkInterface {
             session: signInOrSignUp.createdSessionId,
             redirectUrl,
             navigate: async ({ session }) => {
-              await navigateToTask(session, {
+              await navigateIfTaskExists(session, {
                 baseUrl: displayConfig.signInUrl,
                 navigate: this.navigate,
               });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1827,7 +1827,7 @@ export class Clerk implements ClerkInterface {
 
     const setActiveNavigate: SetActiveNavigate = async ({ session }) => {
       await navigateIfTaskExists(session, {
-        baseUrl: displayConfig.signInUrl,
+        baseUrl: params.signInUrl ?? displayConfig.signInUrl,
         navigate: this.navigate,
       });
     };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -18,7 +18,6 @@ import type {
   __experimental_CheckoutInstance,
   __experimental_CheckoutOptions,
   __internal_CheckoutProps,
-  __internal_ComponentNavigationContext,
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_SubscriptionDetailsProps,
@@ -50,6 +49,7 @@ import type {
   JoinWaitlistParams,
   ListenerCallback,
   NavigateOptions,
+  OnPendingSessionFn,
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationResource,
@@ -232,7 +232,6 @@ export class Clerk implements ClerkInterface {
   #options: ClerkOptions = {};
   #pageLifecycle: ReturnType<typeof createPageLifecycle> | null = null;
   #touchThrottledUntil = 0;
-  #componentNavigationContext: __internal_ComponentNavigationContext | null = null;
   #publicEventBus = createClerkEventBus();
 
   public __internal_getCachedResources:
@@ -1200,7 +1199,13 @@ export class Clerk implements ClerkInterface {
   /**
    * `setActive` can be used to set the active session and/or organization.
    */
-  public setActive = async ({ session, organization, beforeEmit, redirectUrl }: SetActiveParams): Promise<void> => {
+  public setActive = async ({
+    session,
+    organization,
+    beforeEmit,
+    redirectUrl,
+    onPendingSession,
+  }: SetActiveParams): Promise<void> => {
     this.__internal_setActiveInProgress = true;
     try {
       if (!this.client) {
@@ -1259,7 +1264,7 @@ export class Clerk implements ClerkInterface {
       }
 
       if (newSession?.status === 'pending') {
-        await this.#handlePendingSession(newSession);
+        await this.#handlePendingSession(newSession, onPendingSession);
         return;
       }
 
@@ -1329,41 +1334,18 @@ export class Clerk implements ClerkInterface {
     }
   };
 
-  #handlePendingSession = async (session: PendingSessionResource) => {
-    /**
-     * Do not revalidate server cache when `setActive` is called with a pending
-     * session within components, to avoid flash of content and unmount during
-     * internal navigation
-     */
-    const shouldInvalidateCache = !this.#componentNavigationContext;
-
-    const onBeforeSetActive: SetActiveHook =
-      shouldInvalidateCache &&
-      typeof window !== 'undefined' &&
-      typeof window.__unstable__onBeforeSetActive === 'function'
-        ? window.__unstable__onBeforeSetActive
-        : noop;
-
-    const onAfterSetActive: SetActiveHook =
-      shouldInvalidateCache &&
-      typeof window !== 'undefined' &&
-      typeof window.__unstable__onAfterSetActive === 'function'
-        ? window.__unstable__onAfterSetActive
-        : noop;
-
-    await onBeforeSetActive();
-
+  #handlePendingSession = async (session: PendingSessionResource, onPendingSession?: OnPendingSessionFn) => {
     if (!this.environment) {
       return;
     }
 
-    let newSession: SignedInSessionResource | null = session;
+    let currentSession: SignedInSessionResource | null = session;
 
-    // Handles multi-session scenario when switching between `pending` sessions
-    // and satisfying task requirements such as organization selection
     if (inActiveBrowserTab() || !this.#options.standardBrowser) {
+      // Handles multi-session scenario when switching between `pending` sessions
+      // and satisfying task requirements such as organization selection
       await this.#touchCurrentSession(session);
-      newSession = this.#getSessionFromClient(session.id) ?? session;
+      currentSession = this.#getSessionFromClient(session.id) ?? session;
     }
 
     // Syncs __session and __client_uat, in case the `pending` session
@@ -1373,19 +1355,26 @@ export class Clerk implements ClerkInterface {
       eventBus.emit(events.TokenUpdate, { token: null });
     }
 
-    if (newSession?.currentTask) {
-      await navigateToTask(session.currentTask.key, {
-        options: this.#options,
-        environment: this.environment,
-        globalNavigate: this.navigate,
-        componentNavigationContext: this.#componentNavigationContext,
+    if (currentSession.status === 'pending') {
+      const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
+      const onPendingSessionHook = this.__internal_getOption('onPendingSession') ?? onPendingSession;
+      const taskUrls = this.__internal_getOption('taskUrls');
+
+      await tracker.track(async () => {
+        if (onPendingSessionHook) {
+          await onPendingSessionHook({ session: currentSession });
+        } else if (taskUrls) {
+          await this.navigate(taskUrls[session.currentTask.key]);
+        }
       });
+
+      if (tracker.isUnloading()) {
+        return;
+      }
     }
 
-    this.#setAccessors(session);
+    this.#setAccessors(currentSession);
     this.#emit();
-
-    await onAfterSetActive();
   };
 
   public addListener = (listener: ListenerCallback): UnsubscribeCallback => {
@@ -1420,12 +1409,6 @@ export class Clerk implements ClerkInterface {
       this.#navigationListeners = this.#navigationListeners.filter(l => l !== listener);
     };
     return unsubscribe;
-  };
-
-  public __internal_setComponentNavigationContext = (context: __internal_ComponentNavigationContext) => {
-    this.#componentNavigationContext = context;
-
-    return () => (this.#componentNavigationContext = null);
   };
 
   public navigate = async (to: string | undefined, options?: NavigateOptions): Promise<unknown> => {
@@ -1857,10 +1840,18 @@ export class Clerk implements ClerkInterface {
       });
     };
 
+    const onPendingSession: OnPendingSessionFn = ({ session }) =>
+      navigateToTask(session, {
+        baseUrl: displayConfig.signInUrl,
+        navigate: this.navigate,
+        options: this.#options,
+      });
+
     if (si.status === 'complete') {
       return this.setActive({
         session: si.sessionId,
         redirectUrl: redirectUrls.getAfterSignInUrl(),
+        onPendingSession,
       });
     }
 
@@ -1874,6 +1865,7 @@ export class Clerk implements ClerkInterface {
           return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignInUrl(),
+            onPendingSession,
           });
         case 'needs_first_factor':
           return navigateToFactorOne();
@@ -1923,6 +1915,7 @@ export class Clerk implements ClerkInterface {
           return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignUpUrl(),
+            onPendingSession,
           });
         case 'missing_requirements':
           return navigateToNextStepSignUp({ missingFields: res.missingFields });
@@ -2148,6 +2141,12 @@ export class Clerk implements ClerkInterface {
           await this.setActive({
             session: signInOrSignUp.createdSessionId,
             redirectUrl,
+            onPendingSession: ({ session }) =>
+              navigateToTask(session, {
+                baseUrl: displayConfig.signInUrl,
+                navigate: this.navigate,
+                options: this.#options,
+              }),
           });
         }
         break;

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -49,7 +49,6 @@ import type {
   JoinWaitlistParams,
   ListenerCallback,
   NavigateOptions,
-  OnPendingSessionFn,
   OrganizationListProps,
   OrganizationProfileProps,
   OrganizationResource,
@@ -62,6 +61,7 @@ import type {
   RedirectOptions,
   Resources,
   SDKMetadata,
+  SetActiveNavigate,
   SetActiveParams,
   SignedInSessionResource,
   SignInProps,
@@ -1300,7 +1300,9 @@ export class Clerk implements ClerkInterface {
         });
       }
 
-      const shouldNavigate = (redirectUrl || setActiveNavigate) && !beforeEmit;
+      const taskUrl =
+        sessionIsPending && this.session?.currentTask && this.#options.taskUrls?.[this.session?.currentTask.key];
+      const shouldNavigate = (redirectUrl || taskUrl || setActiveNavigate) && !beforeEmit;
       if (shouldNavigate) {
         await tracker.track(async () => {
           if (!this.client) {
@@ -1308,19 +1310,17 @@ export class Clerk implements ClerkInterface {
             return;
           }
 
-          if (sessionIsPending) {
+          if (!sessionIsPending) {
             this.#setTransitiveState();
           }
 
-          if (setActiveNavigate) {
-            await setActiveNavigate();
+          if (taskUrl) {
+            await this.navigate(taskUrl);
             return;
           }
 
-          const taskUrl =
-            sessionIsPending && this.session?.currentTask && this.#options.taskUrls?.[this.session?.currentTask.key];
-          if (taskUrl) {
-            await this.navigate(taskUrl);
+          if (setActiveNavigate && newSession) {
+            await setActiveNavigate({ session: newSession });
             return;
           }
 
@@ -1821,18 +1821,18 @@ export class Clerk implements ClerkInterface {
       });
     };
 
-    const onPendingSession: OnPendingSessionFn = ({ session }) =>
-      navigateToTask(session, {
+    const setActiveNavigate: SetActiveNavigate = async ({ session }) => {
+      await navigateToTask(session, {
         baseUrl: displayConfig.signInUrl,
         navigate: this.navigate,
-        options: this.#options,
       });
+    };
 
     if (si.status === 'complete') {
       return this.setActive({
         session: si.sessionId,
         redirectUrl: redirectUrls.getAfterSignInUrl(),
-        onPendingSession,
+        navigate: setActiveNavigate,
       });
     }
 
@@ -1846,7 +1846,7 @@ export class Clerk implements ClerkInterface {
           return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignInUrl(),
-            onPendingSession,
+            navigate: setActiveNavigate,
           });
         case 'needs_first_factor':
           return navigateToFactorOne();
@@ -1896,7 +1896,7 @@ export class Clerk implements ClerkInterface {
           return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignUpUrl(),
-            onPendingSession,
+            navigate: setActiveNavigate,
           });
         case 'missing_requirements':
           return navigateToNextStepSignUp({ missingFields: res.missingFields });
@@ -1909,7 +1909,7 @@ export class Clerk implements ClerkInterface {
       return this.setActive({
         session: su.sessionId,
         redirectUrl: redirectUrls.getAfterSignUpUrl(),
-        onPendingSession,
+        navigate: setActiveNavigate,
       });
     }
 
@@ -1934,7 +1934,7 @@ export class Clerk implements ClerkInterface {
         return this.setActive({
           session: sessionId,
           redirectUrl: redirectUrls.getAfterSignInUrl(),
-          onPendingSession,
+          navigate: setActiveNavigate,
         });
       }
     }
@@ -2124,12 +2124,12 @@ export class Clerk implements ClerkInterface {
           await this.setActive({
             session: signInOrSignUp.createdSessionId,
             redirectUrl,
-            onPendingSession: ({ session }) =>
-              navigateToTask(session, {
+            navigate: async ({ session }) => {
+              await navigateToTask(session, {
                 baseUrl: displayConfig.signInUrl,
                 navigate: this.navigate,
-                options: this.#options,
-              }),
+              });
+            },
           });
         }
         break;
@@ -2346,8 +2346,8 @@ export class Clerk implements ClerkInterface {
     this.#authService = await AuthCookieService.create(
       this,
       this.#fapiClient,
-
-      this.#instanceType,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.#instanceType!,
       this.#publicEventBus,
     );
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -151,11 +151,7 @@ import {
   Organization,
   Waitlist,
 } from './resources/internal';
-import {
-  INTERNAL_SESSION_TASK_ROUTE_BY_KEY,
-  navigateIfTaskExists,
-  warnMissingPendingTaskHandlers,
-} from './sessionTasks';
+import { getTaskEndpoint, navigateIfTaskExists, warnMissingPendingTaskHandlers } from './sessionTasks';
 import { State } from './state';
 import { warnings } from './warnings';
 
@@ -1569,7 +1565,7 @@ export class Clerk implements ClerkInterface {
     return buildURL(
       {
         base: this.buildSignInUrl(),
-        hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`,
+        hashPath: getTaskEndpoint(currentTask),
       },
       {
         stringify: true,

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1263,8 +1263,6 @@ export class Clerk implements ClerkInterface {
         }
       }
 
-      debugger;
-
       if (newSession?.status === 'pending') {
         await this.#handlePendingSession(newSession, onPendingSession);
         return;
@@ -1337,8 +1335,6 @@ export class Clerk implements ClerkInterface {
   };
 
   #handlePendingSession = async (session: PendingSessionResource, onPendingSession?: OnPendingSessionFn) => {
-    debugger;
-
     if (!this.environment) {
       return;
     }
@@ -1361,12 +1357,12 @@ export class Clerk implements ClerkInterface {
 
     if (currentSession.status === 'pending') {
       const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
+
       const onPendingSessionHook = this.#options['onPendingSession'] ?? onPendingSession;
       const taskUrls = this.#options['taskUrls'];
 
       await tracker.track(async () => {
         if (onPendingSessionHook) {
-          debugger;
           await onPendingSessionHook({ session: currentSession });
         } else if (taskUrls) {
           await this.navigate(taskUrls[session.currentTask.key]);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -110,12 +110,12 @@ import {
   isError,
   isOrganizationId,
   isRedirectForFAPIInitiatedFlow,
+  isSignedInAndSingleSessionModeEnabled,
   noOrganizationExists,
   noUserExists,
   processCssLayerNameExtraction,
   removeClerkQueryParam,
   requiresUserInput,
-  sessionExistsAndSingleSessionModeEnabled,
   stripOrigin,
   windowNavigate,
 } from '../utils';
@@ -552,7 +552,7 @@ export class Clerk implements ClerkInterface {
 
   public openSignIn = (props?: SignInProps): void => {
     this.assertComponentsReady(this.#componentControls);
-    if (sessionExistsAndSingleSessionModeEnabled(this, this.environment)) {
+    if (isSignedInAndSingleSessionModeEnabled(this, this.environment)) {
       if (this.#instanceType === 'development') {
         throw new ClerkRuntimeError(warnings.cannotOpenSignInOrSignUp, {
           code: CANNOT_RENDER_SINGLE_SESSION_ENABLED_ERROR_CODE,
@@ -686,7 +686,7 @@ export class Clerk implements ClerkInterface {
 
   public openSignUp = (props?: SignUpProps): void => {
     this.assertComponentsReady(this.#componentControls);
-    if (sessionExistsAndSingleSessionModeEnabled(this, this.environment)) {
+    if (isSignedInAndSingleSessionModeEnabled(this, this.environment)) {
       if (this.#instanceType === 'development') {
         throw new ClerkRuntimeError(warnings.cannotOpenSignInOrSignUp, {
           code: CANNOT_RENDER_SINGLE_SESSION_ENABLED_ERROR_CODE,
@@ -1263,6 +1263,8 @@ export class Clerk implements ClerkInterface {
         }
       }
 
+      debugger;
+
       if (newSession?.status === 'pending') {
         await this.#handlePendingSession(newSession, onPendingSession);
         return;
@@ -1335,6 +1337,8 @@ export class Clerk implements ClerkInterface {
   };
 
   #handlePendingSession = async (session: PendingSessionResource, onPendingSession?: OnPendingSessionFn) => {
+    debugger;
+
     if (!this.environment) {
       return;
     }
@@ -1357,11 +1361,12 @@ export class Clerk implements ClerkInterface {
 
     if (currentSession.status === 'pending') {
       const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
-      const onPendingSessionHook = this.__internal_getOption('onPendingSession') ?? onPendingSession;
-      const taskUrls = this.__internal_getOption('taskUrls');
+      const onPendingSessionHook = this.#options['onPendingSession'] ?? onPendingSession;
+      const taskUrls = this.#options['taskUrls'];
 
       await tracker.track(async () => {
         if (onPendingSessionHook) {
+          debugger;
           await onPendingSessionHook({ session: currentSession });
         } else if (taskUrls) {
           await this.navigate(taskUrls[session.currentTask.key]);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1232,7 +1232,7 @@ export class Clerk implements ClerkInterface {
       const sessionIsPending = newSession?.status === 'pending';
 
       if (sessionIsPending) {
-        warnMissingPendingTaskHandlers(params);
+        warnMissingPendingTaskHandlers({ ...this.#options, ...params });
       }
 
       // At this point, the `session` variable should contain either an `SignedInSessionResource`
@@ -1305,7 +1305,7 @@ export class Clerk implements ClerkInterface {
       }
 
       const taskUrl =
-        sessionIsPending && this.session?.currentTask && this.#options.taskUrls?.[this.session?.currentTask.key];
+        sessionIsPending && newSession?.currentTask && this.#options.taskUrls?.[newSession?.currentTask.key];
       const shouldNavigate = (redirectUrl || taskUrl || setActiveNavigate) && !beforeEmit;
       if (shouldNavigate) {
         await tracker.track(async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
+  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
-  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -2353,8 +2353,8 @@ export class Clerk implements ClerkInterface {
     this.#authService = await AuthCookieService.create(
       this,
       this.#fapiClient,
-
-      this.#instanceType,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.#instanceType!,
       this.#publicEventBus,
     );
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -19,7 +19,6 @@ import type {
   __experimental_CheckoutOptions,
   __internal_CheckoutProps,
   __internal_ComponentNavigationContext,
-  __internal_NavigateToTaskIfAvailableParams,
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_SubscriptionDetailsProps,
@@ -30,9 +29,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -1374,9 +1373,7 @@ export class Clerk implements ClerkInterface {
       eventBus.emit(events.TokenUpdate, { token: null });
     }
 
-    // Only triggers navigation for internal AIO components routing or custom URLs
-    const shouldNavigateOnSetActive = this.#componentNavigationContext;
-    if (newSession?.currentTask && shouldNavigateOnSetActive) {
+    if (newSession?.currentTask) {
       await navigateToTask(session.currentTask.key, {
         options: this.#options,
         environment: this.environment,
@@ -1387,60 +1384,6 @@ export class Clerk implements ClerkInterface {
 
     this.#setAccessors(session);
     this.#emit();
-
-    await onAfterSetActive();
-  };
-
-  public __internal_navigateToTaskIfAvailable = async ({
-    redirectUrlComplete,
-  }: __internal_NavigateToTaskIfAvailableParams = {}): Promise<void> => {
-    const onBeforeSetActive: SetActiveHook =
-      typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
-        ? window.__unstable__onBeforeSetActive
-        : noop;
-
-    const onAfterSetActive: SetActiveHook =
-      typeof window !== 'undefined' && typeof window.__unstable__onAfterSetActive === 'function'
-        ? window.__unstable__onAfterSetActive
-        : noop;
-
-    const session = this.session;
-    if (!session || !this.environment) {
-      return;
-    }
-
-    if (session.status === 'pending') {
-      await navigateToTask(session.currentTask.key, {
-        options: this.#options,
-        environment: this.environment,
-        globalNavigate: this.navigate,
-        componentNavigationContext: this.#componentNavigationContext,
-      });
-      return;
-    }
-
-    await onBeforeSetActive();
-
-    if (redirectUrlComplete) {
-      const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
-
-      await tracker.track(async () => {
-        if (!this.client) {
-          return;
-        }
-
-        if (this.client.isEligibleForTouch()) {
-          const absoluteRedirectUrl = new URL(redirectUrlComplete, window.location.href);
-          await this.navigate(this.buildUrlWithAuth(this.client.buildTouchUrl({ redirectUrl: absoluteRedirectUrl })));
-        } else {
-          await this.navigate(redirectUrlComplete);
-        }
-      });
-
-      if (tracker.isUnloading()) {
-        return;
-      }
-    }
 
     await onAfterSetActive();
   };
@@ -1915,11 +1858,10 @@ export class Clerk implements ClerkInterface {
     };
 
     if (si.status === 'complete') {
-      await this.setActive({
+      return this.setActive({
         session: si.sessionId,
         redirectUrl: redirectUrls.getAfterSignInUrl(),
       });
-      return this.__internal_navigateToTaskIfAvailable();
     }
 
     const userExistsButNeedsToSignIn =
@@ -1929,11 +1871,10 @@ export class Clerk implements ClerkInterface {
       const res = await signIn.create({ transfer: true });
       switch (res.status) {
         case 'complete':
-          await this.setActive({
+          return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignInUrl(),
           });
-          return this.__internal_navigateToTaskIfAvailable();
         case 'needs_first_factor':
           return navigateToFactorOne();
         case 'needs_second_factor':
@@ -1979,11 +1920,10 @@ export class Clerk implements ClerkInterface {
       const res = await signUp.create({ transfer: true });
       switch (res.status) {
         case 'complete':
-          await this.setActive({
+          return this.setActive({
             session: res.createdSessionId,
             redirectUrl: redirectUrls.getAfterSignUpUrl(),
           });
-          return this.__internal_navigateToTaskIfAvailable();
         case 'missing_requirements':
           return navigateToNextStepSignUp({ missingFields: res.missingFields });
         default:
@@ -1992,11 +1932,10 @@ export class Clerk implements ClerkInterface {
     }
 
     if (su.status === 'complete') {
-      await this.setActive({
+      return this.setActive({
         session: su.sessionId,
         redirectUrl: redirectUrls.getAfterSignUpUrl(),
       });
-      return this.__internal_navigateToTaskIfAvailable();
     }
 
     if (si.status === 'needs_second_factor') {
@@ -2030,10 +1969,6 @@ export class Clerk implements ClerkInterface {
 
     if (su.externalAccountStatus === 'verified' && su.status === 'missing_requirements') {
       return navigateToNextStepSignUp({ missingFields: signUp.missingFields });
-    }
-
-    if (this.__internal_hasAfterAuthFlows) {
-      return this.__internal_navigateToTaskIfAvailable({ redirectUrlComplete: redirectUrls.getAfterSignInUrl() });
     }
 
     return navigateToSignIn();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -28,9 +28,9 @@ import type {
   AuthenticateWithGoogleOneTapParams,
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -54,7 +54,6 @@ import type {
   OrganizationProfileProps,
   OrganizationResource,
   OrganizationSwitcherProps,
-  PendingSessionResource,
   PricingTableProps,
   PublicKeyCredentialCreationOptionsWithoutExtensions,
   PublicKeyCredentialRequestOptionsWithoutExtensions,
@@ -119,7 +118,7 @@ import {
   stripOrigin,
   windowNavigate,
 } from '../utils';
-import { assertNoLegacyProp, warnNoTaskOptions } from '../utils/assertNoLegacyProp';
+import { assertNoLegacyProp } from '../utils/assertNoLegacyProp';
 import { CLERK_ENVIRONMENT_STORAGE_ENTRY, SafeLocalStorage } from '../utils/localStorage';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
 import { RedirectUrls } from '../utils/redirectUrls';
@@ -1199,14 +1198,11 @@ export class Clerk implements ClerkInterface {
   /**
    * `setActive` can be used to set the active session and/or organization.
    */
-  public setActive = async ({
-    session,
-    organization,
-    beforeEmit,
-    redirectUrl,
-    onPendingSession,
-  }: SetActiveParams): Promise<void> => {
+  public setActive = async (params: SetActiveParams): Promise<void> => {
+    const { organization, beforeEmit, redirectUrl, navigate: setActiveNavigate } = params;
+    let { session } = params;
     this.__internal_setActiveInProgress = true;
+
     try {
       if (!this.client) {
         throw new Error('setActive is being called before the client is loaded. Wait for init.');
@@ -1216,6 +1212,10 @@ export class Clerk implements ClerkInterface {
         throw new Error(
           'setActive should either be called with a session param or there should be already an active session.',
         );
+      }
+
+      if (typeof session === 'string') {
+        session = (this.client.sessions.find(x => x.id === session) as SignedInSessionResource) || null;
       }
 
       const onBeforeSetActive: SetActiveHook =
@@ -1228,11 +1228,8 @@ export class Clerk implements ClerkInterface {
           ? window.__unstable__onAfterSetActive
           : noop;
 
-      if (typeof session === 'string') {
-        session = (this.client.sessions.find(x => x.id === session) as SignedInSessionResource) || null;
-      }
-
       let newSession = session === undefined ? this.session : session;
+      const sessionIsPending = newSession?.status === 'pending';
 
       // At this point, the `session` variable should contain either an `SignedInSessionResource`
       // ,`null` or `undefined`.
@@ -1263,19 +1260,13 @@ export class Clerk implements ClerkInterface {
         }
       }
 
-      if (newSession?.status === 'pending') {
-        warnNoTaskOptions({
-          ...this.#options,
-          onPendingSession: this.#options['onPendingSession'] ?? onPendingSession,
-        });
-        await this.#handlePendingSession(newSession, onPendingSession);
-        return;
+      // Do not revalidate server cache for pending sessions to avoid unmount of `SignIn/SignUp` AIOs when navigating to task
+      if (!sessionIsPending) {
+        /**
+         * Hint to each framework, that the user will be signed out when `{session: null}` is provided.
+         */
+        await onBeforeSetActive(newSession === null ? 'sign-out' : undefined);
       }
-
-      /**
-       * Hint to each framework, that the user will be signed out when `{session: null}` is provided.
-       */
-      await onBeforeSetActive(newSession === null ? 'sign-out' : undefined);
 
       //1. setLastActiveSession to passed user session (add a param).
       //   Note that this will also update the session's active organization
@@ -1309,19 +1300,44 @@ export class Clerk implements ClerkInterface {
         });
       }
 
-      if (redirectUrl && !beforeEmit) {
+      const shouldNavigate = (redirectUrl || setActiveNavigate) && !beforeEmit;
+      if (shouldNavigate) {
         await tracker.track(async () => {
           if (!this.client) {
             // Typescript is not happy because since thinks this.client might have changed to undefined because the function is asynchronous.
             return;
           }
-          this.#setTransitiveState();
-          if (this.client.isEligibleForTouch()) {
-            const absoluteRedirectUrl = new URL(redirectUrl, window.location.href);
-            await this.navigate(this.buildUrlWithAuth(this.client.buildTouchUrl({ redirectUrl: absoluteRedirectUrl })));
-          } else {
-            await this.navigate(redirectUrl);
+
+          if (sessionIsPending) {
+            this.#setTransitiveState();
           }
+
+          if (setActiveNavigate) {
+            await setActiveNavigate();
+            return;
+          }
+
+          const taskUrl =
+            sessionIsPending && this.session?.currentTask && this.#options.taskUrls?.[this.session?.currentTask.key];
+          if (taskUrl) {
+            await this.navigate(taskUrl);
+            return;
+          }
+
+          if (!redirectUrl) {
+            return;
+          }
+
+          if (!this.client.isEligibleForTouch()) {
+            await this.navigate(redirectUrl);
+            return;
+          }
+
+          const absoluteRedirectUrl = new URL(redirectUrl, window.location.href);
+          const redirectUrlWithAuth = this.buildUrlWithAuth(
+            this.client.buildTouchUrl({ redirectUrl: absoluteRedirectUrl }),
+          );
+          await this.navigate(redirectUrlWithAuth);
         });
       }
 
@@ -1332,54 +1348,14 @@ export class Clerk implements ClerkInterface {
 
       this.#setAccessors(newSession);
       this.#emit();
-      await onAfterSetActive();
+
+      // Do not revalidate server cache for pending sessions to avoid unmount of `SignIn/SignUp` AIOs when navigating to task
+      if (!sessionIsPending) {
+        await onAfterSetActive();
+      }
     } finally {
       this.__internal_setActiveInProgress = false;
     }
-  };
-
-  #handlePendingSession = async (session: PendingSessionResource, onPendingSession?: OnPendingSessionFn) => {
-    if (!this.environment) {
-      return;
-    }
-
-    let currentSession: SignedInSessionResource | null = session;
-
-    if (inActiveBrowserTab() || !this.#options.standardBrowser) {
-      // Handles multi-session scenario when switching between `pending` sessions
-      // and satisfying task requirements such as organization selection
-      await this.#touchCurrentSession(session);
-      currentSession = this.#getSessionFromClient(session.id) ?? session;
-    }
-
-    // Syncs __session and __client_uat, in case the `pending` session
-    // has expired, it needs to trigger a sign-out
-    const token = await session.getToken();
-    if (!token) {
-      eventBus.emit(events.TokenUpdate, { token: null });
-    }
-
-    if (currentSession.status === 'pending') {
-      const tracker = createBeforeUnloadTracker(this.#options.standardBrowser);
-
-      const onPendingSessionHook = onPendingSession ?? this.#options['onPendingSession'];
-      const taskUrls = this.#options['taskUrls'];
-
-      await tracker.track(async () => {
-        if (onPendingSessionHook) {
-          await onPendingSessionHook({ session: currentSession });
-        } else if (taskUrls) {
-          await this.navigate(taskUrls[session.currentTask.key]);
-        }
-      });
-
-      if (tracker.isUnloading()) {
-        return;
-      }
-    }
-
-    this.#setAccessors(currentSession);
-    this.#emit();
   };
 
   public addListener = (listener: ListenerCallback): UnsubscribeCallback => {
@@ -2370,8 +2346,8 @@ export class Clerk implements ClerkInterface {
     this.#authService = await AuthCookieService.create(
       this,
       this.#fapiClient,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.#instanceType!,
+
+      this.#instanceType,
       this.#publicEventBus,
     );
 

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -43,7 +43,6 @@ import type {
 } from '@clerk/types';
 
 import {
-  buildURL,
   generateSignatureWithCoinbaseWallet,
   generateSignatureWithMetamask,
   generateSignatureWithOKXWallet,
@@ -251,24 +250,13 @@ export class SignIn extends BaseResource implements SignInResource {
     navigateCallback: (url: URL | string) => void,
   ): Promise<void> => {
     const { strategy, redirectUrl, redirectUrlComplete, identifier, oidcPrompt, continueSignIn } = params || {};
-
-    const redirectUrlWithAuthToken = SignIn.clerk.buildUrlWithAuth(redirectUrl);
-
-    // When after-auth is enabled, redirect to SSO callback route.
-    // This ensures organization selection tasks are displayed after sign-in,
-    // rather than redirecting to potentially unprotected pages while the session is pending.
-    const actionCompleteRedirectUrl = SignIn.clerk.__internal_hasAfterAuthFlows
-      ? buildURL({
-          base: redirectUrlWithAuthToken,
-          search: `?redirect_url=${redirectUrlComplete}`,
-        }).toString()
-      : redirectUrlComplete;
+    const actionCompleteRedirectUrl = redirectUrlComplete;
 
     if (!this.id || !continueSignIn) {
       await this.create({
         strategy,
         identifier,
-        redirectUrl: redirectUrlWithAuthToken,
+        redirectUrl,
         actionCompleteRedirectUrl,
       });
     }

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -249,8 +249,10 @@ export class SignIn extends BaseResource implements SignInResource {
     params: AuthenticateWithRedirectParams,
     navigateCallback: (url: URL | string) => void,
   ): Promise<void> => {
-    const { strategy, redirectUrl, redirectUrlComplete, identifier, oidcPrompt, continueSignIn } = params || {};
+    const { strategy, redirectUrlComplete, identifier, oidcPrompt, continueSignIn } = params || {};
     const actionCompleteRedirectUrl = redirectUrlComplete;
+
+    const redirectUrl = SignIn.clerk.buildUrlWithAuth(params.redirectUrl);
 
     if (!this.id || !continueSignIn) {
       await this.create({
@@ -264,7 +266,7 @@ export class SignIn extends BaseResource implements SignInResource {
     if (strategy === 'saml' || strategy === 'enterprise_sso') {
       await this.prepareFirstFactor({
         strategy,
-        redirectUrl: SignIn.clerk.buildUrlWithAuth(redirectUrl),
+        redirectUrl,
         actionCompleteRedirectUrl,
         oidcPrompt,
       });

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -290,18 +290,11 @@ export class SignUp extends BaseResource implements SignUpResource {
 
     const redirectUrlWithAuthToken = SignUp.clerk.buildUrlWithAuth(redirectUrl);
 
-    // When force after-auth is enabled, redirect to SSO callback route.
-    // This ensures organization selection tasks are displayed after sign-up,
-    // rather than redirecting to potentially unprotected pages while the session is pending.
-    const actionCompleteRedirectUrl = SignUp.clerk.__internal_hasAfterAuthFlows
-      ? redirectUrlWithAuthToken
-      : redirectUrlComplete;
-
     const authenticateFn = () => {
       const authParams = {
         strategy,
         redirectUrl: redirectUrlWithAuthToken,
-        actionCompleteRedirectUrl,
+        actionCompleteRedirectUrl: redirectUrlComplete,
         unsafeMetadata,
         emailAddress,
         legalAccepted,

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -2,16 +2,16 @@ import type { ClerkOptions, PendingSessionResource, SessionTask } from '@clerk/t
 
 import { buildURL } from '../utils';
 
+/**
+ * @internal
+ */
 export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], string> = {
   'choose-organization': 'choose-organization',
 } as const;
 
-interface NavigateToTaskOptions {
-  navigate: (to: string) => Promise<unknown>;
-  baseUrl: string;
-  options?: ClerkOptions;
-}
-
+/**
+ * @internal
+ */
 export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
   return buildURL(
     {
@@ -25,7 +25,18 @@ export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof bui
 /**
  * @internal
  */
-export function navigateToTask(session: PendingSessionResource, { options, navigate, baseUrl }: NavigateToTaskOptions) {
+export function navigateToTask(
+  session: PendingSessionResource,
+  {
+    options,
+    navigate,
+    baseUrl,
+  }: {
+    navigate: (to: string) => Promise<unknown>;
+    baseUrl: string;
+    options?: ClerkOptions;
+  },
+) {
   const currentTaskKey = session.currentTask.key;
 
   return navigate(options?.taskUrls?.[currentTaskKey] ?? buildTaskURL(session.currentTask, { base: baseUrl }));

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -1,4 +1,4 @@
-import type { ClerkOptions, PendingSessionResource, SessionTask } from '@clerk/types';
+import type { SessionResource, SessionTask } from '@clerk/types';
 
 import { buildURL } from '../utils';
 
@@ -26,18 +26,19 @@ export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof bui
  * @internal
  */
 export function navigateToTask(
-  session: PendingSessionResource,
+  session: SessionResource,
   {
-    options,
     navigate,
     baseUrl,
   }: {
     navigate: (to: string) => Promise<unknown>;
     baseUrl: string;
-    options?: ClerkOptions;
   },
 ) {
-  const currentTaskKey = session.currentTask.key;
+  const currentTask = session.currentTask;
+  if (!currentTask) {
+    return;
+  }
 
-  return navigate(options?.taskUrls?.[currentTaskKey] ?? buildTaskURL(session.currentTask, { base: baseUrl }));
+  return navigate(buildTaskURL(currentTask, { base: baseUrl }));
 }

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -1,4 +1,5 @@
-import type { SessionResource, SessionTask } from '@clerk/types';
+import { logger } from '@clerk/shared/logger';
+import type { ClerkOptions, SessionResource, SessionTask, SetActiveParams } from '@clerk/types';
 
 import { buildURL } from '../utils';
 
@@ -41,4 +42,20 @@ export function navigateIfTaskExists(
   }
 
   return navigate(buildTaskURL(currentTask, { base: baseUrl }));
+}
+
+export function warnMissingPendingTaskHandlers(options: Record<string, unknown>) {
+  const taskOptions = ['taskUrls', 'navigate'] as Array<
+    keyof (Pick<SetActiveParams, 'navigate'> & Pick<ClerkOptions, 'taskUrls'>)
+  >;
+
+  const hasAtLeastOneTaskOption = Object.keys(options).some(option => taskOptions.includes(option as any));
+  if (hasAtLeastOneTaskOption) {
+    return;
+  }
+
+  // TODO - Link to after-auth docs once it gets released
+  logger.warnOnce(
+    `Clerk: Session has pending tasks but no handling is configured. To handle pending tasks automatically, provide either "taskUrls" for navigation to custom URLs or "navigate" for programmatic navigation. Without these options, users may get stuck on incomplete flows.`,
+  );
 }

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -1,9 +1,4 @@
-import type {
-  __internal_ComponentNavigationContext,
-  ClerkOptions,
-  EnvironmentResource,
-  SessionTask,
-} from '@clerk/types';
+import type { ClerkOptions, PendingSessionResource, SessionTask } from '@clerk/types';
 
 import { buildURL } from '../utils';
 
@@ -12,38 +7,23 @@ export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], stri
 } as const;
 
 interface NavigateToTaskOptions {
-  componentNavigationContext: __internal_ComponentNavigationContext | null;
-  globalNavigate: (to: string) => Promise<unknown>;
-  options: ClerkOptions;
-  environment: EnvironmentResource;
+  navigate: (to: string) => Promise<unknown>;
+  baseUrl: string;
+  options?: ClerkOptions;
 }
 
 /**
- * Handles navigation to the tasks URL based on the application context such
- * as internal component routing or custom flows.
  * @internal
  */
-export function navigateToTask(
-  routeKey: keyof typeof INTERNAL_SESSION_TASK_ROUTE_BY_KEY,
-  { componentNavigationContext, globalNavigate, options, environment }: NavigateToTaskOptions,
-) {
-  const customTaskUrl = options?.taskUrls?.[routeKey];
-  const internalTaskRoute = `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[routeKey]}`;
+export function navigateToTask(session: PendingSessionResource, { options, navigate, baseUrl }: NavigateToTaskOptions) {
+  const currentTaskKey = session.currentTask.key;
 
-  if (componentNavigationContext && !customTaskUrl) {
-    return componentNavigationContext.navigate(componentNavigationContext.indexPath + internalTaskRoute);
-  }
-
-  const signInUrl = options['signInUrl'] || environment.displayConfig.signInUrl;
-  const signUpUrl = options['signUpUrl'] || environment.displayConfig.signUpUrl;
-  const isReferrerSignUpUrl = window.location.href.startsWith(signUpUrl);
-
-  return globalNavigate(
-    customTaskUrl ??
+  return navigate(
+    options?.taskUrls?.[currentTaskKey] ??
       buildURL(
         {
-          base: isReferrerSignUpUrl ? signUpUrl : signInUrl,
-          hashPath: internalTaskRoute,
+          base: baseUrl,
+          hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`,
         },
         { stringify: true },
       ),

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -24,7 +24,7 @@ export function buildTaskUrl(task: SessionTask, opts: Pick<Parameters<typeof bui
   return buildURL(
     {
       base: opts.base,
-      hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[task.key]}`,
+      hashPath: getTaskEndpoint(task),
       searchParams: params,
     },
     { stringify: true },

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -13,7 +13,7 @@ export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], stri
 /**
  * @internal
  */
-export function buildTasksUrl(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
+export function buildTaskUrl(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
   const params = forwardClerkQueryParams();
 
   return buildURL(
@@ -44,7 +44,7 @@ export function navigateIfTaskExists(
     return;
   }
 
-  return navigate(buildTasksUrl(currentTask, { base: baseUrl }));
+  return navigate(buildTaskUrl(currentTask, { base: baseUrl }));
 }
 
 export function warnMissingPendingTaskHandlers(options: Record<string, unknown>) {

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -13,6 +13,11 @@ export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], stri
 /**
  * @internal
  */
+export const getTaskEndpoint = (task: SessionTask) => `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[task.key]}`;
+
+/**
+ * @internal
+ */
 export function buildTaskUrl(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
   const params = forwardClerkQueryParams();
 

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -49,13 +49,13 @@ export function warnMissingPendingTaskHandlers(options: Record<string, unknown>)
     keyof (Pick<SetActiveParams, 'navigate'> & Pick<ClerkOptions, 'taskUrls'>)
   >;
 
-  const hasAtLeastOneTaskOption = Object.keys(options).some(option => taskOptions.includes(option as any));
-  if (hasAtLeastOneTaskOption) {
+  const hasAtLeastOneOption = Object.keys(options).some(option => taskOptions.includes(option as any));
+  if (hasAtLeastOneOption) {
     return;
   }
 
   // TODO - Link to after-auth docs once it gets released
   logger.warnOnce(
-    `Clerk: Session has pending tasks but no handling is configured. To handle pending tasks automatically, provide either "taskUrls" for navigation to custom URLs or "navigate" for programmatic navigation. Without these options, users may get stuck on incomplete flows.`,
+    `Clerk: Session has pending tasks but no handling is configured. To handle pending tasks, provide either "taskUrls" for navigation to custom URLs or "navigate" for programmatic navigation. Without these options, users may get stuck on incomplete flows.`,
   );
 }

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -25,7 +25,7 @@ export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof bui
 /**
  * @internal
  */
-export function navigateToTask(
+export function navigateIfTaskExists(
   session: SessionResource,
   {
     navigate,

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -12,20 +12,21 @@ interface NavigateToTaskOptions {
   options?: ClerkOptions;
 }
 
+export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
+  return buildURL(
+    {
+      base: opts.base,
+      hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[task.key]}`,
+    },
+    { stringify: true },
+  );
+}
+
 /**
  * @internal
  */
 export function navigateToTask(session: PendingSessionResource, { options, navigate, baseUrl }: NavigateToTaskOptions) {
   const currentTaskKey = session.currentTask.key;
 
-  return navigate(
-    options?.taskUrls?.[currentTaskKey] ??
-      buildURL(
-        {
-          base: baseUrl,
-          hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`,
-        },
-        { stringify: true },
-      ),
-  );
+  return navigate(options?.taskUrls?.[currentTaskKey] ?? buildTaskURL(session.currentTask, { base: baseUrl }));
 }

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -13,7 +13,7 @@ export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], stri
 /**
  * @internal
  */
-export function buildTaskURL(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
+export function buildTasksUrl(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
   return buildURL(
     {
       base: opts.base,
@@ -41,7 +41,7 @@ export function navigateIfTaskExists(
     return;
   }
 
-  return navigate(buildTaskURL(currentTask, { base: baseUrl }));
+  return navigate(buildTasksUrl(currentTask, { base: baseUrl }));
 }
 
 export function warnMissingPendingTaskHandlers(options: Record<string, unknown>) {

--- a/packages/clerk-js/src/core/sessionTasks.ts
+++ b/packages/clerk-js/src/core/sessionTasks.ts
@@ -1,7 +1,7 @@
 import { logger } from '@clerk/shared/logger';
 import type { ClerkOptions, SessionResource, SessionTask, SetActiveParams } from '@clerk/types';
 
-import { buildURL } from '../utils';
+import { buildURL, forwardClerkQueryParams } from '../utils';
 
 /**
  * @internal
@@ -14,10 +14,13 @@ export const INTERNAL_SESSION_TASK_ROUTE_BY_KEY: Record<SessionTask['key'], stri
  * @internal
  */
 export function buildTasksUrl(task: SessionTask, opts: Pick<Parameters<typeof buildURL>[0], 'base'>) {
+  const params = forwardClerkQueryParams();
+
   return buildURL(
     {
       base: opts.base,
       hashPath: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[task.key]}`,
+      searchParams: params,
     },
     { stringify: true },
   );

--- a/packages/clerk-js/src/ui/common/redirects.ts
+++ b/packages/clerk-js/src/ui/common/redirects.ts
@@ -1,6 +1,3 @@
-import type { ClerkOptions, SessionTask } from '@clerk/types';
-
-import { INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '../../core/sessionTasks';
 import { buildURL } from '../../utils/url';
 import type { SignInContextType, SignUpContextType, UserProfileContextType } from './../contexts';
 
@@ -26,33 +23,6 @@ export function buildVerificationRedirectUrl({
     endpoint:
       isCombinedFlow && intent === 'sign-up' ? `/create${MAGIC_LINK_VERIFY_PATH_ROUTE}` : MAGIC_LINK_VERIFY_PATH_ROUTE,
   });
-}
-
-export function buildSessionTaskRedirectUrl({
-  routing,
-  path,
-  baseUrl,
-  task,
-  taskUrls,
-}: Pick<SignInContextType | SignUpContextType, 'routing' | 'path'> & {
-  baseUrl: string;
-  task?: SessionTask;
-  taskUrls?: ClerkOptions['taskUrls'];
-}) {
-  if (!task) {
-    return null;
-  }
-
-  return (
-    taskUrls?.[task.key] ??
-    buildRedirectUrl({
-      routing,
-      baseUrl,
-      path,
-      endpoint: `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[task.key]}`,
-      authQueryString: null,
-    })
-  );
 }
 
 export function buildSSOCallbackURL(

--- a/packages/clerk-js/src/ui/common/withRedirect.tsx
+++ b/packages/clerk-js/src/ui/common/withRedirect.tsx
@@ -89,3 +89,57 @@ export const withRedirectToAfterSignUp = <P extends AvailableComponentProps>(Com
 
   return HOC;
 };
+
+export const withRedirectToSignInTask = <P extends AvailableComponentProps>(Component: ComponentType<P>) => {
+  const displayName = Component.displayName || Component.name || 'Component';
+  Component.displayName = displayName;
+
+  const HOC = (props: P) => {
+    const signInCtx = useSignInContext();
+
+    return withRedirect(
+      Component,
+      clerk => !!clerk.session?.currentTask,
+      ({ clerk }) => {
+        const currentTask = clerk.session?.currentTask;
+        if (!currentTask || !signInCtx?.taskUrl) {
+          return '';
+        }
+
+        return signInCtx?.taskUrl;
+      },
+      undefined,
+    )(props);
+  };
+
+  HOC.displayName = `withRedirectToAfterSignIn(${displayName})`;
+
+  return HOC;
+};
+
+export const withRedirectToSignUpTask = <P extends AvailableComponentProps>(Component: ComponentType<P>) => {
+  const displayName = Component.displayName || Component.name || 'Component';
+  Component.displayName = displayName;
+
+  const HOC = (props: P) => {
+    const signUpCtx = useSignUpContext();
+
+    return withRedirect(
+      Component,
+      clerk => !!clerk.session?.currentTask,
+      ({ clerk }) => {
+        const currentTask = clerk.session?.currentTask;
+        if (!currentTask || !signUpCtx?.taskUrl) {
+          return '';
+        }
+
+        return signUpCtx?.taskUrl;
+      },
+      undefined,
+    )(props);
+  };
+
+  HOC.displayName = `withRedirectToAfterSignIn(${displayName})`;
+
+  return HOC;
+};

--- a/packages/clerk-js/src/ui/common/withRedirect.tsx
+++ b/packages/clerk-js/src/ui/common/withRedirect.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { warnings } from '../../core/warnings';
 import type { ComponentGuard } from '../../utils';
-import { sessionExistsAndSingleSessionModeEnabled } from '../../utils';
+import { isSignedInAndSingleSessionModeEnabled } from '../../utils';
 import { useEnvironment, useOptions, useSignInContext, useSignUpContext } from '../contexts';
 import { useRouter } from '../router';
 import type { AvailableComponentProps } from '../types';
@@ -60,11 +60,9 @@ export const withRedirectToAfterSignIn = <P extends AvailableComponentProps>(Com
     const signInCtx = useSignInContext();
     return withRedirect(
       Component,
-      sessionExistsAndSingleSessionModeEnabled,
-      ({ clerk }) => signInCtx.sessionTaskUrl || signInCtx.afterSignInUrl || clerk.buildAfterSignInUrl(),
-      signInCtx.sessionTaskUrl
-        ? warnings.cannotRenderSignInComponentWhenTaskExists
-        : warnings.cannotRenderSignInComponentWhenSessionExists,
+      isSignedInAndSingleSessionModeEnabled,
+      ({ clerk }) => signInCtx.afterSignInUrl || clerk.buildAfterSignInUrl(),
+      warnings.cannotRenderSignInComponentWhenSessionExists,
     )(props);
   };
 
@@ -81,11 +79,9 @@ export const withRedirectToAfterSignUp = <P extends AvailableComponentProps>(Com
     const signUpCtx = useSignUpContext();
     return withRedirect(
       Component,
-      sessionExistsAndSingleSessionModeEnabled,
-      ({ clerk }) => signUpCtx.sessionTaskUrl || signUpCtx.afterSignUpUrl || clerk.buildAfterSignUpUrl(),
-      signUpCtx.sessionTaskUrl
-        ? warnings.cannotRenderSignUpComponentWhenTaskExists
-        : warnings.cannotRenderSignUpComponentWhenSessionExists,
+      isSignedInAndSingleSessionModeEnabled,
+      ({ clerk }) => signUpCtx.afterSignUpUrl || clerk.buildAfterSignUpUrl(),
+      warnings.cannotRenderSignUpComponentWhenSessionExists,
     )(props);
   };
 

--- a/packages/clerk-js/src/ui/common/withRedirect.tsx
+++ b/packages/clerk-js/src/ui/common/withRedirect.tsx
@@ -99,7 +99,8 @@ export const withRedirectToSignInTask = <P extends AvailableComponentProps>(Comp
 
     return withRedirect(
       Component,
-      clerk => Boolean(clerk.session?.currentTask && signInCtx?.taskUrl),
+      (clerk, environment) =>
+        !!environment?.authConfig.singleSessionMode && !!(clerk.session?.currentTask && signInCtx?.taskUrl),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       () => signInCtx.taskUrl!,
       undefined,
@@ -120,7 +121,8 @@ export const withRedirectToSignUpTask = <P extends AvailableComponentProps>(Comp
 
     return withRedirect(
       Component,
-      clerk => Boolean(clerk.session?.currentTask && signUpCtx?.taskUrl),
+      (clerk, environment) =>
+        !!environment?.authConfig.singleSessionMode && !!(clerk.session?.currentTask && signUpCtx?.taskUrl),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       () => signUpCtx.taskUrl!,
       undefined,

--- a/packages/clerk-js/src/ui/common/withRedirect.tsx
+++ b/packages/clerk-js/src/ui/common/withRedirect.tsx
@@ -99,20 +99,14 @@ export const withRedirectToSignInTask = <P extends AvailableComponentProps>(Comp
 
     return withRedirect(
       Component,
-      clerk => !!clerk.session?.currentTask,
-      ({ clerk }) => {
-        const currentTask = clerk.session?.currentTask;
-        if (!currentTask || !signInCtx?.taskUrl) {
-          return '';
-        }
-
-        return signInCtx?.taskUrl;
-      },
+      clerk => Boolean(clerk.session?.currentTask && signInCtx?.taskUrl),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      () => signInCtx.taskUrl!,
       undefined,
     )(props);
   };
 
-  HOC.displayName = `withRedirectToAfterSignIn(${displayName})`;
+  HOC.displayName = `withRedirectToSignInTask(${displayName})`;
 
   return HOC;
 };
@@ -126,20 +120,14 @@ export const withRedirectToSignUpTask = <P extends AvailableComponentProps>(Comp
 
     return withRedirect(
       Component,
-      clerk => !!clerk.session?.currentTask,
-      ({ clerk }) => {
-        const currentTask = clerk.session?.currentTask;
-        if (!currentTask || !signUpCtx?.taskUrl) {
-          return '';
-        }
-
-        return signUpCtx?.taskUrl;
-      },
+      clerk => Boolean(clerk.session?.currentTask && signUpCtx?.taskUrl),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      () => signUpCtx.taskUrl!,
       undefined,
     )(props);
   };
 
-  HOC.displayName = `withRedirectToAfterSignIn(${displayName})`;
+  HOC.displayName = `withRedirectToSignUpTask(${displayName})`;
 
   return HOC;
 };

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -24,7 +24,7 @@ const SessionTasksStart = () => {
   useEffect(() => {
     // Simulates additional latency to avoid a abrupt UI transition when navigating to the next task
     const timeoutId = setTimeout(() => {
-      void clerk.__internal_navigateToTaskIfAvailable({ redirectUrlComplete });
+      // TODO - call setActive?
     }, 500);
     return () => clearTimeout(timeoutId);
   }, [navigate, clerk, redirectUrlComplete]);

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -107,12 +107,12 @@ export const SessionTasks = withCardStateProvider(() => {
   }
 
   const navigateOnSetActive = async ({ session }: { session: SessionResource }) => {
-    const currentTaskKey = session.currentTask?.key;
-    if (!currentTaskKey) {
+    const currentTask = session.currentTask;
+    if (!currentTask) {
       return navigate(redirectUrlComplete);
     }
 
-    return navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
+    return navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   return (

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -24,7 +24,10 @@ const SessionTasksStart = () => {
   useEffect(() => {
     // Simulates additional latency to avoid a abrupt UI transition when navigating to the next task
     const timeoutId = setTimeout(() => {
-      // TODO - call setActive?
+      const currentTaskKey = clerk.session?.currentTask?.key;
+      if (!currentTaskKey) return;
+
+      void navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
     }, 500);
     return () => clearTimeout(timeoutId);
   }, [navigate, clerk, redirectUrlComplete]);

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -27,7 +27,10 @@ const SessionTasksStart = () => {
       const currentTaskKey = clerk.session?.currentTask?.key;
       if (!currentTaskKey) return;
 
-      void navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
+      void navigate(
+        clerk.__internal_getOption('taskUrls')?.[currentTaskKey] ??
+          `./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`,
+      );
     }, 500);
     return () => clearTimeout(timeoutId);
   }, [navigate, clerk, redirectUrlComplete]);

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -1,5 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
+import type { SetActiveNavigate } from '@clerk/types';
 import { useContext, useEffect, useRef } from 'react';
 
 import { Card } from '@/ui/elements/Card';
@@ -27,7 +28,6 @@ const SessionTasksStart = () => {
       const currentTaskKey = clerk.session?.currentTask?.key;
       if (!currentTaskKey) return;
 
-      // TODO -> Fix navigation here
       void navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
     }, 500);
     return () => clearTimeout(timeoutId);
@@ -106,8 +106,17 @@ export const SessionTasks = withCardStateProvider(() => {
     );
   }
 
+  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+    const currentTaskKey = session.currentTask?.key;
+    if (!currentTaskKey) {
+      return;
+    }
+
+    return navigate(`./${currentTaskKey}`);
+  };
+
   return (
-    <SessionTasksContext.Provider value={{ redirectUrlComplete, currentTaskContainer }}>
+    <SessionTasksContext.Provider value={{ redirectUrlComplete, currentTaskContainer, onPendingSession }}>
       <SessionTasksRoutes />
     </SessionTasksContext.Provider>
   );

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
-import type { SetActiveNavigate } from '@clerk/types';
+import type { SessionResource } from '@clerk/types';
 import { useContext, useEffect, useRef } from 'react';
 
 import { Card } from '@/ui/elements/Card';
@@ -106,17 +106,17 @@ export const SessionTasks = withCardStateProvider(() => {
     );
   }
 
-  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+  const navigateOnSetActive = async ({ session }: { session: SessionResource }) => {
     const currentTaskKey = session.currentTask?.key;
     if (!currentTaskKey) {
-      return;
+      return navigate(redirectUrlComplete);
     }
 
     return navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
   };
 
   return (
-    <SessionTasksContext.Provider value={{ redirectUrlComplete, currentTaskContainer, onPendingSession }}>
+    <SessionTasksContext.Provider value={{ redirectUrlComplete, currentTaskContainer, navigateOnSetActive }}>
       <SessionTasksRoutes />
     </SessionTasksContext.Provider>
   );

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -39,7 +39,7 @@ const SessionTasksStart = () => {
   );
 };
 
-function SessionTaskRoutes(): JSX.Element {
+function SessionTasksRoutes(): JSX.Element {
   const ctx = useSessionTasksContext();
 
   return (
@@ -61,7 +61,7 @@ function SessionTaskRoutes(): JSX.Element {
 /**
  * @internal
  */
-export const SessionTask = withCardStateProvider(() => {
+export const SessionTasks = withCardStateProvider(() => {
   const clerk = useClerk();
   const { navigate } = useRouter();
   const signInContext = useContext(SignInContext);
@@ -104,7 +104,7 @@ export const SessionTask = withCardStateProvider(() => {
 
   return (
     <SessionTasksContext.Provider value={{ redirectUrlComplete, currentTaskContainer }}>
-      <SessionTaskRoutes />
+      <SessionTasksRoutes />
     </SessionTasksContext.Provider>
   );
 });

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -112,7 +112,7 @@ export const SessionTasks = withCardStateProvider(() => {
       return;
     }
 
-    return navigate(`./${currentTaskKey}`);
+    return navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
   };
 
   return (

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -27,10 +27,8 @@ const SessionTasksStart = () => {
       const currentTaskKey = clerk.session?.currentTask?.key;
       if (!currentTaskKey) return;
 
-      void navigate(
-        clerk.__internal_getOption('taskUrls')?.[currentTaskKey] ??
-          `./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`,
-      );
+      // TODO -> Fix navigation here
+      void navigate(`./${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
     }, 500);
     return () => clearTimeout(timeoutId);
   }, [navigate, clerk, redirectUrlComplete]);

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -97,7 +97,7 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { redirectUrlComplete } = useSessionTasksContext();
+  const { redirectUrlComplete, onPendingSession } = useSessionTasksContext();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -109,6 +109,7 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
       await setActive({
         organization,
         redirectUrl: redirectUrlComplete,
+        navigate: onPendingSession,
       });
     });
   };

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -97,6 +97,7 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
+
   const { redirectUrlComplete } = useSessionTasksContext();
   const { isLoaded, setActive } = useOrganizationList();
 
@@ -108,6 +109,7 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
     return card.runAsync(async () => {
       await setActive({
         organization,
+        redirectUrl: redirectUrlComplete,
       });
     });
   };

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -98,7 +98,6 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
   const { redirectUrlComplete } = useSessionTasksContext();
-  const { __internal_navigateToTaskIfAvailable } = useClerk();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -110,8 +109,6 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
       await setActive({
         organization,
       });
-
-      await __internal_navigateToTaskIfAvailable({ redirectUrlComplete });
     });
   };
 

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -2,6 +2,7 @@ import { useClerk, useOrganizationList, useUser } from '@clerk/shared/react';
 import type {
   OrganizationResource,
   OrganizationSuggestionResource,
+  SetActiveParams,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
 import React, { useState } from 'react';
@@ -97,7 +98,7 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { redirectUrlComplete, onPendingSession } = useSessionTasksContext();
+  const { redirectUrlComplete, navigateOnSetActive } = useSessionTasksContext();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -106,11 +107,19 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
 
   const handleOrganizationClicked = (organization: OrganizationResource) => {
     return card.runAsync(async () => {
-      await setActive({
+      const setActiveParams: SetActiveParams = {
         organization,
         redirectUrl: redirectUrlComplete,
-        navigate: onPendingSession,
-      });
+      };
+
+      // TODO - Add `onComplete` or `onNextTask` callbacks for `TaskChooseOrganization` standalone usage
+      if (navigateOnSetActive) {
+        setActiveParams.navigate = async ({ session }) => {
+          await navigateOnSetActive({ session, redirectUrl: redirectUrlComplete });
+        };
+      }
+
+      await setActive(setActiveParams);
     });
   };
 

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -97,7 +97,6 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-
   const { redirectUrlComplete } = useSessionTasksContext();
   const { isLoaded, setActive } = useOrganizationList();
 

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -2,7 +2,6 @@ import { useClerk, useOrganizationList, useUser } from '@clerk/shared/react';
 import type {
   OrganizationResource,
   OrganizationSuggestionResource,
-  SetActiveParams,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
 import React, { useState } from 'react';
@@ -16,7 +15,7 @@ import {
   sharedMainIdentifierSx,
 } from '@/ui/common/organizations/OrganizationPreview';
 import { organizationListParams, populateCacheUpdateItem } from '@/ui/components/OrganizationSwitcher/utils';
-import { useSessionTasksContext } from '@/ui/contexts/components/SessionTasks';
+import { useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import { Col, descriptors, localizationKeys, Text } from '@/ui/customizables';
 import { Action, Actions } from '@/ui/elements/Actions';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
@@ -98,7 +97,7 @@ export const ChooseOrganizationScreen = withCardStateProvider(
 
 const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
   const card = useCardState();
-  const { redirectUrlComplete, navigateOnSetActive } = useSessionTasksContext();
+  const { redirectUrlComplete } = useTaskChooseOrganizationContext();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
@@ -107,19 +106,10 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
 
   const handleOrganizationClicked = (organization: OrganizationResource) => {
     return card.runAsync(async () => {
-      const setActiveParams: SetActiveParams = {
+      await setActive({
         organization,
         redirectUrl: redirectUrlComplete,
-      };
-
-      // TODO - Add `onComplete` or `onNextTask` callbacks for `TaskChooseOrganization` standalone usage
-      if (navigateOnSetActive) {
-        setActiveParams.navigate = async ({ session }) => {
-          await navigateOnSetActive({ session, redirectUrl: redirectUrlComplete });
-        };
-      }
-
-      await setActive(setActiveParams);
+      });
     });
   };
 

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -1,4 +1,4 @@
-import { useClerk, useOrganizationList } from '@clerk/shared/react';
+import { useOrganizationList } from '@clerk/shared/react';
 
 import { useSessionTasksContext } from '@/ui/contexts/components/SessionTasks';
 import { localizationKeys } from '@/ui/customizables';
@@ -19,7 +19,6 @@ type CreateOrganizationScreenProps = {
 
 export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrganizationScreenProps) => {
   const card = useCardState();
-  const { __internal_navigateToTaskIfAvailable } = useClerk();
   const { redirectUrlComplete } = useSessionTasksContext();
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
     userMemberships: organizationListParams.userMemberships,
@@ -47,8 +46,6 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
       const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
 
       await setActive({ organization });
-
-      await __internal_navigateToTaskIfAvailable({ redirectUrlComplete });
     } catch (err) {
       handleError(err, [nameField, slugField], card.setError);
     }

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -19,7 +19,7 @@ type CreateOrganizationScreenProps = {
 
 export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrganizationScreenProps) => {
   const card = useCardState();
-  const { redirectUrlComplete } = useSessionTasksContext();
+  const { redirectUrlComplete, onPendingSession } = useSessionTasksContext();
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
     userMemberships: organizationListParams.userMemberships,
   });
@@ -45,7 +45,7 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
     try {
       const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
 
-      await setActive({ organization, redirectUrl: redirectUrlComplete });
+      await setActive({ organization, redirectUrl: redirectUrlComplete, navigate: onPendingSession });
     } catch (err) {
       handleError(err, [nameField, slugField], card.setError);
     }

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -1,4 +1,5 @@
 import { useOrganizationList } from '@clerk/shared/react';
+import type { SetActiveParams } from '@clerk/types';
 
 import { useSessionTasksContext } from '@/ui/contexts/components/SessionTasks';
 import { localizationKeys } from '@/ui/customizables';
@@ -19,7 +20,7 @@ type CreateOrganizationScreenProps = {
 
 export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrganizationScreenProps) => {
   const card = useCardState();
-  const { redirectUrlComplete, onPendingSession } = useSessionTasksContext();
+  const { redirectUrlComplete, navigateOnSetActive } = useSessionTasksContext();
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
     userMemberships: organizationListParams.userMemberships,
   });
@@ -45,7 +46,19 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
     try {
       const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
 
-      await setActive({ organization, redirectUrl: redirectUrlComplete, navigate: onPendingSession });
+      const setActiveParams: SetActiveParams = {
+        organization,
+        redirectUrl: redirectUrlComplete,
+      };
+
+      // TODO - Add `onComplete` or `onNextTask` callbacks for `TaskChooseOrganization` standalone usage
+      if (navigateOnSetActive) {
+        setActiveParams.navigate = async ({ session }) => {
+          await navigateOnSetActive({ session, redirectUrl: redirectUrlComplete });
+        };
+      }
+
+      await setActive(setActiveParams);
     } catch (err) {
       handleError(err, [nameField, slugField], card.setError);
     }

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -45,7 +45,7 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
     try {
       const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
 
-      await setActive({ organization });
+      await setActive({ organization, redirectUrl: redirectUrlComplete });
     } catch (err) {
       handleError(err, [nameField, slugField], card.setError);
     }

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -1,7 +1,6 @@
 import { useOrganizationList } from '@clerk/shared/react';
-import type { SetActiveParams } from '@clerk/types';
 
-import { useSessionTasksContext } from '@/ui/contexts/components/SessionTasks';
+import { useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import { localizationKeys } from '@/ui/customizables';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Form } from '@/ui/elements/Form';
@@ -20,7 +19,7 @@ type CreateOrganizationScreenProps = {
 
 export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrganizationScreenProps) => {
   const card = useCardState();
-  const { redirectUrlComplete, navigateOnSetActive } = useSessionTasksContext();
+  const { redirectUrlComplete } = useTaskChooseOrganizationContext();
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
     userMemberships: organizationListParams.userMemberships,
   });
@@ -46,19 +45,10 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
     try {
       const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
 
-      const setActiveParams: SetActiveParams = {
+      await setActive({
         organization,
         redirectUrl: redirectUrlComplete,
-      };
-
-      // TODO - Add `onComplete` or `onNextTask` callbacks for `TaskChooseOrganization` standalone usage
-      if (navigateOnSetActive) {
-        setActiveParams.navigate = async ({ session }) => {
-          await navigateOnSetActive({ session, redirectUrl: redirectUrlComplete });
-        };
-      }
-
-      await setActive(setActiveParams);
+      });
     } catch (err) {
       handleError(err, [nameField, slugField], card.setError);
     }

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/withTaskGuard.ts
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/withTaskGuard.ts
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react';
 
 import { warnings } from '@/core/warnings';
 import { withRedirect } from '@/ui/common';
-import { useSessionTasksContext } from '@/ui/contexts/components/SessionTasks';
+import { useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import type { AvailableComponentProps } from '@/ui/types';
 
 export const withTaskGuard = <P extends AvailableComponentProps>(Component: ComponentType<P>) => {
@@ -10,7 +10,7 @@ export const withTaskGuard = <P extends AvailableComponentProps>(Component: Comp
   Component.displayName = displayName;
 
   const HOC = (props: P) => {
-    const ctx = useSessionTasksContext();
+    const ctx = useTaskChooseOrganizationContext();
     return withRedirect(
       Component,
       clerk => !clerk.session?.currentTask,

--- a/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
@@ -5,7 +5,7 @@ import { Header } from '@/ui/elements/Header';
 import { PreviewButton } from '@/ui/elements/PreviewButton';
 import { UserPreview } from '@/ui/elements/UserPreview';
 
-import { withRedirectToAfterSignIn } from '../../common';
+import { withRedirectToAfterSignIn, withRedirectToSignInTask } from '../../common';
 import { useEnvironment, useSignInContext, useSignOutContext } from '../../contexts';
 import { Col, descriptors, Flow, localizationKeys } from '../../customizables';
 import { Add, SwitchArrowRight } from '../../icons';
@@ -125,4 +125,6 @@ const SignInAccountSwitcherInternal = () => {
     </Flow.Part>
   );
 };
-export const SignInAccountSwitcher = withRedirectToAfterSignIn(withCardStateProvider(SignInAccountSwitcherInternal));
+export const SignInAccountSwitcher = withRedirectToSignInTask(
+  withRedirectToAfterSignIn(withCardStateProvider(SignInAccountSwitcherInternal)),
+);

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -6,7 +6,7 @@ import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { ErrorCard } from '@/ui/elements/ErrorCard';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 
-import { withRedirectToAfterSignIn } from '../../common';
+import { withRedirectToAfterSignIn, withRedirectToSignInTask } from '../../common';
 import { useCoreSignIn, useEnvironment } from '../../contexts';
 import { useAlternativeStrategies } from '../../hooks/useAlternativeStrategies';
 import { localizationKeys } from '../../localization';
@@ -251,4 +251,6 @@ function SignInFactorOneInternal(): JSX.Element {
   }
 }
 
-export const SignInFactorOne = withRedirectToAfterSignIn(withCardStateProvider(SignInFactorOneInternal));
+export const SignInFactorOne = withRedirectToSignInTask(
+  withRedirectToAfterSignIn(withCardStateProvider(SignInFactorOneInternal)),
+);

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
@@ -34,7 +34,7 @@ export const SignInFactorOneAlternativeChannelCodeForm = (props: SignInFactorOne
   const signIn = useCoreSignIn();
   const card = useCardState();
   const { navigate } = useRouter();
-  const { afterSignInUrl, onPendingSession } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const { setActive } = useClerk();
   const supportEmail = useSupportEmail();
   const clerk = useClerk();
@@ -67,8 +67,9 @@ export const SignInFactorOneAlternativeChannelCodeForm = (props: SignInFactorOne
           case 'complete':
             return setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           case 'needs_second_factor':
             return navigate('../factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
@@ -68,7 +68,7 @@ export const SignInFactorOneAlternativeChannelCodeForm = (props: SignInFactorOne
             return setActive({
               session: res.createdSessionId,
               redirectUrl: afterSignInUrl,
-              onPendingSession,
+              navigate: onPendingSession,
             });
           case 'needs_second_factor':
             return navigate('../factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneAlternativeChannelCodeForm.tsx
@@ -34,7 +34,7 @@ export const SignInFactorOneAlternativeChannelCodeForm = (props: SignInFactorOne
   const signIn = useCoreSignIn();
   const card = useCardState();
   const { navigate } = useRouter();
-  const { afterSignInUrl } = useSignInContext();
+  const { afterSignInUrl, onPendingSession } = useSignInContext();
   const { setActive } = useClerk();
   const supportEmail = useSupportEmail();
   const clerk = useClerk();
@@ -65,7 +65,11 @@ export const SignInFactorOneAlternativeChannelCodeForm = (props: SignInFactorOne
 
         switch (res.status) {
           case 'complete':
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
+            return setActive({
+              session: res.createdSessionId,
+              redirectUrl: afterSignInUrl,
+              onPendingSession,
+            });
           case 'needs_second_factor':
             return navigate('../factor-two');
           case 'needs_new_password':

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -35,7 +35,7 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   const signIn = useCoreSignIn();
   const card = useCardState();
   const { navigate } = useRouter();
-  const { afterSignInUrl, onPendingSession } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const { setActive } = useClerk();
   const supportEmail = useSupportEmail();
   const clerk = useClerk();
@@ -106,8 +106,9 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
           case 'complete':
             return setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           case 'needs_second_factor':
             return navigate('../factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -104,7 +104,11 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
 
         switch (res.status) {
           case 'complete':
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
+            return setActive({
+              session: res.createdSessionId,
+              redirectUrl: afterSignInUrl,
+              navigate: onPendingSession,
+            });
           case 'needs_second_factor':
             return navigate('../factor-two');
           case 'needs_new_password':

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -35,7 +35,7 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   const signIn = useCoreSignIn();
   const card = useCardState();
   const { navigate } = useRouter();
-  const { afterSignInUrl } = useSignInContext();
+  const { afterSignInUrl, onPendingSession } = useSignInContext();
   const { setActive } = useClerk();
   const supportEmail = useSupportEmail();
   const clerk = useClerk();
@@ -104,7 +104,7 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
 
         switch (res.status) {
           case 'complete':
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
+            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
           case 'needs_second_factor':
             return navigate('../factor-two');
           case 'needs_new_password':

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -74,7 +74,11 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
       .then(res => {
         switch (res.status) {
           case 'complete':
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
+            return setActive({
+              session: res.createdSessionId,
+              redirectUrl: afterSignInUrl,
+              navigate: onPendingSession,
+            });
           case 'needs_second_factor':
             return navigate('../factor-two');
           default:

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -55,7 +55,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
   const card = useCardState();
   const { setActive } = useClerk();
   const signIn = useCoreSignIn();
-  const { afterSignInUrl } = useSignInContext();
+  const { afterSignInUrl, onPendingSession } = useSignInContext();
   const supportEmail = useSupportEmail();
   const passwordControl = usePasswordControl(props);
   const { navigate } = useRouter();
@@ -74,7 +74,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
       .then(res => {
         switch (res.status) {
           case 'complete':
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
+            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
           case 'needs_second_factor':
             return navigate('../factor-two');
           default:

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -55,7 +55,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
   const card = useCardState();
   const { setActive } = useClerk();
   const signIn = useCoreSignIn();
-  const { afterSignInUrl, onPendingSession } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const supportEmail = useSupportEmail();
   const passwordControl = usePasswordControl(props);
   const { navigate } = useRouter();
@@ -76,8 +76,9 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
           case 'complete':
             return setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           case 'needs_second_factor':
             return navigate('../factor-two');

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwo.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwo.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { withCardStateProvider } from '@/ui/elements/contexts';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 
-import { withRedirectToAfterSignIn } from '../../common';
+import { withRedirectToAfterSignIn, withRedirectToSignInTask } from '../../common';
 import { useCoreSignIn } from '../../contexts';
 import { SignInFactorTwoAlternativeMethods } from './SignInFactorTwoAlternativeMethods';
 import { SignInFactorTwoBackupCodeCard } from './SignInFactorTwoBackupCodeCard';
@@ -82,4 +82,6 @@ function SignInFactorTwoInternal(): JSX.Element {
   }
 }
 
-export const SignInFactorTwo = withRedirectToAfterSignIn(withCardStateProvider(SignInFactorTwoInternal));
+export const SignInFactorTwo = withRedirectToSignInTask(
+  withRedirectToAfterSignIn(withCardStateProvider(SignInFactorTwoInternal)),
+);

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -52,7 +52,11 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
               queryParams.set('createdSessionId', res.createdSessionId);
               return navigate(`../reset-password-success?${queryParams.toString()}`);
             }
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
+            return setActive({
+              session: res.createdSessionId,
+              redirectUrl: afterSignInUrl,
+              navigate: onPendingSession,
+            });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -24,7 +24,7 @@ type SignInFactorTwoBackupCodeCardProps = {
 export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCardProps) => {
   const { onShowAlternativeMethodsClicked } = props;
   const signIn = useCoreSignIn();
-  const { afterSignInUrl } = useSignInContext();
+  const { afterSignInUrl, onPendingSession } = useSignInContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
   const supportEmail = useSupportEmail();
@@ -52,7 +52,7 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
               queryParams.set('createdSessionId', res.createdSessionId);
               return navigate(`../reset-password-success?${queryParams.toString()}`);
             }
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
+            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -24,7 +24,7 @@ type SignInFactorTwoBackupCodeCardProps = {
 export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCardProps) => {
   const { onShowAlternativeMethodsClicked } = props;
   const signIn = useCoreSignIn();
-  const { afterSignInUrl, onPendingSession } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
   const supportEmail = useSupportEmail();
@@ -54,8 +54,9 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
             }
             return setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
@@ -33,7 +33,7 @@ type SignInFactorTwoCodeFormProps = SignInFactorTwoCodeCard & {
 export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => {
   const signIn = useCoreSignIn();
   const card = useCardState();
-  const { afterSignInUrl } = useSignInContext();
+  const { afterSignInUrl, onPendingSession } = useSignInContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
   const supportEmail = useSupportEmail();
@@ -79,7 +79,7 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
               queryParams.set('createdSessionId', res.createdSessionId);
               return navigate(`../reset-password-success?${queryParams.toString()}`);
             }
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl });
+            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
@@ -79,7 +79,11 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
               queryParams.set('createdSessionId', res.createdSessionId);
               return navigate(`../reset-password-success?${queryParams.toString()}`);
             }
-            return setActive({ session: res.createdSessionId, redirectUrl: afterSignInUrl, onPendingSession });
+            return setActive({
+              session: res.createdSessionId,
+              redirectUrl: afterSignInUrl,
+              navigate: onPendingSession,
+            });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoCodeForm.tsx
@@ -33,7 +33,7 @@ type SignInFactorTwoCodeFormProps = SignInFactorTwoCodeCard & {
 export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => {
   const signIn = useCoreSignIn();
   const card = useCardState();
-  const { afterSignInUrl, onPendingSession } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
   const supportEmail = useSupportEmail();
@@ -81,8 +81,9 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
             }
             return setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           default:
             return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInSSOCallback.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInSSOCallback.tsx
@@ -1,3 +1,3 @@
-import { SSOCallback, withRedirectToAfterSignIn } from '../../common';
+import { SSOCallback, withRedirectToAfterSignIn, withRedirectToSignInTask } from '../../common';
 
-export const SignInSSOCallback = withRedirectToAfterSignIn(SSOCallback);
+export const SignInSSOCallback = withRedirectToSignInTask(withRedirectToAfterSignIn(SSOCallback));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -237,7 +237,7 @@ function SignInStartInternal(): JSX.Element {
             return clerk.setActive({
               session: res.createdSessionId,
               redirectUrl: afterSignInUrl,
-              onPendingSession,
+              navigate: onPendingSession,
             });
           default: {
             console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
@@ -389,7 +389,7 @@ function SignInStartInternal(): JSX.Element {
           return clerk.setActive({
             session: res.createdSessionId,
             redirectUrl: afterSignInUrl,
-            onPendingSession,
+            navigate: onPendingSession,
           });
         default: {
           console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -30,6 +30,7 @@ import {
   getIdentifierControlDisplayValues,
   groupIdentifiers,
   withRedirectToAfterSignIn,
+  withRedirectToSignInTask,
 } from '../../common';
 import { useCoreSignIn, useEnvironment, useSignInContext } from '../../contexts';
 import { Col, descriptors, Flow, localizationKeys } from '../../customizables';
@@ -678,4 +679,6 @@ const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> })
   );
 };
 
-export const SignInStart = withRedirectToAfterSignIn(withCardStateProvider(SignInStartInternal));
+export const SignInStart = withRedirectToSignInTask(
+  withRedirectToAfterSignIn(withCardStateProvider(SignInStartInternal)),
+);

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -199,7 +199,6 @@ function SignInStartInternal(): JSX.Element {
     }
   }, [identifierField.value, identifierAttributes]);
 
-  // TODO -> Maybe navigate on a effect here?
   useEffect(() => {
     if (!organizationTicket) {
       return;

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -84,7 +84,7 @@ function SignInStartInternal(): JSX.Element {
   const signIn = useCoreSignIn();
   const { navigate } = useRouter();
   const ctx = useSignInContext();
-  const { afterSignInUrl, signUpUrl, waitlistUrl, isCombinedFlow } = ctx;
+  const { afterSignInUrl, signUpUrl, waitlistUrl, isCombinedFlow, onPendingSession } = ctx;
   const supportEmail = useSupportEmail();
   const identifierAttributes = useMemo<SignInStartIdentifier[]>(
     () => groupIdentifiers(userSettings.enabledFirstFactorIdentifiers),
@@ -236,6 +236,7 @@ function SignInStartInternal(): JSX.Element {
             return clerk.setActive({
               session: res.createdSessionId,
               redirectUrl: afterSignInUrl,
+              onPendingSession,
             });
           default: {
             console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
@@ -387,6 +388,7 @@ function SignInStartInternal(): JSX.Element {
           return clerk.setActive({
             session: res.createdSessionId,
             redirectUrl: afterSignInUrl,
+            onPendingSession,
           });
         default: {
           console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -198,6 +198,7 @@ function SignInStartInternal(): JSX.Element {
     }
   }, [identifierField.value, identifierAttributes]);
 
+  // TODO -> Maybe navigate on a effect here?
   useEffect(() => {
     if (!organizationTicket) {
       return;

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -473,6 +473,7 @@ function SignInStartInternal(): JSX.Element {
         signUpMode: userSettings.signUp.mode,
         redirectUrl,
         redirectUrlComplete,
+        navigateOnSetActive,
         passwordEnabled: userSettings.attributes.password?.required ?? false,
         alternativePhoneCodeChannel:
           alternativePhoneCodeProvider?.channel ||

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -85,7 +85,7 @@ function SignInStartInternal(): JSX.Element {
   const signIn = useCoreSignIn();
   const { navigate } = useRouter();
   const ctx = useSignInContext();
-  const { afterSignInUrl, signUpUrl, waitlistUrl, isCombinedFlow, onPendingSession } = ctx;
+  const { afterSignInUrl, signUpUrl, waitlistUrl, isCombinedFlow, navigateOnSetActive } = ctx;
   const supportEmail = useSupportEmail();
   const identifierAttributes = useMemo<SignInStartIdentifier[]>(
     () => groupIdentifiers(userSettings.enabledFirstFactorIdentifiers),
@@ -236,8 +236,9 @@ function SignInStartInternal(): JSX.Element {
             removeClerkQueryParam('__clerk_ticket');
             return clerk.setActive({
               session: res.createdSessionId,
-              redirectUrl: afterSignInUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+              },
             });
           default: {
             console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
@@ -388,8 +389,9 @@ function SignInStartInternal(): JSX.Element {
         case 'complete':
           return clerk.setActive({
             session: res.createdSessionId,
-            redirectUrl: afterSignInUrl,
-            navigate: onPendingSession,
+            navigate: async ({ session }) => {
+              await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+            },
           });
         default: {
           console.error(clerkInvalidFAPIResponse(res.status, supportEmail));

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -440,7 +440,12 @@ function SignInStartInternal(): JSX.Element {
     } else if (alreadySignedInError) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const sid = alreadySignedInError.meta!.sessionId!;
-      await clerk.setActive({ session: sid, redirectUrl: afterSignInUrl });
+      await clerk.setActive({
+        session: sid,
+        navigate: async ({ session }) => {
+          await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+        },
+      });
     } else if (isCombinedFlow && accountDoesNotExistError) {
       const attribute = getSignUpAttributeFromIdentifier(identifierField);
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/handleCombinedFlowTransfer.test.ts
@@ -40,6 +40,7 @@ describe('handleCombinedFlowTransfer', () => {
       clerk: mockClerk as unknown as LoadedClerk,
       afterSignUpUrl: 'https://test.com',
       passwordEnabled: false,
+      navigateOnSetActive: jest.fn(),
     });
 
     expect(mockCompleteSignUpFlow).toHaveBeenCalled();
@@ -64,6 +65,7 @@ describe('handleCombinedFlowTransfer', () => {
       clerk: mockClerk as unknown as LoadedClerk,
       afterSignUpUrl: 'https://test.com',
       passwordEnabled: false,
+      navigateOnSetActive: jest.fn(),
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -90,6 +92,7 @@ describe('handleCombinedFlowTransfer', () => {
       clerk: mockClerk as unknown as LoadedClerk,
       afterSignUpUrl: 'https://test.com',
       passwordEnabled: true,
+      navigateOnSetActive: jest.fn(),
     });
 
     expect(mockNavigate).toHaveBeenCalled();
@@ -116,6 +119,7 @@ describe('handleCombinedFlowTransfer', () => {
       clerk: mockClerk as unknown as LoadedClerk,
       afterSignUpUrl: 'https://test.com',
       passwordEnabled: false,
+      navigateOnSetActive: jest.fn(),
     });
 
     expect(mockNavigate).toHaveBeenCalled();
@@ -142,6 +146,7 @@ describe('handleCombinedFlowTransfer', () => {
       clerk: mockClerk as unknown as LoadedClerk,
       afterSignUpUrl: 'https://test.com',
       passwordEnabled: false,
+      navigateOnSetActive: jest.fn(),
     });
 
     expect(mockNavigate).toHaveBeenCalled();

--- a/packages/clerk-js/src/ui/components/SignIn/handleCombinedFlowTransfer.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/handleCombinedFlowTransfer.ts
@@ -1,4 +1,11 @@
-import type { LoadedClerk, PhoneCodeChannel, PhoneCodeStrategy, SignUpModes, SignUpResource } from '@clerk/types';
+import type {
+  LoadedClerk,
+  PhoneCodeChannel,
+  PhoneCodeStrategy,
+  SessionResource,
+  SignUpModes,
+  SignUpResource,
+} from '@clerk/types';
 
 import { SIGN_UP_MODES } from '../../../core/constants';
 import type { RouteContextValue } from '../../router/RouteContext';
@@ -17,6 +24,7 @@ type HandleCombinedFlowTransferProps = {
   redirectUrlComplete?: string;
   passwordEnabled: boolean;
   alternativePhoneCodeChannel?: PhoneCodeChannel | null;
+  navigateOnSetActive: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
 };
 
 /**
@@ -35,6 +43,7 @@ export function handleCombinedFlowTransfer({
   redirectUrl,
   redirectUrlComplete,
   passwordEnabled,
+  navigateOnSetActive,
   alternativePhoneCodeChannel,
 }: HandleCombinedFlowTransferProps): Promise<unknown> | void {
   if (signUpMode === SIGN_UP_MODES.WAITLIST) {
@@ -83,7 +92,13 @@ export function handleCombinedFlowTransfer({
           signUp: res,
           verifyEmailPath: 'create/verify-email-address',
           verifyPhonePath: 'create/verify-phone-number',
-          handleComplete: () => clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl }),
+          handleComplete: () =>
+            clerk.setActive({
+              session: res.createdSessionId,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+              },
+            }),
           navigate,
           redirectUrl,
           redirectUrlComplete,

--- a/packages/clerk-js/src/ui/components/SignIn/index.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/index.tsx
@@ -14,7 +14,7 @@ import { Flow } from '@/ui/customizables';
 import { useFetch } from '@/ui/hooks';
 import { usePreloadTasks } from '@/ui/hooks/usePreloadTasks';
 import { SessionTasks as LazySessionTasks } from '@/ui/lazyModules/components';
-import { Route, Switch, useRouter, VIRTUAL_ROUTER_BASE_PATH } from '@/ui/router';
+import { Route, Switch, VIRTUAL_ROUTER_BASE_PATH } from '@/ui/router';
 import type { SignUpCtx } from '@/ui/types';
 import { normalizeRoutingOptions } from '@/utils/normalizeRoutingOptions';
 
@@ -161,9 +161,6 @@ const usePreloadSignUp = (enabled = false) =>
   useFetch(enabled ? preloadSignUp : undefined, 'preloadComponent', { staleTime: Infinity });
 
 function SignInRoot() {
-  const { __internal_setComponentNavigationContext } = useClerk();
-  const { navigate, indexPath } = useRouter();
-
   const signInContext = useSignInContext();
   const normalizedSignUpContext = {
     componentName: 'SignUp',
@@ -182,10 +179,6 @@ function SignInRoot() {
   usePreloadSignUp(signInContext.isCombinedFlow);
 
   usePreloadTasks();
-
-  React.useEffect(() => {
-    return __internal_setComponentNavigationContext?.({ indexPath, navigate });
-  }, [indexPath, navigate]);
 
   return (
     <SignUpContext.Provider value={normalizedSignUpContext}>

--- a/packages/clerk-js/src/ui/components/SignIn/index.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/index.tsx
@@ -131,12 +131,12 @@ function SignInRoutes(): JSX.Element {
               >
                 <LazySignUpVerifyPhone />
               </Route>
-              <Route path='tasks'>
-                <LazySessionTasks />
-              </Route>
               <Route index>
                 <LazySignUpContinue />
               </Route>
+            </Route>
+            <Route path='tasks'>
+              <LazySessionTasks />
             </Route>
             <Route index>
               <LazySignUpStart />

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -35,11 +35,12 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
           return setActive({
             session: res.createdSessionId,
             redirectUrl: afterSignInUrl,
-            onPendingSession: ({ session }) =>
-              navigateToTask(session, {
+            navigate: async ({ session }) => {
+              await navigateToTask(session, {
                 baseUrl: signInUrl,
                 navigate: navigate,
-              }),
+              });
+            },
           });
         case 'needs_second_factor':
           return onSecondFactor();

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -34,8 +34,12 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
         case 'complete':
           return setActive({
             session: res.createdSessionId,
-            redirectUrl: afterSignInUrl,
             navigate: async ({ session }) => {
+              if (!session.currentTask) {
+                await navigate(afterSignInUrl);
+                return;
+              }
+
               await navigateIfTaskExists(session, {
                 baseUrl: signInUrl,
                 navigate: navigate,

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -2,7 +2,6 @@ import { isClerkRuntimeError, isUserLockedError } from '@clerk/shared/error';
 import { useClerk } from '@clerk/shared/react';
 import { useCallback, useEffect } from 'react';
 
-import { navigateIfTaskExists } from '@/core/sessionTasks';
 import { useCardState } from '@/ui/elements/contexts';
 import { useRouter } from '@/ui/router';
 import { handleError } from '@/ui/utils/errorHandler';
@@ -17,7 +16,7 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
   // @ts-expect-error -- private method for the time being
   const { setActive, __internal_navigateWithError } = useClerk();
   const supportEmail = useSupportEmail();
-  const { afterSignInUrl, signInUrl } = useSignInContext();
+  const { afterSignInUrl, signInUrl, navigateOnSetActive } = useSignInContext();
   const { authenticateWithPasskey } = useCoreSignIn();
   const { navigate } = useRouter();
 
@@ -35,15 +34,7 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
           return setActive({
             session: res.createdSessionId,
             navigate: async ({ session }) => {
-              if (!session.currentTask) {
-                await navigate(afterSignInUrl);
-                return;
-              }
-
-              await navigateIfTaskExists(session, {
-                baseUrl: signInUrl,
-                navigate: navigate,
-              });
+              await navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
             },
           });
         case 'needs_second_factor':

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -2,7 +2,7 @@ import { isClerkRuntimeError, isUserLockedError } from '@clerk/shared/error';
 import { useClerk } from '@clerk/shared/react';
 import { useCallback, useEffect } from 'react';
 
-import { navigateToTask } from '@/core/sessionTasks';
+import { navigateIfTaskExists } from '@/core/sessionTasks';
 import { useCardState } from '@/ui/elements/contexts';
 import { useRouter } from '@/ui/router';
 import { handleError } from '@/ui/utils/errorHandler';
@@ -36,7 +36,7 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
             session: res.createdSessionId,
             redirectUrl: afterSignInUrl,
             navigate: async ({ session }) => {
-              await navigateToTask(session, {
+              await navigateIfTaskExists(session, {
                 baseUrl: signInUrl,
                 navigate: navigate,
               });

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -3,7 +3,6 @@ import { useClerk } from '@clerk/shared/react';
 import { useCallback, useEffect } from 'react';
 
 import { useCardState } from '@/ui/elements/contexts';
-import { useRouter } from '@/ui/router';
 import { handleError } from '@/ui/utils/errorHandler';
 
 import { clerkInvalidFAPIResponse } from '../../../core/errors';
@@ -16,9 +15,8 @@ function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>
   // @ts-expect-error -- private method for the time being
   const { setActive, __internal_navigateWithError } = useClerk();
   const supportEmail = useSupportEmail();
-  const { afterSignInUrl, signInUrl, navigateOnSetActive } = useSignInContext();
+  const { afterSignInUrl, navigateOnSetActive } = useSignInContext();
   const { authenticateWithPasskey } = useCoreSignIn();
-  const { navigate } = useRouter();
 
   useEffect(() => {
     return () => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -38,7 +38,7 @@ function SignUpContinueInternal() {
     unsafeMetadata,
     initialValues = {},
     isCombinedFlow: _isCombinedFlow,
-    onPendingSession,
+    navigateOnSetActive,
   } = useSignUpContext();
   const signUp = useCoreSignUp();
   const isWithinSignInContext = !!React.useContext(SignInContext);
@@ -180,7 +180,12 @@ function SignUpContinueInternal() {
           verifyEmailPath: './verify-email-address',
           verifyPhonePath: './verify-phone-number',
           handleComplete: () =>
-            clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
+            clerk.setActive({
+              session: res.createdSessionId,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+              },
+            }),
           navigate,
           oidcPrompt: ctx.oidcPrompt,
         }),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -38,6 +38,7 @@ function SignUpContinueInternal() {
     unsafeMetadata,
     initialValues = {},
     isCombinedFlow: _isCombinedFlow,
+    onPendingSession,
   } = useSignUpContext();
   const signUp = useCoreSignUp();
   const isWithinSignInContext = !!React.useContext(SignInContext);
@@ -178,7 +179,8 @@ function SignUpContinueInternal() {
           signUp: res,
           verifyEmailPath: './verify-email-address',
           verifyPhonePath: './verify-phone-number',
-          handleComplete: () => clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl }),
+          handleComplete: () =>
+            clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
           navigate,
           oidcPrompt: ctx.oidcPrompt,
         }),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -180,7 +180,7 @@ function SignUpContinueInternal() {
           verifyEmailPath: './verify-email-address',
           verifyPhonePath: './verify-phone-number',
           handleComplete: () =>
-            clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
+            clerk.setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
           navigate,
           oidcPrompt: ctx.oidcPrompt,
         }),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
@@ -17,7 +17,7 @@ export const SignUpEmailLinkCard = () => {
   const { t } = useLocalizations();
   const signUp = useCoreSignUp();
   const signUpContext = useSignUpContext();
-  const { afterSignUpUrl, onPendingSession } = signUpContext;
+  const { afterSignUpUrl, navigateOnSetActive } = signUpContext;
   const card = useCardState();
   const { navigate } = useRouter();
   const { setActive } = useClerk();
@@ -57,7 +57,12 @@ export const SignUpEmailLinkCard = () => {
         verifyEmailPath: '../verify-email-address',
         verifyPhonePath: '../verify-phone-number',
         handleComplete: () =>
-          setActive({ session: su.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
+          setActive({
+            session: su.createdSessionId,
+            navigate: async ({ session }) => {
+              await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+            },
+          }),
         navigate,
       });
     }

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
@@ -17,7 +17,7 @@ export const SignUpEmailLinkCard = () => {
   const { t } = useLocalizations();
   const signUp = useCoreSignUp();
   const signUpContext = useSignUpContext();
-  const { afterSignUpUrl } = signUpContext;
+  const { afterSignUpUrl, onPendingSession } = signUpContext;
   const card = useCardState();
   const { navigate } = useRouter();
   const { setActive } = useClerk();
@@ -56,7 +56,8 @@ export const SignUpEmailLinkCard = () => {
         continuePath: '../continue',
         verifyEmailPath: '../verify-email-address',
         verifyPhonePath: '../verify-phone-number',
-        handleComplete: () => setActive({ session: su.createdSessionId, redirectUrl: afterSignUpUrl }),
+        handleComplete: () =>
+          setActive({ session: su.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
         navigate,
       });
     }

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
@@ -57,7 +57,7 @@ export const SignUpEmailLinkCard = () => {
         verifyEmailPath: '../verify-email-address',
         verifyPhonePath: '../verify-phone-number',
         handleComplete: () =>
-          setActive({ session: su.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
+          setActive({ session: su.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
         navigate,
       });
     }

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSSOCallback.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSSOCallback.tsx
@@ -1,3 +1,8 @@
-import { SSOCallback, withRedirectToAfterSignUp } from '../../common';
+import {
+  SSOCallback,
+  withRedirectToAfterSignUp,
+  withRedirectToSignUpTask,
+  withRedirectToSignUpTask,
+} from '../../common';
 
-export const SignUpSSOCallback = withRedirectToAfterSignUp(SSOCallback);
+export const SignUpSSOCallback = withRedirectToSignUpTask(withRedirectToAfterSignUp(SSOCallback));

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSSOCallback.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSSOCallback.tsx
@@ -1,8 +1,3 @@
-import {
-  SSOCallback,
-  withRedirectToAfterSignUp,
-  withRedirectToSignUpTask,
-  withRedirectToSignUpTask,
-} from '../../common';
+import { SSOCallback, withRedirectToAfterSignUp, withRedirectToSignUpTask } from '../../common';
 
 export const SignUpSSOCallback = withRedirectToSignUpTask(withRedirectToAfterSignUp(SSOCallback));

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -166,7 +166,11 @@ function SignUpStartInternal(): JSX.Element {
           handleComplete: () => {
             removeClerkQueryParam('__clerk_ticket');
             removeClerkQueryParam('__clerk_invitation_token');
-            return setActive({ session: signUp.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession });
+            return setActive({
+              session: signUp.createdSessionId,
+              redirectUrl: afterSignUpUrl,
+              navigate: onPendingSession,
+            });
           },
           navigate,
           oidcPrompt,
@@ -335,7 +339,7 @@ function SignUpStartInternal(): JSX.Element {
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
           handleComplete: () =>
-            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
+            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
           navigate,
           redirectUrl,
           redirectUrlComplete,

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -43,7 +43,7 @@ function SignUpStartInternal(): JSX.Element {
   const { setActive } = useClerk();
   const ctx = useSignUpContext();
   const isWithinSignInContext = !!React.useContext(SignInContext);
-  const { afterSignUpUrl, signInUrl, unsafeMetadata, onPendingSession } = ctx;
+  const { afterSignUpUrl, signInUrl, unsafeMetadata, navigateOnSetActive } = ctx;
   const isCombinedFlow = !!(ctx.isCombinedFlow && !!isWithinSignInContext);
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(() =>
     getInitialActiveIdentifier(attributes, userSettings.signUp.progressive, {
@@ -168,8 +168,9 @@ function SignUpStartInternal(): JSX.Element {
             removeClerkQueryParam('__clerk_invitation_token');
             return setActive({
               session: signUp.createdSessionId,
-              redirectUrl: afterSignUpUrl,
-              navigate: onPendingSession,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+              },
             });
           },
           navigate,
@@ -339,7 +340,12 @@ function SignUpStartInternal(): JSX.Element {
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
           handleComplete: () =>
-            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
+            setActive({
+              session: res.createdSessionId,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+              },
+            }),
           navigate,
           redirectUrl,
           redirectUrlComplete,

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -43,7 +43,7 @@ function SignUpStartInternal(): JSX.Element {
   const { setActive } = useClerk();
   const ctx = useSignUpContext();
   const isWithinSignInContext = !!React.useContext(SignInContext);
-  const { afterSignUpUrl, signInUrl, unsafeMetadata } = ctx;
+  const { afterSignUpUrl, signInUrl, unsafeMetadata, onPendingSession } = ctx;
   const isCombinedFlow = !!(ctx.isCombinedFlow && !!isWithinSignInContext);
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(() =>
     getInitialActiveIdentifier(attributes, userSettings.signUp.progressive, {
@@ -166,7 +166,7 @@ function SignUpStartInternal(): JSX.Element {
           handleComplete: () => {
             removeClerkQueryParam('__clerk_ticket');
             removeClerkQueryParam('__clerk_invitation_token');
-            return setActive({ session: signUp.createdSessionId, redirectUrl: afterSignUpUrl });
+            return setActive({ session: signUp.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession });
           },
           navigate,
           oidcPrompt,
@@ -334,7 +334,8 @@ function SignUpStartInternal(): JSX.Element {
           signUp: res,
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
-          handleComplete: () => setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl }),
+          handleComplete: () =>
+            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
           navigate,
           redirectUrl,
           redirectUrlComplete,

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -16,7 +16,7 @@ import { createUsernameError } from '@/ui/utils/usernameUtils';
 
 import { ERROR_CODES, SIGN_UP_MODES } from '../../../core/constants';
 import { getClerkQueryParam, removeClerkQueryParam } from '../../../utils/getClerkQueryParam';
-import { withRedirectToAfterSignUp } from '../../common';
+import { withRedirectToAfterSignUp, withRedirectToSignUpTask } from '../../common';
 import { SignInContext, useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts';
 import { descriptors, Flex, Flow, localizationKeys, useAppearance, useLocalizations } from '../../customizables';
 import { CaptchaElement } from '../../elements/CaptchaElement';
@@ -449,4 +449,6 @@ function SignUpStartInternal(): JSX.Element {
   );
 }
 
-export const SignUpStart = withRedirectToAfterSignUp(withCardStateProvider(SignUpStartInternal));
+export const SignUpStart = withRedirectToSignUpTask(
+  withRedirectToAfterSignUp(withCardStateProvider(SignUpStartInternal)),
+);

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -44,7 +44,7 @@ export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) 
           verifyPhonePath: '../verify-phone-number',
           continuePath: '../continue',
           handleComplete: () =>
-            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
+            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
           navigate,
         });
       })

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -24,7 +24,7 @@ type SignInFactorOneCodeFormProps = {
 };
 
 export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) => {
-  const { afterSignUpUrl } = useSignUpContext();
+  const { afterSignUpUrl, onPendingSession } = useSignUpContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
 
@@ -43,7 +43,8 @@ export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) 
           verifyEmailPath: '../verify-email-address',
           verifyPhonePath: '../verify-phone-number',
           continuePath: '../continue',
-          handleComplete: () => setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl }),
+          handleComplete: () =>
+            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, onPendingSession }),
           navigate,
         });
       })

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -24,7 +24,7 @@ type SignInFactorOneCodeFormProps = {
 };
 
 export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) => {
-  const { afterSignUpUrl, onPendingSession } = useSignUpContext();
+  const { afterSignUpUrl, navigateOnSetActive } = useSignUpContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
 
@@ -44,7 +44,12 @@ export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) 
           verifyPhonePath: '../verify-phone-number',
           continuePath: '../continue',
           handleComplete: () =>
-            setActive({ session: res.createdSessionId, redirectUrl: afterSignUpUrl, navigate: onPendingSession }),
+            setActive({
+              session: res.createdSessionId,
+              navigate: async ({ session }) => {
+                await navigateOnSetActive({ session, redirectUrl: afterSignUpUrl });
+              },
+            }),
           navigate,
         });
       })

--- a/packages/clerk-js/src/ui/components/SignUp/index.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/index.tsx
@@ -7,7 +7,7 @@ import { SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowC
 import { SignUpContext, useSignUpContext, withCoreSessionSwitchGuard } from '../../contexts';
 import { Flow } from '../../customizables';
 import { usePreloadTasks } from '../../hooks/usePreloadTasks';
-import { Route, Switch, useRouter, VIRTUAL_ROUTER_BASE_PATH } from '../../router';
+import { Route, Switch, VIRTUAL_ROUTER_BASE_PATH } from '../../router';
 import { SignUpContinue } from './SignUpContinue';
 import { SignUpSSOCallback } from './SignUpSSOCallback';
 import { SignUpStart } from './SignUpStart';
@@ -25,13 +25,7 @@ function RedirectToSignUp() {
 function SignUpRoutes(): JSX.Element {
   usePreloadTasks();
 
-  const { __internal_setComponentNavigationContext } = useClerk();
-  const { navigate, indexPath } = useRouter();
   const signUpContext = useSignUpContext();
-
-  React.useEffect(() => {
-    return __internal_setComponentNavigationContext?.({ indexPath, navigate });
-  }, [indexPath, navigate]);
 
   return (
     <Flow.Root flow='signUp'>

--- a/packages/clerk-js/src/ui/components/SignUp/index.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/index.tsx
@@ -2,6 +2,8 @@ import { useClerk } from '@clerk/shared/react';
 import type { SignUpModalProps, SignUpProps } from '@clerk/types';
 import React from 'react';
 
+import { usePreloadTasks } from '@/ui/hooks/usePreloadTasks';
+
 import { SessionTasks as LazySessionTasks } from '../../../ui/lazyModules/components';
 import { SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowCard';
 import { SignUpContext, useSignUpContext, withCoreSessionSwitchGuard } from '../../contexts';
@@ -22,6 +24,8 @@ function RedirectToSignUp() {
 }
 
 function SignUpRoutes(): JSX.Element {
+  usePreloadTasks();
+
   const signUpContext = useSignUpContext();
 
   return (

--- a/packages/clerk-js/src/ui/components/SignUp/index.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/index.tsx
@@ -6,7 +6,6 @@ import { SessionTasks as LazySessionTasks } from '../../../ui/lazyModules/compon
 import { SignUpEmailLinkFlowComplete } from '../../common/EmailLinkCompleteFlowCard';
 import { SignUpContext, useSignUpContext, withCoreSessionSwitchGuard } from '../../contexts';
 import { Flow } from '../../customizables';
-import { usePreloadTasks } from '../../hooks/usePreloadTasks';
 import { Route, Switch, VIRTUAL_ROUTER_BASE_PATH } from '../../router';
 import { SignUpContinue } from './SignUpContinue';
 import { SignUpSSOCallback } from './SignUpSSOCallback';
@@ -23,8 +22,6 @@ function RedirectToSignUp() {
 }
 
 function SignUpRoutes(): JSX.Element {
-  usePreloadTasks();
-
   const signUpContext = useSignUpContext();
 
   return (

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -1,7 +1,7 @@
 import { useClerk } from '@clerk/shared/react';
 import type { SignedInSessionResource, UserButtonProps, UserResource } from '@clerk/types';
 
-import { navigateToTask } from '@/core/sessionTasks';
+import { navigateIfTaskExists } from '@/core/sessionTasks';
 import { useEnvironment } from '@/ui/contexts';
 import { useCardState } from '@/ui/elements/contexts';
 import { sleep } from '@/ui/utils/sleep';
@@ -77,7 +77,7 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
       session,
       redirectUrl: opts.afterSwitchSessionUrl,
       navigate: async ({ session }) => {
-        await navigateToTask(session, {
+        await navigateIfTaskExists(session, {
           baseUrl: opts.signInUrl ?? displayConfig.signInUrl,
           navigate,
         });

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -21,7 +21,7 @@ type UseMultisessionActionsParams = {
 } & Pick<UserButtonProps, 'userProfileMode' | 'appearance' | 'userProfileProps'>;
 
 export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
-  const { setActive, signOut, openUserProfile, __internal_getOption } = useClerk();
+  const { setActive, signOut, openUserProfile } = useClerk();
   const card = useCardState();
   const { signedInSessions, otherSessions } = useMultipleSessions({ user: opts.user });
   const { navigate } = useRouter();
@@ -76,11 +76,10 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
     return setActive({
       session,
       redirectUrl: opts.afterSwitchSessionUrl,
-      onPendingSession: async ({ session }) => {
+      navigate: async ({ session }) => {
         await navigateToTask(session, {
-          baseUrl: displayConfig.signInUrl,
-          navigate: navigate,
-          options: { taskUrls: __internal_getOption('taskUrls') },
+          baseUrl: opts.signInUrl ?? displayConfig.signInUrl,
+          navigate,
         });
       },
     }).finally(() => {

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -19,7 +19,7 @@ type UseMultisessionActionsParams = {
 } & Pick<UserButtonProps, 'userProfileMode' | 'appearance' | 'userProfileProps'>;
 
 export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
-  const { setActive, signOut, openUserProfile, __internal_navigateToTaskIfAvailable } = useClerk();
+  const { setActive, signOut, openUserProfile } = useClerk();
   const card = useCardState();
   const { signedInSessions, otherSessions } = useMultipleSessions({ user: opts.user });
   const { navigate } = useRouter();
@@ -70,12 +70,10 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
   const handleSessionClicked = (session: SignedInSessionResource) => async () => {
     card.setLoading();
 
-    return setActive({ session, redirectUrl: opts.afterSwitchSessionUrl })
-      .then(() => __internal_navigateToTaskIfAvailable())
-      .finally(() => {
-        card.setIdle();
-        opts.actionCompleteCallback?.();
-      });
+    return setActive({ session, redirectUrl: opts.afterSwitchSessionUrl }).finally(() => {
+      card.setIdle();
+      opts.actionCompleteCallback?.();
+    });
   };
 
   const handleAddAccountClicked = () => {

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -21,7 +21,7 @@ type UseMultisessionActionsParams = {
 } & Pick<UserButtonProps, 'userProfileMode' | 'appearance' | 'userProfileProps'>;
 
 export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
-  const { setActive, signOut, openUserProfile } = useClerk();
+  const { setActive, signOut, openUserProfile, __internal_getOption } = useClerk();
   const card = useCardState();
   const { signedInSessions, otherSessions } = useMultipleSessions({ user: opts.user });
   const { navigate } = useRouter();
@@ -80,7 +80,7 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
         await navigateToTask(session, {
           baseUrl: displayConfig.signInUrl,
           navigate: navigate,
-          // TODO -> Pass `clerk` into callback so we can access the taskUrls here
+          options: { taskUrls: __internal_getOption('taskUrls') },
         });
       },
     }).finally(() => {

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -75,8 +75,12 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
 
     return setActive({
       session,
-      redirectUrl: opts.afterSwitchSessionUrl,
       navigate: async ({ session }) => {
+        if (!session.currentTask && opts.afterSwitchSessionUrl) {
+          await navigate(opts.afterSwitchSessionUrl);
+          return;
+        }
+
         await navigateIfTaskExists(session, {
           baseUrl: opts.signInUrl ?? displayConfig.signInUrl,
           navigate,

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -26,7 +26,7 @@ import {
   UserVerificationContext,
   WaitlistContext,
 } from './components';
-import { SessionTasksContext, TaskChooseOrganizationContext } from './components/SessionTasks';
+import { TaskChooseOrganizationContext } from './components/SessionTasks';
 
 export function ComponentContextProvider({
   componentName,
@@ -115,9 +115,7 @@ export function ComponentContextProvider({
         <TaskChooseOrganizationContext.Provider
           value={{ componentName: 'TaskChooseOrganization', ...(props as TaskChooseOrganizationProps) }}
         >
-          <SessionTasksContext.Provider value={{ ...(props as TaskChooseOrganizationProps) }}>
-            {children}
-          </SessionTasksContext.Provider>
+          {children}
         </TaskChooseOrganizationContext.Provider>
       );
     default:

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -1,5 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
+import type { OnPendingSessionFn } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
@@ -32,6 +33,7 @@ export type SignInContextType = Omit<SignInCtx, 'fallbackRedirectUrl' | 'forceRe
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
   isCombinedFlow: boolean;
+  onPendingSession: OnPendingSessionFn;
 };
 
 export const SignInContext = createContext<SignInCtx | null>(null);
@@ -129,6 +131,15 @@ export const useSignInContext = (): SignInContextType => {
     taskUrls: clerk.__internal_getOption('taskUrls'),
   });
 
+  const onPendingSession: OnPendingSessionFn = async ({ session }) => {
+    switch (session.currentTask?.key) {
+      case 'choose-organization': {
+        // TODO - preserve redirect_url
+        await navigate(buildURL({ base: signInUrl, hashPath: '/tasks/choose-organization' }, { stringify: true }));
+      }
+    }
+  };
+
   return {
     ...(ctx as SignInCtx),
     transferable: ctx.transferable ?? true,
@@ -148,5 +159,6 @@ export const useSignInContext = (): SignInContextType => {
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
     authQueryString,
     isCombinedFlow,
+    onPendingSession,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { getTaskEndpoint, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -131,7 +131,13 @@ export const useSignInContext = (): SignInContextType => {
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTaskUrl(clerk.session?.currentTask, { base: signInUrl }))
+      buildRedirectUrl({
+        routing: ctx.routing,
+        baseUrl: signInUrl,
+        authQueryString,
+        path: ctx.path,
+        endpoint: getTaskEndpoint(clerk.session?.currentTask),
+      }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -121,12 +121,12 @@ export const useSignInContext = (): SignInContextType => {
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
   const navigateOnSetActive = async ({ session, redirectUrl }: { session: SessionResource; redirectUrl: string }) => {
-    const currentTaskKey = session.currentTask?.key;
-    if (!currentTaskKey) {
+    const currentTask = session.currentTask;
+    if (!currentTask) {
       return navigate(redirectUrl);
     }
 
-    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
+    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -37,7 +37,7 @@ export const SignInContext = createContext<SignInCtx | null>(null);
 
 export const useSignInContext = (): SignInContextType => {
   const context = useContext(SignInContext);
-  const { navigate, indexPath } = useRouter();
+  const { navigate, basePath } = useRouter();
   const { displayConfig, userSettings } = useEnvironment();
   const { queryParams, queryString } = useRouter();
   const signUpMode = userSettings.signUp.mode;
@@ -126,7 +126,7 @@ export const useSignInContext = (): SignInContextType => {
       return navigate(redirectUrl);
     }
 
-    return navigate(indexPath + `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
+    return navigate(`/${basePath}/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
-import type { OnPendingSessionFn } from '@clerk/types';
+import type { SetActiveNavigate } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { buildTaskURL } from '@/core/sessionTasks';
@@ -29,7 +29,7 @@ export type SignInContextType = Omit<SignInCtx, 'fallbackRedirectUrl' | 'forceRe
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
   isCombinedFlow: boolean;
-  onPendingSession: OnPendingSessionFn;
+  onPendingSession: SetActiveNavigate;
   taskUrl: string | null;
 };
 
@@ -120,15 +120,13 @@ export const useSignInContext = (): SignInContextType => {
 
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
-  const onPendingSession: OnPendingSessionFn = async ({ session }) => {
-    const currentTaskKey = session.currentTask.key;
-    const customTaskUrl = clerk.__internal_getOption('taskUrls')?.[currentTaskKey];
-
-    switch (currentTaskKey) {
-      case 'choose-organization': {
-        await navigate(customTaskUrl ?? `../tasks/${currentTaskKey}`);
-      }
+  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+    const currentTaskKey = session.currentTask?.key;
+    if (!currentTaskKey) {
+      return;
     }
+
+    return navigate(`/tasks/${currentTaskKey}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,8 +3,6 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { OnPendingSessionFn } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { navigateToTask } from '@/core/sessionTasks';
-
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
 import { RedirectUrls } from '../../../utils/redirectUrls';
@@ -120,13 +118,11 @@ export const useSignInContext = (): SignInContextType => {
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
   const onPendingSession: OnPendingSessionFn = async ({ session }) => {
-    switch (session.currentTask?.key) {
+    const currentTaskKey = session.currentTask.key;
+
+    switch (currentTaskKey) {
       case 'choose-organization': {
-        // TODO - preserve redirect_url
-        await navigateToTask(session, {
-          navigate,
-          baseUrl: signInUrl,
-        });
+        await navigate(`../tasks/${currentTaskKey}`);
       }
     }
   };

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -122,10 +122,11 @@ export const useSignInContext = (): SignInContextType => {
 
   const onPendingSession: OnPendingSessionFn = async ({ session }) => {
     const currentTaskKey = session.currentTask.key;
+    const customTaskUrl = clerk.__internal_getOption('taskUrls')?.[currentTaskKey];
 
     switch (currentTaskKey) {
       case 'choose-organization': {
-        await navigate(`../tasks/${currentTaskKey}`);
+        await navigate(customTaskUrl ?? `../tasks/${currentTaskKey}`);
       }
     }
   };
@@ -136,7 +137,7 @@ export const useSignInContext = (): SignInContextType => {
     : null;
 
   return {
-    ...(ctx as SignInCtx),
+    ...ctx,
     transferable: ctx.transferable ?? true,
     oauthFlow: ctx.oauthFlow || 'auto',
     componentName,

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { buildTasksUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -37,7 +37,7 @@ export const SignInContext = createContext<SignInCtx | null>(null);
 
 export const useSignInContext = (): SignInContextType => {
   const context = useContext(SignInContext);
-  const { navigate } = useRouter();
+  const { navigate, indexPath } = useRouter();
   const { displayConfig, userSettings } = useEnvironment();
   const { queryParams, queryString } = useRouter();
   const signUpMode = userSettings.signUp.mode;
@@ -126,12 +126,12 @@ export const useSignInContext = (): SignInContextType => {
       return navigate(redirectUrl);
     }
 
-    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
+    return navigate(indexPath + `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTaskURL(clerk.session?.currentTask, { base: signInUrl }))
+      buildTasksUrl(clerk.session?.currentTask, { base: signInUrl }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTasksUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { buildTaskUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -131,7 +131,7 @@ export const useSignInContext = (): SignInContextType => {
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTasksUrl(clerk.session?.currentTask, { base: signInUrl }))
+      buildTaskUrl(clerk.session?.currentTask, { base: signInUrl }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
-import type { SetActiveNavigate } from '@clerk/types';
+import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
@@ -29,7 +29,7 @@ export type SignInContextType = Omit<SignInCtx, 'fallbackRedirectUrl' | 'forceRe
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
   isCombinedFlow: boolean;
-  onPendingSession: SetActiveNavigate;
+  navigateOnSetActive: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
   taskUrl: string | null;
 };
 
@@ -120,10 +120,10 @@ export const useSignInContext = (): SignInContextType => {
 
   const signUpContinueUrl = buildURL({ base: signUpUrl, hashPath: '/continue' }, { stringify: true });
 
-  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+  const navigateOnSetActive = async ({ session, redirectUrl }: { session: SessionResource; redirectUrl: string }) => {
     const currentTaskKey = session.currentTask?.key;
     if (!currentTaskKey) {
-      return;
+      return navigate(redirectUrl);
     }
 
     return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
@@ -152,7 +152,7 @@ export const useSignInContext = (): SignInContextType => {
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
     authQueryString,
     isCombinedFlow,
-    onPendingSession,
+    navigateOnSetActive,
     taskUrl,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,6 +3,8 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { OnPendingSessionFn } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
+import { buildTaskURL } from '@/core/sessionTasks';
+
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
 import { RedirectUrls } from '../../../utils/redirectUrls';
@@ -28,6 +30,7 @@ export type SignInContextType = Omit<SignInCtx, 'fallbackRedirectUrl' | 'forceRe
   ssoCallbackUrl: string;
   isCombinedFlow: boolean;
   onPendingSession: OnPendingSessionFn;
+  taskUrl: string | null;
 };
 
 export const SignInContext = createContext<SignInCtx | null>(null);
@@ -127,6 +130,11 @@ export const useSignInContext = (): SignInContextType => {
     }
   };
 
+  const taskUrl = clerk.session?.currentTask
+    ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
+      buildTaskURL(clerk.session?.currentTask, { base: signInUrl }))
+    : null;
+
   return {
     ...(ctx as SignInCtx),
     transferable: ctx.transferable ?? true,
@@ -146,5 +154,6 @@ export const useSignInContext = (): SignInContextType => {
     authQueryString,
     isCombinedFlow,
     onPendingSession,
+    taskUrl,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SetActiveNavigate } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskURL } from '@/core/sessionTasks';
+import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -126,7 +126,7 @@ export const useSignInContext = (): SignInContextType => {
       return;
     }
 
-    return navigate(`../tasks/${currentTaskKey}`);
+    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { getTaskEndpoint, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { getTaskEndpoint } from '@/core/sessionTasks';
 
 import { SIGN_IN_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -126,7 +126,10 @@ export const useSignInContext = (): SignInContextType => {
       return navigate(redirectUrl);
     }
 
-    return navigate(`/${basePath}/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
+    const taskEndpoint = getTaskEndpoint(currentTask);
+    const taskNavigationPath = isCombinedFlow ? '/create' + taskEndpoint : taskEndpoint;
+
+    return navigate(`/${basePath + taskNavigationPath}`);
   };
 
   const taskUrl = clerk.session?.currentTask
@@ -136,7 +139,9 @@ export const useSignInContext = (): SignInContextType => {
         baseUrl: signInUrl,
         authQueryString,
         path: ctx.path,
-        endpoint: getTaskEndpoint(clerk.session?.currentTask),
+        endpoint: isCombinedFlow
+          ? '/create' + getTaskEndpoint(clerk.session?.currentTask)
+          : getTaskEndpoint(clerk.session?.currentTask),
       }))
     : null;
 

--- a/packages/clerk-js/src/ui/contexts/components/SignIn.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignIn.ts
@@ -126,7 +126,7 @@ export const useSignInContext = (): SignInContextType => {
       return;
     }
 
-    return navigate(`/tasks/${currentTaskKey}`);
+    return navigate(`../tasks/${currentTaskKey}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -116,12 +116,12 @@ export const useSignUpContext = (): SignUpContextType => {
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
 
   const navigateOnSetActive = async ({ session, redirectUrl }: { session: SessionResource; redirectUrl: string }) => {
-    const currentTaskKey = session.currentTask?.key;
-    if (!currentTaskKey) {
+    const currentTask = session.currentTask;
+    if (!currentTask) {
       return navigate(redirectUrl);
     }
 
-    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
+    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -36,7 +36,7 @@ export const SignUpContext = createContext<SignUpCtx | null>(null);
 
 export const useSignUpContext = (): SignUpContextType => {
   const context = useContext(SignUpContext);
-  const { navigate, indexPath } = useRouter();
+  const { navigate, basePath } = useRouter();
   const { displayConfig, userSettings } = useEnvironment();
   const { queryParams, queryString } = useRouter();
   const signUpMode = userSettings.signUp.mode;
@@ -121,7 +121,7 @@ export const useSignUpContext = (): SignUpContextType => {
       return navigate(redirectUrl);
     }
 
-    return navigate(indexPath + `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
+    return navigate(`/${basePath}/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { getTaskEndpoint, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -126,7 +126,13 @@ export const useSignUpContext = (): SignUpContextType => {
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTaskUrl(clerk.session?.currentTask, { base: signUpUrl }))
+      buildRedirectUrl({
+        routing: ctx.routing,
+        baseUrl: signInUrl,
+        authQueryString,
+        path: ctx.path,
+        endpoint: getTaskEndpoint(clerk.session?.currentTask),
+      }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -5,12 +5,7 @@ import { createContext, useContext, useMemo } from 'react';
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
 import { RedirectUrls } from '../../../utils/redirectUrls';
-import {
-  buildRedirectUrl,
-  buildSessionTaskRedirectUrl,
-  MAGIC_LINK_VERIFY_PATH_ROUTE,
-  SSO_CALLBACK_PATH_ROUTE,
-} from '../../common/redirects';
+import { buildRedirectUrl, MAGIC_LINK_VERIFY_PATH_ROUTE, SSO_CALLBACK_PATH_ROUTE } from '../../common/redirects';
 import { useEnvironment, useOptions } from '../../contexts';
 import type { ParsedQueryString } from '../../router';
 import { useRouter } from '../../router';
@@ -27,7 +22,6 @@ export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRe
   afterSignUpUrl: string;
   afterSignInUrl: string;
   waitlistUrl: string;
-  sessionTaskUrl: string | null;
   isCombinedFlow: boolean;
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
@@ -116,14 +110,6 @@ export const useSignUpContext = (): SignUpContextType => {
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
 
-  const sessionTaskUrl = buildSessionTaskRedirectUrl({
-    task: clerk.session?.currentTask,
-    path: ctx.path,
-    routing: ctx.routing,
-    baseUrl: signUpUrl,
-    taskUrls: clerk.__internal_getOption('taskUrls'),
-  });
-
   return {
     ...ctx,
     oauthFlow: ctx.oauthFlow || 'auto',
@@ -136,7 +122,6 @@ export const useSignUpContext = (): SignUpContextType => {
     afterSignInUrl,
     emailLinkRedirectUrl,
     ssoCallbackUrl,
-    sessionTaskUrl,
     navigateAfterSignUp,
     queryParams,
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -1,5 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
+import type { OnPendingSessionFn } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
@@ -25,6 +26,7 @@ export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRe
   isCombinedFlow: boolean;
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
+  onPendingSession: OnPendingSessionFn;
 };
 
 export const SignUpContext = createContext<SignUpCtx | null>(null);
@@ -110,6 +112,16 @@ export const useSignUpContext = (): SignUpContextType => {
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
 
+  const onPendingSession: OnPendingSessionFn = async ({ session }) => {
+    const currentTaskKey = session.currentTask.key;
+
+    switch (currentTaskKey) {
+      case 'choose-organization': {
+        await navigate(`../tasks/${currentTaskKey}`);
+      }
+    }
+  };
+
   return {
     ...ctx,
     oauthFlow: ctx.oauthFlow || 'auto',
@@ -127,5 +139,6 @@ export const useSignUpContext = (): SignUpContextType => {
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
     authQueryString,
     isCombinedFlow,
+    onPendingSession,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTasksUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { buildTaskUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -126,7 +126,7 @@ export const useSignUpContext = (): SignUpContextType => {
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTasksUrl(clerk.session?.currentTask, { base: signUpUrl }))
+      buildTaskUrl(clerk.session?.currentTask, { base: signUpUrl }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -121,7 +121,7 @@ export const useSignUpContext = (): SignUpContextType => {
       return;
     }
 
-    return navigate(`/tasks/${currentTaskKey}`);
+    return navigate(`../tasks/${currentTaskKey}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SetActiveNavigate } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskURL } from '@/core/sessionTasks';
+import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -121,7 +121,7 @@ export const useSignUpContext = (): SignUpContextType => {
       return;
     }
 
-    return navigate(`../tasks/${currentTaskKey}`);
+    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
-import type { OnPendingSessionFn } from '@clerk/types';
+import type { SetActiveNavigate } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { buildTaskURL } from '@/core/sessionTasks';
@@ -28,7 +28,7 @@ export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRe
   isCombinedFlow: boolean;
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
-  onPendingSession: OnPendingSessionFn;
+  onPendingSession: SetActiveNavigate;
   taskUrl: string | null;
 };
 
@@ -115,15 +115,13 @@ export const useSignUpContext = (): SignUpContextType => {
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
 
-  const onPendingSession: OnPendingSessionFn = async ({ session }) => {
-    const currentTaskKey = session.currentTask.key;
-    const customTaskUrl = clerk.__internal_getOption('taskUrls')?.[currentTaskKey];
-
-    switch (currentTaskKey) {
-      case 'choose-organization': {
-        await navigate(customTaskUrl ?? `../tasks/${currentTaskKey}`);
-      }
+  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+    const currentTaskKey = session.currentTask?.key;
+    if (!currentTaskKey) {
+      return;
     }
+
+    return navigate(`/tasks/${currentTaskKey}`);
   };
 
   const taskUrl = clerk.session?.currentTask

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -3,6 +3,8 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { OnPendingSessionFn } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
+import { buildTaskURL } from '@/core/sessionTasks';
+
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
 import { RedirectUrls } from '../../../utils/redirectUrls';
@@ -27,6 +29,7 @@ export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRe
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
   onPendingSession: OnPendingSessionFn;
+  taskUrl: string | null;
 };
 
 export const SignUpContext = createContext<SignUpCtx | null>(null);
@@ -122,6 +125,11 @@ export const useSignUpContext = (): SignUpContextType => {
     }
   };
 
+  const taskUrl = clerk.session?.currentTask
+    ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
+      buildTaskURL(clerk.session?.currentTask, { base: signUpUrl }))
+    : null;
+
   return {
     ...ctx,
     oauthFlow: ctx.oauthFlow || 'auto',
@@ -140,5 +148,6 @@ export const useSignUpContext = (): SignUpContextType => {
     authQueryString,
     isCombinedFlow,
     onPendingSession,
+    taskUrl,
   };
 };

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -3,7 +3,7 @@ import { isAbsoluteUrl } from '@clerk/shared/url';
 import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
-import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
+import { buildTasksUrl, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
 
 import { SIGN_UP_INITIAL_VALUE_KEYS } from '../../../core/constants';
 import { buildURL } from '../../../utils';
@@ -36,7 +36,7 @@ export const SignUpContext = createContext<SignUpCtx | null>(null);
 
 export const useSignUpContext = (): SignUpContextType => {
   const context = useContext(SignUpContext);
-  const { navigate } = useRouter();
+  const { navigate, indexPath } = useRouter();
   const { displayConfig, userSettings } = useEnvironment();
   const { queryParams, queryString } = useRouter();
   const signUpMode = userSettings.signUp.mode;
@@ -121,12 +121,12 @@ export const useSignUpContext = (): SignUpContextType => {
       return navigate(redirectUrl);
     }
 
-    return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
+    return navigate(indexPath + `/tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTask.key]}`);
   };
 
   const taskUrl = clerk.session?.currentTask
     ? (clerk.__internal_getOption('taskUrls')?.[clerk.session?.currentTask.key] ??
-      buildTaskURL(clerk.session?.currentTask, { base: signUpUrl }))
+      buildTasksUrl(clerk.session?.currentTask, { base: signUpUrl }))
     : null;
 
   return {

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -117,10 +117,11 @@ export const useSignUpContext = (): SignUpContextType => {
 
   const onPendingSession: OnPendingSessionFn = async ({ session }) => {
     const currentTaskKey = session.currentTask.key;
+    const customTaskUrl = clerk.__internal_getOption('taskUrls')?.[currentTaskKey];
 
     switch (currentTaskKey) {
       case 'choose-organization': {
-        await navigate(`../tasks/${currentTaskKey}`);
+        await navigate(customTaskUrl ?? `../tasks/${currentTaskKey}`);
       }
     }
   };

--- a/packages/clerk-js/src/ui/contexts/components/SignUp.ts
+++ b/packages/clerk-js/src/ui/contexts/components/SignUp.ts
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { isAbsoluteUrl } from '@clerk/shared/url';
-import type { SetActiveNavigate } from '@clerk/types';
+import type { SessionResource } from '@clerk/types';
 import { createContext, useContext, useMemo } from 'react';
 
 import { buildTaskURL, INTERNAL_SESSION_TASK_ROUTE_BY_KEY } from '@/core/sessionTasks';
@@ -28,7 +28,7 @@ export type SignUpContextType = Omit<SignUpCtx, 'fallbackRedirectUrl' | 'forceRe
   isCombinedFlow: boolean;
   emailLinkRedirectUrl: string;
   ssoCallbackUrl: string;
-  onPendingSession: SetActiveNavigate;
+  navigateOnSetActive: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
   taskUrl: string | null;
 };
 
@@ -115,10 +115,10 @@ export const useSignUpContext = (): SignUpContextType => {
   // TODO: Avoid building this url again to remove duplicate code. Get it from window.Clerk instead.
   const secondFactorUrl = buildURL({ base: signInUrl, hashPath: '/factor-two' }, { stringify: true });
 
-  const onPendingSession: SetActiveNavigate = async ({ session }) => {
+  const navigateOnSetActive = async ({ session, redirectUrl }: { session: SessionResource; redirectUrl: string }) => {
     const currentTaskKey = session.currentTask?.key;
     if (!currentTaskKey) {
-      return;
+      return navigate(redirectUrl);
     }
 
     return navigate(`../tasks/${INTERNAL_SESSION_TASK_ROUTE_BY_KEY[currentTaskKey]}`);
@@ -146,7 +146,7 @@ export const useSignUpContext = (): SignUpContextType => {
     initialValues: { ...ctx.initialValues, ...initialValuesFromQueryParams },
     authQueryString,
     isCombinedFlow,
-    onPendingSession,
+    navigateOnSetActive,
     taskUrl,
   };
 };

--- a/packages/clerk-js/src/ui/lazyModules/components.ts
+++ b/packages/clerk-js/src/ui/lazyModules/components.ts
@@ -122,7 +122,7 @@ export const OAuthConsent = lazy(() =>
 );
 
 export const SessionTasks = lazy(() =>
-  componentImportPaths.SessionTasks().then(module => ({ default: module.SessionTask })),
+  componentImportPaths.SessionTasks().then(module => ({ default: module.SessionTasks })),
 );
 
 export const preloadComponent = async (component: unknown) => {

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -137,7 +137,7 @@ export type CheckoutCtx = __internal_CheckoutProps & {
 export type SessionTasksCtx = {
   redirectUrlComplete: string;
   currentTaskContainer?: React.RefObject<HTMLDivElement> | null;
-  navigateOnSetActive?: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
+  navigateOnSetActive: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
 };
 
 export type TaskChooseOrganizationCtx = TaskChooseOrganizationProps & {

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -12,6 +12,7 @@ import type {
   OrganizationProfileProps,
   OrganizationSwitcherProps,
   PricingTableProps,
+  SetActiveNavigate,
   SignInFallbackRedirectUrl,
   SignInForceRedirectUrl,
   SignInProps,
@@ -136,6 +137,7 @@ export type CheckoutCtx = __internal_CheckoutProps & {
 export type SessionTasksCtx = {
   redirectUrlComplete: string;
   currentTaskContainer?: React.RefObject<HTMLDivElement> | null;
+  onPendingSession?: SetActiveNavigate;
 };
 
 export type TaskChooseOrganizationCtx = TaskChooseOrganizationProps & {

--- a/packages/clerk-js/src/ui/types.ts
+++ b/packages/clerk-js/src/ui/types.ts
@@ -12,7 +12,7 @@ import type {
   OrganizationProfileProps,
   OrganizationSwitcherProps,
   PricingTableProps,
-  SetActiveNavigate,
+  SessionResource,
   SignInFallbackRedirectUrl,
   SignInForceRedirectUrl,
   SignInProps,
@@ -137,7 +137,7 @@ export type CheckoutCtx = __internal_CheckoutProps & {
 export type SessionTasksCtx = {
   redirectUrlComplete: string;
   currentTaskContainer?: React.RefObject<HTMLDivElement> | null;
-  onPendingSession?: SetActiveNavigate;
+  navigateOnSetActive?: (opts: { session: SessionResource; redirectUrl: string }) => Promise<unknown>;
 };
 
 export type TaskChooseOrganizationCtx = TaskChooseOrganizationProps & {

--- a/packages/clerk-js/src/utils/assertNoLegacyProp.ts
+++ b/packages/clerk-js/src/utils/assertNoLegacyProp.ts
@@ -1,4 +1,5 @@
 import { logger } from '@clerk/shared/logger';
+import type { ClerkOptions } from '@clerk/types';
 
 export function assertNoLegacyProp(props: Record<string, any>) {
   const legacyProps = ['redirectUrl', 'afterSignInUrl', 'afterSignUpUrl', 'after_sign_in_url', 'after_sign_up_url'];
@@ -22,4 +23,18 @@ export function warnForNewPropShadowingLegacyProp(
       `Clerk: The "${newKey}" prop ("${newValue}") has priority over the legacy "${legacyKey}" (or "redirectUrl") ("${legacyValue}"), which will be completely ignored in this case. "${legacyKey}" (or "redirectUrl" prop) should be replaced with the new "fallbackRedirectUrl" or "forceRedirectUrl" props instead. Learn more: https://clerk.com/docs/guides/custom-redirects#redirect-url-props`,
     );
   }
+}
+
+export function warnNoTaskOptions(options: ClerkOptions) {
+  const taskOptions = ['taskUrls', 'onPendingSession'];
+
+  const hasAtLeastOneTaskOption = Object.keys(options).some(option => taskOptions.includes(option));
+  if (hasAtLeastOneTaskOption) {
+    return;
+  }
+
+  logger.warnOnce(
+    // TODO - Link to after-auth docs once it gets released
+    `Clerk: After-auth is enabled and no task options configured. Consider providing "taskUrls" or "onPendingSession" to handle pending session tasks.`,
+  );
 }

--- a/packages/clerk-js/src/utils/assertNoLegacyProp.ts
+++ b/packages/clerk-js/src/utils/assertNoLegacyProp.ts
@@ -1,5 +1,4 @@
 import { logger } from '@clerk/shared/logger';
-import type { ClerkOptions } from '@clerk/types';
 
 export function assertNoLegacyProp(props: Record<string, any>) {
   const legacyProps = ['redirectUrl', 'afterSignInUrl', 'afterSignUpUrl', 'after_sign_in_url', 'after_sign_up_url'];
@@ -23,18 +22,4 @@ export function warnForNewPropShadowingLegacyProp(
       `Clerk: The "${newKey}" prop ("${newValue}") has priority over the legacy "${legacyKey}" (or "redirectUrl") ("${legacyValue}"), which will be completely ignored in this case. "${legacyKey}" (or "redirectUrl" prop) should be replaced with the new "fallbackRedirectUrl" or "forceRedirectUrl" props instead. Learn more: https://clerk.com/docs/guides/custom-redirects#redirect-url-props`,
     );
   }
-}
-
-export function warnNoTaskOptions(options: ClerkOptions) {
-  const taskOptions = ['taskUrls', 'onPendingSession'];
-
-  const hasAtLeastOneTaskOption = Object.keys(options).some(option => taskOptions.includes(option));
-  if (hasAtLeastOneTaskOption) {
-    return;
-  }
-
-  logger.warnOnce(
-    // TODO - Link to after-auth docs once it gets released
-    `Clerk: After-auth is enabled and no task options configured. Consider providing "taskUrls" or "onPendingSession" to handle pending session tasks.`,
-  );
 }

--- a/packages/clerk-js/src/utils/componentGuards.ts
+++ b/packages/clerk-js/src/utils/componentGuards.ts
@@ -6,8 +6,8 @@ export type ComponentGuard = (
   options?: ClerkOptions,
 ) => boolean;
 
-export const sessionExistsAndSingleSessionModeEnabled: ComponentGuard = (clerk, environment) => {
-  return !!(clerk.session && environment?.authConfig.singleSessionMode);
+export const isSignedInAndSingleSessionModeEnabled: ComponentGuard = (clerk, environment) => {
+  return !!(clerk.isSignedIn && environment?.authConfig.singleSessionMode);
 };
 
 export const noUserExists: ComponentGuard = clerk => {

--- a/packages/nextjs/src/client-boundary/controlComponents.ts
+++ b/packages/nextjs/src/client-boundary/controlComponents.ts
@@ -1,20 +1,20 @@
 'use client';
 
 export {
-  AuthenticateWithRedirectCallback,
-  ClerkDegraded,
-  ClerkFailed,
   ClerkLoaded,
   ClerkLoading,
+  ClerkDegraded,
+  ClerkFailed,
+  SignedOut,
+  SignedIn,
   Protect,
-  RedirectToCreateOrganization,
-  RedirectToOrganizationProfile,
   RedirectToSignIn,
   RedirectToSignUp,
   RedirectToTasks,
   RedirectToUserProfile,
-  SignedIn,
-  SignedOut,
+  AuthenticateWithRedirectCallback,
+  RedirectToCreateOrganization,
+  RedirectToOrganizationProfile,
 } from '@clerk/clerk-react';
 
 export { MultisessionAppSupport } from '@clerk/clerk-react/internal';

--- a/packages/nextjs/src/client-boundary/controlComponents.ts
+++ b/packages/nextjs/src/client-boundary/controlComponents.ts
@@ -1,20 +1,19 @@
 'use client';
 
 export {
-  ClerkLoaded,
-  ClerkLoading,
+  AuthenticateWithRedirectCallback,
   ClerkDegraded,
   ClerkFailed,
-  SignedOut,
-  SignedIn,
+  ClerkLoaded,
+  ClerkLoading,
   Protect,
-  RedirectToSignIn,
-  RedirectToSignUp,
-  RedirectToTask,
-  RedirectToUserProfile,
-  AuthenticateWithRedirectCallback,
   RedirectToCreateOrganization,
   RedirectToOrganizationProfile,
+  RedirectToSignIn,
+  RedirectToSignUp,
+  RedirectToUserProfile,
+  SignedIn,
+  SignedOut,
 } from '@clerk/clerk-react';
 
 export { MultisessionAppSupport } from '@clerk/clerk-react/internal';

--- a/packages/nextjs/src/client-boundary/controlComponents.ts
+++ b/packages/nextjs/src/client-boundary/controlComponents.ts
@@ -11,6 +11,7 @@ export {
   RedirectToOrganizationProfile,
   RedirectToSignIn,
   RedirectToSignUp,
+  RedirectToTasks,
   RedirectToUserProfile,
   SignedIn,
   SignedOut,

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -12,7 +12,6 @@ export {
   RedirectToOrganizationProfile,
   RedirectToSignIn,
   RedirectToSignUp,
-  RedirectToTask,
   RedirectToUserProfile,
 } from './client-boundary/controlComponents';
 

--- a/packages/react-router/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react-router/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -20,6 +20,7 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
+  "RedirectToTasks",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/react-router/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react-router/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -20,7 +20,6 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
-  "RedirectToTask",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -166,6 +166,26 @@ export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<Re
   return null;
 }, 'RedirectToSignUp');
 
+export const RedirectToTasks = withClerk(({ clerk }: WithClerkProp) => {
+  const { session } = clerk;
+
+  React.useEffect(() => {
+    if (!session) {
+      void clerk.redirectToSignIn();
+      return;
+    }
+
+    if (!session.currentTask) {
+      void clerk.redirectToAfterSignIn();
+      return;
+    }
+
+    void clerk.redirectToTasks();
+  }, []);
+
+  return null;
+}, 'RedirectToTasks');
+
 /**
  * @function
  * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-user-profile) instead.

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -167,19 +167,7 @@ export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<Re
 }, 'RedirectToSignUp');
 
 export const RedirectToTasks = withClerk(({ clerk }: WithClerkProp) => {
-  const { session } = clerk;
-
   React.useEffect(() => {
-    if (!session) {
-      void clerk.redirectToSignIn();
-      return;
-    }
-
-    if (!session.currentTask) {
-      void clerk.redirectToAfterSignIn();
-      return;
-    }
-
     void clerk.redirectToTasks();
   }, []);
 

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -166,21 +166,6 @@ export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<Re
   return null;
 }, 'RedirectToSignUp');
 
-export const RedirectToTask = withClerk(({ clerk }: WithClerkProp) => {
-  const { session } = clerk;
-
-  React.useEffect(() => {
-    if (!session) {
-      void clerk.redirectToSignIn();
-      return;
-    }
-
-    void clerk.__internal_navigateToTaskIfAvailable();
-  }, []);
-
-  return null;
-}, 'RedirectToTask');
-
 /**
  * @function
  * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk#redirect-to-user-profile) instead.

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -25,6 +25,7 @@ export {
   RedirectToOrganizationProfile,
   RedirectToSignIn,
   RedirectToSignUp,
+  RedirectToTasks,
   RedirectToUserProfile,
   SignedIn,
   SignedOut,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -25,7 +25,6 @@ export {
   RedirectToOrganizationProfile,
   RedirectToSignIn,
   RedirectToSignUp,
-  RedirectToTask,
   RedirectToUserProfile,
   SignedIn,
   SignedOut,

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -4,7 +4,6 @@ import { loadClerkJsScript } from '@clerk/shared/loadClerkJsScript';
 import { handleValueOrFn } from '@clerk/shared/utils';
 import type {
   __internal_CheckoutProps,
-  __internal_NavigateToTaskIfAvailableParams,
   __internal_OAuthConsentProps,
   __internal_PlanDetailsProps,
   __internal_SubscriptionDetailsProps,
@@ -740,14 +739,6 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     // Handle case where accounts has clerk-react@4 installed, but clerk-js@3 is manually loaded
     if (clerkjs && '__unstable__updateProps' in clerkjs) {
       return (clerkjs as any).__unstable__updateProps(props);
-    }
-  };
-
-  __internal_navigateToTaskIfAvailable = async (params?: __internal_NavigateToTaskIfAvailableParams): Promise<void> => {
-    if (this.clerkjs) {
-      return this.clerkjs.__internal_navigateToTaskIfAvailable(params);
-    } else {
-      return Promise.reject();
     }
   };
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -104,7 +104,6 @@ type IsomorphicLoadedClerk = Without<
   | '__internal_reloadInitialResources'
   | 'billing'
   | 'apiKeys'
-  | '__internal_setComponentNavigationContext'
   | '__internal_setActiveInProgress'
   | '__internal_hasAfterAuthFlows'
 > & {

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -388,6 +388,15 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     }
   };
 
+  buildTasksUrl = (): string | void => {
+    const callback = () => this.clerkjs?.buildTasksUrl() || '';
+    if (this.clerkjs && this.loaded) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('buildTasksUrl', callback);
+    }
+  };
+
   buildUrlWithAuth = (to: string): string | void => {
     const callback = () => this.clerkjs?.buildUrlWithAuth(to) || '';
     if (this.clerkjs && this.loaded) {
@@ -1263,6 +1272,16 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       return callback();
     } else {
       this.premountMethodCalls.set('redirectToWaitlist', callback);
+      return;
+    }
+  };
+
+  redirectToTasks = async () => {
+    const callback = () => this.clerkjs?.redirectToTasks();
+    if (this.clerkjs && this.loaded) {
+      return callback();
+    } else {
+      this.premountMethodCalls.set('redirectToTasks', callback);
       return;
     }
   };

--- a/packages/remix/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/remix/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -21,7 +21,6 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
-  "RedirectToTask",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/remix/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/remix/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -21,6 +21,7 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
+  "RedirectToTasks",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/tanstack-react-start/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/tanstack-react-start/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -32,6 +32,7 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
+  "RedirectToTasks",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/tanstack-react-start/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/tanstack-react-start/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -32,7 +32,6 @@ exports[`root public exports > should not change unexpectedly 1`] = `
   "RedirectToOrganizationProfile",
   "RedirectToSignIn",
   "RedirectToSignUp",
-  "RedirectToTask",
   "RedirectToUserProfile",
   "SignIn",
   "SignInButton",

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1071,7 +1071,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
     taskUrls?: Record<SessionTask['key'], string>;
 
     /**
-     * Event handler for session transitions to `pending`
+     * Event handler called when a session transitions to `pending` status after successful sign-in.
      */
     onPendingSession?: OnPendingSessionFn;
   };
@@ -1199,6 +1199,9 @@ export type SetActiveParams = {
    */
   redirectUrl?: string;
 
+  /**
+   * Event handler called when a session transitions to `pending` status after successful sign-in.
+   */
   onPendingSession?: OnPendingSessionFn;
 };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1208,8 +1208,7 @@ export type SetActiveParams = {
   /**
    * A custom navigation function to be called just before the session and/or organization is set.
    *
-   * When provided, it takes precedence
-   * over the `redirectUrl` parameter for navigation.
+   * When provided, it takes precedence over the `redirectUrl` parameter for navigation.
    *
    * @example
    * ```typescript

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1069,11 +1069,6 @@ export type ClerkOptions = ClerkOptionsNavigation &
      * @default undefined - Uses Clerk's default task flow URLs
      */
     taskUrls?: Record<SessionTask['key'], string>;
-
-    /**
-     * Event handler called when a session transitions to `pending` status after successful sign-in.
-     */
-    onPendingSession?: OnPendingSessionFn;
   };
 
 export interface NavigateOptions {
@@ -1200,9 +1195,9 @@ export type SetActiveParams = {
   redirectUrl?: string;
 
   /**
-   * Event handler called when a session transitions to `pending` status after successful sign-in.
+   * TODO
    */
-  onPendingSession?: OnPendingSessionFn;
+  navigate?: SetActiveNavigate;
 };
 
 /**

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -120,6 +120,7 @@ export type SDKMetadata = {
 export type ListenerCallback = (emission: Resources) => void;
 export type UnsubscribeCallback = () => void;
 export type BeforeEmitCallback = (session?: SignedInSessionResource | null) => void | Promise<any>;
+export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;
 
 export type SignOutCallback = () => void | Promise<any>;
 
@@ -949,11 +950,6 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
-/**
- * @inline
- */
-export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;
-
 export type ClerkOptions = ClerkOptionsNavigation &
   ClerkOptionsNavigation &
   SignInForceRedirectUrl &
@@ -1210,8 +1206,13 @@ export type SetActiveParams = {
    * ```typescript
    * await clerk.setActive({
    *   session,
-   *   navigate: async () => {
-   *     // Custom navigation logic
+   *   navigate: async ({ session }) => {
+   *     const currentTask = session.currentTask;
+   *     if (currentTask) {
+   *       await router.push(`/onboarding/${currentTask.key}`)
+   *       return
+   *     }
+   *
    *     router.push('/dashboard');
    *   }
    * });

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -950,7 +950,6 @@ type ClerkOptionsNavigation =
     };
 
 /**
- * A custom navigation function to be called just before the session and/or organization is set.
  * @inline
  */
 export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -951,6 +951,7 @@ type ClerkOptionsNavigation =
 
 /**
  * A custom navigation function to be called just before the session and/or organization is set.
+ * @inline
  */
 export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -840,12 +840,6 @@ export interface Clerk {
   joinWaitlist: (params: JoinWaitlistParams) => Promise<WaitlistResource>;
 
   /**
-   * Navigates to the current task or redirects to `redirectUrlComplete` once the session is `active`.
-   * @internal
-   */
-  __internal_navigateToTaskIfAvailable: (params?: __internal_NavigateToTaskIfAvailableParams) => Promise<void>;
-
-  /**
    * This is an optional function.
    * This function is used to load cached Client and Environment resources if Clerk fails to load them from the Frontend API.
    * @internal
@@ -2157,14 +2151,6 @@ export interface AuthenticateWithOKXWalletParams {
 export interface AuthenticateWithGoogleOneTapParams {
   token: string;
   legalAccepted?: boolean;
-}
-
-export interface __internal_NavigateToTaskIfAvailableParams {
-  /**
-   * Full URL or path to navigate to after successfully resolving all tasks
-   * @default undefined
-   */
-  redirectUrlComplete?: string;
 }
 
 export interface LoadedClerk extends Clerk {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -676,6 +676,11 @@ export interface Clerk {
   buildOrganizationProfileUrl(): string;
 
   /**
+   * Returns the configured url where tasks are mounted.
+   */
+  buildTasksUrl(): string;
+
+  /**
    * Returns the configured afterSignInUrl of the instance.
    */
   buildAfterSignInUrl({ params }?: { params?: URLSearchParams }): string;
@@ -761,6 +766,11 @@ export interface Clerk {
    * Redirects to the configured URL where `<Waitlist/>` is mounted.
    */
   redirectToWaitlist: () => void;
+
+  /**
+   * Redirects to the configured URL where tasks are mounted.
+   */
+  redirectToTasks(): Promise<unknown>;
 
   /**
    * Completes a Google One Tap redirection flow started by

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -626,13 +626,6 @@ export interface Clerk {
   __internal_addNavigationListener: (callback: () => void) => UnsubscribeCallback;
 
   /**
-   * Registers the internal navigation context from UI components in order to
-   * be triggered from `Clerk` methods
-   * @internal
-   */
-  __internal_setComponentNavigationContext: (context: __internal_ComponentNavigationContext) => () => void;
-
-  /**
    * Set the active session and organization explicitly.
    *
    * If the session param is `null`, the active session is deleted.
@@ -1076,6 +1069,11 @@ export type ClerkOptions = ClerkOptionsNavigation &
      * @default undefined - Uses Clerk's default task flow URLs
      */
     taskUrls?: Record<SessionTask['key'], string>;
+
+    /**
+     * Event handler for session transitions to `pending`
+     */
+    onPendingSession?: OnPendingSessionFn;
   };
 
 export interface NavigateOptions {
@@ -1200,6 +1198,8 @@ export type SetActiveParams = {
    * The full URL or path to redirect to just before the active session and/or organization is set.
    */
   redirectUrl?: string;
+
+  onPendingSession?: OnPendingSessionFn;
 };
 
 /**

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -961,7 +961,6 @@ type ClerkOptionsNavigation =
     };
 
 export type ClerkOptions = ClerkOptionsNavigation &
-  ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -49,7 +49,7 @@ import type {
   SignUpFallbackRedirectUrl,
   SignUpForceRedirectUrl,
 } from './redirects';
-import type { SessionTask, SignedInSessionResource } from './session';
+import type { SessionResource, SessionTask, SignedInSessionResource } from './session';
 import type { SessionVerificationLevel } from './sessionVerification';
 import type { SignInResource } from './signIn';
 import type { SignUpResource } from './signUp';
@@ -949,7 +949,13 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
+/**
+ * A custom navigation function to be called just before the session and/or organization is set.
+ */
+export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;
+
 export type ClerkOptions = ClerkOptionsNavigation &
+  ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &
@@ -1190,12 +1196,26 @@ export type SetActiveParams = {
   beforeEmit?: BeforeEmitCallback;
 
   /**
-   * The full URL or path to redirect to just before the active session and/or organization is set.
+   * The full URL or path to redirect to just before the session and/or organization is set.
    */
   redirectUrl?: string;
 
   /**
-   * TODO
+   * A custom navigation function to be called just before the session and/or organization is set.
+   *
+   * When provided, it takes precedence
+   * over the `redirectUrl` parameter for navigation.
+   *
+   * @example
+   * ```typescript
+   * await clerk.setActive({
+   *   session,
+   *   navigate: async () => {
+   *     // Custom navigation logic
+   *     router.push('/dashboard');
+   *   }
+   * });
+   * ```
    */
   navigate?: SetActiveNavigate;
 };

--- a/packages/vue/src/components/controlComponents.ts
+++ b/packages/vue/src/components/controlComponents.ts
@@ -60,6 +60,26 @@ export const RedirectToSignUp = defineComponent((props: RedirectOptions) => {
   return () => null;
 });
 
+export const RedirectToTasks = defineComponent((props: RedirectOptions) => {
+  const { sessionCtx } = useClerkContext();
+
+  useClerkLoaded(clerk => {
+    if (!sessionCtx.value) {
+      void clerk.redirectToSignIn(props);
+      return;
+    }
+
+    if (!sessionCtx.value?.currentTask) {
+      void clerk.redirectToAfterSignIn();
+      return;
+    }
+
+    void clerk.redirectToTasks();
+  });
+
+  return () => null;
+});
+
 /**
  * @deprecated Use [`redirectToUserProfile()`](https://clerk.com/docs/references/javascript/clerk/redirect-methods#redirect-to-user-profile) instead.
  */

--- a/packages/vue/src/components/controlComponents.ts
+++ b/packages/vue/src/components/controlComponents.ts
@@ -1,8 +1,8 @@
 import { deprecated } from '@clerk/shared/deprecated';
 import type {
+  ProtectProps as _ProtectProps,
   HandleOAuthCallbackParams,
   PendingSessionOptions,
-  ProtectProps as _ProtectProps,
   RedirectOptions,
 } from '@clerk/types';
 import { defineComponent } from 'vue';
@@ -55,21 +55,6 @@ export const RedirectToSignIn = defineComponent((props: RedirectOptions) => {
 export const RedirectToSignUp = defineComponent((props: RedirectOptions) => {
   useClerkLoaded(clerk => {
     void clerk.redirectToSignUp(props);
-  });
-
-  return () => null;
-});
-
-export const RedirectToTask = defineComponent((props: RedirectOptions) => {
-  const { sessionCtx } = useClerkContext();
-
-  useClerkLoaded(clerk => {
-    if (!sessionCtx.value) {
-      void clerk.redirectToSignIn(props);
-      return;
-    }
-
-    void clerk.__internal_navigateToTaskIfAvailable();
   });
 
   return () => null;

--- a/packages/vue/src/components/controlComponents.ts
+++ b/packages/vue/src/components/controlComponents.ts
@@ -1,8 +1,8 @@
 import { deprecated } from '@clerk/shared/deprecated';
 import type {
-  ProtectProps as _ProtectProps,
   HandleOAuthCallbackParams,
   PendingSessionOptions,
+  ProtectProps as _ProtectProps,
   RedirectOptions,
 } from '@clerk/types';
 import { defineComponent } from 'vue';

--- a/packages/vue/src/components/controlComponents.ts
+++ b/packages/vue/src/components/controlComponents.ts
@@ -60,20 +60,8 @@ export const RedirectToSignUp = defineComponent((props: RedirectOptions) => {
   return () => null;
 });
 
-export const RedirectToTasks = defineComponent((props: RedirectOptions) => {
-  const { sessionCtx } = useClerkContext();
-
+export const RedirectToTasks = defineComponent(() => {
   useClerkLoaded(clerk => {
-    if (!sessionCtx.value) {
-      void clerk.redirectToSignIn(props);
-      return;
-    }
-
-    if (!sessionCtx.value?.currentTask) {
-      void clerk.redirectToAfterSignIn();
-      return;
-    }
-
     void clerk.redirectToTasks();
   });
 


### PR DESCRIPTION
## Description

This PR introduces a new API to navigate on `setActive`, that can be leveraged for after-auth flows to handle pending sessions, featuring a callback mechanism that enables developers to integrate their application logic, such as navigation. 

Previously, our flows were mistakenly navigating after `setActive`, which could cause issues with session revalidation and re-render of pages.

From now on, we're proposing two options to deal with after-auth: `taskUrls` or `navigate`

### `navigate`

A callback function that can be provided as an `setActive` option.

```ts
setActive({ 
  navigate: async ({ session }) => { 
     const currentTask = session.currentTask; 

     if (currentTask){ 
      // Developer has full control over navigation logic
      // (this also allows our AIO components to pass their navigation context such as modal routing)
       await router.push(`/onboarding/${currentTask.key}`)
       return 
     }

    await router.push('/dashboard')
  }
})
```

### `taskUrls` (existing)

A map of URLs per session task key that can be provided as a Clerk option. On `setActive`, it'll be used for navigation.

```tsx
<ClerkProvider 
   taskUrls={{'choose-organization': '/onboarding/choose-organization' }}
/>
```

### AIOs behavior 

https://github.com/user-attachments/assets/5a0c5f52-f8fd-45d0-9b56-1b82a52a1e87

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-task routing APIs (buildTasksUrl, redirectToTasks) and optional navigate callback for setActive; sign-in/sign-up contexts and session-tasks expose navigateOnSetActive and taskUrl; new HOCs to redirect to sign-in/sign-up tasks.

* **Refactor**
  * Renamed RedirectToTask→RedirectToTasks and SessionTask→SessionTasks; centralized task-based navigation and removed legacy internal navigate-to-task plumbing.

* **Tests**
  * Expanded coverage for pending-session flows, setActive navigation behavior, and task→URL mappings.

* **Chores**
  * Updated bundle thresholds and changesets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->