### PR TITLE
fix(backend): Add missing fields to CommercePlan

### DIFF
--- a/.changeset/violet-games-happen.md
+++ b/.changeset/violet-games-happen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add missing fields to CommercePlan type.

--- a/packages/backend/src/api/resources/CommercePlan.ts
+++ b/packages/backend/src/api/resources/CommercePlan.ts
@@ -62,6 +62,18 @@ export class BillingPlan {
      * The features the Plan offers.
      */
     readonly features: Feature[],
+    /**
+     * The URL of the Plan's avatar image.
+     */
+    readonly avatarUrl: string | null,
+    /**
+     * Number of free trial days for this plan.
+     */
+    readonly freeTrialDays: number | null,
+    /**
+     * Whether free trial is enabled for this plan.
+     */
+    readonly freeTrialEnabled: boolean,
   ) {}
 
   static fromJSON(data: BillingPlanJSON): BillingPlan {
@@ -79,6 +91,7 @@ export class BillingPlan {
           : null
       ) as T extends null ? null : BillingMoneyAmount;
     };
+
     return new BillingPlan(
       data.id,
       data.name,
@@ -93,6 +106,9 @@ export class BillingPlan {
       formatAmountJSON(data.annual_monthly_fee),
       data.for_payer_type,
       (data.features ?? []).map(feature => Feature.fromJSON(feature)),
+      data.avatar_url,
+      data.free_trial_days,
+      data.free_trial_enabled,
     );
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -851,6 +851,9 @@ export interface BillingPlanJSON extends ClerkResourceJSON {
   annual_monthly_fee: BillingMoneyAmountJSON | null;
   for_payer_type: 'org' | 'user';
   features?: FeatureJSON[];
+  free_trial_days: number | null;
+  free_trial_enabled: boolean;
+  avatar_url: string | null;
 }
 
 type BillingSubscriptionItemStatus =


### PR DESCRIPTION
## Description

This PR adds the missing `avatar_url`, `free_trial_days`, and `free_trial_enabled` fields to the `CommercePlan` resource in the `backend` package.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced billing plan information with three new optional fields: avatar URL, free trial days count, and free trial enabled status for improved plan presentation and trial management capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->