### PR TITLE
feat(ci): pass source commit to sdk-infra-workers canary release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -74,7 +74,7 @@ jobs:
               repo: 'sdk-infra-workers',
               workflow_id: 'update-pkg-versions.yml',
               ref: 'main',
-              inputs: { clerkjsVersion, clerkUiVersion }
+              inputs: { clerkjsVersion, clerkUiVersion, sourceCommit: context.sha }
             })
 
             if (nextjsVersion.includes('canary')) {


### PR DESCRIPTION
## Summary

Pass `context.sha` when triggering the `update-pkg-versions` workflow in sdk-infra-workers. This enables release PRs to show clickable links back to the source commits in clerk/javascript.

## Related

- clerk/sdk-infra-workers#349 - Consumes this new input to generate rich release PR descriptions

## Test plan

- [ ] After merging both PRs, trigger a canary release and verify the release PR shows commit links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to pass commit SHA to dispatched workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->