### PR TITLE
fix(clerk-js): Do not open orgs prompt when `choose-organization` task is pending

### DIFF
--- a/.changeset/afraid-women-buy.md
+++ b/.changeset/afraid-women-buy.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Prevent enable organization prompt from appearing if there is a session with a pending `choose-organization` task.
+
+This resolves an issue where, after organizations are enabled via the Dashboard, cached environment resources may cause the prompt to show again when the user is redirected to complete the `choose-organization` task.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -2510,6 +2510,11 @@ describe('Clerk singleton', () => {
   });
 
   describe('__internal_attemptToEnableEnvironmentSetting', () => {
+    afterEach(() => {
+      mockEnvironmentFetch.mockReset();
+      mockClientFetch.mockReset();
+    });
+
     describe('for organizations', () => {
       it('does not open prompt if organizations is enabled in development', async () => {
         mockEnvironmentFetch.mockReturnValue(
@@ -2628,6 +2633,68 @@ describe('Clerk singleton', () => {
         });
 
         expect(result?.isEnabled).toBe(false);
+        expect(__internal_openEnableOrganizationsPromptSpy).not.toHaveBeenCalled();
+      });
+
+      // Handles case where environment gets enabled via BAPI, but it gets cached and the user is redirected to the choose-organization task
+      // The enable org prompt should not appear in the task screen since orgs have already been enabled
+      it('does not open prompt if organizations is disabled in development and session has choose-organization task', async () => {
+        const mockSession = {
+          id: '1',
+          remove: vi.fn(),
+          status: 'pending',
+          user: {},
+          touch: vi.fn(() => Promise.resolve()),
+          getToken: vi.fn(),
+          lastActiveToken: { getRawString: () => 'mocked-token' },
+          tasks: [{ key: 'choose-organization' }],
+          currentTask: { key: 'choose-organization' },
+          reload: vi.fn(() =>
+            Promise.resolve({
+              id: '1',
+              status: 'pending',
+              user: {},
+              tasks: [{ key: 'choose-organization' }],
+              currentTask: {
+                key: 'choose-organization',
+              },
+            }),
+          ),
+        };
+
+        mockEnvironmentFetch.mockReturnValue(
+          Promise.resolve({
+            userSettings: mockUserSettings,
+            displayConfig: mockDisplayConfig,
+            isSingleSession: () => false,
+            isProduction: () => false,
+            isDevelopmentOrStaging: () => true,
+            organizationSettings: {
+              enabled: false,
+            },
+          }),
+        );
+
+        mockClientFetch.mockReturnValue(
+          Promise.resolve({
+            signedInSessions: [mockSession],
+          }),
+        );
+
+        const sut = new Clerk(developmentPublishableKey);
+
+        const __internal_openEnableOrganizationsPromptSpy = vi.fn();
+        sut.__internal_openEnableOrganizationsPrompt = __internal_openEnableOrganizationsPromptSpy;
+
+        await sut.load();
+
+        const result = await sut.__internal_attemptToEnableEnvironmentSetting({
+          for: 'organizations',
+          caller: 'OrganizationSwitcher',
+        });
+
+        // Contains the organization task, so the prompt should not be opened
+        expect(result?.isEnabled).toBe(true);
         expect(__internal_openEnableOrganizationsPromptSpy).not.toHaveBeenCalled();
       });
     });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -761,7 +761,11 @@ export class Clerk implements ClerkInterface {
 
     switch (setting) {
       case 'organizations': {
-        const isSettingDisabled = disabledOrganizationsFeature(this, this.environment);
+        const isSettingDisabled =
+          disabledOrganizationsFeature(this, this.environment) &&
+          // Handles case where environment gets enabled via BAPI, but it gets cached and the user is redirected to the choose-organization task
+          // The enable org prompt should not appear in the task screen since orgs have already been enabled
+          this.session?.currentTask?.key !== 'choose-organization';
 
         if (!isSettingDisabled) {
           return { isEnabled: true };


### PR DESCRIPTION
## Description

The environment resource is currently cached on the network level, therefore, when enabling orgs via BAPI, and coming back to the app, the session gets updated to have a session task but it could still have `organizationSettings.enabled=false`

This PR introduces an additional check to only trigger the prompt if there's not a `choose-organization` task 

The `choose-organization` task only gets added once orgs are enabled

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the enable-organization prompt could unexpectedly reappear when returning to complete a pending choose-organization task. After enabling organizations in the Dashboard, users will no longer see the prompt again for existing sessions with that pending task, resulting in a smoother organization onboarding and task-completion flow for affected users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->