### PR TITLE
chore(vue): Replace callback props with event emitters in billing buttons

### DIFF
--- a/.changeset/cuddly-masks-beam.md
+++ b/.changeset/cuddly-masks-beam.md
@@ -4,5 +4,5 @@
 
 Replaced callback props with event emitters in billing buttons:
 
-props `onSubscriptionComplete` → emit `subscriptionComplete`  
-props `onSubscriptionCancel`   → emit `subscriptionCancel`
+props `onSubscriptionComplete` → emit `subscription-complete`  
+props `onSubscriptionCancel`   → emit `subscription-cancel`

--- a/packages/vue/src/components/CheckoutButton.vue
+++ b/packages/vue/src/components/CheckoutButton.vue
@@ -27,7 +27,7 @@ function getChildComponent() {
   return assertSingleChild(children, 'CheckoutButton');
 }
 
-const emit = defineEmits(['subscriptionComplete']);
+const emit = defineEmits<{ (e: 'subscription-complete'): void }>();
 
 function clickHandler() {
   if (!clerk.value) {
@@ -39,8 +39,8 @@ function clickHandler() {
     planPeriod: props.planPeriod,
     for: props.for,
     newSubscriptionRedirectUrl: props.newSubscriptionRedirectUrl,
-    onSubscriptionComplete: () => emit('subscriptionComplete'),
     ...props.checkoutProps,
+    onSubscriptionComplete: () => emit('subscription-complete'),
   });
 }
 </script>

--- a/packages/vue/src/components/SubscriptionDetailsButton.vue
+++ b/packages/vue/src/components/SubscriptionDetailsButton.vue
@@ -27,7 +27,7 @@ function getChildComponent() {
   return assertSingleChild(children, 'SubscriptionDetailsButton');
 }
 
-const emit = defineEmits(['subscriptionCancel']);
+const emit = defineEmits<{ (e: 'subscription-cancel'): void }>();
 
 function clickHandler() {
   if (!clerk.value) {
@@ -36,8 +36,8 @@ function clickHandler() {
 
   return clerk.value.__internal_openSubscriptionDetails({
     for: props.for,
-    onSubscriptionCancel: () => emit('subscriptionCancel'),
     ...props.subscriptionDetailsProps,
+    onSubscriptionCancel: () => emit('subscription-cancel'),
   });
 }
 </script>


### PR DESCRIPTION
## Description

This PR converts callback props to [Vue event emitters](https://vuejs.org/guide/components/events#emitting-and-listening-to-events) in billing button components to follow Vue patterns.

**Usage**

Before

```vue
<SubscriptionDetailsButton :onSubscriptionCancel="() => console.log('Subscription canceled')">
  <button class="custom-button">Manage Subscription</button>
</SubscriptionDetailsButton>
```

After

```vue
<SubscriptionDetailsButton @subscription-cancel="() => console.log('Subscription canceled')">
  <button class="custom-button">Manage Subscription</button>
</SubscriptionDetailsButton>
```

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Checkout button now emits a subscription-complete event.
  * Subscription details button now emits a subscription-cancel event.
* Refactor
  * Replaced callback props with event emitters for billing buttons.
  * Removed onSubscriptionComplete and onSubscriptionCancel props; use corresponding events instead.
* Chores
  * Minor version bump for @clerk/vue.

Migration:
- Replace onSubscriptionComplete prop with a listener for subscription-complete.
- Replace onSubscriptionCancel prop with a listener for subscription-cancel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->