### PR TITLE
fix(clerk-js): Use path routing to build tasks URL

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -35,9 +35,9 @@ import type {
   AuthenticateWithMetamaskParams,
   AuthenticateWithOKXWalletParams,
   BillingNamespace,
-  Clerk as ClerkInterface,
   ClerkAPIError,
   ClerkAuthenticateWithWeb3Params,
+  Clerk as ClerkInterface,
   ClerkOptions,
   ClientJSONSnapshot,
   ClientResource,
@@ -124,6 +124,7 @@ import {
   isOrganizationId,
   isRedirectForFAPIInitiatedFlow,
   isSignedInAndSingleSessionModeEnabled,
+  joinPaths,
   noOrganizationExists,
   noUserExists,
   processCssLayerNameExtraction,
@@ -1668,14 +1669,16 @@ export class Clerk implements ClerkInterface {
       return customTaskUrl;
     }
 
+    const signInUrl = this.buildSignInUrl(options);
+    const { origin, pathname, searchParams } = new URL(signInUrl, window.location.origin);
+
     return buildURL(
       {
-        base: this.buildSignInUrl(options),
-        hashPath: getTaskEndpoint(currentTask),
+        base: origin,
+        pathname: joinPaths(pathname, getTaskEndpoint(currentTask)),
+        searchParams: searchParams,
       },
-      {
-        stringify: true,
-      },
+      { stringify: true },
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4409,9 +4409,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5':
     resolution: {integrity: sha512-8sExkWRK+zVybw3+2/kBkYBFeLnEUWz1fT7BLHplpzmtqkOfTbAQ9gkt4pzwGIIZmg4Qn5US5ACjUBenrhezwQ==}
 
-  '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-8sExkWRK+zVybw3+2/kBkYBFeLnEUWz1fT7BLHplpzmtqkOfTbAQ9gkt4pzwGIIZmg4Qn5US5ACjUBenrhezwQ==}
-
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
     engines: {node: '>=14.0.0'}
@@ -19724,8 +19721,6 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-beta.29': {}
 
   '@rolldown/pluginutils@1.0.0-beta.43': {}
-
-  '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5': {}
 


### PR DESCRIPTION
## Description

Currently, when using `RedirectToTasks`, it navigates to `/sign-in#/tasks/choose-organization`, which doesn't work well for custom flows on Next.js as hash routing isn't used 

This PR updates the `buildTasksUrl` function to use pathname by default.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
