### PR TITLE
fix(repo): Use intermediate env variable in workflow script

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -24,7 +24,9 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Lint Pull Request Title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           npm init --scope=clerk --yes
           npm i --save-dev @commitlint/config-conventional @commitlint/cli globby --audit=false --fund=false
-          echo '${{ github.event.pull_request.title }}' | npm exec @commitlint/cli -- --config commitlint.config.ts
+          echo "$PR_TITLE" | npm exec @commitlint/cli -- --config commitlint.config.ts


### PR DESCRIPTION
## Description

This prevents command injection through variable interpolation in the PR Title Linter workflow. The job did _not_ execute automatically on PRs opened by users outside of Clerk org so abusing this would require a decent bit of unlikely user interaction for a maintainer to run the job on a sketchy-looking PR but it's worth fixing anyway.

Related to https://linear.app/clerk/issue/SEC-113/review-semgrep-findings-for-github-actions-shell-injection

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow for PR title linting to pass the title via an environment variable, improving reliability and handling of spaces/special characters.
  * Maintains the same validation behavior while simplifying how the title is provided to the linter.
  * No impact on product functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->