### PR TITLE
fix: allow clearing fetch cache on sign out

### DIFF
--- a/packages/clerk-js/src/core/cacheClearManager.ts
+++ b/packages/clerk-js/src/core/cacheClearManager.ts
@@ -1,0 +1,28 @@
+import { debugLogger } from '@/utils/debug';
+
+const clearCallbacks = new Map<string, () => void>();
+
+/**
+ * Registers a callback to be executed when caches are cleared.
+ * @param id - Unique identifier for the callback
+ * @param callback - Function to execute when clearing caches
+ * @returns Function to unregister the callback
+ */
+export const registerClearCallback = (id: string, callback: () => void): (() => void) => {
+  clearCallbacks.set(id, callback);
+  return () => clearCallbacks.delete(id);
+};
+
+/**
+ * Clears all registered caches by executing all registered callbacks.
+ * Continues execution even if individual callbacks throw errors.
+ */
+export const clearAllCaches = (): void => {
+  clearCallbacks.forEach(callback => {
+    try {
+      callback();
+    } catch (error) {
+      debugLogger.error('Error executing clear callback', { error }, 'CacheClearManager');
+    }
+  });
+};

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -525,6 +525,10 @@ export class Clerk implements ClerkInterface {
       // Notify other tabs that user is signing out and clean up cookies.
       eventBus.emit(events.UserSignOut, null);
 
+      if (typeof window !== 'undefined' && (window as any).__clerkClearFetchCache) {
+        (window as any).__clerkClearFetchCache();
+      }
+
       this.#setTransitiveState();
 
       await tracker.track(async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -525,8 +525,13 @@ export class Clerk implements ClerkInterface {
       // Notify other tabs that user is signing out and clean up cookies.
       eventBus.emit(events.UserSignOut, null);
 
-      if (typeof window !== 'undefined' && (window as any).__clerkClearFetchCache) {
-        (window as any).__clerkClearFetchCache();
+      if (typeof window !== 'undefined') {
+        try {
+          const { clearAllCaches } = await import('./cacheClearManager');
+          clearAllCaches();
+        } catch (error) {
+          debugLogger.debug('CacheClearManager not available during signOut, skipping cache clear', { error }, 'clerk');
+        }
       }
 
       this.#setTransitiveState();

--- a/packages/clerk-js/src/core/requestCache.ts
+++ b/packages/clerk-js/src/core/requestCache.ts
@@ -1,0 +1,61 @@
+import { debugLogger } from '@/utils/debug';
+
+export type RequestCacheState<T = unknown> = {
+  data: T | null;
+  error: Error | null;
+  isLoading: boolean;
+  isValidating: boolean;
+  cachedAt?: number;
+};
+
+const cache = new Map<string, RequestCacheState<unknown>>();
+const subscribers = new Set<() => void>();
+
+/**
+ * Gets a cache entry
+ */
+export const getCacheEntry = <T>(key: string): RequestCacheState<T> | undefined => {
+  return cache.get(key) as RequestCacheState<T> | undefined;
+};
+
+/**
+ * Sets a cache entry and notifies subscribers
+ */
+export const setCacheEntry = <T>(
+  key: string,
+  state: RequestCacheState<T> | ((current: RequestCacheState<T> | undefined) => RequestCacheState<T>),
+): void => {
+  const currentState = cache.get(key) as RequestCacheState<T> | undefined;
+  const newState = typeof state === 'function' ? state(currentState) : state;
+  cache.set(key, newState as RequestCacheState<unknown>);
+  notifySubscribers();
+};
+
+/**
+ * Subscribes to cache changes
+ */
+export const subscribe = (callback: () => void): (() => void) => {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+};
+
+/**
+ * Clears the entire request cache
+ */
+export const clearRequestCache = (): void => {
+  cache.clear();
+  notifySubscribers();
+};
+
+/**
+ * Notifies all subscribers of cache changes
+ */
+const notifySubscribers = (): void => {
+  subscribers.forEach(callback => {
+    try {
+      callback();
+    } catch (error) {
+      debugLogger.error('Error executing subscriber callback', { error }, 'RequestCache');
+    }
+  });
+};

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -31,6 +31,15 @@ export const clearFetchCache = () => {
   requestCache = new Map<string, State>();
 };
 
+/**
+ * Global function to clear the fetch cache.
+ * This is exposed on the window object to allow core modules to clear the cache
+ * without importing from UI modules.
+ */
+if (typeof window !== 'undefined') {
+  (window as any).__clerkClearFetchCache = clearFetchCache;
+}
+
 const serialize = (key: unknown) => (typeof key === 'string' ? key : JSON.stringify(key));
 
 const useCache = <K = any, V = any>(


### PR DESCRIPTION
## Description

Improving upon https://github.com/clerk/javascript/pull/6688 to handle post-sign out cache clearing more robustly

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
