### PR TITLE
feat(clerk-js): Hide passkeys section when enterprise account disables additional identifications

### DIFF
--- a/.changeset/rotten-baths-wish.md
+++ b/.changeset/rotten-baths-wish.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide passkeys section when user has an enterprise account with the disable additional identifiers setting enabled

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -4,7 +4,7 @@
     { "path": "./dist/clerk.browser.js", "maxSize": "78KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "119KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "61KB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "114.1KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "117.1KB" },
     { "path": "./dist/ui-common*.legacy.*.js", "maxSize": "118KB" },
     { "path": "./dist/vendors*.js", "maxSize": "41KB" },
     { "path": "./dist/coinbase*.js", "maxSize": "38KB" },

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    { "path": "./dist/clerk.js", "maxSize": "626.1KB" },
+    { "path": "./dist/clerk.js", "maxSize": "629KB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "78KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "119KB" },
     { "path": "./dist/clerk.headless*.js", "maxSize": "61KB" },

--- a/packages/clerk-js/src/ui/components/UserProfile/AccountPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AccountPage.tsx
@@ -4,7 +4,7 @@ import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
 
-import { useEnvironment } from '../../contexts';
+import { useEnvironment, useUserProfileContext } from '../../contexts';
 import { Col, descriptors, localizationKeys } from '../../customizables';
 import { ConnectedAccountsSection } from './ConnectedAccountsSection';
 import { EmailsSection } from './EmailsSection';
@@ -18,6 +18,7 @@ export const AccountPage = withCardStateProvider(() => {
   const { attributes, social, enterpriseSSO } = useEnvironment().userSettings;
   const card = useCardState();
   const { user } = useUser();
+  const { shouldAllowIdentificationCreation } = useUserProfileContext();
 
   const showUsername = attributes.username?.enabled;
   const showEmail = attributes.email_address?.enabled;
@@ -25,13 +26,6 @@ export const AccountPage = withCardStateProvider(() => {
   const showConnectedAccounts = social && Object.values(social).filter(p => p.enabled).length > 0;
   const showEnterpriseAccounts = user && enterpriseSSO.enabled;
   const showWeb3 = attributes.web3_wallet?.enabled;
-
-  const shouldAllowIdentificationCreation =
-    !showEnterpriseAccounts ||
-    !user.enterpriseAccounts.some(
-      enterpriseAccount =>
-        enterpriseAccount.active && enterpriseAccount.enterpriseConnection?.disableAdditionalIdentifications,
-    );
 
   return (
     <Col

--- a/packages/clerk-js/src/ui/components/UserProfile/SecurityPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/SecurityPage.tsx
@@ -4,7 +4,7 @@ import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
 
-import { useEnvironment } from '../../contexts';
+import { useEnvironment, useUserProfileContext } from '../../contexts';
 import { Col, descriptors, localizationKeys } from '../../customizables';
 import { ActiveDevicesSection } from './ActiveDevicesSection';
 import { DeleteSection } from './DeleteSection';
@@ -17,8 +17,9 @@ export const SecurityPage = withCardStateProvider(() => {
   const { attributes, instanceIsPasswordBased } = useEnvironment().userSettings;
   const card = useCardState();
   const { user } = useUser();
+  const { shouldAllowIdentificationCreation } = useUserProfileContext();
   const showPassword = instanceIsPasswordBased;
-  const showPasskey = attributes.passkey?.enabled;
+  const showPasskey = attributes.passkey?.enabled && shouldAllowIdentificationCreation;
   const showMfa = getSecondFactors(attributes).length > 0;
   const showDelete = user?.deleteSelfEnabled;
 

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
@@ -70,7 +70,6 @@ describe('SecurityPage', () => {
             last_used_at: Date.now(),
             verification: null,
             updated_at: Date.now(),
-            credential_id: 'some_id',
           },
         ],
       });
@@ -83,6 +82,195 @@ describe('SecurityPage', () => {
     getByText('Chrome on Mac');
     getByText(/^Created:/);
     getByText(/^Last used:/);
+  });
+
+  describe('Passkeys section visibility', () => {
+    describe('with active enterprise connection', () => {
+      it('shows the passkeys section when passkeys are enabled', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withEnterpriseSso();
+          f.withPasskey();
+          f.withUser({
+            email_addresses: ['test@clerk.com'],
+            passkeys: [
+              {
+                object: 'passkey',
+                id: '1234',
+                name: 'Chrome on Mac',
+                created_at: Date.now(),
+                last_used_at: Date.now(),
+                verification: null,
+                updated_at: Date.now(),
+              },
+            ],
+            enterprise_accounts: [
+              {
+                object: 'enterprise_account',
+                active: true,
+                first_name: 'Laura',
+                last_name: 'Serafim',
+                protocol: 'saml',
+                provider_user_id: null,
+                public_metadata: {},
+                email_address: 'test@clerk.com',
+                provider: 'saml_okta',
+                enterprise_connection: {
+                  object: 'enterprise_connection',
+                  provider: 'saml_okta',
+                  name: 'Okta Workforce',
+                  id: 'ent_123',
+                  active: true,
+                  allow_idp_initiated: false,
+                  allow_subdomains: false,
+                  disable_additional_identifications: false,
+                  sync_user_attributes: false,
+                  domain: 'foocorp.com',
+                  created_at: 123,
+                  updated_at: 123,
+                  logo_public_url: null,
+                  protocol: 'saml',
+                },
+                verification: {
+                  status: 'verified',
+                  strategy: 'saml',
+                  verified_at_client: 'foo',
+                  attempts: 0,
+                  error: {
+                    code: 'identifier_already_signed_in',
+                    long_message: "You're already signed in",
+                    message: "You're already signed in",
+                  },
+                  expire_at: 123,
+                  id: 'ver_123',
+                  object: 'verification',
+                },
+                id: 'eac_123',
+              },
+            ],
+          });
+        });
+        fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+        render(<SecurityPage />, { wrapper });
+        await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
+        screen.getByText('Passkeys');
+        screen.getByText('Chrome on Mac');
+      });
+
+      it('hides the passkeys section when disable_additional_identifications is true', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withEnterpriseSso();
+          f.withPasskey();
+          f.withUser({
+            email_addresses: ['test@clerk.com'],
+            passkeys: [
+              {
+                object: 'passkey',
+                id: '1234',
+                name: 'Chrome on Mac',
+                created_at: Date.now(),
+                last_used_at: Date.now(),
+                verification: null,
+                updated_at: Date.now(),
+              },
+            ],
+            enterprise_accounts: [
+              {
+                object: 'enterprise_account',
+                active: true,
+                first_name: 'Laura',
+                last_name: 'Serafim',
+                protocol: 'saml',
+                provider_user_id: null,
+                public_metadata: {},
+                email_address: 'test@clerk.com',
+                provider: 'saml_okta',
+                enterprise_connection: {
+                  object: 'enterprise_connection',
+                  provider: 'saml_okta',
+                  name: 'Okta Workforce',
+                  id: 'ent_123',
+                  active: true,
+                  allow_idp_initiated: false,
+                  allow_subdomains: false,
+                  disable_additional_identifications: true,
+                  sync_user_attributes: false,
+                  domain: 'foocorp.com',
+                  created_at: 123,
+                  updated_at: 123,
+                  logo_public_url: null,
+                  protocol: 'saml',
+                },
+                verification: {
+                  status: 'verified',
+                  strategy: 'saml',
+                  verified_at_client: 'foo',
+                  attempts: 0,
+                  error: {
+                    code: 'identifier_already_signed_in',
+                    long_message: "You're already signed in",
+                    message: "You're already signed in",
+                  },
+                  expire_at: 123,
+                  id: 'ver_123',
+                  object: 'verification',
+                },
+                id: 'eac_123',
+              },
+            ],
+          });
+        });
+        fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+        render(<SecurityPage />, { wrapper });
+        await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
+        expect(screen.queryByText('Passkeys')).not.toBeInTheDocument();
+        expect(screen.queryByText('Chrome on Mac')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('without enterprise connection', () => {
+      it('shows the passkeys section when passkeys are enabled', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withPasskey();
+          f.withUser({
+            email_addresses: ['test@clerk.com'],
+            passkeys: [
+              {
+                object: 'passkey',
+                id: '1234',
+                name: 'Chrome on Mac',
+                created_at: Date.now(),
+                last_used_at: Date.now(),
+                verification: null,
+                updated_at: Date.now(),
+              },
+            ],
+          });
+        });
+        fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+        render(<SecurityPage />, { wrapper });
+        await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
+        screen.getByText('Passkeys');
+        screen.getByText('Chrome on Mac');
+      });
+
+      it('hides the passkeys section when passkeys are not enabled', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withUser({
+            email_addresses: ['test@clerk.com'],
+          });
+        });
+        fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+        render(<SecurityPage />, { wrapper });
+        await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
+        expect(screen.queryByText('Passkeys')).not.toBeInTheDocument();
+      });
+    });
   });
 
   it('shows the active devices of the user and has appropriate buttons', async () => {


### PR DESCRIPTION
- Add `shouldAllowCreation` prop to PasskeySection component to control visibility
- Update SecurityPage to check enterprise account restrictions and pass shouldAllowCreation prop
- Hide entire PasskeySection when user has active enterprise account with disableAdditionalIdentifications flag

This change prevents users from adding passkeys when their enterprise connection explicitly disables additional identification methods, maintaining security policies set by enterprise administrators.

This commit follows a simillar pattern introduced earlier on this PR: https://github.com/clerk/javascript/pull/4211

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passkey creation and the Passkeys section are hidden for enterprise accounts that disallow additional identifications; visibility still respects passkey enablement and enterprise SSO/account settings.

* **Tests**
  * Added tests covering Passkeys section visibility across enterprise and non-enterprise scenarios with varied account settings.

* **Chores**
  * Public passkey data shape updated; bundle size thresholds adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->