### PR TITLE
test(testing,ui): Add Client Trust tests; Handle two factor attempt/prepare

### DIFF
--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -204,6 +204,12 @@ const withProtectService = base
   .setEnvVariable('private', 'CLERK_SECRET_KEY', instanceKeys.get('with-protect-service').sk)
   .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', instanceKeys.get('with-protect-service').pk);
 
+const withNeedsClientTrust = base
+  .clone()
+  .setId('withNeedsClientTrust')
+  .setEnvVariable('private', 'CLERK_SECRET_KEY', instanceKeys.get('with-needs-client-trust').sk)
+  .setEnvVariable('public', 'CLERK_PUBLISHABLE_KEY', instanceKeys.get('with-needs-client-trust').pk);
+
 export const envs = {
   base,
   sessionsProd1,
@@ -223,6 +229,7 @@ export const envs = {
   withEmailLinks,
   withKeyless,
   withLegalConsent,
+  withNeedsClientTrust,
   withRestrictedMode,
   withReverification,
   withSessionTasks,

--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -32,6 +32,7 @@ export const createLongRunningApps = () => {
     { id: 'next.appRouter.withSessionTasks', config: next.appRouter, env: envs.withSessionTasks },
     { id: 'next.appRouter.withSessionTasksResetPassword', config: next.appRouter, env: envs.withSessionTasksResetPassword },
     { id: 'next.appRouter.withLegalConsent', config: next.appRouter, env: envs.withLegalConsent },
+    { id: 'next.appRouter.withNeedsClientTrust', config: next.appRouter, env: envs.withNeedsClientTrust },
 
     /**
      * Quickstart apps

--- a/integration/tests/client-trust.test.ts
+++ b/integration/tests/client-trust.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+import { appConfigs } from '../presets';
+import type { FakeUser } from '../testUtils';
+import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+
+testAgainstRunningApps({ withEnv: [appConfigs.envs.withNeedsClientTrust] })(
+  'client trust flow @generic @nextjs',
+  ({ app }) => {
+    test.describe.configure({ mode: 'serial' });
+
+    let fakeUser: FakeUser;
+
+    test.beforeAll(async () => {
+      const u = createTestUtils({ app });
+      fakeUser = u.services.users.createFakeUser();
+      await u.services.users.createBapiUser(fakeUser);
+    });
+
+    test.afterAll(async () => {
+      await fakeUser.deleteIfExists();
+      await app.teardown();
+    });
+
+    test('sign in with email and password results in needs_client_trust', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      // Sign in with a new device
+      await u.po.signIn.goTo();
+      await u.po.signIn.setIdentifier(fakeUser.email);
+      await u.po.signIn.continue();
+      await u.po.signIn.setPassword(fakeUser.password);
+      await u.po.signIn.continue();
+
+      // After password is correctly entered, should navigate to client-trust route
+      // This verifies that the sign-in status is 'needs_client_trust'
+      await u.page.waitForURL(/\/sign-in\/client-trust/);
+
+      // Should contain the new device verification notice
+      await expect(u.page.getByText("You're signing in from a new device.")).toBeVisible();
+
+      // User should not be signed in yet since client trust step is required
+      await u.po.expect.toBeSignedOut();
+
+      await u.po.signIn.enterTestOtpCode();
+      await u.po.expect.toBeSignedIn();
+
+      await u.po.userButton.toggleTrigger();
+      await u.po.userButton.waitForPopover();
+      await u.po.userButton.triggerSignOut();
+
+      await u.po.expect.toBeSignedOut();
+
+      await u.po.signIn.goTo();
+      await u.po.signIn.signInWithEmailAndInstantPassword({
+        email: fakeUser.email,
+        password: fakeUser.password,
+      });
+
+      // Sign in again with a now "known" device
+      await u.po.expect.toBeSignedIn();
+    });
+  },
+);

--- a/packages/testing/src/playwright/unstable/page-objects/common.ts
+++ b/packages/testing/src/playwright/unstable/page-objects/common.ts
@@ -33,7 +33,9 @@ export const common = ({ page }: { page: EnhancedPage }) => {
         const prepareVerificationPromise = page.waitForResponse(
           response =>
             response.request().method() === 'POST' &&
-            (response.url().includes('prepare_verification') || response.url().includes('prepare_first_factor')),
+            (response.url().includes('prepare_verification') ||
+              response.url().includes('prepare_first_factor') ||
+              response.url().includes('prepare_second_factor')),
         );
         await prepareVerificationPromise;
       }
@@ -52,7 +54,9 @@ export const common = ({ page }: { page: EnhancedPage }) => {
         const attemptVerificationPromise = page.waitForResponse(
           response =>
             response.request().method() === 'POST' &&
-            (response.url().includes('attempt_verification') || response.url().includes('attempt_first_factor')),
+            (response.url().includes('attempt_verification') ||
+              response.url().includes('attempt_first_factor') ||
+              response.url().includes('attempt_second_factor')),
         );
         await attemptVerificationPromise;
       }


### PR DESCRIPTION
## Description

Adds E2E integration tests for the `needs_client_trust` sign-in status.

Also, adds support for awaiting `prepare_second_factor` and `attempt_second_factor` requests while using `enterOtpCode(...)`.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
