### PR TITLE
fix(types): Change return type of SetActiveNavigate to allow void or Promise

### DIFF
--- a/.changeset/nice-pans-jog.md
+++ b/.changeset/nice-pans-jog.md
@@ -1,0 +1,5 @@
+---
+"@clerk/types": patch
+---
+
+fix(types): Change return type of SetActiveNavigate to allow void or Promise

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -120,7 +120,7 @@ export type SDKMetadata = {
 export type ListenerCallback = (emission: Resources) => void;
 export type UnsubscribeCallback = () => void;
 export type BeforeEmitCallback = (session?: SignedInSessionResource | null) => void | Promise<any>;
-export type SetActiveNavigate = ({ session }: { session: SessionResource }) => Promise<unknown>;
+export type SetActiveNavigate = ({ session }: { session: SessionResource }) => void | Promise<unknown>;
 
 export type SignOutCallback = () => void | Promise<any>;
 


### PR DESCRIPTION
## Description
So that adding `async` just to make TS happy is no longer needed: 

```ts
await signIn.finalize({
        navigate: async () => {
                    ^ this shouldnt be needed
          router.push("/dashboard");
        },
});
```
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Navigation callback now supports both synchronous and asynchronous execution, letting callers choose whether to await it.
  * Backward compatible: existing integrations continue working; TypeScript consumers can opt to treat the callback as void or Promise-returning as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->