### PR TITLE
fix(astro): Ensure runInjectionScript runs on initial page loads with view transitions enabled

### DIFF
--- a/.changeset/ready-cats-tease.md
+++ b/.changeset/ready-cats-tease.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': patch
+---
+
+Fixed an issue when using `ClientRouter` where Clerk components don't load until navigation is performed.

--- a/packages/astro/src/integration/create-integration.ts
+++ b/packages/astro/src/integration/create-integration.ts
@@ -126,9 +126,10 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
             }
 
             if (transitionEnabledOnThisPage()) {
-              const { navigate, swapFunctions } = await import('astro:transitions/client');
+              // We must do the dynamic imports within the event listeners because otherwise we may race and miss initial astro:page-load
+              document.addEventListener('astro:before-swap', async (e) => {
+                const { swapFunctions } = await import('astro:transitions/client');
 
-              document.addEventListener('astro:before-swap', (e) => {
                 const clerkComponents = document.querySelector('#clerk-components');
                 // Keep the div element added by Clerk
                 if (clerkComponents) {
@@ -140,6 +141,8 @@ function createIntegration<Params extends HotloadAstroClerkIntegrationParams>() 
               });
 
               document.addEventListener('astro:page-load', async (e) => {
+                const { navigate } = await import('astro:transitions/client');
+
                 await runInjectionScript({
                   ...${JSON.stringify(internalParams)},
                   routerPush: navigate,


### PR DESCRIPTION
## Description

Core 2 PR for https://github.com/clerk/javascript/pull/7801

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
