### PR TITLE
feat(shared): Improve error handling for clerk-js loading

### DIFF
--- a/.changeset/tangy-bees-follow.md
+++ b/.changeset/tangy-bees-follow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Improve error handling when loading clerk-js.

--- a/packages/shared/src/errors/runtimeError.ts
+++ b/packages/shared/src/errors/runtimeError.ts
@@ -18,7 +18,12 @@ export class ClerkRuntimeError extends Error {
    */
   code: string;
 
-  constructor(message: string, { code }: { code: string }) {
+  /**
+   * The original error that was caught to throw an instance of ClerkRuntimeError.
+   */
+  cause?: Error;
+
+  constructor(message: string, { code, cause }: { code: string; cause?: Error }) {
     const prefix = '🔒 Clerk:';
     const regex = new RegExp(prefix.replace(' ', '\\s*'), 'i');
     const sanitized = message.replace(regex, '');
@@ -27,6 +32,7 @@ export class ClerkRuntimeError extends Error {
 
     Object.setPrototypeOf(this, ClerkRuntimeError.prototype);
 
+    this.cause = cause;
     this.code = code;
     this.message = _message;
     this.clerkRuntimeError = true;

--- a/packages/shared/src/loadClerkJsScript.ts
+++ b/packages/shared/src/loadClerkJsScript.ts
@@ -1,13 +1,15 @@
 import type { ClerkOptions, SDKMetadata, Without } from '@clerk/types';
 
-import { buildErrorThrower } from './error';
+import { buildErrorThrower, ClerkRuntimeError } from './error';
 import { createDevOrStagingUrlCache, parsePublishableKey } from './keys';
 import { loadScript } from './loadScript';
 import { isValidProxyUrl, proxyUrlToAbsoluteURL } from './proxy';
 import { addClerkPrefix } from './url';
 import { versionSelector } from './versionSelector';
 
-const FAILED_TO_LOAD_ERROR = 'Clerk: Failed to load Clerk';
+const ERROR_CODE = 'failed_to_load_clerk_js';
+const ERROR_CODE_TIMEOUT = 'failed_to_load_clerk_js_timeout';
+const FAILED_TO_LOAD_ERROR = 'Failed to load Clerk';
 
 const { isDevOrStagingUrl } = createDevOrStagingUrlCache();
 
@@ -96,7 +98,7 @@ function waitForClerkWithTimeout(timeoutMs: number): Promise<HTMLScriptElement |
       cleanup(timeoutId, pollInterval);
 
       if (!isClerkProperlyLoaded()) {
-        reject(new Error(FAILED_TO_LOAD_ERROR));
+        reject(new ClerkRuntimeError(FAILED_TO_LOAD_ERROR, { code: ERROR_CODE_TIMEOUT }));
       } else {
         resolve(null);
       }
@@ -162,8 +164,11 @@ const loadClerkJsScript = async (opts?: LoadClerkJsScriptOptions): Promise<HTMLS
     crossOrigin: 'anonymous',
     nonce: opts.nonce,
     beforeLoad: applyClerkJsScriptAttributes(opts),
-  }).catch(() => {
-    throw new Error(FAILED_TO_LOAD_ERROR);
+  }).catch(error => {
+    throw new ClerkRuntimeError(FAILED_TO_LOAD_ERROR + (error.message ? `, ${error.message}` : ''), {
+      code: ERROR_CODE,
+      cause: error,
+    });
   });
 
   return loadPromise;

--- a/packages/shared/src/loadScript.ts
+++ b/packages/shared/src/loadScript.ts
@@ -11,6 +11,9 @@ type LoadScriptOptions = {
   beforeLoad?: (script: HTMLScriptElement) => void;
 };
 
+/**
+ *
+ */
 export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTMLScriptElement> {
   const { async, defer, beforeLoad, crossOrigin, nonce } = opts || {};
 
@@ -21,7 +24,7 @@ export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTM
       }
 
       if (!document || !document.body) {
-        reject(NO_DOCUMENT_ERROR);
+        reject(new Error(NO_DOCUMENT_ERROR));
       }
 
       const script = document.createElement('script');
@@ -37,9 +40,9 @@ export async function loadScript(src = '', opts: LoadScriptOptions): Promise<HTM
         resolve(script);
       });
 
-      script.addEventListener('error', () => {
+      script.addEventListener('error', event => {
         script.remove();
-        reject();
+        reject(event.error);
       });
 
       script.src = src;


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
This improves error handling during clerk-js loading. Specifically, it uses our `ClerkRuntimeError` class and ensures we are propagating underlying errors up so we can see the cause. Previously, we swallowed errors and only threw a generic error with a generic message ("Clerk: Failed to load Clerk").

Additionally, I've added an optional `cause` option to `ClerkRuntimeError` that allows us to pass along the original, unwrapped error for additional introspect (h/t @jacekradko)

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
