### PR TITLE
fix(shared): Make arguments for sendCode optional

### DIFF
--- a/.changeset/forty-lamps-yawn.md
+++ b/.changeset/forty-lamps-yawn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix issue where an argument to `signIn.emailCode.send()` was marked as required.

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -398,7 +398,7 @@ export interface SignInFutureResource {
     /**
      * Used to send an email code to sign-in
      */
-    sendCode: (params: SignInFutureEmailCodeSendParams) => Promise<{ error: ClerkError | null }>;
+    sendCode: (params?: SignInFutureEmailCodeSendParams) => Promise<{ error: ClerkError | null }>;
 
     /**
      * Used to verify a code sent via email to sign-in


### PR DESCRIPTION
## Description

Fixes an issue where the argument to `signIn.emailCode.sendCode` was marked as required in the types.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the `emailCode.send()` method required an argument that should have been optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->