### PR TITLE
fix(clerk-js): Add support for user_banned error in OAuth flows

### DIFF
--- a/.changeset/two-pots-beam.md
+++ b/.changeset/two-pots-beam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add support for the user_banned error on OAuth flows

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -39,6 +39,7 @@ export const ERROR_CODES = {
   FRAUD_DEVICE_BLOCKED: 'device_blocked',
   FRAUD_ACTION_BLOCKED: 'action_blocked',
   SIGNUP_RATE_LIMIT_EXCEEDED: 'signup_rate_limit_exceeded',
+  USER_BANNED: 'user_banned',
 } as const;
 
 export const SIGN_IN_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username'];

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -289,6 +289,7 @@ function SignInStartInternal(): JSX.Element {
           case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
           case ERROR_CODES.FRAUD_ACTION_BLOCKED:
           case ERROR_CODES.SIGNUP_RATE_LIMIT_EXCEEDED:
+          case ERROR_CODES.USER_BANNED:
             card.setError(error);
             break;
           default:

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -219,6 +219,7 @@ function SignUpStartInternal(): JSX.Element {
           case ERROR_CODES.FRAUD_DEVICE_BLOCKED:
           case ERROR_CODES.FRAUD_ACTION_BLOCKED:
           case ERROR_CODES.SIGNUP_RATE_LIMIT_EXCEEDED:
+          case ERROR_CODES.USER_BANNED:
             card.setError(error);
             break;
           default:


### PR DESCRIPTION
## Description

The previous fix for USER-37 on the backend makes sure that we properly handle banned users who try to sign in with OAuth. However, this error was not being passed through by the SDK, so we were only displaying the general error "Unable to complete action at this time. If the problem persists please contact support." Pass through the OAuth error so we display the user banned error message instead for better UX. Tested on local Clerk with both sign in and sign up transfer flow.

Fixes USER-37.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added explicit handling for “user_banned” during OAuth sign-in and sign-up, showing a clear, user-facing error message.
* Bug Fixes
  * Aligns OAuth error handling with existing fraud and rate-limit cases to avoid generic fallback errors and provide consistent feedback.
* Chores
  * Prepared a patch release and updated internal change documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->