### PR TITLE
fix(tanstack-react-start): resolve navigation promise after location change

### DIFF
--- a/.changeset/fix-tanstack-redirect-navigation.md
+++ b/.changeset/fix-tanstack-redirect-navigation.md
@@ -1,0 +1,5 @@
+---
+"@clerk/tanstack-react-start": patch
+---
+
+Fix incorrect redirects when navigating away from sign-in/sign-up pages. The navigation promise is now resolved only after the location actually changes, preventing Clerk from issuing faulty redirects to non-existent pages.

--- a/packages/tanstack-react-start/src/client/useAwaitableNavigate.ts
+++ b/packages/tanstack-react-start/src/client/useAwaitableNavigate.ts
@@ -22,7 +22,7 @@ export const useAwaitableNavigate = () => {
     return new Promise(res => {
       startTransition(() => {
         resolveFunctionsRef.current.push(res);
-        res(navigate(options));
+        navigate(options);
       });
     });
   };


### PR DESCRIPTION
## Summary

Fixes incorrect redirects when navigating away from sign-in/sign-up pages in TanStack React Start applications.

## Problem

When users navigated away from the sign-in page (e.g., clicking "go home" to navigate to `/`), Clerk would issue faulty redirects to non-existent pages like `/login#/?redirect_url=http%3A%2F%2Flocalhost%3A3001%2F`.

The root cause was in `useAwaitableNavigate`: the navigation promise was being resolved immediately (`res(navigate(options))`) before the location actually changed. This happened because:

1. `startTransition` defers the navigation
2. But the promise was resolved immediately on line 25
3. Clerk's redirect logic saw the promise resolve but the location hadn't changed yet
4. Clerk thought navigation "failed" and tried to redirect again

## Solution

Changed line 25 from:
```ts
res(navigate(options));
```

to:
```ts
navigate(options);
```

Now the promise is only resolved after the location actually changes (via the `useEffect` that watches the location), matching the behavior of the React Router implementation.

## Changes

- Modified `packages/tanstack-react-start/src/client/useAwaitableNavigate.ts` to remove premature promise resolution
- Added changeset documenting the fix

## Testing

The fix aligns the TanStack React Start implementation with the proven React Router implementation, which doesn't have this issue.

Fixes #7362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where navigation away from sign-in and sign-up pages would incorrectly redirect to non-existent pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->