### PR TITLE
fix(clerk-js): Ensure social buttons always contain the same label format

### DIFF
--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -96,12 +96,15 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
   );
   const strategyRowOneLength = strategyRows.at(lastAuthenticationStrategyPresent ? 1 : 0)?.length ?? 0;
 
+  // When last auth strategy is present, check remaining strategies count for button type
+  const remainingStrategiesCount = lastAuthenticationStrategyPresent ? strategies.length - 1 : strategies.length;
+
   const preferBlockButtons =
     socialButtonsVariant === 'blockButton'
       ? true
       : socialButtonsVariant === 'iconButton'
         ? false
-        : strategies.length <= SOCIAL_BUTTON_BLOCK_THRESHOLD;
+        : remainingStrategiesCount <= SOCIAL_BUTTON_BLOCK_THRESHOLD;
 
   const startOauth = async (strategy: OAuthStrategy | Web3Strategy) => {
     card.setLoading(strategy);
@@ -161,12 +164,12 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
         >
           {row.map(strategy => {
             const label =
-              strategies.length === SOCIAL_BUTTON_PRE_TEXT_THRESHOLD
+              remainingStrategiesCount <= SOCIAL_BUTTON_PRE_TEXT_THRESHOLD
                 ? `Continue with ${strategyToDisplayData[strategy].name}`
                 : strategyToDisplayData[strategy].name;
 
             const localizedText =
-              strategies.length === SOCIAL_BUTTON_PRE_TEXT_THRESHOLD
+              remainingStrategiesCount <= SOCIAL_BUTTON_PRE_TEXT_THRESHOLD
                 ? localizationKeys('socialButtonsBlockButton', {
                     provider: strategyToDisplayData[strategy].name,
                   })
@@ -224,15 +227,6 @@ type SocialButtonProps = PropsOfComponent<typeof Button> & {
 const SocialButtonIcon = forwardRef((props: SocialButtonProps, ref: Ref<HTMLButtonElement> | null): JSX.Element => {
   const { icon, label, id, textLocalizationKey, lastAuthenticationStrategy, ...rest } = props;
 
-  if (lastAuthenticationStrategy) {
-    return (
-      <SocialButtonBlock
-        {...props}
-        ref={ref}
-      />
-    );
-  }
-
   return (
     <Button
       ref={ref}
@@ -245,9 +239,11 @@ const SocialButtonIcon = forwardRef((props: SocialButtonProps, ref: Ref<HTMLButt
       sx={t => ({
         minHeight: t.sizes.$8,
         width: '100%',
+        position: 'relative',
       })}
       {...rest}
     >
+      {lastAuthenticationStrategy && <LastAuthenticationStrategyBadge overlay />}
       {icon}
     </Button>
   );


### PR DESCRIPTION
## Description

This PR updates social buttons rendering logic to render the same button type across all buttons when last used is true.

| last use false | last used true |
|--------|--------|
| <img width="567" height="681" alt="Screenshot 2025-10-31 at 2 11 06 PM" src="https://github.com/user-attachments/assets/5d37dae5-baf1-4200-b162-94bee95d7be1" /> | <img width="588" height="624" alt="Screenshot 2025-10-31 at 2 08 42 PM" src="https://github.com/user-attachments/assets/d6dbd2d9-2751-4878-b879-c94e09b0429f" /> |
| <img width="569" height="649" alt="Screenshot 2025-10-31 at 2 10 51 PM" src="https://github.com/user-attachments/assets/99e302db-1d12-426e-b638-d0b4b18b0597" /> | <img width="586" height="679" alt="Screenshot 2025-10-31 at 2 08 53 PM" src="https://github.com/user-attachments/assets/1119c94d-468e-4466-8149-3311330bc0ad" /> |
| <img width="561" height="593" alt="Screenshot 2025-10-31 at 2 10 38 PM" src="https://github.com/user-attachments/assets/c44658bf-95bb-4198-81b4-b3d491b29227" /> | <img width="549" height="636" alt="Screenshot 2025-10-31 at 2 09 13 PM" src="https://github.com/user-attachments/assets/12fa0488-8e6a-4e9d-8d60-5761d6df1c0d" /> |
| <img width="579" height="597" alt="Screenshot 2025-10-31 at 2 10 27 PM" src="https://github.com/user-attachments/assets/e20b2857-2941-454b-b592-01806c97527f" /> | <img width="551" height="672" alt="Screenshot 2025-10-31 at 2 09 20 PM" src="https://github.com/user-attachments/assets/3ed2b980-3c8d-44ed-9e86-a13bc4aa31e3" /> |

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
