### PR TITLE
fix: update input variable on release canary workflow

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -67,7 +67,7 @@ jobs:
                 repo: 'sdk-infra-workers',
                 workflow_id: 'update-pkg-versions.yml',
                 ref: 'main',
-                inputs: { version: clerkjsVersion }
+                inputs: { clerkjsVersion: clerkjsVersion }
               })
 
             if (nextjsVersion.includes('canary')) {


### PR DESCRIPTION
## Description

Release canary is failing: 

<img width="757" height="102" alt="image" src="https://github.com/user-attachments/assets/f446ce1c-e1a0-4979-b91f-df5fcf2039f7" />

Updating the input variable name according to the workflow file.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates with no user-facing changes.

* **Chores**
  * Updated internal configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->