### PR TITLE
feat(backend,clerk-expo): Add last authenitcation strategy

### DIFF
--- a/.changeset/honest-banks-happen.md
+++ b/.changeset/honest-banks-happen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add lastAuthenticationStrategy to API resources

--- a/.changeset/warm-loops-roll.md
+++ b/.changeset/warm-loops-roll.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Add last_authentication_strategy to dummy cache data

--- a/packages/backend/src/api/resources/Client.ts
+++ b/packages/backend/src/api/resources/Client.ts
@@ -1,3 +1,5 @@
+import type { LastAuthenticationStrategy } from '@clerk/types';
+
 import type { ClientJSON } from './JSON';
 import { Session } from './Session';
 
@@ -31,6 +33,10 @@ export class Client {
      */
     readonly lastActiveSessionId: string | null,
     /**
+     * The last authentication strategy used by the `Client`.
+     */
+    readonly lastAuthenticationStrategy: LastAuthenticationStrategy | null,
+    /**
      * The date when the `Client` was first created.
      */
     readonly createdAt: number,
@@ -48,6 +54,7 @@ export class Client {
       data.sign_in_id,
       data.sign_up_id,
       data.last_active_session_id,
+      data.last_authentication_strategy,
       data.created_at,
       data.updated_at,
     );

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -1,4 +1,4 @@
-import type { SignUpStatus, VerificationStatus } from '@clerk/types';
+import type { LastAuthenticationStrategy, SignUpStatus, VerificationStatus } from '@clerk/types';
 
 import type {
   ActorTokenStatus,
@@ -142,6 +142,7 @@ export interface ClientJSON extends ClerkResourceJSON {
   sign_in_id: string | null;
   sign_up_id: string | null;
   last_active_session_id: string | null;
+  last_authentication_strategy: LastAuthenticationStrategy | null;
   created_at: number;
   updated_at: number;
 }

--- a/packages/expo/src/cache/dummy-data/client-resource.ts
+++ b/packages/expo/src/cache/dummy-data/client-resource.ts
@@ -125,6 +125,7 @@ export const DUMMY_CLERK_CLIENT_RESOURCE = {
   },
   last_active_session_id: null,
   cookie_expires_at: null,
+  last_authentication_strategy: null,
   created_at: new Date().getTime(),
   updated_at: new Date().getTime(),
 } as unknown as ClientJSONSnapshot;


### PR DESCRIPTION
## Description

Adds `last_authentication_strategy`/`lastAuthenticationStrategy` to Backend Client API and Expo "dummy" data.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
USER-3393

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes “last authentication strategy” on client resources in the backend API.
  * Client JSON responses now include the last authentication strategy field.
  * Expo dummy cache data updated to include the last authentication strategy.

* **Chores**
  * Added changesets to schedule a minor release for backend and a patch release for Expo, documenting the new last authentication strategy field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->