### PR TITLE
chore(repo): Use GITHUB_TOKEN in lock-threads workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/stale@v9
         name: Regular stale action
         with:
-          repo-token: ${{ secrets.CLERK_COOKIE_PAT }}
           days-before-issue-stale: 30
           days-before-pr-stale: 50
           days-before-issue-close: 10
@@ -61,7 +60,6 @@ jobs:
       - uses: actions/stale@v9
         name: Stale action for needs-reproduction issues
         with:
-          repo-token: ${{ secrets.CLERK_COOKIE_PAT }}
           days-before-issue-stale: 7
           days-before-issue-close: 1
           exempt-all-assignees: true
@@ -78,7 +76,6 @@ jobs:
             After 8 days without a reproduction being supplied, we are closing this issue. Keep in mind, I'm just a robot, so if I've closed this issue in error, please reply here and my human colleagues will reopen it. Likewise if a reproduction is prepared after it has been closed.
       - uses: dessant/lock-threads@v4
         with:
-          github-token: ${{ secrets.CLERK_COOKIE_PAT }}
           issue-inactive-days: '365'
           issue-comment: 'This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.'
           process-only: 'issues'


### PR DESCRIPTION
## Description

Both `lock-threads` and `stale` actions will read the `GITHUB_TOKEN` when we don't give one explicitely.

- https://github.com/actions/stale
- https://github.com/dessant/lock-threads

This reduces usage of long-lived tokens and reduces attack surface should those actions be compromised one day.

We already give `write` permission for both `issues` and `pull-requests` in the workflow so that doesn't need to change.

Related to SEC-223

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified authentication in automated workflows by removing explicit credential inputs and relying on default/implicit authentication.
  * Reduced exposed configuration surface in CI processes and standardized credential handling to streamline maintenance and improve security posture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->