### PR TITLE
fix(ci): Prevent race condition in API keys search filter integration test

### DIFF
--- a/integration/tests/machine-auth/component.test.ts
+++ b/integration/tests/machine-auth/component.test.ts
@@ -594,7 +594,7 @@ test.describe('api keys component @machine', () => {
 
       const getAPIKeyCount = createAPIKeyCountHelper(u);
 
-      // Use a unique search term with timestamp to avoid matching leftover keys from previous test runs
+      // Create a specific search term that will match our new key
       const timestamp = Date.now();
       const searchTerm = `searchfilter-${timestamp}`;
       const newApiKeyName = `${searchTerm}-key`;
@@ -605,14 +605,13 @@ test.describe('api keys component @machine', () => {
 
       // Wait for search to actually filter results - either empty state appears
       // or the loading/fetching state completes with no matching results.
-      // The unique timestamp-based search term should never match existing keys.
       await expect(async () => {
         const emptyMessage = u.page.locator('[data-localization-key*="emptyRow"]');
         const isEmptyVisible = await emptyMessage.isVisible().catch(() => false);
         expect(isEmptyVisible).toBe(true);
       }).toPass({ timeout: 10000 });
 
-      // Verify no results initially match (unique timestamp-based search term)
+      // Verify no results initially match
       expect(await getAPIKeyCount()).toBe(0);
 
       // Create API key that matches the search
@@ -642,16 +641,6 @@ test.describe('api keys component @machine', () => {
         { timeout: 5000 },
       );
       await expect(table.locator('.cl-tableRow', { hasText: newApiKeyName })).toBeVisible();
-
-      // Clean up - revoke the API key created in this test
-      const menuButton = table.locator('.cl-tableRow', { hasText: newApiKeyName }).locator('.cl-menuButton');
-      await menuButton.click();
-      const revokeButton = u.page.getByRole('menuitem', { name: 'Revoke key' });
-      await revokeButton.click();
-      await u.po.apiKeys.waitForRevokeModalOpened();
-      await u.po.apiKeys.typeRevokeConfirmation('Revoke');
-      await u.po.apiKeys.clickConfirmRevokeButton();
-      await u.po.apiKeys.waitForRevokeModalClosed();
     });
 
     test('api key list invalidation: works when on second page of results', async ({ page, context }) => {


### PR DESCRIPTION
## Description

The test was failing because it checked the API key count before the search filter results had returned. Since API keys are served from Cloudflare Workers, there can be a delay before search results reflect the filtered data.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability by using unique timestamp-based identifiers to avoid collisions.
  * Replaced a fixed debounced wait with an assertion-based wait (up to 10s) for search/filter results.
  * Increased several wait timeouts (from ~2s to ~5s) to reduce flakiness during API key creation and table loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->