### PR TITLE
fix(nextjs): Keyless drift detection not firing due to async node fs methods

### DIFF
--- a/packages/nextjs/src/server/keyless-telemetry.ts
+++ b/packages/nextjs/src/server/keyless-telemetry.ts
@@ -44,18 +44,18 @@ function getTelemetryFlagFilePath(): string {
 async function tryMarkTelemetryEventAsFired(): Promise<boolean> {
   try {
     if (canUseKeyless) {
-      const { mkdir, writeFile } = nodeFsOrThrow();
+      const { mkdirSync, writeFileSync } = nodeFsOrThrow();
       const flagFilePath = getTelemetryFlagFilePath();
       const flagDirectory = dirname(flagFilePath);
 
       // Ensure the directory exists before attempting to write the file
-      await mkdir(flagDirectory, { recursive: true });
+      await mkdirSync(flagDirectory, { recursive: true });
 
       const flagData = {
         firedAt: new Date().toISOString(),
         event: EVENT_KEYLESS_ENV_DRIFT_DETECTED,
       };
-      await writeFile(flagFilePath, JSON.stringify(flagData, null, 2), { flag: 'wx' });
+      await writeFileSync(flagFilePath, JSON.stringify(flagData, null, 2), { flag: 'wx' });
       return true;
     } else {
       return false;


### PR DESCRIPTION
## Description

The telemetry event `KEYLESS_ENV_DRIFT_DETECTED` is not sent due to the error `Failed to create telemetry flag file: TypeError: mkdir is not a function`. This PR Changes `mkdir`, and `writeFile` to `mkdirSync`, and `writeFileSync` in the keyless telemetry logic. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
