### PR TITLE
fix(ui): set MIN_CLERK_JS_VERSION to current clerk-js version

### DIFF
--- a/.changeset/fix-ui-min-version.md
+++ b/.changeset/fix-ui-min-version.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix MIN_CLERK_JS_VERSION to match current clerk-js version until major release

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -1,4 +1,5 @@
-export const MIN_CLERK_JS_VERSION = '6.0.0';
+// TODO(USER-4603): Bump to '6.0.0' before Core 3 release
+export const MIN_CLERK_JS_VERSION = '5.114.0';
 
 export const USER_PROFILE_NAVBAR_ROUTE_ID = {
   ACCOUNT: 'account',


### PR DESCRIPTION
## Summary

- Sets `MIN_CLERK_JS_VERSION` to `5.114.0` (current clerk-js version) instead of `6.0.0`
- The version check was merged before the major version bump, breaking the dev sandbox
- This ensures compatibility until the major release while still protecting against older v5 versions

## Test plan

- [x] Run `pnpm dev:sandbox` and verify no version mismatch error
- [ ] Verify version check still works for versions < 5.114.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum Clerk JS version requirement in the UI package to align with the current library version.

* **Chores**
  * Added a changeset to record a patch-level version alignment and note a future version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->