### PR TITLE
fix(clerk-js): Await the navigation on password sign-in completion

### DIFF
--- a/.changeset/green-books-lick.md
+++ b/.changeset/green-books-lick.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix navigation that was not awaited when attempting to set the session active on password sign-in

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -79,7 +79,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
             return setActive({
               session: res.createdSessionId,
               navigate: ({ session }) => {
-                void navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
+                return navigateOnSetActive({ session, redirectUrl: afterSignInUrl });
               },
             });
           case 'needs_second_factor':


### PR DESCRIPTION
## Description

Port of #7443 to Core 2

This fixes a previously introduced bug that was not awaiting the navigateOnSetActive in setActive called on password submit on sign-in. 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
