### PR TITLE
Revert "feat(backend): Add `user_id` field to `organizationInvitation.accepted` webhook events"

### DIFF
--- a/.changeset/blue-teeth-report.md
+++ b/.changeset/blue-teeth-report.md
@@ -1,7 +1,0 @@
----
-'@clerk/backend': minor
----
-
-Add `user_id` field to `organizationInvitation.accepted` webhook events.
-
-Creates a new `OrganizationInvitationAcceptedJSON` interface that extends `OrganizationInvitationJSON` with a required `user_id` field, and updates the webhook type system to use this interface specifically for `organizationInvitation`.accepted events.

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -392,10 +392,6 @@ export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   expires_at: number;
 }
 
-export interface OrganizationInvitationAcceptedJSON extends OrganizationInvitationJSON {
-  user_id: string;
-}
-
 /**
  * @interface
  */

--- a/packages/backend/src/api/resources/Webhooks.ts
+++ b/packages/backend/src/api/resources/Webhooks.ts
@@ -5,7 +5,6 @@ import type {
   DeletedObjectJSON,
   EmailJSON,
   OrganizationDomainJSON,
-  OrganizationInvitationAcceptedJSON,
   OrganizationInvitationJSON,
   OrganizationJSON,
   OrganizationMembershipJSON,
@@ -53,13 +52,8 @@ export type OrganizationMembershipWebhookEvent = Webhook<
 >;
 
 export type OrganizationInvitationWebhookEvent = Webhook<
-  'organizationInvitation.created' | 'organizationInvitation.revoked',
+  'organizationInvitation.accepted' | 'organizationInvitation.created' | 'organizationInvitation.revoked',
   OrganizationInvitationJSON
->;
-
-export type OrganizationInvitationAcceptedWebhookEvent = Webhook<
-  'organizationInvitation.accepted',
-  OrganizationInvitationAcceptedJSON
 >;
 
 export type RoleWebhookEvent = Webhook<'role.created' | 'role.updated' | 'role.deleted', RoleJSON>;
@@ -104,7 +98,6 @@ export type WebhookEvent =
   | OrganizationDomainWebhookEvent
   | OrganizationMembershipWebhookEvent
   | OrganizationInvitationWebhookEvent
-  | OrganizationInvitationAcceptedWebhookEvent
   | RoleWebhookEvent
   | PermissionWebhookEvent
   | WaitlistEntryWebhookEvent


### PR DESCRIPTION
Reverts clerk/javascript#6887

Need to add `status = 'accepted'` to `OrganizationInvitationAcceptedJSON` interface for congruency. 