### PR TITLE
chore(backend): Add `slug_disabled` to `OrganizationSettings`

### DIFF
--- a/.changeset/famous-papers-build.md
+++ b/.changeset/famous-papers-build.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add `slug_disabled` field on organization settings

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -261,6 +261,7 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
   creator_role: string;
   admin_delete_enabled: boolean;
   domains_enabled: boolean;
+  slug_disabled: boolean;
   domains_enrollment_modes: Array<DomainsEnrollmentModes>;
   domains_default_role: string;
 }

--- a/packages/backend/src/api/resources/OrganizationSettings.ts
+++ b/packages/backend/src/api/resources/OrganizationSettings.ts
@@ -10,6 +10,7 @@ export class OrganizationSettings {
     readonly creatorRole: string,
     readonly adminDeleteEnabled: boolean,
     readonly domainsEnabled: boolean,
+    readonly slugDisabled: boolean,
     readonly domainsEnrollmentModes: Array<DomainsEnrollmentModes>,
     readonly domainsDefaultRole: string,
   ) {}
@@ -23,6 +24,7 @@ export class OrganizationSettings {
       data.creator_role,
       data.admin_delete_enabled,
       data.domains_enabled,
+      data.slug_disabled,
       data.domains_enrollment_modes,
       data.domains_default_role,
     );


### PR DESCRIPTION
## Description

Introduces a new field `slug_disabled` on the update organization settings method for `/v1/instance/organization_settings`

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Organization settings now include a new boolean flag indicating when organization slugs are disabled. This value is exposed in the settings payload, enabling clients to detect and adjust behavior when slug usage is turned off.
- Bug Fixes
  - None.
- Documentation
  - None.
- Refactor
  - None.
- Style
  - None.
- Tests
  - None.
- Chores
  - None.
- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->