### PR TITLE
investigating failing e2es

### DIFF
--- a/integration/templates/next-app-router/next.config.js
+++ b/integration/templates/next-app-router/next.config.js
@@ -3,7 +3,6 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  outputFileTracingRoot: '/',
 };
 
 module.exports = nextConfig;

--- a/integration/tests/elements/next-sign-in.test.ts
+++ b/integration/tests/elements/next-sign-in.test.ts
@@ -32,7 +32,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('Next.js S
 
   test('sign in with email and password', async ({ page, context }) => {
     const u = createTestUtils({ app, page, context });
-    await u.po.signIn.goTo({ headlessSelector: '[data-test-id="sign-in-step-start"]' });
+    await u.po.signIn.goTo({ headlessSelector: '[data-test-id="sign-in-step-start"]', timeout: 30000 });
 
     await u.po.signIn.setIdentifier(fakeUser.email);
     await u.po.signIn.continue();

--- a/integration/tests/protect.test.ts
+++ b/integration/tests/protect.test.ts
@@ -53,7 +53,7 @@ testAgainstRunningApps({
     await expect(u.page.getByText(/User has access/i)).toBeVisible();
     await u.page.goToRelative('/settings/rcc-protect');
     await expect(u.page.getByText(/User has access/i)).toBeVisible();
-    await u.page.goToRelative('/settings/useAuth-has');
+    await u.page.goToRelative('/settings/useAuth-has', { timeout: 60000 });
     await expect(u.page.getByText(/User has access/i)).toBeVisible();
     await u.page.goToRelative('/settings/auth-has');
     await expect(u.page.getByText(/User has access/i)).toBeVisible();

--- a/integration/tests/reverification.test.ts
+++ b/integration/tests/reverification.test.ts
@@ -244,7 +244,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
           u.page.getByText(
             /\{\s*"clerk_error"\s*:\s*\{\s*"type"\s*:\s*"forbidden"\s*,\s*"reason"\s*:\s*"reverification-error"\s*,\s*"metadata"\s*:\s*\{\s*"reverification"\s*:\s*\{\s*"level"\s*:\s*"second_factor"\s*,\s*"afterMinutes"\s*:\s*1\s*\}\s*\}\s*\}\s*\}/i,
           ),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 10000 });
       });
 
       test(`reverification recovery from ${capitalize(type)}`, async ({ page, context }) => {
@@ -271,7 +271,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
           });
         });
 
-        await u.page.goToRelative(`/action-with-use-reverification`);
+        await u.page.goToRelative(`/action-with-use-reverification`, { timeout: 60000 });
         await u.po.expect.toBeSignedIn();
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await u.po.userVerification.waitForMounted();

--- a/integration/tests/session-tasks-sign-up.test.ts
+++ b/integration/tests/session-tasks-sign-up.test.ts
@@ -59,7 +59,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withSessionTasks] })(
         email: regularFakeUser.email,
         password: regularFakeUser.password,
       });
-      await u.po.expect.toBeSignedIn();
+      await u.po.expect.toBeSignedIn({ timeOut: 30000 });
 
       // Redirects back to tasks when accessing protected route by `auth.protect`
       await u.page.goToRelative('/page-protected');

--- a/packages/testing/src/playwright/unstable/page-objects/expect.ts
+++ b/packages/testing/src/playwright/unstable/page-objects/expect.ts
@@ -21,10 +21,14 @@ export const createExpectPageObject = ({ page }: { page: EnhancedPage }) => {
         { timeout: args?.timeOut },
       );
     },
-    toBeSignedIn: async () => {
-      return page.waitForFunction(() => {
-        return !!window.Clerk?.user;
-      });
+    toBeSignedIn: async (args?: { timeOut?: number }) => {
+      return page.waitForFunction(
+        () => {
+          return !!window.Clerk?.user;
+        },
+        null,
+        { timeout: args?.timeOut },
+      );
     },
     toBeSignedInAsActor: async () => {
       return page.waitForFunction(() => {


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Testing utilities now support configurable timeouts for sign-in checks and navigation, allowing more control over wait behavior.
- Tests
  - Increased timeouts across sign-in, protection, and reverification flows to improve reliability and reduce flakiness.
- Chores
  - Simplified Next.js template configuration by removing an unnecessary file tracing root setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->