### PR TITLE
fix(clerk-js): Add error handling for `setActive` with stale organization data

### DIFF
--- a/.changeset/tall-ears-worry.md
+++ b/.changeset/tall-ears-worry.md
@@ -1,6 +1,8 @@
 ---
+'@clerk/localizations': patch
 '@clerk/clerk-js': patch
 '@clerk/shared': patch
+'@clerk/types': patch
 ---
 
 Add error handling for `setActive` with stale organization data

--- a/.changeset/tall-ears-worry.md
+++ b/.changeset/tall-ears-worry.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Apply revalidation of organization memberships for `TaskChooseOrganization` component

--- a/.changeset/tall-ears-worry.md
+++ b/.changeset/tall-ears-worry.md
@@ -3,4 +3,4 @@
 '@clerk/shared': patch
 ---
 
-Apply revalidation of organization memberships for `TaskChooseOrganization` component
+Add error handling for `setActive` with stale organization data

--- a/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/OrganizationListPage.tsx
@@ -49,7 +49,6 @@ const CreateOrganizationButton = ({
 };
 
 export const OrganizationListPage = withCardStateProvider(() => {
-  const card = useCardState();
   const { userMemberships, userSuggestions, userInvitations } = useOrganizationListInView();
   const isLoading = userMemberships?.isLoading || userInvitations?.isLoading || userSuggestions?.isLoading;
   const hasAnyData = !!(userMemberships?.count || userInvitations?.count || userSuggestions?.count);
@@ -59,7 +58,6 @@ export const OrganizationListPage = withCardStateProvider(() => {
   return (
     <Card.Root>
       <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}` })}>
-        <Card.Alert sx={t => ({ margin: `${t.space.$none} ${t.space.$5}` })}>{card.error}</Card.Alert>
         {isLoading && (
           <Flex
             direction={'row'}
@@ -86,6 +84,7 @@ export const OrganizationListPage = withCardStateProvider(() => {
 });
 
 const OrganizationListFlows = ({ showListInitially }: { showListInitially: boolean }) => {
+  const card = useCardState();
   const { navigateAfterCreateOrganization, skipInvitationScreen, hideSlug } = useOrganizationListContext();
   const [isCreateOrganizationFlow, setCreateOrganizationFlow] = useState(!showListInitially);
   return (
@@ -95,30 +94,35 @@ const OrganizationListFlows = ({ showListInitially }: { showListInitially: boole
       )}
 
       {isCreateOrganizationFlow && (
-        <Box
-          sx={t => ({
-            padding: `${t.space.$none} ${t.space.$5} ${t.space.$5}`,
-          })}
-        >
-          <CreateOrganizationForm
-            flow='organizationList'
-            startPage={{ headerTitle: localizationKeys('organizationList.createOrganization') }}
-            skipInvitationScreen={skipInvitationScreen}
-            navigateAfterCreateOrganization={org =>
-              navigateAfterCreateOrganization(org).then(() => setCreateOrganizationFlow(false))
-            }
-            onCancel={
-              showListInitially && isCreateOrganizationFlow ? () => setCreateOrganizationFlow(false) : undefined
-            }
-            hideSlug={hideSlug}
-          />
-        </Box>
+        <>
+          <Card.Alert sx={t => ({ margin: `${t.space.$none} ${t.space.$5}` })}>{card.error}</Card.Alert>
+
+          <Box
+            sx={t => ({
+              padding: `${t.space.$none} ${t.space.$5} ${t.space.$5}`,
+            })}
+          >
+            <CreateOrganizationForm
+              flow='organizationList'
+              startPage={{ headerTitle: localizationKeys('organizationList.createOrganization') }}
+              skipInvitationScreen={skipInvitationScreen}
+              navigateAfterCreateOrganization={org =>
+                navigateAfterCreateOrganization(org).then(() => setCreateOrganizationFlow(false))
+              }
+              onCancel={
+                showListInitially && isCreateOrganizationFlow ? () => setCreateOrganizationFlow(false) : undefined
+              }
+              hideSlug={hideSlug}
+            />
+          </Box>
+        </>
       )}
     </>
   );
 };
 
 export const OrganizationListPageList = (props: { onCreateOrganizationClick: () => void }) => {
+  const card = useCardState();
   const environment = useEnvironment();
 
   const { ref, userMemberships, userSuggestions, userInvitations } = useOrganizationListInView();
@@ -128,6 +132,8 @@ export const OrganizationListPageList = (props: { onCreateOrganizationClick: () 
   const hasNextPage = userMemberships?.hasNextPage || userInvitations?.hasNextPage || userSuggestions?.hasNextPage;
 
   const onCreateOrganizationClick = () => {
+    // Clear error originated from the list when switching to form
+    card.setError(undefined);
     props.onCreateOrganizationClick();
   };
 
@@ -154,6 +160,7 @@ export const OrganizationListPageList = (props: { onCreateOrganizationClick: () 
           })}
         />
       </Header.Root>
+      <Card.Alert sx={t => ({ margin: `${t.space.$none} ${t.space.$5}` })}>{card.error}</Card.Alert>
       <Col elementDescriptor={descriptors.main}>
         <PreviewListItems>
           <Actions role='menu'>

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
@@ -15,6 +15,7 @@ import { OrganizationListPreviewButton } from './shared';
 export const MembershipPreview = (props: { organization: OrganizationResource }) => {
   const { user } = useUser();
   const card = useCardState();
+  const { navigateAfterSelectOrganization } = useOrganizationListContext();
   const { t } = useLocalizations();
   const { isLoaded, setActive } = useOrganizationList();
 
@@ -28,6 +29,8 @@ export const MembershipPreview = (props: { organization: OrganizationResource })
         await setActive({
           organization,
         });
+
+        await navigateAfterSelectOrganization(organization);
       } catch (err) {
         if (!isClerkAPIResponseError(err)) {
           handleError(err, [], card.setError);
@@ -35,7 +38,8 @@ export const MembershipPreview = (props: { organization: OrganizationResource })
         }
 
         switch (err.errors?.[0]?.code) {
-          case 'organization_not_found_or_unauthorized': {
+          case 'organization_not_found_or_unauthorized':
+          case 'not_a_member_in_organization': {
             if (user?.createOrganizationEnabled) {
               card.setError(t(localizationKeys('unstable__errors.organization_not_found_or_unauthorized')));
             } else {

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserMembershipList.tsx
@@ -1,32 +1,62 @@
 import { useOrganizationList, useUser } from '@clerk/shared/react';
 import type { OrganizationResource } from '@clerk/types';
 
+import { isClerkAPIResponseError } from '@/index.headless';
 import { sharedMainIdentifierSx } from '@/ui/common/organizations/OrganizationPreview';
+import { localizationKeys, useLocalizations } from '@/ui/customizables';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { OrganizationPreview } from '@/ui/elements/OrganizationPreview';
 import { PersonalWorkspacePreview } from '@/ui/elements/PersonalWorkspacePreview';
+import { handleError } from '@/ui/utils/errorHandler';
 
 import { useOrganizationListContext } from '../../contexts';
-import { localizationKeys } from '../../localization';
 import { OrganizationListPreviewButton } from './shared';
 
-export const MembershipPreview = withCardStateProvider((props: { organization: OrganizationResource }) => {
+export const MembershipPreview = (props: { organization: OrganizationResource }) => {
+  const { user } = useUser();
   const card = useCardState();
-  const { navigateAfterSelectOrganization } = useOrganizationListContext();
+  const { t } = useLocalizations();
   const { isLoaded, setActive } = useOrganizationList();
 
   if (!isLoaded) {
     return null;
   }
+
   const handleOrganizationClicked = (organization: OrganizationResource) => {
     return card.runAsync(async () => {
-      await setActive({
-        organization,
-      });
+      try {
+        await setActive({
+          organization,
+        });
+      } catch (err) {
+        if (!isClerkAPIResponseError(err)) {
+          handleError(err, [], card.setError);
+          return;
+        }
 
-      await navigateAfterSelectOrganization(organization);
+        switch (err.errors?.[0]?.code) {
+          case 'organization_not_found_or_unauthorized': {
+            if (user?.createOrganizationEnabled) {
+              card.setError(t(localizationKeys('unstable__errors.organization_not_found_or_unauthorized')));
+            } else {
+              card.setError(
+                t(
+                  localizationKeys(
+                    'unstable__errors.organization_not_found_or_unauthorized_with_create_organization_disabled',
+                  ),
+                ),
+              );
+            }
+            break;
+          }
+          default: {
+            handleError(err, [], card.setError);
+          }
+        }
+      }
     });
   };
+
   return (
     <OrganizationListPreviewButton onClick={() => handleOrganizationClicked(props.organization)}>
       <OrganizationPreview
@@ -36,7 +66,8 @@ export const MembershipPreview = withCardStateProvider((props: { organization: O
       />
     </OrganizationListPreviewButton>
   );
-});
+};
+
 export const PersonalAccountPreview = withCardStateProvider(() => {
   const card = useCardState();
   const { hidePersonal, navigateAfterSelectPersonal } = useOrganizationListContext();

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -4,7 +4,7 @@ import type {
   OrganizationSuggestionResource,
   UserOrganizationInvitationResource,
 } from '@clerk/types';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import {
   OrganizationPreviewButton,
@@ -136,11 +136,9 @@ const InvitationPreview = (props: UserOrganizationInvitationResource) => {
   const card = useCardState();
   const { getOrganization } = useClerk();
   const [acceptedInvitation, setAcceptedInvitation] = useState<OrganizationResource | null>(null);
-  const { userInvitations, userMemberships } = useOrganizationList({
+  const { userInvitations } = useOrganizationList({
     userInvitations: organizationListParams.userInvitations,
-    userMemberships: organizationListParams.userMemberships,
   });
-  const organizationId = useRef('');
 
   const handleAccept = () => {
     return (
@@ -148,7 +146,6 @@ const InvitationPreview = (props: UserOrganizationInvitationResource) => {
         // When accepting an invitation we don't want to trigger a revalidation as this will cause a layout shift, prefer updating in place
         .runAsync(async () => {
           const updatedItem = await props.accept();
-          organizationId.current = updatedItem.publicOrganizationData.id;
 
           const organization = await getOrganization(props.publicOrganizationData.id);
           return [updatedItem, organization] as const;
@@ -161,12 +158,6 @@ const InvitationPreview = (props: UserOrganizationInvitationResource) => {
         .catch(err => handleError(err, [], card.setError))
     );
   };
-
-  // Temporary fix to not render duplicated invitations and memberships
-  const hasMembership = userMemberships.data?.some(membership => membership.organization.id === organizationId.current);
-  if (hasMembership) {
-    return null;
-  }
 
   if (acceptedInvitation) {
     return <MembershipPreview organization={acceptedInvitation} />;

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -130,7 +130,7 @@ const MembershipPreview = withCardStateProvider((props: { organization: Organiza
 const InvitationPreview = withCardStateProvider((props: UserOrganizationInvitationResource) => {
   const card = useCardState();
   const { getOrganization } = useClerk();
-  const [acceptInvitation, setAcceptedInvitation] = useState<OrganizationResource | null>(null);
+  const [acceptedInvitation, setAcceptedInvitation] = useState<OrganizationResource | null>(null);
   const { userInvitations, userMemberships } = useOrganizationList({
     userInvitations: organizationListParams.userInvitations,
     userMemberships: organizationListParams.userMemberships,
@@ -163,8 +163,8 @@ const InvitationPreview = withCardStateProvider((props: UserOrganizationInvitati
     return null;
   }
 
-  if (acceptInvitation) {
-    return <MembershipPreview organization={acceptInvitation} />;
+  if (acceptedInvitation) {
+    return <MembershipPreview organization={acceptedInvitation} />;
   }
 
   return (

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -2,7 +2,7 @@ import { useOrganizationList } from '@clerk/shared/react';
 
 import { useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import { localizationKeys } from '@/ui/customizables';
-import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
+import { useCardState } from '@/ui/elements/contexts';
 import { Form } from '@/ui/elements/Form';
 import { FormButtonContainer } from '@/ui/elements/FormButtons';
 import { FormContainer } from '@/ui/elements/FormContainer';
@@ -17,7 +17,7 @@ type CreateOrganizationScreenProps = {
   onCancel?: () => void;
 };
 
-export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrganizationScreenProps) => {
+export const CreateOrganizationScreen = (props: CreateOrganizationScreenProps) => {
   const card = useCardState();
   const { redirectUrlComplete } = useTaskChooseOrganizationContext();
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
@@ -74,11 +74,8 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
         <Header.Title localizationKey={localizationKeys('taskChooseOrganization.createOrganization.title')} />
         <Header.Subtitle localizationKey={localizationKeys('taskChooseOrganization.createOrganization.subtitle')} />
       </Header.Root>
-      <FormContainer>
-        <Form.Root
-          onSubmit={onSubmit}
-          sx={t => ({ padding: `${t.space.$none} ${t.space.$10} ${t.space.$8}` })}
-        >
+      <FormContainer sx={t => ({ padding: `${t.space.$none} ${t.space.$10} ${t.space.$8}` })}>
+        <Form.Root onSubmit={onSubmit}>
           <Form.ControlRow elementId={nameField.id}>
             <Form.PlainInput
               {...nameField.props}
@@ -115,4 +112,4 @@ export const CreateOrganizationScreen = withCardStateProvider((props: CreateOrga
       </FormContainer>
     </>
   );
-});
+};

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -1,4 +1,4 @@
-import { useClerk, useSession, useUserContext } from '@clerk/shared/react';
+import { useClerk, useSession, useUser } from '@clerk/shared/react';
 import { useState } from 'react';
 
 import { useSignOutContext, withCoreSessionSwitchGuard } from '@/ui/contexts';
@@ -14,7 +14,7 @@ import { CreateOrganizationScreen } from './CreateOrganizationScreen';
 
 const TaskChooseOrganizationInternal = () => {
   const { signOut } = useClerk();
-  const user = useUserContext();
+  const { user } = useUser();
   const { session } = useSession();
   const { userMemberships, userSuggestions, userInvitations } = useOrganizationListInView();
   const { otherSessions } = useMultipleSessions({ user });

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -1,5 +1,5 @@
 import { useClerk, useSession, useUserContext } from '@clerk/shared/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { useSignOutContext, withCoreSessionSwitchGuard } from '@/ui/contexts';
 import { descriptors, Flex, Flow, localizationKeys, Spinner } from '@/ui/customizables';
@@ -31,17 +31,6 @@ const TaskChooseOrganizationInternal = () => {
   const isLoading = userMemberships?.isLoading || userInvitations?.isLoading || userSuggestions?.isLoading;
   const hasExistingResources = !!(userMemberships?.count || userInvitations?.count || userSuggestions?.count);
   const identifier = user?.primaryEmailAddress?.emailAddress ?? user?.username;
-
-  // TODO (ORGS-784): Introduce architecture to invalidate SWR queries based on client piggybacking
-  // Revalidates organization memberships from client piggybacking
-  const hasUpdatedOnClient = user?.organizationMemberships?.length !== userMemberships.count;
-  useEffect(() => {
-    if (!hasUpdatedOnClient) {
-      return;
-    }
-
-    void userMemberships?.revalidate?.();
-  }, [hasUpdatedOnClient, userMemberships]);
 
   return (
     <Flow.Root flow='taskChooseOrganization'>

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -32,8 +32,8 @@ const TaskChooseOrganizationInternal = () => {
   const hasExistingResources = !!(userMemberships?.count || userInvitations?.count || userSuggestions?.count);
   const identifier = user?.primaryEmailAddress?.emailAddress ?? user?.username;
 
-  // Revalidates organization memberships from client piggybacking
   // TODO (ORGS-784): Introduce architecture to invalidate SWR queries based on client piggybacking
+  // Revalidates organization memberships from client piggybacking
   const hasUpdatedOnClient = user?.organizationMemberships?.length !== userMemberships.count;
   useEffect(() => {
     if (!hasUpdatedOnClient) {

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -853,6 +853,8 @@ export const arSA: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'تم تسجيل مفتاح المرور مسبقاً مع هذا الجهاز',
     passkey_not_supported: 'مفاتيح المرور غير مدعومة على هذا الجهاز',
     passkey_pa_not_supported: 'يتطلب التسجيل أداة مصادقة النظام الأساسي ولكن الجهاز لا يدعمها',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -861,6 +861,8 @@ export const beBY: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'Квота ўдзельнікаў арганізацыі перавышана.',
     organization_minimum_permissions_needed: 'Патрабуюцца мінімальныя правы доступу.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Passkey ужо існуе. Калі ласка, выкарыстоўвайце іншы.',
     passkey_not_supported: 'Passkey не падтрымліваецца на гэтай платформе.',
     passkey_pa_not_supported: 'Passkey для гэтага прыкладання не падтрымліваецца.',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -853,6 +853,8 @@ export const bgBG: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'Квотата за членове на организацията е изчерпана.',
     organization_minimum_permissions_needed: 'Трябва да имате минимални разрешения за достъп.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -864,6 +864,8 @@ export const bnIN: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: 'এই ডোমেন ইতিমধ্যে আপনার সংগঠনের SSO-এর জন্য ব্যবহৃত হচ্ছে',
     organization_membership_quota_exceeded: 'আপনি অপেক্ষিত আমন্ত্রণ সহ সংগঠনের সদস্যতার সীমায় পৌঁছে গেছেন।',
     organization_minimum_permissions_needed: 'অন্তত একজন সংগঠনের সদস্যের ন্যূনতম প্রয়োজনীয় অনুমতি থাকতে হবে।',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'এই ডিভাইসে ইতিমধ্যে একটি পাসকি নিবন্ধিত আছে।',
     passkey_not_supported: 'এই ডিভাইসে পাসকি সমর্থিত নয়।',
     passkey_pa_not_supported:

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -855,6 +855,8 @@ export const caES: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -864,6 +864,8 @@ export const csCZ: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Přístupový klíč je již registrován na tomto zařízení.',
     passkey_not_supported: 'Přístupové klíče nejsou podporovány na tomto zařízení.',
     passkey_pa_not_supported: 'Registrace vyžaduje autentizační metodu platformy, ale zařízení ji nepodporuje.',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -853,6 +853,8 @@ export const daDK: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Adgangsnøgle findes allerede.',
     passkey_not_supported: 'Adgangsnøgler understøttes ikke på denne enhed.',
     passkey_pa_not_supported: 'Adgangsnøgler understøttes ikke på dette styresystem.',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -872,6 +872,8 @@ export const deDE: LocalizationResource = {
       'Sie haben Ihr Limit an Organisationsmitgliedschaften einschließlich ausstehender Einladungen erreicht.',
     organization_minimum_permissions_needed:
       'Es muss mindestens ein Organisationsmitglied mit den erforderlichen Mindestberechtigungen geben.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Auf diesem Gerät ist bereits ein Passkey registriert.',
     passkey_not_supported: 'Passkeys werden auf diesem Gerät nicht unterstützt.',
     passkey_pa_not_supported:

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -858,6 +858,8 @@ export const elGR: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -861,6 +861,8 @@ export const enGB: LocalizationResource = {
       'You have reached your limit of organisation memberships, including outstanding invitations.',
     organization_minimum_permissions_needed:
       'There has to be at least one organisation member with the minimum required permissions.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'A passkey is already registered with this device.',
     passkey_not_supported: 'Passkeys are not supported on this device.',
     passkey_pa_not_supported: 'Registration requires a platform authenticator but the device does not support it.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -852,9 +852,9 @@ export const enUS: LocalizationResource = {
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
     organization_not_found_or_unauthorized:
-      'You are no longer a member of this organization. Please select or create another organization.',
+      'You are no longer a member of this organization. Please choose or create another one.',
     organization_not_found_or_unauthorized_with_create_organization_disabled:
-      'You are no longer a member of this organization. Please select another organization.',
+      'You are no longer a member of this organization. Please choose another one.',
     passkey_already_exists: 'A passkey is already registered with this device.',
     passkey_not_supported: 'Passkeys are not supported on this device.',
     passkey_pa_not_supported: 'Registration requires a platform authenticator but the device does not support it.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -813,10 +813,6 @@ export const enUS: LocalizationResource = {
     },
   },
   unstable__errors: {
-    organization_not_found_or_unauthorized:
-      'You are no longer a member of this organization. Please select or create another organization.',
-    organization_not_found_or_unauthorized_with_create_organization_disabled:
-      'You are no longer a member of this organization. Please select another organization.',
     already_a_member_in_organization: '{{email}} is already a member of the organization.',
     captcha_invalid: undefined,
     captcha_unavailable:
@@ -855,6 +851,10 @@ export const enUS: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized:
+      'You are no longer a member of this organization. Please select or create another organization.',
+    organization_not_found_or_unauthorized_with_create_organization_disabled:
+      'You are no longer a member of this organization. Please select another organization.',
     passkey_already_exists: 'A passkey is already registered with this device.',
     passkey_not_supported: 'Passkeys are not supported on this device.',
     passkey_pa_not_supported: 'Registration requires a platform authenticator but the device does not support it.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -813,6 +813,8 @@ export const enUS: LocalizationResource = {
     },
   },
   unstable__errors: {
+    organization_not_found_or_unauthorized:
+      'You are no longer a member of this organization. Please refresh the page to try again.',
     already_a_member_in_organization: '{{email}} is already a member of the organization.',
     captcha_invalid: undefined,
     captcha_unavailable:

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -814,7 +814,9 @@ export const enUS: LocalizationResource = {
   },
   unstable__errors: {
     organization_not_found_or_unauthorized:
-      'You are no longer a member of this organization. Please refresh the page to try again.',
+      'You are no longer a member of this organization. Please select or create another organization.',
+    organization_not_found_or_unauthorized_with_create_organization_disabled:
+      'You are no longer a member of this organization. Please select another organization.',
     already_a_member_in_organization: '{{email}} is already a member of the organization.',
     captcha_invalid: undefined,
     captcha_unavailable:

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -864,6 +864,8 @@ export const esCR: LocalizationResource = {
     organization_membership_quota_exceeded:
       'Alcanzaste el limite de miembros en la organización, incluyendo las invitaciones enviadas.',
     organization_minimum_permissions_needed: 'Debe existir al menos un miembro en la organización.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ya se ha registrado una llave de acceso en este dispositivo.',
     passkey_not_supported: 'Las llaves de acceso no son compatibles con este dispositivo.',
     passkey_pa_not_supported:

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -859,6 +859,8 @@ export const esES: LocalizationResource = {
       'Has alcanzado tu límite de miembros de la organización, incluyendo invitaciones pendientes.',
     organization_minimum_permissions_needed:
       'Es necesario que haya al menos un miembro de la organización con los permisos mínimos necesarios.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ya existe una clave de acceso.',
     passkey_not_supported: 'Las claves de acceso no son compatibles.',
     passkey_pa_not_supported: 'La clave de acceso no es compatible con la autenticación de dispositivos.',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -864,6 +864,8 @@ export const esMX: LocalizationResource = {
     organization_membership_quota_exceeded:
       'Alcanzaste el limite de miembros en la organización, incluyendo las invitaciones enviadas.',
     organization_minimum_permissions_needed: 'Debe existir al menos un miembro en la organización.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ya se ha registrado una llave de acceso en este dispositivo.',
     passkey_not_supported: 'Las llaves de acceso no son compatibles con este dispositivo.',
     passkey_pa_not_supported:

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -867,6 +867,8 @@ export const esUY: LocalizationResource = {
       'Has alcanzado el límite de membresías en organizaciones, incluyendo invitaciones pendientes.',
     organization_minimum_permissions_needed:
       'Debe haber al menos un miembro de la organización con los permisos mínimos requeridos.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ya hay una clave de acceso registrada en este dispositivo.',
     passkey_not_supported: 'Las claves de acceso no son compatibles con este dispositivo.',
     passkey_pa_not_supported: 'El registro requiere un autenticador de plataforma, pero el dispositivo no lo soporta.',

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -865,6 +865,8 @@ export const faIR: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: 'این دامنه برای اتصال سازمانی موجود است.',
     organization_membership_quota_exceeded: 'حد مجاز عضویت سازمان تجاوز شده است.',
     organization_minimum_permissions_needed: 'حداقل مجوزهای مورد نیاز برای سازمان الزامی است.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'یک کلید عبور از قبل در این دستگاه ثبت شده است.',
     passkey_not_supported: 'کلیدهای عبور در این دستگاه پشتیبانی نمی‌شوند.',
     passkey_pa_not_supported: 'ثبت نام نیاز به یک احراز هویت کننده پلتفرم دارد اما دستگاه از آن پشتیبانی نمی‌کند.',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -856,6 +856,8 @@ export const fiFI: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Pääsyavain on jo rekisteröity tähän laitteeseen.',
     passkey_not_supported: 'Pääsyavain ei ole tuettu tällä laitteella.',
     passkey_pa_not_supported: 'Rekisteröinti vaatii alustan autentikaattorin, mutta laite ei tue sitä.',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -866,6 +866,8 @@ export const frFR: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: "Le quota de membres de l'organisation a été dépassé.",
     organization_minimum_permissions_needed: 'Permissions minimales nécessaires pour accéder à cette organisation.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Cette clé de sécurité existe déjà.',
     passkey_not_supported: 'Les clés de sécurité ne sont pas prises en charge sur cet appareil.',
     passkey_pa_not_supported: 'Les clés de sécurité ne sont pas prises en charge dans cet environnement.',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -846,6 +846,8 @@ export const heIL: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'הגעת למגבלת החברות בארגון, כולל הזמנות יוצאות דופן.',
     organization_minimum_permissions_needed: 'חייב להיות חבר ארגון אחד לפחות עם ההרשאות המינימליות הנדרשות.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'מפתח הסיסמה כבר רשום במכשיר זה.',
     passkey_not_supported: 'מפתחות סיסמה אינם נתמכים במכשיר זה.',
     passkey_pa_not_supported: 'ההרשמה דורשת מאמת פלטפורמה אך המכשיר אינו תומך בכך.',

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -865,6 +865,8 @@ export const hiIN: LocalizationResource = {
     organization_membership_quota_exceeded:
       'आप अपने संगठन की सदस्यता की सीमा तक पहुंच गए हैं, जिसमें बकाया आमंत्रण भी शामिल हैं।',
     organization_minimum_permissions_needed: 'संगठन के कम से कम एक सदस्य के पास न्यूनतम आवश्यक अनुमतियां होनी चाहिए।',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'इस डिवाइस के साथ पहले से ही एक पासकी पंजीकृत है।',
     passkey_not_supported: 'इस डिवाइस पर पासकी समर्थित नहीं हैं।',
     passkey_pa_not_supported:

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -861,6 +861,8 @@ export const hrHR: LocalizationResource = {
       'Dostigli ste ograničenje članstava u organizacijama, uključujući otvorene pozivnice.',
     organization_minimum_permissions_needed:
       'Mora postojati barem jedan član organizacije s minimalnim potrebnim dozvolama.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Pristupni ključ je već registriran na ovom uređaju.',
     passkey_not_supported: 'Pristupni ključevi nisu podržani na ovom uređaju.',
     passkey_pa_not_supported: 'Registracija zahtijeva platformski autentifikator, ali uređaj ga ne podržava.',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -856,6 +856,8 @@ export const huHU: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Egy passkey már regisztrálva van ehhez az eszközhöz.',
     passkey_not_supported: 'Passkeyk nem támogatottak ezen az eszközön.',
     passkey_pa_not_supported: 'A regisztrációhoz egy platform hitelesítő kell, de ez az eszköz ezt nem támogatja.',

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -865,6 +865,8 @@ export const idID: LocalizationResource = {
       'Anda telah mencapai batas keanggotaan organisasi, termasuk undangan yang belum selesai.',
     organization_minimum_permissions_needed:
       'Harus ada setidaknya satu anggota organisasi dengan izin minimum yang diperlukan.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Passkey sudah terdaftar di perangkat ini.',
     passkey_not_supported: 'Passkey tidak didukung di perangkat ini.',
     passkey_pa_not_supported: 'Pendaftaran memerlukan platform autentikator tetapi perangkat tidak mendukungnya.',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -859,6 +859,8 @@ export const isIS: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Lykill er þegar skráður með þessu tæki.',
     passkey_not_supported: 'Lyklar eru ekki studdir á þessu tæki.',
     passkey_pa_not_supported: 'Skráning krefst vettvangs auðkennis en tækið styður það ekki.',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -864,6 +864,8 @@ export const itIT: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: "Hai raggiunto il limite massimo di membri nell'organizzazione.",
     organization_minimum_permissions_needed: 'Non hai i permessi minimi necessari per completare questa operazione.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -856,6 +856,8 @@ export const jaJP: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -845,6 +845,8 @@ export const kkKZ: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: 'Бұл домен ұйымыңыздың SSO үшін қолданылады.',
     organization_membership_quota_exceeded: 'Ұйым мүшеліктерінің шектеуіне жеттіңіз.',
     organization_minimum_permissions_needed: 'Ұйымда кемінде бір әкімші болуы керек.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Бұл құрылғыда passkey тіркелген.',
     passkey_not_supported: 'Бұл құрылғыда passkey қолдауы жоқ.',
     passkey_pa_not_supported: 'Тіркеу үшін платформа аутентификаторы қажет.',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -849,6 +849,8 @@ export const koKR: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -856,6 +856,8 @@ export const mnMN: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -870,6 +870,8 @@ export const msMY: LocalizationResource = {
       'Anda telah mencapai had keahlian organisasi anda, termasuk jemputan tertunggak.',
     organization_minimum_permissions_needed:
       'Mesti ada sekurang-kurangnya satu ahli organisasi dengan kebenaran minimum yang diperlukan.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Kunci pas sudah didaftarkan dengan peranti ini.',
     passkey_not_supported: 'Kunci pas tidak disokong pada peranti ini.',
     passkey_pa_not_supported: 'Pendaftaran memerlukan pengesah platform tetapi peranti tidak menyokongnya.',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -855,6 +855,8 @@ export const nbNO: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -855,6 +855,8 @@ export const nlBE: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'Het lidmaatschapsquotum van de organisatie is overschreden.',
     organization_minimum_permissions_needed: 'Minimale machtigingen vereist voor de organisatie.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Deze passkey bestaat al.',
     passkey_not_supported: 'Passkeys worden niet ondersteund door deze browser.',
     passkey_pa_not_supported: 'Passkeys worden niet ondersteund door deze browser.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -855,6 +855,8 @@ export const nlNL: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'Het lidmaatschapsquotum van de organisatie is overschreden.',
     organization_minimum_permissions_needed: 'Minimale machtigingen vereist voor de organisatie.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Deze passkey bestaat al.',
     passkey_not_supported: 'Passkeys worden niet ondersteund door deze browser.',
     passkey_pa_not_supported: 'Passkeys worden niet ondersteund door deze browser.',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -864,6 +864,8 @@ export const plPL: LocalizationResource = {
     organization_membership_quota_exceeded: 'Osiągnięto limit członkostwa w organizacji, w tym zaległych zaproszeń.',
     organization_minimum_permissions_needed:
       'Musi istnieć co najmniej jeden członek organizacji z minimalnymi wymaganymi uprawnieniami.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Klucz dostępu jest już zarejestrowany w tym urządzeniu.',
     passkey_not_supported: 'Klucze dostępu nie są obsługiwane przez to urządzenie.',
     passkey_pa_not_supported: 'Rejestracja wymaga platformy uwierzytelniającej, ale urządzenie jej nie obsługuje.',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -14,26 +14,6 @@ import type { LocalizationResource } from '@clerk/types';
 
 export const ptBR: LocalizationResource = {
   locale: 'pt-BR',
-  taskChooseOrganization: {
-    signOut: {
-      actionLink: 'Sair',
-      actionText: 'Conectado como {{identifier}}',
-    },
-    createOrganization: {
-      title: 'Configure sua conta',
-      subtitle: 'Conte-nos um pouco sobre sua organização',
-      formButtonSubmit: 'Criar nova organização',
-      formButtonReset: 'Cancelar',
-    },
-    chooseOrganization: {
-      title: 'Escolha uma organização',
-      subtitle: 'Junte-se a uma organização existente ou crie uma nova',
-      suggestionsAcceptedLabel: 'Aprovação pendente',
-      action__createOrganization: 'Criar nova organização',
-      action__suggestionsAccept: 'Solicitar participação',
-      action__invitationAccept: 'Participar',
-    },
-  },
   apiKeys: {
     action__add: 'Adicionar nova chave',
     action__search: 'Pesquisar chaves',
@@ -827,6 +807,26 @@ export const ptBR: LocalizationResource = {
   },
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',
   socialButtonsBlockButtonManyInView: '{{provider|titleize}}',
+  taskChooseOrganization: {
+    chooseOrganization: {
+      action__createOrganization: 'Criar nova organização',
+      action__invitationAccept: 'Participar',
+      action__suggestionsAccept: 'Solicitar participação',
+      subtitle: 'Junte-se a uma organização existente ou crie uma nova',
+      suggestionsAcceptedLabel: 'Aprovação pendente',
+      title: 'Escolha uma organização',
+    },
+    createOrganization: {
+      formButtonReset: 'Cancelar',
+      formButtonSubmit: 'Criar nova organização',
+      subtitle: 'Conte-nos um pouco sobre sua organização',
+      title: 'Configure sua conta',
+    },
+    signOut: {
+      actionLink: 'Sair',
+      actionText: 'Conectado como {{identifier}}',
+    },
+  },
   unstable__errors: {
     already_a_member_in_organization: '{{email}} já é membro da organização.',
     captcha_invalid:
@@ -869,6 +869,8 @@ export const ptBR: LocalizationResource = {
       'Você chegou ao seu limite de membros da organização, incluindo convites pendentes.',
     organization_minimum_permissions_needed:
       'É necessário que haja pelo menos um membro da organização com as permissões mínimas necessárias.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Uma chave de acesso já está registrada neste dispositivo.',
     passkey_not_supported: 'Chaves de acesso não são suportadas neste dispositivo.',
     passkey_pa_not_supported: 'Registro precisa de chave de acesso mas dispositivo não a suporta.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -855,6 +855,8 @@ export const ptPT: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -857,6 +857,8 @@ export const roRO: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -870,6 +870,8 @@ export const ruRU: LocalizationResource = {
       'Вы достигли предела количества участий в организациях, включая ожидающие приглашения.',
     organization_minimum_permissions_needed:
       'Должен быть как минимум один участник организации с минимально необходимыми разрешениями.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ключ доступа уже зарегистрирован на этом устройстве.',
     passkey_not_supported: 'Ключи доступа не поддерживаются на этом устройстве.',
     passkey_pa_not_supported: 'Для регистрации требуется платформа аутентификатор, но устройство его не поддерживает.',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -862,6 +862,8 @@ export const skSK: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Na tomto zariadení už existuje passkey pre tento účet.',
     passkey_not_supported: 'Váš prehliadač alebo zariadenie nepodporuje passkey.',
     passkey_pa_not_supported: 'Registrácia vyžaduje autentifikátor ale toto zariadenie ho nepodporuje.',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -855,6 +855,8 @@ export const srRS: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Ključ za prolaz je već registrovan sa ovim uređajem.',
     passkey_not_supported: 'Ključevi za prolaz nisu podržani na ovom uređaju.',
     passkey_pa_not_supported: 'Registracija zahteva platformski autentifikator, ali uređaj to ne podržava.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -858,6 +858,8 @@ export const svSE: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: 'Medlemskapet är fullt.',
     organization_minimum_permissions_needed: 'Du måste ha tillräckligt med behörigheter.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Passnyckeln finns redan.',
     passkey_not_supported: 'Passnyckel stöds inte.',
     passkey_pa_not_supported: 'Passnyckel PA stöds inte.',

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -870,6 +870,8 @@ export const taIN: LocalizationResource = {
       'நிலுவையிலுள்ள அழைப்புகள் உட்பட, நீங்கள் நிறுவன உறுப்பினர் எண்ணிக்கை வரம்பை அடைந்துவிட்டீர்கள்.',
     organization_minimum_permissions_needed:
       'குறைந்தபட்ச தேவையான அனுமதிகளுடன் குறைந்தது ஒரு நிறுவன உறுப்பினர் இருக்க வேண்டும்.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'இந்த சாதனத்துடன் ஒரு பாஸ்கீ ஏற்கனவே பதிவு செய்யப்பட்டுள்ளது.',
     passkey_not_supported: 'இந்த சாதனத்தில் பாஸ்கீகள் ஆதரிக்கப்படவில்லை.',
     passkey_pa_not_supported: 'பதிவுக்கு ஒரு தளம் அங்கீகரிப்பாளர் தேவைப்படுகிறது, ஆனால் சாதனம் அதை ஆதரிக்கவில்லை.',

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -866,6 +866,8 @@ export const teIN: LocalizationResource = {
     organization_membership_quota_exceeded:
       'మీరు మీ సంస్థ సభ్యత్వాలను, పెండింగ్ ఆహ్వానాలతో సహా పరిమితిని చేరుకున్నారు.',
     organization_minimum_permissions_needed: 'కనీస అవసరమైన అనుమతులు కలిగిన కనీసం ఒక సంస్థ సభ్యుడు ఉండాలి.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'ఈ పరికరంతో పాస్‌కీ ఇప్పటికే నమోదు చేయబడింది.',
     passkey_not_supported: 'పాస్‌కీలు ఈ పరికరంలో మద్దతు లేవు.',
     passkey_pa_not_supported: 'నమోదు కోసం ప్లాట్‌ఫామ్ ప్రమాణీకరణకర్త అవసరం కానీ పరికరం దానికి మద్దతు ఇవ్వదు.',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -854,6 +854,8 @@ export const thTH: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: 'โดเมนนี้ถูกใช้สำหรับ SSO ขององค์กรของคุณแล้ว',
     organization_membership_quota_exceeded: 'คุณได้ถึงขีดจำกัดการเป็นสมาชิกองค์กรแล้ว รวมถึงคำเชิญที่รอดำเนินการ',
     organization_minimum_permissions_needed: 'ต้องมีสมาชิกองค์กรอย่างน้อยหนึ่งคนที่มีสิทธิ์ขั้นต่ำที่จำเป็น',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'พาสคีย์ถูกลงทะเบียนกับอุปกรณ์นี้แล้ว',
     passkey_not_supported: 'อุปกรณ์นี้ไม่รองรับพาสคีย์',
     passkey_pa_not_supported: 'การลงทะเบียนต้องใช้ระบบยืนยันตัวตนของแพลตฟอร์ม แต่อุปกรณ์ไม่รองรับ',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -858,6 +858,8 @@ export const trTR: LocalizationResource = {
     organization_membership_quota_exceeded: 'Organizasyon üye kotası aşıldı.',
     organization_minimum_permissions_needed:
       'Bu işlemi gerçekleştirmek için gerekli asgari izinlere sahip olmalısınız.',
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Bu hesaba zaten bir geçiş anahtarı bağlı.',
     passkey_not_supported: 'Geçiş anahtarları şu anda desteklenmiyor.',
     passkey_pa_not_supported: 'Bu platform için geçiş anahtarları desteklenmiyor.',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -852,6 +852,8 @@ export const ukUA: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -862,6 +862,8 @@ export const viVN: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: 'Mã passkey đã được đăng ký với thiết bị này.',
     passkey_not_supported: 'Mã passkey không được hỗ trợ trên thiết bị này.',
     passkey_pa_not_supported: 'Đăng ký yêu cầu một bộ xác thực nền tảng nhưng thiết bị không hỗ trợ nó.',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -840,6 +840,8 @@ export const zhCN: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -840,6 +840,8 @@ export const zhTW: LocalizationResource = {
     organization_domain_exists_for_enterprise_connection: undefined,
     organization_membership_quota_exceeded: undefined,
     organization_minimum_permissions_needed: undefined,
+    organization_not_found_or_unauthorized: undefined,
+    organization_not_found_or_unauthorized_with_create_organization_disabled: undefined,
     passkey_already_exists: undefined,
     passkey_not_supported: undefined,
     passkey_pa_not_supported: undefined,

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -323,7 +323,6 @@ export function useOrganizationList<T extends UseOrganizationListParams>(params?
     {
       type: 'userMemberships',
       userId: user?.id,
-      memberships: user?.organizationMemberships.length ?? 0,
     },
   );
 

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -1330,4 +1330,5 @@ type UnstableErrors = WithParamName<{
   organization_domain_exists_for_enterprise_connection: LocalizationValue;
   organization_membership_quota_exceeded: LocalizationValue;
   organization_not_found_or_unauthorized: LocalizationValue;
+  organization_not_found_or_unauthorized_with_create_organization_disabled: LocalizationValue;
 }>;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -1329,4 +1329,5 @@ type UnstableErrors = WithParamName<{
   organization_domain_blocked: LocalizationValue;
   organization_domain_exists_for_enterprise_connection: LocalizationValue;
   organization_membership_quota_exceeded: LocalizationValue;
+  organization_not_found_or_unauthorized: LocalizationValue;
 }>;


### PR DESCRIPTION
## Description

This PR introduces error handling for `/touch` and `/tokens` error within `setActive` when the organization doesn't exist. This can happen when the client has stale organization data. 

We're applying fixes to both `OrganizationList` and `TaskChooseOrganization`

https://github.com/user-attachments/assets/94535095-bee3-4b4d-8a05-0131385551da

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when selecting/activating organizations; stale membership errors are surfaced, localized, and cleared.

* **Refactor**
  * Replaced wrapper-based card state with hook-based state across organization choose/create flows; previews are plain components and invitation acceptance updates UI in-place.

* **Localization**
  * Added error keys "organization_not_found_or_unauthorized" and a variant across locales; en-US and pt‑BR include messages, others are placeholders.

* **Types**
  * Added the new unstable error keys to types.

* **Chores**
  * Added a changeset for patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->