### PR TITLE
feat(backend): Add `invite`, `reject`, and `delete` to `WaitlistEntryApi` resource

### DIFF
--- a/.changeset/icy-mangos-care.md
+++ b/.changeset/icy-mangos-care.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add invite, reject, and delete to Waitlist Entry API resources

--- a/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
+++ b/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
@@ -25,10 +25,17 @@ type WaitlistEntryCreateParams = {
 };
 
 type WaitlistEntryInviteParams = {
+  /**
+   * When true, do not error if an invitation already exists. Default: false.
+   */
   ignoreExisting?: boolean;
 };
 
 export class WaitlistEntryAPI extends AbstractAPI {
+  /**
+   * List waitlist entries.
+   * @param params Optional parameters (e.g., `query`, `status`, `orderBy`).
+   */
   public async list(params: WaitlistEntryListParams = {}) {
     return this.request<PaginatedResourceResponse<WaitlistEntry>>({
       method: 'GET',
@@ -37,6 +44,10 @@ export class WaitlistEntryAPI extends AbstractAPI {
     });
   }
 
+  /**
+   * Create a waitlist entry.
+   * @param params The parameters for creating a waitlist entry.
+   */
   public async create(params: WaitlistEntryCreateParams) {
     return this.request<WaitlistEntry>({
       method: 'POST',
@@ -45,31 +56,44 @@ export class WaitlistEntryAPI extends AbstractAPI {
     });
   }
 
-  public async invite(waitlist_entry_id: string, params: WaitlistEntryInviteParams = {}) {
-    this.requireId(waitlist_entry_id);
+  /**
+   * Invite a waitlist entry.
+   * @param id The waitlist entry ID.
+   * @param params Optional parameters (e.g., `ignoreExisting`).
+   */
+  public async invite(id: string, params: WaitlistEntryInviteParams = {}) {
+    this.requireId(id);
 
     return this.request<WaitlistEntry>({
       method: 'POST',
-      path: joinPaths(basePath, waitlist_entry_id, 'invite'),
+      path: joinPaths(basePath, id, 'invite'),
       bodyParams: params,
     });
   }
 
-  public async reject(waitlist_entry_id: string) {
-    this.requireId(waitlist_entry_id);
+  /**
+   * Reject a waitlist entry.
+   * @param id The waitlist entry ID.
+   */
+  public async reject(id: string) {
+    this.requireId(id);
 
     return this.request<WaitlistEntry>({
       method: 'POST',
-      path: joinPaths(basePath, waitlist_entry_id, 'reject'),
+      path: joinPaths(basePath, id, 'reject'),
     });
   }
 
-  public async delete(waitlist_entry_id: string) {
-    this.requireId(waitlist_entry_id);
+  /**
+   * Delete a waitlist entry.
+   * @param id The waitlist entry ID.
+   */
+  public async delete(id: string) {
+    this.requireId(id);
 
     return this.request<DeletedObject>({
       method: 'DELETE',
-      path: joinPaths(basePath, waitlist_entry_id),
+      path: joinPaths(basePath, id),
     });
   }
 }

--- a/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
+++ b/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
@@ -25,7 +25,7 @@ type WaitlistEntryCreateParams = {
 };
 
 type WaitlistEntryInviteParams = {
-  ignore_existing?: boolean;
+  ignoreExisting?: boolean;
 };
 
 export class WaitlistEntryAPI extends AbstractAPI {

--- a/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
+++ b/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
@@ -1,5 +1,7 @@
 import type { ClerkPaginationRequest } from '@clerk/types';
+import { joinPaths } from 'src/util/path';
 
+import type { DeletedObject } from '../resources/DeletedObject';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import type { WaitlistEntryStatus } from '../resources/Enums';
 import type { WaitlistEntry } from '../resources/WaitlistEntry';
@@ -22,6 +24,10 @@ type WaitlistEntryCreateParams = {
   notify?: boolean;
 };
 
+type WaitlistEntryInviteParams = {
+  ignore_existing?: boolean;
+};
+
 export class WaitlistEntryAPI extends AbstractAPI {
   public async list(params: WaitlistEntryListParams = {}) {
     return this.request<PaginatedResourceResponse<WaitlistEntry>>({
@@ -36,6 +42,34 @@ export class WaitlistEntryAPI extends AbstractAPI {
       method: 'POST',
       path: basePath,
       bodyParams: params,
+    });
+  }
+
+  public async invite(waitlist_entry_id: string, params: WaitlistEntryInviteParams = {}) {
+    this.requireId(waitlist_entry_id);
+
+    return this.request<WaitlistEntry>({
+      method: 'POST',
+      path: joinPaths(basePath, waitlist_entry_id, 'invite'),
+      bodyParams: params,
+    });
+  }
+
+  public async reject(waitlist_entry_id: string) {
+    this.requireId(waitlist_entry_id);
+
+    return this.request<WaitlistEntry>({
+      method: 'POST',
+      path: joinPaths(basePath, waitlist_entry_id, 'reject'),
+    });
+  }
+
+  public async delete(waitlist_entry_id: string) {
+    this.requireId(waitlist_entry_id);
+
+    return this.request<DeletedObject>({
+      method: 'DELETE',
+      path: joinPaths(basePath, waitlist_entry_id),
     });
   }
 }


### PR DESCRIPTION
## Description

Adds the following methods to the WaitlistEntryApi Resource:

```
.invite(id, { ignoreExisting? })
.reject(id)
.delete(id)
```

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API actions to manage waitlist entries: invite, reject, and delete.
  * Invite supports an optional flag to skip re-inviting existing users.
  * Responses return the updated waitlist entry or a deletion confirmation.

* **Chores**
  * Added a changeset entry for a minor release documenting the expanded waitlist entry API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->