### PR TITLE
feat(clerk-js,react,shared): Add support for reset password via phone code

### DIFF
--- a/.changeset/lazy-eagles-lay.md
+++ b/.changeset/lazy-eagles-lay.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/react': minor
+---
+
+Add support for resetting a password via phone code.

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -890,6 +890,133 @@ describe('SignIn', () => {
       });
     });
 
+    describe('sendResetPasswordPhoneCode', () => {
+      afterEach(() => {
+        vi.clearAllMocks();
+      });
+
+      it('creates signIn with phoneNumber when no existing signIn', async () => {
+        const mockFetch = vi
+          .fn()
+          .mockResolvedValueOnce({
+            client: null,
+            response: {
+              id: 'signin_123',
+              identifier: '+15551234567',
+              supported_first_factors: [
+                {
+                  strategy: 'reset_password_phone_code',
+                  phone_number_id: 'phone_123',
+                  safe_identifier: '+15551234567',
+                },
+              ],
+            },
+          })
+          .mockResolvedValueOnce({
+            client: null,
+            response: { id: 'signin_123' },
+          });
+        BaseResource._fetch = mockFetch;
+
+        const signIn = new SignIn();
+        await signIn.__internal_future.resetPasswordPhoneCode.sendCode({ phoneNumber: '+15551234567' });
+
+        expect(mockFetch).toHaveBeenNthCalledWith(1, {
+          method: 'POST',
+          path: '/client/sign_ins',
+          body: { identifier: '+15551234567' },
+        });
+
+        expect(mockFetch).toHaveBeenNthCalledWith(2, {
+          method: 'POST',
+          path: '/client/sign_ins/signin_123/prepare_first_factor',
+          body: {
+            phoneNumberId: 'phone_123',
+            strategy: 'reset_password_phone_code',
+          },
+        });
+      });
+
+      it('prepares first factor with reset password phone code', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signin_123' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signIn = new SignIn({
+          id: 'signin_123',
+          supported_first_factors: [
+            {
+              strategy: 'reset_password_phone_code',
+              phone_number_id: 'phone_123',
+              safe_identifier: '+15551234567',
+            },
+          ],
+        } as any);
+        await signIn.__internal_future.resetPasswordPhoneCode.sendCode();
+
+        expect(mockFetch).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/client/sign_ins/signin_123/prepare_first_factor',
+          body: {
+            phoneNumberId: 'phone_123',
+            strategy: 'reset_password_phone_code',
+          },
+        });
+      });
+
+      it('throws error when no signIn ID and no phoneNumber', async () => {
+        const signIn = new SignIn();
+
+        await expect(signIn.__internal_future.resetPasswordPhoneCode.sendCode()).rejects.toThrow();
+      });
+
+      it('returns error when reset password phone code factor not found', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: {
+            id: 'signin_123',
+            identifier: '+15551234567',
+            supported_first_factors: [{ strategy: 'password' }],
+          },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signIn = new SignIn();
+        const result = await signIn.__internal_future.resetPasswordPhoneCode.sendCode({ phoneNumber: '+15551234567' });
+
+        expect(result.error).toBeTruthy();
+        expect(result.error?.code).toBe('factor_not_found');
+      });
+    });
+
+    describe('verifyResetPasswordPhoneCode', () => {
+      afterEach(() => {
+        vi.clearAllMocks();
+      });
+
+      it('attempts first factor with reset password phone code', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signin_123' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signIn = new SignIn({ id: 'signin_123' } as any);
+        await signIn.__internal_future.resetPasswordPhoneCode.verifyCode({ code: '123456' });
+
+        expect(mockFetch).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/client/sign_ins/signin_123/attempt_first_factor',
+          body: {
+            code: '123456',
+            strategy: 'reset_password_phone_code',
+          },
+        });
+      });
+    });
+
     describe('submitResetPassword', () => {
       afterEach(() => {
         vi.clearAllMocks();

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -225,6 +225,11 @@ export class StateProxy implements State {
           'verifyCode',
           'submitPassword',
         ] as const),
+        resetPasswordPhoneCode: this.wrapMethods(() => target().resetPasswordPhoneCode, [
+          'sendCode',
+          'verifyCode',
+          'submitPassword',
+        ] as const),
         phoneCode: this.wrapMethods(() => target().phoneCode, ['sendCode', 'verifyCode'] as const),
         mfa: this.wrapMethods(() => target().mfa, [
           'sendPhoneCode',

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -138,6 +138,14 @@ export interface SignInFutureResetPasswordSubmitParams {
   signOutOfOtherSessions?: boolean;
 }
 
+export interface SignInFutureResetPasswordPhoneCodeSendParams {
+  /**
+   * The user's phone number in [E.164 format](https://en.wikipedia.org/wiki/E.164). Only supported if
+   * [phone number](https://clerk.com/docs/guides/configure/auth-strategies/sign-up-sign-in-options#phone) is enabled.
+   */
+  phoneNumber?: string;
+}
+
 export type SignInFuturePhoneCodeSendParams = {
   /**
    * The mechanism to use to send the code to the provided phone number. Defaults to `'sms'`.
@@ -162,6 +170,13 @@ export type SignInFuturePhoneCodeSendParams = {
 );
 
 export interface SignInFuturePhoneCodeVerifyParams {
+  /**
+   * The one-time code that was sent to the user.
+   */
+  code: string;
+}
+
+export interface SignInFutureResetPasswordPhoneCodeVerifyParams {
   /**
    * The one-time code that was sent to the user.
    */
@@ -449,6 +464,26 @@ export interface SignInFutureResource {
      * Used to verify a password reset code sent via email. Will cause `signIn.status` to become `'needs_new_password'`.
      */
     verifyCode: (params: SignInFutureEmailCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
+
+    /**
+     * Used to submit a new password, and move the `signIn.status` to `'complete'`.
+     */
+    submitPassword: (params: SignInFutureResetPasswordSubmitParams) => Promise<{ error: ClerkError | null }>;
+  };
+
+  /**
+   *
+   */
+  resetPasswordPhoneCode: {
+    /**
+     * Used to send a password reset code to the first phone number on the account
+     */
+    sendCode: (params?: SignInFutureResetPasswordPhoneCodeSendParams) => Promise<{ error: ClerkError | null }>;
+
+    /**
+     * Used to verify a password reset code sent via phone. Will cause `signIn.status` to become `'needs_new_password'`.
+     */
+    verifyCode: (params: SignInFutureResetPasswordPhoneCodeVerifyParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to submit a new password, and move the `signIn.status` to `'complete'`.


### PR DESCRIPTION
## Description

This PR implements `resetPasswordPhoneCode` following the same patterns we already use for `resetPasswordEmailCode`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password reset via phone code. Users can now request a reset code be sent to their phone number, verify the code, and set a new password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->