### PR TITLE
fix(ui): Skip strategy selection screen if it's the only available on setup mfa session task

### DIFF
--- a/.changeset/pretty-queens-relate.md
+++ b/.changeset/pretty-queens-relate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Skip the strategy selection screen if only one MFA strategy is available for the setup MFA session task

--- a/packages/ui/src/components/SessionTasks/tasks/TaskSetupMfa/__tests__/TaskSetupMfa.test.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskSetupMfa/__tests__/TaskSetupMfa.test.tsx
@@ -33,6 +33,8 @@ describe('TaskSetupMFA', () => {
           identifier: 'test@clerk.com',
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       const { queryByText, queryByRole } = render(<TaskSetupMFA />, { wrapper });
@@ -60,7 +62,7 @@ describe('TaskSetupMFA', () => {
       expect(getByRole('button', { name: /sms code/i })).toBeInTheDocument();
     });
 
-    it('should render SMS code item on the first screen if only SMS code is enabled', async () => {
+    it('should skip selection screen and go directly to SMS code flow when only SMS code is enabled', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withUser({
           email_addresses: ['test@clerk.com'],
@@ -70,14 +72,14 @@ describe('TaskSetupMFA', () => {
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
-      const { getByRole, queryByRole } = render(<TaskSetupMFA />, { wrapper });
+      const { findByText, queryByText } = render(<TaskSetupMFA />, { wrapper });
 
-      expect(queryByRole('button', { name: /authenticator application/i })).not.toBeInTheDocument();
-      expect(getByRole('button', { name: /sms code/i })).toBeInTheDocument();
+      await findByText(/add phone number/i);
+      expect(queryByText(/set up two-step verification/i)).not.toBeInTheDocument();
     });
 
-    it('should render TOTP item on the first screen if only TOTP is enabled', async () => {
-      const { wrapper } = await createFixtures(f => {
+    it('should skip selection screen and go directly to TOTP flow when only TOTP is enabled', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
         f.withUser({
           email_addresses: ['test@clerk.com'],
           identifier: 'test@clerk.com',
@@ -86,10 +88,15 @@ describe('TaskSetupMFA', () => {
         f.withAuthenticatorApp({ enabled: true });
       });
 
-      const { getByRole, queryByRole } = render(<TaskSetupMFA />, { wrapper });
+      fixtures.clerk.user?.createTOTP.mockResolvedValue({
+        uri: 'otpauth://totp/Test:test@clerk.com?secret=TESTSECRET&issuer=Test',
+        secret: 'TESTSECRET',
+      } as TOTPResource);
 
-      expect(getByRole('button', { name: /authenticator application/i })).toBeInTheDocument();
-      expect(queryByRole('button', { name: /sms code/i })).not.toBeInTheDocument();
+      const { findByText, queryByText } = render(<TaskSetupMFA />, { wrapper });
+
+      await findByText(/add authenticator application/i);
+      expect(queryByText(/set up two-step verification/i)).not.toBeInTheDocument();
     });
   });
   describe('authenticator application', () => {
@@ -101,6 +108,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -127,6 +135,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -159,6 +168,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -190,6 +200,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
         f.withBackupCode();
       });
 
@@ -234,6 +245,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -275,6 +287,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -351,6 +364,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockRejectedValueOnce(
@@ -384,6 +398,7 @@ describe('TaskSetupMFA', () => {
           tasks: [{ key: 'setup-mfa' }],
         });
         f.withAuthenticatorApp({ enabled: true });
+        f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
       fixtures.clerk.user?.createTOTP.mockResolvedValue({
@@ -438,6 +453,7 @@ describe('TaskSetupMFA', () => {
           phone_numbers: [{ phone_number: '+306911111111', id: 'phone_1' }],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -460,6 +476,7 @@ describe('TaskSetupMFA', () => {
           identifier: 'test@clerk.com',
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -481,6 +498,7 @@ describe('TaskSetupMFA', () => {
           phone_numbers: [{ phone_number: '+306911111111', id: 'phone_1' }],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -514,6 +532,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
         f.withBackupCode();
       });
@@ -556,6 +575,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -602,6 +622,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -662,6 +683,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -705,6 +727,7 @@ describe('TaskSetupMFA', () => {
           identifier: 'test@clerk.com',
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -746,6 +769,7 @@ describe('TaskSetupMFA', () => {
           identifier: 'test@clerk.com',
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -794,6 +818,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 
@@ -846,6 +871,7 @@ describe('TaskSetupMFA', () => {
           ],
           tasks: [{ key: 'setup-mfa' }],
         });
+        f.withAuthenticatorApp({ enabled: true });
         f.withPhoneNumber({ second_factors: ['phone_code'], used_for_second_factor: true });
       });
 

--- a/packages/ui/src/components/SessionTasks/tasks/TaskSetupMfa/index.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskSetupMfa/index.tsx
@@ -13,6 +13,12 @@ import { SetupMfaStartScreen } from './SetupMfaStartScreen';
 import { SmsCodeFlow } from './SmsCodeFlowScreen';
 import { TOTPCodeFlow } from './TOTPCodeFlowScreen';
 
+const WIZARD_STEPS = {
+  start: 0,
+  phoneCode: 1,
+  totp: 2,
+} as const;
+
 const TaskSetupMFAInternal = () => {
   const clerk = useClerk();
   const { user } = useUser();
@@ -38,7 +44,11 @@ const TaskSetupMFAInternal = () => {
     });
   }, [attributes, user]);
 
-  const wizard = useWizard({ defaultStep: 0 });
+  const defaultStep =
+    secondFactorsAvailableToAdd.indexOf('phone_code') > -1 ? WIZARD_STEPS.phoneCode : WIZARD_STEPS.totp;
+  const wizard = useWizard({
+    defaultStep: secondFactorsAvailableToAdd.length > 1 ? WIZARD_STEPS.start : defaultStep,
+  });
   const { redirectUrlComplete } = useTaskSetupMFAContext();
   const { navigateOnSetActive, redirectOnActiveSession } = useSessionTasksContext();
 


### PR DESCRIPTION
## Description

**Only phone number enabled**

https://github.com/user-attachments/assets/27e65e59-810c-4cb0-8cf3-dd98a645abe4

**Only TOTP enabled**

https://github.com/user-attachments/assets/19fb3f94-0767-487a-8296-00e93d95cba8

**Both enabled** 

https://github.com/user-attachments/assets/d7bd239f-b22c-4588-a1b1-a350d0746342


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined MFA setup flow: when only one authentication method is available, the strategy selection screen is now automatically skipped, allowing users to proceed directly to configuring their chosen method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->