### PR TITLE
fix(shared,clerk-js): Prevent requests when billing is disabled

### DIFF
--- a/.changeset/slimy-nights-mate.md
+++ b/.changeset/slimy-nights-mate.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Bug fix that allowed `useStatements()`, `usePaymentMethods()` and `usePaymentAttempts()` to fire a request when the billing feature was turned off for the instance.

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
@@ -64,6 +64,8 @@ describe('UserProfile', () => {
 
       render(<UserProfile />, { wrapper });
       await waitFor(() => expect(screen.queryByRole('button', { name: /Billing/i })).toBeNull());
+      expect(fixtures.clerk.billing.getSubscription).not.toHaveBeenCalled();
+      expect(fixtures.clerk.billing.getStatements).not.toHaveBeenCalled();
     });
 
     it('includes Billing when enabled and instance has paid plans', async () => {
@@ -100,6 +102,8 @@ describe('UserProfile', () => {
       render(<UserProfile />, { wrapper });
       const billingElements = await screen.findAllByRole('button', { name: /Billing/i });
       expect(billingElements.length).toBeGreaterThan(0);
+      expect(fixtures.clerk.billing.getSubscription).toHaveBeenCalled();
+      expect(fixtures.clerk.billing.getStatements).toHaveBeenCalled();
     });
 
     it('includes Billing when enabled and user has past statements', async () => {
@@ -116,6 +120,8 @@ describe('UserProfile', () => {
       render(<UserProfile />, { wrapper });
       const billingElements = await screen.findAllByRole('button', { name: /Billing/i });
       expect(billingElements.length).toBeGreaterThan(0);
+      expect(fixtures.clerk.billing.getSubscription).toHaveBeenCalled();
+      expect(fixtures.clerk.billing.getStatements).toHaveBeenCalled();
     });
 
     it('does not include Billing when enabled but no paid plans, no subscription, and no statements', async () => {
@@ -131,6 +137,8 @@ describe('UserProfile', () => {
 
       render(<UserProfile />, { wrapper });
       await waitFor(() => expect(screen.queryByRole('button', { name: /Billing/i })).toBeNull());
+      expect(fixtures.clerk.billing.getSubscription).toHaveBeenCalled();
+      expect(fixtures.clerk.billing.getStatements).toHaveBeenCalled();
     });
   });
 });

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -164,7 +164,7 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, config, 
   const swrFetcher =
     !cacheMode && !!fetcher
       ? (cacheKeyParams: Record<string, unknown>) => {
-          if (isSignedIn === false) {
+          if (isSignedIn === false || shouldFetch === false) {
             return null;
           }
           const requestParams = getDifferentKeys(cacheKeyParams, cacheKeys);


### PR DESCRIPTION
## Description

A bug would allow the paginated billing hooks to fire a request when the feature was turned off, causing a 403 error response from FAPI. This PR addresses #6784, and solves the issue for anyone who consumes these hooks.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
