### PR TITLE
fix(backend): Export missing Billing types

### DIFF
--- a/.changeset/warm-steaks-count.md
+++ b/.changeset/warm-steaks-count.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Export missing Billing types

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -100,9 +100,13 @@ export type {
   PaginatedResponseJSON,
   TestingTokenJSON,
   WebhooksSvixJSON,
+  BillingPayerJSON,
   BillingPlanJSON,
   BillingSubscriptionJSON,
   BillingSubscriptionItemJSON,
+  BillingPaymentAttemptWebhookEventJSON,
+  BillingSubscriptionItemWebhookEventJSON,
+  BillingSubscriptionWebhookEventJSON,
 } from './api/resources/JSON';
 
 /**


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded public API with additional Billing types for payer and billing webhook events, improving type coverage for billing integrations.
* **Chores**
  * Added a changeset for a minor backend release to publish the new Billing type exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->