### PR TITLE
chore(nextjs): Accept `treatPendingAsSignedOut` option on `currentUser`

### DIFF
--- a/.changeset/lemon-friends-build.md
+++ b/.changeset/lemon-friends-build.md
@@ -1,0 +1,15 @@
+---
+'@clerk/nextjs': patch
+---
+
+Accept `treatPendingAsSignedOut` option on `currentUser`
+
+```ts
+  // If the session has a `pending` status, user will be `null` default, treated as a signed-out state
+  const user = await currentUser()
+```
+
+```ts
+  // If the session has a `pending` status, `user` will be defined, treated as a signed-in state
+  const user = await currentUser({ treatPendingAsSignedOut: false })
+```

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -1,7 +1,10 @@
 import type { User } from '@clerk/backend';
+import type { PendingSessionOptions } from '@clerk/types';
 
 import { clerkClient } from '../../server/clerkClient';
 import { auth } from './auth';
+
+type CurrentUserOptions = PendingSessionOptions;
 
 /**
  * The `currentUser` helper returns the [Backend User](https://clerk.com/docs/references/backend/types/backend-user) object of the currently active user. It can be used in Server Components, Route Handlers, and Server Actions.
@@ -24,11 +27,11 @@ import { auth } from './auth';
  * }
  * ```
  */
-export async function currentUser(): Promise<User | null> {
+export async function currentUser(opts?: CurrentUserOptions): Promise<User | null> {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('server-only');
 
-  const { userId } = await auth();
+  const { userId } = await auth({ treatPendingAsSignedOut: opts?.treatPendingAsSignedOut });
   if (!userId) {
     return null;
   }


### PR DESCRIPTION
## Description

Currently, `auth` already accepts `treatPendingAsSignedOut`, and since `currentUser` leverages it, it should also accept that option so that users can opt-out. 

```ts
  // If the session has a `pending` status, `userId` will be `null` by default, treated as a signed-out state
  const { userId } = await currentUser()
```

```ts
  // If the session has a `pending` status, `userId` will be defined, treated as a signed-in state
  const { userId } = await currentUser({ treatPendingAsSignedOut: false })
```

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to currentUser to control how pending sessions are handled.
  * By default, pending sessions are treated as signed out; you can opt in to treat them as signed in to access the user during pending state.

* **Documentation**
  * Updated guides with examples showing:
    * currentUser returns null when a session is pending (default).
    * currentUser with the new option disabled returns a defined user during a pending session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->