### PR TITLE
fix(react): Get transferable state in sign in proxy

### DIFF
--- a/.changeset/nice-jobs-sort.md
+++ b/.changeset/nice-jobs-sort.md
@@ -1,0 +1,5 @@
+---
+'@clerk/react': minor
+---
+
+Get transferable state in sign in proxy.

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -142,7 +142,9 @@ export class StateProxy implements State {
       signIn: {
         status: 'needs_identifier' as const,
         availableStrategies: [],
-        isTransferable: false,
+        get isTransferable() {
+          return gateProperty(target, 'isTransferable', false);
+        },
         get id() {
           return gateProperty(target, 'id', undefined);
         },


### PR DESCRIPTION
## Description

While working on custom flow docs for the `sign up if missing` flow added in https://github.com/clerk/javascript/pull/7749, I realize that we were unable to fetch the current sign in transferable state from the sign in object, because it was not being updated in the sign in React state proxy. Add a getter for this state instead of hardcoding it to false. This was verified with a local test app.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- SignIn now dynamically evaluates and reports accurate account transfer capability based on runtime conditions, replacing the previous static default with real-time assessment that provides users with precise transfer eligibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->