### PR TITLE
ci(repo): update base branch references for release/core-2

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/main",
+  "baseBranch": "origin/release/core-2",
   "updateInternalDependencies": "patch",
   "snapshot": {
     "useCalculatedVersion": true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             echo 'Skipping';
             exit 0;
           else
-            pnpm changeset status --since=origin/main;
+            pnpm changeset status --since=origin/release/core-2;
           fi
 
   build-packages:


### PR DESCRIPTION
- Set changesets baseBranch to origin/release/core-2
- Update CI changeset status check to use release/core-2

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration and CI workflow settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->