### PR TITLE
feat(testing): sign in via email in tests

### DIFF
--- a/.changeset/easy-parrots-slide.md
+++ b/.changeset/easy-parrots-slide.md
@@ -1,0 +1,13 @@
+---
+'@clerk/testing': minor
+---
+
+Introduce new helper to allow signing a user in via email address:
+
+```ts
+import { clerk } from '@clerk/testing/playwright'
+
+test('sign in', async ({ page }) => {
+  clerk.signIn({ emailAddress: 'foo@bar.com', page })
+})
+```

--- a/packages/clerk-js/sandbox/integration/helpers.ts
+++ b/packages/clerk-js/sandbox/integration/helpers.ts
@@ -19,3 +19,19 @@ export async function signInWithEmailCode(page: Page): Promise<void> {
     signInParams: { strategy: 'email_code', identifier: 'sandbox+clerk_test@clerk.dev' },
   });
 }
+
+/**
+ * Signs in a user using the new email-based ticket strategy for integration tests.
+ * Finds the user by email, creates a sign-in token, and uses the ticket strategy.
+ * @param page - The Playwright page instance
+ * @param emailAddress - The email address of the user to sign in (defaults to sandbox test user)
+ * @example
+ * ```ts
+ * await signInWithEmail(page);
+ * await page.goto('/protected-page');
+ * ```
+ */
+export async function signInWithEmail(page: Page, emailAddress = 'sandbox+clerk_test@clerk.dev'): Promise<void> {
+  await page.goto('/sign-in');
+  await clerk.signIn({ emailAddress, page });
+}

--- a/packages/clerk-js/sandbox/integration/sign-in.spec.ts
+++ b/packages/clerk-js/sandbox/integration/sign-in.spec.ts
@@ -18,3 +18,26 @@ test('sign in', async ({ page }) => {
   await page.locator(actionLinkElement).hover();
   await expect(page.locator(rootElement)).toHaveScreenshot('sign-in-action-link-hover.png');
 });
+
+test('sign in with email', async ({ page }) => {
+  await page.goto('/sign-in');
+
+  await clerk.signIn({
+    emailAddress: 'sandbox+clerk_test@clerk.dev',
+    page,
+  });
+
+  await page.waitForFunction(() => window.Clerk?.user !== null);
+
+  const userInfo = await page.evaluate(() => ({
+    isSignedIn: window.Clerk?.user !== null && window.Clerk?.user !== undefined,
+    email: window.Clerk?.user?.primaryEmailAddress?.emailAddress,
+    userId: window.Clerk?.user?.id,
+    isLoaded: window.Clerk?.loaded,
+  }));
+
+  expect(userInfo.isSignedIn).toBe(true);
+  expect(userInfo.email).toBe('sandbox+clerk_test@clerk.dev');
+  expect(userInfo.userId).toBeTruthy();
+  expect(userInfo.isLoaded).toBe(true);
+});

--- a/packages/testing/src/common/helpers-utils.ts
+++ b/packages/testing/src/common/helpers-utils.ts
@@ -9,58 +9,114 @@ export const signInHelper = async ({ signInParams, windowObject }: SignInHelperP
     if (!w.Clerk.client) {
       return;
     }
+
     const signIn = w.Clerk.client.signIn;
-    if (signInParams.strategy === 'password') {
-      const res = await signIn.create(signInParams);
-      await w.Clerk.setActive({
-        session: res.createdSessionId,
-      });
-    } else {
-      // Assert that the identifier is a test email or phone number
-      if (signInParams.strategy === 'phone_code' && !/^\+1\d{3}55501\d{2}$/.test(signInParams.identifier)) {
-        throw new Error(
-          `Phone number should be a test phone number.\n
-       Example: +1XXX55501XX.\n
-       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#phone-numbers`,
-        );
-      }
-      if (signInParams.strategy === 'email_code' && !signInParams.identifier.includes('+clerk_test')) {
-        throw new Error(
-          `Email should be a test email.\n
-       Any email with the +clerk_test subaddress is a test email address.\n
-       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#email-addresses`,
-        );
+
+    switch (signInParams.strategy) {
+      case 'password': {
+        const res = await signIn.create(signInParams);
+        await w.Clerk.setActive({
+          session: res.createdSessionId,
+        });
+        break;
       }
 
-      // Sign in with code (email_code or phone_code)
-      const { supportedFirstFactors } = await signIn.create({
-        identifier: signInParams.identifier,
-      });
-      const codeFactorFn =
-        signInParams.strategy === 'phone_code'
-          ? (factor: SignInFirstFactor): factor is PhoneCodeFactor => factor.strategy === 'phone_code'
-          : (factor: SignInFirstFactor): factor is EmailCodeFactor => factor.strategy === 'email_code';
-      const codeFactor = supportedFirstFactors?.find(codeFactorFn);
-      if (codeFactor) {
-        const prepareParams =
-          signInParams.strategy === 'phone_code'
-            ? { strategy: signInParams.strategy, phoneNumberId: (codeFactor as PhoneCodeFactor).phoneNumberId }
-            : { strategy: signInParams.strategy, emailAddressId: (codeFactor as EmailCodeFactor).emailAddressId };
-
-        await signIn.prepareFirstFactor(prepareParams);
-        const signInAttempt = await signIn.attemptFirstFactor({
-          strategy: signInParams.strategy,
-          code: '424242',
+      case 'ticket': {
+        const res = await signIn.create({
+          strategy: 'ticket',
+          ticket: signInParams.ticket,
         });
 
-        if (signInAttempt.status === 'complete') {
-          await w.Clerk.setActive({ session: signInAttempt.createdSessionId });
+        if (res.status === 'complete') {
+          await w.Clerk.setActive({
+            session: res.createdSessionId,
+          });
         } else {
-          throw new Error(`Status is ${signInAttempt.status}`);
+          throw new Error(`Sign-in with ticket failed. Status: ${res.status}`);
         }
-      } else {
-        throw new Error(`${signInParams.strategy} is not enabled.`);
+        break;
       }
+
+      case 'phone_code': {
+        // Assert that the identifier is a test phone number
+        if (!/^\+1\d{3}55501\d{2}$/.test(signInParams.identifier)) {
+          throw new Error(
+            `Phone number should be a test phone number.\n
+       Example: +1XXX55501XX.\n
+       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#phone-numbers`,
+          );
+        }
+
+        // Sign in with phone code
+        const { supportedFirstFactors } = await signIn.create({
+          identifier: signInParams.identifier,
+        });
+        const phoneFactor = supportedFirstFactors?.find(
+          (factor: SignInFirstFactor): factor is PhoneCodeFactor => factor.strategy === 'phone_code',
+        );
+
+        if (phoneFactor) {
+          await signIn.prepareFirstFactor({
+            strategy: 'phone_code',
+            phoneNumberId: phoneFactor.phoneNumberId,
+          });
+          const signInAttempt = await signIn.attemptFirstFactor({
+            strategy: 'phone_code',
+            code: '424242',
+          });
+
+          if (signInAttempt.status === 'complete') {
+            await w.Clerk.setActive({ session: signInAttempt.createdSessionId });
+          } else {
+            throw new Error(`Status is ${signInAttempt.status}`);
+          }
+        } else {
+          throw new Error('phone_code is not enabled.');
+        }
+        break;
+      }
+
+      case 'email_code': {
+        // Assert that the identifier is a test email
+        if (!signInParams.identifier.includes('+clerk_test')) {
+          throw new Error(
+            `Email should be a test email.\n
+       Any email with the +clerk_test subaddress is a test email address.\n
+       Learn more here: https://clerk.com/docs/testing/test-emails-and-phones#email-addresses`,
+          );
+        }
+
+        // Sign in with email code
+        const { supportedFirstFactors } = await signIn.create({
+          identifier: signInParams.identifier,
+        });
+        const emailFactor = supportedFirstFactors?.find(
+          (factor: SignInFirstFactor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+        );
+
+        if (emailFactor) {
+          await signIn.prepareFirstFactor({
+            strategy: 'email_code',
+            emailAddressId: emailFactor.emailAddressId,
+          });
+          const signInAttempt = await signIn.attemptFirstFactor({
+            strategy: 'email_code',
+            code: '424242',
+          });
+
+          if (signInAttempt.status === 'complete') {
+            await w.Clerk.setActive({ session: signInAttempt.createdSessionId });
+          } else {
+            throw new Error(`Status is ${signInAttempt.status}`);
+          }
+        } else {
+          throw new Error('email_code is not enabled.');
+        }
+        break;
+      }
+
+      default:
+        throw new Error(`Unsupported strategy: ${(signInParams as any).strategy}`);
     }
   } catch (err: any) {
     throw new Error(`Clerk: Failed to sign in: ${err?.message}`);

--- a/packages/testing/src/common/types.ts
+++ b/packages/testing/src/common/types.ts
@@ -59,6 +59,10 @@ export type ClerkSignInParams =
   | {
       strategy: 'phone_code' | 'email_code';
       identifier: string;
+    }
+  | {
+      strategy: 'ticket';
+      ticket: string;
     };
 
 export type SignInHelperParams = {


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Introduce new functionality to our test helper that allows signing in with only an email:

```ts
import { clerk } from '@clerk/testing/playwright';

test('sign in', async ({ page }) => {
  await clerk.signIn({ emailAddress: 'foo@bar.com', page })
})
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
