### PR TITLE
chore(clerk-js): Backport CHIPS removal to release/core-2

### DIFF
--- a/.changeset/remove-chips-build-variant.md
+++ b/.changeset/remove-chips-build-variant.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/shared": patch
+---
+
+Remove CHIPS build variant and use `partitioned_cookies` environment flag from the Clerk API to control partitioned cookie behavior at runtime.

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -42,7 +42,6 @@
     "bundlewatch:fix": "node bundlewatch-fix.mjs",
     "clean": "rimraf ./dist",
     "dev": "rspack serve --config rspack.config.js",
-    "dev:chips": "rspack serve --config rspack.config.js --env variant=\"clerk.chips.browser\"",
     "dev:headless": "rspack serve --config rspack.config.js --env variant=\"clerk.headless.browser\"",
     "dev:origin": "rspack serve --config rspack.config.js --env devOrigin=http://localhost:${PORT:-4000}",
     "dev:sandbox": "rspack serve --config rspack.config.js --env devOrigin=http://localhost:${PORT:-4000} --env sandbox=1",

--- a/packages/clerk-js/rspack.config.js
+++ b/packages/clerk-js/rspack.config.js
@@ -16,7 +16,6 @@ const variants = {
   clerkHeadless: 'clerk.headless',
   clerkHeadlessBrowser: 'clerk.headless.browser',
   clerkLegacyBrowser: 'clerk.legacy.browser',
-  clerkCHIPS: 'clerk.chips.browser',
 };
 
 const variantToSourceFile = {
@@ -26,7 +25,6 @@ const variantToSourceFile = {
   [variants.clerkHeadless]: './src/index.headless.ts',
   [variants.clerkHeadlessBrowser]: './src/index.headless.browser.ts',
   [variants.clerkLegacyBrowser]: './src/index.legacy.browser.ts',
-  [variants.clerkCHIPS]: './src/index.browser.ts',
 };
 
 /**
@@ -58,7 +56,6 @@ const common = ({ mode, variant, disableRHC = false }) => {
          */
         __BUILD_FLAG_KEYLESS_UI__: isDevelopment(mode),
         __BUILD_DISABLE_RHC__: JSON.stringify(disableRHC),
-        __BUILD_VARIANT_CHIPS__: variant === variants.clerkCHIPS,
       }),
       new rspack.EnvironmentPlugin({
         CLERK_ENV: mode,
@@ -447,13 +444,6 @@ const prodConfig = ({ mode, env, analysis }) => {
     // externalsForHeadless(),
   );
 
-  const clerkCHIPS = merge(
-    entryForVariant(variants.clerkCHIPS),
-    common({ mode, variant: variants.clerkCHIPS }),
-    commonForProd(),
-    commonForProdChunked(),
-  );
-
   const clerkEsm = merge(
     entryForVariant(variants.clerk),
     common({ mode, variant: variants.clerk }),
@@ -567,7 +557,6 @@ const prodConfig = ({ mode, env, analysis }) => {
     clerkLegacyBrowser,
     clerkHeadless,
     clerkHeadlessBrowser,
-    clerkCHIPS,
     clerkEsm,
     clerkEsmNoRHC,
     clerkCjs,
@@ -669,11 +658,6 @@ const devConfig = ({ mode, env }) => {
       common({ mode, variant: variants.clerkHeadlessBrowser }),
       commonForDev(),
       // externalsForHeadless(),
-    ),
-    [variants.clerkCHIPS]: merge(
-      entryForVariant(variants.clerkCHIPS),
-      common({ mode, variant: variants.clerkCHIPS }),
-      commonForDev(),
     ),
   };
 

--- a/packages/clerk-js/src/core/auth/__tests__/devBrowser.test.ts
+++ b/packages/clerk-js/src/core/auth/__tests__/devBrowser.test.ts
@@ -50,7 +50,8 @@ describe('Thrown errors', () => {
     const devBrowserHandler = createDevBrowser({
       frontendApi: 'white-koala-42.clerk.accounts.dev',
       fapiClient: mockFapiClient,
-      publishableKey: 'pk_test_d2hpdGUta29hbGEtNDIuY2xlcmsuYWNjb3VudHMuZGV2JA',
+      cookieSuffix: 'test-suffix',
+      cookieOptions: { usePartitionedCookies: () => false },
     });
 
     await expect(devBrowserHandler.setup()).rejects.toThrow(

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -13,10 +13,16 @@ export type DevBrowserCookieHandler = {
   remove: () => void;
 };
 
-const getCookieAttributes = (): { sameSite: string; secure: boolean } => {
-  const sameSite = inCrossOriginIframe() || requiresSameSiteNone() ? 'None' : 'Lax';
+export type DevBrowserCookieOptions = {
+  usePartitionedCookies: () => boolean;
+};
+
+const getCookieAttributes = (options: DevBrowserCookieOptions) => {
+  const isPartitioned = options.usePartitionedCookies();
+  const sameSite = isPartitioned || inCrossOriginIframe() || requiresSameSiteNone() ? 'None' : 'Lax';
   const secure = getSecureAttribute(sameSite);
-  return { sameSite, secure };
+  const partitioned = isPartitioned && secure;
+  return { sameSite, secure, partitioned } as const;
 };
 
 /**
@@ -25,7 +31,10 @@ const getCookieAttributes = (): { sameSite: string; secure: boolean } => {
  * The cookie is used to authenticate FAPI requests and pass
  * authentication from AP to the app.
  */
-export const createDevBrowserCookie = (cookieSuffix: string): DevBrowserCookieHandler => {
+export const createDevBrowserCookie = (
+  cookieSuffix: string,
+  options: DevBrowserCookieOptions,
+): DevBrowserCookieHandler => {
   const devBrowserCookie = createCookieHandler(DEV_BROWSER_JWT_KEY);
   const suffixedDevBrowserCookie = createCookieHandler(getSuffixedCookieName(DEV_BROWSER_JWT_KEY, cookieSuffix));
 
@@ -33,16 +42,30 @@ export const createDevBrowserCookie = (cookieSuffix: string): DevBrowserCookieHa
 
   const set = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
-    const { sameSite, secure } = getCookieAttributes();
+    const { sameSite, secure, partitioned } = getCookieAttributes(options);
 
-    suffixedDevBrowserCookie.set(jwt, { expires, sameSite, secure });
-    devBrowserCookie.set(jwt, { expires, sameSite, secure });
+    // Remove old non-partitioned cookies — the browser treats partitioned and
+    // non-partitioned cookies with the same name as distinct cookies.
+    if (partitioned) {
+      suffixedDevBrowserCookie.remove();
+      devBrowserCookie.remove();
+    }
+
+    suffixedDevBrowserCookie.set(jwt, { expires, sameSite, secure, partitioned });
+    devBrowserCookie.set(jwt, { expires, sameSite, secure, partitioned });
   };
 
   const remove = () => {
-    const attributes = getCookieAttributes();
+    const attributes = getCookieAttributes(options);
     suffixedDevBrowserCookie.remove(attributes);
     devBrowserCookie.remove(attributes);
+
+    // Also remove non-partitioned variants — the browser treats partitioned and
+    // non-partitioned cookies with the same name as distinct cookies.
+    if (attributes.partitioned) {
+      suffixedDevBrowserCookie.remove();
+      devBrowserCookie.remove();
+    }
   };
 
   return {

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -14,11 +14,16 @@ export type SessionCookieHandler = {
   get: () => string | undefined;
 };
 
-const getCookieAttributes = (): { sameSite: string; secure: boolean; partitioned: boolean } => {
-  const sameSite = __BUILD_VARIANT_CHIPS__ ? 'None' : inCrossOriginIframe() || requiresSameSiteNone() ? 'None' : 'Lax';
+export type SessionCookieOptions = {
+  usePartitionedCookies: () => boolean;
+};
+
+const getCookieAttributes = (options: SessionCookieOptions) => {
+  const isPartitioned = options.usePartitionedCookies();
+  const sameSite = isPartitioned || inCrossOriginIframe() || requiresSameSiteNone() ? 'None' : 'Lax';
   const secure = getSecureAttribute(sameSite);
-  const partitioned = __BUILD_VARIANT_CHIPS__ && secure;
-  return { sameSite, secure, partitioned };
+  const partitioned = isPartitioned && secure;
+  return { sameSite, secure, partitioned } as const;
 };
 
 /**
@@ -26,24 +31,32 @@ const getCookieAttributes = (): { sameSite: string; secure: boolean; partitioned
  * The cookie is used by the Clerk backend SDKs to identify
  * the authenticated user.
  */
-export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler => {
+export const createSessionCookie = (cookieSuffix: string, options: SessionCookieOptions): SessionCookieHandler => {
   const sessionCookie = createCookieHandler(SESSION_COOKIE_NAME);
   const suffixedSessionCookie = createCookieHandler(getSuffixedCookieName(SESSION_COOKIE_NAME, cookieSuffix));
 
   const remove = () => {
-    const attributes = getCookieAttributes();
+    const attributes = getCookieAttributes(options);
     sessionCookie.remove(attributes);
     suffixedSessionCookie.remove(attributes);
+
+    // Also remove non-partitioned variants — the browser treats partitioned and
+    // non-partitioned cookies with the same name as distinct cookies.
+    if (attributes.partitioned) {
+      sessionCookie.remove();
+      suffixedSessionCookie.remove();
+    }
   };
 
   const set = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const { sameSite, secure, partitioned } = getCookieAttributes();
+    const { sameSite, secure, partitioned } = getCookieAttributes(options);
 
-    // If setting Partitioned to true, remove the existing session cookies.
-    // This is to avoid conflicts with the same cookie name without Partitioned attribute.
+    // Remove old non-partitioned cookies — the browser treats partitioned and
+    // non-partitioned cookies with the same name as distinct cookies.
     if (partitioned) {
-      remove();
+      sessionCookie.remove();
+      suffixedSessionCookie.remove();
     }
 
     sessionCookie.set(token, { expires, sameSite, secure, partitioned });

--- a/packages/clerk-js/src/core/auth/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/devBrowser.ts
@@ -5,6 +5,7 @@ import type { ClerkAPIErrorJSON } from '@clerk/shared/types';
 import { isDevOrStagingUrl } from '../../utils';
 import { clerkErrorDevInitFailed } from '../errors';
 import type { FapiClient } from '../fapiClient';
+import type { DevBrowserCookieOptions } from './cookies/devBrowser';
 import { createDevBrowserCookie } from './cookies/devBrowser';
 
 export interface DevBrowser {
@@ -17,16 +18,24 @@ export interface DevBrowser {
   setDevBrowserJWT(jwt: string): void;
 
   removeDevBrowserJWT(): void;
+
+  refreshCookies(): void;
 }
 
 export type CreateDevBrowserOptions = {
   frontendApi: string;
   cookieSuffix: string;
   fapiClient: FapiClient;
+  cookieOptions: DevBrowserCookieOptions;
 };
 
-export function createDevBrowser({ cookieSuffix, frontendApi, fapiClient }: CreateDevBrowserOptions): DevBrowser {
-  const devBrowserCookie = createDevBrowserCookie(cookieSuffix);
+export function createDevBrowser({
+  cookieSuffix,
+  frontendApi,
+  fapiClient,
+  cookieOptions,
+}: CreateDevBrowserOptions): DevBrowser {
+  const devBrowserCookie = createDevBrowserCookie(cookieSuffix, cookieOptions);
 
   function getDevBrowserJWT() {
     return devBrowserCookie.get();
@@ -99,11 +108,19 @@ export function createDevBrowser({ cookieSuffix, frontendApi, fapiClient }: Crea
     setDevBrowserJWT(data?.id);
   }
 
+  function refreshCookies() {
+    const jwt = getDevBrowserJWT();
+    if (jwt) {
+      setDevBrowserJWT(jwt);
+    }
+  }
+
   return {
     clear,
     setup,
     getDevBrowserJWT,
     setDevBrowserJWT,
     removeDevBrowserJWT,
+    refreshCookies,
   };
 }

--- a/packages/clerk-js/src/core/resources/Environment.ts
+++ b/packages/clerk-js/src/core/resources/Environment.ts
@@ -22,6 +22,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   displayConfig: DisplayConfigResource = new DisplayConfig();
   maintenanceMode: boolean = false;
   clientDebugMode: boolean = false;
+  partitionedCookies: boolean = false;
   pathRoot = '/environment';
   userSettings: UserSettingsResource = new UserSettings();
   organizationSettings: OrganizationSettingsResource = new OrganizationSettings();
@@ -52,6 +53,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
     this.displayConfig = new DisplayConfig(data.display_config);
     this.maintenanceMode = this.withDefault(data.maintenance_mode, this.maintenanceMode);
     this.clientDebugMode = this.withDefault(data.client_debug_mode, this.clientDebugMode);
+    this.partitionedCookies = this.withDefault(data.partitioned_cookies, this.partitionedCookies);
     this.organizationSettings = new OrganizationSettings(data.organization_settings);
     this.userSettings = new UserSettings(data.user_settings);
     this.commerceSettings = new CommerceSettings(data.commerce_settings);
@@ -94,6 +96,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
       id: this.id ?? '',
       maintenance_mode: this.maintenanceMode,
       client_debug_mode: this.clientDebugMode,
+      partitioned_cookies: this.partitionedCookies,
       organization_settings: this.organizationSettings.__internal_toSnapshot(),
       user_settings: this.userSettings.__internal_toSnapshot(),
       commerce_settings: this.commerceSettings.__internal_toSnapshot(),

--- a/packages/clerk-js/src/global.d.ts
+++ b/packages/clerk-js/src/global.d.ts
@@ -11,7 +11,6 @@ declare const __DEV__: boolean;
  * Build time feature flags.
  */
 declare const __BUILD_DISABLE_RHC__: string;
-declare const __BUILD_VARIANT_CHIPS__: boolean;
 
 interface Window {
   __unstable__onBeforeSetActive: (intent?: 'sign-out') => Promise<void> | void;

--- a/packages/clerk-js/vitest.config.mts
+++ b/packages/clerk-js/vitest.config.mts
@@ -26,7 +26,6 @@ export default defineConfig({
   plugins: [react({ jsxRuntime: 'automatic', jsxImportSource: '@emotion/react' }), viteSvgMockPlugin()],
   define: {
     __BUILD_DISABLE_RHC__: JSON.stringify(false),
-    __BUILD_VARIANT_CHIPS__: JSON.stringify(false),
     __PKG_NAME__: JSON.stringify('@clerk/clerk-js'),
     __PKG_VERSION__: JSON.stringify('test'),
   },
@@ -40,7 +39,6 @@ export default defineConfig({
         'src/**/*.d.ts',
         'src/**/index.ts',
         'src/**/index.browser.ts',
-        'src/**/index.chips.browser.ts',
         'src/**/index.headless.ts',
         'src/**/index.headless.browser.ts',
         'src/**/index.legacy.browser.ts',

--- a/packages/shared/src/types/environment.ts
+++ b/packages/shared/src/types/environment.ts
@@ -22,5 +22,6 @@ export interface EnvironmentResource extends ClerkResource {
   onWindowLocationHost: () => boolean;
   maintenanceMode: boolean;
   clientDebugMode: boolean;
+  partitionedCookies: boolean;
   __internal_toSnapshot: () => EnvironmentJSONSnapshot;
 }

--- a/packages/shared/src/types/json.ts
+++ b/packages/shared/src/types/json.ts
@@ -90,6 +90,7 @@ export interface EnvironmentJSON extends ClerkResourceJSON {
   display_config: DisplayConfigJSON;
   maintenance_mode: boolean;
   organization_settings: OrganizationSettingsJSON;
+  partitioned_cookies?: boolean;
   user_settings: UserSettingsJSON;
   protect_config: ProtectConfigJSON;
 }


### PR DESCRIPTION
## Summary
- Backports dc886a9575a0c7366c57cba59ecde260baeb6dad from `main` to `release/core-2`
- Removes the CHIPS build variant and replaces it with an environment flag (`usePartitionedCookies`) for partitioned cookies
- Cookie handlers (`session`, `devBrowser`, `clientUat`) now accept options to dynamically determine partitioned cookie behavior based on the environment configuration

## Test plan
- [ ] Verify clerk-js builds successfully
- [ ] Verify partitioned cookie behavior works correctly via environment flag
- [ ] Run clerk-js tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)