### PR TITLE
chore(remix): Add deprecation warning for maintenance mode

### DIFF
--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -1,5 +1,16 @@
 import './globalPolyfill';
 
+console.warn(`
+Clerk - DEPRECATION WARNING: @clerk/remix is now in maintenance mode.
+
+@clerk/remix will only receive security updates. No new features will be added.
+
+Please migrate to @clerk/react-router for continued development and new features:
+
+Migration guide: https://reactrouter.com/upgrading/remix
+React Router SDK: https://clerk.com/docs/quickstarts/react-router
+`);
+
 export * from './client';
 
 // Override Clerk React error thrower to show that errors come from @clerk/remix

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -1,6 +1,8 @@
 import './globalPolyfill';
 
-console.warn(`
+import { logger } from '@clerk/shared/logger';
+
+logger.warnOnce(`
 Clerk - DEPRECATION WARNING: @clerk/remix is now in maintenance mode.
 
 @clerk/remix will only receive security updates. No new features will be added.


### PR DESCRIPTION
## Description

Adds a deprecation warning to the `@clerk/remix` package to inform users that it's now in maintenance mode and will only receive security updates. Remix itself is in maintenance mode and only receives security updates.

They (remix authors) are working on another "Remix" package that is not React-based, and may confuse future users.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
