### PR TITLE
chore(repo): add commit message rules to cursor config

### DIFF
--- a/.cursor/rules/monorepo.mdc
+++ b/.cursor/rules/monorepo.mdc
@@ -103,3 +103,11 @@ Release Management
 - Canary and snapshot releases for testing
 - Git tags and GitHub releases for version tracking
 - Coordinated releases to maintain compatibility between packages
+
+Commit Messages
+
+- Commit messages must follow the conventional commit format using lowercase
+- Commit messages must be in English
+- Commit messages must be concise and to the point
+- Commit messages must be prefixed with the type of change
+- Commit messages must be prefixed with the scope of the change (package name or `js` for `clekr-js`, repo, release, e2e, \*)


### PR DESCRIPTION
these only affect commit messages made by the agent, not the sparkle button in cursor

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
