### PR TITLE
fix(ui): add clerk dependency to redirect effect hooks

### DIFF
--- a/.changeset/fix-signin-signup-redirect-conflict.md
+++ b/.changeset/fix-signin-signup-redirect-conflict.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": patch
+---
+
+Fix redirect conflicts when SignIn and SignUp components are used together on the same page. Added missing dependency arrays to useEffect hooks in redirect functions to prevent unwanted redirects during other component flows.

--- a/packages/ui/src/components/SignIn/index.tsx
+++ b/packages/ui/src/components/SignIn/index.tsx
@@ -41,7 +41,7 @@ function RedirectToSignIn() {
   const clerk = useClerk();
   React.useEffect(() => {
     void clerk.redirectToSignIn();
-  }, []);
+  }, [clerk]);
   return null;
 }
 

--- a/packages/ui/src/components/SignUp/index.tsx
+++ b/packages/ui/src/components/SignUp/index.tsx
@@ -22,7 +22,7 @@ function RedirectToSignUp() {
   const clerk = useClerk();
   React.useEffect(() => {
     void clerk.redirectToSignUp();
-  }, []);
+  }, [clerk]);
   return null;
 }
 


### PR DESCRIPTION
## Summary

Fixes redirect conflicts when SignIn and SignUp components are used together on the same page.

## Problem

When both `<SignIn />` and `<SignUp />` components are rendered on the same page, they interfere with each other's navigation flows, causing unexpected redirects to the Clerk domain.

### Root Cause

The `RedirectToSignIn` and `RedirectToSignUp` components had incomplete dependency arrays in their useEffect hooks:

```tsx
React.useEffect(() => {
  void clerk.redirectToSignUp();
}, []); // ❌ Missing 'clerk' dependency
```

This violates React's exhaustive-deps rule and can cause unpredictable behavior.

## Solution

Added `clerk` to the dependency arrays:

```tsx
React.useEffect(() => {
  void clerk.redirectToSignUp();
}, [clerk]); // ✅ Proper dependency tracking
```

## Changes

- Updated `RedirectToSignIn` in [packages/ui/src/components/SignIn/index.tsx](packages/ui/src/components/SignIn/index.tsx)
- Updated `RedirectToSignUp` in [packages/ui/src/components/SignUp/index.tsx](packages/ui/src/components/SignUp/index.tsx)
- Added changeset for patch release

## Notes

Related to issue #7456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirect conflicts when SignIn and SignUp components are rendered on the same page, preventing unintended redirects during authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->