### PR TITLE
chore(clerk-js,types): Remove deprecated `UserSettings.saml`

### DIFF
--- a/.changeset/happy-apes-care.md
+++ b/.changeset/happy-apes-care.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Remove deprecated `saml` property from `UserSettings` in favor of `enterpriseSSO`

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -6,7 +6,6 @@ import type {
   PasskeySettingsData,
   PasswordSettingsData,
   PhoneCodeChannel,
-  SamlSettings,
   SignInData,
   SignUpData,
   UsernameSettingsData,
@@ -112,9 +111,6 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     show_sign_in_button: false,
   };
   passwordSettings: PasswordSettingsData = {} as PasswordSettingsData;
-  saml: SamlSettings = {
-    enabled: false,
-  };
   signIn: SignInData = {
     second_factor: {
       required: false,
@@ -229,7 +225,6 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
               : Math.min(data.password_settings?.max_length ?? defaultMaxPasswordLength, defaultMaxPasswordLength),
         }
       : this.passwordSettings;
-    this.saml = this.withDefault(data.saml, this.saml);
     this.signIn = this.withDefault(data.sign_in, this.signIn);
     this.signUp = this.withDefault(data.sign_up, this.signUp);
     this.social = this.withDefault(data.social, this.social);
@@ -256,7 +251,6 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
       attributes: this.attributes,
       passkey_settings: this.passkeySettings,
       password_settings: this.passwordSettings,
-      saml: this.saml,
       sign_in: this.signIn,
       sign_up: this.signUp,
       social: this.social,

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -86,11 +86,6 @@ export type PasskeySettingsData = {
 export type OAuthProviders = {
   [provider in OAuthStrategy]: OAuthProviderSettings;
 };
-
-export type SamlSettings = {
-  enabled: boolean;
-};
-
 export type EnterpriseSSOSettings = {
   enabled: boolean;
 };
@@ -115,10 +110,6 @@ export interface UserSettingsJSON extends ClerkResourceJSON {
   actions: Actions;
   social: OAuthProviders;
 
-  /**
-   * @deprecated Use `enterprise_sso` instead.
-   */
-  saml: SamlSettings;
   enterprise_sso: EnterpriseSSOSettings;
 
   sign_in: SignInData;
@@ -132,10 +123,6 @@ export interface UserSettingsResource extends ClerkResource {
   id?: undefined;
   social: OAuthProviders;
 
-  /**
-   * @deprecated Use `enterprise_sso` instead.
-   */
-  saml: SamlSettings;
   enterpriseSSO: EnterpriseSSOSettings;
 
   attributes: Attributes;


### PR DESCRIPTION
## Description


Removes the deprecated `UserSettings.saml` property in favor of `UserSettings.enterpriseSSO`


This should be merged to https://github.com/clerk/javascript/tree/vincent-and-the-doctor as a breaking change

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [X] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated `saml` property from UserSettings. Users should transition to `enterpriseSSO` for Single Sign-On configuration.

* **Chores**
  * Removed `SamlSettings` type and associated references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->