### PR TITLE
fix(clerk-js): Remove the hydrate cache change for session (#7329)

### DIFF
--- a/.changeset/two-candles-yawn.md
+++ b/.changeset/two-candles-yawn.md
@@ -1,5 +1,0 @@
----
-'@clerk/clerk-js': patch
----
-
-Reverts the changes done https://github.com/clerk/javascript/pull/7105, as it was causing JWT's returned from client piggybacking not get inserted into cache even though their claims have actually changed


### PR DESCRIPTION
## Description

Port of https://github.com/clerk/javascript/pull/7329
<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
