### PR TITLE
fix(nuxt): Prevent Nuxt route middlewares from seeing intermediate states during navigation

### DIFF
--- a/.changeset/funny-peaches-float.md
+++ b/.changeset/funny-peaches-float.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nuxt": patch
+---
+
+Fixed an issue where Nuxt route middleware saw intermediate states during navigation, causing unwanted redirects during sign-in/sign-out flows.

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -4,6 +4,9 @@ import { clerkPlugin } from '@clerk/vue';
 import { setErrorThrowerOptions } from '@clerk/vue/internal';
 import { defineNuxtPlugin, navigateTo, useRuntimeConfig, useState } from 'nuxt/app';
 
+// @ts-expect-error: Handled by Nuxt.
+import { nextTick } from '#imports';
+
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });
 setClerkJsLoadingErrorPackageName(PACKAGE_NAME);
 
@@ -25,8 +28,16 @@ export default defineNuxtPlugin(nuxtApp => {
       version: PACKAGE_VERSION,
       environment: process.env.NODE_ENV,
     },
-    routerPush: (to: string) => navigateTo(to),
-    routerReplace: (to: string) => navigateTo(to, { replace: true }),
+    routerPush: (to: string) => {
+      return nextTick(() => {
+        void navigateTo(to);
+      });
+    },
+    routerReplace: (to: string) => {
+      return nextTick(() => {
+        void navigateTo(to, { replace: true });
+      });
+    },
     initialState: initialState.value,
   });
 });


### PR DESCRIPTION
## Description

During auth transitions (sign-in and sign-out), Vue shows intermediate state changes causing UI flicker and confusing redirects. For example (notice how it goes from `/sign-in` -> `/dashboard` -> `sign-in` -> `/dashboard`):

https://github.com/user-attachments/assets/906451ea-0748-4d24-adc5-f29e657f71b4

What's happening above:

1. User signs in with email/password
2. Clerk redirects to `fallbackRedirectUrl ` or `forceRedirectUrl`
3. Navigation starts immediately
4. [Nuxt route middleware](https://nuxt.com/docs/4.x/guide/directory-structure/app/middleware) runs and checks auth state via `useAuth().userId.value`
5. But Vue is still processing state updates (`user -> null -> undefined -> user`)
6. Middleware sees null or undefined and redirects to sign-in
7. When state finally settles to user, it redirects back to `fallbackRedirectUrl` or `forceRedirectUrl`

By adding [`nextTick()`](https://vuejs.org/api/general#nexttick),  it's ensuring that navigation happens after the state is fully settled, preventing route middleware from seeing intermediate states.

Fixed demo, from `/sign-in` -> `/dashboard`

https://github.com/user-attachments/assets/e2a98ced-3f64-441d-961e-00c5c514e627

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved routing stability in Nuxt to prevent unwanted redirects during sign-in/sign-out. Navigation timing is now deferred to avoid middleware reacting to intermediate navigation states, resulting in smoother and more predictable auth flows.

- Chores
  - Added a changeset entry for a patch release of the Nuxt package, documenting the fix and ensuring proper versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->