### PR TITLE
feat(ui): Add autocomplete="new-password"

### DIFF
--- a/.changeset/sixty-maps-search.md
+++ b/.changeset/sixty-maps-search.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': minor
+---
+
+Add `autocomplete="new-password"` for password inputs during password creation.

--- a/packages/ui/src/components/SessionTasks/tasks/TaskResetPassword/index.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskResetPassword/index.tsx
@@ -152,6 +152,7 @@ const TaskResetPasswordInternal = () => {
                         }
                         return confirmField.props.onChange(e);
                       }}
+                      autoComplete='new-password'
                     />
                   </Form.ControlRow>
                   <Form.ControlRow elementId={sessionsField.id}>

--- a/packages/ui/src/components/SignIn/ResetPassword.tsx
+++ b/packages/ui/src/components/SignIn/ResetPassword.tsx
@@ -136,6 +136,7 @@ const ResetPasswordInternal = () => {
                   {...passwordField.props}
                   isRequired
                   autoFocus
+                  autoComplete='new-password'
                 />
               </Form.ControlRow>
               <Form.ControlRow elementId={confirmField.id}>
@@ -147,6 +148,7 @@ const ResetPasswordInternal = () => {
                     }
                     return confirmField.props.onChange(e);
                   }}
+                  autoComplete='new-password'
                 />
               </Form.ControlRow>
               {!requiresNewPassword && (

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -109,6 +109,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 {...formState.password.props}
                 isRequired={fields.password?.required}
                 isOptional={!fields.password?.required}
+                autoComplete='new-password'
               />
             </Form.ControlRow>
           )}

--- a/packages/ui/src/components/UserProfile/PasswordForm.tsx
+++ b/packages/ui/src/components/UserProfile/PasswordForm.tsx
@@ -168,6 +168,7 @@ export const PasswordForm = withCardStateProvider((props: PasswordFormProps) => 
             isRequired
             autoFocus={!user.passwordEnabled}
             isDisabled={passwordEditDisabled}
+            autoComplete='new-password'
           />
         </Form.ControlRow>
         <Form.ControlRow elementId={confirmField.id}>
@@ -181,6 +182,7 @@ export const PasswordForm = withCardStateProvider((props: PasswordFormProps) => 
             }}
             isRequired
             isDisabled={passwordEditDisabled}
+            autoComplete='new-password'
           />
         </Form.ControlRow>
         <Form.ControlRow elementId={sessionsField.id}>


### PR DESCRIPTION
## Description

This PR adds the `autocomplete="new-password"` attribute to all password inputs involved with new passwords (sign-up, reset password, change password).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Password input fields across all authentication and account management flows have been optimized to deliver improved browser password manager compatibility, including sign-in, sign-up, password reset, and account password change flows, with enhanced autofill support providing users a seamless and efficient credential entry experience throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->