### PR TITLE
fix(clerk-js): Hide CTA for `<PricingTable forOrganization/>` and orgId is null

### DIFF
--- a/.changeset/sweet-humans-poke.md
+++ b/.changeset/sweet-humans-poke.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Hide CTA for `<PricingTable forOrganization/>` when the user is does not have an active organization selected.

--- a/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.spec.ts
+++ b/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.spec.ts
@@ -1,0 +1,126 @@
+import type { BillingPlanResource, BillingSubscriptionItemResource, BillingSubscriptionPlanPeriod } from '@clerk/types';
+import { describe, expect, it } from 'vitest';
+
+import { getPricingFooterState } from './pricing-footer-state';
+
+const basePlan: BillingPlanResource = {
+  id: 'plan_1',
+  name: 'Pro',
+  fee: { amount: 1000, amountFormatted: '10.00', currency: 'USD', currencySymbol: '$' },
+  annualFee: { amount: 10000, amountFormatted: '100.00', currency: 'USD', currencySymbol: '$' },
+  annualMonthlyFee: { amount: 833, amountFormatted: '8.33', currency: 'USD', currencySymbol: '$' },
+  description: 'desc',
+  isDefault: false,
+  isRecurring: true,
+  hasBaseFee: true,
+  forPayerType: 'user',
+  publiclyVisible: true,
+  slug: 'pro',
+  avatarUrl: '',
+  features: [],
+  freeTrialDays: 14,
+  freeTrialEnabled: true,
+  pathRoot: '',
+  reload: async () => undefined as any,
+};
+
+const makeSub = (overrides: Partial<BillingSubscriptionItemResource>): BillingSubscriptionItemResource => ({
+  id: 'si_1',
+  plan: basePlan,
+  planPeriod: 'month',
+  status: 'active',
+  createdAt: new Date('2021-01-01'),
+  paymentSourceId: 'src_1',
+  pastDueAt: null,
+  periodStart: new Date('2021-01-01'),
+  periodEnd: new Date('2021-01-31'),
+  canceledAt: null,
+  isFreeTrial: false,
+  cancel: async () => undefined as any,
+  pathRoot: '',
+  reload: async () => undefined as any,
+  ...overrides,
+});
+
+const run = (args: {
+  subscription?: BillingSubscriptionItemResource;
+  plan?: BillingPlanResource;
+  planPeriod?: BillingSubscriptionPlanPeriod;
+  forOrganizations?: boolean;
+  hasActiveOrganization?: boolean;
+}) =>
+  getPricingFooterState({
+    subscription: args.subscription,
+    plan: args.plan ?? basePlan,
+    planPeriod: args.planPeriod ?? 'month',
+    forOrganizations: args.forOrganizations,
+    hasActiveOrganization: args.hasActiveOrganization ?? false,
+  });
+
+describe('usePricingFooterState', () => {
+  it('hides footer when org plans and no active org', () => {
+    const res = run({ subscription: undefined, forOrganizations: true, hasActiveOrganization: false });
+    expect(res).toEqual({ shouldShowFooter: false, shouldShowFooterNotice: false });
+  });
+
+  it('shows footer when no subscription and user plans', () => {
+    const res = run({ subscription: undefined, forOrganizations: false });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: false });
+  });
+
+  it('shows notice when subscription is upcoming', () => {
+    const res = run({ subscription: makeSub({ status: 'upcoming' }) });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: true });
+  });
+
+  it('shows footer when active but canceled', () => {
+    const res = run({ subscription: makeSub({ status: 'active', canceledAt: new Date('2021-02-01') }) });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: false });
+  });
+
+  it('shows footer when switching period to paid annual', () => {
+    const res = run({
+      subscription: makeSub({ status: 'active', planPeriod: 'month' }),
+      planPeriod: 'annual',
+      plan: basePlan,
+    });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: false });
+  });
+
+  it('shows notice when active free trial', () => {
+    const res = run({ subscription: makeSub({ status: 'active', isFreeTrial: true }) });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: true });
+  });
+
+  it('hides footer when active and matching period without trial', () => {
+    const res = run({ subscription: makeSub({ status: 'active', planPeriod: 'month', isFreeTrial: false }) });
+    expect(res).toEqual({ shouldShowFooter: false, shouldShowFooterNotice: false });
+  });
+
+  it('shows footer when switching period to paid monthly', () => {
+    const res = run({
+      subscription: makeSub({ status: 'active', planPeriod: 'annual' }),
+      planPeriod: 'month',
+      plan: basePlan,
+    });
+    expect(res).toEqual({ shouldShowFooter: true, shouldShowFooterNotice: false });
+  });
+
+  it('does not show footer when switching period if annualMonthlyFee is 0', () => {
+    const freeAnnualPlan: BillingPlanResource = {
+      ...basePlan,
+      annualMonthlyFee: { ...basePlan.annualMonthlyFee, amount: 0, amountFormatted: '0.00' },
+    };
+    const res = run({
+      subscription: makeSub({ status: 'active', planPeriod: 'month' }),
+      planPeriod: 'annual',
+      plan: freeAnnualPlan,
+    });
+    expect(res).toEqual({ shouldShowFooter: false, shouldShowFooterNotice: false });
+  });
+
+  it('hides footer when subscription is past_due', () => {
+    const res = run({ subscription: makeSub({ status: 'past_due' }) });
+    expect(res).toEqual({ shouldShowFooter: false, shouldShowFooterNotice: false });
+  });
+});

--- a/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
+++ b/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
@@ -8,6 +8,10 @@ type UsePricingFooterStateParams = {
   hasActiveOrganization: boolean;
 };
 
+/**
+ * Calculates the correct show/hide state for the footer of a card in the `<PricingTableDefault/>` component.
+ * @returns [shouldShowFooter, shouldShowFooterNotice]
+ */
 const valueResolution = (params: UsePricingFooterStateParams): [boolean, boolean] => {
   const { subscription, plan, planPeriod, forOrganizations, hasActiveOrganization } = params;
   const show_with_notice: [boolean, boolean] = [true, true];

--- a/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
+++ b/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
@@ -1,0 +1,54 @@
+import type { BillingPlanResource, BillingSubscriptionItemResource, BillingSubscriptionPlanPeriod } from '@clerk/types';
+
+type UsePricingFooterStateParams = {
+  subscription: BillingSubscriptionItemResource | undefined;
+  plan: BillingPlanResource;
+  planPeriod: BillingSubscriptionPlanPeriod;
+  forOrganizations?: boolean;
+  hasActiveOrganization: boolean;
+};
+
+const valueResolution = (params: UsePricingFooterStateParams): [boolean, boolean] => {
+  const { subscription, plan, planPeriod, forOrganizations, hasActiveOrganization } = params;
+  const show_with_notice: [boolean, boolean] = [true, true];
+  const show_without_notice: [boolean, boolean] = [true, false];
+  const hide: [boolean, boolean] = [false, false];
+
+  // No subscription
+  if (!subscription) {
+    if (forOrganizations && !hasActiveOrganization) {
+      return hide;
+    }
+    return show_without_notice;
+  }
+
+  // Upcoming subscription
+  if (subscription.status === 'upcoming') {
+    return show_with_notice;
+  }
+
+  // Active subscription
+  if (subscription.status === 'active') {
+    const isCanceled = !!subscription.canceledAt;
+    const isSwitchingPaidPeriod = planPeriod !== subscription.planPeriod && plan.annualMonthlyFee.amount > 0;
+    const isActiveFreeTrial = plan.freeTrialEnabled && subscription.isFreeTrial;
+
+    if (isCanceled || isSwitchingPaidPeriod) {
+      return show_without_notice;
+    }
+
+    if (isActiveFreeTrial) {
+      return show_with_notice;
+    }
+
+    return hide;
+  }
+  return hide;
+};
+
+export const getPricingFooterState = (
+  params: UsePricingFooterStateParams,
+): { shouldShowFooter: boolean; shouldShowFooterNotice: boolean } => {
+  const [shouldShowFooter, shouldShowFooterNotice] = valueResolution(params);
+  return { shouldShowFooter, shouldShowFooterNotice };
+};


### PR DESCRIPTION
## Description

This PR updates the existing logic and adds unit tests.
The new addition in the existing logic is 
```ts
  if (!subscription) {
    if (forOrganizations && !hasActiveOrganization) {
      return hide;
    }
    return show_without_notice;
  }
```
| Before | After |
| ---- | ---- |
| <img width="1340" height="462" alt="image" src="https://github.com/user-attachments/assets/5c3ee6be-4950-46a5-91c9-353776f3ed6a" /> |  <img width="1344" height="401" alt="image" src="https://github.com/user-attachments/assets/fadde08a-874e-459e-87c0-c7277b582f9a" /> |





<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pricing table hides the CTA when viewing organization plans without an active organization selected.
* **Bug Fixes**
  * Refined pricing footer visibility and notice logic across states (upcoming, canceled, trial, period switches, past due).
  * Subscription badge now appears only when a subscription exists.
* **Tests**
  * Added comprehensive tests validating pricing footer visibility and notice behavior.
* **Chores**
  * Added changeset for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->