### PR TITLE
fix(shared): prevent prototype pollution in deep merge utilities (backport #7621)

### DIFF
--- a/.changeset/secure-foxes-guard.md
+++ b/.changeset/secure-foxes-guard.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix prototype pollution vulnerability in `fastDeepMergeAndReplace` and `fastDeepMergeAndKeep` utilities by blocking dangerous keys (`__proto__`, `constructor`, `prototype`) during object merging.

--- a/packages/shared/src/__tests__/fastDeepMerge.spec.ts
+++ b/packages/shared/src/__tests__/fastDeepMerge.spec.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { fastDeepMergeAndKeep, fastDeepMergeAndReplace } from '../utils/fastDeepMerge';
+
+// Helper to clean up any accidental prototype pollution during tests
+afterEach(() => {
+  // @ts-expect-error - cleaning up potential pollution
+  delete Object.prototype.polluted;
+  // @ts-expect-error - cleaning up potential pollution
+  delete Object.prototype.isAdmin;
+});
 
 describe('fastDeepMergeReplace', () => {
   it('merges simple objects', () => {
@@ -59,5 +67,101 @@ describe('fastDeepMergeKeep', () => {
     const target = { a: '10', obj: { a: '10', b: '20' } };
     fastDeepMergeAndKeep(source, target);
     expect(target).toEqual({ a: '10', b: '2', c: '3', obj: { a: '10', b: '20' } });
+  });
+});
+
+describe('prototype pollution prevention', () => {
+  describe('fastDeepMergeAndReplace', () => {
+    it('should not pollute Object.prototype via __proto__', () => {
+      const payload = JSON.parse('{"__proto__": {"polluted": "true"}}');
+      const target = {};
+
+      fastDeepMergeAndReplace(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+      // @ts-expect-error - checking for pollution
+      expect({}.polluted).toBeUndefined();
+    });
+
+    it('should not pollute via constructor.prototype', () => {
+      const payload = { constructor: { prototype: { isAdmin: true } } };
+      const target = {};
+
+      fastDeepMergeAndReplace(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.isAdmin).toBeUndefined();
+      // @ts-expect-error - checking for pollution
+      expect({}.isAdmin).toBeUndefined();
+    });
+
+    it('should not pollute via nested __proto__', () => {
+      const payload = JSON.parse('{"nested": {"__proto__": {"polluted": "nested"}}}');
+      const target = { nested: {} };
+
+      fastDeepMergeAndReplace(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+    });
+
+    it('should still merge safe keys normally', () => {
+      const payload = JSON.parse('{"__proto__": {"polluted": "true"}, "safe": "value"}');
+      const target = {};
+
+      fastDeepMergeAndReplace(payload, target);
+
+      expect(target).toEqual({ safe: 'value' });
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+    });
+  });
+
+  describe('fastDeepMergeAndKeep', () => {
+    it('should not pollute Object.prototype via __proto__', () => {
+      const payload = JSON.parse('{"__proto__": {"polluted": "true"}}');
+      const target = {};
+
+      fastDeepMergeAndKeep(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+      // @ts-expect-error - checking for pollution
+      expect({}.polluted).toBeUndefined();
+    });
+
+    it('should not pollute via constructor.prototype', () => {
+      const payload = { constructor: { prototype: { isAdmin: true } } };
+      const target = {};
+
+      fastDeepMergeAndKeep(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.isAdmin).toBeUndefined();
+      // @ts-expect-error - checking for pollution
+      expect({}.isAdmin).toBeUndefined();
+    });
+
+    it('should not pollute via nested __proto__', () => {
+      const payload = JSON.parse('{"nested": {"__proto__": {"polluted": "nested"}}}');
+      const target = { nested: {} };
+
+      fastDeepMergeAndKeep(payload, target);
+
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+    });
+
+    it('should still merge safe keys normally', () => {
+      const payload = JSON.parse('{"__proto__": {"polluted": "true"}, "safe": "value"}');
+      const target = {};
+
+      fastDeepMergeAndKeep(payload, target);
+
+      expect(target).toEqual({ safe: 'value' });
+      // @ts-expect-error - checking for pollution
+      expect(Object.prototype.polluted).toBeUndefined();
+    });
   });
 });

--- a/packages/shared/src/utils/fastDeepMerge.ts
+++ b/packages/shared/src/utils/fastDeepMerge.ts
@@ -1,3 +1,6 @@
+// Keys that could lead to prototype pollution attacks
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Merges 2 objects without creating new object references
  * The merged props will appear on the `target` object
@@ -12,6 +15,10 @@ export const fastDeepMergeAndReplace = (
   }
 
   for (const key in source) {
+    // Skip dangerous keys to prevent prototype pollution
+    if (DANGEROUS_KEYS.has(key)) {
+      continue;
+    }
     if (Object.prototype.hasOwnProperty.call(source, key) && source[key] !== null && typeof source[key] === `object`) {
       if (target[key] === undefined) {
         target[key] = new (Object.getPrototypeOf(source[key]).constructor)();
@@ -32,6 +39,10 @@ export const fastDeepMergeAndKeep = (
   }
 
   for (const key in source) {
+    // Skip dangerous keys to prevent prototype pollution
+    if (DANGEROUS_KEYS.has(key)) {
+      continue;
+    }
     if (Object.prototype.hasOwnProperty.call(source, key) && source[key] !== null && typeof source[key] === `object`) {
       if (target[key] === undefined) {
         target[key] = new (Object.getPrototypeOf(source[key]).constructor)();


### PR DESCRIPTION
## Summary

Backport of #7621 to `release/core-2`.

- Add safeguards to `fastDeepMergeAndReplace` and `fastDeepMergeAndKeep` to skip dangerous keys (`__proto__`, `constructor`, `prototype`) during object merging
- Add comprehensive tests for prototype pollution prevention

This fixes a security vulnerability (SEC-252) where malicious input passed through appearance configurations or localization settings could modify `Object.prototype`, potentially causing denial of service or application manipulation.