### PR TITLE
feat(tanstack-react-start): Add experimental export

### DIFF
--- a/.changeset/tame-tips-own.md
+++ b/.changeset/tame-tips-own.md
@@ -1,0 +1,5 @@
+---
+'@clerk/tanstack-react-start': patch
+---
+
+Add `@clerk/tanstack-react-start/experimental` export with new `useSignIn` and `useSignUp` hooks.

--- a/packages/tanstack-react-start/package.json
+++ b/packages/tanstack-react-start/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/webhooks.d.ts",
       "default": "./dist/webhooks.js"
     },
+    "./experimental": {
+      "types": "./dist/experimental.d.ts",
+      "default": "./dist/experimental.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -51,7 +55,8 @@
     "dist",
     "errors",
     "server",
-    "webhooks"
+    "webhooks",
+    "experimental"
   ],
   "scripts": {
     "build": "pnpm clean && tsup",

--- a/packages/tanstack-react-start/src/experimental.ts
+++ b/packages/tanstack-react-start/src/experimental.ts
@@ -1,0 +1,1 @@
+export { useSignInSignal as useSignIn, useSignUpSignal as useSignUp } from '@clerk/clerk-react/experimental';


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an experimental auth surface with hooks: useSignIn and useSignUp, available via @clerk/tanstack-react-start/experimental, enabling sign-in and sign-up flows in TanStack Start apps.
- Chores
  - Published the experimental entry so it can be imported by consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->