### PR TITLE
feat(clerk-js,types): Display organization slug based on environment settings

### DIFF
--- a/.changeset/dull-paws-march.md
+++ b/.changeset/dull-paws-march.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Display organization slug based on environment settings

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -18,6 +18,11 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
     enrollmentModes: [],
     defaultRole: null,
   };
+  slugs: {
+    disabled: boolean;
+  } = {
+    disabled: false,
+  };
   enabled: boolean = false;
   maxAllowedMemberships: number = 1;
   forceOrganizationSelection!: boolean;
@@ -40,6 +45,10 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
       this.domains.enabled = this.withDefault(data.domains.enabled, this.domains.enabled);
       this.domains.enrollmentModes = this.withDefault(data.domains.enrollment_modes, this.domains.enrollmentModes);
       this.domains.defaultRole = this.withDefault(data.domains.default_role, this.domains.defaultRole);
+    }
+
+    if (data.slugs) {
+      this.slugs.disabled = this.withDefault(data.slugs.disabled, this.slugs.disabled);
     }
 
     this.enabled = this.withDefault(data.enabled, this.enabled);

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -18,7 +18,7 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
     enrollmentModes: [],
     defaultRole: null,
   };
-  slugs: {
+  slug: {
     disabled: boolean;
   } = {
     disabled: false,
@@ -47,8 +47,8 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
       this.domains.defaultRole = this.withDefault(data.domains.default_role, this.domains.defaultRole);
     }
 
-    if (data.slugs) {
-      this.slugs.disabled = this.withDefault(data.slugs.disabled, this.slugs.disabled);
+    if (data.slug) {
+      this.slug.disabled = this.withDefault(data.slug.disabled, this.slug.disabled);
     }
 
     this.enabled = this.withDefault(data.enabled, this.enabled);

--- a/packages/clerk-js/src/test/fixture-helpers.ts
+++ b/packages/clerk-js/src/test/fixture-helpers.ts
@@ -342,13 +342,22 @@ const createOrganizationSettingsFixtureHelpers = (environment: EnvironmentJSON) 
   const withForceOrganizationSelection = () => {
     os.force_organization_selection = true;
   };
+  const withOrganizationSlug = (enabled = false) => {
+    os.slug.disabled = !enabled;
+  };
 
   const withOrganizationDomains = (modes?: OrganizationEnrollmentMode[], defaultRole?: string) => {
     os.domains.enabled = true;
     os.domains.enrollment_modes = modes || ['automatic_invitation', 'manual_invitation'];
     os.domains.default_role = defaultRole ?? null;
   };
-  return { withOrganizations, withMaxAllowedMemberships, withOrganizationDomains, withForceOrganizationSelection };
+  return {
+    withOrganizations,
+    withMaxAllowedMemberships,
+    withOrganizationDomains,
+    withForceOrganizationSelection,
+    withOrganizationSlug,
+  };
 };
 
 const createBillingSettingsFixtureHelpers = (environment: EnvironmentJSON) => {

--- a/packages/clerk-js/src/test/fixtures.ts
+++ b/packages/clerk-js/src/test/fixtures.ts
@@ -89,6 +89,9 @@ const createBaseOrganizationSettings = (): OrganizationSettingsJSON => {
       enabled: false,
       enrollment_modes: [],
     },
+    slug: {
+      disabled: true,
+    },
   } as unknown as OrganizationSettingsJSON;
 };
 

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -37,7 +37,7 @@ type CreateOrganizationFormProps = {
   /**
    * @deprecated
    * This prop will be removed in a future version.
-   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
+   * Configure whether organization slug is enabled via the Clerk Dashboard under Organization Settings.
    */
   hideSlug?: boolean;
 };

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -2,6 +2,7 @@ import { useOrganization, useOrganizationList } from '@clerk/shared/react';
 import type { CreateOrganizationParams, OrganizationResource } from '@clerk/types';
 import React from 'react';
 
+import { useEnvironment } from '@/ui/contexts';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Form } from '@/ui/elements/Form';
 import { FormButtonContainer } from '@/ui/elements/FormButtons';
@@ -45,6 +46,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
     userMemberships: organizationListParams.userMemberships,
   });
   const { organization } = useOrganization();
+  const { organizationSettings } = useEnvironment();
   const [file, setFile] = React.useState<File | null>();
 
   const nameField = useFormControl('name', '', {
@@ -61,6 +63,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
 
   const dataChanged = !!nameField.value;
   const canSubmit = dataChanged;
+  const organizationSlugEnabled = !props.hideSlug || !organizationSettings.slugs.disabled;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -75,7 +78,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
     try {
       const createOrgParams: CreateOrganizationParams = { name: nameField.value };
 
-      if (!props.hideSlug) {
+      if (organizationSlugEnabled) {
         createOrgParams.slug = slugField.value;
       }
 
@@ -188,7 +191,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
               ignorePasswordManager
             />
           </Form.ControlRow>
-          {!props.hideSlug && (
+          {organizationSlugEnabled && (
             <Form.ControlRow elementId={slugField.id}>
               <Form.PlainInput
                 {...slugField.props}

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -68,7 +68,9 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
 
   const dataChanged = !!nameField.value;
   const canSubmit = dataChanged;
-  const organizationSlugEnabled = !props.hideSlug || !organizationSettings.slug.disabled;
+
+  // Environment setting takes precedence over prop
+  const organizationSlugEnabled = !organizationSettings.slug.disabled && !props.hideSlug;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -34,6 +34,11 @@ type CreateOrganizationFormProps = {
     headerTitle?: LocalizationKey;
     headerSubtitle?: LocalizationKey;
   };
+  /**
+   * @deprecated
+   * This prop will be removed in a future version.
+   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
+   */
   hideSlug?: boolean;
 };
 
@@ -63,7 +68,7 @@ export const CreateOrganizationForm = withCardStateProvider((props: CreateOrgani
 
   const dataChanged = !!nameField.value;
   const canSubmit = dataChanged;
-  const organizationSlugEnabled = !props.hideSlug || !organizationSettings.slugs.disabled;
+  const organizationSlugEnabled = !props.hideSlug || !organizationSettings.slug.disabled;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
@@ -114,8 +114,8 @@ describe('CreateOrganization', () => {
     });
   });
 
-  describe('with organization slug disabled on environment', () => {
-    it('renders component without slug field', async () => {
+  describe('with organization slug configured on environment', () => {
+    it('when disabled, renders component without slug field', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withOrganizationSlug(false);
@@ -133,6 +133,104 @@ describe('CreateOrganization', () => {
         ),
       );
 
+      const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+
+      expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
+
+      await userEvent.type(getByLabelText(/Name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      await waitFor(() => {
+        expect(queryByText(/Invite new members/i)).toBeInTheDocument();
+      });
+    });
+
+    it('when enabled, renders component slug field', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(true);
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+        });
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(
+        Promise.resolve(
+          getCreatedOrg({
+            maxAllowedMemberships: 1,
+            slug: 'new-org-1722578361',
+          }),
+        ),
+      );
+
+      const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+
+      expect(queryByLabelText(/Slug/i)).toBeInTheDocument();
+
+      await userEvent.type(getByLabelText(/Name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      await waitFor(() => {
+        expect(queryByText(/Invite new members/i)).toBeInTheDocument();
+      });
+    });
+
+    it('when enabled and `hideSlug` prop is passed, renders component without slug field', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(true);
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+        });
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(
+        Promise.resolve(
+          getCreatedOrg({
+            maxAllowedMemberships: 1,
+            slug: 'new-org-1722578361',
+          }),
+        ),
+      );
+
+      props.setProps({ hideSlug: true });
+      const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+
+      expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
+
+      await userEvent.type(getByLabelText(/Name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      await waitFor(() => {
+        expect(queryByText(/Invite new members/i)).toBeInTheDocument();
+      });
+    });
+
+    it('when disabled and `hideSlug` prop is passed, renders component without slug field', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(false); // Environment disables slug
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+        });
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(
+        Promise.resolve(
+          getCreatedOrg({
+            maxAllowedMemberships: 1,
+            slug: 'new-org-1722578361',
+          }),
+        ),
+      );
+
+      props.setProps({ hideSlug: true });
       const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
         wrapper,
       });

--- a/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
@@ -80,35 +80,71 @@ describe('CreateOrganization', () => {
     expect(getByRole('heading', { name: 'Create organization', level: 1 })).toBeInTheDocument();
   });
 
-  it('renders component without slug field', async () => {
-    const { wrapper, fixtures, props } = await createFixtures(f => {
-      f.withOrganizations();
-      f.withUser({
-        email_addresses: ['test@clerk.com'],
+  describe('with `hideSlug` prop', () => {
+    it('renders component without slug field', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+        });
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(
+        Promise.resolve(
+          getCreatedOrg({
+            maxAllowedMemberships: 1,
+            slug: 'new-org-1722578361',
+          }),
+        ),
+      );
+
+      props.setProps({ hideSlug: true });
+      const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+
+      expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
+
+      await userEvent.type(getByLabelText(/Name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      await waitFor(() => {
+        expect(queryByText(/Invite new members/i)).toBeInTheDocument();
       });
     });
+  });
 
-    fixtures.clerk.createOrganization.mockReturnValue(
-      Promise.resolve(
-        getCreatedOrg({
-          maxAllowedMemberships: 1,
-          slug: 'new-org-1722578361',
-        }),
-      ),
-    );
+  describe('with organization slug disabled on environment', () => {
+    it('renders component without slug field', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(false);
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+        });
+      });
 
-    props.setProps({ hideSlug: true });
-    const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
-      wrapper,
-    });
+      fixtures.clerk.createOrganization.mockReturnValue(
+        Promise.resolve(
+          getCreatedOrg({
+            maxAllowedMemberships: 1,
+            slug: 'new-org-1722578361',
+          }),
+        ),
+      );
 
-    expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
+      const { userEvent, getByRole, queryByText, queryByLabelText, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
 
-    await userEvent.type(getByLabelText(/Name/i), 'new org');
-    await userEvent.click(getByRole('button', { name: /create organization/i }));
+      expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(queryByText(/Invite new members/i)).toBeInTheDocument();
+      await userEvent.type(getByLabelText(/Name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      await waitFor(() => {
+        expect(queryByText(/Invite new members/i)).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
@@ -85,6 +85,7 @@ describe('OrganizationList', () => {
     it('hides the personal account with no data to list', async () => {
       const { wrapper, props } = await createFixtures(f => {
         f.withOrganizations();
+        f.withOrganizationSlug(true);
         f.withUser({
           email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
@@ -210,6 +211,7 @@ describe('OrganizationList', () => {
     it('display CreateOrganization within OrganizationList', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withOrganizations();
+        f.withOrganizationSlug(true);
         f.withUser({
           email_addresses: ['test@clerk.com'],
           create_organization_enabled: true,

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/CreateOrganizationScreen.tsx
@@ -1,5 +1,7 @@
 import { useOrganizationList } from '@clerk/shared/react';
+import type { CreateOrganizationParams } from '@clerk/types';
 
+import { useEnvironment } from '@/ui/contexts';
 import { useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import { localizationKeys } from '@/ui/customizables';
 import { useCardState } from '@/ui/elements/contexts';
@@ -25,6 +27,7 @@ export const CreateOrganizationScreen = (props: CreateOrganizationScreenProps) =
   const { createOrganization, isLoaded, setActive } = useOrganizationList({
     userMemberships: organizationListParams.userMemberships,
   });
+  const { organizationSettings } = useEnvironment();
 
   const nameField = useFormControl('name', '', {
     type: 'text',
@@ -37,6 +40,8 @@ export const CreateOrganizationScreen = (props: CreateOrganizationScreenProps) =
     placeholder: localizationKeys('taskChooseOrganization.createOrganization.formFieldInputPlaceholder__slug'),
   });
 
+  const organizationSlugEnabled = !organizationSettings.slug.disabled;
+
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -45,7 +50,13 @@ export const CreateOrganizationScreen = (props: CreateOrganizationScreenProps) =
     }
 
     try {
-      const organization = await createOrganization({ name: nameField.value, slug: slugField.value });
+      const createOrgParams: CreateOrganizationParams = { name: nameField.value };
+
+      if (organizationSlugEnabled) {
+        createOrgParams.slug = slugField.value;
+      }
+
+      const organization = await createOrganization(createOrgParams);
 
       await setActive({
         organization,
@@ -90,15 +101,17 @@ export const CreateOrganizationScreen = (props: CreateOrganizationScreenProps) =
               ignorePasswordManager
             />
           </Form.ControlRow>
-          <Form.ControlRow elementId={slugField.id}>
-            <Form.PlainInput
-              {...slugField.props}
-              onChange={event => updateSlugField(event.target.value)}
-              isRequired
-              pattern='^(?=.*[a-z0-9])[a-z0-9\-]+$'
-              ignorePasswordManager
-            />
-          </Form.ControlRow>
+          {organizationSlugEnabled && (
+            <Form.ControlRow elementId={slugField.id}>
+              <Form.PlainInput
+                {...slugField.props}
+                onChange={event => updateSlugField(event.target.value)}
+                isRequired
+                pattern='^(?=.*[a-z0-9])[a-z0-9\-]+$'
+                ignorePasswordManager
+              />
+            </Form.ControlRow>
+          )}
 
           <FormButtonContainer sx={() => ({ flexDirection: 'column' })}>
             <Form.SubmitButton

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
@@ -204,4 +204,38 @@ describe('TaskChooseOrganization', () => {
 
     expect(await findByText(/testuser/)).toBeInTheDocument();
   });
+
+  describe('on create organization form', () => {
+    it("does not display slug field if it's disabled on environment", async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(false);
+        f.withForceOrganizationSelection();
+        f.withUser({
+          create_organization_enabled: true,
+          tasks: [{ key: 'choose-organization' }],
+        });
+      });
+
+      const { queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
+
+      expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("display slug field if it's enabled on environment", async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withOrganizations();
+      f.withOrganizationSlug(true);
+      f.withForceOrganizationSelection();
+      f.withUser({
+        create_organization_enabled: true,
+        tasks: [{ key: 'choose-organization' }],
+      });
+    });
+
+    const { queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
+
+    expect(queryByLabelText(/Slug/i)).toBeInTheDocument();
+  });
 });

--- a/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
@@ -217,25 +217,27 @@ describe('TaskChooseOrganization', () => {
         });
       });
 
-      const { queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
+      const { findByRole, queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
 
+      expect(await findByRole('textbox', { name: /name/i })).toBeInTheDocument();
       expect(queryByLabelText(/Slug/i)).not.toBeInTheDocument();
     });
-  });
 
-  it("display slug field if it's enabled on environment", async () => {
-    const { wrapper } = await createFixtures(f => {
-      f.withOrganizations();
-      f.withOrganizationSlug(true);
-      f.withForceOrganizationSelection();
-      f.withUser({
-        create_organization_enabled: true,
-        tasks: [{ key: 'choose-organization' }],
+    it("display slug field if it's enabled on environment", async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationSlug(true);
+        f.withForceOrganizationSelection();
+        f.withUser({
+          create_organization_enabled: true,
+          tasks: [{ key: 'choose-organization' }],
+        });
       });
+
+      const { findByRole, queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
+
+      expect(await findByRole('textbox', { name: /name/i })).toBeInTheDocument();
+      expect(queryByLabelText(/Slug/i)).toBeInTheDocument();
     });
-
-    const { queryByLabelText } = render(<TaskChooseOrganization />, { wrapper });
-
-    expect(queryByLabelText(/Slug/i)).toBeInTheDocument();
   });
 });

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1563,7 +1563,7 @@ export type CreateOrganizationProps = RoutingOptions & {
   /**
    * @deprecated
    * This prop will be removed in a future version.
-   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
+   * Configure whether organization slug is enabled via the Clerk Dashboard under Organization Settings.
    */
   hideSlug?: boolean;
 };
@@ -1724,7 +1724,7 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
     /**
      * @deprecated
      * This prop will be removed in a future version.
-     * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
+     * Configure whether organization slug is enabled via the Clerk Dashboard under Organization Settings.
      */
     hideSlug?: boolean;
     /**
@@ -1785,7 +1785,7 @@ export type OrganizationListProps = {
   /**
    * @deprecated
    * This prop will be removed in a future version.
-   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
+   * Configure whether organization slug is enabled via the Clerk Dashboard under Organization Settings.
    */
   hideSlug?: boolean;
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -1561,8 +1561,9 @@ export type CreateOrganizationProps = RoutingOptions & {
    */
   appearance?: CreateOrganizationTheme;
   /**
-   * Hides the optional "slug" field in the organization creation screen.
-   * @default false
+   * @deprecated
+   * This prop will be removed in a future version.
+   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
    */
   hideSlug?: boolean;
 };
@@ -1721,8 +1722,9 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
      */
     skipInvitationScreen?: boolean;
     /**
-     * Hides the optional "slug" field in the organization creation screen.
-     * @default false
+     * @deprecated
+     * This prop will be removed in a future version.
+     * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
      */
     hideSlug?: boolean;
     /**
@@ -1781,8 +1783,9 @@ export type OrganizationListProps = {
    */
   afterSelectPersonalUrl?: ((user: UserResource) => string) | LooseExtractedParams<PrimitiveKeys<UserResource>>;
   /**
-   * Hides the optional "slug" field in the organization creation screen.
-   * @default false
+   * @deprecated
+   * This prop will be removed in a future version.
+   * Configure whether organization slug is required via the Clerk Dashboard under Organization Settings.
    */
   hideSlug?: boolean;
 };

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -17,7 +17,7 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
     enrollment_modes: OrganizationEnrollmentMode[];
     default_role: string | null;
   };
-  slugs: {
+  slug: {
     disabled: boolean;
   };
 }
@@ -34,7 +34,7 @@ export interface OrganizationSettingsResource extends ClerkResource {
     enrollmentModes: OrganizationEnrollmentMode[];
     defaultRole: string | null;
   };
-  slugs: {
+  slug: {
     disabled: boolean;
   };
   __internal_toSnapshot: () => OrganizationSettingsJSONSnapshot;

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -17,6 +17,9 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
     enrollment_modes: OrganizationEnrollmentMode[];
     default_role: string | null;
   };
+  slugs: {
+    disabled: boolean;
+  };
 }
 
 export interface OrganizationSettingsResource extends ClerkResource {
@@ -30,6 +33,9 @@ export interface OrganizationSettingsResource extends ClerkResource {
     enabled: boolean;
     enrollmentModes: OrganizationEnrollmentMode[];
     defaultRole: string | null;
+  };
+  slugs: {
+    disabled: boolean;
   };
   __internal_toSnapshot: () => OrganizationSettingsJSONSnapshot;
 }


### PR DESCRIPTION
## Description

Resolves ORGS-886

Conditionally display the organization slug field based on instance organization settings. Also, deprecates the `hideSlug` prop in favor of the runtime setting.

https://github.com/user-attachments/assets/3c9739bc-67ff-48c4-86f7-8beed9a923ba

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization slug visibility and inclusion in create flows now honor environment settings.

* **Documentation**
  * hideSlug prop marked deprecated; slug behavior should be configured via the Clerk Dashboard.
  * Public types and organization settings now expose slug.disabled.

* **Tests**
  * Fixtures and tests expanded to cover slug-enabled and slug-disabled scenarios.

* **Chores**
  * Dependency patch updates and accompanying changeset added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->