### PR TITLE
feat(clerk-js,clerk-react,types): Add support for additional props

### DIFF
--- a/.changeset/weak-deer-tie.md
+++ b/.changeset/weak-deer-tie.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+[Experimental] Add support for additional properties to Signal SignIn/SignUp

--- a/integration/templates/custom-flows-react-vite/src/routes/SignIn.tsx
+++ b/integration/templates/custom-flows-react-vite/src/routes/SignIn.tsx
@@ -104,7 +104,7 @@ export function SignIn({ className, ...props }: React.ComponentProps<'div'>) {
           </CardHeader>
           <CardContent>
             <div className='grid gap-6'>
-              {signIn.availableStrategies
+              {signIn.supportedFirstFactors
                 .filter(({ strategy }) => strategy !== 'reset_password_email_code')
                 .map(({ strategy }) => (
                   <Button

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -608,13 +608,33 @@ class SignInFuture implements SignInFutureResource {
 
   constructor(readonly resource: SignIn) {}
 
+  get id() {
+    return this.resource.id;
+  }
+
+  get identifier() {
+    return this.resource.identifier;
+  }
+
+  get createdSessionId() {
+    return this.resource.createdSessionId;
+  }
+
+  get userData() {
+    return this.resource.userData;
+  }
+
   get status() {
     // @TODO hooks-revamp: Consolidate this fallback val with stateProxy
     return this.resource.status || 'needs_identifier';
   }
 
-  get availableStrategies() {
+  get supportedFirstFactors() {
     return this.resource.supportedFirstFactors ?? [];
+  }
+
+  get supportedSecondFactors() {
+    return this.resource.supportedSecondFactors ?? [];
   }
 
   get isTransferable() {
@@ -635,6 +655,10 @@ class SignInFuture implements SignInFutureResource {
 
   get firstFactorVerification() {
     return this.resource.firstFactorVerification;
+  }
+
+  get secondFactorVerification() {
+    return this.resource.secondFactorVerification;
   }
 
   async sendResetPasswordEmailCode(): Promise<{ error: unknown }> {

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -551,9 +551,73 @@ class SignUpFuture implements SignUpFutureResource {
 
   constructor(readonly resource: SignUp) {}
 
+  get id() {
+    return this.resource.id;
+  }
+
+  get requiredFields() {
+    return this.resource.requiredFields;
+  }
+
+  get optionalFields() {
+    return this.resource.optionalFields;
+  }
+
+  get missingFields() {
+    return this.resource.missingFields;
+  }
+
   get status() {
     // @TODO hooks-revamp: Consolidate this fallback val with stateProxy
     return this.resource.status || 'missing_requirements';
+  }
+
+  get username() {
+    return this.resource.username;
+  }
+
+  get firstName() {
+    return this.resource.firstName;
+  }
+
+  get lastName() {
+    return this.resource.lastName;
+  }
+
+  get emailAddress() {
+    return this.resource.emailAddress;
+  }
+
+  get phoneNumber() {
+    return this.resource.phoneNumber;
+  }
+
+  get web3Wallet() {
+    return this.resource.web3wallet;
+  }
+
+  get hasPassword() {
+    return this.resource.hasPassword;
+  }
+
+  get unsafeMetadata() {
+    return this.resource.unsafeMetadata;
+  }
+
+  get createdSessionId() {
+    return this.resource.createdSessionId;
+  }
+
+  get createdUserId() {
+    return this.resource.createdUserId;
+  }
+
+  get abandonAt() {
+    return this.resource.abandonAt;
+  }
+
+  get legalAcceptedAt() {
+    return this.resource.legalAcceptedAt;
   }
 
   get unverifiedFields() {

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -45,6 +45,45 @@ export class StateProxy implements State {
         status: 'needs_identifier' as const,
         availableStrategies: [],
         isTransferable: false,
+        get id() {
+          return gateProperty(target, 'id', undefined);
+        },
+        get supportedFirstFactors() {
+          return gateProperty(target, 'supportedFirstFactors', []);
+        },
+        get supportedSecondFactors() {
+          return gateProperty(target, 'supportedSecondFactors', []);
+        },
+        get secondFactorVerification() {
+          return gateProperty(target, 'secondFactorVerification', {
+            status: null,
+            error: null,
+            expireAt: null,
+            externalVerificationRedirectURL: null,
+            nonce: null,
+            attempts: null,
+            message: null,
+            strategy: null,
+            verifiedAtClient: null,
+            verifiedFromTheSameClient: () => false,
+            __internal_toSnapshot: () => {
+              throw new Error('__internal_toSnapshot called before Clerk is loaded');
+            },
+            pathRoot: '',
+            reload: () => {
+              throw new Error('__internal_toSnapshot called before Clerk is loaded');
+            },
+          });
+        },
+        get identifier() {
+          return gateProperty(target, 'identifier', null);
+        },
+        get createdSessionId() {
+          return gateProperty(target, 'createdSessionId', null);
+        },
+        get userData() {
+          return gateProperty(target, 'userData', {});
+        },
         get firstFactorVerification() {
           return gateProperty(target, 'firstFactorVerification', {
             status: null,
@@ -107,6 +146,54 @@ export class StateProxy implements State {
       errors: defaultErrors(),
       fetchStatus: 'idle' as const,
       signUp: {
+        get id() {
+          return gateProperty(target, 'id', undefined);
+        },
+        get requiredFields() {
+          return gateProperty(target, 'requiredFields', []);
+        },
+        get optionalFields() {
+          return gateProperty(target, 'optionalFields', []);
+        },
+        get missingFields() {
+          return gateProperty(target, 'missingFields', []);
+        },
+        get username() {
+          return gateProperty(target, 'username', null);
+        },
+        get firstName() {
+          return gateProperty(target, 'firstName', null);
+        },
+        get lastName() {
+          return gateProperty(target, 'lastName', null);
+        },
+        get emailAddress() {
+          return gateProperty(target, 'emailAddress', null);
+        },
+        get phoneNumber() {
+          return gateProperty(target, 'phoneNumber', null);
+        },
+        get web3Wallet() {
+          return gateProperty(target, 'web3Wallet', null);
+        },
+        get hasPassword() {
+          return gateProperty(target, 'hasPassword', false);
+        },
+        get unsafeMetadata() {
+          return gateProperty(target, 'unsafeMetadata', {});
+        },
+        get createdSessionId() {
+          return gateProperty(target, 'createdSessionId', null);
+        },
+        get createdUserId() {
+          return gateProperty(target, 'createdUserId', null);
+        },
+        get abandonAt() {
+          return gateProperty(target, 'abandonAt', null);
+        },
+        get legalAcceptedAt() {
+          return gateProperty(target, 'legalAcceptedAt', null);
+        },
         get status() {
           return gateProperty(target, 'status', 'missing_requirements');
         },

--- a/packages/types/src/signInFuture.ts
+++ b/packages/types/src/signInFuture.ts
@@ -1,6 +1,6 @@
 import type { SetActiveNavigate } from './clerk';
 import type { PhoneCodeChannel } from './phoneCodeChannel';
-import type { SignInFirstFactor, SignInStatus } from './signInCommon';
+import type { SignInFirstFactor, SignInSecondFactor, SignInStatus, UserData } from './signInCommon';
 import type { OAuthStrategy, Web3Strategy } from './strategies';
 import type { VerificationResource } from './verification';
 
@@ -128,9 +128,19 @@ export interface SignInFutureFinalizeParams {
  */
 export interface SignInFutureResource {
   /**
+   * The unique identifier for the current sign-in attempt.
+   */
+  readonly id?: string;
+
+  /**
    * The list of first-factor strategies that are available for the current sign-in attempt.
    */
-  readonly availableStrategies: SignInFirstFactor[];
+  readonly supportedFirstFactors: SignInFirstFactor[];
+
+  /**
+   * The list of second-factor strategies that are available for the current sign-in attempt.
+   */
+  readonly supportedSecondFactors: SignInSecondFactor[];
 
   /**
    * The status of the current sign-in attempt as a string (for example, `'needs_identifier'`, `'needs_first_factor'`,
@@ -147,6 +157,26 @@ export interface SignInFutureResource {
   readonly existingSession?: { sessionId: string };
 
   readonly firstFactorVerification: VerificationResource;
+
+  /**
+   * The second-factor verification for the current sign-in attempt.
+   */
+  readonly secondFactorVerification: VerificationResource;
+
+  /**
+   * The identifier for the current sign-in attempt.
+   */
+  readonly identifier: string | null;
+
+  /**
+   * The created session ID for the current sign-in attempt.
+   */
+  readonly createdSessionId: string | null;
+
+  /**
+   * The user data for the current sign-in attempt.
+   */
+  readonly userData: UserData;
 
   /**
    * Used to supply an identifier for the sign-in attempt. Calling this method will populate data on the sign-in

--- a/packages/types/src/signUpFuture.ts
+++ b/packages/types/src/signUpFuture.ts
@@ -1,6 +1,6 @@
 import type { SetActiveNavigate } from './clerk';
 import type { PhoneCodeChannel } from './phoneCodeChannel';
-import type { SignUpIdentificationField, SignUpStatus } from './signUpCommon';
+import type { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUpCommon';
 import type { Web3Strategy } from './strategies';
 
 interface SignUpFutureAdditionalParams {
@@ -72,9 +72,29 @@ export interface SignUpFutureFinalizeParams {
  */
 export interface SignUpFutureResource {
   /**
+   * The unique identifier for the current sign-up attempt.
+   */
+  readonly id?: string;
+
+  /**
    * The status of the current sign-up attempt as a string (for example, `'missing_requirements'`, `'complete'`, `'abandoned'`, etc.)
    */
   readonly status: SignUpStatus;
+
+  /**
+   * The list of required fields for the current sign-up attempt.
+   */
+  readonly requiredFields: SignUpField[];
+
+  /**
+   * The list of optional fields for the current sign-up attempt.
+   */
+  readonly optionalFields: SignUpField[];
+
+  /**
+   * The list of missing fields for the current sign-up attempt.
+   */
+  readonly missingFields: SignUpField[];
 
   /**
    * An array of strings representing unverified fields such as `’email_address’`. Can be used to detect when verification is necessary.
@@ -88,6 +108,30 @@ export interface SignUpFutureResource {
   readonly isTransferable: boolean;
 
   readonly existingSession?: { sessionId: string };
+
+  readonly username: string | null;
+
+  readonly firstName: string | null;
+
+  readonly lastName: string | null;
+
+  readonly emailAddress: string | null;
+
+  readonly phoneNumber: string | null;
+
+  readonly web3Wallet: string | null;
+
+  readonly hasPassword: boolean;
+
+  readonly unsafeMetadata: SignUpUnsafeMetadata;
+
+  readonly createdSessionId: string | null;
+
+  readonly createdUserId: string | null;
+
+  readonly abandonAt: number | null;
+
+  readonly legalAcceptedAt: number | null;
 
   create: (params: SignUpFutureCreateParams) => Promise<{ error: unknown }>;
 


### PR DESCRIPTION
## Description

This PR adds additional properties to our Signal-based SignIn/SignUp resources, bringing them to parity with the existing API.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SignIn now exposes id, identifier, createdSessionId, userData, supportedFirstFactors, supportedSecondFactors, and secondFactorVerification.
  * SignUp now exposes id, required/optional/missing fields, username, profile/contact fields, hasPassword, unsafeMetadata, createdSessionId/createdUserId, abandonAt, and legalAcceptedAt.
  * React state proxies surface the same SignIn/SignUp properties with safe defaults.

* **Chores**
  * Minor releases prepared for core packages.
  * Experimental: added support for additional properties in SignIn/SignUp signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->