### PR TITLE
chore(clerk-js,types): Clean up deprecated attribute

### DIFF
--- a/.changeset/seven-buses-teach.md
+++ b/.changeset/seven-buses-teach.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Billing Beta] Remove deprecated `subscription` attribute from Billing

--- a/packages/clerk-js/src/core/resources/CommercePayment.ts
+++ b/packages/clerk-js/src/core/resources/CommercePayment.ts
@@ -19,10 +19,6 @@ export class CommercePayment extends BaseResource implements CommercePaymentReso
   paidAt?: Date;
   updatedAt!: Date;
   paymentSource!: CommercePaymentSourceResource;
-  /**
-   * @deprecated
-   */
-  subscription!: CommerceSubscriptionItemResource;
   subscriptionItem!: CommerceSubscriptionItemResource;
   chargeType!: CommercePaymentChargeType;
   status!: CommercePaymentStatus;
@@ -43,7 +39,6 @@ export class CommercePayment extends BaseResource implements CommercePaymentReso
     this.failedAt = data.failed_at ? unixEpochToDate(data.failed_at) : undefined;
     this.updatedAt = unixEpochToDate(data.updated_at);
     this.paymentSource = new CommercePaymentSource(data.payment_source);
-    this.subscription = new CommerceSubscriptionItem(data.subscription);
     this.subscriptionItem = new CommerceSubscriptionItem(data.subscription_item);
     this.chargeType = data.charge_type;
     this.status = data.status;

--- a/packages/types/src/commerce.ts
+++ b/packages/types/src/commerce.ts
@@ -646,16 +646,6 @@ export interface CommercePaymentResource extends ClerkResource {
    */
   paymentSource: CommercePaymentSourceResource;
   /**
-   * @deprecated Use `subscriptionItem` instead.
-   * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
-   * It is advised to pin the SDK version and the clerk-js version to a specific version to avoid breaking changes.
-   * @example
-   * ```tsx
-   * <ClerkProvider clerkJsVersion="x.x.x" />
-   * ```
-   */
-  subscription: CommerceSubscriptionItemResource;
-  /**
    * @experimental This is an experimental API for the Billing feature that is available under a public beta, and the API is subject to change.
    * It is advised to pin the SDK version and the clerk-js version to a specific version to avoid breaking changes.
    * @example


### PR DESCRIPTION
This commit removes the `subscription` attribute from Billing structs. We deprecated this attribute a few weeks ago, and now it's time to remove it in-favor of `subscription_item`.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed a deprecated Billing attribute; use subscriptionItem going forward. Update any integrations referencing the old subscription field to ensure compatibility.

* **Chores**
  * Published minor package updates to reflect the removal across client and type packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->