### PR TITLE
chore(repo): Limit GITHUB_TOKEN for pr-title-linter workflow

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -10,6 +10,9 @@ on:
       - opened
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   pr-title-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Sets maximum permissions for the workflow. `pull-requests: read` is not needed even if this workflow acts on the PR. `github.event.pull_request.title` remains accessible, it's just the API calls that would fail if there were any.

Resolves https://github.com/clerk/javascript/security/code-scanning/188  
Related to SEC-217

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to grant read access to repository contents so automated checks can inspect needed files; no other workflow steps or triggers were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->