### PR TITLE
chore(expo): Add retry logic for server errors during init in native

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2653,13 +2653,16 @@ export class Clerk implements ClerkInterface {
       ]);
     } catch (err) {
       const isServerError = isClerkRuntimeError(err) && err.code === 'network_error';
+
       if (isServerError && this.shouldFallbackToCachedResources()) {
+        // Offline apps: Use cached resources when network fails
         const cachedResources = await this.__internal_getCachedResources?.();
         environment = new Environment(cachedResources?.environment);
         Client.clearInstance();
         client = Client.getOrCreateInstance(cachedResources?.client);
         ++initializationDegradedCounter;
       } else if (isServerError) {
+        // Non-offline apps: Retry once after 10 seconds for 5xx errors
         try {
           await new Promise(resolve => setTimeout(resolve, 10000));
           [environment, client] = await Promise.all([

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -4,6 +4,7 @@ import type { BrowserClerk, HeadlessBrowserClerk } from '@clerk/clerk-react';
 import { is4xxError } from '@clerk/shared/error';
 import type {
   ClientJSONSnapshot,
+  ClientResource,
   EnvironmentJSONSnapshot,
   PublicKeyCredentialCreationOptionsWithoutExtensions,
   PublicKeyCredentialRequestOptionsWithoutExtensions,
@@ -153,7 +154,15 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
             environment: EnvironmentJSONSnapshot | null;
           }> => {
             await retryInitializeResourcesFromFAPI();
-            return { client: null, environment: null };
+
+            // @ts-expect-error - This is an internal API
+            const environment = __internal_clerk?.__unstable__environment as EnvironmentResource;
+            const client = __internal_clerk?.client as ClientResource;
+
+            return {
+              client: client.__internal_toSnapshot(),
+              environment: environment.__internal_toSnapshot(),
+            };
           };
         }
       }


### PR DESCRIPTION
## Description

This PR adds retry mechanism for non-offline Expo apps to handle 5xx server errors during initial resource loading, fixing issues where users experiencing temporary sign-outs due to server issues on app load.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
