### PR TITLE
fix(backend): type JwtTemplatesApi.list as PaginatedResourceResponse

### DIFF
--- a/.changeset/thick-points-watch.md
+++ b/.changeset/thick-points-watch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+fix(backend): type JwtTemplatesApi.list as PaginatedResourceResponse

--- a/packages/backend/src/api/endpoints/JwtTemplatesApi.ts
+++ b/packages/backend/src/api/endpoints/JwtTemplatesApi.ts
@@ -2,6 +2,7 @@ import type { ClerkPaginationRequest } from '@clerk/shared/types';
 import { joinPaths } from 'src/util/path';
 
 import type { DeletedObject, JwtTemplate } from '../resources';
+import type { PaginatedResourceResponse } from '../resources/Deserializer';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/jwt_templates';
@@ -48,7 +49,7 @@ type UpdateJWTTemplateParams = CreateJWTTemplateParams & {
 
 export class JwtTemplatesApi extends AbstractAPI {
   public async list(params: ClerkPaginationRequest = {}) {
-    return this.request<JwtTemplate[]>({
+    return this.request<PaginatedResourceResponse<JwtTemplate[]>>({
       method: 'GET',
       path: basePath,
       queryParams: { ...params, paginated: true },


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JWT templates list endpoint now returns paginated results (clients will receive paginated response structure).

* **Chores**
  * Patch release note and changelog updated for the backend package to reflect the pagination change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->