### PR TITLE
feat(expo): Rename package to @clerk/expo

### DIFF
--- a/.changeset/strong-bars-learn.md
+++ b/.changeset/strong-bars-learn.md
@@ -1,7 +1,7 @@
 ---
 '@clerk/chrome-extension': patch
 '@clerk/elements': patch
-'@clerk/clerk-expo': patch
+'@clerk/expo': patch
 '@clerk/nextjs': patch
 '@clerk/react-router': patch
 '@clerk/tanstack-react-start': patch

--- a/.changeset/tricky-humans-stand.md
+++ b/.changeset/tricky-humans-stand.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': major
+---
+
+Rename package to `@clerk/expo`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       matrix:
         include:
           - node-version: 20
-            test-filter: '--filter=@clerk/astro --filter=@clerk/backend --filter=@clerk/express --filter=@clerk/nextjs --filter=@clerk/react --filter=@clerk/shared --filter=@clerk/remix --filter=@clerk/tanstack-react-start --filter=@clerk/elements --filter=@clerk/vue --filter=@clerk/nuxt --filter=@clerk/clerk-expo'
+            test-filter: '--filter=@clerk/astro --filter=@clerk/backend --filter=@clerk/express --filter=@clerk/nextjs --filter=@clerk/react --filter=@clerk/shared --filter=@clerk/remix --filter=@clerk/tanstack-react-start --filter=@clerk/elements --filter=@clerk/vue --filter=@clerk/nuxt --filter=@clerk/expo'
           - node-version: 22
             test-filter: '**'
 

--- a/integration/presets/expo.ts
+++ b/integration/presets/expo.ts
@@ -10,7 +10,7 @@ const expoWeb = applicationConfig()
   .addScript('dev', 'pnpm dev')
   .addScript('build', 'pnpm build')
   .addScript('serve', 'pnpm start')
-  .addDependency('@clerk/clerk-expo', linkPackage('expo'));
+  .addDependency('@clerk/expo', linkPackage('expo'));
 
 export const expo = {
   expoWeb,

--- a/integration/templates/expo-web/app/_layout.tsx
+++ b/integration/templates/expo-web/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, useRouter } from 'expo-router';
-import { ClerkLoaded, ClerkProvider } from '@clerk/clerk-expo';
+import { ClerkLoaded, ClerkProvider } from '@clerk/expo';
 
 export default function RootLayout() {
   const router = useRouter();

--- a/integration/templates/expo-web/app/custom-sign-in.tsx
+++ b/integration/templates/expo-web/app/custom-sign-in.tsx
@@ -1,4 +1,4 @@
-import { useSignIn } from '@clerk/clerk-expo';
+import { useSignIn } from '@clerk/expo';
 import { Link, useRouter } from 'expo-router';
 import { Text, TextInput, Button, View } from 'react-native';
 import React from 'react';

--- a/integration/templates/expo-web/app/custom-sign-up.tsx
+++ b/integration/templates/expo-web/app/custom-sign-up.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextInput, Button, View } from 'react-native';
-import { useSignUp } from '@clerk/clerk-expo';
+import { useSignUp } from '@clerk/expo';
 import { useRouter } from 'expo-router';
 
 export default function SignUpScreen() {

--- a/integration/templates/expo-web/app/index.tsx
+++ b/integration/templates/expo-web/app/index.tsx
@@ -1,6 +1,6 @@
 import { Text, View } from 'react-native';
-import { SignedIn, SignedOut } from '@clerk/clerk-expo';
-import { UserButton } from '@clerk/clerk-expo/web';
+import { SignedIn, SignedOut } from '@clerk/expo';
+import { UserButton } from '@clerk/expo/web';
 
 export default function Index() {
   return (

--- a/integration/templates/expo-web/app/sign-in.tsx
+++ b/integration/templates/expo-web/app/sign-in.tsx
@@ -1,5 +1,5 @@
 import { Text, View } from 'react-native';
-import { SignIn } from '@clerk/clerk-expo/web';
+import { SignIn } from '@clerk/expo/web';
 
 export default function Index() {
   return (

--- a/integration/templates/expo-web/metro.config.js
+++ b/integration/templates/expo-web/metro.config.js
@@ -8,10 +8,10 @@ const path = require('node:path');
 
 /** @type {() => string | undefined} */
 const getClerkExpoPath = () => {
-  const clerkExpoPath = packageJson.dependencies['@clerk/clerk-expo'];
+  const clerkExpoPath = packageJson.dependencies['@clerk/expo'];
 
   if (clerkExpoPath?.startsWith('*')) {
-    const pathToModule = require.resolve('@clerk/clerk-expo');
+    const pathToModule = require.resolve('@clerk/expo');
     return pathToModule.replace('dist/index.js', '');
   }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "changeset": "changeset",
     "changeset:empty": "pnpm changeset --empty",
     "clean": "turbo clean",
-    "dev": "TURBO_UI=0 FORCE_COLOR=1 turbo dev --filter=@clerk/* --filter=!@clerk/clerk-expo --filter=!@clerk/tanstack-react-start --filter=!@clerk/elements --filter=!@clerk/remix --filter=!@clerk/chrome-extension",
+    "dev": "TURBO_UI=0 FORCE_COLOR=1 turbo dev --filter=@clerk/* --filter=!@clerk/expo --filter=!@clerk/tanstack-react-start --filter=!@clerk/elements --filter=!@clerk/remix --filter=!@clerk/chrome-extension",
     "dev:js": "TURBO_UI=0 FORCE_COLOR=1 turbo dev:current --filter=@clerk/clerk-js",
     "format": "turbo format && node scripts/format-non-workspace.mjs",
     "format:check": "turbo format:check && node scripts/format-non-workspace.mjs --check",

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2715,7 +2715,7 @@ export class Clerk implements ClerkInterface {
     this.#publicEventBus.emit(clerkEvents.Status, initializationDegradedCounter > 0 ? 'degraded' : 'ready');
   };
 
-  // This is used by @clerk/clerk-expo
+  // This is used by @clerk/expo
   __internal_reloadInitialResources = async (): Promise<void> => {
     const [environment, client] = await Promise.all([
       Environment.getInstance().fetch({ touch: false, fetchMaxTries: 1 }),

--- a/packages/expo-passkeys/README.md
+++ b/packages/expo-passkeys/README.md
@@ -38,8 +38,8 @@
 ## Usage
 
 ```tsx
-import { ClerkProvider } from '@clerk/clerk-expo';
-import { passkeys } from '@clerk/clerk-expo/passkeys';
+import { ClerkProvider } from '@clerk/expo';
+import { passkeys } from '@clerk/expo/passkeys';
 
 <ClerkProvider __experimental_passkeys={passkeys}>{/* Your app here */}</ClerkProvider>;
 ```

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -6,7 +6,7 @@
     </picture>
   </a>
   <br />
-  <h1 align="center">@clerk/clerk-expo</h1>
+  <h1 align="center">@clerk/expo</h1>
 </p>
 
 <div align="center">
@@ -61,9 +61,9 @@ We're open to all community contributions! If you'd like to contribute in any wa
 
 ## Security
 
-`@clerk/clerk-expo` follows good practices of security, but 100% security cannot be assured.
+`@clerk/expo` follows good practices of security, but 100% security cannot be assured.
 
-`@clerk/clerk-expo` is provided **"as is"** without any **warranty**. Use at your own risk.
+`@clerk/expo` is provided **"as is"** without any **warranty**. Use at your own risk.
 
 _For more information and to report security issues, please refer to our [security documentation](https://github.com/clerk/javascript/blob/main/docs/SECURITY.md)._
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clerk/clerk-expo",
+  "name": "@clerk/expo",
   "version": "2.16.1",
   "description": "Clerk React Native/Expo library",
   "keywords": [

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -18,7 +18,7 @@ export * from './provider/ClerkProvider';
 export * from './hooks';
 export * from './components';
 
-// Override Clerk React error thrower to show that errors come from @clerk/clerk-expo
+// Override Clerk React error thrower to show that errors come from @clerk/expo
 setErrorThrowerOptions({ packageName: PACKAGE_NAME });
 
 export type { TokenCache } from './cache/types';

--- a/packages/expo/src/secure-store/index.ts
+++ b/packages/expo/src/secure-store/index.ts
@@ -1,7 +1,7 @@
 import { resourceCache } from '../resource-cache';
 
 /**
- * @deprecated Use `resourceCache` from `@clerk/clerk-expo/resource-cache` instead.
+ * @deprecated Use `resourceCache` from `@clerk/expo/resource-cache` instead.
  */
 const secureStore = resourceCache;
 

--- a/packages/expo/vitest.setup.mts
+++ b/packages/expo/vitest.setup.mts
@@ -1,6 +1,6 @@
 import { beforeAll } from 'vitest';
 
-globalThis.PACKAGE_NAME = '@clerk/clerk-expo';
+globalThis.PACKAGE_NAME = '@clerk/expo';
 globalThis.PACKAGE_VERSION = '0.0.0-test';
 
 beforeAll(() => {});

--- a/packages/upgrade/src/guide-generators/core-2/expo/index.js
+++ b/packages/upgrade/src/guide-generators/core-2/expo/index.js
@@ -13,7 +13,7 @@ const version = 'core-2';
 const semverVersion = 'v1';
 const name = 'expo';
 const properName = 'Expo';
-const packageName = '@clerk/clerk-expo';
+const packageName = '@clerk/expo';
 const cwd = `${version}/${name}`;
 
 async function generate() {

--- a/playground/expo/App.tsx
+++ b/playground/expo/App.tsx
@@ -1,5 +1,5 @@
-import { ClerkProvider, SignedIn, SignedOut, useAuth, useSignIn, useUser } from '@clerk/clerk-expo';
-import { passkeys } from '@clerk/clerk-expo/passkeys';
+import { ClerkProvider, SignedIn, SignedOut, useAuth, useSignIn, useUser } from '@clerk/expo';
+import { passkeys } from '@clerk/expo/passkeys';
 import * as SecureStore from 'expo-secure-store';
 import React from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';

--- a/playground/expo/package.json
+++ b/playground/expo/package.json
@@ -8,11 +8,11 @@
     "ios": "expo run:ios",
     "start": "expo start",
     "web": "expo start --web",
-    "yalc:add": "pnpm yalc add @clerk/clerk-expo @clerk/clerk-js @clerk/react @clerk/types @clerk/shared @clerk/types @clerk/expo-passkeys",
+    "yalc:add": "pnpm yalc add @clerk/expo @clerk/clerk-js @clerk/react @clerk/types @clerk/shared @clerk/types @clerk/expo-passkeys",
     "expo:update": "pnpm expo install --fix"
   },
   "dependencies": {
-    "@clerk/clerk-expo": "file:.yalc/@clerk/clerk-expo",
+    "@clerk/expo": "file:.yalc/@clerk/expo",
     "@clerk/clerk-js": "file:.yalc/@clerk/clerk-js",
     "@clerk/react": "file:.yalc/@clerk/react",
     "@clerk/expo-passkeys": "file:.yalc/@clerk/expo-passkeys",

--- a/renovate.json5
+++ b/renovate.json5
@@ -275,7 +275,7 @@
       groupName: "[DEV] minor & patch dependencies",
       groupSlug: "clerk-expo-dev-minor",
       matchFileNames: [
-        "packages/clerk-expo/package.json",
+        "packages/expo/package.json",
       ],
       matchDepTypes: [
         "devDependencies",
@@ -291,7 +291,7 @@
       groupName: "[DEV] major dependencies",
       groupSlug: "clerk-expo-dev-major",
       matchFileNames: [
-        "packages/clerk-expo/package.json",
+        "packages/expo/package.json",
       ],
       matchDepTypes: [
         "devDependencies",
@@ -305,7 +305,7 @@
       groupName: "minor & patch dependencies",
       groupSlug: "clerk-expo-prod-minor",
       matchFileNames: [
-        "packages/clerk-expo/package.json",
+        "packages/expo/package.json",
       ],
       matchDepTypes: [
         "dependencies",
@@ -320,7 +320,7 @@
       groupName: "major dependencies",
       groupSlug: "clerk-expo-prod-major",
       matchFileNames: [
-        "packages/clerk-expo/package.json",
+        "packages/expo/package.json",
       ],
       matchDepTypes: [
         "dependencies",

--- a/scripts/canary.mjs
+++ b/scripts/canary.mjs
@@ -17,7 +17,7 @@ const snapshot = `---
 '@clerk/react': patch
 '@clerk/remix': patch
 '@clerk/types': patch
-'@clerk/clerk-expo': patch
+'@clerk/expo': patch
 '@clerk/express': patch
 '@clerk/testing': patch
 '@clerk/elements': patch

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -17,7 +17,7 @@ const snapshot = `---
 '@clerk/react': patch
 '@clerk/remix': patch
 '@clerk/types': patch
-'@clerk/clerk-expo': patch
+'@clerk/expo': patch
 '@clerk/express': patch
 '@clerk/testing': patch
 '@clerk/elements': patch

--- a/turbo.json
+++ b/turbo.json
@@ -284,7 +284,7 @@
       "outputLogs": "new-only"
     },
     "//#test:integration:expo-web": {
-      "dependsOn": ["@clerk/testing#build", "@clerk/clerk-js#build", "@clerk/clerk-expo#build", "@clerk/react#build"],
+      "dependsOn": ["@clerk/testing#build", "@clerk/clerk-js#build", "@clerk/expo#build", "@clerk/react#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"


### PR DESCRIPTION
## Description

This PR renames the `@clerk/clerk-expo` package to `@clerk/expo`. It's slated for the next major release.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
