### PR TITLE
fix(clerk-js): Remove beforeunload event listener from SafeLock (#7775)

### DIFF
--- a/.changeset/remove-beforeunload-safelock.md
+++ b/.changeset/remove-beforeunload-safelock.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removed redundant `beforeunload` event listener from SafeLock that was disabling the browser's back-forward cache (bfcache), degrading navigation performance.

--- a/packages/clerk-js/src/core/auth/safeLock.ts
+++ b/packages/clerk-js/src/core/auth/safeLock.ts
@@ -3,12 +3,6 @@ import Lock from 'browser-tabs-lock';
 export function SafeLock(key: string) {
   const lock = new Lock();
 
-  // TODO: Figure out how to fix this linting error
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  window.addEventListener('beforeunload', async () => {
-    await lock.releaseLock(key);
-  });
-
   const acquireLockAndRun = async (cb: () => Promise<unknown>) => {
     if ('locks' in navigator && isSecureContext) {
       const controller = new AbortController();


### PR DESCRIPTION
## Description

Core 2 version of #7775 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
