### PR TITLE
refactor(clerk-js): Improve password input toggle positioning/sizing

### DIFF
--- a/packages/clerk-js/src/ui/elements/PasswordInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PasswordInput.tsx
@@ -100,7 +100,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         //@ts-expect-error Type mismatch between ForwardRef and RefObject due to null
         ref={mergeRefs(ref, inputRef)}
         type={hidden ? 'password' : 'text'}
-        sx={theme => ({ paddingRight: `calc(${theme.space.$5x5} + ${theme.space.$1})` })}
+        sx={theme => ({ paddingRight: `calc(${theme.space.$5x5} + ${theme.space.$2})` })}
       />
       <IconButton
         elementDescriptor={descriptors.formFieldInputShowPasswordButton}
@@ -117,6 +117,12 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
           borderRadius: `calc(${theme.radii.$md} - ${theme.space.$1})`,
           paddingInline: 0,
           aspectRatio: '1/1',
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: `calc(${theme.space.$1} * -1)`,
+            borderRadius: `calc(${theme.radii.$md} - ${theme.space.$1})`,
+          },
         })}
         icon={hidden ? Eye : EyeSlash}
       />


### PR DESCRIPTION
## Description

| STATE | BEFORE | AFTER |
|--------|--------|--------|
| Default | <img width="1336" height="352" alt="Screenshot 2025-10-27 at 10 32 05 AM" src="https://github.com/user-attachments/assets/3a99c959-31fe-4ea7-b773-9738a403b2fe" /> | <img width="1328" height="344" alt="Screenshot 2025-10-27 at 10 31 11 AM" src="https://github.com/user-attachments/assets/44fb402a-eeb8-430e-9631-964b3d87c6b9" /> |
| Hover | <img width="1365" height="374" alt="Screenshot 2025-10-27 at 10 32 22 AM" src="https://github.com/user-attachments/assets/f3cb03ae-d11d-4839-a910-fed8205a15f1" /> | <img width="1368" height="352" alt="Screenshot 2025-10-27 at 10 30 13 AM" src="https://github.com/user-attachments/assets/cc11cb60-fb65-4084-a7be-a866e83e8abf" /> |
| Focus | <img width="1290" height="274" alt="Screenshot 2025-10-27 at 10 33 47 AM" src="https://github.com/user-attachments/assets/bb19fd7b-b22b-4c91-b839-62960b51d727" /> | <img width="1327" height="296" alt="Screenshot 2025-10-27 at 10 31 43 AM" src="https://github.com/user-attachments/assets/6a862adc-21e2-4862-9366-238d8b09c235" /> | 

- Improves password input toggle sizing
- Ensures toggle button is focusable by removing `-1` tab index usage

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
