### PR TITLE
Fix typo in Norwegian localization for organization title

### DIFF
--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -266,7 +266,7 @@ export const nbNO: LocalizationResource = {
     subtitle: 'for å fortsette til {{applicationName}}',
     suggestionsAcceptedLabel: 'Venter på godkjenning',
     title: 'Velg en bruker',
-    titleWithoutPersonal: 'Velg en organiasjon',
+    titleWithoutPersonal: 'Velg en organisasjon',
   },
   organizationProfile: {
     apiKeysPage: {


### PR DESCRIPTION
## Description

One missing letter.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: UI localization typo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a spelling error in the organization selection interface for Norwegian language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->