### PR TITLE
fix(elements): Correctly specify dependency on `type-fest` package

### DIFF
--- a/.changeset/silent-women-dance.md
+++ b/.changeset/silent-women-dance.md
@@ -1,0 +1,5 @@
+---
+'@clerk/elements': patch
+---
+
+Correctly specify dependency on `type-fest` package.

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -81,13 +81,13 @@
     "@xstate/react": "^6.0.0",
     "client-only": "^0.0.1",
     "tslib": "catalog:repo",
+    "type-fest": "^4.41.0",
     "xstate": "^5.20.2"
   },
   "devDependencies": {
     "@statelyai/inspect": "^0.4.0",
     "concurrently": "^9.2.0",
-    "next": "14.2.32",
-    "type-fest": "^4.41.0"
+    "next": "14.2.32"
   },
   "peerDependencies": {
     "next": "^13.5.4 || ^14.0.3 || ^15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       tslib:
         specifier: catalog:repo
         version: 2.8.1
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       xstate:
         specifier: ^5.20.2
         version: 5.20.2
@@ -619,9 +622,6 @@ importers:
       next:
         specifier: 14.2.32
         version: 14.2.32(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      type-fest:
-        specifier: ^4.41.0
-        version: 4.41.0
 
   packages/expo:
     dependencies:
@@ -2917,7 +2917,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}


### PR DESCRIPTION
## Description

`@clerk/elements` references types from the `type-fest` package in its generated output, but it only specifies `type-fest` as a `devDependency`. This results in the package not being installed when `@clerk/elements` is installed, resulting in broken types.

<img width="1194" height="594" alt="CleanShot 2025-09-04 at 15 02 38@2x" src="https://github.com/user-attachments/assets/a3056d64-b5bf-4046-8147-c5be93970378" />


This PR fixes the issue by moving `type-fest` to `dependencies`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency configuration in Elements to include a required runtime package, preventing potential install/build errors for consumers.

* **Chores**
  * Added release metadata to publish a patch update for Elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->