### PR TITLE
fix(clerk-js): Update accepted suggestion preview on task choose organizations

### DIFF
--- a/.changeset/better-bikes-repair.md
+++ b/.changeset/better-bikes-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix `TaskChooseOrganizationScreen` to render accepted suggestions properly

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/ChooseOrganizationScreen.tsx
@@ -231,26 +231,24 @@ const SuggestionPreview = withCardStateProvider((props: OrganizationSuggestionRe
     );
   };
 
-  if (props.status === 'accepted') {
-    return (
-      <Text
-        colorScheme='secondary'
-        localizationKey={localizationKeys('taskChooseOrganization.chooseOrganization.suggestionsAcceptedLabel')}
-      />
-    );
-  }
-
   return (
     <OrganizationPreviewListItem
       organizationData={props.publicOrganizationData}
       elementId='taskChooseOrganization'
       elementDescriptor={descriptors.taskChooseOrganizationPreviewItem}
     >
-      <OrganizationPreviewListItemButton
-        onClick={handleAccept}
-        isLoading={card.isLoading}
-        localizationKey={localizationKeys('taskChooseOrganization.chooseOrganization.action__suggestionsAccept')}
-      />
+      {props.status === 'accepted' ? (
+        <Text
+          colorScheme='secondary'
+          localizationKey={localizationKeys('taskChooseOrganization.chooseOrganization.suggestionsAcceptedLabel')}
+        />
+      ) : (
+        <OrganizationPreviewListItemButton
+          onClick={handleAccept}
+          isLoading={card.isLoading}
+          localizationKey={localizationKeys('taskChooseOrganization.chooseOrganization.action__suggestionsAccept')}
+        />
+      )}
     </OrganizationPreviewListItem>
   );
 });


### PR DESCRIPTION
## Description

| Before | After |
| --- | --- |
| <img width="848" height="678" alt="CleanShot 2025-09-18 at 15 21 47@2x" src="https://github.com/user-attachments/assets/27db56e4-66c7-4c73-b73c-8baf9cf86fee" /> | <img width="854" height="786" alt="CleanShot 2025-09-18 at 15 21 05@2x" src="https://github.com/user-attachments/assets/9b7163ec-fe8f-40a7-86f7-c18a964bdac7" /> |
## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed display of accepted organization suggestions in the Choose Organization screen within Session Tasks; accepted items now show the correct label and no longer display an action button.
  - Improves UI clarity and consistency without changing workflows or APIs.

- Chores
  - Patch release of the UI package to deliver the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->