### PR TITLE
chore(backend): Add extend trial endpoint

### DIFF
--- a/.changeset/public-goats-sort.md
+++ b/.changeset/public-goats-sort.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Extend the trial of a subscription item via the BillingAPI.

--- a/packages/backend/src/api/endpoints/BillingApi.ts
+++ b/packages/backend/src/api/endpoints/BillingApi.ts
@@ -23,6 +23,14 @@ type CancelSubscriptionItemParams = {
   endNow?: boolean;
 };
 
+type ExtendSubscriptionItemFreeTrialParams = {
+  /**
+   * RFC3339 timestamp to extend the free trial to.
+   * Must be in the future and not more than 365 days from the current trial end.
+   */
+  extendTo: Date;
+};
+
 export class BillingAPI extends AbstractAPI {
   /**
    * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
@@ -46,6 +54,22 @@ export class BillingAPI extends AbstractAPI {
       method: 'DELETE',
       path: joinPaths(basePath, 'subscription_items', subscriptionItemId),
       queryParams: params,
+    });
+  }
+
+  /**
+   * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
+   * It is advised to pin the SDK version to avoid breaking changes.
+   */
+  public async extendSubscriptionItemFreeTrial(
+    subscriptionItemId: string,
+    params: ExtendSubscriptionItemFreeTrialParams,
+  ) {
+    this.requireId(subscriptionItemId);
+    return this.request<CommerceSubscriptionItem>({
+      method: 'POST',
+      path: joinPaths('/billing', 'subscription_items', subscriptionItemId, 'extend_free_trial'),
+      bodyParams: params,
     });
   }
 


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to extend a subscription item’s free trial via the Billing API by specifying a new trial end date.
  * Supports RFC3339 timestamps; the date must be in the future and no more than 365 days beyond the current trial end.

* **Documentation**
  * Marked the feature as experimental and recommended pinning the SDK version to avoid potential breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->