### PR TITLE
chore(shared): Bump target/lib to ES2022

### DIFF
--- a/.changeset/quiet-lobsters-greet.md
+++ b/.changeset/quiet-lobsters-greet.md
@@ -2,4 +2,4 @@
 "@clerk/shared": patch
 ---
 
-Bump target/lib for `@clerk/shared` to ES2020
+Bump target/lib for `@clerk/shared` to ES2022

--- a/.changeset/quiet-lobsters-greet.md
+++ b/.changeset/quiet-lobsters-greet.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Bump target/lib for `@clerk/shared` to ES2020

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -445,6 +445,7 @@ export default tseslint.config([
       'jsdoc/require-description-complete-sentence': 'warn',
       'jsdoc/require-param': ['warn', { ignoreWhenAllParamsMissing: true }],
       'jsdoc/require-param-description': 'warn',
+      'jsdoc/require-description-complete-sentence': 'off',
       'jsdoc/require-returns': 'off',
       'jsdoc/tag-lines': [
         'warn',

--- a/packages/clerk-js/src/ui/hooks/useDebounce.ts
+++ b/packages/clerk-js/src/ui/hooks/useDebounce.ts
@@ -2,14 +2,29 @@ import { useEffect, useState } from 'react';
 
 export function useDebounce<T>(value: T, delayInMs?: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const [timeoutState, setTimeoutState] = useState<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delayInMs || 500);
+    const handleDebounce = () => {
+      if (timeoutState) {
+        clearTimeout(timeoutState);
+        setTimeoutState(undefined);
+      }
 
+      setTimeoutState(
+        setTimeout(() => {
+          setDebouncedValue(value);
+          setTimeoutState(undefined);
+        }, delayInMs || 500),
+      );
+    };
+
+    handleDebounce();
     return () => {
-      clearTimeout(timeoutId);
+      if (timeoutState) {
+        clearTimeout(timeoutState);
+        setTimeoutState(undefined);
+      }
     };
   }, [JSON.stringify(value), delayInMs]);
 

--- a/packages/clerk-js/src/ui/hooks/useDebounce.ts
+++ b/packages/clerk-js/src/ui/hooks/useDebounce.ts
@@ -2,29 +2,14 @@ import { useEffect, useState } from 'react';
 
 export function useDebounce<T>(value: T, delayInMs?: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
-  const [timeoutState, setTimeoutState] = useState<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
-    const handleDebounce = () => {
-      if (timeoutState) {
-        clearTimeout(timeoutState);
-        setTimeoutState(undefined);
-      }
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayInMs || 500);
 
-      setTimeoutState(
-        setTimeout(() => {
-          setDebouncedValue(value);
-          setTimeoutState(undefined);
-        }, delayInMs || 500),
-      );
-    };
-
-    handleDebounce();
     return () => {
-      if (timeoutState) {
-        clearTimeout(timeoutState);
-        setTimeoutState(undefined);
-      }
+      clearTimeout(timeoutId);
     };
   }, [JSON.stringify(value), delayInMs]);
 

--- a/packages/clerk-js/vitest.config.mts
+++ b/packages/clerk-js/vitest.config.mts
@@ -32,7 +32,7 @@ export default defineConfig({
   },
   test: {
     coverage: {
-      enabled: true,
+      enabled: false,
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['src/**/*.{ts,tsx}'],

--- a/packages/clerk-js/vitest.setup.mts
+++ b/packages/clerk-js/vitest.setup.mts
@@ -43,6 +43,7 @@ if (typeof window !== 'undefined') {
     TextEncoder: { value: TextEncoder },
     Response: { value: FakeResponse },
     crypto: { value: crypto.webcrypto },
+    isSecureContext: { value: true, writable: true },
   });
 
   // Mock ResizeObserver

--- a/packages/clerk-js/vitest.setup.mts
+++ b/packages/clerk-js/vitest.setup.mts
@@ -4,11 +4,40 @@ import * as crypto from 'node:crypto';
 import { TextDecoder, TextEncoder } from 'node:util';
 
 import { cleanup, configure } from '@testing-library/react';
-import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 
 configure({});
 
-afterEach(cleanup);
+// Track all timers created during tests to clean them up
+const activeTimers = new Set<ReturnType<typeof setTimeout>>();
+const originalSetTimeout = global.setTimeout;
+const originalClearTimeout = global.clearTimeout;
+
+// Wrap setTimeout to track all timers
+global.setTimeout = ((callback: any, delay?: any, ...args: any[]) => {
+  const timerId = originalSetTimeout(callback, delay, ...args);
+  activeTimers.add(timerId);
+  return timerId;
+}) as typeof setTimeout;
+
+// Wrap clearTimeout to remove from tracking
+global.clearTimeout = ((timerId?: ReturnType<typeof setTimeout>) => {
+  if (timerId) {
+    activeTimers.delete(timerId);
+    originalClearTimeout(timerId);
+  }
+}) as typeof clearTimeout;
+
+beforeEach(() => {
+  activeTimers.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  // Clear all tracked timers to prevent post-test execution
+  activeTimers.forEach(timerId => originalClearTimeout(timerId));
+  activeTimers.clear();
+});
 
 // Store the original method
 // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/shared/src/__tests__/deprecated.test.ts
+++ b/packages/shared/src/__tests__/deprecated.test.ts
@@ -191,7 +191,7 @@ describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
 
   test('deprecate class property shows warning', () => {
     class Example {
-      someProp: string;
+      declare someProp: string;
       constructor(someProp: string) {
         this.someProp = someProp;
       }
@@ -234,7 +234,7 @@ describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
 
   test('deprecate class readonly property shows warning', () => {
     class Example {
-      readonly someReadOnlyProp: string;
+      declare readonly someReadOnlyProp: string;
       constructor(someReadOnlyProp: string) {
         this.someReadOnlyProp = someReadOnlyProp;
       }
@@ -265,7 +265,7 @@ describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
 
     test('deprecate class readonly property does not show warning', () => {
       class Example {
-        readonly someReadOnlyPropInProd: string;
+        declare readonly someReadOnlyPropInProd: string;
         constructor(someReadOnlyPropInProd: string) {
           this.someReadOnlyPropInProd = someReadOnlyPropInProd;
         }
@@ -293,7 +293,7 @@ describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
 
     test('deprecate class readonly property does not show warning', () => {
       class Example {
-        readonly someReadOnlyPropInProd: string;
+        declare readonly someReadOnlyPropInProd: string;
         constructor(someReadOnlyPropInProd: string) {
           this.someReadOnlyPropInProd = someReadOnlyPropInProd;
         }

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import type {
   ClerkPaginatedResponse,
   GetDomainsParams,

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import type {
   ClerkPaginatedResponse,
   CreateOrganizationParams,

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2022",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
@@ -12,7 +12,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "jsx": "react",
-    "lib": ["ES6", "DOM", "WebWorker"],
+    "lib": ["ES2022", "DOM", "WebWorker"],
     "allowJs": true
   },
   "exclude": ["node_modules"],

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(overrideOptions => {
     minify: false,
     sourcemap: true,
     dts: true,
-    target: 'es2020',
+    target: 'es2022',
     external: ['react', 'react-dom'],
     esbuildPlugins: [WebWorkerMinifyPlugin as any],
     define: {


### PR DESCRIPTION
## Description
This ensure that all built-in global types are in sync with the actual runtime values
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/test targets to ES2022 and published a patch; no public API changes.
* **Style / Lint**
  * Turned off JSDoc "complete sentence" rule and removed local lint-suppression comments.
* **Tests**
  * Hardened test setup and cleanup (timer tracking, environment mocks) and adjusted test typings.
* **Config**
  * Disabled test coverage collection.
* **Notes**
  * No runtime behavior or public-facing changes; older runtimes may require polyfills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->