### PR TITLE
fix(clerk-js): Prepare calls would fire only once

### DIFF
--- a/.changeset/crazy-days-tan.md
+++ b/.changeset/crazy-days-tan.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes issue where "prepare" API request would only fire once, preventing end users from receiving fresh otp codes.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -82,11 +82,25 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       .catch(err => handleError(err, [], card.setError));
   };
 
-  useFetch(shouldAvoidPrepare ? undefined : () => signIn?.prepareFirstFactor(props.factor), cacheKey, {
-    staleTime: 100,
-    onSuccess: () => props.onFactorPrepare(),
-    onError: err => handleError(err, [], card.setError),
-  });
+  useFetch(
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signIn
+            ?.prepareFirstFactor(props.factor)
+            .then(res => {
+              props.onFactorPrepare();
+              return res;
+            })
+            .catch(err => {
+              handleError(err, [], card.setError);
+              return err;
+            }),
+    cacheKey,
+    {
+      staleTime: 100,
+    },
+  );
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
     signIn

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -82,25 +82,11 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       .catch(err => handleError(err, [], card.setError));
   };
 
-  useFetch(
-    shouldAvoidPrepare
-      ? undefined
-      : () =>
-          signIn
-            ?.prepareFirstFactor(props.factor)
-            .then(res => {
-              props.onFactorPrepare();
-              return res;
-            })
-            .catch(err => {
-              handleError(err, [], card.setError);
-              return err;
-            }),
-    cacheKey,
-    {
-      staleTime: 100,
-    },
-  );
+  useFetch(shouldAvoidPrepare ? undefined : () => signIn?.prepareFirstFactor(props.factor), cacheKey, {
+    staleTime: 100,
+    onSuccess: () => props.onFactorPrepare(),
+    onError: err => handleError(err, [], card.setError),
+  });
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
     signIn

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -82,19 +82,11 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       .catch(err => handleError(err, [], card.setError));
   };
 
-  useFetch(
-    shouldAvoidPrepare
-      ? undefined
-      : () =>
-          signIn
-            ?.prepareFirstFactor(props.factor)
-            .then(() => props.onFactorPrepare())
-            .catch(err => handleError(err, [], card.setError)),
-    cacheKey,
-    {
-      staleTime: 100,
-    },
-  );
+  useFetch(shouldAvoidPrepare ? undefined : () => signIn?.prepareFirstFactor(props.factor), cacheKey, {
+    staleTime: 100,
+    onSuccess: () => props.onFactorPrepare(),
+    onError: err => handleError(err, [], card.setError),
+  });
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
     signIn

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOneCodeForm.spec.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOneCodeForm.spec.tsx
@@ -56,9 +56,11 @@ describe('SignInFactorOneCodeForm', () => {
           name: 'signIn.prepareFirstFactor',
           factorKey: 'phone_code_idn_123',
         },
-        {
+        expect.objectContaining({
           staleTime: 100,
-        },
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        }),
       );
     });
 
@@ -91,9 +93,11 @@ describe('SignInFactorOneCodeForm', () => {
           name: 'signIn.prepareFirstFactor',
           factorKey: 'phone_code_idn_123_whatsapp',
         },
-        {
+        expect.objectContaining({
           staleTime: 100,
-        },
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        }),
       );
     });
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -24,7 +24,13 @@ export const SignUpEmailCodeCard = () => {
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    shouldAvoidPrepare ? undefined : () => signUp.prepareEmailAddressVerification({ strategy: 'email_code' }),
+    shouldAvoidPrepare
+      ? undefined
+      : () =>
+          signUp.prepareEmailAddressVerification({ strategy: 'email_code' }).catch(err => {
+            handleError(err, [], card.setError);
+            return err;
+          }),
     {
       name: 'prepare',
       strategy: 'email_code',
@@ -32,7 +38,6 @@ export const SignUpEmailCodeCard = () => {
     },
     {
       staleTime: 100,
-      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -24,12 +24,7 @@ export const SignUpEmailCodeCard = () => {
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    shouldAvoidPrepare
-      ? undefined
-      : () =>
-          signUp
-            .prepareEmailAddressVerification({ strategy: 'email_code' })
-            .catch(err => handleError(err, [], card.setError)),
+    shouldAvoidPrepare ? undefined : () => signUp.prepareEmailAddressVerification({ strategy: 'email_code' }),
     {
       name: 'prepare',
       strategy: 'email_code',
@@ -37,6 +32,7 @@ export const SignUpEmailCodeCard = () => {
     },
     {
       staleTime: 100,
+      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailCodeCard.tsx
@@ -24,13 +24,7 @@ export const SignUpEmailCodeCard = () => {
 
   // TODO: Introduce a useMutation to handle mutating requests
   useFetch(
-    shouldAvoidPrepare
-      ? undefined
-      : () =>
-          signUp.prepareEmailAddressVerification({ strategy: 'email_code' }).catch(err => {
-            handleError(err, [], card.setError);
-            return err;
-          }),
+    shouldAvoidPrepare ? undefined : () => signUp.prepareEmailAddressVerification({ strategy: 'email_code' }),
     {
       name: 'prepare',
       strategy: 'email_code',
@@ -38,6 +32,7 @@ export const SignUpEmailCodeCard = () => {
     },
     {
       staleTime: 100,
+      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -36,10 +36,7 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     // because the verification is already created on the Start screen
     shouldAvoidPrepare || isAlternativePhoneCodeProvider
       ? undefined
-      : () =>
-          signUp
-            .preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined })
-            .catch(err => handleError(err, [], card.setError)),
+      : () => signUp.preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined }),
     {
       name: 'signUp.preparePhoneNumberVerification',
       strategy: 'phone_code',
@@ -47,6 +44,7 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     },
     {
       staleTime: 100,
+      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -36,7 +36,11 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     // because the verification is already created on the Start screen
     shouldAvoidPrepare || isAlternativePhoneCodeProvider
       ? undefined
-      : () => signUp.preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined }),
+      : () =>
+          signUp.preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined }).catch(err => {
+            handleError(err, [], card.setError);
+            return err;
+          }),
     {
       name: 'signUp.preparePhoneNumberVerification',
       strategy: 'phone_code',
@@ -44,7 +48,6 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     },
     {
       staleTime: 100,
-      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpPhoneCodeCard.tsx
@@ -36,11 +36,7 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     // because the verification is already created on the Start screen
     shouldAvoidPrepare || isAlternativePhoneCodeProvider
       ? undefined
-      : () =>
-          signUp.preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined }).catch(err => {
-            handleError(err, [], card.setError);
-            return err;
-          }),
+      : () => signUp.preparePhoneNumberVerification({ strategy: 'phone_code', channel: undefined }),
     {
       name: 'signUp.preparePhoneNumberVerification',
       strategy: 'phone_code',
@@ -48,6 +44,7 @@ export const SignUpPhoneCodeCard = withCardStateProvider(() => {
     },
     {
       staleTime: 100,
+      onError: err => handleError(err, [], card.setError),
     },
   );
 

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -135,13 +135,6 @@ export const useFetch = <K, T>(
       typeof getCache()?.cachedAt === 'undefined' ? true : Date.now() - (getCache()?.cachedAt || 0) >= staleTime;
     const isRequestOnGoing = getCache()?.isValidating ?? false;
 
-    console.log('fetcherMissing', fetcherMissing);
-    console.log('isCacheStale', isCacheStale);
-    console.log('isRequestOnGoing', isRequestOnGoing);
-
-    console.log('toSkip', fetcherMissing || !isCacheStale || isRequestOnGoing);
-    console.log('getCache()', getCache());
-
     if (fetcherMissing || !isCacheStale || isRequestOnGoing) {
       return;
     }

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -167,7 +167,7 @@ export const useFetch = <K, T>(
           }, waitTime);
         }
       })
-      .catch((e: Error) => {
+      .catch((e: Error | null) => {
         setCache({
           data: getCache()?.data ?? null,
           isLoading: false,
@@ -175,7 +175,9 @@ export const useFetch = <K, T>(
           error: e,
           cachedAt: Date.now(),
         });
-        options?.onError?.(e);
+        if (e) {
+          options?.onError?.(e);
+        }
       });
   }, [serialize(params), setCache, getCache, revalidateCache]);
 

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -88,6 +88,7 @@ export const useFetch = <K, T>(
   options?: {
     throttleTime?: number;
     onSuccess?: (data: T) => void;
+    onError?: (error: Error) => void;
     staleTime?: number;
   },
   resourceId?: string,
@@ -134,6 +135,13 @@ export const useFetch = <K, T>(
       typeof getCache()?.cachedAt === 'undefined' ? true : Date.now() - (getCache()?.cachedAt || 0) >= staleTime;
     const isRequestOnGoing = getCache()?.isValidating ?? false;
 
+    console.log('fetcherMissing', fetcherMissing);
+    console.log('isCacheStale', isCacheStale);
+    console.log('isRequestOnGoing', isRequestOnGoing);
+
+    console.log('toSkip', fetcherMissing || !isCacheStale || isRequestOnGoing);
+    console.log('getCache()', getCache());
+
     if (fetcherMissing || !isCacheStale || isRequestOnGoing) {
       return;
     }
@@ -174,6 +182,7 @@ export const useFetch = <K, T>(
           error: e,
           cachedAt: Date.now(),
         });
+        options?.onError?.(e);
       });
   }, [serialize(params), setCache, getCache, revalidateCache]);
 


### PR DESCRIPTION
## Description

Proper fix for #6688 as it propagate promise results to prepare calls for SignIn and SignUp to allow request cache to work properly.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where prepare requests ran only once so users now reliably receive fresh OTPs for sign-in and sign-up.

* **Refactor**
  * Centralized and improved error handling across email/phone/code verification flows for more consistent reporting and recovery.

* **Tests**
  * Relaxed tests to accept the enhanced fetch options (including success/error handlers) for greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->