### PR TITLE
fix: set register actionLink in german localization file to "Registri…

### DIFF
--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -705,7 +705,7 @@ export const deDE: LocalizationResource = {
       detailsLabel: 'Bevor wir Ihr Passwort zurücksetzen können, müssen wir Ihre Identität überprüfen.',
     },
     start: {
-      actionLink: 'Anmelden',
+      actionLink: 'Registrieren',
       actionLink__join_waitlist: 'Warteliste beitreten',
       actionLink__use_email: 'E-Mail nutzen',
       actionLink__use_email_username: 'E-Mail oder Benutzernamen nutzen',


### PR DESCRIPTION
## Description

<img width="439" height="285" alt="image" src="https://github.com/user-attachments/assets/40935455-5939-4724-9daa-b115fde2161d" />

Changed translation value for start.actionLink signIn page.
"Registrieren" instead of "Anmelden" (which is associated with "login"/"sign in" instead of the desired action of signing up)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Adjustment of Localization data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected German localization on the sign-in start screen: the action link label now reads “Registrieren” instead of “Anmelden.” This improves clarity and reduces confusion for German-speaking users during onboarding. No other text or behavior changed. Applies across the sign-in flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->