### PR TITLE
fix(e2e): Update nextjs version detection logic to work with tags

### DIFF
--- a/integration/tests/middleware-placement.test.ts
+++ b/integration/tests/middleware-placement.test.ts
@@ -15,6 +15,11 @@ function parseSemverMajor(range?: string): number | undefined {
   return match ? Number.parseInt(match[0], 10) : undefined;
 }
 
+/**
+ * Detects the installed Next.js version for a given application.
+ * Reads the version from node_modules/next/package.json to ensure
+ * we get the actual installed version rather than a tag like "latest" or "canary".
+ */
 async function detectNext(app: Application): Promise<{ version: string | undefined | null }> {
   // app.appDir exists for normal Application; for long-running apps, read it from the state file by serverUrl
   const appDir =
@@ -25,16 +30,12 @@ async function detectNext(app: Application): Promise<{ version: string | undefin
     return { version: null };
   }
 
-  // const pkg = await fs.readJSON(path.join(appDir, 'package.json'));
-  // const nextRange: string | undefined = pkg.dependencies?.next || pkg.devDependencies?.next;
-  // Prefer the resolved installed version from node_modules if available. This avoids issues with tags like
-  // "latest" or "canary" specified in the dependency range, ensuring we always parse a numeric semver.
   let installedVersion: string | undefined;
   try {
     const nextPkg = await fs.readJSON(path.join(appDir, 'node_modules', 'next', 'package.json'));
     installedVersion = String(nextPkg?.version || '');
   } catch {
-    // Ignore if not installed yet; we'll fall back to the declared range
+    // ignore
   }
 
   console.log('---detectNext---', installedVersion);


### PR DESCRIPTION
## Description

The previous implementation did not account for version tags.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Next.js version detection to prefer the installed package version for more accurate results; falls back to declared value only if needed and yields null when no app directory is present.
* **Chores**
  * Added additional runtime logging to aid troubleshooting during detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->