### PR TITLE
feat(clerk-js,clerk-react,types): Update signal hooks to always return values

### DIFF
--- a/.changeset/rotten-falcons-cover.md
+++ b/.changeset/rotten-falcons-cover.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+[Experimental] Signals `isLoaded` removal

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -91,7 +91,7 @@ export class SignIn extends BaseResource implements SignInResource {
    *
    * An instance of `SignInFuture`, which has a different API than `SignIn`, intended to be used in custom flows.
    */
-  __internal_future: SignInFuture | null = new SignInFuture(this);
+  __internal_future: SignInFuture = new SignInFuture(this);
 
   /**
    * @internal Only used for internal purposes, and is not intended to be used directly.
@@ -638,7 +638,7 @@ class SignInFuture implements SignInFutureResource {
     });
   }
 
-  async finalize({ navigate }: { navigate?: SetActiveNavigate }): Promise<{ error: unknown }> {
+  async finalize({ navigate }: { navigate?: SetActiveNavigate } = {}): Promise<{ error: unknown }> {
     return runAsyncResourceTask(this.resource, async () => {
       if (!this.resource.createdSessionId) {
         throw new Error('Cannot finalize sign-in without a created session.');

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -87,7 +87,7 @@ export class SignUp extends BaseResource implements SignUpResource {
    *
    * An instance of `SignUpFuture`, which has a different API than `SignUp`, intended to be used in custom flows.
    */
-  __internal_future: SignUpFuture | null = new SignUpFuture(this);
+  __internal_future: SignUpFuture = new SignUpFuture(this);
 
   /**
    * @internal Only used for internal purposes, and is not intended to be used directly.
@@ -539,7 +539,7 @@ class SignUpFuture implements SignUpFutureResource {
     });
   }
 
-  async finalize({ navigate }: { navigate?: SetActiveNavigate }): Promise<{ error: unknown }> {
+  async finalize({ navigate }: { navigate?: SetActiveNavigate } = {}): Promise<{ error: unknown }> {
     return runAsyncResourceTask(this.resource, async () => {
       if (!this.resource.createdSessionId) {
         throw new Error('Cannot finalize sign-up without a created session.');

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -56,6 +56,7 @@ import type {
 
 import { errorThrower } from './errors/errorThrower';
 import { unsupportedNonBrowserDomainOrProxyUrlFunction } from './errors/messages';
+import { StateProxy } from './stateProxy';
 import type {
   BrowserClerk,
   BrowserClerkConstructor,
@@ -158,6 +159,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
   #proxyUrl: DomainOrProxyUrl['proxyUrl'];
   #publishableKey: string;
   #eventBus = createClerkEventBus();
+  #stateProxy: StateProxy;
 
   get publishableKey(): string {
     return this.#publishableKey;
@@ -250,6 +252,7 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     this.options = options;
     this.Clerk = Clerk;
     this.mode = inBrowser() ? 'browser' : 'server';
+    this.#stateProxy = new StateProxy(this);
 
     if (!this.options.sdkMetadata) {
       this.options.sdkMetadata = SDK_METADATA;
@@ -723,8 +726,8 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
     return this.clerkjs?.billing;
   }
 
-  get __internal_state(): State | undefined {
-    return this.clerkjs?.__internal_state;
+  get __internal_state(): State {
+    return this.loaded && this.clerkjs ? this.clerkjs.__internal_state : this.#stateProxy;
   }
 
   get apiKeys(): APIKeysNamespace | undefined {

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -1,8 +1,8 @@
+import { inBrowser } from '@clerk/shared/browser';
 import type { Errors, State } from '@clerk/types';
 
-import type { IsomorphicClerk } from './isomorphicClerk';
-import { inBrowser } from '@clerk/shared';
 import { errorThrower } from './errors/errorThrower';
+import type { IsomorphicClerk } from './isomorphicClerk';
 
 const defaultErrors = (): Errors => ({
   fields: {

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -1,0 +1,108 @@
+import type { Errors, State } from '@clerk/types';
+
+import type { IsomorphicClerk } from './isomorphicClerk';
+
+const defaultErrors = (): Errors => ({
+  fields: {
+    firstName: null,
+    lastName: null,
+    emailAddress: null,
+    identifier: null,
+    phoneNumber: null,
+    password: null,
+    username: null,
+    code: null,
+    captcha: null,
+    legalAccepted: null,
+  },
+  raw: [],
+  global: [],
+});
+
+export class StateProxy implements State {
+  constructor(private isomorphicClerk: IsomorphicClerk) {}
+
+  private readonly signInSignalProxy = this.buildSignInProxy();
+  private readonly signUpSignalProxy = this.buildSignUpProxy();
+
+  signInSignal() {
+    return this.signInSignalProxy;
+  }
+  signUpSignal() {
+    return this.signUpSignalProxy;
+  }
+
+  private buildSignInProxy() {
+    const target = () => this.client.signIn.__internal_future;
+
+    return {
+      errors: defaultErrors(),
+      fetchStatus: 'idle' as const,
+      signIn: {
+        status: 'needs_identifier' as const,
+        availableStrategies: [],
+
+        create: this.gateMethod(target, 'create'),
+        password: this.gateMethod(target, 'password'),
+        sso: this.gateMethod(target, 'sso'),
+        finalize: this.gateMethod(target, 'finalize'),
+
+        emailCode: this.wrapMethods(() => target().emailCode, ['sendCode', 'verifyCode'] as const),
+        resetPasswordEmailCode: this.wrapMethods(() => target().resetPasswordEmailCode, [
+          'sendCode',
+          'verifyCode',
+          'submitPassword',
+        ] as const),
+      },
+    };
+  }
+
+  private buildSignUpProxy() {
+    const target = () => this.client.signUp.__internal_future;
+
+    return {
+      errors: defaultErrors(),
+      fetchStatus: 'idle' as const,
+      signUp: {
+        status: 'missing_requirements' as const,
+        unverifiedFields: [],
+
+        password: this.gateMethod(target, 'password'),
+        finalize: this.gateMethod(target, 'finalize'),
+
+        verifications: this.wrapMethods(() => target().verifications, ['sendEmailCode', 'verifyEmailCode'] as const),
+      },
+    };
+  }
+
+  __internal_effect(_: () => void): () => void {
+    throw new Error('__internal_effect called before Clerk is loaded');
+  }
+  __internal_computed<T>(_: (prev?: T) => T): () => T {
+    throw new Error('__internal_computed called before Clerk is loaded');
+  }
+
+  private get client() {
+    const c = this.isomorphicClerk.client;
+    if (!c) throw new Error('Clerk client not ready');
+    return c;
+  }
+
+  private gateMethod<T extends object, K extends keyof T & string>(getTarget: () => T, key: K) {
+    type F = Extract<T[K], (...args: unknown[]) => unknown>;
+    return (async (...args: Parameters<F>): Promise<ReturnType<F>> => {
+      if (!this.isomorphicClerk.loaded) {
+        await new Promise<void>(resolve => this.isomorphicClerk.addOnLoaded(resolve));
+      }
+      const t = getTarget();
+      return (t[key] as (...args: Parameters<F>) => ReturnType<F>).apply(t, args);
+    }) as F;
+  }
+
+  private wrapMethods<T extends object, K extends readonly (keyof T & string)[]>(
+    getTarget: () => T,
+    keys: K,
+  ): Pick<T, K[number]> {
+    return Object.fromEntries(keys.map(k => [k, this.gateMethod(getTarget, k)])) as Pick<T, K[number]>;
+  }
+}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -235,7 +235,7 @@ export interface Clerk {
    * Entrypoint for Clerk's Signal API containing resource signals along with accessible versions of `computed()` and
    * `effect()` that can be used to subscribe to changes from Signals.
    */
-  __internal_state: State | undefined;
+  __internal_state: State;
 
   /**
    * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -124,6 +124,11 @@ export interface SignInResource extends ClerkResource {
    * @internal
    */
   __internal_toSnapshot: () => SignInJSONSnapshot;
+
+  /**
+   * @internal
+   */
+  __internal_future: SignInFutureResource;
 }
 
 export interface SignInFutureResource {
@@ -151,7 +156,7 @@ export interface SignInFutureResource {
     redirectUrl: string;
     redirectUrlComplete: string;
   }) => Promise<{ error: unknown }>;
-  finalize: (params: { navigate?: SetActiveNavigate }) => Promise<{ error: unknown }>;
+  finalize: (params?: { navigate?: SetActiveNavigate }) => Promise<{ error: unknown }>;
 }
 
 export type SignInStatus =

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -117,6 +117,11 @@ export interface SignUpResource extends ClerkResource {
   authenticateWithCoinbaseWallet: (params?: SignUpAuthenticateWithWeb3Params) => Promise<SignUpResource>;
   authenticateWithOKXWallet: (params?: SignUpAuthenticateWithWeb3Params) => Promise<SignUpResource>;
   __internal_toSnapshot: () => SignUpJSONSnapshot;
+
+  /**
+   * @internal
+   */
+  __internal_future: SignUpFutureResource;
 }
 
 export interface SignUpFutureResource {
@@ -127,7 +132,7 @@ export interface SignUpFutureResource {
     verifyEmailCode: (params: { code: string }) => Promise<{ error: unknown }>;
   };
   password: (params: { emailAddress: string; password: string }) => Promise<{ error: unknown }>;
-  finalize: (params: { navigate?: SetActiveNavigate }) => Promise<{ error: unknown }>;
+  finalize: (params?: { navigate?: SetActiveNavigate }) => Promise<{ error: unknown }>;
 }
 
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';


### PR DESCRIPTION
…n values

## Description

This PR updates our Signal implementation to ensure that a value is _always_ returned, especially when accessed via `IsomorphicClerk` before `clerk-js` has loaded. This is achieved with a new `StateProxy` class instance that will intercept method calls and wait for `clerk-js` to be loaded before calling them, in addition to returning sane default values. When `clerk-js` is loaded, the `__internal_state` property of `IsomorphicClerk` switches to the `clerkjs.__internal_state` property, bypassing the `StateProxy`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sign-in and sign-up signals are now always available (no null returns).
  - finalize() in sign-in/up flows accepts no arguments for simpler usage.

- **Refactor**
  - Internal clerk state now consistently available across environments, improving pre-load behavior of auth flows.

- **Chores**
  - Bumped minor versions of multiple packages.
  - Experimental note: removal of the isLoaded flag from signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->