### PR TITLE
fix(astro): Fall back to process.env for runtime environment variables

### DIFF
--- a/.changeset/tame-parents-drive.md
+++ b/.changeset/tame-parents-drive.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/astro': patch
+'@clerk/astro': major
 ---
 
-Fix `PUBLIC_CLERK_PUBLISHABLE_KEY` not readable from runtime environment when using the Astro Node adapter. Added `process.env` as a fallback in `getContextEnvVar()` for cases where `import.meta.env.PUBLIC_*` is statically replaced at build time by Vite.
+Changed environment variable resolution order in `getContextEnvVar()` to prefer `process.env` over `import.meta.env`. Runtime environment variables (e.g., set in the Node.js adapter) now take precedence over build-time values statically replaced by Vite. This ensures that environment variables set at runtime behave as expected when deploying with the Astro Node adapter or similar runtime environments.

--- a/packages/astro/src/server/__tests__/get-safe-env.test.ts
+++ b/packages/astro/src/server/__tests__/get-safe-env.test.ts
@@ -42,18 +42,7 @@ describe('getSafeEnv', () => {
     delete process.env.CLERK_SECRET_KEY;
   });
 
-  it('reads from import.meta.env when runtime.env is not available', () => {
-    vi.stubEnv('PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_from_meta');
-    vi.stubEnv('CLERK_SECRET_KEY', 'sk_from_meta');
-
-    const locals = createLocals({ runtime: { env: undefined as unknown as InternalEnv } });
-    const env = getSafeEnv(locals);
-
-    expect(env.pk).toBe('pk_from_meta');
-    expect(env.sk).toBe('sk_from_meta');
-  });
-
-  it('falls back to process.env when import.meta.env has no value', () => {
+  it('reads from process.env when runtime.env is not available', () => {
     process.env.PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_from_process';
     process.env.CLERK_SECRET_KEY = 'sk_from_process';
 
@@ -68,7 +57,6 @@ describe('getSafeEnv', () => {
   });
 
   it('returns undefined when no env source has the value', () => {
-    // Clean process.env so the fallback finds nothing
     delete process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
     delete process.env.CLERK_SECRET_KEY;
 
@@ -103,7 +91,7 @@ describe('getClientSafeEnv', () => {
     vi.unstubAllEnvs();
   });
 
-  it('falls back to process.env for publishableKey', () => {
+  it('reads from process.env for publishableKey', () => {
     process.env.PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_from_process';
 
     const locals = createLocals({ runtime: { env: undefined as unknown as InternalEnv } });
@@ -114,7 +102,7 @@ describe('getClientSafeEnv', () => {
     delete process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
   });
 
-  it('falls back to process.env for all public env vars', () => {
+  it('reads from process.env for all public env vars', () => {
     process.env.PUBLIC_CLERK_DOMAIN = 'test.domain.com';
     process.env.PUBLIC_CLERK_SIGN_IN_URL = '/sign-in';
     process.env.PUBLIC_CLERK_SIGN_UP_URL = '/sign-up';

--- a/packages/astro/src/server/get-safe-env.ts
+++ b/packages/astro/src/server/get-safe-env.ts
@@ -14,18 +14,14 @@ function getContextEnvVar(envVarName: keyof InternalEnv, contextOrLocals: Contex
     return locals.runtime.env[envVarName];
   }
 
-  const envValue = import.meta.env[envVarName];
-  if (envValue) {
-    return envValue;
-  }
-
-  // Fallback to process.env for runtime environments (e.g., Node.js adapter)
-  // where import.meta.env.PUBLIC_* is statically replaced at build time by Vite
-  if (typeof process !== 'undefined' && process.env) {
+  // Prefer process.env for runtime environments (e.g., Node.js adapter)
+  // where import.meta.env.PUBLIC_* is statically replaced at build time by Vite.
+  // Runtime values should take precedence over build-time values.
+  if (typeof process !== 'undefined' && process.env?.[envVarName]) {
     return process.env[envVarName];
   }
 
-  return undefined;
+  return import.meta.env[envVarName] || undefined;
 }
 
 /**

--- a/packages/upgrade/src/versions/core-3/changes/astro-env-var-precedence.md
+++ b/packages/upgrade/src/versions/core-3/changes/astro-env-var-precedence.md
@@ -1,0 +1,22 @@
+---
+title: 'Runtime environment variables now take precedence over build-time values'
+packages: ['astro']
+matcher:
+  - 'PUBLIC_CLERK_PUBLISHABLE_KEY'
+  - 'PUBLIC_CLERK_DOMAIN'
+  - 'PUBLIC_CLERK_SIGN_IN_URL'
+  - 'PUBLIC_CLERK_SIGN_UP_URL'
+  - 'import.meta.env'
+category: 'behavior-change'
+warning: true
+---
+
+Environment variable resolution in `@clerk/astro` now prefers `process.env` over `import.meta.env`. This means runtime environment variables (e.g., set in the Node.js adapter or container) take precedence over values statically replaced by Vite at build time.
+
+The new resolution order is:
+
+1. `locals.runtime.env` (Cloudflare Workers)
+2. `process.env` (Node.js runtime)
+3. `import.meta.env` (Vite build-time static replacement)
+
+Previously, `import.meta.env` was checked before `process.env`. If you rely on build-time `PUBLIC_*` values that differ from your runtime `process.env`, you may need to update your configuration to ensure the correct values are set in `process.env` at runtime.


### PR DESCRIPTION
Add process.env as a third fallback in getContextEnvVar() so that PUBLIC_CLERK_PUBLISHABLE_KEY and other env vars set at runtime (e.g., via the Astro Node adapter) are properly read when import.meta.env.PUBLIC_* is statically replaced at build time by Vite.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

fixes https://github.com/clerk/javascript/issues/7841

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes runtime reading of the publishable key when build-time env replacements aren’t available by adding a fallback to process.env.

* **Tests**
  * Adds comprehensive tests for environment variable precedence and fallback behavior across different runtime environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->