### PR TITLE
feat(backend): Add OauthAccessToken idToken member

### DIFF
--- a/.changeset/oauth-idtoken-member.md
+++ b/.changeset/oauth-idtoken-member.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": patch
+---
+
+Add optional `idToken` member to `OauthAccessToken` returned by `getUserOauthAccessToken`. The ID token is retrieved from OIDC providers and is only present for OIDC-compliant OAuth 2.0 providers when available.

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -316,6 +316,8 @@ export interface OauthAccessTokenJSON {
   // Only set in OAuth 1.0 tokens
   token_secret?: string;
   expires_at?: number;
+  // Only present for OIDC-compliant OAuth 2.0 providers when available
+  id_token?: string;
 }
 
 export interface OAuthApplicationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/OauthAccessToken.ts
+++ b/packages/backend/src/api/resources/OauthAccessToken.ts
@@ -10,6 +10,11 @@ export class OauthAccessToken {
     readonly scopes?: string[],
     readonly tokenSecret?: string,
     readonly expiresAt?: number,
+    /**
+     * The ID token retrieved from the OIDC provider.
+     * Only present for OIDC-compliant OAuth 2.0 providers when available.
+     */
+    readonly idToken?: string,
   ) {}
 
   static fromJSON(data: OauthAccessTokenJSON) {
@@ -22,6 +27,7 @@ export class OauthAccessToken {
       data.scopes,
       data.token_secret,
       data.expires_at,
+      data.id_token,
     );
   }
 }


### PR DESCRIPTION
_Core-2 PR for #7583_

## Description

Adds an optional `idToken` member to the `OauthAccessToken` object returned by `getUserOauthAccessToken`. This `idToken` represents the ID token retrieved from OIDC providers, and is only present for OIDC-compliant OAuth 2.0 providers when available.

This change involves:
- Adding `id_token?: string` to the `OauthAccessTokenJSON` interface in `JSON.ts`.
- Adding `idToken?: string` to the `OauthAccessToken` class constructor and updating the `fromJSON` method in `OauthAccessToken.ts`.
- Adding JSDoc comments for the new `idToken` property.

### API Changes

- https://github.com/clerk/clerk_go/pull/15739
- https://github.com/clerk/clerk_go/pull/15842

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

---
<a href="https://cursor.com/background-agent?bcId=bc-a21ca33e-b4ce-4d20-8348-faea32a1125f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a21ca33e-b4ce-4d20-8348-faea32a1125f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth access tokens now optionally include ID tokens from OpenID Connect-compliant providers. When available from your OAuth provider, the ID token delivers additional user identity information for enhanced security and user verification. This is only included when your provider supports OpenID Connect and returns an ID token in the response.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->