### PR TITLE
fix(clerk-js, shared): Display empty data for authenticated billing hooks after sign out

### DIFF
--- a/.changeset/major-steaks-hug.md
+++ b/.changeset/major-steaks-hug.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Display empty data for authenticated billing hooks after sign out.

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -148,6 +148,7 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, config, 
   const cacheMode = config.__experimental_mode === 'cache';
   const triggerInfinite = config.infinite ?? false;
   const keepPreviousData = config.keepPreviousData ?? false;
+  const isSignedIn = config.isSignedIn;
 
   const pagesCacheKey = {
     ...cacheKeys,
@@ -159,10 +160,13 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, config, 
   // cacheMode being `true` indicates that the cache key is defined, but the fetcher is not.
   // This allows to ready the cache instead of firing a request.
   const shouldFetch = !triggerInfinite && enabled && (!cacheMode ? !!fetcher : true);
-  const swrKey = shouldFetch ? pagesCacheKey : null;
+  const swrKey = isSignedIn ? pagesCacheKey : shouldFetch ? pagesCacheKey : null;
   const swrFetcher =
     !cacheMode && !!fetcher
       ? (cacheKeyParams: Record<string, unknown>) => {
+          if (isSignedIn === false) {
+            return null;
+          }
           const requestParams = getDifferentKeys(cacheKeyParams, cacheKeys);
           return fetcher({ ...params, ...requestParams });
         }

--- a/packages/shared/src/react/hooks/usePaymentAttempts.tsx
+++ b/packages/shared/src/react/hooks/usePaymentAttempts.tsx
@@ -11,6 +11,9 @@ export const usePaymentAttempts = createCommercePaginatedHook<CommercePaymentRes
   resourceType: 'commerce-payment-attempts',
   useFetcher: () => {
     const clerk = useClerkInstanceContext();
-    return clerk.billing.getPaymentAttempts;
+    if (clerk.loaded) {
+      return clerk.billing.getPaymentAttempts;
+    }
+    return undefined;
   },
 });

--- a/packages/shared/src/react/hooks/usePlans.tsx
+++ b/packages/shared/src/react/hooks/usePlans.tsx
@@ -11,6 +11,9 @@ export const usePlans = createCommercePaginatedHook<CommercePlanResource, GetPla
   resourceType: 'commerce-plans',
   useFetcher: _for => {
     const clerk = useClerkInstanceContext();
+    if (!clerk.loaded) {
+      return undefined;
+    }
     return ({ orgId, ...rest }) => {
       // Cleanup `orgId` from the params
       return clerk.billing.getPlans({ ...rest, for: _for });

--- a/packages/shared/src/react/hooks/useStatements.tsx
+++ b/packages/shared/src/react/hooks/useStatements.tsx
@@ -11,6 +11,9 @@ export const useStatements = createCommercePaginatedHook<CommerceStatementResour
   resourceType: 'commerce-statements',
   useFetcher: () => {
     const clerk = useClerkInstanceContext();
-    return clerk.billing.getStatements;
+    if (clerk.loaded) {
+      return clerk.billing.getStatements;
+    }
+    return undefined;
   },
 });

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -118,6 +118,13 @@ export type PagesOrInfiniteConfig = PaginatedHookConfig<{
    * @hidden
    */
   __experimental_mode?: 'cache';
+
+  /**
+   * @experimental
+   *
+   * @hidden
+   */
+  isSignedIn?: boolean;
 }>;
 
 /**


### PR DESCRIPTION
## Description

This PR ensures:
1. authed billing hooks clean up data on sign out
1. billing hooks do not error when clerk is not loaded

This happens when the billing hooks use `keepPreviousData: true` (default behaviour of AIOs). We want to keep using that to avoid CLS and content flashing on revalidations, but at the same time we don't want to display the previous "stale" data after the user has signed out.

### Before
https://github.com/user-attachments/assets/bdd891d9-95c9-40a6-9f14-7aca3e9209f6


### After
https://github.com/user-attachments/assets/3cb157d4-9459-46f4-9f9f-b2f1009b669c







<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Billing and subscription data no longer fetches while signed out; empty data is shown after sign-out.
  - Prevents premature network calls until the app is fully loaded, reducing flicker and errors.
  - Improves pagination and caching behavior by respecting sign-in state.

- Chores
  - Added release metadata for a patch update to @clerk/shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->