### PR TITLE
fix(integration): fix flaky keyless popover tests

### DIFF
--- a/integration/tests/next-quickstart-keyless.test.ts
+++ b/integration/tests/next-quickstart-keyless.test.ts
@@ -84,26 +84,11 @@ test.describe('Keyless mode @quickstart', () => {
 
     const claim = await u.po.keylessPopover.promptsToClaim();
 
-    const [newPage] = await Promise.all([context.waitForEvent('page'), claim.click()]);
-
-    await newPage.waitForLoadState();
-
-    await newPage.waitForURL(url => {
-      const urlToReturnTo = `${dashboardUrl}apps/claim?token=`;
-
-      const signUpForceRedirectUrl = url.searchParams.get('sign_up_force_redirect_url');
-
-      const signUpForceRedirectUrlCheck =
-        signUpForceRedirectUrl?.startsWith(urlToReturnTo) ||
-        (signUpForceRedirectUrl?.startsWith(`${dashboardUrl}prepare-account`) &&
-          signUpForceRedirectUrl?.includes(encodeURIComponent('apps/claim?token=')));
-
-      return (
-        url.pathname === '/apps/claim/sign-in' &&
-        url.searchParams.get('sign_in_force_redirect_url')?.startsWith(urlToReturnTo) &&
-        signUpForceRedirectUrlCheck
-      );
-    });
+    // Verify the claim link points to the correct dashboard URL
+    // without navigating to the external dashboard, which is flaky in CI.
+    const href = await claim.getAttribute('href');
+    expect(href).toContain(`${dashboardUrl}apps/claim?token=`);
+    expect(href).toContain('return_url=');
   });
 
   test('Lands on claimed application with missing explicit keys, expanded by default, click to get keys from dashboard.', async ({
@@ -119,15 +104,11 @@ test.describe('Keyless mode @quickstart', () => {
     expect(await u.po.keylessPopover.isExpanded()).toBe(true);
     await expect(u.po.keylessPopover.promptToUseClaimedKeys()).toBeVisible();
 
-    const [newPage] = await Promise.all([
-      context.waitForEvent('page'),
-      u.po.keylessPopover.promptToUseClaimedKeys().click(),
-    ]);
-
-    await newPage.waitForLoadState();
-    await newPage.waitForURL(url => {
-      return url.href.startsWith(`${dashboardUrl}sign-in?redirect_url=${encodeURIComponent(dashboardUrl)}apps%2Fapp_`);
-    });
+    // Verify the link points to the correct dashboard URL
+    // without navigating to the external dashboard, which is flaky in CI.
+    const href = await u.po.keylessPopover.promptToUseClaimedKeys().getAttribute('href');
+    expect(href).toContain(dashboardUrl);
+    expect(href).toContain('apps/app_');
   });
 
   test('Claimed application with keys inside .env, on dismiss, keyless prompt is removed.', async ({

--- a/integration/tests/tanstack-start/keyless.test.ts
+++ b/integration/tests/tanstack-start/keyless.test.ts
@@ -64,26 +64,11 @@ test.describe('Keyless mode @tanstack-react-start', () => {
 
     const claim = await u.po.keylessPopover.promptsToClaim();
 
-    const [newPage] = await Promise.all([context.waitForEvent('page'), claim.click()]);
-
-    await newPage.waitForLoadState();
-
-    await newPage.waitForURL(url => {
-      const urlToReturnTo = `${dashboardUrl}apps/claim?token=`;
-
-      const signUpForceRedirectUrl = url.searchParams.get('sign_up_force_redirect_url');
-
-      const signUpForceRedirectUrlCheck =
-        signUpForceRedirectUrl?.startsWith(urlToReturnTo) ||
-        (signUpForceRedirectUrl?.startsWith(`${dashboardUrl}prepare-account`) &&
-          signUpForceRedirectUrl?.includes(encodeURIComponent('apps/claim?token=')));
-
-      return (
-        url.pathname === '/apps/claim/sign-in' &&
-        url.searchParams.get('sign_in_force_redirect_url')?.startsWith(urlToReturnTo) &&
-        signUpForceRedirectUrlCheck
-      );
-    });
+    // Verify the claim link points to the correct dashboard URL
+    // without navigating to the external dashboard, which is flaky in CI.
+    const href = await claim.getAttribute('href');
+    expect(href).toContain(`${dashboardUrl}apps/claim?token=`);
+    expect(href).toContain('return_url=');
   });
 
   test('Lands on claimed application with missing explicit keys, expanded by default, click to get keys from dashboard.', async ({
@@ -99,15 +84,11 @@ test.describe('Keyless mode @tanstack-react-start', () => {
     expect(await u.po.keylessPopover.isExpanded()).toBe(true);
     await expect(u.po.keylessPopover.promptToUseClaimedKeys()).toBeVisible();
 
-    const [newPage] = await Promise.all([
-      context.waitForEvent('page'),
-      u.po.keylessPopover.promptToUseClaimedKeys().click(),
-    ]);
-
-    await newPage.waitForLoadState();
-    await newPage.waitForURL(url => {
-      return url.href.startsWith(`${dashboardUrl}sign-in?redirect_url=${encodeURIComponent(dashboardUrl)}apps%2Fapp_`);
-    });
+    // Verify the link points to the correct dashboard URL
+    // without navigating to the external dashboard, which is flaky in CI.
+    const href = await u.po.keylessPopover.promptToUseClaimedKeys().getAttribute('href');
+    expect(href).toContain(dashboardUrl);
+    expect(href).toContain('apps/app_');
   });
 
   test('Keyless popover is removed after adding keys to .env and restarting.', async ({ page, context }) => {


### PR DESCRIPTION
## Summary
- Replace external dashboard navigation with `href` attribute assertions in keyless popover integration tests
- The "Toggle collapse popover and claim" and "Lands on claimed application" tests were flaky because they navigated to the external Clerk Dashboard and waited for redirects, which is subject to network latency and dashboard availability in CI
- Instead of opening a new tab and waiting for the dashboard redirect chain, the tests now verify the link's `href` attribute contains the correct dashboard URL and expected parameters

## Test plan
- [ ] Verify `quickstart` (chrome, 15) integration tests pass
- [ ] Verify `quickstart` (chrome, 16) integration tests pass
- [ ] Verify `tanstack-react-start` (chrome) integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing navigation-based assertions with direct href verification in keyless authentication flows, reducing flaky CI behavior and eliminating cross-origin navigation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->