### PR TITLE
chore(clerk-expo): Accept `showInRecents` option for opening web browser on `useSSO`

### DIFF
--- a/.changeset/odd-monkeys-rush.md
+++ b/.changeset/odd-monkeys-rush.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Accepts `showInRecents` in `authSessionOptions` for `useSSO`, preventing the Android web browser tab from closing when navigating away during the SSO flow

--- a/packages/expo/src/hooks/useSSO.ts
+++ b/packages/expo/src/hooks/useSSO.ts
@@ -8,6 +8,7 @@ import { errorThrower } from '../utils/errors';
 export type StartSSOFlowParams = {
   redirectUrl?: string;
   unsafeMetadata?: SignUpUnsafeMetadata;
+  authSessionOptions?: Pick<WebBrowser.AuthSessionOpenOptions, 'showInRecents'>;
 } & (
   | {
       strategy: OAuthStrategy;
@@ -41,7 +42,7 @@ export function useSSO() {
       };
     }
 
-    const { strategy, unsafeMetadata } = startSSOFlowParams ?? {};
+    const { strategy, unsafeMetadata, authSessionOptions } = startSSOFlowParams ?? {};
 
     /**
      * Creates a redirect URL based on the application platform
@@ -69,6 +70,7 @@ export function useSSO() {
     const authSessionResult = await WebBrowser.openAuthSessionAsync(
       externalVerificationRedirectURL.toString(),
       redirectUrl,
+      authSessionOptions,
     );
     if (authSessionResult.type !== 'success' || !authSessionResult.url) {
       return {


### PR DESCRIPTION
## Description

Ported from https://github.com/clerk/javascript/pull/6050 @FabianUntermoser 

Allows passing `showInRecents` option to ` WebBrowser.openAuthSessionAsync`, which prevents the web browser tab from closing when navigating away during the SSO login on Android

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional auth-session setting for SSO to control “show in recents.”
  * On Android, prevents the browser tab from closing when users navigate away mid-SSO, improving continuity and user experience.

* **Chores**
  * Added a patch changeset entry for the Expo package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->