### PR TITLE
feat(clerk-js): Improve reset mechanism

### DIFF
--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -9,6 +9,7 @@ import type {
 } from '@clerk/shared/types';
 
 import { unixEpochToDate } from '../../utils/date';
+import { eventBus } from '../events';
 import { SessionTokenCache } from '../tokenCache';
 import { BaseResource, Session, SignIn, SignUp } from './internal';
 
@@ -91,6 +92,18 @@ export class Client extends BaseResource implements ClientResource {
       SessionTokenCache.clear();
       return e as unknown as ClientResource;
     });
+  }
+
+  resetSignIn(): void {
+    this.signIn = new SignIn(null);
+    // Cast needed because this.signIn is typed as SignInResource (interface), not SignIn (class extending BaseResource)
+    eventBus.emit('resource:error', { resource: this.signIn as SignIn, error: null });
+  }
+
+  resetSignUp(): void {
+    this.signUp = new SignUp(null);
+    // Cast needed because this.signUp is typed as SignUpResource (interface), not SignUp (class extending BaseResource)
+    eventBus.emit('resource:error', { resource: this.signUp as SignUp, error: null });
   }
 
   clearCache(): void {

--- a/packages/clerk-js/src/core/state.ts
+++ b/packages/clerk-js/src/core/state.ts
@@ -109,11 +109,11 @@ export class State implements StateInterface {
 }
 
 /**
- * Returns true if the new resource is null and the previous resource has not been finalized. This is used to prevent
- * nullifying the resource after it's been completed.
+ * Returns true if the new resource is null and the previous resource cannot be discarded. This is used to prevent
+ * nullifying the resource after it's been completed or explicitly reset.
  */
 function shouldIgnoreNullUpdate(previousResource: SignIn | null, newResource: SignIn | null): boolean;
 function shouldIgnoreNullUpdate(previousResource: SignUp | null, newResource: SignUp | null): boolean;
 function shouldIgnoreNullUpdate(previousResource: SignIn | SignUp | null, newResource: SignIn | SignUp | null) {
-  return !newResource?.id && previousResource && previousResource.__internal_future?.hasBeenFinalized === false;
+  return !newResource?.id && previousResource && previousResource.__internal_future?.canBeDiscarded === false;
 }

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -150,8 +150,8 @@ export class StateProxy implements State {
             },
           });
         },
-        get hasBeenFinalized() {
-          return gateProperty(target, 'hasBeenFinalized', false);
+        get canBeDiscarded() {
+          return gateProperty(target, 'canBeDiscarded', false);
         },
 
         create: this.gateMethod(target, 'create'),
@@ -258,8 +258,8 @@ export class StateProxy implements State {
         get isTransferable() {
           return gateProperty(target, 'isTransferable', false);
         },
-        get hasBeenFinalized() {
-          return gateProperty(target, 'hasBeenFinalized', false);
+        get canBeDiscarded() {
+          return gateProperty(target, 'canBeDiscarded', false);
         },
 
         create: gateMethod(target, 'create'),

--- a/packages/shared/src/types/client.ts
+++ b/packages/shared/src/types/client.ts
@@ -15,6 +15,8 @@ export interface ClientResource extends ClerkResource {
   destroy: () => Promise<void>;
   removeSessions: () => Promise<ClientResource>;
   clearCache: () => void;
+  resetSignIn: () => void;
+  resetSignUp: () => void;
   isEligibleForTouch: () => boolean;
   buildTouchUrl: (params: { redirectUrl: URL }) => string;
   lastActiveSessionId: string | null;

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -344,11 +344,11 @@ export interface SignInFutureResource {
   readonly userData: UserData;
 
   /**
-   * Indicates that the sign-in has been finalized.
+   * Indicates that the sign-in can be discarded (has been finalized or explicitly reset).
    *
    * @internal
    */
-  readonly hasBeenFinalized: boolean;
+  readonly canBeDiscarded: boolean;
 
   /**
    * Creates a new `SignIn` instance initialized with the provided parameters. The instance maintains the sign-in

--- a/packages/shared/src/types/signUpFuture.ts
+++ b/packages/shared/src/types/signUpFuture.ts
@@ -384,11 +384,11 @@ export interface SignUpFutureResource {
   readonly locale: string | null;
 
   /**
-   * Indicates that the sign-up has been finalized.
+   * Indicates that the sign-up can be discarded (has been finalized or explicitly reset).
    *
    * @internal
    */
-  readonly hasBeenFinalized: boolean;
+  readonly canBeDiscarded: boolean;
 
   /**
    * Creates a new `SignUp` instance initialized with the provided parameters. The instance maintains the sign-up


### PR DESCRIPTION
## Description

This PR refactors the `reset()` mechanism to split logic across the `Client` and `SignIn/UpFuture` where appropriate. It also changes `hasBeenFinalized` to `canBeDiscarded` to accommodate the disposal of reset resources correctly.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
