### PR TITLE
fix(nextjs): Resolve path module import error in keyless-telemetry

### DIFF
--- a/.changeset/angry-cobras-confess.md
+++ b/.changeset/angry-cobras-confess.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Resolve path module import error in keyless telemetry

--- a/packages/nextjs/src/server/keyless-telemetry.ts
+++ b/packages/nextjs/src/server/keyless-telemetry.ts
@@ -1,9 +1,8 @@
 import type { TelemetryEventRaw } from '@clerk/types';
-import { dirname, join } from 'path';
 
 import { canUseKeyless } from '../utils/feature-flags';
 import { createClerkClientWithOptions } from './createClerkClient';
-import { nodeFsOrThrow } from './fs/utils';
+import { nodeFsOrThrow, nodePathOrThrow } from './fs/utils';
 
 const EVENT_KEYLESS_ENV_DRIFT_DETECTED = 'KEYLESS_ENV_DRIFT_DETECTED';
 const EVENT_SAMPLING_RATE = 1; // 100% sampling rate
@@ -27,7 +26,8 @@ type EventKeylessEnvDriftPayload = {
  * @returns The absolute path to the telemetry flag file in the project's .clerk/.tmp directory
  */
 function getTelemetryFlagFilePath(): string {
-  return join(process.cwd(), TELEMETRY_FLAG_FILE);
+  const path = nodePathOrThrow();
+  return path.join(process.cwd(), TELEMETRY_FLAG_FILE);
 }
 
 /**
@@ -45,8 +45,9 @@ function tryMarkTelemetryEventAsFired(): boolean {
   try {
     if (canUseKeyless) {
       const { mkdirSync, writeFileSync } = nodeFsOrThrow();
+      const path = nodePathOrThrow();
       const flagFilePath = getTelemetryFlagFilePath();
-      const flagDirectory = dirname(flagFilePath);
+      const flagDirectory = path.dirname(flagFilePath);
 
       // Ensure the directory exists before attempting to write the file
       mkdirSync(flagDirectory, { recursive: true });


### PR DESCRIPTION
## Description

Replace direct Node.js `'path'` module import with internal safe Node.js API used throughout the `@clerk/nextjs` package

Fixes #6675

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Streamlined internal path handling in telemetry-related logic by routing filesystem/path operations through a unified utility.
  - Improves consistency and maintainability with no change to runtime behavior or user-facing telemetry settings.

- Chores
  - Added a patch-level changeset documenting the fix for the telemetry path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->