### PR TITLE
fix(ui): Correct lint:attw command

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,7 @@
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",
     "lint": "eslint src",
-    "lint:attw": "attw --pack . --profile esm-only",
+    "lint:attw": "attw --pack . --profile esm-only --ignore-rules internal-resolution-error",
     "lint:publint": "publint",
     "showerrors": "tsc",
     "test:ci": "vitest --maxWorkers=70%",


### PR DESCRIPTION
## Description

This change is needed because `@clerk/ui` is an ESM-only package, which is not compatible with node16 CJS checks

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
