### PR TITLE
fix(clerk-js): If password is enabled, instanceIsPasswordBased is true

### DIFF
--- a/.changeset/khaki-ravens-cheer.md
+++ b/.changeset/khaki-ravens-cheer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Update `UserSettings.instanceIsPasswordBased` to return true if password is enabled but not required.

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -191,7 +191,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
   }
 
   get instanceIsPasswordBased() {
-    return Boolean(this.attributes?.password?.enabled && this.attributes.password?.required);
+    return Boolean(this.attributes?.password?.enabled);
   }
 
   get hasValidAuthFactor() {

--- a/packages/clerk-js/src/core/resources/__tests__/UserSettings.spec.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/UserSettings.spec.ts
@@ -75,6 +75,18 @@ describe('UserSettings', () => {
         },
       },
     } as any as UserSettingsJSON);
+
+    expect(sut.instanceIsPasswordBased).toEqual(true);
+
+    sut = new UserSettings({
+      attributes: {
+        password: {
+          enabled: false,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+
     expect(sut.instanceIsPasswordBased).toEqual(false);
   });
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -437,7 +437,7 @@ describe('SignInStart', () => {
       it(`calls sign in with identifier again with only the email if the api respondes with the error ${code}`, async () => {
         const { wrapper, fixtures } = await createFixtures(f => {
           f.withEmailAddress();
-          f.withPassword({ required: true });
+          f.withPassword();
         });
 
         const errJSON = {

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/SecurityPage.test.tsx
@@ -32,9 +32,7 @@ describe('SecurityPage', () => {
 
   it('renders the Password section if instance is password based', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
-      f.withPassword({
-        required: true,
-      });
+      f.withPassword();
       f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));


### PR DESCRIPTION
The Clerk Dashboard now has improved support for enabling an instance configuration with password enabled, but not required. Such a configuration makes passwords optional on sign-up, allows users to add them to accounts, and allows users to use them for sign-in. Previously, passwords were both enabled and required together.

If the instance is configured with password enabled but not required, the SDK should still treat the instance as password based. Modify `UserSettings.instanceIsPasswordBased` to return true in this configuration. This (a) makes sure that the password card is displayed on the SecurityPage so that users can modify their passwords, and (b) allows instant password sign in.

Fixes USER-3245. Tested with unit testing and with local Clerk.

Revised and simplified version of
https://github.com/clerk/javascript/pull/6592 which modifies `UserSettings.instanceIsPasswordBased` instead of adding a new property.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected (for `clerk-js` package)
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Instances with passwords enabled (even if not required) are now treated as password-based. This ensures password sign-in flows behave consistently, instant password autofill works as expected, and the Password section appears in security settings when applicable.

- Tests
  - Updated test scenarios to reflect the new password-enabled behavior, removing assumptions that passwords must be required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->