### PR TITLE
fix(clerk-js): Add private _create method for use inside runAsyncResourceTask

### DIFF
--- a/.changeset/giant-cats-lay.md
+++ b/.changeset/giant-cats-lay.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Experimental] Fix `signIn.password` emailAddress parameter name.

--- a/.changeset/purple-toys-refuse.md
+++ b/.changeset/purple-toys-refuse.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+[Experimental] Fix issue where calling `this.create()` would not correctly propogate errors.

--- a/.changeset/purple-toys-refuse.md
+++ b/.changeset/purple-toys-refuse.md
@@ -3,4 +3,4 @@
 '@clerk/types': minor
 ---
 
-[Experimental] Fix issue where calling `this.create()` would not correctly propogate errors.
+[Experimental] Fix issue where calling `this.create()` would not correctly propagate errors.

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -884,13 +884,18 @@ class SignInFuture implements SignInFutureResource {
         throw new Error('modal flow is not supported yet');
       }
 
-      if (!this.resource.id) {
-        await this._create({
-          strategy,
-          redirectUrl: SignIn.clerk.buildUrlWithAuth(redirectCallbackUrl),
-          actionCompleteRedirectUrl: redirectUrl,
-        });
+      let actionCompleteRedirectUrl = redirectUrl;
+      try {
+        new URL(redirectUrl);
+      } catch {
+        actionCompleteRedirectUrl = window.location.origin + redirectUrl;
       }
+
+      await this._create({
+        strategy,
+        redirectUrl: SignIn.clerk.buildUrlWithAuth(redirectCallbackUrl),
+        actionCompleteRedirectUrl,
+      });
 
       const { status, externalVerificationRedirectURL } = this.resource.firstFactorVerification;
 

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -703,12 +703,16 @@ class SignInFuture implements SignInFutureResource {
     });
   }
 
+  private async _create(params: SignInFutureCreateParams): Promise<void> {
+    await this.resource.__internal_basePost({
+      path: this.resource.pathRoot,
+      body: params,
+    });
+  }
+
   async create(params: SignInFutureCreateParams): Promise<{ error: unknown }> {
     return runAsyncResourceTask(this.resource, async () => {
-      await this.resource.__internal_basePost({
-        path: this.resource.pathRoot,
-        body: params,
-      });
+      await this._create(params);
     });
   }
 
@@ -744,7 +748,7 @@ class SignInFuture implements SignInFutureResource {
 
     return runAsyncResourceTask(this.resource, async () => {
       if (emailAddress) {
-        await this.create({ identifier: emailAddress });
+        await this._create({ identifier: emailAddress });
       }
 
       const emailCodeFactor = this.selectFirstFactor({ strategy: 'email_code', emailAddressId });

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -789,7 +789,7 @@ class SignInFuture implements SignInFutureResource {
 
     return runAsyncResourceTask(this.resource, async () => {
       if (emailAddress) {
-        await this.create({ identifier: emailAddress });
+        await this._create({ identifier: emailAddress });
       }
 
       const emailLinkFactor = this.selectFirstFactor({ strategy: 'email_link', emailAddressId });
@@ -852,7 +852,7 @@ class SignInFuture implements SignInFutureResource {
 
     return runAsyncResourceTask(this.resource, async () => {
       if (phoneNumber) {
-        await this.create({ identifier: phoneNumber });
+        await this._create({ identifier: phoneNumber });
       }
 
       const phoneCodeFactor = this.selectFirstFactor({ strategy: 'phone_code', phoneNumberId });
@@ -885,7 +885,7 @@ class SignInFuture implements SignInFutureResource {
       }
 
       if (!this.resource.id) {
-        await this.create({
+        await this._create({
           strategy,
           redirectUrl: SignIn.clerk.buildUrlWithAuth(redirectCallbackUrl),
           actionCompleteRedirectUrl: redirectUrl,
@@ -928,7 +928,7 @@ class SignInFuture implements SignInFutureResource {
           throw new Error(`Unsupported Web3 provider: ${provider}`);
       }
 
-      await this.create({ identifier });
+      await this._create({ identifier });
 
       const web3FirstFactor = this.resource.supportedFirstFactors?.find(
         f => f.strategy === strategy,

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -717,13 +717,13 @@ class SignInFuture implements SignInFutureResource {
   }
 
   async password(params: SignInFuturePasswordParams): Promise<{ error: unknown }> {
-    if ([params.identifier, params.email, params.phoneNumber].filter(Boolean).length > 1) {
-      throw new Error('Only one of identifier, email, or phoneNumber can be provided');
+    if ([params.identifier, params.emailAddress, params.phoneNumber].filter(Boolean).length > 1) {
+      throw new Error('Only one of identifier, emailAddress, or phoneNumber can be provided');
     }
 
     return runAsyncResourceTask(this.resource, async () => {
       // TODO @userland-errors:
-      const identifier = params.identifier || params.email || params.phoneNumber;
+      const identifier = params.identifier || params.emailAddress || params.phoneNumber;
       const previousIdentifier = this.resource.identifier;
       await this.resource.__internal_basePost({
         path: this.resource.pathRoot,

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -760,12 +760,20 @@ class SignUpFuture implements SignUpFutureResource {
     const { strategy, redirectUrl, redirectCallbackUrl } = params;
     return runAsyncResourceTask(this.resource, async () => {
       const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken();
+
+      let redirectUrlComplete = redirectUrl;
+      try {
+        new URL(redirectUrl);
+      } catch {
+        redirectUrlComplete = window.location.origin + redirectUrl;
+      }
+
       await this.resource.__internal_basePost({
         path: this.resource.pathRoot,
         body: {
           strategy,
           redirectUrl: SignUp.clerk.buildUrlWithAuth(redirectCallbackUrl),
-          redirectUrlComplete: redirectUrl,
+          redirectUrlComplete,
           captchaToken,
           captchaWidgetType,
           captchaError,

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -660,20 +660,24 @@ class SignUpFuture implements SignUpFutureResource {
     return { captchaToken, captchaWidgetType, captchaError };
   }
 
+  private async _create(params: SignUpFutureCreateParams): Promise<void> {
+    const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken();
+
+    const body: Record<string, unknown> = {
+      transfer: params.transfer,
+      captchaToken,
+      captchaWidgetType,
+      captchaError,
+      ...params,
+      unsafeMetadata: params.unsafeMetadata ? normalizeUnsafeMetadata(params.unsafeMetadata) : undefined,
+    };
+
+    await this.resource.__internal_basePost({ path: this.resource.pathRoot, body });
+  }
+
   async create(params: SignUpFutureCreateParams): Promise<{ error: unknown }> {
     return runAsyncResourceTask(this.resource, async () => {
-      const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken();
-
-      const body: Record<string, unknown> = {
-        transfer: params.transfer,
-        captchaToken,
-        captchaWidgetType,
-        captchaError,
-        ...params,
-        unsafeMetadata: params.unsafeMetadata ? normalizeUnsafeMetadata(params.unsafeMetadata) : undefined,
-      };
-
-      await this.resource.__internal_basePost({ path: this.resource.pathRoot, body });
+      await this._create(params);
     });
   }
 
@@ -808,7 +812,7 @@ class SignUpFuture implements SignUpFutureResource {
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const web3Wallet = identifier || this.resource.web3wallet!;
-      await this.create({ web3Wallet, unsafeMetadata, legalAccepted });
+      await this._create({ web3Wallet, unsafeMetadata, legalAccepted });
       await this.resource.__internal_basePost({
         body: { strategy },
         action: 'prepare_verification',

--- a/packages/types/src/signInFuture.ts
+++ b/packages/types/src/signInFuture.ts
@@ -15,14 +15,14 @@ export interface SignInFutureCreateParams {
 
 export type SignInFuturePasswordParams =
   | {
-      identifier: string;
       password: string;
-      email?: never;
+      identifier: string;
+      emailAddress?: never;
       phoneNumber?: never;
     }
   | {
       password: string;
-      email: string;
+      emailAddress: string;
       identifier?: never;
       phoneNumber?: never;
     }
@@ -30,13 +30,13 @@ export type SignInFuturePasswordParams =
       password: string;
       phoneNumber: string;
       identifier?: never;
-      email?: never;
+      emailAddress?: never;
     }
   | {
       password: string;
       phoneNumber?: never;
       identifier?: never;
-      email?: never;
+      emailAddress?: never;
     };
 
 export type SignInFutureEmailCodeSendParams =

--- a/packages/types/src/signUpFuture.ts
+++ b/packages/types/src/signUpFuture.ts
@@ -11,6 +11,9 @@ interface SignUpFutureAdditionalParams {
 }
 
 export interface SignUpFutureCreateParams extends SignUpFutureAdditionalParams {
+  emailAddress?: string;
+  phoneNumber?: string;
+  username?: string;
   transfer?: boolean;
   ticket?: string;
   web3Wallet?: string;


### PR DESCRIPTION
## Description

This PR fixes an issue where errors thrown from `this.create` weren't correctly propagated to Signals since we were nesting calls to `runAsyncResourceTask`. This is fixed by adding a private `_create` method that other methods can call which does not use `runAsyncResourceTask`.

It also fixes an issue where `email` was used instead of `emailAddress` for `signIn.password()`.

It also fixes an issue where the `redirectUrl` parameter used in the SSO flow was not made absolute before calling the FAPI endpoint.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded sign-up inputs: optional email address, phone number, and username during account creation.
* **Bug Fixes**
  * Improved error propagation in sign-in and sign-up creation flows so issues are reliably surfaced.
  * Standardized sign-in password parameter to use "emailAddress" consistently.
  * Ensures redirect URLs are handled as absolute URLs when needed.
* **Refactor**
  * Streamlined request handling for sign-in and sign-up creation flows for consistency.
* **Chores**
  * Bumped related packages to new minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->