### PR TITLE
feat(clerk-js,types): Signal SignUp APIs

### DIFF
--- a/.changeset/big-queens-tap.md
+++ b/.changeset/big-queens-tap.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Experimental] Signal SignUp APIs

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -13,6 +13,7 @@ import type {
   PreparePhoneNumberVerificationParams,
   PrepareVerificationParams,
   PrepareWeb3WalletVerificationParams,
+  SetActiveNavigate,
   SignUpAuthenticateWithWeb3Params,
   SignUpCreateParams,
   SignUpField,
@@ -48,6 +49,7 @@ import {
 } from '../errors';
 import { eventBus } from '../events';
 import { BaseResource, ClerkRuntimeError, SignUpVerifications } from './internal';
+import { runAsyncResourceTask } from '../../utils/runAsyncResourceTask';
 
 declare global {
   interface Window {
@@ -470,9 +472,55 @@ export class SignUp extends BaseResource implements SignUpResource {
 }
 
 class SignUpFuture implements SignUpFutureResource {
+  verifications = {
+    sendEmailCode: this.sendEmailCode.bind(this),
+    verifyEmailCode: this.verifyEmailCode.bind(this),
+  };
+
   constructor(readonly resource: SignUp) {}
 
   get status() {
     return this.resource.status;
+  }
+
+  get unverifiedFields() {
+    return this.resource.unverifiedFields;
+  }
+
+  async password({ emailAddress, password }: { emailAddress: string; password: string }): Promise<{ error: unknown }> {
+    return runAsyncResourceTask(this.resource, async () => {
+      await this.resource.__internal_basePost({
+        path: this.resource.pathRoot,
+        body: { emailAddress, password },
+      });
+    });
+  }
+
+  async sendEmailCode(): Promise<{ error: unknown }> {
+    return runAsyncResourceTask(this.resource, async () => {
+      await this.resource.__internal_basePost({
+        body: { strategy: 'email_code' },
+        action: 'prepare_verification',
+      });
+    });
+  }
+
+  async verifyEmailCode({ code }: { code: string }): Promise<{ error: unknown }> {
+    return runAsyncResourceTask(this.resource, async () => {
+      await this.resource.__internal_basePost({
+        body: { strategy: 'email_code', code },
+        action: 'attempt_verification',
+      });
+    });
+  }
+
+  async finalize({ navigate }: { navigate?: SetActiveNavigate }): Promise<{ error: unknown }> {
+    return runAsyncResourceTask(this.resource, async () => {
+      if (!this.resource.createdSessionId) {
+        throw new Error('Cannot finalize sign-up without a created session.');
+      }
+
+      await SignUp.clerk.setActive({ session: this.resource.createdSessionId, navigate });
+    });
   }
 }

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -41,6 +41,7 @@ import { _authenticateWithPopup } from '../../utils/authenticateWithPopup';
 import { CaptchaChallenge } from '../../utils/captcha/CaptchaChallenge';
 import { createValidatePassword } from '../../utils/passwords/password';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
+import { runAsyncResourceTask } from '../../utils/runAsyncResourceTask';
 import {
   clerkInvalidFAPIResponse,
   clerkMissingOptionError,
@@ -49,7 +50,6 @@ import {
 } from '../errors';
 import { eventBus } from '../events';
 import { BaseResource, ClerkRuntimeError, SignUpVerifications } from './internal';
-import { runAsyncResourceTask } from '../../utils/runAsyncResourceTask';
 
 declare global {
   interface Window {

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -1,6 +1,7 @@
 import type { PhoneCodeChannel } from 'phoneCodeChannel';
 
 import type { FirstNameAttribute, LastNameAttribute, LegalAcceptedAttribute, PasswordAttribute } from './attributes';
+import type { SetActiveNavigate } from './clerk';
 import type { AttemptEmailAddressVerificationParams, PrepareEmailAddressVerificationParams } from './emailAddress';
 import type {
   EmailAddressIdentifier,
@@ -120,6 +121,13 @@ export interface SignUpResource extends ClerkResource {
 
 export interface SignUpFutureResource {
   status: SignUpStatus | null;
+  unverifiedFields: SignUpIdentificationField[];
+  verifications: {
+    sendEmailCode: () => Promise<{ error: unknown }>;
+    verifyEmailCode: (params: { code: string }) => Promise<{ error: unknown }>;
+  };
+  password: (params: { emailAddress: string; password: string }) => Promise<{ error: unknown }>;
+  finalize: (params: { navigate?: SetActiveNavigate }) => Promise<{ error: unknown }>;
 }
 
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';


### PR DESCRIPTION
## Description

This PR adds the APIs necessary for sign-ups with the default instance configuration to our Signal implementation, which is not intended for public use yet.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Experimental SignUp enhancements: send and verify email codes, set email/password credentials, view unverified fields, and finalize sign up with optional navigation.

- Documentation
  - Added note highlighting the experimental "Signal SignUp" APIs.

- Chores
  - Minor version bumps for @clerk/clerk-js and @clerk/types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->