### PR TITLE
fix(backend): Inconsistent create params for Invite & Org Invite

### DIFF
--- a/.changeset/all-hats-float.md
+++ b/.changeset/all-hats-float.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Align create params for Invitation and OrganizationInvitation with backend API

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -8,12 +8,16 @@ import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/invitations';
 
+type TemplateSlug = 'invitation' | 'waitlist_invitation';
+
 type CreateParams = {
   emailAddress: string;
-  redirectUrl?: string;
-  publicMetadata?: UserPublicMetadata;
-  notify?: boolean;
+  expiresInDays?: number;
   ignoreExisting?: boolean;
+  notify?: boolean;
+  publicMetadata?: UserPublicMetadata;
+  redirectUrl?: string;
+  templateSlug: TemplateSlug;
 };
 
 type GetInvitationListParams = ClerkPaginationRequest<{

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -164,19 +164,23 @@ type DeleteOrganizationMembershipParams = {
 
 type CreateOrganizationInvitationParams = {
   organizationId: string;
-  inviterUserId?: string;
   emailAddress: string;
   role: OrganizationMembershipRole;
-  redirectUrl?: string;
+  expiresInDays?: number;
+  inviterUserId?: string;
+  privateMetadata?: OrganizationInvitationPrivateMetadata;
   publicMetadata?: OrganizationInvitationPublicMetadata;
+  redirectUrl?: string;
 };
 
 type CreateBulkOrganizationInvitationParams = Array<{
-  inviterUserId?: string;
   emailAddress: string;
   role: OrganizationMembershipRole;
-  redirectUrl?: string;
+  expiresInDays?: number;
+  inviterUserId?: string;
+  privateMetadata?: OrganizationInvitationPrivateMetadata;
   publicMetadata?: OrganizationInvitationPublicMetadata;
+  redirectUrl?: string;
 }>;
 
 type GetOrganizationInvitationListParams = ClerkPaginationRequest<{


### PR DESCRIPTION
## Description

Updates inconsistent create params for Invites & Organization Invites (including bulk).

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->
Fixes USER-3259

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitation creation now supports selecting a template (invitation or waitlist), optional expiration, notify recipient, ignore existing users, redirect URL, and public metadata.
  * Organization invitations now support optional expiration, inviter user ID, private and public metadata, and redirect URL; bulk invitations accept the same options.

* **Chores**
  * Prepared a patch release entry aligning invitation creation parameters with the backend API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->