### PR TITLE
chore(repo): Remove channel variant bundlewatch config

### DIFF
--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -2,7 +2,6 @@
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "538KB" },
     { "path": "./dist/clerk.browser.js", "maxSize": "63KB" },
-    { "path": "./dist/clerk.channel.browser.js", "maxSize": "64KB" },
     { "path": "./dist/clerk.chips.browser.js", "maxSize": "63KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "105KB" },
     { "path": "./dist/clerk.no-rhc.js", "maxSize": "305KB" },


### PR DESCRIPTION
## Description

This variant is no longer

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
