### PR TITLE
fix(clerk-js): Improve appearance selectors for tasks

### DIFF
--- a/.changeset/shy-times-wash.md
+++ b/.changeset/shy-times-wash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix TaskChooseOrganization component selector

--- a/.changeset/shy-times-wash.md
+++ b/.changeset/shy-times-wash.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Fix TaskChooseOrganization component selector
+Improve appearance selectors for tasks, such as including it within `SignIn/SignUp` components

--- a/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/index.tsx
@@ -3,6 +3,7 @@ import { eventComponentMounted } from '@clerk/shared/telemetry';
 import type { SessionResource } from '@clerk/types';
 import { useEffect, useRef } from 'react';
 
+import { Flow } from '@/ui/customizables';
 import { Card } from '@/ui/elements/Card';
 import { withCardStateProvider } from '@/ui/elements/contexts';
 import { LoadingCardContainer } from '@/ui/elements/LoadingCard';
@@ -35,12 +36,14 @@ const SessionTasksStart = () => {
   }, [navigate, clerk, redirectUrlComplete]);
 
   return (
-    <Card.Root>
-      <Card.Content>
-        <LoadingCardContainer />
-      </Card.Content>
-      <Card.Footer />
-    </Card.Root>
+    <Flow.Part part='start'>
+      <Card.Root>
+        <Card.Content>
+          <LoadingCardContainer />
+        </Card.Content>
+        <Card.Footer />
+      </Card.Root>
+    </Flow.Part>
   );
 };
 
@@ -48,18 +51,20 @@ function SessionTasksRoutes(): JSX.Element {
   const ctx = useSessionTasksContext();
 
   return (
-    <Switch>
-      <Route path={INTERNAL_SESSION_TASK_ROUTE_BY_KEY['choose-organization']}>
-        <TaskChooseOrganizationContext.Provider
-          value={{ componentName: 'TaskChooseOrganization', redirectUrlComplete: ctx.redirectUrlComplete }}
-        >
-          <TaskChooseOrganization />
-        </TaskChooseOrganizationContext.Provider>
-      </Route>
-      <Route index>
-        <SessionTasksStart />
-      </Route>
-    </Switch>
+    <Flow.Root flow='tasks'>
+      <Switch>
+        <Route path={INTERNAL_SESSION_TASK_ROUTE_BY_KEY['choose-organization']}>
+          <TaskChooseOrganizationContext.Provider
+            value={{ componentName: 'TaskChooseOrganization', redirectUrlComplete: ctx.redirectUrlComplete }}
+          >
+            <TaskChooseOrganization />
+          </TaskChooseOrganizationContext.Provider>
+        </Route>
+        <Route index>
+          <SessionTasksStart />
+        </Route>
+      </Switch>
+    </Flow.Root>
   );
 }
 

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -35,27 +35,29 @@ const TaskChooseOrganizationInternal = () => {
   return (
     <Flow.Root flow='taskChooseOrganization'>
       <Card.Root>
-        <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}`, gap: t.space.$7 })}>
-          {isLoading ? (
-            <Flex
-              direction={'row'}
-              align={'center'}
-              justify={'center'}
-              sx={t => ({
-                height: '100%',
-                minHeight: t.sizes.$100,
-              })}
-            >
-              <Spinner
-                size={'lg'}
-                colorScheme={'primary'}
-                elementDescriptor={descriptors.spinner}
-              />
-            </Flex>
-          ) : (
-            <TaskChooseOrganizationFlows initialFlow={hasExistingResources ? 'choose' : 'create'} />
-          )}
-        </Card.Content>
+        <Flow.Part part={hasExistingResources ? 'chooseOrganization' : 'createOrganization'}>
+          <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}`, gap: t.space.$7 })}>
+            {isLoading ? (
+              <Flex
+                direction={'row'}
+                align={'center'}
+                justify={'center'}
+                sx={t => ({
+                  height: '100%',
+                  minHeight: t.sizes.$100,
+                })}
+              >
+                <Spinner
+                  size={'lg'}
+                  colorScheme={'primary'}
+                  elementDescriptor={descriptors.spinner}
+                />
+              </Flex>
+            ) : (
+              <TaskChooseOrganizationFlows initialFlow={hasExistingResources ? 'choose' : 'create'} />
+            )}
+          </Card.Content>
+        </Flow.Part>
 
         <Card.Footer>
           <Card.Action

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -34,7 +34,7 @@ const TaskChooseOrganizationInternal = () => {
 
   return (
     <Flow.Root flow='taskChooseOrganization'>
-      <Flow.Part part={hasExistingResources ? 'chooseOrganization' : 'createOrganization'}>
+      <Flow.Part part='chooseOrganization'>
         <Card.Root>
           <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}`, gap: t.space.$7 })}>
             {isLoading ? (

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -34,8 +34,8 @@ const TaskChooseOrganizationInternal = () => {
 
   return (
     <Flow.Root flow='taskChooseOrganization'>
-      <Card.Root>
-        <Flow.Part part={hasExistingResources ? 'chooseOrganization' : 'createOrganization'}>
+      <Flow.Part part={hasExistingResources ? 'chooseOrganization' : 'createOrganization'}>
+        <Card.Root>
           <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}`, gap: t.space.$7 })}>
             {isLoading ? (
               <Flex
@@ -57,31 +57,31 @@ const TaskChooseOrganizationInternal = () => {
               <TaskChooseOrganizationFlows initialFlow={hasExistingResources ? 'choose' : 'create'} />
             )}
           </Card.Content>
-        </Flow.Part>
 
-        <Card.Footer>
-          <Card.Action
-            elementId='signOut'
-            gap={2}
-            justify='center'
-            sx={() => ({ width: '100%' })}
-          >
-            {identifier && (
-              <Card.ActionText
-                truncate
-                localizationKey={localizationKeys('taskChooseOrganization.signOut.actionText', {
-                  identifier,
-                })}
+          <Card.Footer>
+            <Card.Action
+              elementId='signOut'
+              gap={2}
+              justify='center'
+              sx={() => ({ width: '100%' })}
+            >
+              {identifier && (
+                <Card.ActionText
+                  truncate
+                  localizationKey={localizationKeys('taskChooseOrganization.signOut.actionText', {
+                    identifier,
+                  })}
+                />
+              )}
+              <Card.ActionLink
+                sx={() => ({ flexShrink: 0 })}
+                onClick={handleSignOut}
+                localizationKey={localizationKeys('taskChooseOrganization.signOut.actionLink')}
               />
-            )}
-            <Card.ActionLink
-              sx={() => ({ flexShrink: 0 })}
-              onClick={handleSignOut}
-              localizationKey={localizationKeys('taskChooseOrganization.signOut.actionLink')}
-            />
-          </Card.Action>
-        </Card.Footer>
-      </Card.Root>
+            </Card.Action>
+          </Card.Footer>
+        </Card.Root>
+      </Flow.Part>
     </Flow.Root>
   );
 };

--- a/packages/clerk-js/src/ui/elements/contexts/index.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/index.tsx
@@ -123,8 +123,7 @@ export type FlowMetadata = {
     | 'popover'
     | 'complete'
     | 'accountSwitcher'
-    | 'chooseOrganization'
-    | 'createOrganization';
+    | 'chooseOrganization';
 };
 
 const [FlowMetadataCtx, useFlowMetadata] = createContextAndHook<FlowMetadata>('FlowMetadata');

--- a/packages/clerk-js/src/ui/elements/contexts/index.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/index.tsx
@@ -101,6 +101,7 @@ export type FlowMetadata = {
     | 'oauthConsent'
     | 'subscriptionDetails'
     | 'subscriptionDetails'
+    | 'tasks'
     | 'taskChooseOrganization';
   part?:
     | 'start'
@@ -122,7 +123,9 @@ export type FlowMetadata = {
     | 'popupCallback'
     | 'popover'
     | 'complete'
-    | 'accountSwitcher';
+    | 'accountSwitcher'
+    | 'chooseOrganization'
+    | 'createOrganization';
 };
 
 const [FlowMetadataCtx, useFlowMetadata] = createContextAndHook<FlowMetadata>('FlowMetadata');

--- a/packages/clerk-js/src/ui/elements/contexts/index.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/index.tsx
@@ -100,7 +100,6 @@ export type FlowMetadata = {
     | 'apiKeys'
     | 'oauthConsent'
     | 'subscriptionDetails'
-    | 'subscriptionDetails'
     | 'tasks'
     | 'taskChooseOrganization';
   part?:


### PR DESCRIPTION
## Description

The `TaskChooseOrganization` component was missing the root selector we infer from the flow routes.

Before:

<img width="1770" height="294" alt="CleanShot 2025-09-26 at 11 00 15@2x" src="https://github.com/user-attachments/assets/613f2229-fe00-4c62-b332-6fe258416701" />

After:

<img width="1746" height="228" alt="CleanShot 2025-09-26 at 13 03 32@2x" src="https://github.com/user-attachments/assets/ee7c74f4-4739-483a-9178-8b8255f25772" />

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task appearance/selectors so organization options display correctly during onboarding/tasks (visible in Sign In/Sign Up flows).

* **Refactor**
  * Consolidated session task screens under a unified "tasks" flow and added dedicated task parts for organization selection to improve consistency and customization. No behavioral changes beyond the bug fix.

* **Chores**
  * Bumped dependency metadata for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->