### PR TITLE
fix(ui): Remove `maxAllowedMemberships` guard from "Create organization" action

### DIFF
--- a/.changeset/smart-dots-teach.md
+++ b/.changeset/smart-dots-teach.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix incorrect guard for hiding "Create organization" action. The `maxAllowedMemberships` setting limits seats per organization, not the number of organizations a user can create.

--- a/packages/ui/src/common/CreateOrganizationAction.tsx
+++ b/packages/ui/src/common/CreateOrganizationAction.tsx
@@ -1,6 +1,5 @@
 import { useUser } from '@clerk/shared/react/index';
 
-import { useEnvironment } from '../contexts';
 import { Action } from '../elements/Actions';
 import { Add } from '../icons';
 
@@ -8,13 +7,8 @@ type CreateOrganizationActionProps = Omit<React.ComponentProps<typeof Action>, '
 
 export const CreateOrganizationAction = (props: CreateOrganizationActionProps) => {
   const { user } = useUser();
-  const { organizationSettings } = useEnvironment();
 
-  const currentMembershipCount = (user?.organizationMemberships ?? []).length;
-  const canCreateAdditionalMembership =
-    !organizationSettings.maxAllowedMemberships || currentMembershipCount < organizationSettings.maxAllowedMemberships;
-
-  if (!user?.createOrganizationEnabled || !canCreateAdditionalMembership) {
+  if (!user?.createOrganizationEnabled) {
     return null;
   }
 

--- a/packages/ui/src/components/OrganizationList/__tests__/OrganizationList.test.tsx
+++ b/packages/ui/src/components/OrganizationList/__tests__/OrganizationList.test.tsx
@@ -344,27 +344,6 @@ describe('OrganizationList', () => {
       expect(queryByRole('button', { name: 'Create organization' })).not.toBeInTheDocument();
     });
 
-    it('does not display CreateOrganization action if not allowed to create additional membership', async () => {
-      const { wrapper } = await createFixtures(f => {
-        f.withOrganizations();
-        f.withMaxAllowedMemberships({ max: 1 });
-        f.withUser({
-          email_addresses: ['test@clerk.com'],
-          create_organization_enabled: true,
-          organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
-        });
-      });
-
-      const { findByRole, queryByRole } = render(<OrganizationList />, {
-        wrapper,
-      });
-
-      await waitFor(async () => {
-        expect(await findByRole('heading', { name: /choose an account/i })).toBeInTheDocument();
-      });
-      expect(queryByRole('menuitem', { name: 'Create organization' })).not.toBeInTheDocument();
-    });
-
     describe('navigation', () => {
       it('constructs afterSelectPersonalUrl from `:id` ', async () => {
         const { wrapper, fixtures, props } = await createFixtures(f => {

--- a/packages/ui/src/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -1,7 +1,6 @@
 import { UNSAFE_PortalProvider } from '@clerk/shared/react';
 import type { MembershipRole } from '@clerk/shared/types';
 import { waitFor } from '@testing-library/react';
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import { bindCreateFixtures } from '@/test/create-fixtures';
@@ -291,23 +290,6 @@ describe('OrganizationSwitcher', () => {
       expect(getAllByText('Org1')).not.toBeNull();
       expect(getByText('Personal account')).toBeInTheDocument();
       expect(getByText('Org2')).toBeInTheDocument();
-    });
-
-    it('does not allow creating organization if max allowed memberships is reached', async () => {
-      const { wrapper, props } = await createFixtures(f => {
-        f.withOrganizations();
-        f.withMaxAllowedMemberships({ max: 1 });
-        f.withUser({
-          email_addresses: ['test@clerk.com'],
-          create_organization_enabled: true,
-          organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
-        });
-      });
-
-      props.setProps({ hidePersonal: true });
-      const { queryByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
-      await userEvent.click(getByRole('button', { name: 'Open organization switcher' }));
-      expect(queryByText('Create organization')).not.toBeInTheDocument();
     });
 
     it('does allow creating organization if max allowed memberships is not reached', async () => {

--- a/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/__tests__/TaskChooseOrganization.test.tsx
@@ -264,46 +264,6 @@ describe('TaskChooseOrganization', () => {
     expect(await findByText(/testuser/)).toBeInTheDocument();
   });
 
-  it('does not allow creating organization if not allowed to create additional membership', async () => {
-    const { wrapper, fixtures } = await createFixtures(f => {
-      f.withOrganizations();
-      f.withMaxAllowedMemberships({ max: 1 });
-      f.withForceOrganizationSelection();
-      f.withUser({
-        email_addresses: ['test@clerk.com'],
-        create_organization_enabled: true,
-        tasks: [{ key: 'choose-organization' }],
-        // Include an organization membership so user has reached max memberships
-        organization_memberships: [{ name: 'Existing Org', slug: 'org1' }],
-      });
-    });
-
-    fixtures.clerk.user?.getOrganizationMemberships.mockReturnValueOnce(
-      Promise.resolve({
-        data: [
-          createFakeUserOrganizationMembership({
-            id: '1',
-            organization: {
-              id: '1',
-              name: 'Existing Org',
-              slug: 'org1',
-              membersCount: 1,
-              adminDeleteEnabled: false,
-              maxAllowedMemberships: 1,
-              pendingInvitationsCount: 1,
-            },
-          }),
-        ],
-        total_count: 1,
-      }),
-    );
-
-    const { findByText, queryByText } = render(<TaskChooseOrganization />, { wrapper });
-
-    expect(await findByText('Existing Org')).toBeInTheDocument();
-    expect(queryByText('Create new organization')).not.toBeInTheDocument();
-  });
-
   describe('on create organization form', () => {
     it("does not display slug field if it's disabled on environment", async () => {
       const { wrapper } = await createFixtures(f => {


### PR DESCRIPTION
## Description

This PR removes the guard for hiding "Create organization" action based on `maxAllowedMemberships` setting limits, since it relates to seats per organization, not the number of organizations a user can create.

We're going to introduce a property on FAPI `GET /me/organization_memberships` to indicate the amount of organizations that a user has created, in order to introduce any UI guards in the future based on `User.create_organizations_limit`

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the permission logic controlling when the "Create organization" action is available to users
  * Clarified that maxAllowedMemberships represents the maximum member capacity within a single organization, distinct from limiting how many organizations users can create

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->