### PR TITLE
chore(clerk-js): Add new v0 domain to popup preferred origins

### DIFF
--- a/.changeset/twelve-breads-repair.md
+++ b/.changeset/twelve-breads-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add `.v0.app` as a preferred popup origin for OAuth flows.

--- a/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
+++ b/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
@@ -6,7 +6,7 @@ const POPUP_PREFERRED_ORIGINS = [
   '.webcontainer-api.io',
   '.vusercontent.net',
   '.v0.dev',
-  '.v0.app'
+  '.v0.app',
 ];
 
 /**

--- a/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
+++ b/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
@@ -6,6 +6,7 @@ const POPUP_PREFERRED_ORIGINS = [
   '.webcontainer-api.io',
   '.vusercontent.net',
   '.v0.dev',
+  '.v0.app'
 ];
 
 /**


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

v0 is now serving from v0.app, adding this domain to the list of origins that prefer the oauth popup flow.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Expanded the set of origins that prefer the OAuth popup flow to include domains ending with .v0.app.

- **Chores**
  - Added a patch release entry documenting the preferred OAuth popup origin update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->