### PR TITLE
fix(types): Correct deprecation warnings for legacy redirect props in ClerkProvider

### DIFF
--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -961,13 +961,28 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
+type ClerkProviderLegacyRedirectProps = {
+  /**
+   * @deprecated Use `signInFallbackRedirectUrl` or `signInForceRedirectUrl` instead.
+   */
+  afterSignInUrl?: string | null;
+  /**
+   * @deprecated Use `signUpFallbackRedirectUrl` or `signUpForceRedirectUrl` instead.
+   */
+  afterSignUpUrl?: string | null;
+  /**
+   * @deprecated Use `signInFallbackRedirectUrl`, `signInForceRedirectUrl`, `signUpFallbackRedirectUrl`, or `signUpForceRedirectUrl` instead.
+   */
+  redirectUrl?: string | null;
+};
+
 export type ClerkOptions = ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
   SignUpForceRedirectUrl &
   SignUpFallbackRedirectUrl &
   NewSubscriptionRedirectUrl &
-  LegacyRedirectProps &
+  ClerkProviderLegacyRedirectProps &
   AfterSignOutUrl &
   AfterMultiSessionSingleSignOutUrl & {
     /**

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -961,7 +961,7 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
-type ClerkProviderLegacyRedirectProps = {
+type ClerkOptionsLegacyRedirectProps = {
   /**
    * @deprecated Use `signInFallbackRedirectUrl` or `signInForceRedirectUrl` instead.
    */
@@ -982,7 +982,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
   SignUpForceRedirectUrl &
   SignUpFallbackRedirectUrl &
   NewSubscriptionRedirectUrl &
-  ClerkProviderLegacyRedirectProps &
+  ClerkOptionsLegacyRedirectProps &
   AfterSignOutUrl &
   AfterMultiSessionSingleSignOutUrl & {
     /**

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -20,11 +20,11 @@ export type AfterMultiSessionSingleSignOutUrl = {
  */
 export type LegacyRedirectProps = {
   /**
-   * @deprecated Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
+   * @deprecated Use `signInFallbackRedirectUrl` or `signInForceRedirectUrl` instead.
    */
   afterSignInUrl?: string | null;
   /**
-   * @deprecated Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
+   * @deprecated Use `signUpFallbackRedirectUrl` or `signUpForceRedirectUrl` instead.
    */
   afterSignUpUrl?: string | null;
   /**

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -20,11 +20,11 @@ export type AfterMultiSessionSingleSignOutUrl = {
  */
 export type LegacyRedirectProps = {
   /**
-   * @deprecated Use `signInFallbackRedirectUrl` or `signInForceRedirectUrl` instead.
+   * @deprecated Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
    */
   afterSignInUrl?: string | null;
   /**
-   * @deprecated Use `signUpFallbackRedirectUrl` or `signUpForceRedirectUrl` instead.
+   * @deprecated Use `fallbackRedirectUrl` or `forceRedirectUrl` instead.
    */
   afterSignUpUrl?: string | null;
   /**


### PR DESCRIPTION
## Description

The [ `LegacyRedirectProps`](https://github.com/clerk/javascript/blob/7d2f3ec63f044256723d35f9ebb33db13675083b/packages/types/src/redirects.ts#L21,L34) type is shared between:
- **ClerkProvider**: Uses specific prefixed props (`signInFallbackRedirectUrl`, `signUpFallbackRedirectUrl`, etc.)
- **SignIn/SignUp components**: Support generic props (`fallbackRedirectUrl`, `forceRedirectUrl`) in addition to the prefixed ones

The current deprecation warnings suggest using `fallbackRedirectUrl` or `forceRedirectUrl` props, which don't exist in ClerkProvider. This PR fixes it.

Fixes https://github.com/clerk/javascript/issues/6655

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
