### PR TITLE
chore(tanstack-react-start,nuxt): Pass `treatPendingAsSignedOut` to auth functions

### DIFF
--- a/.changeset/ninety-wombats-think.md
+++ b/.changeset/ninety-wombats-think.md
@@ -15,6 +15,7 @@ const authStateFn = createServerFn({ method: 'GET' }).handler(async () => {
   return { userId }
 })
 ```
+
 Nuxt
 
 ```ts

--- a/.changeset/ninety-wombats-think.md
+++ b/.changeset/ninety-wombats-think.md
@@ -3,14 +3,14 @@
 "@clerk/tanstack-react-start": patch
 ---
 
-Allows passing of `treatPendingAsSignedOut` to auth functions:
+Allows passing of [`treatPendingAsSignedOut`](https://clerk.com/docs/authentication/configuration/session-tasks#session-handling) to auth functions:
 
 TanStack Start
 
 ```ts
 const authStateFn = createServerFn({ method: 'GET' }).handler(async () => {
   const request = getWebRequest()
-  const { userId } = await getAuth(request, { treatPendingAsSignedOut: true })
+  const { userId } = await getAuth(request, { treatPendingAsSignedOut: false }) // defaults to true
 
   return { userId }
 })
@@ -19,7 +19,7 @@ Nuxt
 
 ```ts
 export default eventHandler((event) => {
-  const { userId } = event.context.auth({ treatPendingAsSignedOut: true })
+  const { userId } = event.context.auth({ treatPendingAsSignedOut: false }) // defaults to true
 
   return { userId }
 })

--- a/.changeset/ninety-wombats-think.md
+++ b/.changeset/ninety-wombats-think.md
@@ -1,0 +1,26 @@
+---
+"@clerk/nuxt": patch
+"@clerk/tanstack-react-start": patch
+---
+
+Allows passing of `treatPendingAsSignedOut` to auth functions:
+
+TanStack Start
+
+```ts
+const authStateFn = createServerFn({ method: 'GET' }).handler(async () => {
+  const request = getWebRequest()
+  const { userId } = await getAuth(request, { treatPendingAsSignedOut: true })
+
+  return { userId }
+})
+```
+Nuxt
+
+```ts
+export default eventHandler((event) => {
+  const { userId } = event.context.auth({ treatPendingAsSignedOut: true })
+
+  return { userId }
+})
+```

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -1,5 +1,5 @@
 import type { AuthenticateRequestOptions } from '@clerk/backend/internal';
-import { AuthStatus, constants, getAuthObjectForAcceptedToken, TokenType } from '@clerk/backend/internal';
+import { AuthStatus, constants, getAuthObjectForAcceptedToken } from '@clerk/backend/internal';
 import { deprecated } from '@clerk/shared/deprecated';
 import { handleNetlifyCacheInDevInstance } from '@clerk/shared/netlifyCacheHandler';
 import type { PendingSessionOptions } from '@clerk/types';
@@ -111,8 +111,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
 
     const authObjectFn = (opts?: PendingSessionOptions) => requestState.toAuth(opts);
     const authHandler: AuthFn = ((options?: AuthOptions) => {
-      const acceptsToken = options?.acceptsToken ?? TokenType.SessionToken;
-      return getAuthObjectForAcceptedToken({ authObject: authObjectFn(options), acceptsToken });
+      return getAuthObjectForAcceptedToken({ authObject: authObjectFn(options), acceptsToken: options?.acceptsToken });
     }) as AuthFn;
 
     const auth = new Proxy(authHandler, {

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -2,6 +2,7 @@ import type { AuthenticateRequestOptions } from '@clerk/backend/internal';
 import { AuthStatus, constants, getAuthObjectForAcceptedToken, TokenType } from '@clerk/backend/internal';
 import { deprecated } from '@clerk/shared/deprecated';
 import { handleNetlifyCacheInDevInstance } from '@clerk/shared/netlifyCacheHandler';
+import type { PendingSessionOptions } from '@clerk/types';
 import type { EventHandler } from 'h3';
 import { createError, eventHandler, setResponseHeader } from 'h3';
 
@@ -108,10 +109,10 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
       });
     }
 
-    const authObject = requestState.toAuth();
+    const authObjectFn = (opts?: PendingSessionOptions) => requestState.toAuth(opts);
     const authHandler: AuthFn = ((options?: AuthOptions) => {
       const acceptsToken = options?.acceptsToken ?? TokenType.SessionToken;
-      return getAuthObjectForAcceptedToken({ authObject, acceptsToken });
+      return getAuthObjectForAcceptedToken({ authObject: authObjectFn(options), acceptsToken });
     }) as AuthFn;
 
     const auth = new Proxy(authHandler, {
@@ -120,13 +121,13 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
         // If the property exists on the function, return it
         if (prop in target) return Reflect.get(target, prop, receiver);
         // Otherwise, get it from the authObject
-        return authObject?.[prop as keyof typeof authObject];
+        return authObjectFn()?.[prop as keyof typeof authObjectFn];
       },
     });
 
     event.context.auth = auth;
     // Internal serializable state that will be passed to the client
-    event.context.__clerk_initial_state = createInitialState(authObject);
+    event.context.__clerk_initial_state = createInitialState(authObjectFn());
 
     await handler?.(event);
   });

--- a/packages/nuxt/src/runtime/server/types.ts
+++ b/packages/nuxt/src/runtime/server/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '@clerk/backend/internal';
 import type { PendingSessionOptions } from '@clerk/types';
 
-export type AuthOptions = PendingSessionOptions & { acceptsToken?: AuthenticateRequestOptions['acceptsToken'] };
+export type AuthOptions = PendingSessionOptions & Pick<AuthenticateRequestOptions, 'acceptsToken'>;
 
 /**
  * @internal This type is used to define the `auth` function in the event context.

--- a/packages/nuxt/src/runtime/server/types.ts
+++ b/packages/nuxt/src/runtime/server/types.ts
@@ -6,8 +6,9 @@ import type {
   SessionTokenType,
   TokenType,
 } from '@clerk/backend/internal';
+import type { PendingSessionOptions } from '@clerk/types';
 
-export type AuthOptions = { acceptsToken?: AuthenticateRequestOptions['acceptsToken'] };
+export type AuthOptions = PendingSessionOptions & { acceptsToken?: AuthenticateRequestOptions['acceptsToken'] };
 
 /**
  * @internal This type is used to define the `auth` function in the event context.
@@ -41,5 +42,5 @@ export interface AuthFn {
    * @example
    * const auth = event.context.auth()
    */
-  (): SessionAuthObject;
+  (options?: PendingSessionOptions): SessionAuthObject;
 }

--- a/packages/tanstack-react-start/src/server/getAuth.ts
+++ b/packages/tanstack-react-start/src/server/getAuth.ts
@@ -1,11 +1,12 @@
 import type { AuthenticateRequestOptions, GetAuthFn } from '@clerk/backend/internal';
 import { getAuthObjectForAcceptedToken } from '@clerk/backend/internal';
+import type { PendingSessionOptions } from '@clerk/types';
 import { getContext } from '@tanstack/react-start/server';
 
 import { errorThrower } from '../utils';
 import { clerkHandlerNotConfigured, noFetchFnCtxPassedInGetAuth } from '../utils/errors';
 
-type GetAuthOptions = { acceptsToken?: AuthenticateRequestOptions['acceptsToken'] };
+type GetAuthOptions = PendingSessionOptions & Pick<AuthenticateRequestOptions, 'acceptsToken'>;
 
 export const getAuth: GetAuthFn<Request, true> = (async (request: Request, opts?: GetAuthOptions) => {
   if (!request) {
@@ -19,7 +20,7 @@ export const getAuth: GetAuthFn<Request, true> = (async (request: Request, opts?
   }
 
   // We're keeping it a promise for now to minimize breaking changes
-  const authObject = await Promise.resolve(authObjectFn());
+  const authObject = await Promise.resolve(authObjectFn({ treatPendingAsSignedOut: opts?.treatPendingAsSignedOut }));
 
   return getAuthObjectForAcceptedToken({ authObject, acceptsToken: opts?.acceptsToken });
 }) as GetAuthFn<Request, true>;

--- a/packages/tanstack-react-start/src/server/middlewareHandler.ts
+++ b/packages/tanstack-react-start/src/server/middlewareHandler.ts
@@ -1,5 +1,6 @@
 import { AuthStatus, constants } from '@clerk/backend/internal';
 import { handleNetlifyCacheInDevInstance } from '@clerk/shared/netlifyCacheHandler';
+import type { PendingSessionOptions } from '@clerk/types';
 import type { AnyRouter } from '@tanstack/react-router';
 import {
   type CustomizeStartHandler,
@@ -30,7 +31,7 @@ export function createClerkHandler<TRouter extends AnyRouter>(
     });
 
     // Set auth object here so it is available immediately in server functions via getAuth()
-    event.context.auth = () => requestState.toAuth();
+    event.context.auth = (options?: PendingSessionOptions) => requestState.toAuth(options);
 
     return eventHandler(async ({ request, router, responseHeaders }) => {
       const locationHeader = requestState.headers.get(constants.Headers.Location);


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth helpers now accept optional per-call settings (e.g., treatPendingAsSignedOut) for finer pending-session handling.
  * Per-call token acceptance can be specified when calling auth/getAuth.

* **Improvements**
  * Unified options support across server frameworks and examples; middleware/context auth forwards options.

* **Compatibility**
  * Public API shapes remain compatible; existing calls continue to work without providing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->