### PR TITLE
fix(repo): Update React to v19 for Next.js 15 compatibility in playground

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -14,13 +14,13 @@
     "@clerk/nextjs": "canary",
     "@clerk/themes": "canary",
     "next": "^15",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@types/node": "18.8.3",
-    "@types/react": "18.2.33",
-    "@types/react-dom": "18.2.14",
+    "@types/react": "19.1.10",
+    "@types/react-dom": "19.1.7",
     "eslint": "8.24.0",
     "eslint-config-next": "12.3.1",
     "typescript": "4.8.4"


### PR DESCRIPTION
## Description

Next.js 15 requires React 19 (or the release candidate), but the playground is using React 18.3.1, leading to the following build error: 
```
./node_modules/next/dist/esm/server/create-deduped-by-callsite-server-error-logger.js
Attempted import error: 'cache' is not exported from 'react' (imported as 'React').
```

The cache function was introduced in React 19, which is why Next.js 15 is trying to import it but can't find it.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded React and ReactDOM to 19.1.1 in the Next.js playground.
  * Updated TypeScript typings to React 19 (@types/react 19.1.10, @types/react-dom 19.1.7).

* **Impact**
  * Aligns the playground with the latest React runtime and typings, preparing it for new APIs and behaviors introduced in React 19.
  * Users may notice minor rendering and event model adjustments consistent with React 19 defaults.
  * No feature changes or UI redesigns; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->