### PR TITLE
fix(repo): Skip husky in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,16 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: "ci(repo): Version packages (Core 3)"
-          title: "ci(repo): Version packages (Core 3)"
+          commit: 'ci(repo): Version packages (Core 3)'
+          title: 'ci(repo): Version packages (Core 3)'
           publish: pnpm turbo build $TURBO_ARGS --force && pnpm release
           # Workaround for https://github.com/changesets/changesets/issues/421
           version: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.CLERK_COOKIE_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: '0'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Trigger workflows on related repos
@@ -138,12 +139,12 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
-          filter: "blob:none"
+          filter: 'blob:none'
           show-progress: false
 
       - name: Cache node_modules (Node v${{ matrix.version }})
         uses: ./.github/actions/init
         with:
           node-version: ${{ matrix.version }}
-          turbo-team: ""
-          turbo-token: ""
+          turbo-team: ''
+          turbo-token: ''


### PR DESCRIPTION
## Description

Skip Husky in CI. We are running lint-staged during release commits, which could stop the commit

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration and environment settings to improve build reliability and deployment consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->