### PR TITLE
fix(clerk-js): Only log warning for dev instance

### DIFF
--- a/.changeset/odd-books-win.md
+++ b/.changeset/odd-books-win.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Ensure that organization component warnings are only shown when no user session exists in development

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -753,7 +753,7 @@ export class Clerk implements ClerkInterface {
   ): __internal_AttemptToEnableEnvironmentSettingResult => {
     const { for: setting, caller } = params;
 
-    if (!this.user) {
+    if (!this.user && this.#instanceType === 'development') {
       logger.warnOnce(
         `Clerk: "${caller}" requires an active user session. Ensure a user is signed in before executing ${caller}.`,
       );


### PR DESCRIPTION
## Description

Fix issue where `__internal_enableEnvironmentSettingPrompt` was logging an warning even for production instances when the user didn't have a session while rendering org components.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization component warnings now only display in development mode when no user session exists, reducing unnecessary warnings in production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->