### PR TITLE
fix(shared): Invalidate organization memberships query

### DIFF
--- a/.changeset/upset-sides-kneel.md
+++ b/.changeset/upset-sides-kneel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Invalidate organization memberships based on client user

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -323,6 +323,7 @@ export function useOrganizationList<T extends UseOrganizationListParams>(params?
     {
       type: 'userMemberships',
       userId: user?.id,
+      memberships: user?.organizationMemberships.length ?? 0,
     },
   );
 


### PR DESCRIPTION
## Description

Before:

https://github.com/user-attachments/assets/3f18d20b-d3ac-4840-837c-3a2d584bb1a9

After:

https://github.com/user-attachments/assets/3b20ae56-7fd9-4725-b5e9-bf10225e2b57

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Organization membership lists now stay in sync with your account, improving accuracy of counts and smoother pagination when browsing your organizations.
- Bug Fixes
  - Reduced instances of stale membership data, ensuring the list reflects current memberships without manual refresh.
- Chores
  - Added release metadata for a patch update to the shared package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->