### PR TITLE
feat(clerk-js,shared): Adds username into public user data core-2

### DIFF
--- a/.changeset/cute-crabs-agree.md
+++ b/.changeset/cute-crabs-agree.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+---
+
+Add `username` field into `PublicUserData` object.

--- a/packages/clerk-js/src/core/resources/PublicUserData.ts
+++ b/packages/clerk-js/src/core/resources/PublicUserData.ts
@@ -11,6 +11,7 @@ export class PublicUserData implements IPublicUserData {
   hasImage!: boolean;
   identifier!: string;
   userId?: string;
+  username?: string;
 
   constructor(data: PublicUserDataJSON | PublicUserDataJSONSnapshot) {
     this.fromJSON(data);
@@ -24,6 +25,7 @@ export class PublicUserData implements IPublicUserData {
       this.hasImage = data.has_image || false;
       this.identifier = data.identifier || '';
       this.userId = data.user_id;
+      this.username = data.username;
     }
 
     return this;
@@ -37,6 +39,7 @@ export class PublicUserData implements IPublicUserData {
       has_image: this.hasImage,
       identifier: this.identifier,
       user_id: this.userId,
+      username: this.username,
     };
   }
 }

--- a/packages/clerk-js/src/core/resources/__tests__/PublicUserData.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/PublicUserData.test.ts
@@ -13,6 +13,7 @@ describe('PublicUserData', () => {
       has_image: true,
       identifier: 'john-doe',
       user_id: '123',
+      username: 'johndoe',
     });
 
     expect(pud).toMatchObject({
@@ -22,6 +23,7 @@ describe('PublicUserData', () => {
       hasImage: true,
       identifier: 'john-doe',
       userId: '123',
+      username: 'johndoe',
     });
   });
 });

--- a/packages/shared/src/types/json.ts
+++ b/packages/shared/src/types/json.ts
@@ -338,6 +338,7 @@ export interface PublicUserDataJSON {
   has_image: boolean;
   identifier: string;
   user_id?: string;
+  username?: string;
 }
 
 export interface SessionWithActivitiesJSON extends Omit<SessionJSON, 'user'> {


### PR DESCRIPTION
## Description

Add username into public user data

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional username field added to public user profile data and included in serialized API responses/snapshots.

* **Tests**
  * Unit tests updated to cover the new username field in public user data.

* **Chores**
  * Changelog updated to document the new public profile field and prepare a minor version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->