### PR TITLE
chore: optimize Turborepo configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "FORCE_COLOR=1 turbo build --concurrency=${TURBO_CONCURRENCY:-80%}",
     "build:declarations": "FORCE_COLOR=1 turbo build:declarations --concurrency=${TURBO_CONCURRENCY:-80%} --filter=@clerk/nextjs --filter=@clerk/react --filter=@clerk/shared",
-    "bundlewatch": "turbo bundlewatch",
+    "bundlewatch": "turbo run bundlewatch",
     "changeset": "changeset",
     "changeset:empty": "pnpm changeset --empty",
-    "clean": "turbo clean",
+    "clean": "turbo run clean",
     "dev": "TURBO_UI=0 FORCE_COLOR=1 turbo dev --filter=@clerk/* --filter=!@clerk/expo --filter=!@clerk/tanstack-react-start --filter=!@clerk/chrome-extension",
     "dev:fe-libs": "TURBO_UI=0 FORCE_COLOR=1 turbo dev --filter=@clerk/clerk-js --filter=@clerk/ui",
     "dev:js": "TURBO_UI=0 FORCE_COLOR=1 turbo dev:current --filter=@clerk/clerk-js",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turborepo.org/schema.json",
+  "$schema": "https://turborepo.dev/schema.v2.json",
   "remoteCache": {
     "signature": true
   },
@@ -7,8 +7,6 @@
   "globalDependencies": [
     ".github/.cache-version",
     ".npmrc",
-    "eslint.config.mjs",
-    "jest.*.ts",
     "package.json",
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
@@ -85,6 +83,8 @@
     "test": {
       "dependsOn": ["build"],
       "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/jest.*.ts",
         "*.d.ts",
         "bundlewatch.config.json",
         "jest.*",
@@ -109,6 +109,8 @@
     "lint": {
       "dependsOn": ["^build"],
       "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/eslint.config.mjs",
         "**/*.js",
         "**/*.jsx",
         "**/*.ts",
@@ -129,12 +131,13 @@
     },
     "lint:publint": {
       "dependsOn": ["build"],
-      "outputs": [],
-      "cache": false
+      "inputs": ["dist/**", "package.json"],
+      "outputs": []
     },
     "lint:attw": {
-      "outputs": [],
-      "cache": false
+      "dependsOn": ["build"],
+      "inputs": ["dist/**", "package.json"],
+      "outputs": []
     },
     "bundlewatch": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Summary

- Use `turbo run` consistently in root package.json scripts (recommended for written code vs interactive use)
- Update schema URL to `turborepo.dev/schema.v2.json`
- Move `eslint.config.mjs` and `jest.*.ts` from `globalDependencies` to task-level inputs, reducing unnecessary cache invalidation for build tasks
- Enable caching for `lint:publint` and `lint:attw` tasks (previously `cache: false` was wasteful since these tasks are deterministic)

## Testing

These are configuration-only changes. Verify by running:
```bash
turbo run build --dry
turbo run lint --dry
turbo run test --dry
```

## AI usage
Chat transcript: https://opncd.ai/share/ZVGq9lQl