### PR TITLE
fix(ci): fix e2e integration test timeouts

### DIFF
--- a/integration/scripts/httpServer.ts
+++ b/integration/scripts/httpServer.ts
@@ -38,7 +38,7 @@ const serveFromTempDir = async (config: HttpServerConfig): Promise<{ pid: number
     stderr: fs.openSync(stderrFilePath, 'a'),
   });
 
-  await waitForServer(serverUrl, { log: console.log, maxAttempts: Infinity });
+  await waitForServer(serverUrl, { log: console.log, maxAttempts: 60 });
   console.log(`${config.name} is being served from`, serverUrl);
 
   return { pid: proc.pid, serverUrl };

--- a/integration/tests/global.setup.ts
+++ b/integration/tests/global.setup.ts
@@ -5,19 +5,22 @@ import { appConfigs } from '../presets';
 import { fs, parseEnvOptions, startClerkJsHttpServer, startClerkUiHttpServer } from '../scripts';
 
 setup('start long running apps', async () => {
-  setup.setTimeout(90_000);
+  setup.setTimeout(240_000);
 
   await fs.ensureDir(constants.TMP_DIR);
 
-  await startClerkJsHttpServer();
-  await startClerkUiHttpServer();
+  const httpServerStart = Date.now();
+  await Promise.all([startClerkJsHttpServer(), startClerkUiHttpServer()]);
+  console.log(`HTTP servers started in ${Date.now() - httpServerStart}ms`);
 
   const { appIds } = parseEnvOptions();
   if (appIds.length) {
     const apps = appConfigs.longRunningApps.getByPattern(appIds);
     // state cannot be shared using playwright,
     // so we save the state in a file using a strategy similar to `storageState`
+    const appStart = Date.now();
     await Promise.all(apps.map(app => app.init()));
+    console.log(`Apps initialized in ${Date.now() - appStart}ms`);
   } else {
     // start a single app using the available env variables
   }


### PR DESCRIPTION
## Summary
- Integration tests are timing out during `global.setup.ts` (90s timeout exceeded while waiting for long-running apps to start)
- This affects all integration test suites (nextjs, quickstart, handshake, sessions, billing, etc.)
- Same failures reproduce on `main`

## Test plan
- [ ] Investigate root cause of app startup timeouts
- [ ] Fix and verify integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server startup performance by running HTTP servers in parallel instead of sequentially.
  * Extended initialization timeout and added performance monitoring for server and app startup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->