### PR TITLE
chore(expo-passkeys): Add support for Expo 54

### DIFF
--- a/.changeset/curly-plums-tease.md
+++ b/.changeset/curly-plums-tease.md
@@ -1,5 +1,5 @@
 ---
-"@clerk/expo-passkeys": patch
+"@clerk/expo-passkeys": minor
 ---
 
 Add support for Expo 54

--- a/.changeset/curly-plums-tease.md
+++ b/.changeset/curly-plums-tease.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo-passkeys": patch
+---
+
+Add support for Expo 54

--- a/packages/expo-passkeys/package.json
+++ b/packages/expo-passkeys/package.json
@@ -40,7 +40,7 @@
     "expo": "~52.0.47"
   },
   "peerDependencies": {
-    "expo": ">=50 <54",
+    "expo": ">=50 <55",
     "react": "catalog:peer-react",
     "react-native": "*"
   }


### PR DESCRIPTION
## Description

Adjusts the expo peer dep to support Expo 54

https://expo.dev/changelog/sdk-54

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Expo 54, allowing the package to be used in projects targeting the latest Expo 54.x releases.

* **Chores**
  * Updated peer dependency range to include Expo 54.x while maintaining exclusion of future major versions.
  * Added release metadata to publish a minor version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->