### PR TITLE
fix(backend): Update logic for cross origin sync handshake

### DIFF
--- a/.changeset/yellow-vans-walk.md
+++ b/.changeset/yellow-vans-walk.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix logic for forcing a session sync on cross origin requests.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1520,6 +1520,31 @@ describe('tokens.authenticateRequest(options)', () => {
       });
     });
 
+    test('does not trigger handshake when referer is same origin', async () => {
+      const request = mockRequestWithCookies(
+        {
+          host: 'localhost:3000',
+          referer: 'http://localhost:3000',
+          'sec-fetch-dest': 'document',
+        },
+        {
+          __clerk_db_jwt: mockJwt,
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'http://localhost:3000',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        signInUrl: 'http://localhost:3000/sign-in',
+      });
+
+      expect(requestState).toBeSignedIn({
+        signInUrl: 'http://localhost:3000/sign-in',
+      });
+    });
+
     test('does not trigger handshake when no referer header', async () => {
       const request = mockRequestWithCookies(
         {

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1605,5 +1605,196 @@ describe('tokens.authenticateRequest(options)', () => {
         signInUrl: 'https://primary.com/sign-in',
       });
     });
+
+    test('does not trigger handshake when referer is from production accounts portal', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://accounts.example.com/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        publishableKey: PK_LIVE,
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      expect(requestState).toBeSignedIn({
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+    });
+
+    test('does not trigger handshake when referer is from dev accounts portal (current format)', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://foo-bar-13.accounts.dev/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        publishableKey: PK_LIVE,
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      expect(requestState).toBeSignedIn({
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+    });
+
+    test('does not trigger handshake when referer is from dev accounts portal (legacy format)', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://accounts.foo-bar-13.lcl.dev/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        publishableKey: PK_LIVE,
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      expect(requestState).toBeSignedIn({
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+    });
+
+    test('does not trigger cross-origin handshake when referer is from expected accounts portal derived from frontend API', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://accounts.inspired.puma-74.lcl.dev/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      // Should not trigger the specific cross-origin sync handshake we're trying to prevent
+      expect(requestState.reason).not.toBe(AuthErrorReason.PrimaryDomainCrossOriginSync);
+    });
+
+    test('does not trigger handshake when referer is from FAPI domain (redirect-based auth)', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://clerk.inspired.puma-74.lcl.dev/v1/client/sign_ins/12345/attempt_first_factor',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      // Should not trigger the specific cross-origin sync handshake we're trying to prevent
+      expect(requestState.reason).not.toBe(AuthErrorReason.PrimaryDomainCrossOriginSync);
+    });
+
+    test('does not trigger handshake when referer is from FAPI domain with https prefix', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://clerk.inspired.puma-74.lcl.dev/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      // Should not trigger the specific cross-origin sync handshake we're trying to prevent
+      expect(requestState.reason).not.toBe(AuthErrorReason.PrimaryDomainCrossOriginSync);
+    });
+
+    test('still triggers handshake for legitimate cross-origin requests from non-accounts domains', async () => {
+      const request = mockRequestWithCookies(
+        {
+          referer: 'https://satellite.com/sign-in',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-site': 'cross-site',
+        },
+        {
+          __session: mockJwt,
+          __client_uat: '12345',
+        },
+        'https://primary.com/dashboard',
+      );
+
+      const requestState = await authenticateRequest(request, {
+        ...mockOptions(),
+        publishableKey: PK_LIVE,
+        domain: 'primary.com',
+        isSatellite: false,
+        signInUrl: 'https://primary.com/sign-in',
+      });
+
+      expect(requestState).toMatchHandshake({
+        reason: AuthErrorReason.PrimaryDomainCrossOriginSync,
+        domain: 'primary.com',
+        signInUrl: 'https://primary.com/sign-in',
+      });
+    });
   });
 });

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -203,7 +203,7 @@ class AuthenticateContext implements AuthenticateContext {
    *
    * @returns {boolean} True if the referrer is from a Clerk accounts portal or FAPI domain, false otherwise
    */
-  public isClerkDomain(): boolean {
+  public isKnownClerkReferrer(): boolean {
     if (!this.referrer) {
       return false;
     }

--- a/packages/backend/src/tokens/authenticateContext.ts
+++ b/packages/backend/src/tokens/authenticateContext.ts
@@ -188,10 +188,6 @@ class AuthenticateContext implements AuthenticateContext {
     }
 
     try {
-      if (this.getHeader(constants.Headers.SecFetchSite) === 'cross-site') {
-        return true;
-      }
-
       const referrerOrigin = new URL(this.referrer).origin;
       return referrerOrigin !== this.clerkUrl.origin;
     } catch {

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -577,7 +577,7 @@ export const authenticateRequest: AuthenticateRequest = (async (
         !authenticateContext.isSatellite && // We're on primary
         authenticateContext.secFetchDest === 'document' && // Document navigation
         authenticateContext.isCrossOriginReferrer() && // Came from different domain
-        !authenticateContext.isClerkDomain(); // Not from Clerk accounts portal or FAPI
+        !authenticateContext.isKnownClerkReferrer(); // Not from Clerk accounts portal or FAPI
 
       if (shouldForceHandshakeForCrossDomain) {
         return handleMaybeHandshakeStatus(

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -576,7 +576,8 @@ export const authenticateRequest: AuthenticateRequest = (async (
       const shouldForceHandshakeForCrossDomain =
         !authenticateContext.isSatellite && // We're on primary
         authenticateContext.secFetchDest === 'document' && // Document navigation
-        authenticateContext.isCrossOriginReferrer(); // Came from different domain
+        authenticateContext.isCrossOriginReferrer() && // Came from different domain
+        !authenticateContext.isClerkDomain(); // Not from Clerk accounts portal or FAPI
 
       if (shouldForceHandshakeForCrossDomain) {
         return handleMaybeHandshakeStatus(


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Fixes an issue in the cross origin sync handshake logic where we were not considering "known" auth referrers, such as our Account Portal or Frontend API. This resulted in unnecessary handshakes even if a user was newly signed in.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests originating from Clerk-managed domains (accounts portal and frontend API) no longer trigger unnecessary primary-domain session handshakes, reducing unexpected redirects and keeping users signed in; non-Clerk cross-origin requests continue to sync as before.  
* **Tests**
  * Added extensive cross-origin handshake test coverage across many referrer origins and scenarios to prevent regressions.  
* **Chores**
  * Added a patch release entry for the backend package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->