### PR TITLE
fix(types): Update `OrganizationInvitationStatus` according to latest API reference

### DIFF
--- a/.changeset/strong-hounds-trade.md
+++ b/.changeset/strong-hounds-trade.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Remove `expired` from `OrganizationInvitationStatus` according to latest Backend API spec

--- a/packages/backend/src/api/resources/Enums.ts
+++ b/packages/backend/src/api/resources/Enums.ts
@@ -24,7 +24,7 @@ export type OAuthStrategy = `oauth_${OAuthProvider}`;
 /**
  * @inline
  */
-export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired';
+export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';
 
 export type OrganizationDomainVerificationStatus = 'unverified' | 'verified';
 


### PR DESCRIPTION
## Description

Currently, we only accept `'pending' | 'accepted' | 'revoked'` as org invitation statuses - [API code](https://github.com/clerk/clerk_go/blob/ef336d8c9ec39032c71ce82a673c894cdf69b0d0/pkg/constants/constants.go#L591-L592)

This PR updates the type definition in `@clerk/backend` since it is outdated. 

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete "expired" organization invitation status to prevent incorrect status handling. The valid statuses are now: pending, accepted, revoked.

* **Chores**
  * Updated public typings to reflect the current organization invitation statuses.
  * Prepared a patch release.

Impact: If your app checks for an "expired" invitation status, update your logic to use the remaining statuses. Type checks may fail until references to "expired" are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->