### PR TITLE
chore(clerk-js): Display free trial badge `<PricingTable/>`

### DIFF
--- a/.changeset/eighty-bananas-listen.md
+++ b/.changeset/eighty-bananas-listen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Display free trial badge `<PricingTable/>`.

--- a/integration/tests/pricing-table.test.ts
+++ b/integration/tests/pricing-table.test.ts
@@ -299,7 +299,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withBilling] })('pricing tabl
 
       // Verify the user is now shown as having an active free trial
       // The pricing table should show their current plan as active
-      await u.po.pricingTable.waitToBeActive({ planSlug: 'trial' });
+      await u.po.pricingTable.waitToBeFreeTrial({ planSlug: 'trial' });
 
       await u.po.page.goToRelative('/user');
       await u.po.userProfile.waitForMounted();

--- a/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/clerk-js/src/ui/components/PricingTable/PricingTableDefault.tsx
@@ -184,7 +184,11 @@ function Card(props: CardProps) {
         isCompact={isCompact}
         planPeriod={planPeriod}
         setPlanPeriod={setPlanPeriod}
-        badge={showStatusRow ? <SubscriptionBadge subscription={subscription} /> : undefined}
+        badge={
+          showStatusRow ? (
+            <SubscriptionBadge subscription={subscription.isFreeTrial ? { status: 'free_trial' } : subscription} />
+          ) : undefined
+        }
       />
       <Box
         elementDescriptor={descriptors.pricingTableCardBody}

--- a/packages/testing/src/playwright/unstable/page-objects/pricingTable.ts
+++ b/packages/testing/src/playwright/unstable/page-objects/pricingTable.ts
@@ -59,6 +59,9 @@ export const createPricingTablePageObject = (testArgs: { page: EnhancedPage }) =
     waitToBeActive: async ({ planSlug }: { planSlug: string }) => {
       return locators.badge(planSlug).getByText('Active').waitFor({ state: 'visible' });
     },
+    waitToBeFreeTrial: async ({ planSlug }: { planSlug: string }) => {
+      return locators.badge(planSlug).getByText('Free trial').waitFor({ state: 'visible' });
+    },
     getPlanCardCTA: ({ planSlug }: { planSlug: string }) => {
       return locators.footer(planSlug).getByRole('button', {
         name: /get|switch|subscribe/i,


### PR DESCRIPTION
## Description


### Before
<img width="633" height="273" alt="image" src="https://github.com/user-attachments/assets/af4dcd60-b570-4365-bf46-dac438b37168" />

### After
<img width="632" height="269" alt="image" src="https://github.com/user-attachments/assets/56b82149-42e4-422f-acff-646106b3e70f" />

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PricingTable now displays a “Free trial” badge in the plan card header when a subscription includes a free trial.
* **Bug Fixes**
  * Improved badge rendering to ensure the correct subscription status is shown when a status row is present.
* **Tests**
  * Updated test expectations to assert the free trial badge and added a test helper to wait for a “Free trial” badge.
* **Chores**
  * Bumped @clerk/clerk-js with a patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->