### PR TITLE
fix(clerk-js): Reassign fetcherRef when fetcher changes

### DIFF
--- a/.changeset/lucky-lamps-repair.md
+++ b/.changeset/lucky-lamps-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix useFetch to update fetcher ref

--- a/packages/clerk-js/src/ui/hooks/useFetch.ts
+++ b/packages/clerk-js/src/ui/hooks/useFetch.ts
@@ -130,6 +130,7 @@ export const useFetch = <K, T>(
   }, [setCache, setRevalidationCounter]);
 
   useEffect(() => {
+    fetcherRef.current = fetcher;
     const fetcherMissing = !fetcherRef.current;
     const isCacheStale =
       typeof getCache()?.cachedAt === 'undefined' ? true : Date.now() - (getCache()?.cachedAt || 0) >= staleTime;


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

`useFetch` receives a `fetcher` function as a parameter, which is assigned to a ref internally. The problem is that when we switch resources, the `fetcher` function still points to old references. This PR ensures that the `fetcherRef` always points to the latest `fetcher` param.

- How to reproduce:
    - Sign in to an app with orgs, and make sure your signed-in user is a member of at least two different orgs. 
    - Switch from one org to another to trigger a refetch for the organization roles endpoint
    - Check the network tab. Before the fix, the refetch would point to the previous org ID
    - With the fix, the refetch should point to the correct, last selected organization ID

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fetch operations now respect updates to the configured fetcher, ensuring subsequent requests use the latest fetch behavior and preventing stale request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->