### PR TITLE
feat(clerk-js,shared): Add onBeforeRetry to FAPI client

### DIFF
--- a/.changeset/poor-memes-wish.md
+++ b/.changeset/poor-memes-wish.md
@@ -3,4 +3,6 @@
 '@clerk/shared': minor
 ---
 
-Adding x-clerk-retry-attempt header to retries of FAPI client's GET requests
+Add retry attempt tracking to FAPI client GET requests
+
+The FAPI client now adds a `_clerk_retry_attempt` query parameter to retry attempts for GET requests, allowing servers to track and handle retry scenarios appropriately. This parameter is only added during retry attempts, not on the initial request.

--- a/.changeset/poor-memes-wish.md
+++ b/.changeset/poor-memes-wish.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+---
+
+Adding x-clerk-retry-attempt header to retries of FAPI client's GET requests

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -251,6 +251,8 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
             return overwrittenRequestMethod === 'GET' && iterations < maxTries;
           },
           onBeforeRetry: (iteration: number): void => {
+            // Add the retry attempt to the query string params.
+            // We use params to keep the request simple for CORS.
             url.searchParams.set('_clerk_retry_attempt', iteration.toString());
           },
         });

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -250,6 +250,11 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
             // We want to retry only GET requests, as other methods are not idempotent.
             return overwrittenRequestMethod === 'GET' && iterations < maxTries;
           },
+          onBeforeRetry: (iteration: number): void => {
+            if (fetchOpts.headers instanceof Headers) {
+              fetchOpts.headers.set('x-clerk-retry-attempt', iteration.toString());
+            }
+          },
         });
       } else {
         response = new Response('{}', requestInit); // Mock an empty json response

--- a/packages/clerk-js/src/core/resources/__tests__/Token.spec.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Token.spec.ts
@@ -31,7 +31,7 @@ describe('Token', () => {
       });
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+      const [url, options] = (global.fetch as Mock).mock.calls[0];
       expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
       expect(options).toMatchObject({
         method: 'POST',
@@ -67,7 +67,7 @@ describe('Token', () => {
         const token = await Token.create('/path/to/tokens');
 
         expect(global.fetch).toHaveBeenCalledTimes(1);
-        const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+        const [url, options] = (global.fetch as Mock).mock.calls[0];
         expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
         expect(options).toMatchObject({
           method: 'POST',
@@ -91,7 +91,7 @@ describe('Token', () => {
         );
 
         expect(global.fetch).toHaveBeenCalledTimes(1);
-        const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+        const [url, options] = (global.fetch as Mock).mock.calls[0];
         expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
         expect(options).toMatchObject({
           method: 'POST',

--- a/packages/clerk-js/src/core/resources/__tests__/Token.spec.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Token.spec.ts
@@ -30,16 +30,15 @@ describe('Token', () => {
         message: '500',
       });
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        `https://clerk.example.com/v1/path/to/tokens?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
-        // TODO(dimkl): omit extra params from fetch request (eg path, url) - remove expect.objectContaining
-        expect.objectContaining({
-          method: 'POST',
-          body: '',
-          credentials: 'include',
-          headers: new Headers(),
-        }),
-      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
+      expect(options).toMatchObject({
+        method: 'POST',
+        body: '',
+        credentials: 'include',
+        headers: expect.any(Headers),
+      });
     });
 
     describe('with offline browser and network failure', () => {
@@ -67,16 +66,15 @@ describe('Token', () => {
 
         const token = await Token.create('/path/to/tokens');
 
-        expect(global.fetch).toHaveBeenCalledWith(
-          `https://clerk.example.com/v1/path/to/tokens?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
-          // TODO(dimkl): omit extra params from fetch request (eg path, url) - remove expect.objectContaining
-          expect.objectContaining({
-            method: 'POST',
-            body: '',
-            credentials: 'include',
-            headers: new Headers(),
-          }),
-        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+        expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
+        expect(options).toMatchObject({
+          method: 'POST',
+          body: '',
+          credentials: 'include',
+          headers: expect.any(Headers),
+        });
 
         expect(token.getRawString()).toEqual('');
         expect(warnSpy).toBeCalled();
@@ -92,16 +90,15 @@ describe('Token', () => {
           `ClerkJS: Network error at "https://clerk.example.com/v1/path/to/tokens?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test" - TypeError: Failed to fetch. Please try again.`,
         );
 
-        expect(global.fetch).toHaveBeenCalledWith(
-          `https://clerk.example.com/v1/path/to/tokens?__clerk_api_version=${SUPPORTED_FAPI_VERSION}&_clerk_js_version=test`,
-          // TODO(dimkl): omit extra params from fetch request (eg path, url) - remove expect.objectContaining
-          expect.objectContaining({
-            method: 'POST',
-            body: '',
-            credentials: 'include',
-            headers: new Headers(),
-          }),
-        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+        expect(url.toString()).toContain('https://clerk.example.com/v1/path/to/tokens');
+        expect(options).toMatchObject({
+          method: 'POST',
+          body: '',
+          credentials: 'include',
+          headers: expect.any(Headers),
+        });
       });
     });
   });

--- a/packages/shared/src/retry.ts
+++ b/packages/shared/src/retry.ts
@@ -3,6 +3,7 @@ type Milliseconds = number;
 type RetryOptions = Partial<{
   /**
    * The initial delay before the first retry.
+   *
    * @default 125
    */
   initialDelay: Milliseconds;
@@ -10,11 +11,13 @@ type RetryOptions = Partial<{
    * The maximum delay between retries.
    * The delay between retries will never exceed this value.
    * If set to 0, the delay will increase indefinitely.
+   *
    * @default 0
    */
   maxDelayBetweenRetries: Milliseconds;
   /**
    * The multiplier for the exponential backoff.
+   *
    * @default 2
    */
   factor: number;
@@ -23,23 +26,33 @@ type RetryOptions = Partial<{
    * The callback accepts the error that was thrown and the number of iterations.
    * The iterations variable references the number of retries AFTER attempt
    * that caused the error and starts at 1 (as in, this is the 1st, 2nd, nth retry).
+   *
    * @default (error, iterations) => iterations < 5
    */
   shouldRetry: (error: unknown, iterations: number) => boolean;
   /**
    * Controls whether the helper should retry the operation immediately once before applying exponential backoff.
    * The delay for the immediate retry is 100ms.
+   *
    * @default false
    */
   retryImmediately: boolean;
   /**
    * If true, the intervals will be multiplied by a factor in the range of [1,2].
+   *
    * @default true
    */
   jitter: boolean;
+
+  /**
+   * A callback that is invoked before each retry attempt.
+   * The callback receives the iteration number (starting from 1 for the first retry).
+   * This can be used to modify request parameters, add headers, etc.
+   */
+  onBeforeRetry?: (iteration: number) => void | Promise<void>;
 }>;
 
-const defaultOptions: Required<RetryOptions> = {
+const defaultOptions = {
   initialDelay: 125,
   maxDelayBetweenRetries: 0,
   factor: 2,
@@ -81,7 +94,7 @@ const createExponentialDelayAsyncFn = (
  */
 export const retry = async <T>(callback: () => T | Promise<T>, options: RetryOptions = {}): Promise<T> => {
   let iterations = 0;
-  const { shouldRetry, initialDelay, maxDelayBetweenRetries, factor, retryImmediately, jitter } = {
+  const { shouldRetry, initialDelay, maxDelayBetweenRetries, factor, retryImmediately, jitter, onBeforeRetry } = {
     ...defaultOptions,
     ...options,
   };
@@ -101,6 +114,11 @@ export const retry = async <T>(callback: () => T | Promise<T>, options: RetryOpt
       if (!shouldRetry(e, iterations)) {
         throw e;
       }
+
+      if (onBeforeRetry) {
+        await onBeforeRetry(iterations);
+      }
+
       if (retryImmediately && iterations === 1) {
         await sleep(applyJitter(RETRY_IMMEDIATELY_DELAY, jitter));
       } else {


### PR DESCRIPTION
## Description

Adding `x-clerk-retry-attempt` to GET fetch requests initiated as part of retry logic.

Fixes: USER-3480

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET retries now add a _clerk_retry_attempt query marker on retried requests and invoke a pre-retry hook before each retry (not added on the initial request).

* **Documentation**
  * Clarified retry option defaults and documented the pre-retry hook behavior and timing.

* **Tests**
  * Added tests covering retry behavior and updated fetch-related assertions and typings for robustness.

* **Chores**
  * Minor package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->