### PR TITLE
docs(types): Document setActive reference for the hooks using it

### DIFF
--- a/.changeset/fine-masks-judge.md
+++ b/.changeset/fine-masks-judge.md
@@ -1,0 +1,5 @@
+---
+'@clerk/types': minor
+---
+
+Added reference docs link for hooks using setActive

--- a/.changeset/fine-masks-judge.md
+++ b/.changeset/fine-masks-judge.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/types': minor
 ---
-
-Added reference docs link for hooks using setActive

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -131,7 +131,7 @@ export type UseSignInReturn =
        */
       signIn: undefined;
       /**
-       * A function that sets the active session.
+       * A function that sets the active session. See the [reference doc](https://clerk.com/docs/references/javascript/clerk#set-active).
        */
       setActive: undefined;
     }
@@ -155,7 +155,7 @@ export type UseSignUpReturn =
        */
       signUp: undefined;
       /**
-       * A function that sets the active session.
+       * A function that sets the active session. See the [reference doc](https://clerk.com/docs/references/javascript/clerk#set-active).
        */
       setActive: undefined;
     }
@@ -208,7 +208,7 @@ export type UseSessionListReturn =
        */
       sessions: undefined;
       /**
-       * A function that sets the active session and/or organization.
+       * A function that sets the active session and/or organization. See the [reference doc](https://clerk.com/docs/references/javascript/clerk#set-active).
        */
       setActive: undefined;
     }


### PR DESCRIPTION
## Description

Linear issue: https://linear.app/clerk/issue/DOCS-10894/document-setactive-nextjshooksuse-sign-in

Adds reference link for setActive method for hooks using it, after customer feedback around lack of documentation for the method.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Clarified hook documentation by adding reference links for setActive across relevant authentication hooks; no API or behavior changes.
* Chores
  * Added a changeset to prepare a release reflecting the documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->