### PR TITLE
fix(clerk-js): SignUpVerificationCodeForm back navigation for combined flows

### DIFF
--- a/.changeset/puny-queens-dream.md
+++ b/.changeset/puny-queens-dream.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ensure the back navigation within SignUpVerificationCode returns to the appropriate step within combined flow.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpVerificationCodeForm.tsx
@@ -1,11 +1,12 @@
 import { useClerk } from '@clerk/shared/react';
 import type { SignUpResource } from '@clerk/types';
+import React from 'react';
 
 import type { VerificationCodeCardProps } from '@/ui/elements/VerificationCodeCard';
 import { VerificationCodeCard } from '@/ui/elements/VerificationCodeCard';
 
 import { forwardClerkQueryParams } from '../../../utils/getClerkQueryParam';
-import { useSignUpContext } from '../../contexts';
+import { SignInContext, useSignUpContext } from '../../contexts';
 import type { LocalizationKey } from '../../customizables';
 import { useRouter } from '../../router';
 import { completeSignUpFlow } from './util';
@@ -24,13 +25,16 @@ type SignInFactorOneCodeFormProps = {
 };
 
 export const SignUpVerificationCodeForm = (props: SignInFactorOneCodeFormProps) => {
-  const { afterSignUpUrl, navigateOnSetActive } = useSignUpContext();
+  const { afterSignUpUrl, navigateOnSetActive, isCombinedFlow: _isCombinedFlow } = useSignUpContext();
   const { setActive } = useClerk();
   const { navigate } = useRouter();
 
+  const isWithinSignInContext = !!React.useContext(SignInContext);
+  const isCombinedFlow = !!(isWithinSignInContext && _isCombinedFlow);
+
   const goBack = () => {
     const params = forwardClerkQueryParams();
-    return navigate('../', { searchParams: params });
+    return navigate(isCombinedFlow ? '../../' : '../', { searchParams: params });
   };
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {


### PR DESCRIPTION
## Description

Fixes an issue within the combined flow experience where a user enters the wrong phone number, and within the verification step hits the back button, and they were brought back to the sign-up step, vs moving back to the sign-in step. This is problematic because when they do enter the correct number during the sign-up step, they'd get an error that the number is already in use which is confusing.

This fix, ensures they go back to the sign-in step, to ensure when they do enter the right phone number, it correctly moves to the verification step.


BEFORE

https://github.com/user-attachments/assets/45040eac-e8ea-4a37-bb50-8c81f6808540



AFTER

https://github.com/user-attachments/assets/3833f44a-b9d4-406f-b652-f7e2021caa42



Fixes USER-3614

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed back navigation in the sign-up verification step when used inside a combined sign-in/sign-up flow so it returns to the correct previous screen.
  * Enhanced detection of combined sign-in/sign-up flows to ensure consistent, predictable navigation across multi-step authentication and reduce user confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->