### PR TITLE
fix(backend): Use correct name for subscription past due event

### DIFF
--- a/.changeset/four-mice-crash.md
+++ b/.changeset/four-mice-crash.md
@@ -1,0 +1,8 @@
+---
+'@clerk/backend': minor
+---
+
+[Billing Beta] Use correct casing for past due events types.
+
+- `'subscription.past_due'` -> `'subscription.pastDue'`
+- `'subscriptionItem.past_due'` -> `'subscriptionItem.pastDue'`

--- a/packages/backend/src/api/resources/Webhooks.ts
+++ b/packages/backend/src/api/resources/Webhooks.ts
@@ -71,7 +71,7 @@ export type CommercePaymentAttemptWebhookEvent = Webhook<
 >;
 
 export type CommerceSubscriptionWebhookEvent = Webhook<
-  'subscription.created' | 'subscription.updated' | 'subscription.active' | 'subscription.past_due',
+  'subscription.created' | 'subscription.updated' | 'subscription.active' | 'subscription.pastDue',
   CommerceSubscriptionWebhookEventJSON
 >;
 
@@ -84,7 +84,7 @@ export type CommerceSubscriptionItemWebhookEvent = Webhook<
   | 'subscriptionItem.ended'
   | 'subscriptionItem.abandoned'
   | 'subscriptionItem.incomplete'
-  | 'subscriptionItem.past_due'
+  | 'subscriptionItem.pastDue'
   | 'subscriptionItem.freeTrialEnding',
   CommerceSubscriptionItemWebhookEventJSON
 >;


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized webhook event names to camelCase: subscription.pastDue and subscriptionItem.pastDue (previously past_due). Update any webhook listeners or filters accordingly.
* **Chores**
  * Prepared a minor release under the Billing Beta scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->