### PR TITLE
feat(nextjs): Support static export

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -54,6 +54,11 @@
       "types": "./dist/types/experimental.d.ts",
       "import": "./dist/esm/experimental.js",
       "require": "./dist/cjs/experimental.js"
+    },
+    "./static": {
+      "types": "./dist/types/static.d.ts",
+      "import": "./dist/esm/static.js",
+      "require": "./dist/cjs/static.js"
     }
   },
   "types": "./dist/types/index.d.ts",
@@ -61,7 +66,8 @@
     "dist",
     "server",
     "errors",
-    "webhooks"
+    "webhooks",
+    "static"
   ],
   "scripts": {
     "build": "pnpm clean && tsup",

--- a/packages/nextjs/src/static.tsx
+++ b/packages/nextjs/src/static.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { ClerkProviderProps } from '@clerk/clerk-react';
+import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
+import type { Without } from '@clerk/types';
+import React from 'react';
+
+import { mergeNextClerkPropsWithEnv } from './utils/mergeNextClerkPropsWithEnv';
+
+type NextClerkProviderProps = Without<ClerkProviderProps, 'publishableKey'> & {
+  /**
+   * Used to override the default NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY env variable if needed.
+   * This is optional for NextJS as the ClerkProvider will automatically use the NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY env variable if it exists.
+   */
+  publishableKey?: string;
+};
+
+export const ClerkProvider = (props: NextClerkProviderProps) => {
+  const mergedProps = mergeNextClerkPropsWithEnv(props);
+  return <ReactClerkProvider {...mergedProps}>{props.children}</ReactClerkProvider>;
+};

--- a/packages/nextjs/src/static.tsx
+++ b/packages/nextjs/src/static.tsx
@@ -5,9 +5,11 @@ import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import type { Without } from '@clerk/types';
 import React from 'react';
 
+import { useAwaitablePush } from './app-router/client/useAwaitablePush';
+import { useAwaitableReplace } from './app-router/client/useAwaitableReplace';
 import { mergeNextClerkPropsWithEnv } from './utils/mergeNextClerkPropsWithEnv';
 
-type NextClerkProviderProps = Without<ClerkProviderProps, 'publishableKey'> & {
+type NextStaticClerkProviderProps = Without<ClerkProviderProps, 'publishableKey'> & {
   /**
    * Used to override the default NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY env variable if needed.
    * This is optional for NextJS as the ClerkProvider will automatically use the NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY env variable if it exists.
@@ -15,7 +17,27 @@ type NextClerkProviderProps = Without<ClerkProviderProps, 'publishableKey'> & {
   publishableKey?: string;
 };
 
-export const ClerkProvider = (props: NextClerkProviderProps) => {
-  const mergedProps = mergeNextClerkPropsWithEnv(props);
+// StaticClerkProvider is a light wrapper around the `<ClerkProvider/>` exported from `@clerk/clerk-react`
+// It is meant to be used only for developers that want to static export their Next.js app (https://nextjs.org/docs/app/guides/static-exports).
+// This opts out of keyless, the `dynamic` prop (aka SSR) and route revalidation on auth state updates (since RSCs and middleware do not exist in the context of static export).
+
+/**
+ * The ClerkProvider exported from `/static` should only be used for static exports only.
+ * Using this provider means that you opt out of authorization checks on the server.
+ * @param props
+ * @returns
+ */
+const StaticClerkProvider = (props: NextStaticClerkProviderProps) => {
+  const push = useAwaitablePush();
+  const replace = useAwaitableReplace();
+  const mergedProps = mergeNextClerkPropsWithEnv({
+    ...props,
+    // @ts-expect-error Error because of the stricter types of internal `push`
+    routerPush: push,
+    // @ts-expect-error Error because of the stricter types of internal `replace`
+    routerReplace: replace,
+  });
   return <ReactClerkProvider {...mergedProps}>{props.children}</ReactClerkProvider>;
 };
+
+export { StaticClerkProvider as ClerkProvider };


### PR DESCRIPTION
## Description

This PR introduces a new `<ClerkProvider />` (for App Router) exported from `@clerk/nextjs/static` that allows statically exported Next application to function as expected.


### Issue
Previously a developer would receive an error during `next build` that `"Server Actions are not supported with static export"`. This is because the current ClerkProviders for app router use many of the unsupported features that are missing when an application is statically exported.

### Solution
Expose a minimal `<ClerkProvider/>` as a client component that provides clerk.js with the correct routing functions and the convenient environment variable resolution.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
