### PR TITLE
feat: Update OTP to use a single transparent field

### DIFF
--- a/packages/clerk-js/jest.setup.ts
+++ b/packages/clerk-js/jest.setup.ts
@@ -67,4 +67,10 @@ if (typeof window !== 'undefined') {
     }
     return null;
   }) as any) as jest.MockedFunction<HTMLCanvasElement['getContext']>;
+
+  // Mock document.elementFromPoint for input-otp library
+  Object.defineProperty(document, 'elementFromPoint', {
+    value: jest.fn().mockReturnValue(null),
+    writable: true,
+  });
 }

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -82,6 +82,7 @@
     "core-js": "3.41.0",
     "crypto-js": "^4.2.0",
     "dequal": "2.0.3",
+    "input-otp": "1.4.2",
     "qrcode.react": "4.2.0",
     "regenerator-runtime": "0.14.1",
     "swr": "2.3.4"

--- a/packages/clerk-js/src/ui/baseTheme.ts
+++ b/packages/clerk-js/src/ui/baseTheme.ts
@@ -31,7 +31,7 @@ const inputShadowStyles = (
     '&:hover': {
       boxShadow: hoverShadow,
     },
-    '&:focus-within': {
+    '&:focus-within,&[data-focus-within="true"]': {
       boxShadow: [hoverShadow, theme.shadows.$focusRing.replace('{{color}}', colors.focus)].toString(),
     },
   };

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
@@ -34,7 +34,7 @@ describe('SignInFactorTwo', () => {
       );
       render(<SignInFactorTwo />, { wrapper });
 
-      const inputs = screen.getAllByLabelText(/digit/i);
+      const inputs = screen.getAllByTestId('otp-input-segment');
       expect(inputs.length).toBe(6);
     });
 

--- a/packages/clerk-js/src/ui/components/UserVerification/__tests__/UVFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserVerification/__tests__/UVFactorTwo.test.tsx
@@ -30,11 +30,11 @@ describe('UserVerificationFactorTwo', () => {
       supportedSecondFactors: [{ strategy: 'phone_code' }],
     });
 
-    const { getByText, getAllByLabelText } = render(<UserVerificationFactorTwo />, { wrapper });
+    const { getByText, getAllByTestId } = render(<UserVerificationFactorTwo />, { wrapper });
 
     await waitFor(() => {
       getByText('Verification required');
-      const inputs = getAllByLabelText(/digit/i);
+      const inputs = getAllByTestId('otp-input-segment');
       expect(inputs.length).toBe(6);
     });
   });

--- a/packages/clerk-js/src/ui/customizables/index.ts
+++ b/packages/clerk-js/src/ui/customizables/index.ts
@@ -32,6 +32,9 @@ export const Image = makeCustomizable(sanitizeDomProps(makeResponsive(Primitives
 export const Alert = makeCustomizable(sanitizeDomProps(Primitives.Alert));
 export const AlertIcon = makeCustomizable(sanitizeDomProps(Primitives.AlertIcon));
 export const Input = makeCustomizable(sanitizeDomProps(Primitives.Input), { defaultDescriptor: descriptors.input });
+export const OTPInputSegment = makeCustomizable(sanitizeDomProps(Primitives.DivInput), {
+  defaultDescriptor: descriptors.input,
+});
 export const CheckboxInput = makeCustomizable(sanitizeDomProps(Primitives.CheckboxInput), {
   defaultDescriptor: descriptors.checkbox,
 });

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -1,9 +1,11 @@
 import { createContextAndHook } from '@clerk/shared/react';
+import type { SlotProps } from 'input-otp';
+import { OTPInput, REGEXP_ONLY_DIGITS } from 'input-otp';
 import type { PropsWithChildren } from 'react';
 import React, { useCallback } from 'react';
 
 import type { LocalizationKey } from '../customizables';
-import { Box, descriptors, Flex, Input } from '../customizables';
+import { Box, descriptors, Flex, OTPInputSegment } from '../customizables';
 import { useCardState } from '../elements/contexts';
 import { useLoadingStatus } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
@@ -159,29 +161,8 @@ export const OTPResendButton = () => {
 
 export const OTPCodeControl = React.forwardRef<{ reset: any }>((_, ref) => {
   const [disabled, setDisabled] = React.useState(false);
-  const refs = React.useRef<Array<HTMLInputElement | null>>([]);
-  const hiddenInputRef = React.useRef<HTMLInputElement>(null);
-  const firstClickRef = React.useRef(false);
-
-  const { otpControl, isLoading, isDisabled, centerAlign = true } = useOTPInputContext();
+  const { otpControl, isLoading, isDisabled } = useOTPInputContext();
   const { feedback, values, setValues, feedbackType, length } = otpControl.otpInputProps;
-
-  React.useImperativeHandle(ref, () => ({
-    reset: () => {
-      setValues(values.map(() => ''));
-      setDisabled(false);
-
-      if (hiddenInputRef.current) {
-        hiddenInputRef.current.value = '';
-      }
-
-      setTimeout(() => focusInputAt(0), 0);
-    },
-  }));
-
-  React.useLayoutEffect(() => {
-    setTimeout(() => focusInputAt(0), 0);
-  }, []);
 
   React.useEffect(() => {
     if (feedback) {
@@ -189,270 +170,112 @@ export const OTPCodeControl = React.forwardRef<{ reset: any }>((_, ref) => {
     }
   }, [feedback]);
 
-  // Update hidden input when values change
-  React.useEffect(() => {
-    if (hiddenInputRef.current) {
-      hiddenInputRef.current.value = values.join('');
-    }
-  }, [values]);
-
-  // Focus management for password managers
-  React.useEffect(() => {
-    const handleFocus = () => {
-      // If focus is on the hidden input, redirect to first visible input
-      if (document.activeElement === hiddenInputRef.current) {
-        setTimeout(() => focusInputAt(0), 0);
-      }
-    };
-
-    document.addEventListener('focusin', handleFocus);
-    return () => document.removeEventListener('focusin', handleFocus);
-  }, []);
-
-  const handleMultipleCharValue = ({ eventValue, inputPosition }: { eventValue: string; inputPosition: number }) => {
-    const eventValues = (eventValue || '').split('');
-
-    if (eventValues.length === 0 || !eventValues.every(c => isValidInput(c))) {
-      return;
-    }
-
-    if (eventValues.length === length) {
-      setValues([...eventValues]);
-      focusInputAt(length - 1);
-      return;
-    }
-
-    const mergedValues = values.map((value, i) =>
-      i < inputPosition ? value : eventValues[i - inputPosition] || value,
-    );
-    setValues(mergedValues);
-    focusInputAt(inputPosition + eventValues.length);
-  };
-
-  const changeValueAt = (index: number, newValue: string) => {
-    const newValues = [...values];
-    newValues[index] = newValue;
-    setValues(newValues);
-  };
-
-  const focusInputAt = (index: number) => {
-    const clampedIndex = Math.min(Math.max(0, index), refs.current.length - 1);
-    const ref = refs.current[clampedIndex];
-    if (ref) {
-      ref.focus();
-      if (values[clampedIndex]) {
-        ref.select();
-      }
-    }
-  };
-
-  const handleOnClick = (index: number) => (e: React.MouseEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    // Focus on the first digit, when the first click happens.
-    // This is helpful especially for mobile (iOS) devices that cannot autofocus
-    // and user needs to manually tap the input area
-    if (!firstClickRef.current) {
-      focusInputAt(0);
-      firstClickRef.current = true;
-      return;
-    }
-    focusInputAt(index);
-  };
-
-  const handleOnChange = (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    handleMultipleCharValue({ eventValue: e.target.value || '', inputPosition: index });
-  };
-
-  const handleOnInput = (index: number) => (e: React.FormEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    if (isValidInput((e.target as any).value)) {
-      // If a user types on an input that already has a value and the new
-      // value is the same as the old one, onChange will not fire so we
-      // manually move focus to the next input
-      focusInputAt(index + 1);
-    }
-  };
-
-  const handleOnPaste = (index: number) => (e: React.ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    handleMultipleCharValue({ eventValue: e.clipboardData.getData('text/plain') || '', inputPosition: index });
-  };
-
-  const handleOnKeyDown = (index: number) => (e: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key) {
-      case 'Backspace':
-        e.preventDefault();
-        changeValueAt(index, '');
-        focusInputAt(index - 1);
-        return;
-      case 'ArrowLeft':
-        e.preventDefault();
-        focusInputAt(index - 1);
-        return;
-      case 'ArrowRight':
-        e.preventDefault();
-        focusInputAt(index + 1);
-        return;
-      case ' ':
-        e.preventDefault();
-        return;
-    }
-  };
-
-  // Handle hidden input changes (for password manager autofill)
-  const handleHiddenInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/\D/g, '').slice(0, length);
-    const newValues = value.split('').concat(Array.from({ length: length - value.length }, () => ''));
-    setValues(newValues);
-
-    // Focus the appropriate visible input
-    if (value.length > 0) {
-      focusInputAt(Math.min(value.length - 1, length - 1));
-    }
-  };
-
-  const centerSx = centerAlign ? { justifyContent: 'center', alignItems: 'center' } : {};
-
   return (
     <Box
       elementDescriptor={descriptors.otpCodeFieldInputContainer}
       sx={{ position: 'relative' }}
     >
-      {/* Hidden input for password manager compatibility */}
-      <Input
-        ref={hiddenInputRef}
-        type='text'
-        autoComplete='one-time-code'
-        inputMode='numeric'
-        pattern={`[0-9]{${length}}`}
-        minLength={length}
+      <OTPInput
         maxLength={length}
-        spellCheck={false}
-        name='otp'
-        id='otp-input'
-        data-otp-input
-        data-otp-hidden-input
-        data-testid='otp-input'
-        role='textbox'
-        aria-label='One-time password input for password managers'
-        aria-describedby='otp-instructions'
-        aria-hidden
-        tabIndex={-1}
-        onChange={handleHiddenInputChange}
-        onFocus={() => {
-          // When password manager focuses the hidden input, focus the first visible input
-          focusInputAt(0);
+        inputMode='numeric'
+        pattern={REGEXP_ONLY_DIGITS}
+        textAlign='center'
+        value={values.join('')}
+        onChange={newValue => {
+          setValues(newValue.split(''));
         }}
-        sx={() => ({
-          // NOTE: Do not use the visuallyHidden() utility here, as it will break password manager autofill
-          position: 'absolute',
-          opacity: 0,
-          width: '1px',
-          height: '1px',
-          overflow: 'hidden',
-          clip: 'rect(0, 0, 0, 0)',
-          clipPath: 'inset(50%)',
-          whiteSpace: 'nowrap',
-          // Ensure the input is still accessible to password managers
-          // by not using display: none or visibility: hidden
-          pointerEvents: 'none',
-          // Position slightly within the container for better detection
-          top: 0,
-          left: 0,
-        })}
-      />
-
-      {/* Hidden instructions for screen readers and password managers */}
-      <span
-        id='otp-instructions'
-        style={{
-          position: 'absolute',
-          width: '1px',
-          height: '1px',
-          padding: 0,
-          margin: '-1px',
-          overflow: 'hidden',
-          clip: 'rect(0, 0, 0, 0)',
-          border: 0,
-        }}
-      >
-        Enter the {length}-digit verification code
-      </span>
-
-      <Flex
-        isLoading={isLoading}
-        hasError={feedbackType === 'error'}
-        elementDescriptor={descriptors.otpCodeFieldInputs}
-        gap={2}
-        sx={t => ({ direction: 'ltr', padding: t.space.$1, marginLeft: `calc(${t.space.$1} * -1)`, ...centerSx })}
-        role='group'
-        aria-label='Verification code input'
-        aria-describedby='otp-instructions'
-      >
-        {values.map((value: string, index: number) => (
-          <SingleCharInput
-            elementDescriptor={descriptors.otpCodeFieldInput}
-            // eslint-disable-next-line react/no-array-index-key
-            key={index}
-            value={value}
-            onClick={handleOnClick(index)}
-            onChange={handleOnChange(index)}
-            onKeyDown={handleOnKeyDown(index)}
-            onInput={handleOnInput(index)}
-            onPaste={handleOnPaste(index)}
-            id={`digit-${index}-field`}
-            ref={node => (refs.current[index] = node)}
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={index === 0 || undefined}
-            autoComplete='off'
-            aria-label={`${index === 0 ? 'Enter verification code. ' : ''}Digit ${index + 1}`}
-            isDisabled={isDisabled || isLoading || disabled || feedbackType === 'success'}
+        render={({ slots }) => (
+          <Flex
+            align='center'
+            gap={2}
             hasError={feedbackType === 'error'}
-            isSuccessfullyFilled={feedbackType === 'success'}
-            type='text'
-            inputMode='numeric'
-            name={`codeInput-${index}`}
-            data-otp-segment='true'
-            data-1p-ignore='true'
-            data-lpignore='true'
-            maxLength={1}
-            pattern='[0-9]'
-          />
-        ))}
-      </Flex>
+            isLoading={isLoading}
+            role='group'
+          >
+            {slots.map((slot, index: number) => (
+              <Slot
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                elementDescriptor={descriptors.otpCodeFieldInput}
+                isDisabled={isDisabled || isLoading || disabled || feedbackType === 'success'}
+                hasError={feedbackType === 'error'}
+                isSuccessfullyFilled={feedbackType === 'success'}
+                {...slot}
+              />
+            ))}
+          </Flex>
+        )}
+      />
     </Box>
   );
 });
 
-const SingleCharInput = React.forwardRef<
-  HTMLInputElement,
-  PropsOfComponent<typeof Input> & { isSuccessfullyFilled?: boolean }
->((props, ref) => {
-  const { isSuccessfullyFilled, ...rest } = props;
+function Slot(props: SlotProps & PropsOfComponent<typeof OTPInputSegment> & { isSuccessfullyFilled?: boolean }) {
+  const { isSuccessfullyFilled, isActive, ...rest } = props;
   return (
-    <Input
-      ref={ref}
-      type='text'
-      sx={theme => ({
+    <OTPInputSegment
+      {...rest}
+      focusRing={isActive}
+      variant='default'
+      sx={t => ({
         textAlign: 'center',
-        ...common.textVariants(theme).h2,
-        padding: `${theme.space.$0x5} 0`,
+        ...common.textVariants(t).h2,
+        padding: `${t.space.$0x5} 0`,
         boxSizing: 'border-box',
-        height: theme.space.$10,
-        width: theme.space.$10,
-        borderRadius: theme.radii.$md,
-        ...(isSuccessfullyFilled ? { borderColor: theme.colors.$success500 } : common.borderColor(theme, props)),
+        display: 'flex',
+        position: 'relative',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: t.space.$10,
+        width: t.space.$10,
+        color: t.colors.$colorInputForeground,
+        borderWidth: t.borderWidths.$normal,
+        borderRadius: t.radii.$md,
+        ...(isSuccessfullyFilled ? { borderColor: t.colors.$success500 } : common.borderColor(t, props)),
         backgroundColor: 'unset',
-        '&:focus': {},
         [mqu.sm]: {
-          height: theme.space.$8,
-          width: theme.space.$8,
+          height: t.space.$8,
+          width: t.space.$8,
         },
       })}
-      {...rest}
-    />
+    >
+      {props.char !== null && <div>{props.char}</div>}
+      {props.hasFakeCaret && <FakeCaret />}
+    </OTPInputSegment>
   );
-});
+}
 
-const isValidInput = (char: string) => char != undefined && Number.isInteger(+char);
+function FakeCaret() {
+  return (
+    <>
+      <style>{`
+        @keyframes caret-blink-animation {
+          0%, 50% {
+            opacity: 1;
+          }
+          51%, 100% {
+            opacity: 0;
+          }
+        }
+      `}</style>
+      <Flex
+        align='center'
+        justify='center'
+        sx={() => ({
+          animation: 'caret-blink-animation 1s infinite',
+          pointerEvents: 'none',
+          position: 'absolute',
+          inset: 0,
+        })}
+      >
+        <Box
+          sx={t => ({
+            height: t.space.$4,
+            width: t.space.$px,
+            backgroundColor: t.colors.$colorInputForeground,
+          })}
+        />
+      </Flex>
+    </>
+  );
+}

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -180,6 +180,8 @@ export const OTPCodeControl = () => {
       sx={{ position: 'relative' }}
     >
       <OTPInput
+        aria-label='Enter verification code'
+        aria-required
         maxLength={length}
         inputMode='numeric'
         pattern={REGEXP_ONLY_DIGITS}
@@ -218,6 +220,7 @@ function Slot(props: SlotProps & PropsOfComponent<typeof OTPInputSegment> & { is
   const { isSuccessfullyFilled, isActive, ...rest } = props;
   return (
     <OTPInputSegment
+      data-testid='otp-input-segment'
       {...rest}
       focusRing={isActive}
       variant='default'

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -95,7 +95,6 @@ export const useFieldOTP: UseFieldOTP = params => {
 };
 
 const useCodeControl = (formControl: FormControlState, options?: UseCodeInputOptions) => {
-  const otpControlRef = React.useRef<any>();
   const userOnCodeEnteredCallback = React.useRef<onCodeEntryFinishedCallback>();
   const defaultValue = formControl.value;
   const { feedback, feedbackType, onChange, clearFeedback } = formControl;
@@ -108,6 +107,10 @@ const useCodeControl = (formControl: FormControlState, options?: UseCodeInputOpt
     userOnCodeEnteredCallback.current = cb;
   };
 
+  const reset = React.useCallback(() => {
+    setValues(Array.from({ length }, () => ''));
+  }, [length]);
+
   React.useEffect(() => {
     const len = values.filter(c => c).length;
     if (len === length) {
@@ -117,10 +120,11 @@ const useCodeControl = (formControl: FormControlState, options?: UseCodeInputOpt
       const code = values.join('');
       onChange?.({ target: { value: code } } as any);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values.toString()]);
 
-  const otpInputProps = { length, values, setValues, feedback, feedbackType, clearFeedback, ref: otpControlRef };
-  return { otpInputProps, onCodeEntryFinished, reset: () => otpControlRef.current?.reset() };
+  const otpInputProps = { length, values, setValues, feedback, feedbackType, clearFeedback };
+  return { otpInputProps, onCodeEntryFinished, reset };
 };
 
 export type OTPInputProps = {
@@ -159,7 +163,7 @@ export const OTPResendButton = () => {
   );
 };
 
-export const OTPCodeControl = React.forwardRef<{ reset: any }>((_, ref) => {
+export const OTPCodeControl = () => {
   const [disabled, setDisabled] = React.useState(false);
   const { otpControl, isLoading, isDisabled } = useOTPInputContext();
   const { feedback, values, setValues, feedbackType, length } = otpControl.otpInputProps;
@@ -208,7 +212,7 @@ export const OTPCodeControl = React.forwardRef<{ reset: any }>((_, ref) => {
       />
     </Box>
   );
-});
+};
 
 function Slot(props: SlotProps & PropsOfComponent<typeof OTPInputSegment> & { isSuccessfullyFilled?: boolean }) {
   const { isSuccessfullyFilled, isActive, ...rest } = props;

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -252,12 +252,11 @@ const RadioGroup = (
 };
 
 const OTPInput = (props: OTPInputProps) => {
-  const { ref, ...restInputProps } = props.otpControl.otpInputProps;
   const { centerAlign = true } = props;
   return (
     // Use Field.Root in order to pass feedback down to Field.Feedback
     // @ts-ignore
-    <Field.Root {...restInputProps}>
+    <Field.Root {...props.otpControl.otpInputProps}>
       <Field.OTPRoot {...props}>
         {/*TODO: Create a descriptor for OTP wrapper*/}
         <Col
@@ -271,7 +270,7 @@ const OTPInput = (props: OTPInputProps) => {
             hasError={props.otpControl.otpInputProps.feedbackType === 'error'}
             direction='col'
           >
-            <Field.OTPCodeControl ref={ref} />
+            <Field.OTPCodeControl />
             <Field.Feedback
               center
               elementDescriptors={{

--- a/packages/clerk-js/src/ui/elements/InputGroup.tsx
+++ b/packages/clerk-js/src/ui/elements/InputGroup.tsx
@@ -42,9 +42,9 @@ export const InputGroup = forwardRef<
         position: 'relative',
         zIndex: 1,
         ...common.borderVariants(theme).normal,
-        ':focus-within': {
+        ':focus-within,&[data-focus-within="true"]': {
           ...common.borderVariants(theme, {
-            focusRignt: true,
+            focusRing: true,
           }).normal['&:focus'],
         },
       })}

--- a/packages/clerk-js/src/ui/elements/PhoneInput/index.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/index.tsx
@@ -78,7 +78,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
         position: 'relative',
         borderRadius: theme.radii.$md,
         zIndex: 1,
-        '&:focus-within': {
+        '&:focus-within,&[data-focus-within="true"]': {
           ...common.borderVariants(theme, { hasError: rest.hasError }).normal['&:focus'],
         },
       })}

--- a/packages/clerk-js/src/ui/elements/__tests__/CodeControl.spec.tsx
+++ b/packages/clerk-js/src/ui/elements/__tests__/CodeControl.spec.tsx
@@ -35,7 +35,7 @@ const createOTPComponent = (
         isLoading={otpField.isLoading}
         onResendCode={otpField.onResendCode}
       >
-        <OTPCodeControl ref={null} />
+        <OTPCodeControl />
       </OTPRoot>
     );
   });
@@ -443,7 +443,7 @@ describe('CodeControl', () => {
             isDisabled
             onResendCode={otpField.onResendCode}
           >
-            <OTPCodeControl ref={null} />
+            <OTPCodeControl />
           </OTPRoot>
         );
       });
@@ -472,7 +472,7 @@ describe('CodeControl', () => {
             isLoading
             onResendCode={otpField.onResendCode}
           >
-            <OTPCodeControl ref={null} />
+            <OTPCodeControl />
           </OTPRoot>
         );
       });
@@ -508,7 +508,7 @@ describe('CodeControl', () => {
             isLoading={false}
             onResendCode={otpField.onResendCode}
           >
-            <OTPCodeControl ref={null} />
+            <OTPCodeControl />
           </OTPRoot>
         );
       });

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -116,6 +116,37 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref)
   );
 });
 
+/**
+ * This is to allow for the creation of "fake" input elements that are not actually inputs.
+ * This is used to create the OTPInputSegment component.
+ */
+export type DivInputProps = PrimitiveProps<'div'> & StyleVariants<typeof applyVariants> & OwnProps & RequiredProp;
+
+export const DivInput = React.forwardRef<HTMLDivElement, DivInputProps>((props, ref) => {
+  const fieldControl = useFormField() || {};
+  // @ts-expect-error Typescript is complaining that `errorMessageId` does not exist. We are clearly passing them from above.
+  const { feedbackType } = sanitizeInputProps(fieldControl, ['feedbackType', 'data-active']);
+
+  const propsWithoutVariants = filterProps({
+    ...props,
+    hasError: props.hasError,
+  });
+  const { isDisabled, hasError, focusRing, isRequired, ...rest } = propsWithoutVariants;
+
+  return (
+    <div
+      {...rest}
+      ref={ref}
+      id={props.id}
+      aria-invalid={hasError}
+      data-feedback={feedbackType}
+      data-variant={props.variant || 'default'}
+      data-focus-within={focusRing}
+      css={applyVariants(props)}
+    />
+  );
+});
+
 export const CheckboxInput = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <Input

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       dequal:
         specifier: 2.0.3
         version: 2.0.3
+      input-otp:
+        specifier: 1.4.2
+        version: 1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       qrcode.react:
         specifier: 4.2.0
         version: 4.2.0(react@18.3.1)
@@ -2905,7 +2908,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -9222,6 +9225,12 @@ packages:
         optional: true
       react-devtools-core:
         optional: true
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-ip@4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
@@ -25335,6 +25344,11 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  input-otp@1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   internal-ip@4.3.0:
     dependencies:


### PR DESCRIPTION
## Description

Our OTP woes largely come down to one thing: multiple individual inputs.

The interim fixes included adding a bi-directional sync between these fields and a single hidden input and while this helped a lot with password managers, it didn't solve the underlying cause.

This updates OTP to use a single transparent field via `input-otp`.

**Known (intentional) differences from our existing approach:**
- No longer can you select/edit individual fields as they don't exist anymore.

<!-- Fixes #(issue number) -->
Fixes USER-2571

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
