### PR TITLE
feat(backend,clerk-js): Add providerUserId field to ExternalAccount

### DIFF
--- a/.changeset/legal-crabs-shout.md
+++ b/.changeset/legal-crabs-shout.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/backend': minor
+---
+
+Add `providerUserId` field to `ExternalAccount` resource as the preferred way to access the unique user ID from the OAuth provider. The existing `externalId` field is now deprecated in favor of `providerUserId` for better clarity and consistency across the API.

--- a/packages/backend/src/api/resources/ExternalAccount.ts
+++ b/packages/backend/src/api/resources/ExternalAccount.ts
@@ -17,11 +17,16 @@ export class ExternalAccount {
      */
     readonly provider: string,
     /**
+     * The unique ID of the user in the provider.
+     */
+    readonly providerUserId: string,
+    /**
      * The identification with which this external account is associated.
      */
     readonly identificationId: string,
     /**
      * The unique ID of the user in the provider.
+     * @deprecated Use providerUserId instead
      */
     readonly externalId: string,
     /**
@@ -70,6 +75,7 @@ export class ExternalAccount {
     return new ExternalAccount(
       data.id,
       data.provider,
+      data.provider_user_id,
       data.identification_id,
       data.provider_user_id,
       data.approved_scopes,

--- a/packages/clerk-js/src/core/resources/__tests__/ExternalAccount.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/ExternalAccount.test.ts
@@ -9,6 +9,8 @@ describe('External account', () => {
     const externalAccountJSON = {
       object: 'external_account',
       id: targetId,
+      provider_user_id: 'test_provider_user_id',
+      identification_id: 'test_identification_id',
     };
 
     // @ts-ignore
@@ -35,6 +37,8 @@ describe('External account', () => {
       object: 'external_account',
       id: targetId,
       deleted: true,
+      provider_user_id: 'test_provider_user_id',
+      identification_id: 'test_identification_id',
     };
 
     // @ts-ignore


### PR DESCRIPTION
## Description

Add providerUserId as a new field to the ExternalAccount resource to provide a clearer way to access the unique user ID from OAuth providers. This field is now the preferred way to retrieve provider user identifiers.

The existing externalId field is deprecated in favor of providerUserId for better clarity and consistency across the API. The externalId field remains available but is marked with @deprecated JSDoc annotation to guide developers toward the new field.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `providerUserId` field to external accounts for accessing OAuth provider user identifiers.

* **Documentation**
  * Deprecated `externalId` in favor of `providerUserId`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->