### PR TITLE
chore(clerk-js,types,clerk-react,astro,vue): Remove `treatPendingAsSignedOut` as Clerk option

### DIFF
--- a/.changeset/shiny-pants-jump.md
+++ b/.changeset/shiny-pants-jump.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/astro': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+'@clerk/vue': minor
+---
+
+Remove `treatPendingAsSignedOut` from Clerk options

--- a/packages/astro/src/env.d.ts
+++ b/packages/astro/src/env.d.ts
@@ -19,7 +19,6 @@ interface InternalEnv {
   readonly PUBLIC_CLERK_SIGN_UP_URL?: string;
   readonly PUBLIC_CLERK_TELEMETRY_DISABLED?: string;
   readonly PUBLIC_CLERK_TELEMETRY_DEBUG?: string;
-  readonly PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT?: string;
 }
 
 interface ImportMeta {

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -19,15 +19,7 @@ type HotloadAstroClerkIntegrationParams = AstroClerkIntegrationParams & {
 
 function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() {
   return (params?: Params): AstroIntegration => {
-    const {
-      proxyUrl,
-      isSatellite,
-      domain,
-      signInUrl,
-      signUpUrl,
-      enableEnvSchema = true,
-      treatPendingAsSignedOut,
-    } = params || {};
+    const { proxyUrl, isSatellite, domain, signInUrl, signUpUrl, enableEnvSchema = true } = params || {};
 
     // These are not provided when the "bundled" integration is used
     const clerkJSUrl = (params as any)?.clerkJSUrl as string | undefined;
@@ -65,7 +57,6 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
                 /**
                  * Convert the integration params to environment variable in order for it to be readable from the server
                  */
-                ...buildEnvVarFromOption(treatPendingAsSignedOut, 'PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT'),
                 ...buildEnvVarFromOption(signInUrl, 'PUBLIC_CLERK_SIGN_IN_URL'),
                 ...buildEnvVarFromOption(signUpUrl, 'PUBLIC_CLERK_SIGN_UP_URL'),
                 ...buildEnvVarFromOption(isSatellite, 'PUBLIC_CLERK_IS_SATELLITE'),

--- a/packages/astro/src/react/hooks.ts
+++ b/packages/astro/src/react/hooks.ts
@@ -15,7 +15,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 import { authAsyncStorage } from '#async-local-storage';
 
-import { $authStore, $clerkStore } from '../stores/external';
+import { $authStore } from '../stores/external';
 import { $clerk, $csrState } from '../stores/internal';
 
 /**
@@ -87,7 +87,6 @@ type UseAuth = (options?: PendingSessionOptions) => UseAuthReturn;
  */
 export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
   const authContext = useAuthStore();
-  const clerkContext = useStore($clerkStore);
 
   const getToken: GetToken = useCallback(createGetToken(), []);
   const signOut: SignOut = useCallback(createSignOut(), []);
@@ -117,11 +116,7 @@ export const useAuth: UseAuth = ({ treatPendingAsSignedOut } = {}) => {
       has,
     },
     options: {
-      treatPendingAsSignedOut:
-        // Fallback from option provided via SSR / CSR contexts
-        treatPendingAsSignedOut ??
-        clerkContext?.__internal_getOption?.('treatPendingAsSignedOut') ??
-        import.meta.env.PUBLIC_CLERK_TREAT_PENDING_AS_SIGNED_OUT,
+      treatPendingAsSignedOut,
     },
   });
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -189,7 +189,6 @@ const defaultOptions: ClerkOptions = {
   signUpFallbackRedirectUrl: undefined,
   signInForceRedirectUrl: undefined,
   signUpForceRedirectUrl: undefined,
-  treatPendingAsSignedOut: true,
   newSubscriptionRedirectUrl: undefined,
 };
 
@@ -360,10 +359,8 @@ export class Clerk implements ClerkInterface {
   }
 
   get isSignedIn(): boolean {
-    const { treatPendingAsSignedOut } = this.#options;
-
     const hasPendingSession = this?.session?.status === 'pending';
-    if (treatPendingAsSignedOut && hasPendingSession) {
+    if (hasPendingSession) {
       return false;
     }
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -118,8 +118,7 @@ export const useAuth = (initialAuthStateOrOptions: UseAuthOptions = {}): UseAuth
       signOut,
     },
     {
-      treatPendingAsSignedOut:
-        treatPendingAsSignedOut ?? isomorphicClerk.__internal_getOption?.('treatPendingAsSignedOut'),
+      treatPendingAsSignedOut,
     },
   );
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -49,7 +49,7 @@ import type {
   SignUpFallbackRedirectUrl,
   SignUpForceRedirectUrl,
 } from './redirects';
-import type { PendingSessionOptions, SessionTask, SignedInSessionResource } from './session';
+import type { SessionTask, SignedInSessionResource } from './session';
 import type { SessionVerificationLevel } from './sessionVerification';
 import type { SignInResource } from './signIn';
 import type { SignUpResource } from './signUp';
@@ -962,8 +962,7 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
-export type ClerkOptions = PendingSessionOptions &
-  ClerkOptionsNavigation &
+export type ClerkOptions = ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -74,7 +74,7 @@ type UseAuth = (options?: PendingSessionOptions) => ToComputedRefs<UseAuthReturn
  * </template>
  */
 export const useAuth: UseAuth = (options = {}) => {
-  const { clerk, authCtx, ...contextOptions } = useClerkContext();
+  const { clerk, authCtx } = useClerkContext();
 
   const getToken: GetToken = createGetToken(clerk);
   const signOut: SignOut = createSignOut(clerk);
@@ -100,7 +100,7 @@ export const useAuth: UseAuth = (options = {}) => {
         has,
       },
       options: {
-        treatPendingAsSignedOut: options.treatPendingAsSignedOut ?? contextOptions.treatPendingAsSignedOut,
+        treatPendingAsSignedOut: options.treatPendingAsSignedOut,
       },
     });
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -118,8 +118,6 @@ export const clerkPlugin: Plugin<[PluginOptions]> = {
       sessionCtx,
       userCtx,
       organizationCtx,
-      treatPendingAsSignedOut:
-        options.treatPendingAsSignedOut ?? clerk.value?.__internal_getOption?.('treatPendingAsSignedOut'),
     });
   },
 };


### PR DESCRIPTION
## Description

### Context

`treatPendingAsSignedOut` was first introduced in order to allow for control components and applications protection in general, to consider `pending` as signed-out by default, but allowing developers to opt-out.

### Why removing as an option 

`Clerk.isSignedIn` should always return `false` if the session is `pending` in order to gate UI that is protected from an active session, without tasks.

Our AIO components are going to rely on it. If the developer passes `treatPendingAsSignedOut: false` to `ClerkProvider`, it'd break the whole flow and this wouldn't render:
```tsx
<SignedOut>
  <SignIn />
</SignedOut>
```

+ it removes the confusion on why the prop is not propagated for control components on the server boundary. 

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the `treatPendingAsSignedOut` option and all related fallback logic across React, Vue, Astro, and core packages.
  * Pending user sessions are now consistently treated as signed out across all integrations.
  * Updated type definitions and environment configurations to reflect this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->