### PR TITLE
feat(localizations): Add Japanese translations for waitlist and resticted access

### DIFF
--- a/packages/localizations/src/hideokamoto-changeset.md
+++ b/packages/localizations/src/hideokamoto-changeset.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+This PR adds missing Japanese translations for waitlist functionality and restricted access scenarios.

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -776,13 +776,15 @@ export const jaJP: LocalizationResource = {
       title: '電話番号を確認',
     },
     restrictedAccess: {
-      actionLink: undefined,
-      actionText: undefined,
-      blockButton__emailSupport: undefined,
-      blockButton__joinWaitlist: undefined,
-      subtitle: undefined,
-      subtitleWaitlist: undefined,
-      title: undefined,
+      actionLink: 'サインイン',
+      actionText: '既にアカウントをお持ちですか？',
+      blockButton__emailSupport: 'サポートに連絡',
+      blockButton__joinWaitlist: '待機リストに参加',
+      subtitle:
+        '現在サインアップは無効になっています。アクセス権限があると思われる場合は、サポートまでご連絡ください。',
+      subtitleWaitlist:
+        '現在サインアップは無効になっています。リリース時に最初に通知を受け取るには、待機リストにご参加ください。',
+      title: 'アクセス制限',
     },
     start: {
       actionLink: 'サインイン',
@@ -1270,16 +1272,16 @@ export const jaJP: LocalizationResource = {
   },
   waitlist: {
     start: {
-      actionLink: undefined,
-      actionText: undefined,
-      formButton: undefined,
-      subtitle: undefined,
-      title: undefined,
+      actionLink: 'サインイン',
+      actionText: '既にアクセス権をお持ちですか？',
+      formButton: '待機リストに参加',
+      subtitle: 'メールアドレスを入力していただければ、準備が整い次第お知らせいたします',
+      title: '待機リストに参加',
     },
     success: {
-      message: undefined,
-      subtitle: undefined,
-      title: undefined,
+      message: '間もなくリダイレクトされます...',
+      subtitle: '準備が整い次第ご連絡いたします',
+      title: '待機リストへの参加ありがとうございます！',
     },
   },
 } as const;


### PR DESCRIPTION
 ## Description

  This PR adds missing Japanese translations for
  waitlist functionality and restricted access
  scenarios in the `@clerk/localizations` package.

  ### Changes included:
  - **signUp.restrictedAccess section**: Complete
  Japanese translations for restricted signup access
  messages, including action buttons and descriptive
  text
  - **waitlist.start and waitlist.success sections**:
  Full Japanese translations for the entire waitlist
  user flow

  ### Translation details:
  - `restrictedAccess.actionLink`: "サインイン" (Sign
  In)
  - `restrictedAccess.blockButton__emailSupport`:
  "サポートに連絡" (Contact Support)
  - `restrictedAccess.blockButton__joinWaitlist`:
  "待機リストに参加" (Join Waitlist)
  - `restrictedAccess.subtitle`: Explains signup
  restrictions and support contact
  - `restrictedAccess.subtitleWaitlist`: Explains
  waitlist signup for early access
  - `waitlist.start.*`: Complete start flow
  translations including form labels and descriptions
  - `waitlist.success.*`: Success state translations
  with redirect messaging

  These translations improve the Japanese localization
   coverage for user signup restrictions and waitlist
  functionality, providing a better user experience
  for Japanese users.

  ### Testing:
  - All translation keys follow existing Japanese
  localization patterns
  - Translations are contextually appropriate for
  Japanese users
  - No breaking changes to existing functionality

  ## Checklist

  - [x] `pnpm test` runs as expected.
  - [x] `pnpm build` runs as expected.
  - [x] (If applicable) JSDoc comments have been added
   or updated for any package exports
  - [x] (If applicable) Documentation has been updated

  ## Type of change

  - [ ] 🐛 Bug fix
  - [x] 🌟 New feature
  - [ ] 🔨 Breaking change
  - [ ] 📖 Refactoring / dependency upgrade /
  documentation
  - [ ] other:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Japanese localization for Restricted Access and Waitlist flows: localized titles, subtitles, sign-in prompts, join-waitlist/support buttons, guidance text, success message and redirect notice for a consistent Japanese UX.

* **Chores**
  * Added a changeset marking a patch release for the localizations package documenting the added Japanese translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->