### PR TITLE
chore(clerk-js,types,elements): Remove deprecated `saml` strategy

### DIFF
--- a/.changeset/rotten-ghosts-do.md
+++ b/.changeset/rotten-ghosts-do.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/elements': patch
+'@clerk/types': patch
+---
+
+Remove deprecated `saml` strategy in favor of `enterprise_sso`

--- a/.typedoc/__tests__/__snapshots__/file-structure.test.ts.snap
+++ b/.typedoc/__tests__/__snapshots__/file-structure.test.ts.snap
@@ -111,7 +111,6 @@ exports[`Typedoc output > should have a deliberate file structure 1`] = `
   "types/redirect-options.mdx",
   "types/remove-payment-method-params.mdx",
   "types/reverification-config.mdx",
-  "types/saml-strategy.mdx",
   "types/sdk-metadata.mdx",
   "types/server-get-token-options.mdx",
   "types/server-get-token.mdx",

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -28,7 +28,6 @@ import type {
   ResetPasswordEmailCodeFactorConfig,
   ResetPasswordParams,
   ResetPasswordPhoneCodeFactorConfig,
-  SamlConfig,
   SignInCreateParams,
   SignInFirstFactor,
   SignInFutureBackupCodeVerifyParams,
@@ -214,12 +213,6 @@ export class SignIn extends BaseResource implements SignInResource {
       case 'reset_password_email_code':
         config = { emailAddressId: params.emailAddressId } as ResetPasswordEmailCodeFactorConfig;
         break;
-      case 'saml':
-        config = {
-          redirectUrl: params.redirectUrl,
-          actionCompleteRedirectUrl: params.actionCompleteRedirectUrl,
-        } as SamlConfig;
-        break;
       case 'enterprise_sso':
         config = {
           redirectUrl: params.redirectUrl,
@@ -327,7 +320,7 @@ export class SignIn extends BaseResource implements SignInResource {
       });
     }
 
-    if (strategy === 'saml' || strategy === 'enterprise_sso') {
+    if (strategy === 'enterprise_sso') {
       await this.prepareFirstFactor({
         strategy,
         redirectUrl,

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -336,10 +336,7 @@ function SignInStartInternal(): JSX.Element {
        * For instances with Enterprise SSO enabled, perform sign in with password only when it is allowed for the identified user.
        */
       const passwordField = fields.find(f => f.name === 'password')?.value;
-      if (
-        !passwordField ||
-        signInResource.supportedFirstFactors?.some(ff => ff.strategy === 'saml' || ff.strategy === 'enterprise_sso')
-      ) {
+      if (!passwordField || signInResource.supportedFirstFactors?.some(ff => ff.strategy === 'enterprise_sso')) {
         return signInResource;
       }
       return signInResource.attemptFirstFactor({ strategy: 'password', password: passwordField });
@@ -378,7 +375,7 @@ function SignInStartInternal(): JSX.Element {
       switch (res.status) {
         case 'needs_identifier':
           // Check if we need to initiate an enterprise sso flow
-          if (res.supportedFirstFactors?.some(ff => ff.strategy === 'saml' || ff.strategy === 'enterprise_sso')) {
+          if (res.supportedFirstFactors?.some(ff => ff.strategy === 'enterprise_sso')) {
             await authenticateWithEnterpriseSSO();
           }
           break;

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -187,7 +187,7 @@ function SignUpStartInternal(): JSX.Element {
         // Keep the card in loading state during SSO redirect to prevent UI flicker
         // This is necessary because there's a brief delay between initiating the SSO flow
         // and the actual redirect to the external Identity Provider
-        const isRedirectingToSSOProvider = signUp.missingFields.some(mf => mf === 'saml' || mf === 'enterprise_sso');
+        const isRedirectingToSSOProvider = signUp.missingFields.some(mf => mf === 'enterprise_sso');
         if (isRedirectingToSSOProvider) {
           return;
         }

--- a/packages/clerk-js/src/utils/completeSignUpFlow.ts
+++ b/packages/clerk-js/src/utils/completeSignUpFlow.ts
@@ -28,7 +28,7 @@ export const completeSignUpFlow = ({
   if (signUp.status === 'complete') {
     return handleComplete && handleComplete();
   } else if (signUp.status === 'missing_requirements') {
-    if (signUp.missingFields.some(mf => mf === 'saml' || mf === 'enterprise_sso')) {
+    if (signUp.missingFields.some(mf => mf === 'enterprise_sso')) {
       return signUp.authenticateWithRedirect({
         strategy: 'enterprise_sso',
         redirectUrl,

--- a/packages/elements/src/internals/machines/shared/shared.types.ts
+++ b/packages/elements/src/internals/machines/shared/shared.types.ts
@@ -1,11 +1,5 @@
-import type {
-  AuthenticateWithRedirectParams,
-  LoadedClerk,
-  OAuthStrategy,
-  SamlStrategy,
-  SignInStrategy,
-} from '@clerk/types';
-import type { SetRequired, Simplify } from 'type-fest';
+import type { AuthenticateWithRedirectParams, LoadedClerk, OAuthStrategy, SignInStrategy } from '@clerk/types';
+import type { Simplify } from 'type-fest';
 import type { ActorRefFrom } from 'xstate';
 
 import type { FormMachine } from '../form';
@@ -26,11 +20,6 @@ type SamlOnlyKeys = 'identifier' | 'emailAddress';
 
 export type AuthenticateWithRedirectOAuthParams = Simplify<
   Omit<AuthenticateWithRedirectParams, SamlOnlyKeys> & { strategy: OAuthStrategy }
->;
-export type AuthenticateWithRedirectSamlParams = Simplify<
-  SetRequired<AuthenticateWithRedirectParams, SamlOnlyKeys> & {
-    strategy: SamlStrategy;
-  }
 >;
 
 // ================= Strategies ================= //

--- a/packages/elements/src/internals/machines/sign-in/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-in/router.machine.ts
@@ -207,23 +207,6 @@ export const SignInRouterMachine = setup({
         },
       })),
     },
-    'AUTHENTICATE.SAML': {
-      actions: sendTo(ThirdPartyMachineId, ({ context }) => ({
-        type: 'REDIRECT',
-        params: {
-          strategy: 'saml',
-          identifier: context.formRef.getSnapshot().context.fields.get('identifier')?.value,
-          redirectUrl: `${
-            context.router?.mode === ROUTING.virtual
-              ? context.clerk.__unstable__environment?.displayConfig.signInUrl
-              : context.router?.basePath
-          }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignInUrl({
-            params: context.router?.searchParams(),
-          }),
-        },
-      })),
-    },
     'AUTHENTICATE.ENTERPRISE_SSO': {
       actions: sendTo(ThirdPartyMachineId, ({ context }) => ({
         type: 'REDIRECT',

--- a/packages/elements/src/internals/machines/sign-up/router.machine.ts
+++ b/packages/elements/src/internals/machines/sign-up/router.machine.ts
@@ -208,23 +208,6 @@ export const SignUpRouterMachine = setup({
         },
       })),
     },
-    'AUTHENTICATE.SAML': {
-      actions: sendTo(ThirdPartyMachineId, ({ context }) => ({
-        type: 'REDIRECT',
-        params: {
-          strategy: 'saml',
-          emailAddress: context.formRef.getSnapshot().context.fields.get('emailAddress')?.value,
-          redirectUrl: `${
-            context.router?.mode === ROUTING.virtual
-              ? context.clerk.__unstable__environment?.displayConfig.signUpUrl
-              : context.router?.basePath
-          }${SSO_CALLBACK_PATH_ROUTE}`,
-          redirectUrlComplete: context.clerk.buildAfterSignUpUrl({
-            params: context.router?.searchParams(),
-          }),
-        },
-      })),
-    },
     'AUTHENTICATE.ENTERPRISE_SSO': {
       actions: sendTo(ThirdPartyMachineId, ({ context }) => ({
         type: 'REDIRECT',

--- a/packages/elements/src/internals/machines/sign-up/start.types.ts
+++ b/packages/elements/src/internals/machines/sign-up/start.types.ts
@@ -1,5 +1,5 @@
 import type { ClerkAPIResponseError } from '@clerk/shared/error';
-import type { EnterpriseSSOStrategy, OAuthStrategy, SamlStrategy, Web3Strategy } from '@clerk/types';
+import type { EnterpriseSSOStrategy, OAuthStrategy, Web3Strategy } from '@clerk/types';
 import type { ActorRefFrom, ErrorActorEvent } from 'xstate';
 
 import type { FormMachine } from '~/internals/machines/form';
@@ -17,7 +17,6 @@ export type SignUpStartSubmitEvent = { type: 'SUBMIT'; action: 'submit' };
 
 // TODO: Consolidate with SignInStartMachine
 export type SignUpStartRedirectOauthEvent = { type: 'AUTHENTICATE.OAUTH'; strategy: OAuthStrategy };
-export type SignUpStartRedirectSamlEvent = { type: 'AUTHENTICATE.SAML'; strategy?: SamlStrategy };
 export type SignUpStartRedirectEnterpriseSSOEvent = {
   type: 'AUTHENTICATE.ENTERPRISE_SSO';
   strategy?: EnterpriseSSOStrategy;
@@ -26,7 +25,6 @@ export type SignUpStartRedirectWeb3Event = { type: 'AUTHENTICATE.WEB3'; strategy
 
 export type SignUpStartRedirectEvent =
   | SignUpStartRedirectOauthEvent
-  | SignUpStartRedirectSamlEvent
   | SignUpStartRedirectWeb3Event
   | SignUpStartRedirectEnterpriseSSOEvent;
 

--- a/packages/elements/src/internals/machines/types/router.types.ts
+++ b/packages/elements/src/internals/machines/types/router.types.ts
@@ -4,7 +4,6 @@ import type {
   EnterpriseSSOStrategy,
   LoadedClerk,
   OAuthStrategy,
-  SamlStrategy,
   SignInStrategy,
   Web3Strategy,
 } from '@clerk/types';
@@ -46,7 +45,6 @@ export type BaseRouterLoadingEvent<TSteps extends BaseRouterLoadingStep> = (
 ) & { type: 'LOADING'; isLoading: boolean };
 
 export type BaseRouterRedirectOauthEvent = { type: 'AUTHENTICATE.OAUTH'; strategy: OAuthStrategy };
-export type BaseRouterRedirectSamlEvent = { type: 'AUTHENTICATE.SAML'; strategy?: SamlStrategy };
 export type BaseRouterRedirectEnterpriseSSOEvent = {
   type: 'AUTHENTICATE.ENTERPRISE_SSO';
   strategy?: EnterpriseSSOStrategy;
@@ -56,7 +54,6 @@ export type BaseRouterSetClerkEvent = { type: 'CLERK.SET'; clerk: LoadedClerk };
 
 export type BaseRouterRedirectEvent =
   | BaseRouterRedirectOauthEvent
-  | BaseRouterRedirectSamlEvent
   | BaseRouterRedirectWeb3Event
   | BaseRouterRedirectEnterpriseSSOEvent;
 

--- a/packages/elements/src/react/common/connections.tsx
+++ b/packages/elements/src/react/common/connections.tsx
@@ -1,4 +1,4 @@
-import type { EnterpriseSSOStrategy, OAuthProvider, SamlStrategy, Web3Provider } from '@clerk/types';
+import type { EnterpriseSSOStrategy, OAuthProvider, Web3Provider } from '@clerk/types';
 import { Slot } from '@radix-ui/react-slot';
 import { createContext, useContext } from 'react';
 
@@ -29,7 +29,7 @@ export const useConnectionContext = () => {
 
 export interface ConnectionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
-  name: OAuthProvider | Web3Provider | SamlStrategy | EnterpriseSSOStrategy;
+  name: OAuthProvider | Web3Provider | EnterpriseSSOStrategy;
 }
 
 /**

--- a/packages/elements/src/react/common/loading.tsx
+++ b/packages/elements/src/react/common/loading.tsx
@@ -1,6 +1,6 @@
 import { useClerk } from '@clerk/shared/react';
 import { eventComponentMounted } from '@clerk/shared/telemetry';
-import type { EnterpriseSSOStrategy, OAuthProvider, SamlStrategy, Web3Provider } from '@clerk/types';
+import type { EnterpriseSSOStrategy, OAuthProvider, Web3Provider } from '@clerk/types';
 import { useSelector } from '@xstate/react';
 import * as React from 'react';
 
@@ -15,7 +15,7 @@ import type { TSignUpStep } from '~/react/sign-up/step';
 import { SIGN_UP_STEPS } from '~/react/sign-up/step';
 import { isProviderStrategyScope, mapScopeToStrategy } from '~/react/utils/map-scope-to-strategy';
 
-type Strategy = OAuthProvider | SamlStrategy | EnterpriseSSOStrategy | Web3Provider;
+type Strategy = OAuthProvider | EnterpriseSSOStrategy | Web3Provider;
 type LoadingScope<T extends TSignInStep | TSignUpStep> =
   | 'global'
   | `step:${T}`

--- a/packages/elements/src/react/utils/map-scope-to-strategy.ts
+++ b/packages/elements/src/react/utils/map-scope-to-strategy.ts
@@ -1,6 +1,6 @@
-import type { EnterpriseSSOStrategy, OAuthProvider, SamlStrategy, SignInStrategy, Web3Provider } from '@clerk/types';
+import type { EnterpriseSSOStrategy, OAuthProvider, SignInStrategy, Web3Provider } from '@clerk/types';
 
-type Strategy = OAuthProvider | SamlStrategy | EnterpriseSSOStrategy | Web3Provider;
+type Strategy = OAuthProvider | EnterpriseSSOStrategy | Web3Provider;
 
 export function isProviderStrategyScope(value: string): value is Strategy {
   return value.startsWith('provider:');

--- a/packages/elements/src/utils/third-party-strategies.ts
+++ b/packages/elements/src/utils/third-party-strategies.ts
@@ -8,7 +8,6 @@ import type {
   EnvironmentResource,
   OAuthProvider,
   OAuthStrategy,
-  SamlStrategy,
   Web3Provider,
   Web3Strategy,
 } from '@clerk/types';
@@ -22,7 +21,7 @@ export type ThirdPartyStrategy =
       name: string;
     }
   | {
-      strategy: SamlStrategy | EnterpriseSSOStrategy;
+      strategy: EnterpriseSSOStrategy;
       iconUrl?: never;
       name: string;
     };
@@ -34,7 +33,7 @@ export type ThirdPartyProvider =
       name: string;
     }
   | {
-      strategy: SamlStrategy | EnterpriseSSOStrategy;
+      strategy: EnterpriseSSOStrategy;
       iconUrl?: never;
       name: string;
     };
@@ -68,10 +67,6 @@ const strategyToDisplayData: ThirdPartyStrategyToDataMap = fromEntries(
     return [p.strategy, { iconUrl: iconImageUrl(p.provider), id: p.provider, name: p.name }];
   }),
 ) as ThirdPartyStrategyToDataMap;
-
-export function isSamlStrategy(strategy: any): strategy is SamlStrategy {
-  return strategy === 'saml';
-}
 
 export function isEnterpriseSSOStrategy(strategy: any): strategy is EnterpriseSSOStrategy {
   return strategy === 'enterprise_sso';

--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -11,7 +11,6 @@ import type {
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
   ResetPasswordPhoneCodeStrategy,
-  SamlStrategy,
   TOTPStrategy,
   Web3Strategy,
 } from './strategies';
@@ -55,10 +54,6 @@ export type PasskeyFactor = {
 
 export type OauthFactor = {
   strategy: OAuthStrategy;
-};
-
-export type SamlFactor = {
-  strategy: SamlStrategy;
 };
 
 export type EnterpriseSSOFactor = {
@@ -113,11 +108,6 @@ export type OAuthConfig = OauthFactor & {
   actionCompleteRedirectUrl: string;
   oidcPrompt?: string;
   oidcLoginHint?: string;
-};
-
-export type SamlConfig = SamlFactor & {
-  redirectUrl: string;
-  actionCompleteRedirectUrl: string;
 };
 
 export type EnterpriseSSOConfig = EnterpriseSSOFactor & {

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -1,4 +1,4 @@
-import type { EnterpriseSSOStrategy, OAuthStrategy, SamlStrategy } from './strategies';
+import type { EnterpriseSSOStrategy, OAuthStrategy } from './strategies';
 
 export type AfterSignOutUrl = {
   /**
@@ -68,9 +68,9 @@ export type AuthenticateWithRedirectParams = {
 
   /**
    * One of the supported OAuth providers you can use to authenticate with, eg 'oauth_google'.
-   * Alternatively `saml` or `enterprise_sso`, to authenticate with Enterprise SSO.
+   * `enterprise_sso`, to authenticate with Enterprise SSO.
    */
-  strategy: OAuthStrategy | SamlStrategy | EnterpriseSSOStrategy;
+  strategy: OAuthStrategy | EnterpriseSSOStrategy;
 
   /**
    * Identifier to use for targeting a Enterprise Connection at sign-in

--- a/packages/types/src/signInCommon.ts
+++ b/packages/types/src/signInCommon.ts
@@ -25,8 +25,6 @@ import type {
   ResetPasswordPhoneCodeAttempt,
   ResetPasswordPhoneCodeFactor,
   ResetPasswordPhoneCodeFactorConfig,
-  SamlConfig,
-  SamlFactor,
   TOTPAttempt,
   TOTPFactor,
   Web3Attempt,
@@ -51,7 +49,6 @@ import type {
   PhoneCodeStrategy,
   ResetPasswordEmailCodeStrategy,
   ResetPasswordPhoneCodeStrategy,
-  SamlStrategy,
   TicketStrategy,
   TOTPStrategy,
   Web3Strategy,
@@ -81,7 +78,6 @@ export type SignInFirstFactor =
   | ResetPasswordEmailCodeFactor
   | Web3SignatureFactor
   | OauthFactor
-  | SamlFactor
   | EnterpriseSSOFactor;
 
 export type SignInSecondFactor = PhoneCodeFactor | TOTPFactor | BackupCodeFactor;
@@ -104,7 +100,6 @@ export type PrepareFirstFactorParams =
   | ResetPasswordPhoneCodeFactorConfig
   | ResetPasswordEmailCodeFactorConfig
   | OAuthConfig
-  | SamlConfig
   | EnterpriseSSOConfig;
 
 export type AttemptFirstFactorParams =
@@ -122,7 +117,7 @@ export type AttemptSecondFactorParams = PhoneCodeAttempt | TOTPAttempt | BackupC
 
 export type SignInCreateParams = (
   | {
-      strategy: OAuthStrategy | SamlStrategy | EnterpriseSSOStrategy;
+      strategy: OAuthStrategy | EnterpriseSSOStrategy;
       redirectUrl: string;
       actionCompleteRedirectUrl?: string;
       identifier?: string;
@@ -189,5 +184,4 @@ export type SignInStrategy =
   | TOTPStrategy
   | BackupCodeStrategy
   | OAuthStrategy
-  | SamlStrategy
   | EnterpriseSSOStrategy;

--- a/packages/types/src/signUpCommon.ts
+++ b/packages/types/src/signUpCommon.ts
@@ -15,7 +15,6 @@ import type {
   GoogleOneTapStrategy,
   OAuthStrategy,
   PhoneCodeStrategy,
-  SamlStrategy,
   TicketStrategy,
   Web3Strategy,
 } from './strategies';
@@ -49,7 +48,7 @@ export type PrepareVerificationParams =
       oidcLoginHint?: string;
     }
   | {
-      strategy: SamlStrategy | EnterpriseSSOStrategy;
+      strategy: EnterpriseSSOStrategy;
       redirectUrl?: string;
       actionCompleteRedirectUrl?: string;
     };
@@ -75,7 +74,7 @@ export type SignUpVerifiableField =
   | Web3WalletIdentifier;
 
 // TODO: Does it make sense that the identification *field* holds a *strategy*?
-export type SignUpIdentificationField = SignUpVerifiableField | OAuthStrategy | SamlStrategy | EnterpriseSSOStrategy;
+export type SignUpIdentificationField = SignUpVerifiableField | OAuthStrategy | EnterpriseSSOStrategy;
 
 // TODO: Replace with discriminated union type
 export type SignUpCreateParams = Partial<
@@ -83,13 +82,7 @@ export type SignUpCreateParams = Partial<
     externalAccountStrategy: string;
     externalAccountRedirectUrl: string;
     externalAccountActionCompleteRedirectUrl: string;
-    strategy:
-      | OAuthStrategy
-      | SamlStrategy
-      | EnterpriseSSOStrategy
-      | TicketStrategy
-      | GoogleOneTapStrategy
-      | PhoneCodeStrategy;
+    strategy: OAuthStrategy | EnterpriseSSOStrategy | TicketStrategy | GoogleOneTapStrategy | PhoneCodeStrategy;
     redirectUrl: string;
     actionCompleteRedirectUrl: string;
     transfer: boolean;

--- a/packages/types/src/strategies.ts
+++ b/packages/types/src/strategies.ts
@@ -17,8 +17,3 @@ export type EnterpriseSSOStrategy = 'enterprise_sso';
 
 export type OAuthStrategy = `oauth_${OAuthProvider}` | CustomOAuthStrategy;
 export type Web3Strategy = `web3_${Web3Provider}_signature`;
-
-/**
- * @deprecated Use `EnterpriseSSOStrategy` instead.
- */
-export type SamlStrategy = 'saml';


### PR DESCRIPTION
## Description

Removes deprecated `saml` strategy in favor of `enterprise_sso`


This should be merged to https://github.com/clerk/javascript/tree/vincent-and-the-doctor as a breaking change

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Removed SAML authentication strategy across all authentication flows. Enterprise SSO is now the exclusive method for enterprise user authentication. Applications previously using SAML for sign-in or sign-up must migrate to Enterprise SSO for continued support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->