### PR TITLE
feat(backend): Add `subscriptionItem.freeTrialEnding` event

### DIFF
--- a/.changeset/short-ravens-sell.md
+++ b/.changeset/short-ravens-sell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Include `'subscriptionItem.freeTrialEnding'` event in `CommerceSubscriptionItemWebhookEvent`.

--- a/packages/backend/src/api/resources/Webhooks.ts
+++ b/packages/backend/src/api/resources/Webhooks.ts
@@ -84,7 +84,8 @@ export type CommerceSubscriptionItemWebhookEvent = Webhook<
   | 'subscriptionItem.ended'
   | 'subscriptionItem.abandoned'
   | 'subscriptionItem.incomplete'
-  | 'subscriptionItem.past_due',
+  | 'subscriptionItem.past_due'
+  | 'subscriptionItem.freeTrialEnding',
   CommerceSubscriptionItemWebhookEventJSON
 >;
 


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the subscriptionItem.freeTrialEnding webhook event, enabling notifications when a free trial is nearing its end.
- Documentation
  - Documented availability of the subscriptionItem.freeTrialEnding event in commerce subscription item webhooks.
- Chores
  - Updated backend dependency to the latest minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->