### PR TITLE
Remove duplicate 'colorForeground' entry

### DIFF
--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -167,7 +167,6 @@ function appearanceVariableOptions() {
     'colorDanger',
     'colorSuccess',
     'colorWarning',
-    'colorForeground',
     'colorMutedForeground',
     'colorInputForeground',
     'colorInput',


### PR DESCRIPTION
variableInputIds [] incorrectly contained two (2) redundant entries for 'colorForeground'.

Was: 

```
  const variableInputIds = [
    'colorPrimary',
    'colorNeutral',
    'colorBackground',
    'colorPrimaryForeground',
    'colorForeground', <-----------------------------
    'colorDanger',
    'colorSuccess',
    'colorWarning',
    'colorForeground', <-----------------------------
    'colorMutedForeground',
    'colorInputForeground',
    'colorInput',
    'colorShimmer',
    'spacing',
    'borderRadius',
  ] as const;
```

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed colorForeground from appearance customization options, preventing it from being included in appearance-related input controls and configuration updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->