### PR TITLE
refactor(themes): Improve createTheme to use themeParams and update types

### DIFF
--- a/.changeset/young-beds-sing.md
+++ b/.changeset/young-beds-sing.md
@@ -1,0 +1,5 @@
+---
+'@clerk/themes': patch
+---
+
+Improve return type of createTheme

--- a/packages/themes/src/createTheme.ts
+++ b/packages/themes/src/createTheme.ts
@@ -1,10 +1,10 @@
 // Temp way to import the type. We will clean this up when we extract
 // theming into its own package
-import type { Appearance, BaseTheme, DeepPartial, Elements, Theme } from '@clerk/types';
+import type { BaseTheme, DeepPartial, Elements, Theme } from '@clerk/types';
 
 import type { InternalTheme } from '../../clerk-js/src/ui/foundations';
 
-interface CreateClerkThemeParams extends DeepPartial<Theme> {
+interface CreateClerkThemeParams extends DeepPartial<Theme>, Pick<BaseTheme, 'cssLayerName'> {
   /**
    * Optional name for the theme, used for telemetry and debugging.
    * @example 'shadcn', 'neobrutalism', 'custom-dark'
@@ -17,10 +17,10 @@ interface CreateClerkThemeParams extends DeepPartial<Theme> {
   elements?: Elements | ((params: { theme: InternalTheme }) => Elements);
 }
 
-export const experimental_createTheme = (appearance: Appearance<CreateClerkThemeParams>): BaseTheme => {
+export const experimental_createTheme = (themeParams: CreateClerkThemeParams) => {
   // Placeholder method that might hande more transformations in the future
   return {
-    ...appearance,
-    __type: 'prebuilt_appearance',
+    ...themeParams,
+    __type: 'prebuilt_appearance' as const,
   };
 };


### PR DESCRIPTION
Replaces the 'appearance' parameter with 'themeParams' in experimental_createTheme and updates the interface to extend BaseTheme with 'cssLayerName'. Cleans up unused type imports and improves type safety.

| BEFORE | AFTER |
|--------|--------|
| <img width="1154" height="514" alt="Screenshot 2025-09-15 at 3 51 12 PM" src="https://github.com/user-attachments/assets/925b7913-4a32-41da-8b6d-22da4ba40ce9" /> | <img width="1272" height="674" alt="Screenshot 2025-09-15 at 3 50 40 PM" src="https://github.com/user-attachments/assets/65280061-7755-4d87-aa6d-0c3478e17e63" /> | 

## Description

In doing some work for interactive docs, I noticed the return type of the created themes was not fully correct.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified theme creation by accepting direct parameters instead of a wrapper.
  - Improved type precision for theme outputs, leading to better IDE support and safer integrations.
  - Requires specifying a CSS layer name to ensure consistent styling behavior.
  - Tightened literal typing for more reliable theme identification.

- Chores
  - Added a changeset to release a patch update for @clerk/themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->