### PR TITLE
fix(backend): bundle cookie package to fix cjs/esm issues

### DIFF
--- a/.changeset/rotten-months-repair.md
+++ b/.changeset/rotten-months-repair.md
@@ -1,0 +1,6 @@
+---
+"@clerk/backend": patch
+---
+
+Move cookie to devDependencies and bundle it within @clerk/backend to fix module compatibility problems in TanStack Start apps.
+

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -111,12 +111,12 @@
   "dependencies": {
     "@clerk/shared": "workspace:^",
     "@clerk/types": "workspace:^",
-    "cookie": "1.0.2",
     "standardwebhooks": "^1.0.0",
     "tslib": "catalog:repo"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",
+    "cookie": "1.0.2",
     "msw": "2.11.6",
     "npm-run-all": "^4.1.5",
     "snakecase-keys": "9.0.2",

--- a/packages/backend/tsup.config.ts
+++ b/packages/backend/tsup.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(overrideOptions => {
     bundle: true,
     clean: true,
     minify: false,
-    noExternal: ['snakecase-keys'],
+    noExternal: ['snakecase-keys', 'cookie'],
   };
 
   const esm: Options = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,9 +366,6 @@ importers:
       '@clerk/types':
         specifier: workspace:^
         version: link:../types
-      cookie:
-        specifier: 1.0.2
-        version: 1.0.2
       standardwebhooks:
         specifier: ^1.0.0
         version: 1.0.0
@@ -379,6 +376,9 @@ importers:
       '@edge-runtime/vm':
         specifier: 5.0.0
         version: 5.0.0
+      cookie:
+        specifier: 1.0.2
+        version: 1.0.2
       msw:
         specifier: 2.11.6
         version: 2.11.6(@types/node@24.7.2)(typescript@5.8.3)
@@ -11493,7 +11493,6 @@ packages:
   next@14.2.33:
     resolution: {integrity: sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==}
     engines: {node: '>=18.17.0'}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -15211,10 +15210,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}


### PR DESCRIPTION
Why: CJS cookie package causing module compatibility problems in Astro and TanStack Start
What: Move cookie to devDependencies and bundle with tsup noExternal config

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
