### PR TITLE
feat(clerk-js,types): Add support for additional fields for SignUp

### DIFF
--- a/.changeset/pink-cows-stop.md
+++ b/.changeset/pink-cows-stop.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Experimental] Add support for additional params for SignUp

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -25,6 +25,7 @@ import type {
   SignUpFuturePhoneCodeVerifyParams,
   SignUpFutureResource,
   SignUpFutureSSOParams,
+  SignUpFutureUpdateParams,
   SignUpIdentificationField,
   SignUpJSON,
   SignUpJSONSnapshot,
@@ -131,6 +132,14 @@ export class SignUp extends BaseResource implements SignUpResource {
    * of `SignUp`.
    */
   __internal_basePost = this._basePost.bind(this);
+
+  /**
+   * @internal Only used for internal purposes, and is not intended to be used directly.
+   *
+   * This property is used to provide access to underlying Client methods to `SignUpFuture`, which wraps an instance
+   * of `SignUp`.
+   */
+  __internal_basePatch = this._basePatch.bind(this);
 
   constructor(data: SignUpJSON | SignUpJSONSnapshot | null = null) {
     super();
@@ -584,12 +593,62 @@ class SignUpFuture implements SignUpFutureResource {
   }
 
   async create(params: SignUpFutureCreateParams): Promise<{ error: unknown }> {
-    const { transfer } = params;
     return runAsyncResourceTask(this.resource, async () => {
       const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken();
+
+      const body: Record<string, unknown> = {
+        transfer: params.transfer,
+        captchaToken,
+        captchaWidgetType,
+        captchaError,
+      };
+
+      if (params.firstName) {
+        body.firstName = params.firstName;
+      }
+
+      if (params.lastName) {
+        body.lastName = params.lastName;
+      }
+
+      if (params.unsafeMetadata) {
+        body.unsafeMetadata = normalizeUnsafeMetadata(params.unsafeMetadata);
+      }
+
+      if (params.legalAccepted) {
+        body.legalAccepted = params.legalAccepted;
+      }
+
       await this.resource.__internal_basePost({
         path: this.resource.pathRoot,
-        body: { transfer, captchaToken, captchaWidgetType, captchaError },
+        body,
+      });
+    });
+  }
+
+  async update(params: SignUpFutureUpdateParams): Promise<{ error: unknown }> {
+    return runAsyncResourceTask(this.resource, async () => {
+      const body: Record<string, unknown> = {};
+
+      if (params.firstName) {
+        body.firstName = params.firstName;
+      }
+
+      if (params.lastName) {
+        body.lastName = params.lastName;
+      }
+
+      if (params.unsafeMetadata) {
+        body.unsafeMetadata = normalizeUnsafeMetadata(params.unsafeMetadata);
+      }
+
+      if (params.legalAccepted) {
+        body.legalAccepted = params.legalAccepted;
+      }
+
+      await this.resource.__internal_basePatch({
+        path: this.resource.pathRoot,
+        body,
       });
     });
   }
@@ -618,7 +677,26 @@ class SignUpFuture implements SignUpFutureResource {
         body.username = params.username;
       }
 
-      await this.resource.__internal_basePost({ path: this.resource.pathRoot, body });
+      if (params.firstName) {
+        body.firstName = params.firstName;
+      }
+
+      if (params.lastName) {
+        body.lastName = params.lastName;
+      }
+
+      if (params.unsafeMetadata) {
+        body.unsafeMetadata = normalizeUnsafeMetadata(params.unsafeMetadata);
+      }
+
+      if (params.legalAccepted) {
+        body.legalAccepted = params.legalAccepted;
+      }
+
+      await this.resource.__internal_basePost({
+        path: this.resource.pathRoot,
+        body,
+      });
     });
   }
 

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -88,6 +88,7 @@ export class StateProxy implements State {
         },
 
         create: gateMethod(target, 'create'),
+        update: gateMethod(target, 'update'),
         sso: gateMethod(target, 'sso'),
         password: gateMethod(target, 'password'),
         finalize: gateMethod(target, 'finalize'),

--- a/packages/types/src/signUpFuture.ts
+++ b/packages/types/src/signUpFuture.ts
@@ -2,21 +2,30 @@ import type { SetActiveNavigate } from './clerk';
 import type { PhoneCodeChannel } from './phoneCodeChannel';
 import type { SignUpIdentificationField, SignUpStatus } from './signUpCommon';
 
-export interface SignUpFutureCreateParams {
+interface SignUpFutureAdditionalParams {
+  firstName?: string;
+  lastName?: string;
+  unsafeMetadata?: SignUpUnsafeMetadata;
+  legalAccepted?: boolean;
+}
+
+export interface SignUpFutureCreateParams extends SignUpFutureAdditionalParams {
   transfer?: boolean;
 }
+
+export interface SignUpFutureUpdateParams extends SignUpFutureAdditionalParams {}
 
 export interface SignUpFutureEmailCodeVerifyParams {
   code: string;
 }
 
-export type SignUpFuturePasswordParams = {
+export type SignUpFuturePasswordParams = SignUpFutureAdditionalParams & {
   password: string;
 } & (
-  | { emailAddress: string; phoneNumber?: string; username?: string }
-  | { emailAddress?: string; phoneNumber: string; username?: string }
-  | { emailAddress?: string; phoneNumber?: string; username: string }
-);
+    | { emailAddress: string; phoneNumber?: string; username?: string }
+    | { emailAddress?: string; phoneNumber: string; username?: string }
+    | { emailAddress?: string; phoneNumber?: string; username: string }
+  );
 
 export interface SignUpFuturePhoneCodeSendParams {
   phoneNumber?: string;
@@ -66,6 +75,8 @@ export interface SignUpFutureResource {
   readonly existingSession?: { sessionId: string };
 
   create: (params: SignUpFutureCreateParams) => Promise<{ error: unknown }>;
+
+  update: (params: SignUpFutureUpdateParams) => Promise<{ error: unknown }>;
 
   /**
    *


### PR DESCRIPTION
## Description

This PR adds support for additional fields in our Signal SignUp methods that create sign-ups (first name, last name, legal accepted, and unsafe metadata). It also adds the `signUp.update` method.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
