### PR TITLE
fix(nextjs): Use nodeFsOrThrow instead of directly importing fs module in keyless-telemetry

### DIFF
--- a/.changeset/itchy-queens-cough.md
+++ b/.changeset/itchy-queens-cough.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Import fs methods with nodeFsOrThrow rather than direct import.

--- a/packages/nextjs/src/server/keyless-telemetry.ts
+++ b/packages/nextjs/src/server/keyless-telemetry.ts
@@ -1,9 +1,9 @@
 import type { TelemetryEventRaw } from '@clerk/types';
-import { promises as fs } from 'fs';
 import { dirname, join } from 'path';
 
 import { canUseKeyless } from '../utils/feature-flags';
 import { createClerkClientWithOptions } from './createClerkClient';
+import { nodeFsOrThrow } from './fs/utils';
 
 const EVENT_KEYLESS_ENV_DRIFT_DETECTED = 'KEYLESS_ENV_DRIFT_DETECTED';
 const EVENT_SAMPLING_RATE = 1; // 100% sampling rate
@@ -43,18 +43,23 @@ function getTelemetryFlagFilePath(): string {
  */
 async function tryMarkTelemetryEventAsFired(): Promise<boolean> {
   try {
-    const flagFilePath = getTelemetryFlagFilePath();
-    const flagDirectory = dirname(flagFilePath);
+    if (canUseKeyless) {
+      const { mkdir, writeFile } = nodeFsOrThrow();
+      const flagFilePath = getTelemetryFlagFilePath();
+      const flagDirectory = dirname(flagFilePath);
 
-    // Ensure the directory exists before attempting to write the file
-    await fs.mkdir(flagDirectory, { recursive: true });
+      // Ensure the directory exists before attempting to write the file
+      await mkdir(flagDirectory, { recursive: true });
 
-    const flagData = {
-      firedAt: new Date().toISOString(),
-      event: EVENT_KEYLESS_ENV_DRIFT_DETECTED,
-    };
-    await fs.writeFile(flagFilePath, JSON.stringify(flagData, null, 2), { flag: 'wx' });
-    return true;
+      const flagData = {
+        firedAt: new Date().toISOString(),
+        event: EVENT_KEYLESS_ENV_DRIFT_DETECTED,
+      };
+      await writeFile(flagFilePath, JSON.stringify(flagData, null, 2), { flag: 'wx' });
+      return true;
+    } else {
+      return false;
+    }
   } catch (error: unknown) {
     if ((error as { code?: string })?.code === 'EEXIST') {
       return false;


### PR DESCRIPTION
## Description

Fixes build error in `playground/nextjs` action (see [here](https://github.com/clerk/javascript/actions/workflows/preview.retheme.yml)) by import fs methods with `nodeFsOrThrow` rather than direct import.

## Checklist

- [ ] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of telemetry event tracking by only writing flags when the environment supports it, preventing unnecessary filesystem access.
  * Enforced single-write semantics for telemetry flags to avoid duplicate events and reduce noise.
  * Reduced error logs in unsupported scenarios while maintaining existing drift detection behavior.
  * Enhanced stability with safer write operations and clearer handling of previously recorded events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->