### PR TITLE
fix(backend): Prevent excessive handshakes

### DIFF
--- a/.changeset/grumpy-groups-run.md
+++ b/.changeset/grumpy-groups-run.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fixes an issue where a handshake would trigger more than intended in development.

--- a/integration/tests/handshake.test.ts
+++ b/integration/tests/handshake.test.ts
@@ -1437,7 +1437,7 @@ test.describe('Client handshake with an organization activation avoids infinite 
     // Critical cookie: __clerk_redirect_count
     headers.set(
       'Cookie',
-      `${devBrowserCookie} __client_uat=${claims.iat}; __session=${token}; __clerk_redirect_count=1`,
+      `${devBrowserCookie} __client_uat=${claims.iat}; __session=${token}; __clerk_redirect_count=3`,
     );
 
     const res = await fetch(thisApp.serverUrl + '/organizations-by-id/org_a', {

--- a/packages/backend/src/tokens/handshake.ts
+++ b/packages/backend/src/tokens/handshake.ts
@@ -222,6 +222,7 @@ export class HandshakeService {
       const newUrl = new URL(this.authenticateContext.clerkUrl);
       newUrl.searchParams.delete(constants.QueryParameters.Handshake);
       newUrl.searchParams.delete(constants.QueryParameters.HandshakeHelp);
+      newUrl.searchParams.delete(constants.QueryParameters.DevBrowser);
       headers.append(constants.Headers.Location, newUrl.toString());
       headers.set(constants.Headers.CacheControl, 'no-store');
     }
@@ -323,7 +324,7 @@ ${developmentError.getFullMessage()}`,
 
     const newCounterValue = this.authenticateContext.handshakeRedirectLoopCounter + 1;
     const cookieName = constants.Cookies.RedirectCount;
-    headers.append('Set-Cookie', `${cookieName}=${newCounterValue}; SameSite=Lax; HttpOnly; Max-Age=3`);
+    headers.append('Set-Cookie', `${cookieName}=${newCounterValue}; SameSite=Lax; HttpOnly; Max-Age=2`);
     return false;
   }
 

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -386,7 +386,7 @@ export const authenticateRequest: AuthenticateRequest = (async (
     if (!mustActivate) {
       return null;
     }
-    if (authenticateContext.handshakeRedirectLoopCounter > 0) {
+    if (authenticateContext.handshakeRedirectLoopCounter >= 3) {
       // We have an organization that needs to be activated, but this isn't our first time redirecting.
       // This is because we attempted to activate the organization previously, but the organization
       // must not have been valid (either not found, or not valid for this user), and gave us back


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
- Prevent a handshake from triggering in development after a handshake is resolved with a `__clerk_db_jwt` parameter
- Reduce `max-age` of the redirect counter cookie to `2` to reduce false-positives during redirect detection
- Update the org url sync logic to only consider a redirect loop when 3 or more redirects happen in quick succession, instead of just one

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reduced unintended activation handshake triggers in development by cleaning up redirect URLs during dev flows.
  - Allowed up to three redirects before treating the sequence as a loop, reducing false positives.
  - Shortened redirect-loop cookie lifespan for faster recovery during development.

- Chores
  - Added a changeset to publish a patch release for the backend package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->