### PR TITLE
fix(ui): avoid text truncation in arrow buttons

### DIFF
--- a/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/clerk-js/src/ui/components/Subscriptions/SubscriptionsList.tsx
@@ -114,7 +114,7 @@ export function SubscriptionsList({
               t => ({
                 justifyContent: 'start',
                 height: t.sizes.$8,
-                width: isManageButtonVisible ? 'unset' : undefined,
+                width: 'auto',
               }),
             ]}
             leftIcon={subscriptionItems.length > 0 ? ArrowsUpDown : Plus}
@@ -135,7 +135,7 @@ export function SubscriptionsList({
               t => ({
                 justifyContent: 'start',
                 height: t.sizes.$8,
-                width: 'unset',
+                width: 'auto',
               }),
             ]}
             rightIcon={null}

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -78,7 +78,7 @@ export const ArrowBlockButton = React.forwardRef<HTMLButtonElement, ArrowBlockBu
       {(isLoading || leftIcon) && (
         <Flex
           as='span'
-          sx={theme => ({ flex: `0 0 ${theme.space.$5}` })}
+          sx={theme => ({ flex: `0 0 ${theme.space.$4}` })}
         >
           {isLoading ? (
             <Spinner


### PR DESCRIPTION
## Description
This commit fixes button layout issues in billing subscription section

* Change flex-basis from theme.space.$5 to theme.space.$4 to fix text truncation. The other components using this arrow button also seem a bit better because it had more padding than needed.
* Set width: 'auto' on subscription buttons to prevent text truncation and allow buttons to expand to fit content

### Before
<img width="1872" height="1506" alt="before1" src="https://github.com/user-attachments/assets/a85319bf-234d-4124-8b86-a137e7f5ad95" />


### After

<img width="1878" height="1486" alt="after1" src="https://github.com/user-attachments/assets/af9177f1-ac9b-4f79-b9bd-478a0df7ff9a" />
<img width="1872" height="1506" alt="after2" src="https://github.com/user-attachments/assets/d8b6bbc0-27cf-4e6a-ac60-a4393723d713" />


<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
