### PR TITLE
fix(backend): Avoid handshake loop on primary domain sync

### DIFF
--- a/.changeset/clear-forks-ring.md
+++ b/.changeset/clear-forks-ring.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix a case where handshakes would get triggered in a loop on cross origin requests in development.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -577,7 +577,8 @@ export const authenticateRequest: AuthenticateRequest = (async (
         !authenticateContext.isSatellite && // We're on primary
         authenticateContext.secFetchDest === 'document' && // Document navigation
         authenticateContext.isCrossOriginReferrer() && // Came from different domain
-        !authenticateContext.isKnownClerkReferrer(); // Not from Clerk accounts portal or FAPI
+        !authenticateContext.isKnownClerkReferrer() && // Not from Clerk accounts portal or FAPI
+        authenticateContext.handshakeRedirectLoopCounter === 0; // Not in a redirect loop
 
       if (shouldForceHandshakeForCrossDomain) {
         return handleMaybeHandshakeStatus(


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Context: https://clerkinc.slack.com/archives/C08KSPJA6JZ/p1757533420619729

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents redirect loops during cross-origin handshakes in development, improving stability for satellite-to-primary requests.

- **Chores**
  - Added a changeset entry for a patch release of @clerk/backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->