### PR TITLE
Revert "fix(nuxt): Prevent Nuxt route middlewares from seeing intermediate states during navigation"

### DIFF
--- a/.changeset/ten-poets-agree.md
+++ b/.changeset/ten-poets-agree.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nuxt": minor
+---
+
+Remove added `nextTick()` calls when invoking Clerk routing functions.

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -4,9 +4,6 @@ import { clerkPlugin } from '@clerk/vue';
 import { setErrorThrowerOptions } from '@clerk/vue/internal';
 import { defineNuxtPlugin, navigateTo, useRuntimeConfig, useState } from 'nuxt/app';
 
-// @ts-expect-error: Handled by Nuxt.
-import { nextTick } from '#imports';
-
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });
 setClerkJsLoadingErrorPackageName(PACKAGE_NAME);
 
@@ -28,16 +25,8 @@ export default defineNuxtPlugin(nuxtApp => {
       version: PACKAGE_VERSION,
       environment: process.env.NODE_ENV,
     },
-    routerPush: (to: string) => {
-      return nextTick(() => {
-        void navigateTo(to);
-      });
-    },
-    routerReplace: (to: string) => {
-      return nextTick(() => {
-        void navigateTo(to, { replace: true });
-      });
-    },
+    routerPush: (to: string) => navigateTo(to),
+    routerReplace: (to: string) => navigateTo(to, { replace: true }),
     initialState: initialState.value,
   });
 });


### PR DESCRIPTION
Reverts clerk/javascript#6802

The original intent of the PR is to fix issues with `setTransitiveState()` in non-React apps, but looks like it introduced another issue (https://github.com/clerk/javascript/issues/6904). [We have plans to kill `setTransitiveState()`](https://clerkinc.slack.com/archives/C046VRJPCNS/p1759434793600119) so I guess it's better to wait for that than to patch it like this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified client-side navigation by removing an unnecessary asynchronous wrapper, making routing calls more direct.
* **Performance**
  * Slight improvement to navigation responsiveness by eliminating extra scheduling overhead.
* **Chores**
  * Added a changeset noting this minor routing update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->