### PR TITLE
fix(repo): Update TypeScript to v5 for Next.js 15 compatibility in playground

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -21,8 +21,8 @@
     "@types/node": "18.8.3",
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.7",
-    "eslint": "8.24.0",
-    "eslint-config-next": "12.3.1",
-    "typescript": "4.8.4"
+    "eslint": "9.31.0",
+    "eslint-config-next": "15.5.0",
+    "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated development dependencies: ESLint (8.24.0 → 9.31.0), eslint-config-next (12.3.1 → 15.5.0), and TypeScript (4.8.4 → 5.8.3) to improve linting, Next.js alignment, and language support.
  * No changes to runtime dependencies, scripts, or user-facing behavior; application functionality and user experience remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->