### PR TITLE
fix(clerk-js,types): Update `signUp.password` to allow for emailAddress and phoneNumber params

### DIFF
--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -595,10 +595,6 @@ class SignUpFuture implements SignUpFutureResource {
   }
 
   async password(params: SignUpFuturePasswordParams): Promise<{ error: unknown }> {
-    if ([params.emailAddress, params.phoneNumber].filter(Boolean).length > 1) {
-      throw new Error('Only one of emailAddress or phoneNumber can be provided');
-    }
-
     return runAsyncResourceTask(this.resource, async () => {
       const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken();
 

--- a/packages/types/src/signUpFuture.ts
+++ b/packages/types/src/signUpFuture.ts
@@ -9,18 +9,9 @@ export interface SignUpFutureCreateParams {
 export interface SignUpFutureEmailCodeVerifyParams {
   code: string;
 }
-
-export type SignUpFuturePasswordParams =
-  | {
-      emailAddress: string;
-      password: string;
-      phoneNumber?: never;
-    }
-  | {
-      phoneNumber: string;
-      password: string;
-      emailAddress?: never;
-    };
+export type SignUpFuturePasswordParams = {
+  password: string;
+} & ({ emailAddress: string; phoneNumber?: string } | { phoneNumber: string; emailAddress?: string });
 
 export interface SignUpFuturePhoneCodeSendParams {
   phoneNumber?: string;


### PR DESCRIPTION
## Description
Allowed params:
```ts
void this.password({password: '', emailAddress: ''})
void this.password({password: '',  phoneNumber: ''})
void this.password({password: '', emailAddress: '', phoneNumber: ''})
```
`password` is always required. 

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
