### PR TITLE
feat(ui): Special handling of offline_access scope in OAuth Consent screen

### DIFF
--- a/.changeset/quiet-dolphins-swim.md
+++ b/.changeset/quiet-dolphins-swim.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Handle `offline_access` scope in OAuth consent screen by filtering it from the displayed scopes list (as it describes access duration rather than what can be accessed) and appending informational text about staying signed in when the scope is present.

--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -333,7 +333,8 @@ void (async () => {
       const searchParams = new URLSearchParams(window.location.search);
       const scopes = (searchParams.get('scopes')?.split(',') ?? []).map(scope => ({
         scope,
-        description: `Grants access to your ${scope}`,
+        description: scope === 'offline_access' ? null : `Grants access to your ${scope}`,
+        requires_consent: true,
       }));
       Clerk.__internal_mountOAuthConsent(
         app,

--- a/packages/clerk-js/src/ui/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/clerk-js/src/ui/components/OAuthConsent/OAuthConsent.tsx
@@ -16,6 +16,8 @@ import type { ThemableCssProp } from '@/ui/styledSystem';
 import { common } from '@/ui/styledSystem';
 import { colors } from '@/ui/utils/colors';
 
+const OFFLINE_ACCESS_SCOPE = 'offline_access';
+
 export function OAuthConsentInternal() {
   const { scopes, oAuthApplicationName, oAuthApplicationLogoUrl, oAuthApplicationUrl, redirectUrl, onDeny, onAllow } =
     useOAuthConsentContext();
@@ -24,6 +26,10 @@ export function OAuthConsentInternal() {
   const [isUriModalOpen, setIsUriModalOpen] = useState(false);
 
   const primaryEmailAddress = user?.emailAddresses.find(email => email.id === user.primaryEmailAddress?.id);
+
+  // Filter out offline_access from displayed scopes as it doesn't describe what can be accessed
+  const displayedScopes = (scopes || []).filter(item => item.scope !== OFFLINE_ACCESS_SCOPE);
+  const hasOfflineAccess = (scopes || []).some(item => item.scope === OFFLINE_ACCESS_SCOPE);
 
   function getRootDomain(): string {
     try {
@@ -132,7 +138,7 @@ export function OAuthConsentInternal() {
               as='ul'
               sx={t => ({ margin: t.sizes.$none, padding: t.sizes.$none })}
             >
-              {(scopes || []).map(item => (
+              {displayedScopes.map(item => (
                 <Box
                   key={item.scope}
                   sx={t => ({
@@ -240,6 +246,7 @@ export function OAuthConsentInternal() {
                 </Tooltip.Trigger>
                 <Tooltip.Content text={`View full URL`} />
               </Tooltip.Root>
+              .{hasOfflineAccess && " You'll stay signed in until you sign out or revoke access."}
             </Text>
           </Grid>
         </Card.Content>


### PR DESCRIPTION
_Merged into main in #7627, this is the core-2 PR_

## Description

This PR introduces special handling for the `offline_access` OAuth scope on the consent screen.

See [discussion](https://clerkinc.slack.com/archives/C09QU9YTR35/p1768934694827249?thread_ts=1768929722.808269&cid=C09QU9YTR35).

The `offline_access` scope is now:
- Excluded from the list of displayed scopes, as it describes access duration rather than specific permissions.
- Indicated by an additional sentence ("You’ll stay signed in until you sign out or revoke access.") appended to the redirect information text when present.

The sandbox environment has been updated to facilitate testing of these changes.

Part of [USER-4333](https://linear.app/clerk/issue/USER-4333/oauth-app-offline-access-scope-is-missing)

With `offline_access`:
<img width="316" height="488" alt="CleanShot 2026-01-20 at 16 19 37@2x" src="https://github.com/user-attachments/assets/e751dfd4-7cce-4887-a340-fb79c1913213" />

Without `offline_access`:
<img width="320" height="478" alt="CleanShot 2026-01-20 at 16 20 01@2x" src="https://github.com/user-attachments/assets/9f8665f9-1b54-4e91-b760-49baa79bc4d1" />

Sandbox demo URL:

```
http://localhost:4000/oauth-consent?
  scopes=email,profile,offline_access&
  oauth-application-name=My%20App&
  redirect_uri=https://example.com/callback&
  logo-url=https://example.com/logo.png&
  app-url=https://example.com
```

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

---
<a href="https://cursor.com/background-agent?bcId=bc-0a677978-423b-418d-b4f2-4a376ed6e749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a677978-423b-418d-b4f2-4a376ed6e749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth consent screen now shows per-permission descriptions and marks permissions that require explicit consent.
  * "Offline access" is omitted from the main permission list and instead triggers an informational note about staying signed in.

* **Chores**
  * Release metadata updated for a minor UI release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->