### PR TITLE
fix(clerk-react): Prevent props from leaking to child elements in SignUpButton & SignInButton

### DIFF
--- a/.changeset/true-pans-marry.md
+++ b/.changeset/true-pans-marry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Prevent props from leaking to child elements in SignUpButton & SignInButton

--- a/packages/react/src/components/SignInButton.tsx
+++ b/packages/react/src/components/SignInButton.tsx
@@ -8,6 +8,8 @@ import { withClerk } from './withClerk';
 export const SignInButton = withClerk(
   ({ clerk, children, ...props }: WithClerkProp<React.PropsWithChildren<SignInButtonProps>>) => {
     const {
+      // @ts-expect-error - appearance is a valid prop for SignInProps & SignInButtonPropsModal
+      appearance,
       signUpFallbackRedirectUrl,
       forceRedirectUrl,
       fallbackRedirectUrl,
@@ -33,7 +35,7 @@ export const SignInButton = withClerk(
       };
 
       if (mode === 'modal') {
-        return clerk.openSignIn({ ...opts, appearance: props.appearance });
+        return clerk.openSignIn({ ...opts, appearance });
       }
       return clerk.redirectToSignIn({
         ...opts,

--- a/packages/react/src/components/SignUpButton.tsx
+++ b/packages/react/src/components/SignUpButton.tsx
@@ -8,6 +8,10 @@ import { withClerk } from './withClerk';
 export const SignUpButton = withClerk(
   ({ clerk, children, ...props }: WithClerkProp<React.PropsWithChildren<SignUpButtonProps>>) => {
     const {
+      // @ts-expect-error - appearance is a valid prop for SignUpProps & SignUpButtonPropsModal
+      appearance,
+      // @ts-expect-error - unsafeMetadata is a valid prop for SignUpProps & SignUpButtonPropsModal
+      unsafeMetadata,
       fallbackRedirectUrl,
       forceRedirectUrl,
       signInFallbackRedirectUrl,
@@ -34,8 +38,8 @@ export const SignUpButton = withClerk(
       if (mode === 'modal') {
         return clerk.openSignUp({
           ...opts,
-          appearance: props.appearance,
-          unsafeMetadata: props.unsafeMetadata,
+          appearance,
+          unsafeMetadata,
         });
       }
 

--- a/packages/react/src/components/__tests__/SignInButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignInButton.test.tsx
@@ -105,4 +105,18 @@ describe('<SignInButton/>', () => {
       );
     }).toThrow();
   });
+
+  it('does not pass appearance prop to child element', () => {
+    const { container } = render(
+      <SignInButton
+        mode='modal'
+        appearance={{ elements: { rootBox: 'test' } }}
+      >
+        <button type='button'>Sign in</button>
+      </SignInButton>,
+    );
+
+    const button = container.querySelector('button');
+    expect(button?.hasAttribute('appearance')).toBe(false);
+  });
 });

--- a/packages/react/src/components/__tests__/SignUpButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignUpButton.test.tsx
@@ -109,4 +109,29 @@ describe('<SignUpButton/>', () => {
       );
     }).toThrow();
   });
+
+  it('does not pass unsafeMetadata prop to child element', () => {
+    const { container } = render(
+      <SignUpButton unsafeMetadata={{ customField: 'test' }}>
+        <button type='button'>Sign up</button>
+      </SignUpButton>,
+    );
+
+    const button = container.querySelector('button');
+    expect(button?.hasAttribute('unsafeMetadata')).toBe(false);
+  });
+
+  it('does not pass appearance prop to child element', () => {
+    const { container } = render(
+      <SignUpButton
+        mode='modal'
+        appearance={{ elements: { rootBox: 'test' } }}
+      >
+        <button type='button'>Sign up</button>
+      </SignUpButton>,
+    );
+
+    const button = container.querySelector('button');
+    expect(button?.hasAttribute('appearance')).toBe(false);
+  });
 });


### PR DESCRIPTION
# Fix: Prevent Clerk-specific props from leaking to child elements in button components (Core 2 port of #7588)

## Problem

When passing `unsafeMetadata` or `appearance` props to `SignUpButton` (or `appearance` to `SignInButton`) with a custom child element, these props were incorrectly passed down to the child DOM element via the `rest` spread. This caused React warnings about invalid HTML attributes since these are Clerk-specific props that should not be applied to DOM elements.

## Solution

Destructured `appearance` and `unsafeMetadata` (for `SignUpButton`) and `appearance` (for `SignInButton`) directly in the props destructuring statement. By extracting these props before the `...rest` spread, they are automatically excluded from the props passed to child elements.

Added `@ts-expect-error` comments to handle TypeScript union type limitations, as these props only exist when `mode === 'modal'` according to the `SignUpButtonProps` and `SignInButtonProps` type definitions.

## Changes

- **`SignUpButton.tsx`**: Destructure `appearance` and `unsafeMetadata` from props to prevent them from being passed to child elements
- **`SignInButton.tsx`**: Destructure `appearance` from props to prevent it from being passed to child elements
- **Tests**: Added test cases to verify these props are not leaked to child DOM elements


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
