### PR TITLE
feat(clerk-js,nextjs,shared): Add unsafe_disableDevelopmentModeConsoleWarning

### DIFF
--- a/.changeset/fluffy-rocks-shake.md
+++ b/.changeset/fluffy-rocks-shake.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/nextjs': minor
+'@clerk/shared': minor
+---
+
+Add `unsafe_disableDevelopmentModeConsoleWarning` option to disable the development mode warning that's emitted to the console when Clerk is first loaded.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -450,7 +450,7 @@ export class Clerk implements ClerkInterface {
     }
 
     // Log a development mode warning once
-    if (this.#instanceType === 'development') {
+    if (this.#instanceType === 'development' && !options?.unsafe_disableDevelopmentModeConsoleWarning) {
       logger.warnOnce(
         'Clerk: Clerk has been loaded with development keys. Development instances have strict usage limits and should not be used when deploying your application to production. Learn more: https://clerk.com/docs/deployments/overview',
       );

--- a/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
+++ b/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
@@ -31,5 +31,8 @@ export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, '
       debug: isTruthy(process.env.NEXT_PUBLIC_CLERK_TELEMETRY_DEBUG),
     },
     sdkMetadata: SDK_METADATA,
+    unsafe_disableDevelopmentModeConsoleWarning: isTruthy(
+      process.env.NEXT_PUBLIC_CLERK_UNSAFE_DISABLE_DEVELOPMENT_MODE_CONSOLE_WARNING,
+    ),
   };
 };

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -1056,6 +1056,10 @@ type ClerkOptionsNavigation =
       routerDebug?: boolean;
     };
 
+type ClerkUnsafeOptions = {
+  unsafe_disableDevelopmentModeConsoleWarning?: boolean;
+};
+
 export type ClerkOptions = ClerkOptionsNavigation &
   SignInForceRedirectUrl &
   SignInFallbackRedirectUrl &
@@ -1063,7 +1067,8 @@ export type ClerkOptions = ClerkOptionsNavigation &
   SignUpFallbackRedirectUrl &
   NewSubscriptionRedirectUrl &
   AfterSignOutUrl &
-  AfterMultiSessionSingleSignOutUrl & {
+  AfterMultiSessionSingleSignOutUrl &
+  ClerkUnsafeOptions & {
     /**
      * Clerk UI entrypoint.
      */


### PR DESCRIPTION
## Description

This is a reimplementation of a portion of #4951 (thanks @brkalow!). It adds a new `unsafe_disableDevelopmentModeConsoleWarning` option to `ClerkOptions` that disables the development mode warning that's emitted to the console when Clerk is first loaded. It's also supported via the `CLERK_UNSAFE_DISABLE_DEVELOPMENT_MODE_CONSOLE_WARNING` environment variable. Currently this PR supports the environment variable in Next.js (via `NEXT_PUBLIC_CLERK_UNSAFE_DISABLE_DEVELOPMENT_MODE_CONSOLE_WARNING`); support in other SDKs will be added in a later PR.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `unsafe_disableDevelopmentModeConsoleWarning` configuration option to suppress Clerk's development-mode console warnings. Developers can now control console output during development, which helps reduce noise in development environments. This option is available across all Clerk packages and can be configured via environment variables or during Clerk initialization for greater flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->