### PR TITLE
fix(localizations): update pt-BR translations

### DIFF
--- a/.changeset/friendly-birds-dance.md
+++ b/.changeset/friendly-birds-dance.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Add missing pt-BR translations for enterprise connections, password errors, and organization switcher

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -231,7 +231,7 @@ export const ptBR: LocalizationResource = {
   formFieldInputPlaceholder__password: 'Digite sua senha',
   formFieldInputPlaceholder__phoneNumber: 'Digite seu número de telefone',
   formFieldInputPlaceholder__username: 'Digite seu nome de usuário',
-  formFieldInput__emailAddress_format: undefined,
+  formFieldInput__emailAddress_format: 'Formato de exemplo: nome@exemplo.com',
   formFieldLabel__apiKey: 'Chave API',
   formFieldLabel__apiKeyDescription: 'Descrição',
   formFieldLabel__apiKeyExpiration: 'Expiração',
@@ -510,11 +510,11 @@ export const ptBR: LocalizationResource = {
     },
   },
   organizationSwitcher: {
-    action__closeOrganizationSwitcher: undefined,
+    action__closeOrganizationSwitcher: 'Fechar seletor de organização',
     action__createOrganization: 'Criar organização',
     action__invitationAccept: 'Participar',
     action__manageOrganization: 'Gerenciar organização',
-    action__openOrganizationSwitcher: undefined,
+    action__openOrganizationSwitcher: 'Abrir seletor de organização',
     action__suggestionsAccept: 'Solicitar participação',
     notSelected: 'Nenhuma organização selecionada',
     personalWorkspace: 'Conta pessoal',
@@ -676,8 +676,8 @@ export const ptBR: LocalizationResource = {
       title: 'Verifique seu e-mail',
     },
     enterpriseConnections: {
-      subtitle: undefined,
-      title: undefined,
+      subtitle: 'Selecione a conta corporativa com a qual deseja continuar.',
+      title: 'Escolha sua conta corporativa',
     },
     forgotPassword: {
       formTitle: 'Código de redefinição de senha',
@@ -710,13 +710,13 @@ export const ptBR: LocalizationResource = {
       title: 'Insira sua senha',
     },
     passwordCompromised: {
-      title: undefined,
+      title: 'Senha comprometida',
     },
     passwordPwned: {
       title: 'Senha comprometida',
     },
     passwordUntrusted: {
-      title: undefined,
+      title: 'Senha não confiável',
     },
     phoneCode: {
       formTitle: 'Código de verificação',
@@ -814,8 +814,8 @@ export const ptBR: LocalizationResource = {
       },
     },
     enterpriseConnections: {
-      subtitle: undefined,
-      title: undefined,
+      subtitle: 'Selecione a conta corporativa com a qual deseja continuar.',
+      title: 'Escolha sua conta corporativa',
     },
     legalConsent: {
       checkbox: {
@@ -909,7 +909,7 @@ export const ptBR: LocalizationResource = {
       actionLink: 'Sair',
       actionText: 'Conectado como {{identifier}}',
     },
-    subtitle: undefined,
+    subtitle: 'Sua conta requer uma nova senha antes de continuar',
     title: 'Resetar senha',
   },
   unstable__errors: {
@@ -928,7 +928,7 @@ export const ptBR: LocalizationResource = {
     form_identifier_exists__phone_number: 'Telefone já está em uso. Por favor, tente outro.',
     form_identifier_exists__username: 'Nome de usuário já está em uso. Por favor, tente outro.',
     form_identifier_not_found: 'Não foi possível encontrar o usuário.',
-    form_new_password_matches_current: undefined,
+    form_new_password_matches_current: 'A nova senha não pode ser igual à senha atual.',
     form_param_format_invalid: 'Formato inválido.',
     form_param_format_invalid__email_address: 'O endereço de e-mail deve ser um endereço de e-mail válido.',
     form_param_format_invalid__phone_number: 'Número de telefone precisa estar num formato internacional válido.',
@@ -949,7 +949,8 @@ export const ptBR: LocalizationResource = {
     form_password_pwned__sign_in: 'Esta senha foi comprometida, por favor redefina sua senha.',
     form_password_size_in_bytes_exceeded:
       'Sua senha excedeu o número máximo de bytes permitidos, por favor, encurte-a ou remova alguns caracteres especiais.',
-    form_password_untrusted__sign_in: undefined,
+    form_password_untrusted__sign_in:
+      'Sua senha pode estar comprometida. Para proteger sua conta, continue com um método de login alternativo. Você precisará redefinir sua senha após o login.',
     form_password_validation_failed: 'Senha incorreta',
     form_username_invalid_character: 'Nome de usuário contém caracteres inválidos. Por favor, tente outro.',
     form_username_invalid_length: 'Nome de usuário deve ter entre 3 e 256 caracteres.',


### PR DESCRIPTION
## Description                                                                                                                                 
                                                                                                                                                 
Add 12 missing Portuguese (Brazil) translations to `pt-BR.ts`. These translations fill in `undefined` values that were previously falling back to English.  

**Note:** I am a native Brazilian Portuguese speaker.                                                                                                                                  
                                                                                                                                                 
  ### Translations added:                                                                                                                        
  - `formFieldInput__emailAddress_format`                                                                                                        
  - `organizationSwitcher.action__closeOrganizationSwitcher`                                                                                     
  - `organizationSwitcher.action__openOrganizationSwitcher`                                                                                      
  - `signIn.enterpriseConnections.subtitle` / `title`                                                                                            
  - `signIn.passwordCompromised.title`                                                                                                           
  - `signIn.passwordUntrusted.title`                                                                                                             
  - `signUp.enterpriseConnections.subtitle` / `title`                                                                                            
  - `taskResetPassword.subtitle`                                                                                                                 
  - `unstable__errors.form_new_password_matches_current`                                                                                         
  - `unstable__errors.form_password_untrusted__sign_in`

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: localization update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Portuguese (Brazil) translations with comprehensive support for enterprise connections, organization switcher, and password-related error messages, improving user guidance and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->