### PR TITLE
fix(clerk-js): [WIP] Prevent custom pages from re-mounting

### DIFF
--- a/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
+++ b/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
@@ -6,18 +6,25 @@ type ExternalElementMounterProps = {
 };
 
 export const ExternalElementMounter = ({ mount, unmount, ...rest }: ExternalElementMounterProps) => {
-  const nodeRef = useRef(null);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  const stableMountRef = useRef(mount);
+  const stableUnmountRef = useRef(unmount);
+
+  // Update refs when functions change, but don't trigger re-mount
+  stableMountRef.current = mount;
+  stableUnmountRef.current = unmount;
 
   useEffect(() => {
     let elRef: HTMLDivElement | undefined;
     if (nodeRef.current) {
       elRef = nodeRef.current;
-      mount(nodeRef.current);
+      stableMountRef.current(nodeRef.current);
     }
     return () => {
-      unmount(elRef);
+      stableUnmountRef.current(elRef);
     };
-  }, [nodeRef.current]);
+  }, []);
 
   return (
     <div

--- a/packages/clerk-js/src/ui/utils/__tests__/ExternalElementMounter.test.tsx
+++ b/packages/clerk-js/src/ui/utils/__tests__/ExternalElementMounter.test.tsx
@@ -1,0 +1,111 @@
+import { render } from '@testing-library/react';
+
+import { ExternalElementMounter } from '../ExternalElementMounter';
+
+describe('ExternalElementMounter', () => {
+  it('should mount the element when component mounts', () => {
+    const mockMount = jest.fn();
+    const mockUnmount = jest.fn();
+
+    render(
+      <ExternalElementMounter
+        mount={mockMount}
+        unmount={mockUnmount}
+      />,
+    );
+
+    expect(mockMount).toHaveBeenCalledTimes(1);
+    expect(mockMount).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    expect(mockUnmount).not.toHaveBeenCalled();
+  });
+
+  it('should unmount the element when component unmounts', () => {
+    const mockMount = jest.fn();
+    const mockUnmount = jest.fn();
+
+    const { unmount } = render(
+      <ExternalElementMounter
+        mount={mockMount}
+        unmount={mockUnmount}
+      />,
+    );
+
+    expect(mockMount).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockUnmount).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+
+  it('should not re-mount when mount/unmount functions change', () => {
+    const mockMount1 = jest.fn();
+    const mockUnmount1 = jest.fn();
+    const mockMount2 = jest.fn();
+    const mockUnmount2 = jest.fn();
+
+    const { rerender } = render(
+      <ExternalElementMounter
+        mount={mockMount1}
+        unmount={mockUnmount1}
+      />,
+    );
+
+    expect(mockMount1).toHaveBeenCalledTimes(1);
+    expect(mockUnmount1).not.toHaveBeenCalled();
+
+    rerender(
+      <ExternalElementMounter
+        mount={mockMount2}
+        unmount={mockUnmount2}
+      />,
+    );
+
+    expect(mockMount1).toHaveBeenCalledTimes(1);
+    expect(mockMount2).not.toHaveBeenCalled();
+    expect(mockUnmount1).not.toHaveBeenCalled();
+    expect(mockUnmount2).not.toHaveBeenCalled();
+  });
+
+  it('should use the latest unmount function when component unmounts', () => {
+    const mockMount1 = jest.fn();
+    const mockUnmount1 = jest.fn();
+    const mockMount2 = jest.fn();
+    const mockUnmount2 = jest.fn();
+
+    const { rerender, unmount } = render(
+      <ExternalElementMounter
+        mount={mockMount1}
+        unmount={mockUnmount1}
+      />,
+    );
+
+    rerender(
+      <ExternalElementMounter
+        mount={mockMount2}
+        unmount={mockUnmount2}
+      />,
+    );
+
+    unmount();
+
+    expect(mockUnmount1).not.toHaveBeenCalled();
+    expect(mockUnmount2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass through additional props to the div element', () => {
+    const mockMount = jest.fn();
+    const mockUnmount = jest.fn();
+
+    const { container } = render(
+      <ExternalElementMounter
+        mount={mockMount}
+        unmount={mockUnmount}
+        data-testid='test-id'
+      />,
+    );
+
+    const div = container.firstChild as HTMLDivElement;
+    expect(div.getAttribute('data-testid')).toBe('test-id');
+  });
+});


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Bug Fixes
  - Improved stability of external element mounting and unmounting.
  - Ensures the latest callbacks are used across re-renders, preventing unintended remounts.
  - More reliable cleanup on unmount. Public API unchanged.
- Tests
  - Added comprehensive tests for mount/unmount behavior, prop updates, and prop passthrough to the underlying element.
- Chores
  - Internal improvements to reduce lifecycle edge cases without altering existing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->