### PR TITLE
fix(shared): Use static value for `authenticated` in `useOrganizationCreationDefaultsCacheKeys`

### DIFF
--- a/packages/shared/src/react/hooks/createCacheKeys.ts
+++ b/packages/shared/src/react/hooks/createCacheKeys.ts
@@ -9,6 +9,12 @@ export function createCacheKeys<
   U extends Record<string, unknown> | undefined = undefined,
 >(params: {
   stablePrefix: ResourceCacheStableKey | __internal_ResourceCacheStableKey;
+  /**
+   * Describes queries that will contain data that require a user to be authenticated.
+   *
+   * `authenticated` should be not be resolved at runtime.
+   * When`authenticated: true` use it with `useClearQueriesOnSignOut` to automatically clear the cache entries associated with the cache key when a user signs out.
+   */
   authenticated: boolean;
   tracked: T;
   untracked: U extends { args: Params } ? U : never;

--- a/packages/shared/src/react/hooks/useOrganizationCreationDefaults.shared.ts
+++ b/packages/shared/src/react/hooks/useOrganizationCreationDefaults.shared.ts
@@ -8,9 +8,9 @@ export function useOrganizationCreationDefaultsCacheKeys(params: { userId: strin
   return useMemo(() => {
     return createCacheKeys({
       stablePrefix: STABLE_KEYS.ORGANIZATION_CREATION_DEFAULTS_KEY,
-      authenticated: Boolean(userId),
+      authenticated: true,
       tracked: {
-        userId: userId ?? null,
+        userId,
       },
       untracked: {
         args: {},

--- a/packages/shared/src/react/hooks/useOrganizationCreationDefaults.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationCreationDefaults.tsx
@@ -1,3 +1,5 @@
+import { useClearQueriesOnSignOut } from '@/react/hooks/useClearQueriesOnSignOut';
+
 import { eventMethodCalled } from '../../telemetry/events/method-called';
 import type { EnvironmentResource } from '../../types/environment';
 import { defineKeepPreviousDataFn } from '../clerk-rq/keep-previous-data';
@@ -50,7 +52,13 @@ export function useOrganizationCreationDefaults(
 
   clerk.telemetry?.record(eventMethodCalled(HOOK_NAME));
 
-  const { queryKey } = useOrganizationCreationDefaultsCacheKeys({ userId: user?.id ?? null });
+  const { queryKey, authenticated, stableKey } = useOrganizationCreationDefaultsCacheKeys({ userId: user?.id ?? null });
+
+  useClearQueriesOnSignOut({
+    isSignedOut: user === null, // works with the transitive state
+    authenticated,
+    stableKeys: stableKey,
+  });
 
   const queryEnabled = Boolean(user) && enabled && featureEnabled && clerk.loaded;
 


### PR DESCRIPTION
## Description

Improves `useOrganizationCreationDefaultsCacheKeys` and adds comments that better describe the intended use of `authenticated` in `createCacheKeys`. 

Then intention is to have all "authenticated queries" (queries that depend on user or org) to be cleared from the cache in order to avoid rendering stale data about the user after they have signed out.


<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for organization creation workflows
  * Fixed sign-out behavior to properly clear cached organization-related data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->