### PR TITLE
fix(clerk-js): Remove double slash from FAPI client urls

### DIFF
--- a/.changeset/fluffy-comics-peel.md
+++ b/.changeset/fluffy-comics-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixing an issue where an incorrect FAPI client URLs were generated in an app using a proxy configuration.

--- a/.changeset/fluffy-comics-peel.md
+++ b/.changeset/fluffy-comics-peel.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Fixing an issue where an incorrect FAPI client URLs were generated in an app using a proxy configuration.
+Fix double slash in FAPI client URLs when using a proxy configuration (avoids 308 redirects).

--- a/packages/clerk-js/src/core/__tests__/fapiClient.spec.ts
+++ b/packages/clerk-js/src/core/__tests__/fapiClient.spec.ts
@@ -21,6 +21,13 @@ const fapiClientWithProxy = createFapiClient({
   proxyUrl,
 });
 
+const proxyUrlWithTrailingSlash = 'https://clerk.com/api/__clerk/';
+
+const fapiClientWithProxyTrailingSlash = createFapiClient({
+  ...baseFapiClientOptions,
+  proxyUrl: proxyUrlWithTrailingSlash,
+});
+
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
@@ -76,6 +83,20 @@ describe('buildUrl(options)', () => {
   it('returns the full frontend API URL using proxy url', () => {
     expect(fapiClientWithProxy.buildUrl({ path: '/foo' }).href).toBe(
       `${proxyUrl}/v1/foo?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
+    );
+  });
+
+  it('returns the correct URL when proxy URL has a trailing slash', () => {
+    // The expected URL should NOT have double slashes after __clerk
+    expect(fapiClientWithProxyTrailingSlash.buildUrl({ path: '/foo' }).href).toBe(
+      `https://clerk.com/api/__clerk/v1/foo?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
+    );
+  });
+
+  it('handles complex paths correctly with proxy URL with trailing slash', () => {
+    const path = '/client/sign_ins/sia_123/prepare_first_factor';
+    expect(fapiClientWithProxyTrailingSlash.buildUrl({ path }).href).toBe(
+      `https://clerk.com/api/__clerk/v1${path}?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
     );
   });
 

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -149,7 +149,11 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
 
     if (options.proxyUrl) {
       const proxyBase = new URL(options.proxyUrl);
-      const proxyPath = proxyBase.pathname.slice(1, proxyBase.pathname.length);
+      // Remove leading slash and any trailing slash from the proxy pathname
+      let proxyPath = proxyBase.pathname.slice(1);
+      if (proxyPath.endsWith('/')) {
+        proxyPath = proxyPath.slice(0, -1);
+      }
       return buildUrlUtil(
         {
           base: proxyBase.origin,

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -149,7 +149,6 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
 
     if (options.proxyUrl) {
       const proxyBase = new URL(options.proxyUrl);
-      // Remove leading slash and any trailing slash from the proxy pathname
       let proxyPath = proxyBase.pathname.slice(1);
       if (proxyPath.endsWith('/')) {
         proxyPath = proxyPath.slice(0, -1);


### PR DESCRIPTION
## Description

Fixing an issue where we are incorrectly creating FAPI client URLs with an app using a proxy configuration. 

**BEFORE**

See the first prepare call has a double // in the URL which causes FAPI to send a 308 redirect to the corrected URL. 

<img width="420" height="145" alt="Screenshot 2025-09-03 at 9 45 59 PM" src="https://github.com/user-attachments/assets/58d55ad5-d6ae-426e-9a59-49d480c95cb7" />

**AFTER**

All prepare calls have the proper URL and no longer trigger a 308 redirect




## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixes URL construction when a proxy URL ends with a trailing slash, preventing double-slash paths and ensuring requests resolve correctly for both simple and nested routes. Improves reliability of proxied API calls and prevents misrouted or failed requests.

- Tests
  - Adds test coverage for trailing-slash proxy scenarios to validate URL building behavior and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->