### PR TITLE
chore(backend): Add `getOrganizationBillingSubscription` to BillingApi

### DIFF
--- a/packages/backend/src/api/endpoints/BillingApi.ts
+++ b/packages/backend/src/api/endpoints/BillingApi.ts
@@ -2,11 +2,13 @@ import type { ClerkPaginationRequest } from '@clerk/types';
 
 import { joinPaths } from '../../util/path';
 import type { CommercePlan } from '../resources/CommercePlan';
+import type { CommerceSubscription } from '../resources/CommerceSubscription';
 import type { CommerceSubscriptionItem } from '../resources/CommerceSubscriptionItem';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/commerce';
+const organizationBasePath = '/organizations';
 
 type GetOrganizationListParams = ClerkPaginationRequest<{
   payerType: 'org' | 'user';
@@ -43,6 +45,18 @@ export class BillingAPI extends AbstractAPI {
       method: 'DELETE',
       path: joinPaths(basePath, 'subscription_items', subscriptionItemId),
       queryParams: params,
+    });
+  }
+
+  /**
+   * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
+   * It is advised to pin the SDK version to avoid breaking changes.
+   */
+  public async getOrganizationBillingSubscription(organizationId: string) {
+    this.requireId(organizationId);
+    return this.request<CommerceSubscription>({
+      method: 'GET',
+      path: joinPaths(organizationBasePath, organizationId, 'billing', 'subscription'),
     });
   }
 }

--- a/packages/backend/src/api/resources/CommerceSubscription.ts
+++ b/packages/backend/src/api/resources/CommerceSubscription.ts
@@ -1,0 +1,79 @@
+import { type CommerceMoneyAmount } from './CommercePlan';
+import { CommerceSubscriptionItem } from './CommerceSubscriptionItem';
+import type { CommerceSubscriptionJSON } from './JSON';
+
+/**
+ * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
+ * It is advised to pin the SDK version to avoid breaking changes.
+ */
+export class CommerceSubscription {
+  constructor(
+    /**
+     * The unique identifier for the commerce subscription.
+     */
+    readonly id: string,
+    /**
+     * The current status of the subscription.
+     */
+    readonly status: CommerceSubscriptionJSON['status'],
+    /**
+     * The ID of the payer for this subscription.
+     */
+    readonly payerId: string,
+    /**
+     * Unix timestamp (milliseconds) of creation.
+     */
+    readonly createdAt: number,
+    /**
+     * Unix timestamp (milliseconds) of last update.
+     */
+    readonly updatedAt: number,
+    /**
+     * Unix timestamp (milliseconds) when the subscription became active.
+     */
+    readonly activeAt: number | null,
+    /**
+     * Unix timestamp (milliseconds) when the subscription became past due.
+     */
+    readonly pastDueAt: number | null,
+    /**
+     * Array of subscription items in this subscription.
+     */
+    readonly subscriptionItems: CommerceSubscriptionItem[],
+    /**
+     * Information about the next scheduled payment.
+     */
+    readonly nextPayment: { date: number; amount: CommerceMoneyAmount } | null,
+    /**
+     * Whether the payer is eligible for a free trial.
+     */
+    readonly eligibleForFreeTrial: boolean | null,
+  ) {}
+
+  static fromJSON(data: CommerceSubscriptionJSON): CommerceSubscription {
+    const nextPayment = data.next_payment
+      ? {
+          date: data.next_payment.date,
+          amount: {
+            amount: data.next_payment.amount.amount,
+            amountFormatted: data.next_payment.amount.amount_formatted,
+            currency: data.next_payment.amount.currency,
+            currencySymbol: data.next_payment.amount.currency_symbol,
+          },
+        }
+      : null;
+
+    return new CommerceSubscription(
+      data.id,
+      data.status,
+      data.payer_id,
+      data.created_at,
+      data.updated_at,
+      data.active_at ?? null,
+      data.past_due_at ?? null,
+      data.subscription_items.map(item => CommerceSubscriptionItem.fromJSON(item)),
+      nextPayment,
+      data.eligible_for_free_trial ?? null,
+    );
+  }
+}

--- a/packages/backend/src/api/resources/CommerceSubscriptionItem.ts
+++ b/packages/backend/src/api/resources/CommerceSubscriptionItem.ts
@@ -45,17 +45,37 @@ export class CommerceSubscriptionItem {
      */
     readonly planId: string,
     /**
+     * The date and time the subscription item was created.
+     */
+    readonly createdAt: number,
+    /**
+     * The date and time the subscription item was last updated.
+     */
+    readonly updatedAt: number,
+    /**
      * The end of the current period.
      */
-    readonly periodEnd?: number,
+    readonly periodEnd: number | null,
     /**
      * When the subscription item was canceled.
      */
-    readonly canceledAt?: number,
+    readonly canceledAt: number | null,
     /**
      * When the subscription item became past due.
      */
-    readonly pastDueAt?: number,
+    readonly pastDueAt: number | null,
+    /**
+     * When the subscription item ended.
+     */
+    readonly endedAt: number | null,
+    /**
+     * The payer ID.
+     */
+    readonly payerId: string,
+    /**
+     * The payment source ID.
+     */
+    readonly isFreeTrial?: boolean,
     /**
      * The lifetime amount paid for this subscription item.
      */
@@ -63,9 +83,6 @@ export class CommerceSubscriptionItem {
   ) {}
 
   static fromJSON(data: CommerceSubscriptionItemJSON): CommerceSubscriptionItem {
-    function formatAmountJSON(
-      amount: CommerceMoneyAmountJSON | null | undefined,
-    ): CommerceMoneyAmount | null | undefined;
     function formatAmountJSON(
       amount: CommerceMoneyAmountJSON | null | undefined,
     ): CommerceMoneyAmount | null | undefined {
@@ -90,9 +107,14 @@ export class CommerceSubscriptionItem {
       formatAmountJSON(data.amount),
       CommercePlan.fromJSON(data.plan),
       data.plan_id,
+      data.created_at,
+      data.updated_at,
       data.period_end,
       data.canceled_at,
       data.past_due_at,
+      data.ended_at,
+      data.payer_id,
+      data.is_free_trial,
       formatAmountJSON(data.lifetime_paid),
     );
   }

--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -38,6 +38,7 @@ import {
 } from '.';
 import { AccountlessApplication } from './AccountlessApplication';
 import { CommercePlan } from './CommercePlan';
+import { CommerceSubscription } from './CommerceSubscription';
 import { CommerceSubscriptionItem } from './CommerceSubscriptionItem';
 import { Feature } from './Feature';
 import type { PaginatedResponseJSON } from './JSON';
@@ -184,6 +185,8 @@ function jsonToObject(item: any): any {
       return WaitlistEntry.fromJSON(item);
     case ObjectType.CommercePlan:
       return CommercePlan.fromJSON(item);
+    case ObjectType.CommerceSubscription:
+      return CommerceSubscription.fromJSON(item);
     case ObjectType.CommerceSubscriptionItem:
       return CommerceSubscriptionItem.fromJSON(item);
     case ObjectType.Feature:

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -861,10 +861,15 @@ export interface CommerceSubscriptionItemJSON extends ClerkResourceJSON {
   object: typeof ObjectType.CommerceSubscriptionItem;
   status: CommerceSubscriptionItemStatus;
   plan_period: 'month' | 'annual';
+  payer_id: string;
   period_start: number;
-  period_end?: number;
-  canceled_at?: number;
-  past_due_at?: number;
+  period_end: number | null;
+  is_free_trial?: boolean;
+  ended_at: number | null;
+  created_at: number;
+  updated_at: number;
+  canceled_at: number | null;
+  past_due_at: number | null;
   lifetime_paid: CommerceMoneyAmountJSON;
   next_payment: {
     amount: number;
@@ -970,6 +975,22 @@ export interface CommerceSubscriptionWebhookEventJSON extends ClerkResourceJSON 
   payer: CommercePayerJSON;
   payment_source_id: string;
   items: CommerceSubscriptionItemWebhookEventJSON[];
+}
+
+export interface CommerceSubscriptionJSON extends ClerkResourceJSON {
+  object: typeof ObjectType.CommerceSubscription;
+  status: 'active' | 'past_due' | 'canceled' | 'ended' | 'abandoned' | 'incomplete';
+  payer_id: string;
+  created_at: number;
+  updated_at: number;
+  active_at: number | null;
+  past_due_at: number | null;
+  subscription_items: CommerceSubscriptionItemJSON[];
+  next_payment: {
+    date: number;
+    amount: CommerceMoneyAmountJSON;
+  } | null;
+  eligible_for_free_trial?: boolean | null;
 }
 
 export interface WebhooksSvixJSON {

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -58,6 +58,7 @@ export * from './Verification';
 export * from './WaitlistEntry';
 export * from './Web3Wallet';
 export * from './CommercePlan';
+export * from './CommerceSubscription';
 export * from './CommerceSubscriptionItem';
 
 export type {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -101,6 +101,7 @@ export type {
   TestingTokenJSON,
   WebhooksSvixJSON,
   CommercePlanJSON,
+  CommerceSubscriptionJSON,
   CommerceSubscriptionItemJSON,
 } from './api/resources/JSON';
 
@@ -144,6 +145,7 @@ export type {
   User,
   TestingToken,
   CommercePlan,
+  CommerceSubscription,
   CommerceSubscriptionItem,
 } from './api/resources';
 


### PR DESCRIPTION
## Description


Adds serialization for `CommerceSubscription` and updates `CommerceSubscriptionItem` in order to add `getOrganizationBillingSubscription` to BillingApi.
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
