### PR TITLE
fix(backend): handle multiple token types in acceptsToken array

### DIFF
--- a/.changeset/fix-multiple-token-types-array.md
+++ b/.changeset/fix-multiple-token-types-array.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Fix token-type-mismatch error when using multiple `acceptsToken` values in `authenticateRequest`. When `acceptsToken` is an array containing both session and machine token types (e.g., `['session_token', 'api_key']`), the function now correctly routes to the appropriate authentication handler based on the actual token type, instead of always treating them as machine tokens.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -788,6 +788,13 @@ export const authenticateRequest: AuthenticateRequest = (async (
     if (acceptsToken === TokenType.SessionToken) {
       return authenticateRequestWithTokenInHeader();
     }
+    // When acceptsToken is an array, route based on the actual token type
+    if (Array.isArray(acceptsToken)) {
+      if (isMachineToken(authenticateContext.tokenInHeader)) {
+        return authenticateMachineRequestWithTokenInHeader();
+      }
+      return authenticateRequestWithTokenInHeader();
+    }
     return authenticateMachineRequestWithTokenInHeader();
   }
 


### PR DESCRIPTION
Fixes token-type-mismatch error when using multiple `acceptsToken` values in `authenticateRequest`.

## Problem

When `acceptsToken` is an array containing both session and machine token types (e.g., `['session_token', 'api_key']`), the function would always route to the machine token authentication handler, causing session tokens to fail with `token-type-mismatch` errors.

### Root Cause

In [request.ts:784-792](https://github.com/clerk/javascript/blob/main/packages/backend/src/tokens/request.ts#L784-L792), the routing logic checked:

```ts
if (authenticateContext.tokenInHeader) {
  if (acceptsToken === 'any') {
    return authenticateAnyRequestWithTokenInHeader();
  }
  if (acceptsToken === TokenType.SessionToken) {  // ❌ FALSE when acceptsToken is an array
    return authenticateRequestWithTokenInHeader();
  }
  return authenticateMachineRequestWithTokenInHeader();  // ❌ Always executed for arrays
}
```

When `acceptsToken` is `['session_token', 'api_key']`, the condition `acceptsToken === TokenType.SessionToken` evaluates to `false` (array !== string), causing all tokens to be routed to `authenticateMachineRequestWithTokenInHeader()`.

## Solution

Added routing logic that checks the actual token type when `acceptsToken` is an array:

```ts
// When acceptsToken is an array, route based on the actual token type
if (Array.isArray(acceptsToken)) {
  if (isMachineToken(authenticateContext.tokenInHeader)) {
    return authenticateMachineRequestWithTokenInHeader();
  }
  return authenticateRequestWithTokenInHeader();
}
```

Now:
- If the token is a machine token (api_key, m2m_token, oauth_token) → routes to machine handler
- Otherwise → routes to session token handler

## Changes

- Modified `authenticateRequest` in `packages/backend/src/tokens/request.ts` to handle array routing correctly
- Added test for `session_token` in array with machine tokens
- Added test for `api_key` in array with `session_token`
- Added changeset for patch release

## Testing

Added two new test cases:
1. ✅ `session_token` is accepted when in array with `api_key`
2. ✅ `api_key` is accepted when in array with `session_token`

Both scenarios now work correctly without token-type-mismatch errors.

Fixes #7520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed authentication routing to properly handle multiple accepted token types (e.g., session tokens and API keys), ensuring the appropriate authentication handler is correctly selected based on the actual token type in use.

## Tests
* Added test coverage for multi-token authentication scenarios, verifying proper token type handling and routing behavior in various combinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->