### PR TITLE
add signOutCallback to UserButton

### DIFF
--- a/packages/clerk-js/src/ui/contexts/components/UserButton.ts
+++ b/packages/clerk-js/src/ui/contexts/components/UserButton.ts
@@ -21,7 +21,7 @@ export const useUserButtonContext = () => {
     throw new Error('Clerk: useUserButtonContext called outside of the mounted UserButton component.');
   }
 
-  const { componentName, customMenuItems, ...ctx } = context;
+  const { componentName, customMenuItems, signOutCallback, ...ctx } = context;
 
   const signInUrl = ctx.signInUrl || options.signInUrl || displayConfig.signInUrl;
   const userProfileUrl = ctx.userProfileUrl || displayConfig.userProfileUrl;
@@ -31,7 +31,7 @@ export const useUserButtonContext = () => {
   }
 
   const afterSignOutUrl = ctx.afterSignOutUrl || clerk.buildAfterSignOutUrl();
-  const navigateAfterSignOut = () => navigate(afterSignOutUrl);
+  const navigateAfterSignOut = signOutCallback || (() => navigate(afterSignOutUrl));
 
   if (ctx.afterSignOutUrl) {
     deprecatedObjectProperty(
@@ -42,7 +42,8 @@ export const useUserButtonContext = () => {
   }
   const afterMultiSessionSingleSignOutUrl =
     ctx.afterMultiSessionSingleSignOutUrl || clerk.buildAfterMultiSessionSingleSignOutUrl();
-  const navigateAfterMultiSessionSingleSignOut = () => clerk.redirectWithAuth(afterMultiSessionSingleSignOutUrl);
+  const navigateAfterMultiSessionSingleSignOut =
+    signOutCallback || (() => clerk.redirectWithAuth(afterMultiSessionSingleSignOutUrl));
 
   const afterSwitchSessionUrl = ctx.afterSwitchSessionUrl || displayConfig.afterSwitchSessionUrl;
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -120,10 +120,10 @@ export type SDKMetadata = {
 
 export type ListenerCallback = (emission: Resources) => void;
 export type UnsubscribeCallback = () => void;
-export type BeforeEmitCallback = (session?: SignedInSessionResource | null) => void | Promise<any>;
-export type SetActiveNavigate = ({ session }: { session: SessionResource }) => void | Promise<unknown>;
+export type BeforeEmitCallback = (session?: SignedInSessionResource | null) => undefined | Promise<any>;
+export type SetActiveNavigate = ({ session }: { session: SessionResource }) => undefined | Promise<unknown>;
 
-export type SignOutCallback = () => void | Promise<any>;
+export type SignOutCallback = () => undefined | Promise<any>;
 
 export type SignOutOptions = {
   /**
@@ -944,7 +944,7 @@ export type HandleOAuthCallbackParams = TransferableOption &
 
 export type HandleSamlCallbackParams = HandleOAuthCallbackParams;
 
-export type CustomNavigation = (to: string, options?: NavigateOptions) => Promise<unknown> | void;
+export type CustomNavigation = (to: string, options?: NavigateOptions) => Promise<unknown> | undefined;
 
 export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 
@@ -1640,6 +1640,12 @@ export type UserButtonProps = UserButtonProfileMode & {
    * Provide custom menu actions and links to be rendered inside the UserButton.
    */
   customMenuItems?: CustomMenuItem[];
+
+  /**
+   * Callback to be executed after the user signs out. Overrides the default navigation behavior.
+   * If provided, this callback will be used instead of navigating to `afterSignOutUrl`.
+   */
+  signOutCallback?: SignOutCallback;
 };
 
 export type UserAvatarProps = {


### PR DESCRIPTION
## Description

Clerk's `signOut` method offers [a `signOutCallback` param](https://clerk.com/docs/reference/javascript/clerk#sign-out) which can be used for redirects, but can also be used for anything else a developer needs to do or clean up when signing a user out, such as cleaning up local storage, running analytics events, etc.

Previously, we had a prop on `UserButton` that allowed passing in a custom function in this way, but it was [removed in Core 2](https://github.com/clerk/javascript/blob/d8147fb58bfd6caf9a4f0a36fdc48c630d00387f/packages/react/CHANGELOG.md?plain=1#L2033) under the premise that it was only really used for redirecting after sign out and providing an after sign out URL prop would add simplicity and consistency with other component APIs.

I think this was a poorly considered change, as there are a variety of other things that developers could want to do on sign out and this is no longer possible unless you build your own `UserButton` component. We have received customer feedback confirming this need.

This PR re-introduces the `signOutCallback` parameter to `UserButton`, but without changing anything else. If both `signOutCallback` and `afterSignOutUrl` are passed, `signOutCallback` will override the `afterSignOutUrl` redirect behavior.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UserButton now supports a `signOutCallback` prop to customize post-sign-out behavior, allowing developers to override default navigation with custom handlers for both single and multi-session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->