### PR TITLE
fix(shared): Allow task URL customisation for specific tasks

### DIFF
--- a/.changeset/bright-islands-say.md
+++ b/.changeset/bright-islands-say.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix for allowing task url customization for specific tasks instead of requiring them all

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -1177,7 +1177,7 @@ export type ClerkOptions = ClerkOptionsNavigation &
      *
      * @default undefined
      */
-    taskUrls?: Record<SessionTask['key'], string>;
+    taskUrls?: Partial<Record<SessionTask['key'], string>>;
   };
 
 export interface NavigateOptions {


### PR DESCRIPTION
## Description

This PR fixes a type issue that was introduced in previous release that the types require for all tasks to have a custom url, this change make's sure to adjust that so even some of the tasks can have custom url's and not all of them

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Task URL customization now allows you to configure URLs for individual tasks instead of requiring customization for all tasks at once, providing more granular control and flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->