### PR TITLE
fix(clerk-js): Allow signUp.password after signUp.create

### DIFF
--- a/.changeset/slick-streets-stick.md
+++ b/.changeset/slick-streets-stick.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue where `signUp.password()` created a new sign-up when called after `signUp.create()`

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -766,7 +766,11 @@ class SignUpFuture implements SignUpFutureResource {
         unsafeMetadata: params.unsafeMetadata ? normalizeUnsafeMetadata(params.unsafeMetadata) : undefined,
       };
 
-      await this.#resource.__internal_basePost({ path: this.#resource.pathRoot, body });
+      if (this.#resource.id) {
+        await this.#resource.__internal_basePatch({ body });
+      } else {
+        await this.#resource.__internal_basePost({ path: this.#resource.pathRoot, body });
+      }
     });
   }
 

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -596,6 +596,71 @@ describe('SignUp', () => {
       });
     });
 
+    describe('password', () => {
+      afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+      });
+
+      it('creates signup with password when no existing signup', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.password({ password: 'test-password-123' });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              strategy: 'password',
+              password: 'test-password-123',
+            }),
+          }),
+        );
+      });
+
+      it('updates existing signup when already created', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp({ id: 'signup_123' } as any);
+        await signUp.__internal_future.password({ password: 'test-password-123' });
+
+        // Should use PATCH to update existing signup, not POST to create a new one
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'PATCH',
+            path: '/client/sign_ups/signup_123',
+            body: expect.objectContaining({
+              strategy: 'password',
+              password: 'test-password-123',
+            }),
+          }),
+        );
+      });
+
+      it('returns error property on success', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        const result = await signUp.__internal_future.password({ password: 'test-password-123' });
+
+        expect(result).toHaveProperty('error', null);
+      });
+    });
+
     describe('ticket', () => {
       afterEach(() => {
         vi.clearAllMocks();


### PR DESCRIPTION
## Description

This PR fixes an issue where calling `signUp.password()` after `signUp.create()` would create a new resource. Now, calling `signUp.password()` after `signUp.create()` issues a PATCH request to the created sign-up attempt. This isn't how we _intend_ these APIs to be used, but there's no reason they shouldn't work if a user chooses to do them in this way (such as a progressive sign-up).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where calling `signUp.password()` after `signUp.create()` would incorrectly create a new sign-up. The method now properly updates the existing sign-up as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->