### PR TITLE
feat(backend): Mark setPasswordCompromised and unsetPasswordCompromised as stable

### DIFF
--- a/.changeset/curly-hornets-argue.md
+++ b/.changeset/curly-hornets-argue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Dropping the `__experimental_` prefix from `setPasswordCompromised` and `unsetPasswordCompromised` and marking them as stable

--- a/integration/testUtils/usersService.ts
+++ b/integration/testUtils/usersService.ts
@@ -237,7 +237,7 @@ export const createUserService = (clerkClient: ClerkClient) => {
       } satisfies FakeAPIKey;
     },
     setPasswordCompromised: async (userId: string) => {
-      await clerkClient.users.__experimental_setPasswordCompromised(userId);
+      await clerkClient.users.setPasswordCompromised(userId);
     },
   };
 

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -452,7 +452,7 @@ export class UserAPI extends AbstractAPI {
     });
   }
 
-  public async __experimental_setPasswordCompromised(
+  public async setPasswordCompromised(
     userId: string,
     params: SetPasswordCompromisedParams = {
       revokeAllSessions: false,
@@ -466,7 +466,7 @@ export class UserAPI extends AbstractAPI {
     });
   }
 
-  public async __experimental_unsetPasswordCompromised(userId: string) {
+  public async unsetPasswordCompromised(userId: string) {
     this.requireId(userId);
     return this.request<User>({
       method: 'POST',


### PR DESCRIPTION
## Description

This PR drops __experimental prefix from `setPasswordCompromised` and `unsetPasswordCompromised` and marks them as stable

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password compromise management functions (setPasswordCompromised / unsetPasswordCompromised) are promoted from experimental to stable public APIs.
* **Chores**
  * Backend package patched to a new patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->