### PR TITLE
chore(repo): Add typedoc link replacements for commerce types

### DIFF
--- a/.typedoc/custom-plugin.mjs
+++ b/.typedoc/custom-plugin.mjs
@@ -55,6 +55,14 @@ const LINK_REPLACEMENTS = [
   ['verify-token-options', '#verify-token-options'],
   ['localization-resource', '/docs/guides/customizing-clerk/localization'],
   ['confirm-checkout-params', '/docs/reference/javascript/types/billing-checkout-resource#parameters'],
+  ['billing-payment-source-resource', '/docs/reference/javascript/types/billing-payment-source-resource'],
+  ['billing-payer-resource', '/docs/reference/javascript/types/billing-payer-resource'],
+  ['billing-plan-resource', '/docs/reference/javascript/types/billing-plan-resource'],
+  ['billing-checkout-totals', '/docs/reference/javascript/types/billing-checkout-totals'],
+  ['billing-money-amount', '/docs/reference/javascript/types/billing-money-amount'],
+  ['billing-subscription-item-resource', '/docs/reference/javascript/types/billing-subscription-item-resource'],
+  ['feature-resource', '/docs/reference/javascript/types/feature-resource'],
+  ['billing-statement-group', '/docs/reference/javascript/types/billing-statement-group'],
 ];
 
 /**


### PR DESCRIPTION
## Description

Currently, in the docs, clicking on a link to any of these pages will append `.mdx` to the path, and it will break the sidebar.

https://github.com/user-attachments/assets/0fda7809-258c-46c4-8a5f-4870c7953fc1

This PR adds link replacements for these paths so that Typedoc knows what exact path these links should point to

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated docs by expanding link rewriting rules, ensuring references to several billing-related resources and a specific feature/resource type resolve correctly.
  * Reduced broken or misdirected links in MDX content, leading to more reliable navigation across related pages.
  * No behavioral changes to the product; updates solely enhance documentation accuracy and link consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->