### PR TITLE
fix(clerk-js): Ensure Base & Coinbase dependencies aren't bundled for non-RHC environments

### DIFF
--- a/.changeset/funny-laws-fetch.md
+++ b/.changeset/funny-laws-fetch.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Ensure Coinbase dependencies aren't bundled for non-RHC environments
+Remove Base for non-RHC environments to ensure Coinbase dependencies aren't bundled.

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -82,7 +82,9 @@ const common = ({ mode, variant, disableRHC = false }) => {
      * SDKs such as Browser Extensions.
      */
     // TODO: @COMMERCE:  Do we still need this?
-    externals: disableRHC ? ['@stripe/stripe-js', '@stripe/react-stripe-js', '@coinbase/wallet-sdk'] : undefined,
+    externals: disableRHC
+      ? ['@stripe/stripe-js', '@stripe/react-stripe-js', '@coinbase/wallet-sdk', '@base-org/account']
+      : undefined,
     optimization: {
       splitChunks: {
         cacheGroups: {
@@ -481,6 +483,9 @@ const prodConfig = ({ mode, env, analysis }) => {
       }),
       new rspack.IgnorePlugin({
         resourceRegExp: /^@coinbase\/wallet-sdk$/,
+      }),
+      new rspack.IgnorePlugin({
+        resourceRegExp: /^@base-org\/account$/,
       }),
       new rspack.optimize.LimitChunkCountPlugin({
         maxChunks: 1,

--- a/scripts/search-for-rhc.mjs
+++ b/scripts/search-for-rhc.mjs
@@ -28,8 +28,11 @@ await Promise.allSettled([
   asyncSearchRHC('Turnstile', 'cloudflare.com/turnstile/v0/api.js'),
   asyncSearchRHC('clerk-js Hotloading', '/npm/@clerk/clerk-js'),
   asyncSearchRHC('Google One Tap', 'accounts.google.com/gsi/client'),
+  asyncSearchRHC('Coinbase', 'coinbase.com'),
+  asyncSearchRHC('Coinbase Wallet import', 'import\s*"@coinbase/wallet-sdk', true), // eslint-disable-line no-useless-escape
   asyncSearchRHC('Stripe', 'js.stripe.com'),
   asyncSearchRHC('Stripe import', 'import\s*"@stripe/stripe-js', true), // eslint-disable-line no-useless-escape
+  asyncSearchRHC('Base import', 'import\s*"@base-org/account', true), // eslint-disable-line no-useless-escape
 ]).then(results => {
   const errors = results.filter(result => result.status === 'rejected').map(result => result.reason.message);
 


### PR DESCRIPTION
## Description


Ensures Base & Coinbase Wallet dependencies aren't bundled for non-RHC environments.

Note: Base now includes CB Wallet.

<!-- Fixes #(issue number) -->
USER-4320

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents Coinbase Wallet and Base account dependencies from being bundled in non-RHC (no-RHC/production) builds, reducing runtime issues and improving compatibility. Added additional build-time searches to detect remote-hosted Coinbase/Base usages.

- Chores
  - Adds a patch-release changeset recording the bundling behavior change for non-RHC environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->