### PR TITLE
feat(backend): Add bulk create method for waitlist entries

### DIFF
--- a/.changeset/tough-taxis-care.md
+++ b/.changeset/tough-taxis-care.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add `createBulk()` method to `WaitlistEntryAPI` for bulk creating waitlist entries

--- a/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
+++ b/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
@@ -24,6 +24,8 @@ type WaitlistEntryCreateParams = {
   notify?: boolean;
 };
 
+type WaitlistEntryBulkCreateParams = Array<WaitlistEntryCreateParams>;
+
 type WaitlistEntryInviteParams = {
   /**
    * When true, do not error if an invitation already exists. Default: false.
@@ -52,6 +54,18 @@ export class WaitlistEntryAPI extends AbstractAPI {
     return this.request<WaitlistEntry>({
       method: 'POST',
       path: basePath,
+      bodyParams: params,
+    });
+  }
+
+  /**
+   * Bulk create waitlist entries.
+   * @param params An array of parameters for creating waitlist entries.
+   */
+  public async createBulk(params: WaitlistEntryBulkCreateParams) {
+    return this.request<WaitlistEntry[]>({
+      method: 'POST',
+      path: joinPaths(basePath, 'bulk'),
       bodyParams: params,
     });
   }


### PR DESCRIPTION

## Description

Implement `createBulk()` method in WaitlistEntryAPI to enable creating multiple waitlist entries in a single API call. This addresses the need for efficient batch operations when processing multiple waitlist entry requests.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk creation capability for waitlist entries, enabling multiple entries to be created in a single API call through the new createBulk() method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->