### PR TITLE
refactor(clerk-js): Remove unused debugLogger functionality

### DIFF
--- a/.changeset/dull-rules-dance.md
+++ b/.changeset/dull-rules-dance.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removing unused debugLogger functionality

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -85,7 +85,6 @@ import type {
   Web3Provider,
 } from '@clerk/types';
 
-import type { DebugLoggerInterface } from '@/utils/debug';
 import { debugLogger, initDebugLogger } from '@/utils/debug';
 
 import type { MountComponentRenderer } from '../ui/Components';
@@ -163,11 +162,6 @@ type SetActiveHook = (intent?: 'sign-out') => void | Promise<void>;
 
 export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 
-/**
- * Interface for the debug logger with all available logging methods
- */
-// DebugLoggerInterface imported from '@/utils/debug'
-
 declare global {
   interface Window {
     Clerk?: Clerk;
@@ -219,8 +213,6 @@ export class Clerk implements ClerkInterface {
   public __internal_country?: string | null;
   public telemetry: TelemetryCollector | undefined;
   public readonly __internal_state: State = new State();
-  // Deprecated: use global singleton from `@/utils/debug`
-  public debugLogger?: DebugLoggerInterface;
 
   protected internal_last_error: ClerkAPIError | null = null;
   // converted to protected environment to support `updateEnvironment` type assertion

--- a/packages/clerk-js/src/core/modules/debug/__tests__/logger.spec.ts
+++ b/packages/clerk-js/src/core/modules/debug/__tests__/logger.spec.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { DebugLogger } from '../logger';
-import type { DebugLogEntry, DebugLogFilter } from '../types';
+import type { DebugLogEntry } from '../types';
 
-// Mock transport for testing
 class MockTransport {
   public sentEntries: DebugLogEntry[] = [];
 
@@ -70,267 +69,64 @@ describe('DebugLogger', () => {
     });
   });
 
-  describe('filter functionality', () => {
-    describe('level filtering', () => {
-      it('should filter by specific log level', () => {
-        const filters: DebugLogFilter[] = [{ level: 'error' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+  describe('edge cases', () => {
+    it('should handle undefined context', () => {
+      logger.info('message with undefined context', undefined);
 
-        filteredLogger.info('info message');
-        filteredLogger.warn('warn message');
-        filteredLogger.error('error message');
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].level).toBe('error');
-      });
-
-      it('should allow all levels when no level filter is specified', () => {
-        const filters: DebugLogFilter[] = [{}];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('info message');
-        filteredLogger.warn('warn message');
-        filteredLogger.error('error message');
-
-        expect(mockTransport.sentEntries).toHaveLength(3);
-      });
+      expect(mockTransport.sentEntries).toHaveLength(1);
+      expect(mockTransport.sentEntries[0].context).toBeUndefined();
     });
 
-    describe('source filtering', () => {
-      it('should filter by exact string source', () => {
-        const filters: DebugLogFilter[] = [{ source: 'auth-module' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+    it('should handle undefined source', () => {
+      logger.info('message with undefined source', {}, undefined);
 
-        filteredLogger.info('message 1', undefined, 'auth-module');
-        filteredLogger.info('message 2', undefined, 'other-module');
-        filteredLogger.info('message 3', undefined, 'auth-module');
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].source).toBe('auth-module');
-        expect(mockTransport.sentEntries[1].source).toBe('auth-module');
-      });
-
-      it('should filter by RegExp source pattern', () => {
-        const filters: DebugLogFilter[] = [{ source: /auth-.*/ }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message 1', undefined, 'auth-module');
-        filteredLogger.info('message 2', undefined, 'auth-service');
-        filteredLogger.info('message 3', undefined, 'other-module');
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].source).toBe('auth-module');
-        expect(mockTransport.sentEntries[1].source).toBe('auth-service');
-      });
-
-      it('should not log when source is undefined and filter expects a source', () => {
-        const filters: DebugLogFilter[] = [{ source: 'auth-module' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message without source');
-
-        expect(mockTransport.sentEntries).toHaveLength(0);
-      });
+      expect(mockTransport.sentEntries).toHaveLength(1);
+      expect(mockTransport.sentEntries[0].source).toBeUndefined();
     });
 
-    describe('include pattern filtering', () => {
-      it('should include messages matching string patterns', () => {
-        const filters: DebugLogFilter[] = [{ includePatterns: ['user', 'auth'] }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+    it('should handle empty context object', () => {
+      logger.info('message with empty context', {});
 
-        filteredLogger.info('user login successful');
-        filteredLogger.info('auth token refreshed');
-        filteredLogger.info('database connection established');
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].message).toBe('user login successful');
-        expect(mockTransport.sentEntries[1].message).toBe('auth token refreshed');
-      });
-
-      it('should include messages matching RegExp patterns', () => {
-        const filters: DebugLogFilter[] = [{ includePatterns: [/user-.*/] }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('user-123 logged in');
-        filteredLogger.info('user-456 logged out');
-        filteredLogger.info('admin panel accessed');
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].message).toBe('user-123 logged in');
-        expect(mockTransport.sentEntries[1].message).toBe('user-456 logged out');
-      });
+      expect(mockTransport.sentEntries).toHaveLength(1);
+      expect(mockTransport.sentEntries[0].context).toEqual({});
     });
 
-    describe('exclude pattern filtering', () => {
-      it('should exclude messages matching string patterns', () => {
-        const filters: DebugLogFilter[] = [{ excludePatterns: ['debug', 'test'] }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+    it('should handle empty source string', () => {
+      logger.info('message with empty source', {}, '');
 
-        filteredLogger.info('user login successful');
-        filteredLogger.info('debug information logged');
-        filteredLogger.info('test data generated');
+      expect(mockTransport.sentEntries).toHaveLength(1);
+      expect(mockTransport.sentEntries[0].source).toBe('');
+    });
+  });
 
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].message).toBe('user login successful');
-      });
+  describe('transport integration', () => {
+    it('should call transport.send for each log entry', async () => {
+      let sendCallCount = 0;
+      const countingTransport = {
+        async send(_entry: DebugLogEntry): Promise<void> {
+          sendCallCount++;
+        },
+      };
 
-      it('should exclude messages matching RegExp patterns', () => {
-        const filters: DebugLogFilter[] = [{ excludePatterns: [/test-.*/] }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+      const testLogger = new DebugLogger(countingTransport, 'info');
 
-        filteredLogger.info('user login successful');
-        filteredLogger.info('test-123 created');
-        filteredLogger.info('test-456 deleted');
+      testLogger.info('message 1');
+      testLogger.warn('message 2');
+      testLogger.error('message 3');
 
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].message).toBe('user login successful');
-      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(sendCallCount).toBe(3);
     });
 
-    // Note: userId and sessionId filtering are defined in types but not yet implemented
-    // These tests are commented out until the feature is implemented
-    /*
-    describe('userId filtering', () => {
-      it('should filter by specific userId', () => {
-        const filters: DebugLogFilter[] = [{ userId: 'user-123' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
+    it('should include timestamp in log entries', () => {
+      const beforeTime = Date.now();
+      logger.info('test message');
+      const afterTime = Date.now();
 
-        filteredLogger.info('message 1', { userId: 'user-123' });
-        filteredLogger.info('message 2', { userId: 'user-456' });
-        filteredLogger.info('message 3', { userId: 'user-123' });
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].context?.userId).toBe('user-123');
-        expect(mockTransport.sentEntries[1].context?.userId).toBe('user-123');
-      });
-
-      it('should not log when userId is undefined and filter expects a userId', () => {
-        const filters: DebugLogFilter[] = [{ userId: 'user-123' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message without userId');
-
-        expect(mockTransport.sentEntries).toHaveLength(0);
-      });
-    });
-
-    describe('sessionId filtering', () => {
-      it('should filter by specific sessionId', () => {
-        const filters: DebugLogFilter[] = [{ sessionId: 'session-abc' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message 1', { sessionId: 'session-abc' });
-        filteredLogger.info('message 2', { sessionId: 'session-xyz' });
-        filteredLogger.info('message 3', { sessionId: 'session-abc' });
-
-        expect(mockTransport.sentEntries).toHaveLength(2);
-        expect(mockTransport.sentEntries[0].context?.sessionId).toBe('session-abc');
-        expect(mockTransport.sentEntries[1].context?.sessionId).toBe('session-abc');
-      });
-
-      it('should not log when sessionId is undefined and filter expects a sessionId', () => {
-        const filters: DebugLogFilter[] = [{ sessionId: 'session-abc' }];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message without sessionId');
-
-        expect(mockTransport.sentEntries).toHaveLength(0);
-      });
-    });
-    */
-
-    describe('combined filtering', () => {
-      it('should apply multiple filters with AND logic', () => {
-        const filters: DebugLogFilter[] = [
-          { level: 'error' },
-          { source: 'auth-module' },
-          { includePatterns: ['failed'] },
-        ];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.error('login failed', undefined, 'auth-module');
-        filteredLogger.error('login successful', undefined, 'auth-module');
-        filteredLogger.warn('login failed', undefined, 'auth-module');
-        filteredLogger.error('login failed', undefined, 'other-module');
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].message).toBe('login failed');
-        expect(mockTransport.sentEntries[0].level).toBe('error');
-        expect(mockTransport.sentEntries[0].source).toBe('auth-module');
-      });
-
-      it('should handle empty filters array', () => {
-        const filters: DebugLogFilter[] = [];
-        const filteredLogger = new DebugLogger(mockTransport, 'debug', filters);
-
-        filteredLogger.info('message 1');
-        filteredLogger.warn('message 2');
-        filteredLogger.error('message 3');
-
-        expect(mockTransport.sentEntries).toHaveLength(3);
-      });
-    });
-
-    describe('edge cases', () => {
-      it('should handle undefined context', () => {
-        logger.info('message with undefined context', undefined);
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].context).toBeUndefined();
-      });
-
-      it('should handle undefined source', () => {
-        logger.info('message with undefined source', {}, undefined);
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].source).toBeUndefined();
-      });
-
-      it('should handle empty context object', () => {
-        logger.info('message with empty context', {});
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].context).toEqual({});
-      });
-
-      it('should handle empty source string', () => {
-        logger.info('message with empty source', {}, '');
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].source).toBe('');
-      });
-    });
-
-    describe('transport integration', () => {
-      it('should call transport.send for each log entry', async () => {
-        let sendCallCount = 0;
-        const countingTransport = {
-          async send(_entry: DebugLogEntry): Promise<void> {
-            sendCallCount++;
-          },
-        };
-
-        const testLogger = new DebugLogger(countingTransport, 'info');
-
-        testLogger.info('message 1');
-        testLogger.warn('message 2');
-        testLogger.error('message 3');
-
-        // Allow async operations to complete
-        await new Promise(resolve => setTimeout(resolve, 0));
-
-        expect(sendCallCount).toBe(3);
-      });
-
-      it('should include timestamp in log entries', () => {
-        const beforeTime = Date.now();
-        logger.info('test message');
-        const afterTime = Date.now();
-
-        expect(mockTransport.sentEntries).toHaveLength(1);
-        expect(mockTransport.sentEntries[0].timestamp).toBeGreaterThanOrEqual(beforeTime);
-        expect(mockTransport.sentEntries[0].timestamp).toBeLessThanOrEqual(afterTime);
-      });
+      expect(mockTransport.sentEntries).toHaveLength(1);
+      expect(mockTransport.sentEntries[0].timestamp).toBeGreaterThanOrEqual(beforeTime);
+      expect(mockTransport.sentEntries[0].timestamp).toBeLessThanOrEqual(afterTime);
     });
   });
 });

--- a/packages/clerk-js/src/core/modules/debug/__tests__/logger.spec.ts
+++ b/packages/clerk-js/src/core/modules/debug/__tests__/logger.spec.ts
@@ -21,7 +21,7 @@ describe('DebugLogger', () => {
 
   beforeEach(() => {
     mockTransport = new MockTransport();
-    logger = new DebugLogger(mockTransport, 'trace');
+    logger = new DebugLogger(mockTransport, 'debug');
   });
 
   afterEach(() => {
@@ -34,14 +34,12 @@ describe('DebugLogger', () => {
       logger.warn('warn message');
       logger.info('info message');
       logger.debug('debug message');
-      logger.trace('trace message');
 
-      expect(mockTransport.sentEntries).toHaveLength(5);
+      expect(mockTransport.sentEntries).toHaveLength(4);
       expect(mockTransport.sentEntries[0].level).toBe('error');
       expect(mockTransport.sentEntries[1].level).toBe('warn');
       expect(mockTransport.sentEntries[2].level).toBe('info');
       expect(mockTransport.sentEntries[3].level).toBe('debug');
-      expect(mockTransport.sentEntries[4].level).toBe('trace');
     });
 
     it('should include context and source in log entries', () => {
@@ -58,7 +56,6 @@ describe('DebugLogger', () => {
     it('should respect log level filtering', () => {
       const infoLogger = new DebugLogger(mockTransport, 'info');
 
-      infoLogger.trace('trace message');
       infoLogger.debug('debug message');
       infoLogger.info('info message');
       infoLogger.warn('warn message');

--- a/packages/clerk-js/src/core/modules/debug/logger.ts
+++ b/packages/clerk-js/src/core/modules/debug/logger.ts
@@ -58,16 +58,7 @@ export class DebugLogger {
     this.log('info', message, context, source);
   }
 
-  /**
-   * Log a trace message.
-   *
-   * @param message - Text description of the event
-   * @param context - Optional structured context to attach
-   * @param source - Optional logical source identifier
-   */
-  trace(message: string, context?: Record<string, unknown>, source?: string): void {
-    this.log('trace', message, context, source);
-  }
+  // trace level removed
 
   /**
    * Log a warning message.
@@ -99,7 +90,7 @@ export class DebugLogger {
   }
 
   private shouldLogLevel(level: DebugLogLevel): boolean {
-    const levels: DebugLogLevel[] = ['error', 'warn', 'info', 'debug', 'trace'];
+    const levels: DebugLogLevel[] = ['error', 'warn', 'info', 'debug'];
     const currentLevelIndex = levels.indexOf(this.logLevel);
     const messageLevelIndex = levels.indexOf(level);
     return messageLevelIndex <= currentLevelIndex;

--- a/packages/clerk-js/src/core/modules/debug/logger.ts
+++ b/packages/clerk-js/src/core/modules/debug/logger.ts
@@ -1,4 +1,4 @@
-import type { DebugLogEntry, DebugLogFilter, DebugLogLevel, DebugTransport } from './types';
+import type { DebugLogEntry, DebugLogLevel, DebugTransport } from './types';
 
 /**
  * Default log level for debug logging
@@ -11,7 +11,6 @@ const DEFAULT_LOG_LEVEL: DebugLogLevel = 'debug';
  * @public
  */
 export class DebugLogger {
-  private readonly filters?: DebugLogFilter[];
   private readonly logLevel: DebugLogLevel;
   private readonly transport: DebugTransport;
 
@@ -20,12 +19,10 @@ export class DebugLogger {
    *
    * @param transport - Transport used to send log entries
    * @param logLevel - Minimum log level to record. Defaults to `'debug'`
-   * @param filters - Optional list of filters to include or exclude messages
    */
-  constructor(transport: DebugTransport, logLevel?: DebugLogLevel, filters?: DebugLogFilter[]) {
+  constructor(transport: DebugTransport, logLevel?: DebugLogLevel) {
     this.transport = transport;
     this.logLevel = logLevel ?? DEFAULT_LOG_LEVEL;
-    this.filters = filters;
   }
 
   /**
@@ -88,10 +85,6 @@ export class DebugLogger {
       return;
     }
 
-    if (!this.shouldLogFilters(level, message, source)) {
-      return;
-    }
-
     const entry: DebugLogEntry = {
       timestamp: Date.now(),
       level,
@@ -110,73 +103,5 @@ export class DebugLogger {
     const currentLevelIndex = levels.indexOf(this.logLevel);
     const messageLevelIndex = levels.indexOf(level);
     return messageLevelIndex <= currentLevelIndex;
-  }
-
-  private shouldLogFilters(level: DebugLogLevel, message: string, source?: string): boolean {
-    if (!this.filters || this.filters.length === 0) {
-      return true;
-    }
-
-    return this.filters.every(filter => {
-      if (filter.level && filter.level !== level) {
-        return false;
-      }
-
-      if (filter.source && !this.matchesSource(filter.source, source)) {
-        return false;
-      }
-
-      if (
-        filter.includePatterns &&
-        filter.includePatterns.length > 0 &&
-        !this.shouldInclude(message, filter.includePatterns)
-      ) {
-        return false;
-      }
-
-      if (
-        filter.excludePatterns &&
-        filter.excludePatterns.length > 0 &&
-        this.shouldExclude(message, filter.excludePatterns)
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-  }
-
-  /**
-   * Checks if a source matches the given pattern (string or RegExp)
-   */
-  private matchesSource(pattern: string | RegExp, source?: string): boolean {
-    if (typeof pattern === 'string') {
-      return source === pattern;
-    }
-    return source !== undefined && pattern.test(source);
-  }
-
-  /**
-   * Checks if a message should be included based on the given patterns
-   */
-  private shouldInclude(message: string, patterns: (string | RegExp)[]): boolean {
-    return patterns.some(pattern => this.matchesPattern(message, pattern));
-  }
-
-  /**
-   * Checks if a message should be excluded based on the given patterns
-   */
-  private shouldExclude(message: string, patterns: (string | RegExp)[]): boolean {
-    return patterns.some(pattern => this.matchesPattern(message, pattern));
-  }
-
-  /**
-   * Checks if a message matches a given pattern (string or RegExp)
-   */
-  private matchesPattern(message: string, pattern: string | RegExp): boolean {
-    if (typeof pattern === 'string') {
-      return message.includes(pattern);
-    }
-    return pattern.test(message);
   }
 }

--- a/packages/clerk-js/src/core/modules/debug/transports/__tests__/telemetry.spec.ts
+++ b/packages/clerk-js/src/core/modules/debug/transports/__tests__/telemetry.spec.ts
@@ -59,7 +59,6 @@ describe('TelemetryTransport', () => {
       timestamp: Date.now(),
     };
 
-    // Should not throw when no collector is provided
     await expect(transportWithoutCollector.send(logEntry)).resolves.toBeUndefined();
   });
 });

--- a/packages/clerk-js/src/core/modules/debug/transports/composite.ts
+++ b/packages/clerk-js/src/core/modules/debug/transports/composite.ts
@@ -1,4 +1,4 @@
-import type { DebugLogEntry, DebugLogFilter, DebugTransport } from '../types';
+import type { DebugLogEntry, DebugTransport } from '../types';
 
 /**
  * Options for configuring a composite debug transport that fans out logs
@@ -7,7 +7,6 @@ import type { DebugLogEntry, DebugLogFilter, DebugTransport } from '../types';
  * @public
  */
 export interface CompositeLoggerOptions {
-  filters?: DebugLogFilter[];
   logLevel?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
   transports: Array<{
     options?: Record<string, unknown>;

--- a/packages/clerk-js/src/core/modules/debug/transports/composite.ts
+++ b/packages/clerk-js/src/core/modules/debug/transports/composite.ts
@@ -7,7 +7,7 @@ import type { DebugLogEntry, DebugTransport } from '../types';
  * @public
  */
 export interface CompositeLoggerOptions {
-  logLevel?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
+  logLevel?: 'error' | 'warn' | 'info' | 'debug';
   transports: Array<{
     options?: Record<string, unknown>;
     transport: DebugTransport;

--- a/packages/clerk-js/src/core/modules/debug/transports/console.ts
+++ b/packages/clerk-js/src/core/modules/debug/transports/console.ts
@@ -24,7 +24,6 @@ const LEVEL_COLORS = {
   debug: COLORS.green,
   error: COLORS.red,
   info: COLORS.blue,
-  trace: COLORS.magenta,
   warn: COLORS.yellow,
 } as const;
 
@@ -70,9 +69,6 @@ export class ConsoleTransport implements DebugTransport {
         break;
       case 'debug':
         console.debug(message);
-        break;
-      case 'trace':
-        console.trace(message);
         break;
       default:
         console.log(message);

--- a/packages/clerk-js/src/core/modules/debug/transports/telemetry.ts
+++ b/packages/clerk-js/src/core/modules/debug/transports/telemetry.ts
@@ -1,6 +1,6 @@
-import type { TelemetryCollector } from '@clerk/shared/telemetry';
+import type { TelemetryCollector } from '@clerk/types';
 
-import type { DebugLogEntry, DebugLogFilter, DebugLogLevel, DebugTransport } from '../types';
+import type { DebugLogEntry, DebugLogLevel, DebugTransport } from '../types';
 
 /**
  * Options for configuring a telemetry-backed transport.
@@ -10,7 +10,6 @@ import type { DebugLogEntry, DebugLogFilter, DebugLogLevel, DebugTransport } fro
 export interface TelemetryLoggerOptions {
   endpoint?: string;
   logLevel?: DebugLogLevel;
-  filters?: DebugLogFilter[];
 }
 
 /**

--- a/packages/clerk-js/src/core/modules/debug/types.ts
+++ b/packages/clerk-js/src/core/modules/debug/types.ts
@@ -50,9 +50,6 @@ export interface DebugData {
  * Transport interface for sending debug log entries to different destinations
  */
 export interface DebugTransport {
-  /**
-   * Send a single debug log entry
-   */
   send(entry: DebugLogEntry): Promise<void>;
 }
 
@@ -128,22 +125,3 @@ export function isDebugData(obj: unknown): obj is DebugData {
     typeof (obj as DebugData).timestamp === 'number'
   );
 }
-
-/**
- * Utility type for creating partial debug logger configurations
- */
-export type PartialDebugLoggerConfig = Partial<DebugLoggerConfig>;
-
-/**
- * Utility type for creating debug log entries without readonly constraint
- */
-export type MutableDebugLogEntry = {
-  -readonly [K in keyof DebugLogEntry]: DebugLogEntry[K];
-};
-
-/**
- * Utility type for creating debug data without readonly constraint
- */
-export type MutableDebugData = {
-  -readonly [K in keyof DebugData]: DebugData[K];
-};

--- a/packages/clerk-js/src/core/modules/debug/types.ts
+++ b/packages/clerk-js/src/core/modules/debug/types.ts
@@ -75,23 +75,10 @@ export interface ErrorDetails {
  */
 export interface DebugLoggerConfig {
   readonly bufferSize: number;
-  readonly filters?: DebugLogFilter[];
   readonly flushInterval: number;
   readonly logLevel: DebugLogLevel;
   readonly maxLogEntries: number;
   readonly transport?: DebugTransport;
-}
-
-/**
- * Filter configuration for debug logs
- */
-export interface DebugLogFilter {
-  readonly excludePatterns?: (string | RegExp)[];
-  readonly includePatterns?: (string | RegExp)[];
-  readonly level?: DebugLogLevel;
-  readonly sessionId?: string;
-  readonly source?: string | RegExp;
-  readonly userId?: string;
 }
 
 /**

--- a/packages/clerk-js/src/core/modules/debug/types.ts
+++ b/packages/clerk-js/src/core/modules/debug/types.ts
@@ -1,12 +1,12 @@
 /**
  * Debug logging levels for different types of information
  */
-export type DebugLogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
+export type DebugLogLevel = 'error' | 'warn' | 'info' | 'debug';
 
 /**
  * Valid debug log levels
  */
-export const VALID_LOG_LEVELS: readonly DebugLogLevel[] = ['error', 'warn', 'info', 'debug', 'trace'] as const;
+export const VALID_LOG_LEVELS: readonly DebugLogLevel[] = ['error', 'warn', 'info', 'debug'] as const;
 
 /**
  * Valid debug event types

--- a/packages/clerk-js/src/utils/debug.ts
+++ b/packages/clerk-js/src/utils/debug.ts
@@ -1,6 +1,6 @@
 import type { TelemetryCollector } from '@clerk/shared/telemetry';
 
-import type { DebugLogFilter, DebugLogLevel } from '@/core/modules/debug/types';
+import type { DebugLogLevel } from '@/core/modules/debug/types';
 
 /**
  * Lightweight logger surface that callers can import as a singleton.
@@ -16,7 +16,6 @@ export interface DebugLoggerInterface {
 
 type InitOptions = {
   enabled?: boolean;
-  filters?: DebugLogFilter[];
   logLevel?: DebugLogLevel;
   telemetryCollector?: TelemetryCollector;
 };
@@ -84,7 +83,6 @@ async function ensureInitialized(): Promise<void> {
 
     const { getDebugLogger } = await import('@/core/modules/debug');
     const logger = await getDebugLogger({
-      filters: lastOptions?.filters,
       logLevel: lastOptions?.logLevel ?? 'trace',
       telemetryCollector: lastOptions?.telemetryCollector,
     });
@@ -126,12 +124,10 @@ async function ensureInitialized(): Promise<void> {
  * Options and defaults:
  * - options.enabled: defaults to true
  * - options.logLevel: defaults to 'trace'
- * - options.filters: optional include/exclude filters and matching rules
  * - options.telemetryCollector: optional telemetry sink to forward logs
  *
  * @param options - Configuration options
  * @param options.enabled - Enables the logger; when false, logger is a no-op (default: true)
- * @param options.filters - Filters applied to log entries (level, source, include/exclude patterns)
  * @param options.logLevel - Minimal level to log; lower-priority logs are ignored (default: 'trace')
  * @param options.telemetryCollector - Collector used by the debug transport for emitting telemetry
  *
@@ -159,7 +155,6 @@ export function initDebugLogger(options: InitOptions = {}): void {
         const { __internal_resetDebugLogger, getDebugLogger } = await import('@/core/modules/debug');
         __internal_resetDebugLogger();
         const logger = await getDebugLogger({
-          filters: lastOptions?.filters,
           logLevel: lastOptions?.logLevel ?? 'trace',
           telemetryCollector: lastOptions?.telemetryCollector,
         });

--- a/packages/clerk-js/src/utils/debug.ts
+++ b/packages/clerk-js/src/utils/debug.ts
@@ -82,7 +82,7 @@ async function ensureInitialized(options?: Omit<InitOptions, 'enabled'>): Promis
 
     const { getDebugLogger } = await import('@/core/modules/debug');
     const logger = await getDebugLogger({
-      logLevel: options?.logLevel ?? 'debug',
+      logLevel: options?.logLevel,
       telemetryCollector: options?.telemetryCollector,
     });
 
@@ -107,7 +107,7 @@ async function ensureInitialized(options?: Omit<InitOptions, 'enabled'>): Promis
  *
  * @param options - Configuration options
  * @param options.enabled - Enables the logger; when false, logger is a no-op (default: false)
- * @param options.logLevel - Minimal level to log; lower-priority logs are ignored (default: 'trace')
+ * @param options.logLevel - Minimal level to log; lower-priority logs are ignored. Valid levels: 'error' | 'warn' | 'info' | 'debug'.
  * @param options.telemetryCollector - Collector used by the debug transport for emitting telemetry
  *
  * @example


### PR DESCRIPTION
## Description

Removing extraneous debugLogger functionality, primarily log filtering and trace level. Also simplifying to initialization logic. 

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Removed "trace" log level; supported levels: error, warn, info, debug.
  - Removed log filtering and related configuration options.
  - Debug logger is no longer exposed on the main Clerk instance; use the standalone debug logger.
  - Logger initialization now defaults to disabled and must be explicitly enabled.

- **Behavior Changes**
  - In production, console logging remains; telemetry is sent only when a telemetry collector is configured.

- **Tests**
  - Logging tests simplified; added edge-case and transport integration tests.

- **Chores**
  - Release metadata added noting removal of unused debug logger functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->