### PR TITLE
feat(clerk-js): Reuse SignIn/SignUp instances

### DIFF
--- a/.changeset/calm-pillows-slide.md
+++ b/.changeset/calm-pillows-slide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Reuse SignIn and SignUp instances on Client when processing Client response JSON.

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -134,8 +134,19 @@ export class Client extends BaseResource implements ClientResource {
     if (data) {
       this.id = data.id;
       this.sessions = (data.sessions || []).map(s => new Session(s));
-      this.signUp = new SignUp(data.sign_up);
-      this.signIn = new SignIn(data.sign_in);
+
+      if (data.sign_up && this.signUp instanceof SignUp && this.signUp.id === data.sign_up.id) {
+        this.signUp.__internal_updateFromJSON(data.sign_up);
+      } else {
+        this.signUp = new SignUp(data.sign_up);
+      }
+
+      if (data.sign_in && this.signIn instanceof SignIn && this.signIn.id === data.sign_in.id) {
+        this.signIn.__internal_updateFromJSON(data.sign_in);
+      } else {
+        this.signIn = new SignIn(data.sign_in);
+      }
+
       this.lastActiveSessionId = data.last_active_session_id;
       this.captchaBypass = data.captcha_bypass || false;
       this.cookieExpiresAt = data.cookie_expires_at ? unixEpochToDate(data.cookie_expires_at) : null;

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -574,6 +574,10 @@ export class SignIn extends BaseResource implements SignInResource {
     return this;
   }
 
+  public __internal_updateFromJSON(data: SignInJSON | SignInJSONSnapshot | null): this {
+    return this.fromJSON(data);
+  }
+
   public __internal_toSnapshot(): SignInJSONSnapshot {
     return {
       object: 'sign_in',

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -521,6 +521,10 @@ export class SignUp extends BaseResource implements SignUpResource {
     return this;
   }
 
+  public __internal_updateFromJSON(data: SignUpJSON | SignUpJSONSnapshot | null): this {
+    return this.fromJSON(data);
+  }
+
   public __internal_toSnapshot(): SignUpJSONSnapshot {
     return {
       object: 'sign_up',


### PR DESCRIPTION
## Description

This PR updates the Client JSON parsing logic to reuse existing `SignIn` and `SignUp` instances when the incoming IDs match the current instance. This results in a stable referential identity for `client.signIn` and `client.signUp` when possible. Previously, we were creating new instances of `SignIn`/`SignUp` on every request: one from the mutation HTTP request response, and another from the client piggybacking response. This caused two update events to be emitted, each with different instances of the class.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session instances (SignIn and SignUp) are now preserved and updated when receiving data with matching identifiers, rather than being replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->