### PR TITLE
feat(localizations): improve fr-FR translations

### DIFF
--- a/.changeset/warm-knives-guess.md
+++ b/.changeset/warm-knives-guess.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Improve French (fr-FR) translations

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -19,7 +19,7 @@ export const frFR: LocalizationResource = {
     action__search: 'Rechercher des clés',
     copySecret: {
       formButtonPrimary__copyAndClose: 'Copier et fermer',
-      formHint: 'Pour des raisons de sécurité, nous ne vous permettrons pas de le consulter à nouveau plus tard.',
+      formHint: 'Pour des raisons de sécurité, nous ne vous permettrons pas de la consulter à nouveau plus tard.',
       formTitle: 'Copiez votre clé API "{{name}}" maintenant',
     },
     createdAndExpirationStatus__expiresOn:
@@ -225,7 +225,7 @@ export const frFR: LocalizationResource = {
   formFieldInputPlaceholder__emailAddress_username: "Nom d'utilisateur ou adresse e-mail",
   formFieldInputPlaceholder__emailAddresses: 'exemple@email.com, exemple2@email.com',
   formFieldInputPlaceholder__firstName: 'Prénom',
-  formFieldInputPlaceholder__lastName: 'Nom de famille',
+  formFieldInputPlaceholder__lastName: 'Nom',
   formFieldInputPlaceholder__organizationDomain: "Domaine de l'organisation",
   formFieldInputPlaceholder__organizationDomainEmailAddress: "Adresse e-mail de l'organisation",
   formFieldInputPlaceholder__organizationName: "Nom de l'organisation",
@@ -238,7 +238,7 @@ export const frFR: LocalizationResource = {
   formFieldLabel__apiKeyDescription: 'Description',
   formFieldLabel__apiKeyExpiration: 'Expiration',
   formFieldLabel__apiKeyName: 'Nom de la clé secrète',
-  formFieldLabel__automaticInvitations: 'Autoriser les invitations automatiques pour ce domaine',
+  formFieldLabel__automaticInvitations: 'Activer les invitations automatiques pour ce domaine',
   formFieldLabel__backupCode: 'Code de récupération',
   formFieldLabel__confirmDeletion: 'Confirmation',
   formFieldLabel__confirmPassword: 'Confirmer le mot de passe',
@@ -247,7 +247,7 @@ export const frFR: LocalizationResource = {
   formFieldLabel__emailAddress_username: "Adresse e-mail ou nom d'utilisateur",
   formFieldLabel__emailAddresses: 'Adresses e-mail',
   formFieldLabel__firstName: 'Prénom',
-  formFieldLabel__lastName: 'Nom de famille',
+  formFieldLabel__lastName: 'Nom',
   formFieldLabel__newPassword: 'Nouveau mot de passe',
   formFieldLabel__organizationDomain: 'Domaine',
   formFieldLabel__organizationDomainDeletePending: 'Supprimer les invitations et suggestions en attente',
@@ -266,7 +266,7 @@ export const frFR: LocalizationResource = {
     action__signOut: 'Déconnexion',
     title: 'Connecté en tant que {{identifier}}',
   },
-  lastAuthenticationStrategy: 'Dernière utilisation',
+  lastAuthenticationStrategy: 'Utilisé la dernière fois',
   maintenanceMode:
     'Nous effectuons des travaux de maintenance, mais ne vous en inquiétez pas, cela ne devrait pas prendre plus de quelques minutes.',
   membershipRole__admin: 'Administrateur',
@@ -353,7 +353,7 @@ export const frFR: LocalizationResource = {
     },
     createDomainPage: {
       subtitle:
-        "Ajoutez le domaine pour le vérifier. Les utilisateurs possédant une adresses e-mail sur ce domaine peuvent rejoindre l'organisation automatiquement ou faire une demande pour y adhérer.",
+        "Ajoutez le domaine pour le vérifier. Les utilisateurs possédant une adresse e-mail sur ce domaine peuvent rejoindre l'organisation automatiquement ou demander à y adhérer.",
       title: 'Ajouter un domaine',
     },
     invitePage: {
@@ -371,7 +371,7 @@ export const frFR: LocalizationResource = {
       activeMembersTab: {
         menuAction__remove: 'Supprimer',
         tableHeader__actions: 'Actions',
-        tableHeader__joined: 'Rejoint',
+        tableHeader__joined: 'Rejoint le',
         tableHeader__role: 'Rôle',
         tableHeader__user: 'Utilisateur',
       },
@@ -379,7 +379,7 @@ export const frFR: LocalizationResource = {
       invitationsTab: {
         autoInvitations: {
           headerSubtitle:
-            "Invitez des utilisateurs en connectant un domaine de messagerie à votre organisation. Toute personne s'inscrivant avec une adresses e-mail sur ce domaine pourra rejoindre l'organisation.",
+            "Invitez des utilisateurs en connectant un domaine de messagerie à votre organisation. Toute personne s'inscrivant avec une adresse e-mail de ce domaine pourra rejoindre l'organisation.",
           headerTitle: 'Invitations automatiques',
           primaryButton: 'Gérer les domaines validés',
         },
@@ -525,7 +525,7 @@ export const frFR: LocalizationResource = {
     personalWorkspace: 'Espace de travail personnel',
     suggestionsAcceptedLabel: "En attente d'acceptation",
   },
-  paginationButton__next: 'Prochain',
+  paginationButton__next: 'Suivant',
   paginationButton__previous: 'Précédent',
   paginationRowText__displaying: 'Affichage',
   paginationRowText__of: 'de',
@@ -601,7 +601,7 @@ export const frFR: LocalizationResource = {
     },
     alternativeMethods: {
       actionLink: "Obtenir de l'aide",
-      actionText: "Aucune de ces méthode d'authentification ?",
+      actionText: 'Aucune de ces méthodes ne fonctionne ?',
       blockButton__backupCode: 'Utiliser un code de récupération',
       blockButton__emailCode: 'Envoyer le code à {{identifier}}',
       blockButton__emailLink: 'Envoyer le lien à {{identifier}}',
@@ -657,7 +657,7 @@ export const frFR: LocalizationResource = {
       formTitle: 'lien de vérification',
       loading: {
         subtitle: 'Vous allez bientôt être redirigé',
-        title: 'Signing in...',
+        title: 'Connexion en cours...',
       },
       resendButton: 'Renvoyer le lien',
       subtitle: 'pour continuer vers {{applicationName}}',
@@ -712,7 +712,7 @@ export const frFR: LocalizationResource = {
     password: {
       actionLink: 'Utiliser une autre méthode',
       subtitle: 'pour continuer vers {{applicationName}}',
-      title: 'Tapez votre mot de passe',
+      title: 'Entrez votre mot de passe',
     },
     passwordCompromised: {
       title: undefined,
@@ -763,7 +763,7 @@ export const frFR: LocalizationResource = {
       },
       subtitle: 'pour continuer vers {{applicationName}}',
       subtitleCombined: undefined,
-      title: "S'identifier",
+      title: 'Se connecter',
       titleCombined: 'Continuer vers {{applicationName}}',
     },
     totpMfa: {
@@ -776,7 +776,7 @@ export const frFR: LocalizationResource = {
       title: 'Se connecter avec Solana',
     },
   },
-  signInEnterPasswordTitle: 'Tapez votre mot de passe',
+  signInEnterPasswordTitle: 'Entrez votre mot de passe',
   signUp: {
     alternativePhoneCodeProvider: {
       resendButton: 'Vous n’avez pas reçu de code ? Renvoyer',
@@ -784,7 +784,7 @@ export const frFR: LocalizationResource = {
       title: 'Vérifiez votre {{provider}}',
     },
     continue: {
-      actionLink: "S'identifier",
+      actionLink: 'Se connecter',
       actionText: 'Vous avez déjà un compte ?',
       subtitle: 'pour continuer vers {{applicationName}}',
       title: 'Remplir les champs manquants',
@@ -816,7 +816,7 @@ export const frFR: LocalizationResource = {
       verifiedSwitchTab: {
         subtitle: "Revenez à l'onglet nouvellement ouvert pour continuer",
         subtitleNewTab: "Revenir à l'onglet précédent pour continuer",
-        title: 'Courriel vérifié avec succès',
+        title: 'E-mail vérifié avec succès',
       },
     },
     enterpriseConnections: {
@@ -852,7 +852,7 @@ export const frFR: LocalizationResource = {
       title: 'Accès restreint',
     },
     start: {
-      actionLink: "S'identifier",
+      actionLink: 'Se connecter',
       actionLink__use_email: 'Utiliser votre adresse e-mail',
       actionLink__use_phone: 'Utiliser votre téléphone',
       actionText: 'Vous avez déjà un compte ?',
@@ -975,7 +975,7 @@ export const frFR: LocalizationResource = {
     passkey_retrieval_cancelled: 'Récupération de la clé de sécurité annulée.',
     passwordComplexity: {
       maximumLength: 'moins de {{length}} caractères',
-      minimumLength: '{{length}} caractères ou plus',
+      minimumLength: 'au moins {{length}} caractères',
       requireLowercase: 'une lettre minuscule',
       requireNumbers: 'un chiffre',
       requireSpecialCharacter: 'un caractère spécial',
@@ -1032,7 +1032,7 @@ export const frFR: LocalizationResource = {
   userButton: {
     action__addAccount: 'Ajouter un compte',
     action__closeUserMenu: 'Fermer le menu utilisateur',
-    action__manageAccount: 'Gérer son compte',
+    action__manageAccount: 'Gérer mon compte',
     action__openUserMenu: 'Ouvrir le menu utilisateur',
     action__signOut: 'Déconnexion',
     action__signOutAll: 'Se déconnecter de tous les comptes',
@@ -1127,7 +1127,7 @@ export const frFR: LocalizationResource = {
         successMessage: '{{connectedAccount}} a été supprimé de votre compte.',
         title: 'Supprimer le compte connecté',
       },
-      socialButtonsBlockButton: 'Connecter {{provider|titleize}} compte',
+      socialButtonsBlockButton: 'Connecter un compte {{provider|titleize}}',
       successMessage: 'Le fournisseur a été ajouté à votre compte',
       title: 'Ajouter un compte connecté',
     },
@@ -1166,11 +1166,11 @@ export const frFR: LocalizationResource = {
         title: "Supprimer l'adresse e-mail",
       },
       title: 'Ajouter une adresse e-mail',
-      verifyTitle: 'Verifier un e-mail',
+      verifyTitle: 'Vérifier un e-mail',
     },
     formButtonPrimary__add: 'Ajouter',
     formButtonPrimary__continue: 'Continuer',
-    formButtonPrimary__finish: 'Retour',
+    formButtonPrimary__finish: 'Terminer',
     formButtonPrimary__remove: 'Supprimer',
     formButtonPrimary__save: 'Sauvegarder',
     formButtonReset: 'Annuler',
@@ -1274,7 +1274,7 @@ export const frFR: LocalizationResource = {
       imageFormTitle: 'Photo de profil',
       readonly:
         "Les informations de votre profil ont été fournies par la connexion d'entreprise et ne peuvent pas être modifiées.",
-      successMessage: 'Votre profil a été mis a jour.',
+      successMessage: 'Votre profil a été mis à jour.',
       title: 'Mettre à jour le profil',
     },
     start: {
@@ -1286,7 +1286,7 @@ export const frFR: LocalizationResource = {
         actionLabel__connectionFailed: 'Réessayer',
         actionLabel__reauthorize: 'Autoriser maintenant',
         destructiveActionTitle: 'Retirer',
-        primaryButton: 'Connecter le compte',
+        primaryButton: 'Connecter un compte',
         subtitle__disconnected: 'Compte déconnecté. Connectez-vous à nouveau pour accéder aux fonctionnalités.',
         subtitle__reauthorize:
           'Les autorisations requises ont été mises à jour, ce qui peut entraîner des fonctionnalités limitées. Veuillez ré-autoriser cette application pour éviter tout problème.',


### PR DESCRIPTION


## Description

🇫🇷  French developer here 👋🏻 , after the integration of Clerk in a new Saas project I've reviewed the current FR translations and did the following to improved them: 
- Fixed untranslated text
- Fixed grammar and typos
- Improved phrasings for more natural French

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Improvements on `localizations` package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced French translations throughout the application with grammatical refinements, improved terminology consistency, and more natural phrasing. Updates include corrections to form labels, placeholder text, status messages, UI action labels, email-related terminology, date headers, and verb forms for a more cohesive user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->