### PR TITLE
feat(shared): Capture auth component mounted for all SDK types

### DIFF
--- a/.changeset/pretty-rings-compare.md
+++ b/.changeset/pretty-rings-compare.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Increase sampling for high-signal auth components on mount.

--- a/packages/shared/src/telemetry/events/component-mounted.ts
+++ b/packages/shared/src/telemetry/events/component-mounted.ts
@@ -4,6 +4,19 @@ const EVENT_COMPONENT_MOUNTED = 'COMPONENT_MOUNTED';
 const EVENT_COMPONENT_OPENED = 'COMPONENT_OPENED';
 const EVENT_SAMPLING_RATE = 0.1;
 
+/** Increase sampling for high-signal auth components on mount. */
+const AUTH_COMPONENTS = new Set<string>(['SignIn', 'SignUp']);
+
+/**
+ * Returns the per-event sampling rate for component-mounted telemetry events.
+ * Uses a higher rate for SignIn/SignUp to improve signal quality.
+ *
+ *  @internal
+ */
+function getComponentMountedSamplingRate(component: string): number {
+  return AUTH_COMPONENTS.has(component) ? 1 : EVENT_SAMPLING_RATE;
+}
+
 type ComponentMountedBase = {
   component: string;
 };
@@ -18,6 +31,8 @@ type EventPrebuiltComponent = ComponentMountedBase & {
 type EventComponentMounted = ComponentMountedBase & TelemetryEventRaw['payload'];
 
 /**
+ * Factory for prebuilt component telemetry events.
+ *
  * @internal
  */
 function createPrebuiltComponentEvent(event: typeof EVENT_COMPONENT_MOUNTED | typeof EVENT_COMPONENT_OPENED) {
@@ -28,7 +43,8 @@ function createPrebuiltComponentEvent(event: typeof EVENT_COMPONENT_MOUNTED | ty
   ): TelemetryEventRaw<EventPrebuiltComponent> {
     return {
       event,
-      eventSamplingRate: EVENT_SAMPLING_RATE,
+      eventSamplingRate:
+        event === EVENT_COMPONENT_MOUNTED ? getComponentMountedSamplingRate(component) : EVENT_SAMPLING_RATE,
       payload: {
         component,
         appearanceProp: Boolean(props?.appearance),
@@ -91,7 +107,7 @@ export function eventComponentMounted(
 ): TelemetryEventRaw<EventComponentMounted> {
   return {
     event: EVENT_COMPONENT_MOUNTED,
-    eventSamplingRate: EVENT_SAMPLING_RATE,
+    eventSamplingRate: getComponentMountedSamplingRate(component),
     payload: {
       component,
       ...props,


### PR DESCRIPTION
## Description

Enables 100% sampling rate for `SignIn` and `SignUp` components for all SDKs. This will enable a more holistic comparison of Auth Component Mounted data between keyless and other SDK types. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Telemetry: per-event sampling added; SignIn and SignUp mount events now captured at full sampling, other component mounts and open events remain at lower sampling.

- **Chores**
  - Prepared a patch release for @clerk/shared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->