### PR TITLE
fix(shared): Update method return types

### DIFF
--- a/.changeset/orange-grapes-peel.md
+++ b/.changeset/orange-grapes-peel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+[Experimental] Fix method return types for new custom flow APIs.

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -1,3 +1,4 @@
+import type { ClerkError } from '../errors/clerkError';
 import type { SetActiveNavigate } from './clerk';
 import type { PhoneCodeChannel } from './phoneCodeChannel';
 import type { SignInFirstFactor, SignInSecondFactor, SignInStatus, UserData } from './signInCommon';
@@ -340,12 +341,12 @@ export interface SignInFutureResource {
    * > Once the sign-in process is complete, call the `signIn.finalize()` method to set the newly created session as
    * > the active session.
    */
-  create: (params: SignInFutureCreateParams) => Promise<{ error: unknown }>;
+  create: (params: SignInFutureCreateParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to submit a password to sign-in.
    */
-  password: (params: SignInFuturePasswordParams) => Promise<{ error: unknown }>;
+  password: (params: SignInFuturePasswordParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    *
@@ -354,12 +355,12 @@ export interface SignInFutureResource {
     /**
      * Used to send an email code to sign-in
      */
-    sendCode: (params: SignInFutureEmailCodeSendParams) => Promise<{ error: unknown }>;
+    sendCode: (params: SignInFutureEmailCodeSendParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a code sent via email to sign-in
      */
-    verifyCode: (params: SignInFutureEmailCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyCode: (params: SignInFutureEmailCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
   };
 
   /**
@@ -369,12 +370,12 @@ export interface SignInFutureResource {
     /**
      * Used to send an email link to sign-in
      */
-    sendLink: (params: SignInFutureEmailLinkSendParams) => Promise<{ error: unknown }>;
+    sendLink: (params: SignInFutureEmailLinkSendParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Will wait for verification to complete or expire
      */
-    waitForVerification: () => Promise<{ error: unknown }>;
+    waitForVerification: () => Promise<{ error: ClerkError | null }>;
 
     /**
      * The verification status
@@ -404,12 +405,12 @@ export interface SignInFutureResource {
     /**
      * Used to send a phone code to sign-in
      */
-    sendCode: (params: SignInFuturePhoneCodeSendParams) => Promise<{ error: unknown }>;
+    sendCode: (params: SignInFuturePhoneCodeSendParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a code sent via phone to sign-in
      */
-    verifyCode: (params: SignInFuturePhoneCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyCode: (params: SignInFuturePhoneCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
   };
 
   /**
@@ -419,23 +420,23 @@ export interface SignInFutureResource {
     /**
      * Used to send a password reset code to the first email address on the account
      */
-    sendCode: () => Promise<{ error: unknown }>;
+    sendCode: () => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a password reset code sent via email. Will cause `signIn.status` to become `'needs_new_password'`.
      */
-    verifyCode: (params: SignInFutureEmailCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyCode: (params: SignInFutureEmailCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to submit a new password, and move the `signIn.status` to `'complete'`.
      */
-    submitPassword: (params: SignInFutureResetPasswordSubmitParams) => Promise<{ error: unknown }>;
+    submitPassword: (params: SignInFutureResetPasswordSubmitParams) => Promise<{ error: ClerkError | null }>;
   };
 
   /**
    * Used to perform OAuth authentication.
    */
-  sso: (params: SignInFutureSSOParams) => Promise<{ error: unknown }>;
+  sso: (params: SignInFutureSSOParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    *
@@ -444,33 +445,33 @@ export interface SignInFutureResource {
     /**
      * Used to send a phone code as a second factor to sign-in
      */
-    sendPhoneCode: () => Promise<{ error: unknown }>;
+    sendPhoneCode: () => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a phone code sent as a second factor to sign-in
      */
-    verifyPhoneCode: (params: SignInFutureMFAPhoneCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyPhoneCode: (params: SignInFutureMFAPhoneCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a TOTP code as a second factor to sign-in
      */
-    verifyTOTP: (params: SignInFutureTOTPVerifyParams) => Promise<{ error: unknown }>;
+    verifyTOTP: (params: SignInFutureTOTPVerifyParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a backup code as a second factor to sign-in
      */
-    verifyBackupCode: (params: SignInFutureBackupCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyBackupCode: (params: SignInFutureBackupCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
   };
 
   /**
    * Used to perform a ticket-based sign-in.
    */
-  ticket: (params?: SignInFutureTicketParams) => Promise<{ error: unknown }>;
+  ticket: (params?: SignInFutureTicketParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to perform a Web3-based sign-in.
    */
-  web3: (params: SignInFutureWeb3Params) => Promise<{ error: unknown }>;
+  web3: (params: SignInFutureWeb3Params) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Initiates a passkey-based authentication flow, enabling users to authenticate using a previously
@@ -478,11 +479,11 @@ export interface SignInFutureResource {
    * `SignIn.create({ strategy: 'passkey' })` to initialize the sign-in context. This pattern is particularly useful in
    * scenarios where the authentication strategy needs to be determined dynamically at runtime.
    */
-  passkey: (params?: SignInFuturePasskeyParams) => Promise<{ error: unknown }>;
+  passkey: (params?: SignInFuturePasskeyParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to convert a sign-in with `status === 'complete'` into an active session. Will cause anything observing the
    * session state (such as the `useUser()` hook) to update automatically.
    */
-  finalize: (params?: SignInFutureFinalizeParams) => Promise<{ error: unknown }>;
+  finalize: (params?: SignInFutureFinalizeParams) => Promise<{ error: ClerkError | null }>;
 }

--- a/packages/shared/src/types/signUpFuture.ts
+++ b/packages/shared/src/types/signUpFuture.ts
@@ -1,3 +1,4 @@
+import type { ClerkError } from '../errors/clerkError';
 import type { SetActiveNavigate } from './clerk';
 import type { PhoneCodeChannel } from './phoneCodeChannel';
 import type { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUpCommon';
@@ -398,12 +399,12 @@ export interface SignUpFutureResource {
    * > Once the sign-up process is complete, call the `signUp.finalize()` method to set the newly created session as
    * > the active session.
    */
-  create: (params: SignUpFutureCreateParams) => Promise<{ error: unknown }>;
+  create: (params: SignUpFutureCreateParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Updates the current `SignUp`.
    */
-  update: (params: SignUpFutureUpdateParams) => Promise<{ error: unknown }>;
+  update: (params: SignUpFutureUpdateParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    *
@@ -412,47 +413,47 @@ export interface SignUpFutureResource {
     /**
      * Used to send an email code to verify an email address.
      */
-    sendEmailCode: () => Promise<{ error: unknown }>;
+    sendEmailCode: () => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a code sent via email.
      */
-    verifyEmailCode: (params: SignUpFutureEmailCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyEmailCode: (params: SignUpFutureEmailCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to send a phone code to verify a phone number.
      */
-    sendPhoneCode: (params: SignUpFuturePhoneCodeSendParams) => Promise<{ error: unknown }>;
+    sendPhoneCode: (params: SignUpFuturePhoneCodeSendParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a code sent via phone.
      */
-    verifyPhoneCode: (params: SignUpFuturePhoneCodeVerifyParams) => Promise<{ error: unknown }>;
+    verifyPhoneCode: (params: SignUpFuturePhoneCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
   };
 
   /**
    * Used to sign up using an email address and password.
    */
-  password: (params: SignUpFuturePasswordParams) => Promise<{ error: unknown }>;
+  password: (params: SignUpFuturePasswordParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to create an account using an OAuth connection.
    */
-  sso: (params: SignUpFutureSSOParams) => Promise<{ error: unknown }>;
+  sso: (params: SignUpFutureSSOParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to perform a ticket-based sign-up.
    */
-  ticket: (params?: SignUpFutureTicketParams) => Promise<{ error: unknown }>;
+  ticket: (params?: SignUpFutureTicketParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to perform a Web3-based sign-up.
    */
-  web3: (params: SignUpFutureWeb3Params) => Promise<{ error: unknown }>;
+  web3: (params: SignUpFutureWeb3Params) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to convert a sign-up with `status === 'complete'` into an active session. Will cause anything observing the
    * session state (such as the `useUser()` hook) to update automatically.
    */
-  finalize: (params?: SignUpFutureFinalizeParams) => Promise<{ error: unknown }>;
+  finalize: (params?: SignUpFutureFinalizeParams) => Promise<{ error: ClerkError | null }>;
 }


### PR DESCRIPTION
## Description

This PR fixes the method return types of our new custom flow APIs, which are declared in two locations. Previously, we updated the method return type on the actual implemented method to `Promise<{ error: ClerkError | null }>`, but neglected to update the interface types within `shared/types` with the new return type.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed return type definitions for custom flow API methods to properly specify error types instead of generic error handling, improving type safety and enabling better compile-time error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->