### PR TITLE
feat(backend): Use milliseconds instead of seconds for M2M token nomenclature

### DIFF
--- a/packages/backend/src/api/endpoints/M2MTokenApi.ts
+++ b/packages/backend/src/api/endpoints/M2MTokenApi.ts
@@ -12,9 +12,13 @@ type CreateM2MTokenParams = {
    */
   machineSecretKey?: string;
   /**
-   * Number of seconds until the token expires.
+   * Number of milliseconds until the token expires.
    *
    * @default null - Token does not expire
+   */
+  millisecondsUntilExpiration?: number | null;
+  /**
+   * @deprecated Use `millisecondsUntilExpiration` instead. This property will be removed in the next major release.
    */
   secondsUntilExpiration?: number | null;
   claims?: Record<string, unknown> | null;
@@ -59,14 +63,14 @@ export class M2MTokenApi extends AbstractAPI {
   }
 
   async createToken(params?: CreateM2MTokenParams) {
-    const { claims = null, machineSecretKey, secondsUntilExpiration = null } = params || {};
+    const { claims = null, machineSecretKey, millisecondsUntilExpiration = null } = params || {};
 
     const requestOptions = this.#createRequestOptions(
       {
         method: 'POST',
         path: basePath,
         bodyParams: {
-          secondsUntilExpiration,
+          millisecondsUntilExpiration,
           claims,
         },
       },


### PR DESCRIPTION
## Description

Related Slack conversation: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1767646570366689

M2M token timestamps are in milliseconds, not seconds. This PR updates the nomenclature to be more clear.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
