### PR TITLE
fix(tanstack-react-start): Fix navigation promise resolving too early

### DIFF
--- a/.changeset/mighty-hands-crash.md
+++ b/.changeset/mighty-hands-crash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/tanstack-react-start': patch
+---
+
+Fix navigation edge case where the new auth state would sometimes be applied before the navigation finished.


### PR DESCRIPTION
## Description

While debugging why the TanStack Start tests were failing in my branch that refactors to `useSyncExternalStore` I found that the `useAwaitableNavigate` was resolving before the navigation finished. This combined with timing changes in my branch that _should_ have been inconsequential, were breaking the tests.

I am still not a 100% sure of the reason. This PR essentially turns this:

```
res(navigate(options));
```

to this:

```
navigate(options).then(res);
```

which fixes the tests, but since `await` unwraps nested promises, the original code _should_ have been working. This might be a timing thing where the extra `.then` makes things resolve slightly later. 🤔 I will try to get to the bottom of this.

I also removed the `startTransition` that wraps the whole thing, because I did not see the point of it. Using a transition or not for the navigation should be a framework level concern, not a Clerk one. I'd be happy for pushback on this decision, but from my (albeit somewhat limited) testing, things seem to behave the same way before and after.

The reason removing `startTransition` might be important (now or in the future) is that if the framework wants to do something synchronously before the transition starts, it currently can't since we are wrapping it.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a navigation edge case where authentication state updates could be applied before navigation completed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->