### PR TITLE
fix(localizations): Fix formatting of `cs-CZ` localization strings

### DIFF
--- a/.changeset/brave-guests-kick.md
+++ b/.changeset/brave-guests-kick.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Fix formatting of cs-CZ localization strings

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -840,7 +840,8 @@ export const csCZ: LocalizationResource = {
   },
   unstable__errors: {
     already_a_member_in_organization: '{{email}} je již členem organizace.',
-    captcha_invalid: 'Registrace neúspěšná kvůli neúspěšným bezpečnostním validacím. Prosím, obnovte stránku a zkuste to znovu nebo kontaktujte podporu.',
+    captcha_invalid:
+      'Registrace neúspěšná kvůli neúspěšným bezpečnostním validacím. Prosím, obnovte stránku a zkuste to znovu nebo kontaktujte podporu.',
     captcha_unavailable:
       'Registrace nebyla úspěšná kvůli neúspěšné validaci bota. Prosím obnovte stránku a zkuste to znovu, nebo se obraťte na podporu pro další pomoc.',
     form_code_incorrect: 'Kód je nesprávný.',
@@ -855,20 +856,21 @@ export const csCZ: LocalizationResource = {
     form_param_max_length_exceeded__last_name: 'Příjmení nesmí přesáhnout 256 znaků.',
     form_param_max_length_exceeded__name: 'Jméno nesmí přesáhnout 256 znaků.',
     form_param_nil: 'Tento parametr je povinný.',
-     form_param_value_invalid: 'Tento parametr má neplatnou hodnotu.',
-     form_param_type_invalid__email_address: undefined,
-     form_param_type_invalid__phone_number: undefined,
+    form_param_value_invalid: 'Tento parametr má neplatnou hodnotu.',
+    form_param_type_invalid__email_address: undefined,
+    form_param_type_invalid__phone_number: undefined,
     form_password_incorrect: 'Heslo je nesprávné.',
     form_password_length_too_short: 'Heslo je příliš krátké.',
     form_password_not_strong_enough: 'Vaše heslo není dostatečně silné.',
     form_password_pwned: 'Toto heslo bylo nalezeno jako součást prolomení a nelze ho použít, zkuste prosím jiné heslo.',
     form_password_pwned__sign_in:
       'Toto heslo bylo nalezeno jako součást prolomení a nelze ho použít, prosím resetujte si heslo.',
-    form_password_size_in_bytes_exceeded: 'Vaše heslo překročilo maximální povolený počet bajtů, prosím zkrátit ho nebo odstranit některé speciální znaky.',
+    form_password_size_in_bytes_exceeded:
+      'Vaše heslo překročilo maximální povolený počet bajtů, prosím zkrátit ho nebo odstranit některé speciální znaky.',
     form_password_validation_failed: 'Nesprávné heslo',
     form_username_invalid_character: 'Uživatelské jméno může obsahovat pouze alfanumerické znaky a podtržítka.',
     form_username_invalid_length: 'Vaše uživatelské jméno musí mít mezi {{min_length}} a {{max_length}} znaky.',
-    identification_deletion_failed: 'Svůj poslední identifikační údaj nelze smazat.', 
+    identification_deletion_failed: 'Svůj poslední identifikační údaj nelze smazat.',
     not_allowed_access: undefined,
     organization_domain_blocked: undefined,
     organization_domain_common: undefined,


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting of Czech (cs-CZ) localization strings to ensure consistent rendering and spacing across the UI. No changes to translation content or keys; behavior remains the same.

* **Chores**
  * Added a release note declaring a patch release for the localizations package to include the formatting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->