### PR TITLE
feat(clerk-expo): Add support for experimental Signal hooks

### DIFF
--- a/.changeset/twelve-mammals-grab.md
+++ b/.changeset/twelve-mammals-grab.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': minor
+---
+
+Add support for experimental `useSignInSignal` and `useSignUpSignal` hooks.

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -51,6 +51,10 @@
     "./resource-cache": {
       "types": "./dist/resource-cache/index.d.ts",
       "default": "./dist/resource-cache/index.js"
+    },
+    "./experimental": {
+      "types": "./dist/experimental.d.ts",
+      "default": "./dist/experimental.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/expo/src/experimental.ts
+++ b/packages/expo/src/experimental.ts
@@ -1,0 +1,1 @@
+export { useSignInSignal, useSignUpSignal } from '@clerk/clerk-react/experimental';


### PR DESCRIPTION
## Description

This PR exposes the `useSignUpSignal` and `useSignInSignal` hooks via the `/experimental` export, mirroring the setup we're using in `@clerk/clerk-react`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes experimental authentication signal hooks for Expo: useSignInSignal and useSignUpSignal, accessible via the experimental entry point.
* **Chores**
  * Prepares a minor release of the Expo package with updated exports to include the experimental module.
* **Documentation**
  * Notes support for the new experimental hooks in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->