### PR TITLE
chore(clerk-js): Prefer popup flow for .lp.dev origins

### DIFF
--- a/.changeset/shy-places-grab.md
+++ b/.changeset/shy-places-grab.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add `.lp.dev` to list of origins that prefer the popup SSO flow.

--- a/packages/clerk-js/src/ui/utils/__tests__/originPrefersPopup.spec.ts
+++ b/packages/clerk-js/src/ui/utils/__tests__/originPrefersPopup.spec.ts
@@ -105,6 +105,14 @@ describe('originPrefersPopup', () => {
         expect(originPrefersPopup()).toBe(true);
       });
 
+      it('should return true for .lp.dev domains', () => {
+        mockLocationOrigin('https://preview.lp.dev');
+        expect(originPrefersPopup()).toBe(true);
+
+        mockLocationOrigin('https://app.lp.dev');
+        expect(originPrefersPopup()).toBe(true);
+      });
+
       it('should handle HTTPS and HTTP protocols', () => {
         mockLocationOrigin('http://localhost.lovable.app');
         expect(originPrefersPopup()).toBe(true);

--- a/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
+++ b/packages/clerk-js/src/ui/utils/originPrefersPopup.ts
@@ -7,6 +7,7 @@ const POPUP_PREFERRED_ORIGINS = [
   '.vusercontent.net',
   '.v0.dev',
   '.v0.app',
+  '.lp.dev',
 ];
 
 /**


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Prefer the popup flow for `.lp.dev` origins, which are previews for apps generated via [leap.new](https://leap.new).

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables popup SSO on .lp.dev domains by recognizing them as preferred origins (e.g., preview.lp.dev, app.lp.dev), improving sign-in flow on those environments.
- Tests
  - Added test coverage confirming .lp.dev domains are treated as preferred origins when not in an iframe.
- Chores
  - Added changeset entry for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->