### PR TITLE
feat(backend): Add `user_id` field to `organizationInvitation.accepted` webhook events

### DIFF
--- a/.changeset/blue-teeth-report.md
+++ b/.changeset/blue-teeth-report.md
@@ -1,0 +1,7 @@
+---
+'@clerk/backend': minor
+---
+
+Add `user_id` field to `organizationInvitation.accepted` webhook events.
+
+Creates a new `OrganizationInvitationAcceptedJSON` interface that extends `OrganizationInvitationJSON` with a required `user_id` field, and updates the webhook type system to use this interface specifically for `organizationInvitation`.accepted events.

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -392,6 +392,10 @@ export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   expires_at: number;
 }
 
+export interface OrganizationInvitationAcceptedJSON extends OrganizationInvitationJSON {
+  user_id: string;
+}
+
 /**
  * @interface
  */

--- a/packages/backend/src/api/resources/Webhooks.ts
+++ b/packages/backend/src/api/resources/Webhooks.ts
@@ -5,6 +5,7 @@ import type {
   DeletedObjectJSON,
   EmailJSON,
   OrganizationDomainJSON,
+  OrganizationInvitationAcceptedJSON,
   OrganizationInvitationJSON,
   OrganizationJSON,
   OrganizationMembershipJSON,
@@ -52,8 +53,13 @@ export type OrganizationMembershipWebhookEvent = Webhook<
 >;
 
 export type OrganizationInvitationWebhookEvent = Webhook<
-  'organizationInvitation.accepted' | 'organizationInvitation.created' | 'organizationInvitation.revoked',
+  'organizationInvitation.created' | 'organizationInvitation.revoked',
   OrganizationInvitationJSON
+>;
+
+export type OrganizationInvitationAcceptedWebhookEvent = Webhook<
+  'organizationInvitation.accepted',
+  OrganizationInvitationAcceptedJSON
 >;
 
 export type RoleWebhookEvent = Webhook<'role.created' | 'role.updated' | 'role.deleted', RoleJSON>;
@@ -98,6 +104,7 @@ export type WebhookEvent =
   | OrganizationDomainWebhookEvent
   | OrganizationMembershipWebhookEvent
   | OrganizationInvitationWebhookEvent
+  | OrganizationInvitationAcceptedWebhookEvent
   | RoleWebhookEvent
   | PermissionWebhookEvent
   | WaitlistEntryWebhookEvent


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Add `user_id` field to `organizationInvitation.accepted` webhook events.

Creates a new `OrganizationInvitationAcceptedJSON` interface that extends `OrganizationInvitationJSON` with a required `user_id` field, and updates the webhook type system to use this interface specifically for `organizationInvitation`.accepted events.

<!-- Fixes #(issue number) -->
[USER-3577](https://linear.app/clerk/issue/USER-3577/update-organizationinvitationjson-interface-to-include-user-id-field)

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a dedicated "organizationInvitation.accepted" webhook event whose payload now includes a required user_id to identify the account that accepted an invitation.
- Chores
  - Improved webhook event typing and mappings for organization invitation events to increase clarity and reliability for integrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->