### PR TITLE
chore(backend): Rename M2M namespace from `m2mTokens` to `m2m` in api client

### DIFF
--- a/.changeset/serious-chicken-report.md
+++ b/.changeset/serious-chicken-report.md
@@ -1,0 +1,27 @@
+---
+"@clerk/backend": minor
+---
+
+Rename M2M namespace from `m2mTokens` to `m2m` in Backend API client
+
+Before:
+
+```ts
+clerkClient.m2mTokens.create()
+
+clerkClient.m2mTokens.revoke()
+
+clerkClient.m2mTokens.verifySecret({ secret: 'ak_xxx' })
+```
+
+After:
+
+```ts
+clerkClient.m2m.createToken()
+
+clerkClient.m2m.revokeToken()
+
+clerkClient.m2m.verifyToken({ token: 'ak_xxx' })
+```
+
+The `verifySecret()` method is removed. Please use `.verifyToken()` instead.

--- a/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
+++ b/packages/backend/src/api/__tests__/M2MTokenApi.test.ts
@@ -40,7 +40,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.create({
+      const response = await apiClient.m2m.createToken({
         secondsUntilExpiration: 3600,
       });
 
@@ -65,7 +65,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.create({
+      const response = await apiClient.m2m.createToken({
         machineSecretKey: 'ak_xxxxx',
         secondsUntilExpiration: 3600,
       });
@@ -102,7 +102,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const errResponse = await apiClient.m2mTokens.create().catch(err => err);
+      const errResponse = await apiClient.m2m.createToken().catch(err => err);
 
       expect(errResponse.status).toBe(401);
       expect(errResponse.errors[0].code).toBe('machine_secret_key_invalid');
@@ -143,7 +143,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.revoke({
+      const response = await apiClient.m2m.revokeToken({
         m2mTokenId: m2mId,
         revocationReason: 'revoked by test',
       });
@@ -171,7 +171,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.revoke({
+      const response = await apiClient.m2m.revokeToken({
         m2mTokenId: m2mId,
         revocationReason: 'revoked by test',
       });
@@ -195,8 +195,8 @@ describe('M2MToken', () => {
         ),
       );
 
-      const errResponse = await apiClient.m2mTokens
-        .revoke({
+      const errResponse = await apiClient.m2m
+        .revokeToken({
           m2mTokenId: m2mId,
           revocationReason: 'revoked by test',
         })
@@ -223,7 +223,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.verifyToken({
+      const response = await apiClient.m2m.verifyToken({
         token: m2mSecret,
       });
 
@@ -249,7 +249,7 @@ describe('M2MToken', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.verifyToken({
+      const response = await apiClient.m2m.verifyToken({
         token: m2mSecret,
       });
 
@@ -273,86 +273,9 @@ describe('M2MToken', () => {
         ),
       );
 
-      const errResponse = await apiClient.m2mTokens
+      const errResponse = await apiClient.m2m
         .verifyToken({
           token: m2mSecret,
-        })
-        .catch(err => err);
-
-      expect(errResponse.status).toBe(401);
-    });
-  });
-
-  describe('verifySecret (deprecated)', () => {
-    it('verifies a m2m token using machine secret', async () => {
-      const apiClient = createBackendApiClient({
-        apiUrl: 'https://api.clerk.test',
-        machineSecretKey: 'ak_xxxxx',
-      });
-
-      server.use(
-        http.post(
-          'https://api.clerk.test/m2m_tokens/verify',
-          validateHeaders(({ request }) => {
-            expect(request.headers.get('Authorization')).toBe('Bearer ak_xxxxx');
-            return HttpResponse.json(mockM2MToken);
-          }),
-        ),
-      );
-
-      const response = await apiClient.m2mTokens.verifySecret({
-        secret: m2mSecret,
-      });
-
-      expect(response.id).toBe(m2mId);
-      expect(response.token).toBe(m2mSecret);
-      expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
-      expect(response.claims).toEqual({ foo: 'bar' });
-    });
-
-    it('verifies a m2m token using instance secret', async () => {
-      const apiClient = createBackendApiClient({
-        apiUrl: 'https://api.clerk.test',
-        secretKey: 'sk_xxxxx',
-      });
-
-      server.use(
-        http.post(
-          'https://api.clerk.test/m2m_tokens/verify',
-          validateHeaders(({ request }) => {
-            expect(request.headers.get('Authorization')).toBe('Bearer sk_xxxxx');
-            return HttpResponse.json(mockM2MToken);
-          }),
-        ),
-      );
-
-      const response = await apiClient.m2mTokens.verifySecret({
-        secret: m2mSecret,
-      });
-
-      expect(response.id).toBe(m2mId);
-      expect(response.token).toBe(m2mSecret);
-      expect(response.scopes).toEqual(['mch_1xxxxx', 'mch_2xxxxx']);
-      expect(response.claims).toEqual({ foo: 'bar' });
-    });
-
-    it('requires a machine secret or instance secret to verify a m2m token', async () => {
-      const apiClient = createBackendApiClient({
-        apiUrl: 'https://api.clerk.test',
-      });
-
-      server.use(
-        http.post(
-          'https://api.clerk.test/m2m_tokens/verify',
-          validateHeaders(() => {
-            return HttpResponse.json(mockM2MToken);
-          }),
-        ),
-      );
-
-      const errResponse = await apiClient.m2mTokens
-        .verifySecret({
-          secret: m2mSecret,
         })
         .catch(err => err);
 

--- a/packages/backend/src/api/__tests__/factory.test.ts
+++ b/packages/backend/src/api/__tests__/factory.test.ts
@@ -325,7 +325,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.verifyToken({
+      const response = await apiClient.m2m.verifyToken({
         machineSecretKey: 'ak_test_in_header_params', // this will be added to headerParams.Authorization
         token: 'mt_secret_test',
       });
@@ -353,7 +353,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.verifyToken({
+      const response = await apiClient.m2m.verifyToken({
         token: 'mt_secret_test',
       });
       expect(response.id).toBe('mt_test');
@@ -425,7 +425,7 @@ describe('api.client', () => {
         ),
       );
 
-      const response = await apiClient.m2mTokens.verifyToken({
+      const response = await apiClient.m2m.verifyToken({
         token: 'mt_secret_test',
       });
       expect(response.id).toBe('mt_test');

--- a/packages/backend/src/api/endpoints/M2MTokenApi.ts
+++ b/packages/backend/src/api/endpoints/M2MTokenApi.ts
@@ -1,5 +1,3 @@
-import { deprecated } from '@clerk/shared/deprecated';
-
 import { joinPaths } from '../../util/path';
 import type { ClerkBackendApiRequestOptions } from '../request';
 import type { M2MToken } from '../resources/M2MToken';
@@ -33,17 +31,6 @@ type RevokeM2MTokenParams = {
   revocationReason?: string | null;
 };
 
-type VerifyM2MTokenParamsDeprecated = {
-  /**
-   * Custom machine secret key for authentication.
-   */
-  machineSecretKey?: string;
-  /**
-   * Machine-to-machine token secret to verify.
-   */
-  secret: string;
-};
-
 type VerifyM2MTokenParams = {
   /**
    * Custom machine secret key for authentication.
@@ -70,7 +57,7 @@ export class M2MTokenApi extends AbstractAPI {
     return options;
   }
 
-  async create(params?: CreateM2MTokenParams) {
+  async createToken(params?: CreateM2MTokenParams) {
     const { claims = null, machineSecretKey, secondsUntilExpiration = null } = params || {};
 
     const requestOptions = this.#createRequestOptions(
@@ -88,7 +75,7 @@ export class M2MTokenApi extends AbstractAPI {
     return this.request<M2MToken>(requestOptions);
   }
 
-  async revoke(params: RevokeM2MTokenParams) {
+  async revokeToken(params: RevokeM2MTokenParams) {
     const { m2mTokenId, revocationReason = null, machineSecretKey } = params;
 
     this.requireId(m2mTokenId);
@@ -100,28 +87,6 @@ export class M2MTokenApi extends AbstractAPI {
         bodyParams: {
           revocationReason,
         },
-      },
-      machineSecretKey,
-    );
-
-    return this.request<M2MToken>(requestOptions);
-  }
-
-  /**
-   * Verify a machine-to-machine token.
-   *
-   * @deprecated Use {@link verifyToken} instead.
-   */
-  async verifySecret(params: VerifyM2MTokenParamsDeprecated) {
-    const { secret, machineSecretKey } = params;
-
-    deprecated('verifySecret', 'Use `verifyToken({ token: mt_xxx })` instead');
-
-    const requestOptions = this.#createRequestOptions(
-      {
-        method: 'POST',
-        path: joinPaths(basePath, 'verify'),
-        bodyParams: { secret },
       },
       machineSecretKey,
     );

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -72,7 +72,7 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
     jwks: new JwksAPI(request),
     jwtTemplates: new JwtTemplatesApi(request),
     machines: new MachineApi(request),
-    m2mTokens: new M2MTokenApi(
+    m2m: new M2MTokenApi(
       buildRequest({
         ...options,
         skipApiVersionInUrl: true,

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -206,7 +206,7 @@ async function verifyM2MToken(
 ): Promise<MachineTokenReturnType<M2MToken, MachineTokenVerificationError>> {
   try {
     const client = createBackendApiClient(options);
-    const verifiedToken = await client.m2mTokens.verifyToken({ token });
+    const verifiedToken = await client.m2m.verifyToken({ token });
     return { data: verifiedToken, tokenType: TokenType.M2MToken, errors: undefined };
   } catch (err: any) {
     return handleClerkAPIError(TokenType.M2MToken, err, 'Machine token not found');


### PR DESCRIPTION
## Description

Please see [this notion doc](https://www.notion.so/clerkdev/M2M-API-24d2b9ab44fe8064bcf4f5c5bf60e63c?source=copy_link) for the updated namespace.

Rename M2M namespace from `m2mTokens` to `m2m` in Backend API client

Before:

```ts
clerkClient.m2mTokens.create()

clerkClient.m2mTokens.revoke()

clerkClient.m2mTokens.verifySecret({ secret: 'ak_xxx' })
```

After:

```ts
clerkClient.m2m.createToken()

clerkClient.m2m.revokeToken()

clerkClient.m2m.verifyToken({ token: 'ak_xxx' })
```


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed the M2M API namespace from m2mTokens to m2m.
  - Renamed methods: create → createToken, revoke → revokeToken; verifyToken now accessed via m2m.
  - Removed deprecated verifySecret flow and its associated deprecated route.
- Tests
  - Updated tests to use m2m.createToken, m2m.revokeToken, and m2m.verifyToken.
  - Adjusted test authorization flows to align with the new API surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->