### PR TITLE
chore(backend): Remove `secret` in favor of `token` in m2m response

### DIFF
--- a/.changeset/chatty-kings-raise.md
+++ b/.changeset/chatty-kings-raise.md
@@ -1,0 +1,21 @@
+---
+"@clerk/backend": minor
+---
+
+Remove `secret` in favor of `token` in m2m response.
+
+Before:
+
+```ts
+const result = await clerkClient.m2mTokens.create()
+
+console.log(result.secret)
+```
+
+After:
+
+```ts
+const result = await clerkClient.m2mTokens.create()
+
+console.log(result.token)
+```

--- a/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
+++ b/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
@@ -14,8 +14,6 @@ describe('M2MToken', () => {
     subject: 'mch_xxxxx',
     scopes: ['mch_1xxxxx', 'mch_2xxxxx'],
     claims: { foo: 'bar' },
-    // Deprecated in favor of `token`
-    secret: m2mSecret,
     token: m2mSecret,
     revoked: false,
     revocation_reason: null,

--- a/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
+++ b/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
@@ -47,7 +47,6 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
       expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
@@ -74,7 +73,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
+      expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
     });
@@ -152,7 +151,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.revoked).toBe(true);
-      expect(response.secret).toBeUndefined();
+      expect(response.token).toBeUndefined();
       expect(response.revocationReason).toBe('revoked by test');
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
@@ -180,7 +179,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.revoked).toBe(true);
-      expect(response.secret).toBeUndefined();
+      expect(response.token).toBeUndefined();
       expect(response.revocationReason).toBe('revoked by test');
     });
 
@@ -231,7 +230,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
+      expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
     });
@@ -257,7 +256,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
+      expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
     });
@@ -308,7 +307,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
+      expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
     });
@@ -334,7 +333,7 @@ describe('M2MToken', () => {
       });
 
       expect(response.id).toBe(m2mId);
-      expect(response.secret).toBe(m2mSecret);
+      expect(response.token).toBe(m2mSecret);
       expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
       expect(response.claims).toEqual({ foo: 'bar' });
     });

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -734,10 +734,6 @@ export interface MachineSecretKeyJSON {
 
 export interface M2MTokenJSON extends ClerkResourceJSON {
   object: typeof ObjectType.M2MToken;
-  /**
-   * @deprecated Use {@link token} instead.
-   */
-  secret?: string;
   token?: string;
   subject: string;
   scopes: string[];

--- a/packages/backend/src/api/resources/M2MToken.ts
+++ b/packages/backend/src/api/resources/M2MToken.ts
@@ -13,7 +13,6 @@ export class M2MToken {
     readonly createdAt: number,
     readonly updatedAt: number,
     readonly token?: string,
-    readonly secret?: string,
   ) {}
 
   static fromJSON(data: M2MTokenJSON): M2MToken {
@@ -29,7 +28,6 @@ export class M2MToken {
       data.created_at,
       data.updated_at,
       data.token,
-      data.secret,
     );
   }
 }


### PR DESCRIPTION
## Description

Follow up to https://github.com/clerk/javascript/pull/6536, we decided to just remove the `secret` from the response before we do the breaking change in the workers BAPI.

See https://clerkinc.slack.com/archives/C083Q5HRJM9/p1755117726714289

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed M2M token response field from secret to token across the backend package.
  - Removed deprecated secret field from public types and JSON responses.
  - Revoked token responses now return token as undefined instead of using secret.

- Documentation
  - Updated examples to reference result.token instead of result.secret.

- Tests
  - Adjusted tests to expect token in responses and mocks.

- Chores
  - Added changeset for a minor release of the backend package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->