### PR TITLE
[POC] Lightweight version pinning packages - Do not merge

### DIFF
--- a/packages/clerk-js-pinned/package.json
+++ b/packages/clerk-js-pinned/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@clerk/clerk-js-pinned",
+  "version": "5.114.0",
+  "description": "Lightweight package for pinning @clerk/clerk-js version via dependency management",
+  "keywords": [
+    "clerk",
+    "auth",
+    "authentication",
+    "version",
+    "pinning"
+  ],
+  "homepage": "https://clerk.com/",
+  "bugs": {
+    "url": "https://github.com/clerk/javascript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clerk/javascript.git",
+    "directory": "packages/clerk-js-pinned"
+  },
+  "license": "MIT",
+  "author": "Clerk",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown && pnpm build:dts",
+    "build:dts": "dts-bundle-generator -o dist/index.d.ts src/index.ts --no-check && cp dist/index.d.ts dist/index.d.cts",
+    "clean": "rimraf ./dist",
+    "format": "node ../../scripts/format-package.mjs",
+    "format:check": "node ../../scripts/format-package.mjs --check",
+    "lint": "eslint src",
+    "lint:attw": "attw --pack . --profile node16",
+    "lint:publint": "publint"
+  },
+  "devDependencies": {
+    "@clerk/shared": "workspace:^",
+    "dts-bundle-generator": "^9.5.1",
+    "tsdown": "catalog:repo"
+  },
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/clerk-js-pinned/src/index.ts
+++ b/packages/clerk-js-pinned/src/index.ts
@@ -1,0 +1,32 @@
+import type { ClerkJs } from '@clerk/shared/types';
+
+declare const PACKAGE_VERSION: string;
+
+/**
+ * The version of @clerk/clerk-js that this package pins to.
+ * Use this with the `clerkJSVersion` prop for string-based pinning.
+ *
+ * @example
+ * ```tsx
+ * import { version } from '@clerk/clerk-js-pinned';
+ * <ClerkProvider clerkJSVersion={version} />
+ * ```
+ */
+export const version = PACKAGE_VERSION;
+
+/**
+ * Branded object for pinning @clerk/clerk-js version.
+ * Use this with the `clerkJs` prop in ClerkProvider for dependency-managed pinning.
+ *
+ * @example
+ * ```tsx
+ * import { clerkJs } from '@clerk/clerk-js-pinned';
+ * <ClerkProvider clerkJs={clerkJs} />
+ * ```
+ */
+export const clerkJs = {
+  version: PACKAGE_VERSION,
+} as ClerkJs;
+
+// Re-export the type for consumers who need it
+export type { ClerkJs } from '@clerk/shared/types';

--- a/packages/clerk-js-pinned/tsconfig.json
+++ b/packages/clerk-js-pinned/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "noUnusedLocals": true,
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "module": "preserve",
+    "lib": ["ES2023"],
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src"]
+}

--- a/packages/clerk-js-pinned/tsdown.config.mts
+++ b/packages/clerk-js-pinned/tsdown.config.mts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+import packageJson from './package.json' with { type: 'json' };
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  outDir: './dist',
+  dts: false, // We use dts-bundle-generator for bundled types
+  sourcemap: true,
+  clean: true,
+  target: 'es2022',
+  platform: 'neutral',
+  format: ['cjs', 'esm'],
+  minify: false,
+  external: [],
+  define: {
+    PACKAGE_NAME: `"${packageJson.name}"`,
+    PACKAGE_VERSION: `"${packageJson.version}"`,
+  },
+});

--- a/packages/shared/src/loadClerkJsScript.ts
+++ b/packages/shared/src/loadClerkJsScript.ts
@@ -15,6 +15,11 @@ export type LoadClerkJsScriptOptions = {
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';
   clerkJSVersion?: string;
+  /**
+   * Branded object for pinning @clerk/clerk-js version.
+   * Takes precedence over clerkJSVersion if both are provided.
+   */
+  clerkJs?: { version: string };
   sdkMetadata?: SDKMetadata;
   proxyUrl?: string;
   domain?: string;
@@ -217,7 +222,7 @@ export const loadClerkUiScript = async (opts?: LoadClerkUiScriptOptions): Promis
 };
 
 export const clerkJsScriptUrl = (opts: LoadClerkJsScriptOptions) => {
-  const { clerkJSUrl, clerkJSVariant, clerkJSVersion, proxyUrl, domain, publishableKey } = opts;
+  const { clerkJSUrl, clerkJSVariant, clerkJSVersion, clerkJs, proxyUrl, domain, publishableKey } = opts;
 
   if (clerkJSUrl) {
     return clerkJSUrl;
@@ -225,7 +230,8 @@ export const clerkJsScriptUrl = (opts: LoadClerkJsScriptOptions) => {
 
   const scriptHost = buildScriptHost({ publishableKey, proxyUrl, domain });
   const variant = clerkJSVariant ? `${clerkJSVariant.replace(/\.+$/, '')}.` : '';
-  const version = versionSelector(clerkJSVersion);
+  // clerkJs object takes precedence over clerkJSVersion string
+  const version = versionSelector(clerkJs?.version ?? clerkJSVersion);
   return `https://${scriptHost}/npm/@clerk/clerk-js@${version}/dist/clerk.${variant}browser.js`;
 };
 

--- a/packages/shared/src/types/branded.ts
+++ b/packages/shared/src/types/branded.ts
@@ -1,0 +1,80 @@
+/**
+ * Branded/Tagged type utilities for creating nominal types.
+ * These are used to ensure only official Clerk objects can be passed to certain props.
+ */
+
+declare const Tags: unique symbol;
+
+/**
+ * Creates a branded/tagged type that prevents arbitrary objects from being assigned.
+ * The tag exists only at the type level and has no runtime overhead.
+ *
+ * @example
+ * ```typescript
+ * type UserId = Tagged<string, 'UserId'>;
+ * const userId: UserId = 'user_123' as UserId;
+ * ```
+ */
+export type Tagged<BaseType, Tag extends PropertyKey> = BaseType & { [Tags]: { [K in Tag]: void } };
+
+/**
+ * Branded type for Clerk JS version pinning objects.
+ * Used with the `clerkJs` prop in ClerkProvider.
+ *
+ * @example
+ * ```typescript
+ * import { clerkJs } from '@clerk/clerk-js-pinned';
+ * <ClerkProvider clerkJs={clerkJs} />
+ * ```
+ */
+export type ClerkJs = Tagged<
+  {
+    /**
+     * The version string of @clerk/clerk-js to load from CDN.
+     */
+    version: string;
+  },
+  'ClerkJs'
+>;
+
+/**
+ * Branded type for Clerk UI version pinning objects.
+ * Carries appearance type information via phantom property for type-safe customization.
+ *
+ * @example
+ * ```typescript
+ * import { ui } from '@clerk/ui-pinned';
+ * <ClerkProvider ui={ui} appearance={{ ... }} />
+ * ```
+ */
+export type Ui<A = any> = Tagged<
+  {
+    /**
+     * The version string of @clerk/ui to load from CDN.
+     */
+    version: string;
+    /**
+     * Optional custom URL to load @clerk/ui from.
+     */
+    url?: string;
+    /**
+     * Phantom property for type-level appearance inference.
+     * This property never exists at runtime.
+     * @internal
+     */
+    __appearanceType?: A;
+  },
+  'ClerkUi'
+>;
+
+/**
+ * Extracts the appearance type from a Ui object. We have 3 cases:
+ * - If the Ui type has __appearanceType with a specific type, extract it
+ * - If __appearanceType is 'any', fallback to base Appearance type
+ * - Otherwise, fallback to the base Appearance type
+ */
+export type ExtractAppearanceType<T, Default> = T extends { __appearanceType?: infer A }
+  ? 0 extends 1 & A // Check if A is 'any' (this trick works because 1 & any = any, and 0 extends any)
+    ? Default
+    : A
+  : Default;

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -2424,6 +2424,17 @@ export type IsomorphicClerkOptions = Without<ClerkOptions, 'isSatellite'> & {
    */
   clerkJSVersion?: string;
   /**
+   * Branded object for pinning @clerk/clerk-js version.
+   * Import from `@clerk/clerk-js-pinned` for dependency-managed version pinning.
+   *
+   * @example
+   * ```tsx
+   * import { clerkJs } from '@clerk/clerk-js-pinned';
+   * <ClerkProvider clerkJs={clerkJs} />
+   * ```
+   */
+  clerkJs?: { version: string };
+  /**
    * The URL that `@clerk/ui` should be hot-loaded from.
    */
   clerkUiUrl?: string;
@@ -2441,9 +2452,14 @@ export type IsomorphicClerkOptions = Without<ClerkOptions, 'isSatellite'> & {
    */
   nonce?: string;
   /**
-   * @internal
-   * This is a structural-only type for the `ui` object that can be passed
-   * to Clerk.load() and ClerkProvider
+   * Branded object for pinning @clerk/ui version with full appearance type support.
+   * Import from `@clerk/ui-pinned` for dependency-managed version pinning.
+   *
+   * @example
+   * ```tsx
+   * import { ui } from '@clerk/ui-pinned';
+   * <ClerkProvider ui={ui} appearance={{ ... }} />
+   * ```
    */
   ui?: { version: string; url?: string };
 } & MultiDomainAndOrProxy;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,5 @@
 export type * from './apiKeys';
+export type * from './branded';
 export type * from './apiKeysSettings';
 export type * from './attributes';
 export type * from './authConfig';

--- a/packages/ui-pinned/package.json
+++ b/packages/ui-pinned/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@clerk/ui-pinned",
+  "version": "0.0.1",
+  "description": "Lightweight package for pinning @clerk/ui version via dependency management with full type support",
+  "keywords": [
+    "clerk",
+    "ui",
+    "version",
+    "pinning",
+    "theming"
+  ],
+  "homepage": "https://clerk.com/",
+  "bugs": {
+    "url": "https://github.com/clerk/javascript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clerk/javascript.git",
+    "directory": "packages/ui-pinned"
+  },
+  "license": "MIT",
+  "author": "Clerk",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown && pnpm build:dts",
+    "build:dts": "dts-bundle-generator -o dist/index.d.ts src/index.ts --no-check && cp dist/index.d.ts dist/index.d.cts",
+    "clean": "rimraf ./dist",
+    "format": "node ../../scripts/format-package.mjs",
+    "format:check": "node ../../scripts/format-package.mjs --check",
+    "lint": "eslint src",
+    "lint:attw": "attw --pack . --profile node16",
+    "lint:publint": "publint"
+  },
+  "devDependencies": {
+    "@clerk/shared": "workspace:^",
+    "@clerk/ui": "workspace:^",
+    "dts-bundle-generator": "^9.5.1",
+    "tsdown": "catalog:repo"
+  },
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/ui-pinned/src/index.ts
+++ b/packages/ui-pinned/src/index.ts
@@ -1,0 +1,42 @@
+import type { Ui } from '@clerk/shared/types';
+import type { Appearance } from '@clerk/ui/internal';
+
+declare const PACKAGE_VERSION: string;
+
+/**
+ * The version of @clerk/ui that this package pins to.
+ *
+ * @example
+ * ```tsx
+ * import { version } from '@clerk/ui-pinned';
+ * console.log(`Pinning to @clerk/ui version ${version}`);
+ * ```
+ */
+export const version = PACKAGE_VERSION;
+
+/**
+ * Branded object for pinning @clerk/ui version with full type support.
+ * Use this with the `ui` prop in ClerkProvider for dependency-managed pinning
+ * with type-safe appearance customization.
+ *
+ * @example
+ * ```tsx
+ * import { ui } from '@clerk/ui-pinned';
+ *
+ * <ClerkProvider
+ *   ui={ui}
+ *   appearance={{
+ *     variables: {
+ *       colorPrimary: '#000000',
+ *     },
+ *   }}
+ * />
+ * ```
+ */
+export const ui = {
+  version: PACKAGE_VERSION,
+} as Ui<Appearance>;
+
+// Re-export types for consumers who need them
+export type { Ui, ExtractAppearanceType } from '@clerk/shared/types';
+export type { Appearance } from '@clerk/ui/internal';

--- a/packages/ui-pinned/tsconfig.json
+++ b/packages/ui-pinned/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "noUnusedLocals": true,
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "module": "preserve",
+    "lib": ["ES2023"],
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src"]
+}

--- a/packages/ui-pinned/tsdown.config.mts
+++ b/packages/ui-pinned/tsdown.config.mts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+import packageJson from './package.json' with { type: 'json' };
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  outDir: './dist',
+  dts: false, // We use dts-bundle-generator for bundled types
+  sourcemap: true,
+  clean: true,
+  target: 'es2022',
+  platform: 'neutral',
+  format: ['cjs', 'esm'],
+  minify: false,
+  external: [],
+  define: {
+    PACKAGE_NAME: `"${packageJson.name}"`,
+    PACKAGE_VERSION: `"${packageJson.version}"`,
+  },
+});

--- a/packages/ui/src/internal/index.ts
+++ b/packages/ui/src/internal/index.ts
@@ -3,37 +3,8 @@ import type { Appearance } from './appearance';
 export type { ComponentControls, MountComponentRenderer } from '../Components';
 export type { WithInternalRouting } from './routing';
 
-/**
- * Extracts the appearance type from a Ui object. We got 3 cases:
- * - If the Ui type has __appearanceType with a specific type, extract it
- * - If __appearanceType is 'any', fallback to base Appearance type
- * - Otherwise, fallback to the base Appearance type
- */
-export type ExtractAppearanceType<T, Default> = T extends { __appearanceType?: infer A }
-  ? 0 extends 1 & A // Check if A is 'any' (this trick works because 1 & any = any, and 0 extends any)
-    ? Default
-    : A
-  : Default;
-
-declare const Tags: unique symbol;
-type Tagged<BaseType, Tag extends PropertyKey> = BaseType & { [Tags]: { [K in Tag]: void } };
-
-/**
- * Ui type that carries appearance type information via phantom property
- * Tagged to ensure only official ui objects from @clerk/ui can be used
- */
-export type Ui<A = any> = Tagged<
-  {
-    version: string;
-    url?: string;
-    /**
-     * Phantom property for type-level appearance inference
-     * This property never exists at runtime
-     */
-    __appearanceType?: A;
-  },
-  'ClerkUi'
->;
+// Re-export branded types from @clerk/shared for backwards compatibility
+export type { ExtractAppearanceType, Ui } from '@clerk/shared/types';
 
 export type {
   AlphaColorScale,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,18 @@ importers:
         specifier: ^5.10.0
         version: 5.10.0
 
+  packages/clerk-js-pinned:
+    devDependencies:
+      '@clerk/shared':
+        specifier: workspace:^
+        version: link:../shared
+      dts-bundle-generator:
+        specifier: ^9.5.1
+        version: 9.5.1
+      tsdown:
+        specifier: catalog:repo
+        version: 0.15.7(publint@0.3.15)(typescript@5.8.3)(vue-tsc@3.1.4(typescript@5.8.3))
+
   packages/dev-cli:
     dependencies:
       commander:
@@ -1054,6 +1066,21 @@ importers:
       webpack-merge:
         specifier: ^5.10.0
         version: 5.10.0
+
+  packages/ui-pinned:
+    devDependencies:
+      '@clerk/shared':
+        specifier: workspace:^
+        version: link:../shared
+      '@clerk/ui':
+        specifier: workspace:^
+        version: link:../ui
+      dts-bundle-generator:
+        specifier: ^9.5.1
+        version: 9.5.1
+      tsdown:
+        specifier: catalog:repo
+        version: 0.15.7(publint@0.3.15)(typescript@5.8.3)(vue-tsc@3.1.4(typescript@5.8.3))
 
   packages/upgrade:
     dependencies:
@@ -7832,6 +7859,11 @@ packages:
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
+
+  dts-bundle-generator@9.5.1:
+    resolution: {integrity: sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   dts-resolver@2.1.2:
     resolution: {integrity: sha512-xeXHBQkn2ISSXxbJWD828PFjtyg+/UrMDo7W4Ffcs7+YWCquxU8YjV1KoxuiL+eJ5pg3ll+bC6flVv61L3LKZg==}
@@ -23980,6 +24012,11 @@ snapshots:
   dotenv@17.2.3: {}
 
   dset@3.1.4: {}
+
+  dts-bundle-generator@9.5.1:
+    dependencies:
+      typescript: 5.8.3
+      yargs: 17.7.2
 
   dts-resolver@2.1.2: {}
 


### PR DESCRIPTION
> [!CAUTION]
> **This is a proof of concept / exploration - NOT intended for full review or merge.**
> 
> This PR demonstrates a potential approach to lightweight version pinning. It is meant to gather feedback on the direction, not to be production-ready code.

## Summary

Explores `@clerk/clerk-js-pinned` and `@clerk/ui-pinned` packages for dependency-managed version pinning without heavy transitive dependencies.

### Problem

Today, users can pin:
- `@clerk/clerk-js` via a string prop like `clerkJsVersion="x.y.z"`
- `@clerk/ui` via importing a `ui` object from `@clerk/ui`

This is inconsistent and confusing. The naive "make them install @clerk/ui to pin it" approach forces large transitive dependency graphs onto apps that otherwise rely on hot-loaded runtime code.

### Proposed Solution

Create lightweight packages that:
- Export only version metadata and types
- Have zero runtime dependencies
- Provide a consistent import surface for pinning both packages
- Bundle all types inline using `dts-bundle-generator` (no external type dependencies)

### New Packages (POC)

**`@clerk/clerk-js-pinned`** (~0.34KB gzipped)
- Exports `version` string constant
- Exports `clerkJs` branded object for use with new `clerkJs` prop

**`@clerk/ui-pinned`** (~0.41KB gzipped)
- Exports `version` string constant  
- Exports `ui` branded object with full `Appearance` type support
- All 1000+ lines of appearance types are bundled inline

### Usage

```tsx
import { clerkJs } from '@clerk/clerk-js-pinned';
import { ui } from '@clerk/ui-pinned';

<ClerkProvider 
  clerkJs={clerkJs}
  ui={ui}
  appearance={{ variables: { colorPrimary: '#000' } }}
  publishableKey="..."
/>
```

### Changes

- Add `@clerk/clerk-js-pinned` package
- Add `@clerk/ui-pinned` package
- Add `ClerkJs` and `Ui` branded types to `@clerk/shared/types`
- Add `clerkJs` prop to `IsomorphicClerkOptions`
- Update `loadClerkJsScript` to handle `clerkJs` object

## Open Questions

### 1. Lock-step Versioning

How do we keep these packages in sync with their parent packages?

**Proposed approach:** Use changesets `fixed` groups in `.changeset/config.json`:
```json
"fixed": [
  ["@clerk/clerk-js", "@clerk/clerk-js-pinned"],
  ["@clerk/ui", "@clerk/ui-pinned"]
]
```

This ensures when `@clerk/clerk-js` bumps to `5.115.0`, `@clerk/clerk-js-pinned` automatically gets the same version.

**Alternative:** CI automation that bumps pinned packages when parent packages bump.

### 2. Migration Strategy (Backward Compatibility)

The POC maintains the old string-based props for easier migration:

**For clerk-js (coexistence):**
- `clerkJSVersion?: string` - existing string-based approach (**kept**)
- `clerkJs?: { version: string }` - new branded object approach (**added**)

The implementation shows precedence: `clerkJs?.version ?? clerkJSVersion`

**For UI:**
- `ui?: { version: string }` - new branded object approach (**added**)

**Questions:**
- [ ] Should we deprecate `clerkJSVersion` eventually?
- [ ] How do we handle users who have both props set?
- [ ] What is the deprecation timeline?

### 3. Other Open Questions

- [ ] Package naming: `*-pinned` vs something else?
- [ ] Release workflow integration
- [ ] Documentation approach