### PR TITLE
fix(nextjs): Use preload for shared UI variant to avoid race condition

### DIFF
--- a/.changeset/light-drinks-grow.md
+++ b/.changeset/light-drinks-grow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix race condition that could cause `__clerkSharedModules is not defined` error when using the shared React UI variant.

--- a/integration/presets/envs.ts
+++ b/integration/presets/envs.ts
@@ -55,6 +55,11 @@ const withEmailCodes_destroy_client = withEmailCodes
   .clone()
   .setEnvVariable('public', 'EXPERIMENTAL_PERSIST_CLIENT', 'false');
 
+const withSharedUIVariant = withEmailCodes
+  .clone()
+  .setId('withSharedUIVariant')
+  .setEnvVariable('public', 'CLERK_UI_VARIANT', 'shared');
+
 const withEmailLinks = base
   .clone()
   .setId('withEmailLinks')
@@ -210,6 +215,7 @@ export const envs = {
   withReverification,
   withSessionTasks,
   withSessionTasksResetPassword,
+  withSharedUIVariant,
   withSignInOrUpEmailLinksFlow,
   withSignInOrUpFlow,
   withSignInOrUpwithRestrictedModeFlow,

--- a/integration/presets/longRunningApps.ts
+++ b/integration/presets/longRunningApps.ts
@@ -33,6 +33,7 @@ export const createLongRunningApps = () => {
     { id: 'next.appRouter.withSessionTasksResetPassword', config: next.appRouter, env: envs.withSessionTasksResetPassword },
     { id: 'next.appRouter.withLegalConsent', config: next.appRouter, env: envs.withLegalConsent },
     { id: 'next.appRouter.withNeedsClientTrust', config: next.appRouter, env: envs.withNeedsClientTrust },
+    { id: 'next.appRouter.withSharedUIVariant', config: next.appRouter, env: envs.withSharedUIVariant },
 
     /**
      * Quickstart apps

--- a/integration/tests/shared-ui-variant.test.ts
+++ b/integration/tests/shared-ui-variant.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+import { appConfigs } from '../presets';
+import { createTestUtils, testAgainstRunningApps } from '../testUtils';
+
+testAgainstRunningApps({ withEnv: [appConfigs.envs.withSharedUIVariant] })(
+  'shared React variant @nextjs',
+  ({ app }) => {
+    test.describe.configure({ mode: 'parallel' });
+
+    test('loads without __clerkSharedModules error when using shared UI variant', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+      const errors: string[] = [];
+
+      page.on('console', msg => {
+        if (msg.type() === 'error') {
+          errors.push(msg.text());
+        }
+      });
+
+      page.on('pageerror', error => {
+        errors.push(error.message);
+      });
+
+      await page.route('**/ui.browser.js', async route => {
+        const url = route.request().url().replace('ui.browser.js', 'ui.shared.browser.js');
+        const response = await page.request.fetch(url);
+        await route.fulfill({ response });
+      });
+
+      await page.route('**/_next/static/**/*.js', async route => {
+        await new Promise(resolve => setTimeout(resolve, 300));
+        await route.continue();
+      });
+
+      await u.page.goToRelative('/clerk-status');
+
+      await expect(page.getByText('Status: ready')).toBeVisible({ timeout: 30_000 });
+      await u.po.clerk.toBeLoaded();
+
+      const sharedModulesError = errors.find(e => e.includes('__clerkSharedModules'));
+      expect(sharedModulesError).toBeUndefined();
+    });
+  },
+);

--- a/packages/nextjs/src/utils/clerk-script.tsx
+++ b/packages/nextjs/src/utils/clerk-script.tsx
@@ -67,6 +67,9 @@ export function ClerkScripts({ router }: { router: ClerkScriptProps['router'] })
     clerkUIVariant: clerkUIVariant ?? DEFAULT_CLERK_UI_VARIANT,
   };
 
+  const uiScriptUrl = clerkUiScriptUrl(opts);
+  const isSharedVariant = opts.clerkUIVariant === 'shared';
+
   return (
     <>
       <ClerkScript
@@ -75,12 +78,22 @@ export function ClerkScripts({ router }: { router: ClerkScriptProps['router'] })
         dataAttribute='data-clerk-js-script'
         router={router}
       />
-      <ClerkScript
-        scriptUrl={clerkUiScriptUrl(opts)}
-        attributes={buildClerkUiScriptAttributes(opts)}
-        dataAttribute='data-clerk-ui-script'
-        router={router}
-      />
+      {isSharedVariant ? (
+        <link
+          rel='preload'
+          href={uiScriptUrl}
+          as='script'
+          crossOrigin='anonymous'
+          nonce={nonce}
+        />
+      ) : (
+        <ClerkScript
+          scriptUrl={uiScriptUrl}
+          attributes={buildClerkUiScriptAttributes(opts)}
+          dataAttribute='data-clerk-ui-script'
+          router={router}
+        />
+      )}
     </>
   );
 }

--- a/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
+++ b/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
@@ -11,6 +11,7 @@ export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, '
     clerkJSUrl: props.clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS_URL,
     clerkUiUrl: (props as any).clerkUiUrl || process.env.NEXT_PUBLIC_CLERK_UI_URL,
     clerkJSVersion: props.clerkJSVersion || process.env.NEXT_PUBLIC_CLERK_JS_VERSION,
+    clerkUIVariant: (props as any).clerkUIVariant || process.env.NEXT_PUBLIC_CLERK_UI_VARIANT,
     proxyUrl: props.proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '',
     domain: props.domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || '',
     isSatellite: props.isSatellite || isTruthy(process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE),


### PR DESCRIPTION
When using the shared UI variant, the `<script async>` tag could execute before the React registration in `@clerk/ui/register` completed, causing `__clerkSharedModules is not defined` errors.

This changes the shared variant to use `<link rel="preload">` instead, which fetches the script early but defers execution until `loadClerkUiScript()` is called after registration.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a "shared" UI variant with conditional script preloading and an environment preset to enable it.
* **Bug Fixes**
  * Fixed a race condition that could trigger a "__clerkSharedModules is not defined" error when using the shared UI variant.
* **Tests**
  * Added an integration test ensuring the shared UI variant loads without emitting the shared-modules error.
* **Chores**
  * Registered the shared UI variant in app presets and added a changeset for patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->