### PR TITLE
fix(backend): correct `createInvitationBulk` return type to `Promise<Invitation[]>`

### DIFF
--- a/.changeset/spotty-terms-heal.md
+++ b/.changeset/spotty-terms-heal.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+fix: correct `createInvitationBulk` return type to `Promise<Invitation[]>`

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -67,7 +67,7 @@ export class InvitationAPI extends AbstractAPI {
   }
 
   public async createInvitationBulk(params: CreateBulkParams) {
-    return this.request<Invitation>({
+    return this.request<Invitation[]>({
       method: 'POST',
       path: joinPaths(basePath, 'bulk'),
       bodyParams: params,


### PR DESCRIPTION
## Description

Backport of #7136 to `release/core-2`.

* Corrects `createInvitationBulk` to return an array of Invitation instead of a single Invitation.
* Aligns the method's return type with the bulk [REST endpoint](https://clerk.com/docs/reference/backend-api/tag/invitations/post/invitations/bulk) semantics and existing bulk invitation patterns.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.

## Type of change

- [x] 🐛 Bug fix