### PR TITLE
fix(clerk-js,shared): Mark params optional for sendPhoneCode

### DIFF
--- a/.changeset/two-ways-lose.md
+++ b/.changeset/two-ways-lose.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Fix issue were `sendPhoneCode` method was incorrectly requiring a parameter.

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -905,8 +905,8 @@ class SignUpFuture implements SignUpFutureResource {
     });
   }
 
-  async sendPhoneCode(params: SignUpFuturePhoneCodeSendParams): Promise<{ error: ClerkError | null }> {
-    const { channel = 'sms' } = params;
+  async sendPhoneCode(params?: SignUpFuturePhoneCodeSendParams): Promise<{ error: ClerkError | null }> {
+    const { channel = 'sms' } = params || {};
     return runAsyncResourceTask(this.#resource, async () => {
       await this.#resource.__internal_basePost({
         body: { strategy: 'phone_code', channel },

--- a/packages/shared/src/types/signUpFuture.ts
+++ b/packages/shared/src/types/signUpFuture.ts
@@ -321,7 +321,7 @@ export interface SignUpFutureVerifications {
   /**
    * Used to send a phone code to verify a phone number.
    */
-  sendPhoneCode: (params: SignUpFuturePhoneCodeSendParams) => Promise<{ error: ClerkError | null }>;
+  sendPhoneCode: (params?: SignUpFuturePhoneCodeSendParams) => Promise<{ error: ClerkError | null }>;
 
   /**
    * Used to verify a code sent via phone.


### PR DESCRIPTION
## Description

This PR fixes an issue where we expected at least one argument to the `sendPhoneCode` parameter. It has now been made optional.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the phone code sending functionality incorrectly required parameters when they should have been optional. The method now properly handles optional parameters, allowing it to be called with or without arguments as needed. This simplifies API usage and improves the overall authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->