### PR TITLE
chore(backend): Add missing orderBy field to machine list params

### DIFF
--- a/.changeset/gentle-lamps-collect.md
+++ b/.changeset/gentle-lamps-collect.md
@@ -1,0 +1,14 @@
+---
+"@clerk/backend": patch
+---
+
+Added missing `orderBy` field to machines list method
+
+Example:
+
+```ts
+clerkClient.machines.list({
+  ...,
+  orderBy: 'name'
+})
+```

--- a/.changeset/gentle-lamps-collect.md
+++ b/.changeset/gentle-lamps-collect.md
@@ -8,7 +8,7 @@ Example:
 
 ```ts
 clerkClient.machines.list({
-  ...,
+  ...params,
   orderBy: 'name'
 })
 ```

--- a/packages/backend/src/api/endpoints/MachineApi.ts
+++ b/packages/backend/src/api/endpoints/MachineApi.ts
@@ -1,9 +1,12 @@
+import type { ClerkPaginationRequest } from '@clerk/types';
+
 import { joinPaths } from '../../util/path';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import type { Machine } from '../resources/Machine';
 import type { MachineScope } from '../resources/MachineScope';
 import type { MachineSecretKey } from '../resources/MachineSecretKey';
 import { AbstractAPI } from './AbstractApi';
+import type { WithSign } from './util-types';
 
 const basePath = '/machines';
 
@@ -37,11 +40,17 @@ type UpdateMachineParams = {
   defaultTokenTtl?: number;
 };
 
-type GetMachineListParams = {
-  limit?: number;
-  offset?: number;
+type GetMachineListParams = ClerkPaginationRequest<{
+  /**
+   * Sorts machines by name or created_at.
+   * By prepending one of those values with + or -, we can choose to sort in ascending (ASC) or descending (DESC) order.
+   */
+  orderBy?: WithSign<'name' | 'created_at'>;
+  /**
+   * Returns machines that have a ID or name that matches the given query.
+   */
   query?: string;
-};
+}>;
 
 type RotateMachineSecretKeyParams = {
   /**


### PR DESCRIPTION
## Description

https://clerk.com/docs/reference/backend-api/tag/machines/get/machines.query.order_by

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * machines.list now supports sorting via an optional orderBy parameter (name or created_at, ascending/descending).
  * Added query filtering to machines.list for quick matching by ID or name.
  * Enhanced pagination parameters for machines.list, replacing simple limit/offset with a more flexible pagination request.

* **Chores**
  * Updated changeset to document the new sorting, filtering, and pagination capabilities for the machines.list API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->