### PR TITLE
fix(ui): Prevent reset password submission if passwords don't match

### DIFF
--- a/.changeset/busy-snakes-pump.md
+++ b/.changeset/busy-snakes-pump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix issue where the reset password form could be submitted via the enter key even when the confirmation password didn't match.

--- a/packages/ui/src/components/SessionTasks/tasks/TaskResetPassword/index.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskResetPassword/index.tsx
@@ -75,7 +75,7 @@ const TaskResetPasswordInternal = () => {
 
   const resetPassword = () => {
     return card.runAsync(async () => {
-      if (!clerk.user) {
+      if (!canSubmit || !clerk.user) {
         return;
       }
 

--- a/packages/ui/src/components/SignIn/ResetPassword.tsx
+++ b/packages/ui/src/components/SignIn/ResetPassword.tsx
@@ -71,6 +71,10 @@ const ResetPasswordInternal = () => {
   };
 
   const resetPassword = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
     passwordField.clearFeedback();
     confirmField.clearFeedback();
     try {

--- a/packages/ui/src/components/UserProfile/PasswordForm.tsx
+++ b/packages/ui/src/components/UserProfile/PasswordForm.tsx
@@ -108,6 +108,10 @@ export const PasswordForm = withCardStateProvider((props: PasswordFormProps) => 
   };
 
   const updatePassword = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
     try {
       successPagePropsRef.current = {
         title: user.passwordEnabled


### PR DESCRIPTION
## Description

This PR fixes an issue where pressing the enter key in a reset password form would submit the form even when the confirmation password didn't match. This is because the first submit button in the form (rendered by the form primitive) is not disabled. This PR fixes the issue by returning early from the form `onSubmit` handler if `canSubmit` is false. A follow up would be to pass the `canSubmit` prop to the `Form.Root` so that it can correctly label its first submit button as disabled, which prevents the UA from submitting the form when the enter key is pressed.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed password reset and password update forms to properly block submission when password validation fails, preventing forms from being submitted when the new password and confirmation fields do not match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->