### PR TITLE
fix(localizations): Typo in subscription details

### DIFF
--- a/.changeset/smooth-clouds-fetch.md
+++ b/.changeset/smooth-clouds-fetch.md
@@ -1,5 +1,4 @@
 ---
-"@clerk/clerk-js": patch
 "@clerk/localizations": patch
 ---
 

--- a/.changeset/smooth-clouds-fetch.md
+++ b/.changeset/smooth-clouds-fetch.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/localizations": patch
+---
+
+Fixed a typo when canceling a free trial.

--- a/packages/clerk-js/src/ui/components/SubscriptionDetails/__tests__/SubscriptionDetails.test.tsx
+++ b/packages/clerk-js/src/ui/components/SubscriptionDetails/__tests__/SubscriptionDetails.test.tsx
@@ -1214,7 +1214,7 @@ describe('SubscriptionDetails', () => {
       expect(getByText('Cancel free trial for Pro Plan plan?')).toBeVisible();
       expect(
         getByText(
-          "Your trial will stay active until February 1, 2021. After that, you'll lose access to trial features. You won't be changed.",
+          "Your trial will stay active until February 1, 2021. After that, you'll lose access to trial features. You won't be charged.",
         ),
       ).toBeVisible();
       expect(getByText('Keep free trial')).toBeVisible();

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -66,7 +66,7 @@ export const enUS: LocalizationResource = {
     billedMonthlyOnly: 'Only billed monthly',
     cancelFreeTrial: 'Cancel free trial',
     cancelFreeTrialAccessUntil:
-      "Your trial will stay active until {{ date | longDate('en-US') }}. After that, you'll lose access to trial features. You won't be changed.",
+      "Your trial will stay active until {{ date | longDate('en-US') }}. After that, you'll lose access to trial features. You won't be charged.",
     cancelFreeTrialTitle: 'Cancel free trial for {{plan}} plan?',
     cancelSubscription: 'Cancel subscription',
     cancelSubscriptionAccessUntil:


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Noticed a typo when canceling a free trial.

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: typo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wording in the Cancel Free Trial dialog (en-US) to “You won't be charged.” instead of “You won't be changed.” for clearer billing communication on the Pro Plan and similar flows. This typo fix improves user-facing clarity.

* **Tests**
  * Updated test expectations to match the corrected dialog message, ensuring localization and tests remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->