### PR TITLE
fix(vue): Prevent boolean prop coercion for SignIn component props

### DIFF
--- a/.changeset/eight-horses-nail.md
+++ b/.changeset/eight-horses-nail.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Fixed an issue where the `transferable` prop in the `<SignIn />` component was incorrectly defaulting to `false` due to Vue's boolean prop coercion.

--- a/packages/vue/src/components/ui-components/SignIn.vue
+++ b/packages/vue/src/components/ui-components/SignIn.vue
@@ -5,7 +5,10 @@ import type { SignInProps } from '@clerk/types';
 
 const clerk = useClerk();
 
-const props = defineProps<SignInProps>();
+const props = withDefaults(defineProps<SignInProps>(), {
+  transferable: undefined,
+  withSignUp: undefined,
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Description

We have an issue ([slack convo](https://clerkinc.slack.com/archives/C07JK3YT2G2/p1759413698629179)) where signing in via OAuth with an email that doesn't exist leads to a "External account not found" error instead of being transferred to the sign up flow.

The issue is that the `transferable` prop defaults to `true` in our clerk-js components, **but Vue casts Boolean props without default value to `false`**. We need to set a default value of `undefined` for it to use whatever default value is in our clerk-js package. This issue is similar to https://github.com/clerk/javascript/pull/6809.

From https://vuejs.org/guide/components/props

<img width="740" height="319" alt="Screenshot 2025-10-07 at 9 36 33 AM" src="https://github.com/user-attachments/assets/dfafa09b-7b42-49b6-a168-e2956b37bc27" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed SignIn behavior where the "transferable" option could incorrectly default to false; now optional flags behave as intended.

- Refactor
  - Standardized default handling for optional SignIn props for more consistent behavior when options are omitted.

- Chores
  - Added a changeset entry documenting the SignIn fix.

- Compatibility
  - Backward compatible; no action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->