### PR TITLE
hotfix(clerk-js): restore OrganizationPreview in OrganizationSwitcher trigger

### DIFF
--- a/.changeset/restore-org-switcher-preview.md
+++ b/.changeset/restore-org-switcher-preview.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Restore OrganizationPreview in OrganizationSwitcher trigger so the active organization's avatar/name renders again and appearance descriptors are available. Fixes regression introduced when localizing trigger ARIA label in #7086.
+

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -1,6 +1,7 @@
 import { useOrganization, useOrganizationList, useUser } from '@clerk/shared/react';
 import { forwardRef } from 'react';
 
+import { OrganizationPreview } from '@/ui/elements/OrganizationPreview';
 import { PersonalWorkspacePreview } from '@/ui/elements/PersonalWorkspacePreview';
 import { withAvatarShimmer } from '@/ui/elements/withAvatarShimmer';
 
@@ -51,6 +52,16 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
         aria-haspopup='dialog'
         {...rest}
       >
+        {organization && (
+          <OrganizationPreview
+            elementId={'organizationSwitcherTrigger'}
+            gap={3}
+            size='xs'
+            organization={organization}
+            user={user}
+            sx={{ maxWidth: '30ch' }}
+          />
+        )}
         {!organization && (
           <PersonalWorkspacePreview
             size='xs'


### PR DESCRIPTION
…

## Description

Restore the OrganizationPreview in the OrganizationSwitcher trigger so the active organization’s avatar/name is visible again and appearance descriptors are present.

The regression came from the localization change for the trigger’s aria-label in `d33b7b553`, which unintentionally removed the `OrganizationPreview` from the trigger UI.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * Restored the display of the active organization's avatar and name in the Organization Switcher trigger.
  * Fixed a regression preventing appearance customization options from being available for the Organization Switcher trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->