### PR TITLE
chore(clerk-js, types): Drop top level billing flags from environment

### DIFF
--- a/.changeset/seven-trees-double.md
+++ b/.changeset/seven-trees-double.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Billing Beta] Drop top level billing flags from environment. Instead, use the payer specific flags.

--- a/packages/clerk-js/src/core/resources/CommerceSettings.ts
+++ b/packages/clerk-js/src/core/resources/CommerceSettings.ts
@@ -8,9 +8,6 @@ import { BaseResource } from './internal';
 export class CommerceSettings extends BaseResource implements CommerceSettingsResource {
   billing: CommerceSettingsResource['billing'] = {
     stripePublishableKey: '',
-    enabled: false,
-    hasPaidUserPlans: false,
-    hasPaidOrgPlans: false,
     organization: {
       enabled: false,
       hasPaidPlans: false,
@@ -32,9 +29,6 @@ export class CommerceSettings extends BaseResource implements CommerceSettingsRe
     }
 
     this.billing.stripePublishableKey = data.billing.stripe_publishable_key || '';
-    this.billing.enabled = data.billing.enabled || false;
-    this.billing.hasPaidUserPlans = data.billing.has_paid_user_plans || false;
-    this.billing.hasPaidOrgPlans = data.billing.has_paid_org_plans || false;
     this.billing.organization.enabled = data.billing.organization.enabled || false;
     this.billing.organization.hasPaidPlans = data.billing.organization.has_paid_plans || false;
     this.billing.user.enabled = data.billing.user.enabled || false;
@@ -47,9 +41,6 @@ export class CommerceSettings extends BaseResource implements CommerceSettingsRe
     return {
       billing: {
         stripe_publishable_key: this.billing.stripePublishableKey,
-        enabled: this.billing.enabled,
-        has_paid_user_plans: this.billing.hasPaidUserPlans,
-        has_paid_org_plans: this.billing.hasPaidOrgPlans,
         organization: {
           enabled: this.billing.organization.enabled,
           has_paid_plans: this.billing.organization.hasPaidPlans,

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -353,13 +353,10 @@ const createOrganizationSettingsFixtureHelpers = (environment: EnvironmentJSON) 
 const createBillingSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
   const os = environment.commerce_settings.billing;
   const withBilling = () => {
-    os.enabled = true;
     os.user.enabled = true;
     os.user.has_paid_plans = true;
     os.organization.enabled = true;
     os.organization.has_paid_plans = true;
-    os.has_paid_org_plans = true;
-    os.has_paid_user_plans = true;
   };
 
   return { withBilling };

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -213,7 +213,6 @@ const createBaseCommerceSettings = (): CommerceSettingsJSON => {
     object: 'commerce_settings',
     id: 'commerce_settings_1',
     billing: {
-      enabled: false,
       user: {
         enabled: false,
         has_paid_plans: false,
@@ -222,8 +221,6 @@ const createBaseCommerceSettings = (): CommerceSettingsJSON => {
         enabled: false,
         has_paid_plans: false,
       },
-      has_paid_org_plans: false,
-      has_paid_user_plans: false,
       stripe_publishable_key: '',
     },
   };

--- a/packages/types/src/commerceSettings.ts
+++ b/packages/types/src/commerceSettings.ts
@@ -4,10 +4,7 @@ import type { CommerceSettingsJSONSnapshot } from './snapshots';
 
 export interface CommerceSettingsJSON extends ClerkResourceJSON {
   billing: {
-    enabled: boolean;
     stripe_publishable_key: string;
-    has_paid_user_plans: boolean;
-    has_paid_org_plans: boolean;
     organization: {
       enabled: boolean;
       has_paid_plans: boolean;
@@ -21,10 +18,7 @@ export interface CommerceSettingsJSON extends ClerkResourceJSON {
 
 export interface CommerceSettingsResource extends ClerkResource {
   billing: {
-    enabled: boolean;
     stripePublishableKey: string;
-    hasPaidUserPlans: boolean;
-    hasPaidOrgPlans: boolean;
     organization: {
       enabled: boolean;
       hasPaidPlans: boolean;


### PR DESCRIPTION
## Description

Internally clerk-js and our hooks already use the payer specific flags (e.g. `user.enabled`). The react hooks from `@clerk/shared` never got to used this old properties, thus compatibility with old versions is **assured**. We should remove this before the Clerk Billing goes to GA, to ensure that we are not making breaking changes later on. 

Environment is already considered unstable, thus such a change should be permitted.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
