### PR TITLE
fix(backend): Resolve Safari ITP handshake loop

### DIFF
--- a/.changeset/lazy-items-crash.md
+++ b/.changeset/lazy-items-crash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Improve error handling and retry logic when loading `@clerk/clerk-js`.

--- a/integration/templates/next-app-router/src/app/clerk-status/page.tsx
+++ b/integration/templates/next-app-router/src/app/clerk-status/page.tsx
@@ -1,4 +1,5 @@
-import { ClerkLoaded, ClerkLoading, ClerkFailed, ClerkDegraded, useClerk } from '@clerk/clerk-react';
+'use client';
+import { ClerkLoaded, ClerkLoading, ClerkFailed, ClerkDegraded, useClerk } from '@clerk/nextjs';
 
 export default function ClerkStatusPage() {
   const { loaded, status } = useClerk();

--- a/integration/tests/resiliency.test.ts
+++ b/integration/tests/resiliency.test.ts
@@ -21,10 +21,6 @@ const make500ClerkResponse = () => ({
 testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('resiliency @generic', ({ app }) => {
   test.describe.configure({ mode: 'serial' });
 
-  if (app.name.includes('next')) {
-    test.skip();
-  }
-
   let fakeUser: FakeUser;
 
   test.beforeAll(async () => {
@@ -38,221 +34,364 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('resilienc
     await app.teardown();
   });
 
-  test('signed in users can get a fresh session token when Client fails to load', async ({ page, context }) => {
-    const u = createTestUtils({ app, page, context });
-
-    await u.po.signIn.goTo();
-    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
-    await u.po.expect.toBeSignedIn();
-
-    const tokenAfterSignIn = await page.evaluate(() => {
-      return window.Clerk?.session?.getToken();
-    });
-
-    // Simulate developer coming back and client fails to load.
-    await page.route('**/v1/client?**', route => route.fulfill(make500ClerkResponse()));
-
-    await page.waitForTimeout(1_000);
-    await page.reload();
-
-    const waitForClientImmediately = page.waitForResponse(
-      response => response.url().includes('/client?') && response.status() === 500,
-      { timeout: 3_000 },
-    );
-
-    const waitForTokenImmediately = page.waitForResponse(
-      response =>
-        response.url().includes('/tokens?') && response.status() === 200 && response.request().method() === 'POST',
-      { timeout: 3_000 },
-    );
-
-    await page.waitForLoadState('domcontentloaded');
-
-    await waitForClientImmediately;
-    await waitForTokenImmediately;
-
-    // Wait for the client to be loaded. and the internal `getToken({skipCache: true})` to have been completed.
-    await u.po.clerk.toBeLoaded();
-
-    // Read the newly refreshed token.
-    const tokenOnClientOutage = await page.evaluate(() => {
-      return window.Clerk?.session?.getToken();
-    });
-
-    expect(tokenOnClientOutage).not.toEqual(tokenAfterSignIn);
-
-    await u.po.expect.toBeSignedIn();
-  });
-
-  test('resiliency to not break devBrowser - dummy client and is not created on `/client` 4xx errors', async ({
-    page,
-    context,
-  }) => {
-    // Simulate "Needs new dev browser, when db jwt exists but does not match the instance".
-
-    const response = {
-      status: 401,
-      body: JSON.stringify({
-        errors: [
-          {
-            message: '',
-            long_message: '',
-            code: 'dev_browser_unauthenticated',
-          },
-        ],
-        clerk_trace_id: 'some-trace-id',
-      }),
-    };
-
-    const u = createTestUtils({ app, page, context, useTestingToken: false });
-
-    await page.route('**/v1/client?**', route => {
-      return route.fulfill(response);
-    });
-
-    await page.route('**/v1/environment?**', route => {
-      return route.fulfill(response);
-    });
-
-    const waitForClientImmediately = page.waitForResponse(
-      response => response.url().includes('/client?') && response.status() === 401,
-      { timeout: 3_000 },
-    );
-
-    const waitForEnvironmentImmediately = page.waitForResponse(
-      response => response.url().includes('/environment?') && response.status() === 401,
-      { timeout: 3_000 },
-    );
-
-    await u.page.goToAppHome();
-    await page.waitForLoadState('domcontentloaded');
-
-    await waitForEnvironmentImmediately;
-    const waitForDevBrowserImmediately = page.waitForResponse(
-      response => response.url().includes('/dev_browser') && response.status() === 200,
-      {
-        timeout: 4_000,
-      },
-    );
-    await waitForClientImmediately;
-
-    // To remove specific route handlers
-    await page.unrouteAll();
-
-    await waitForDevBrowserImmediately;
-
-    await u.po.clerk.toBeLoaded();
-  });
-
-  test.describe('Clerk.status', () => {
-    test('normal flow shows correct states and transitions', async ({ page, context }) => {
-      const u = createTestUtils({ app, page, context });
-      await u.page.goToRelative('/clerk-status');
-
-      // Initial state checks
-      await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is out')).toBeHidden();
-      await expect(page.getByText('Clerk is degraded')).toBeHidden();
-      await expect(page.getByText('(comp) Waiting for clerk to fail, ready or regraded.')).toBeVisible();
-      await u.po.clerk.toBeLoading();
-
-      // Wait for loading to complete and verify final state
-      await expect(page.getByText('Status: ready', { exact: true })).toBeVisible();
-      await u.po.clerk.toBeLoaded();
-      await u.po.clerk.toBeReady();
-      await expect(page.getByText('Clerk is ready', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
-      await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
-      await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
-
-      // Verify loading component is no longer visible
-      await expect(page.getByText('(comp) Waiting for clerk to fail, ready or regraded.')).toBeHidden();
-    });
-
-    test('clerk-js hotloading failed', async ({ page, context }) => {
+  test.describe('loading resiliency', () => {
+    test('signed in users can get a fresh session token when Client fails to load', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
 
-      await page.route('**/clerk.browser.js', route => route.abort());
+      await u.po.signIn.goTo();
+      await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+      await u.po.expect.toBeSignedIn();
 
-      await u.page.goToRelative('/clerk-status');
-
-      // Initial state checks
-      await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
-
-      // Wait for loading to complete and verify final state
-      // Account for the new 15-second script loading timeout plus buffer for UI updates
-      await expect(page.getByText('Status: error', { exact: true })).toBeVisible({
-        timeout: 16_000,
+      const tokenAfterSignIn = await page.evaluate(() => {
+        return window.Clerk?.session?.getToken();
       });
-      await expect(page.getByText('Clerk is out', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeHidden();
-      await expect(page.getByText('Clerk is loaded', { exact: true })).toBeHidden();
-      await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeHidden();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
 
-      // Verify loading component is no longer visible
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
-    });
-
-    test('clerk-js client fails and status degraded', async ({ page, context }) => {
-      const u = createTestUtils({ app, page, context });
-
+      // Simulate developer coming back and client fails to load.
       await page.route('**/v1/client?**', route => route.fulfill(make500ClerkResponse()));
 
-      await u.page.goToRelative('/clerk-status');
+      await page.waitForTimeout(1_000);
+      await page.reload();
 
-      // Initial state checks
-      await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+      const waitForClientImmediately = page.waitForResponse(
+        response => response.url().includes('/client?') && response.status() === 500,
+        { timeout: 3_000 },
+      );
 
-      // Wait for loading to complete and verify final state
-      await expect(page.getByText('Status: degraded', { exact: true })).toBeVisible({
-        timeout: 10_000,
+      const waitForTokenImmediately = page.waitForResponse(
+        response =>
+          response.url().includes('/tokens?') && response.status() === 200 && response.request().method() === 'POST',
+        { timeout: 3_000 },
+      );
+
+      await page.waitForLoadState('domcontentloaded');
+
+      await waitForClientImmediately;
+      await waitForTokenImmediately;
+
+      // Wait for the client to be loaded. and the internal `getToken({skipCache: true})` to have been completed.
+      await u.po.clerk.toBeLoaded();
+
+      // Read the newly refreshed token.
+      const tokenOnClientOutage = await page.evaluate(() => {
+        return window.Clerk?.session?.getToken();
       });
-      await u.po.clerk.toBeDegraded();
-      await expect(page.getByText('Clerk is degraded', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is ready', { exact: true })).toBeHidden();
-      await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
-      await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
-      await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeHidden();
-      await expect(page.getByText('(comp) Clerk is degraded')).toBeVisible();
 
-      // Verify loading component is no longer visible
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
+      expect(tokenOnClientOutage).not.toEqual(tokenAfterSignIn);
+
+      await u.po.expect.toBeSignedIn();
     });
 
-    test('clerk-js environment fails and status degraded', async ({ page, context }) => {
+    test('resiliency to not break devBrowser - dummy client and is not created on `/client` 4xx errors', async ({
+      page,
+      context,
+    }) => {
+      // Simulate "Needs new dev browser, when db jwt exists but does not match the instance".
+
+      const response = {
+        status: 401,
+        body: JSON.stringify({
+          errors: [
+            {
+              message: '',
+              long_message: '',
+              code: 'dev_browser_unauthenticated',
+            },
+          ],
+          clerk_trace_id: 'some-trace-id',
+        }),
+      };
+
+      const u = createTestUtils({ app, page, context, useTestingToken: false });
+
+      await page.route('**/v1/client?**', route => {
+        return route.fulfill(response);
+      });
+
+      await page.route('**/v1/environment?**', route => {
+        return route.fulfill(response);
+      });
+
+      const waitForClientImmediately = page.waitForResponse(
+        response => response.url().includes('/client?') && response.status() === 401,
+        { timeout: 3_000 },
+      );
+
+      const waitForEnvironmentImmediately = page.waitForResponse(
+        response => response.url().includes('/environment?') && response.status() === 401,
+        { timeout: 3_000 },
+      );
+
+      await u.page.goToAppHome();
+      await page.waitForLoadState('domcontentloaded');
+
+      await waitForEnvironmentImmediately;
+      const waitForDevBrowserImmediately = page.waitForResponse(
+        response => response.url().includes('/dev_browser') && response.status() === 200,
+        {
+          timeout: 4_000,
+        },
+      );
+      await waitForClientImmediately;
+
+      // To remove specific route handlers
+      await page.unrouteAll();
+
+      await waitForDevBrowserImmediately;
+
+      await u.po.clerk.toBeLoaded();
+    });
+
+    test.describe('Clerk.status', () => {
+      test('normal flow shows correct states and transitions', async ({ page, context }) => {
+        const u = createTestUtils({ app, page, context });
+        await u.page.goToRelative('/clerk-status');
+
+        // Initial state checks
+        await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is out')).toBeHidden();
+        await expect(page.getByText('Clerk is degraded')).toBeHidden();
+        await expect(page.getByText('(comp) Waiting for clerk to fail, ready or degraded.')).toBeVisible();
+        await u.po.clerk.toBeLoading();
+
+        // Wait for loading to complete and verify final state
+        await expect(page.getByText('Status: ready', { exact: true })).toBeVisible();
+        await u.po.clerk.toBeLoaded();
+        await u.po.clerk.toBeReady();
+        await expect(page.getByText('Clerk is ready', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
+        await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
+        await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
+
+        // Verify loading component is no longer visible
+        await expect(page.getByText('(comp) Waiting for clerk to fail, ready or degraded.')).toBeHidden();
+      });
+
+      test('clerk-js hotloading failed', async ({ page, context }) => {
+        const u = createTestUtils({ app, page, context });
+
+        await page.route('**/clerk.browser.js', route => route.abort());
+
+        await u.page.goToRelative('/clerk-status');
+
+        // Initial state checks
+        await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+
+        // Wait for loading to complete and verify final state
+        // Account for the new 15-second script loading timeout plus buffer for UI updates
+        await expect(page.getByText('Status: error', { exact: true })).toBeVisible({
+          timeout: 16_000,
+        });
+        await expect(page.getByText('Clerk is out', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeHidden();
+        await expect(page.getByText('Clerk is loaded', { exact: true })).toBeHidden();
+        await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeHidden();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+
+        // Verify loading component is no longer visible
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
+      });
+
+      test('clerk-js client fails and status degraded', async ({ page, context }) => {
+        const u = createTestUtils({ app, page, context });
+
+        await page.route('**/v1/client?**', route => route.fulfill(make500ClerkResponse()));
+
+        await u.page.goToRelative('/clerk-status');
+
+        // Initial state checks
+        await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+
+        // Wait for loading to complete and verify final state
+        await expect(page.getByText('Status: degraded', { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+        await u.po.clerk.toBeDegraded();
+        await expect(page.getByText('Clerk is degraded', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is ready', { exact: true })).toBeHidden();
+        await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
+        await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
+        await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeHidden();
+        await expect(page.getByText('(comp) Clerk is degraded')).toBeVisible();
+
+        // Verify loading component is no longer visible
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
+      });
+
+      test('clerk-js environment fails and status degraded', async ({ page, context }) => {
+        const u = createTestUtils({ app, page, context });
+
+        await page.route('**/v1/environment?**', route => route.fulfill(make500ClerkResponse()));
+
+        await u.page.goToRelative('/clerk-status');
+
+        // Initial state checks
+        await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+        await u.po.clerk.toBeLoading();
+
+        // Wait for loading to complete and verify final state
+        await expect(page.getByText('Status: degraded', { exact: true })).toBeVisible();
+        await u.po.clerk.toBeDegraded();
+        await expect(page.getByText('Clerk is degraded', { exact: true })).toBeVisible();
+        await expect(page.getByText('Clerk is ready', { exact: true })).toBeHidden();
+        await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
+        await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
+        await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
+        await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeHidden();
+        await expect(page.getByText('(comp) Clerk is degraded')).toBeVisible();
+
+        // Verify loading component is no longer visible
+        await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
+      });
+    });
+  });
+
+  test.describe('clerk-js script loading', () => {
+    test('recovers from transient network failure on clerk-js script load', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
 
-      await page.route('**/v1/environment?**', route => route.fulfill(make500ClerkResponse()));
+      let requestCount = 0;
+      await page.route('**/clerk.browser.js', route => {
+        requestCount++;
+        // Fail the first request, allow subsequent requests
+        if (requestCount === 1) {
+          return route.abort('failed');
+        }
+        return route.continue();
+      });
 
       await u.page.goToRelative('/clerk-status');
 
-      // Initial state checks
+      // Initial state should show loading
       await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
-      await u.po.clerk.toBeLoading();
 
-      // Wait for loading to complete and verify final state
-      await expect(page.getByText('Status: degraded', { exact: true })).toBeVisible();
-      await u.po.clerk.toBeDegraded();
-      await expect(page.getByText('Clerk is degraded', { exact: true })).toBeVisible();
-      await expect(page.getByText('Clerk is ready', { exact: true })).toBeHidden();
-      await expect(page.getByText('Clerk is ready or degraded (loaded)')).toBeVisible();
+      // Wait for Clerk to eventually load after retry
+      // Account for retry delay + script load time + initialization
+      await expect(page.getByText('Status: ready', { exact: true })).toBeVisible({
+        timeout: 20_000,
+      });
+
+      await u.po.clerk.toBeLoaded();
       await expect(page.getByText('Clerk is loaded', { exact: true })).toBeVisible();
-      await expect(page.getByText('(comp) Clerk is loaded,(ready or degraded)')).toBeVisible();
-      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeHidden();
-      await expect(page.getByText('(comp) Clerk is degraded')).toBeVisible();
 
-      // Verify loading component is no longer visible
-      await expect(page.getByText('Clerk is loading', { exact: true })).toBeHidden();
+      // Verify retry happened
+      expect(requestCount).toBeGreaterThan(1);
+    });
+
+    test('recovers from HTTP 500 error on clerk-js script load', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      let requestCount = 0;
+      await page.route('**/clerk.browser.js', route => {
+        requestCount++;
+        // Return 500 error on first request, succeed on subsequent
+        if (requestCount === 1) {
+          return route.fulfill({
+            status: 500,
+            body: 'Internal Server Error',
+          });
+        }
+        return route.continue();
+      });
+
+      await u.page.goToRelative('/clerk-status');
+
+      // Initial state should show loading
+      await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+
+      // Wait for Clerk to eventually load after retry
+      await expect(page.getByText('Status: ready', { exact: true })).toBeVisible({
+        timeout: 20_000,
+      });
+
+      await u.po.clerk.toBeLoaded();
+
+      // Verify retry happened
+      expect(requestCount).toBeGreaterThan(1);
+    });
+
+    test('recovers from HTTP 503 service unavailable with retry', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      let requestCount = 0;
+      await page.route('**/clerk.browser.js', route => {
+        requestCount++;
+        // Return 503 error on first two requests, succeed on third
+        if (requestCount <= 2) {
+          return route.fulfill({
+            status: 503,
+            body: 'Service Unavailable',
+          });
+        }
+        return route.continue();
+      });
+
+      await u.page.goToRelative('/clerk-status');
+
+      // Wait for Clerk to eventually load after multiple retries
+      await expect(page.getByText('Status: ready', { exact: true })).toBeVisible({
+        timeout: 25_000,
+      });
+
+      await u.po.clerk.toBeLoaded();
+
+      // Verify multiple retries happened
+      expect(requestCount).toBeGreaterThan(2);
+    });
+
+    test('fails with error status after exhausting all retries', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      // Block all clerk.browser.js requests permanently
+      await page.route('**/clerk.browser.js', route => route.abort('failed'));
+
+      await u.page.goToRelative('/clerk-status');
+
+      // Initial state should show loading
+      await expect(page.getByText('Status: loading', { exact: true })).toBeVisible();
+
+      // Wait for error status after all retries are exhausted
+      // This should take longer due to exponential backoff
+      await expect(page.getByText('Status: error', { exact: true })).toBeVisible({
+        timeout: 30_000,
+      });
+
+      await expect(page.getByText('Clerk is out', { exact: true })).toBeVisible();
+      await expect(page.getByText('Clerk is NOT loaded', { exact: true })).toBeVisible();
+    });
+
+    test('handles slow network with eventual success', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      let requestCount = 0;
+      await page.route('**/clerk.browser.js', async route => {
+        requestCount++;
+        // First request times out (simulate by very long delay)
+        if (requestCount === 1) {
+          // Wait longer than typical timeout, then abort
+          await new Promise(resolve => setTimeout(resolve, 3000));
+          return route.abort('timedout');
+        }
+        // Second request succeeds normally
+        return route.continue();
+      });
+
+      await u.page.goToRelative('/clerk-status');
+
+      // Wait for Clerk to eventually load
+      await expect(page.getByText('Status: ready', { exact: true })).toBeVisible({
+        timeout: 25_000,
+      });
+
+      await u.po.clerk.toBeLoaded();
     });
   });
 });


### PR DESCRIPTION
## Description

Looks like Safari ITP sometimes blocks the Strict cookies on cross-origin redirects  ( `__clerk_uat` ) in development so if you are redirecting directly to a protected route, the middleware will keep trying to handshake in order to acquire that particular cookie leading to an infinite redirect loop. 

In the scenario where we detect a handshake redirect loop (attempt 2+), we just validate the token and return signed in instead of forcing a handshake.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents infinite handshake redirect loops in browsers that block cross-origin cookies (e.g., Safari ITP) by verifying existing session tokens so valid sessions remain signed in.

* **Tests**
  * Added tests covering redirect-loop scenarios to ensure correct handling of valid and invalid session tokens.

* **Chores**
  * Added a patch changeset documenting the redirect-loop fix for the backend package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->