### PR TITLE
fix(themes): Invert Vercel provider icon in dark themes

### DIFF
--- a/.changeset/vercel-theme-invert.md
+++ b/.changeset/vercel-theme-invert.md
@@ -1,0 +1,5 @@
+---
+'@clerk/themes': patch
+---
+
+Add `providerIcon__vercel` inversion for dark mode in `dark` and `shadcn` themes

--- a/packages/themes/src/themes/dark.ts
+++ b/packages/themes/src/themes/dark.ts
@@ -15,6 +15,7 @@ export const dark = experimental_createTheme({
     providerIcon__apple: { filter: 'invert(1)' },
     providerIcon__github: { filter: 'invert(1)' },
     providerIcon__okx_wallet: { filter: 'invert(1)' },
+    providerIcon__vercel: { filter: 'invert(1)' },
     activeDeviceIcon: {
       '--cl-chassis-bottom': '#d2d2d2',
       '--cl-chassis-back': '#e6e6e6',

--- a/packages/themes/src/themes/shadcn.ts
+++ b/packages/themes/src/themes/shadcn.ts
@@ -35,5 +35,6 @@ export const shadcn = experimental_createTheme({
     providerIcon__apple: 'dark:invert',
     providerIcon__github: 'dark:invert',
     providerIcon__okx_wallet: 'dark:invert',
+    providerIcon__vercel: 'dark:invert',
   },
 });


### PR DESCRIPTION
## Summary
- Add `providerIcon__vercel` inversion to `dark` theme with `{ filter: 'invert(1)' }`
- Add `providerIcon__vercel` inversion to `shadcn` theme with `'dark:invert'`

This ensures the Vercel logo is properly visible in dark mode, matching the existing behavior for Apple, GitHub, and OKX Wallet icons.

## References
- https://github.com/clerk/javascript/blob/main/packages/themes/src/themes/dark.ts#L15-L17
- https://github.com/clerk/javascript/blob/main/packages/themes/src/themes/shadcn.ts#L35-L37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel provider icon support with optimized dark mode styling for improved visibility across theme variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->