### PR TITLE
fix(repo): Attempt to fix retheme deployment in CI

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -24,5 +24,6 @@
     "eslint": "9.31.0",
     "eslint-config-next": "15.5.0",
     "typescript": "5.8.3"
-  }
+  },
+  "packageManager": "pnpm@10.16.1"
 }


### PR DESCRIPTION
## Description

This [job](https://github.com/clerk/javascript/actions/runs/17775985736/job/50523688082) seems to be failing because `packageManager` is needed.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the package manager version to PNPM 10.16.1 for the Next.js playground to ensure consistent installs across environments and CI.
  * Minor metadata formatting adjustments to support the new setting.
  * Improves reliability of local development by reducing version-related install issues.
  * No impact on application behavior, scripts, or dependencies; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->