### PR TITLE
feat: Make SubscriptionItem's plan and planId optional and nullable

### DIFF
--- a/packages/backend/src/api/resources/CommerceSubscriptionItem.ts
+++ b/packages/backend/src/api/resources/CommerceSubscriptionItem.ts
@@ -46,11 +46,11 @@ export class CommerceSubscriptionItem {
     /**
      * The plan associated with this subscription item.
      */
-    readonly plan: CommercePlan,
+    readonly plan: CommercePlan | null | undefined,
     /**
      * The plan ID.
      */
-    readonly planId: string,
+    readonly planId: string | null | undefined,
     /**
      * Unix timestamp (milliseconds) of when the subscription item was created.
      */

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -908,24 +908,27 @@ export interface CommerceSubscriptionItemWebhookEventJSON extends ClerkResourceJ
   next_payment_amount: number;
   next_payment_date: number;
   amount: CommerceMoneyAmountJSON;
-  plan: {
-    id: string;
-    instance_id: string;
-    product_id: string;
-    name: string;
-    slug: string;
-    description?: string;
-    is_default: boolean;
-    is_recurring: boolean;
-    amount: number;
-    period: 'month' | 'annual';
-    interval: number;
-    has_base_fee: boolean;
-    currency: string;
-    annual_monthly_amount: number;
-    publicly_visible: boolean;
-  };
-  plan_id: string;
+  plan:
+    | {
+        id: string;
+        instance_id: string;
+        product_id: string;
+        name: string;
+        slug: string;
+        description?: string;
+        is_default: boolean;
+        is_recurring: boolean;
+        amount: number;
+        period: 'month' | 'annual';
+        interval: number;
+        has_base_fee: boolean;
+        currency: string;
+        annual_monthly_amount: number;
+        publicly_visible: boolean;
+      }
+    | null
+    | undefined;
+  plan_id: string | null | undefined;
 }
 
 /**


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
We're introducing changes in future API versions that will either not send plan/plan_id at all on some subscription items, or may send null instead. Which hasn't been determined yet. Updating the client and webhooks to accept either, though.

C1s must take an explicit action before any subscription item will return a null or omitted plan/plan_id, so we'll have the opportunity to warn them.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
