### PR TITLE
fix: replace cookie with cookie-es to fix Vite ESM compatibility

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@clerk/shared": "workspace:^",
-    "cookie": "1.0.2",
+    "cookie-es": "^1.3.1",
     "standardwebhooks": "^1.0.0",
     "tslib": "catalog:repo"
   },

--- a/packages/backend/src/tokens/clerkRequest.ts
+++ b/packages/backend/src/tokens/clerkRequest.ts
@@ -1,4 +1,4 @@
-import { parse } from 'cookie';
+import { parse } from 'cookie-es';
 
 import { constants } from '../constants';
 import type { ClerkUrl } from './clerkUrl';


### PR DESCRIPTION
## Summary

Fixes #7522 
Fixes #7453

This PR replaces the `cookie` package with `cookie-es` in `@clerk/backend` to fix ESM compatibility issues in Vite environments.

## Problem

When using `@clerk/tanstack-react-start` (or any Clerk package that depends on `@clerk/backend`) in Vite dev mode, users encounter this error:

```
The requested module '/node_modules/.pnpm/cookie@1.0.2/node_modules/cookie/dist/index.js'
does not provide an export named 'parse'
```

This happens because:
1. The `cookie` package uses CommonJS-style exports that don't work well with Vite's ESM transformations
2. Vite's dev mode tries to use named imports (`import { parse } from 'cookie'`) but the package doesn't properly expose them in ESM environments
3. This only affects development - production builds work fine because they're fully bundled

### Current Workarounds

Users had to add Vite config workarounds:
```ts
// vite.config.ts
export default {
  optimizeDeps: {
    include: ["cookie"]
  }
}
```

Or use dynamic imports to avoid pulling server modules into client bundles.

## Solution

Replace `cookie` with `cookie-es`:

- **`cookie-es`** is a modern, ESM-first package
- Provides the exact same API as `cookie`
- Properly exports named exports for ESM environments
- Works seamlessly with Vite and other modern bundlers

### Changes Made

1. **packages/backend/package.json**: Replace `"cookie": "1.0.2"` with `"cookie-es": "^1.3.1"`
2. **packages/backend/src/tokens/clerkRequest.ts**: Update import from `'cookie'` to `'cookie-es'`

## Benefits

✅ **No more Vite configuration required** - Users don't need to add `optimizeDeps` config  
✅ **Same API** - `cookie-es` is a drop-in replacement with identical function signatures  
✅ **Modern ESM support** - Proper ES module exports work correctly in all environments  
✅ **Fixes the root cause** - Rather than working around the bundler, we use a package designed for ESM

## Testing

The `parse` function from `cookie-es` has the same signature and behavior as the one from `cookie`:
- Parses cookie strings into objects
- Handles URL encoding/decoding
- Returns the same data structure

Existing tests should continue to pass without modification.

## Impact

This change affects the `@clerk/backend` package, which is consumed by:
- `@clerk/tanstack-react-start`
- `@clerk/nextjs`
- `@clerk/remix`
- Other server-side Clerk packages

All of these will benefit from improved ESM compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cookie parsing dependency to a more recent version, maintaining compatibility with existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->