### PR TITLE
fix(clerk-expo): Resolve Peer Dependency issue for Expo 54 users

### DIFF
--- a/.changeset/friendly-expo-peer-deps.md
+++ b/.changeset/friendly-expo-peer-deps.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Broaden React peer dependency to `^18.0.0 || ^19.0.0` to resolve peer dependency conflicts for Expo 54 users

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -110,8 +110,8 @@
     "expo-local-authentication": ">=13.5.0",
     "expo-secure-store": ">=12.4.0",
     "expo-web-browser": ">=12.5.0",
-    "react": "catalog:peer-react",
-    "react-dom": "catalog:peer-react",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-native": ">=0.73"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Description
Currently React Native Expo users on Expo 54 who try to install clerk with `npm install @clerk/clerk-expo` fail unless they supply --legacy-peer-deps when using npm. 
We have set in our `pnpm-workspace.yaml`:
```
 catalogs:
   peer-react:
     react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
     react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
```
But Expo 54 expects react 19.1.0, and although you could change that, expo will then warn you to run npx expo install --fix, which will revert your react version to 19.1.0....

**But React 19.1.0 is unsafe!!** , Expo says, not for us:
[https://expo.dev/changelog/mitigating-critical-security-vulnerability-in-react-server-components
](https://expo.dev/changelog/mitigating-critical-security-vulnerability-in-react-server-components
)

I see two paths forward. We document well, and tell users it is safe to force legacy peer dependency resolution, or we can loosen the peer dependencies versions react-native. Not really sure if this is done in other places but possibly overriding that peer-react for react-native like:
```
 catalogs:
   peer-react:
     react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
     react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
   peer-react-native:  # adjusted for client-only Expo apps
     react: ^18.0.0 || ~19.0.0 || ~19.1.0 || ~19.2.0 || ~19.3.0-0
```
Expo package then sets:
```
"peerDependencies": {
   "react": "catalog:peer-react-native",
   "react-dom": "catalog:peer-react-native",
   ...
 }
 ```

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened React compatibility to explicitly support React 18 and React 19 in the Expo package peer dependencies.
  * Added a patch changeset to document and release this compatibility update for the Expo package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->