### PR TITLE
chore(react-router): Accept `organizationSyncOptions` option in middleware

### DIFF
--- a/packages/react-router/src/server/clerkMiddleware.ts
+++ b/packages/react-router/src/server/clerkMiddleware.ts
@@ -36,7 +36,9 @@ export const clerkMiddleware = (options?: ClerkMiddlewareOptions): MiddlewareFun
     const loadedOptions = loadOptions(args, options);
     const { audience, authorizedParties } = loadedOptions;
     const { signInUrl, signUpUrl, afterSignInUrl, afterSignUpUrl } = loadedOptions;
+    const { organizationSyncOptions } = loadedOptions;
     const requestState = await clerkClient(args).authenticateRequest(clerkRequest, {
+      organizationSyncOptions,
       audience,
       authorizedParties,
       signInUrl,

--- a/packages/react-router/src/server/types.ts
+++ b/packages/react-router/src/server/types.ts
@@ -1,5 +1,10 @@
 import type { Organization, Session, User, VerifyTokenOptions } from '@clerk/backend';
-import type { RequestState, SignedInAuthObject, SignedOutAuthObject } from '@clerk/backend/internal';
+import type {
+  OrganizationSyncOptions,
+  RequestState,
+  SignedInAuthObject,
+  SignedOutAuthObject,
+} from '@clerk/backend/internal';
 import type {
   LegacyRedirectProps,
   MultiDomainAndOrProxy,
@@ -31,6 +36,12 @@ export type ClerkMiddlewareOptions = {
   machineSecretKey?: string;
   signInUrl?: string;
   signUpUrl?: string;
+  /**
+   * Used to activate a specific [organization](https://clerk.com/docs/guides/organizations/overview) or [personal account](https://clerk.com/docs/guides/dashboard/overview) based on URL path parameters. If there's a mismatch between the active organization in the session (e.g., as reported by `auth()`) and the organization indicated by the URL, an attempt to activate the organization specified in the URL will be made.
+   *
+   * If the activation can't be performed, either because an organization doesn't exist or the user lacks access, the active organization in the session won't be changed. Ultimately, it's the responsibility of the page to verify that the resources are appropriate to render given the URL and handle mismatches appropriately (e.g., by returning a 404).
+   */
+  organizationSyncOptions?: OrganizationSyncOptions;
 } & Pick<VerifyTokenOptions, 'audience' | 'authorizedParties'> &
   MultiDomainAndOrProxy &
   SignInForceRedirectUrl &


### PR DESCRIPTION
## Description

This PR adds the `organizationSyncOptions` type to React Router's `clerkMiddleware()`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
