### PR TITLE
chore(nextjs)!: Throw when missing encryption key

### DIFF
--- a/.changeset/moody-peaches-stare.md
+++ b/.changeset/moody-peaches-stare.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': major
+---
+
+Throw an error when an encryption key is missing when passing a secret key at runtime `clerkMiddleware()`. To migrate, ensure your application specifies a `CLERK_ENCRYPTION_KEY` environment variable when passing `secretKey` as a runtime option.

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -34,3 +34,5 @@ export const authSignatureInvalid = `Clerk: Unable to verify request, this usual
 export const encryptionKeyInvalid = `Clerk: Unable to decrypt request data, this usually means the encryption key is invalid. Ensure the encryption key is properly set. For more information, see: https://clerk.com/docs/reference/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
 
 export const encryptionKeyInvalidDev = `Clerk: Unable to decrypt request data.\n\nRefresh the page if your .env file was just updated. If the issue persists, ensure the encryption key is valid and properly set.\n\nFor more information, see: https://clerk.com/docs/reference/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_invalid)`;
+export const encryptionKeyMissing =
+  'Clerk: Missing `CLERK_ENCRYPTION_KEY`. Required for propagating `secretKey` middleware option. See docs: https://clerk.com/docs/references/nextjs/clerk-middleware#dynamic-keys. (code=encryption_key_missing)';

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -2,7 +2,6 @@ import type { AuthObject } from '@clerk/backend';
 import type { AuthenticateRequestOptions, ClerkRequest, RequestState } from '@clerk/backend/internal';
 import { constants } from '@clerk/backend/internal';
 import { isDevelopmentFromSecretKey } from '@clerk/shared/keys';
-import { logger } from '@clerk/shared/logger';
 import { isHttpOrHttps } from '@clerk/shared/proxy';
 import { handleValueOrFn, isProductionEnvironment } from '@clerk/shared/utils';
 import { NextResponse } from 'next/server';
@@ -15,6 +14,7 @@ import {
   authSignatureInvalid,
   encryptionKeyInvalid,
   encryptionKeyInvalidDev,
+  encryptionKeyMissing,
   missingDomainAndProxy,
   missingSignInUrlInDev,
 } from './errors';
@@ -200,12 +200,7 @@ export function encryptClerkRequestData(
   }
 
   if (requestData.secretKey && !ENCRYPTION_KEY) {
-    // TODO SDK-1833: change this to an error in the next major version of `@clerk/nextjs`
-    logger.warnOnce(
-      'Clerk: Missing `CLERK_ENCRYPTION_KEY`. Required for propagating `secretKey` middleware option. See docs: https://clerk.com/docs/reference/nextjs/clerk-middleware#dynamic-keys',
-    );
-
-    return;
+    throw new Error(encryptionKeyMissing);
   }
 
   const maybeKeylessEncryptionKey = isProductionEnvironment()


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
When passing a secret key at runtime to `clerkMiddleware()`, we need a stable encryption key to safely pass the value from the middleware to the application server. Previously, we avoided throwing an error to prevent a breaking change. Now that we're releasing a major, we are changing this to throw an error.

<!-- Fixes #(issue number) -->
fixes USER-3057

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
