### PR TITLE
fix(repo): fix release publish command for turbo compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           commit: 'ci(repo): Version packages (Core 3)'
           title: 'ci(repo): Version packages (Core 3)'
-          publish: pnpm turbo build $TURBO_ARGS --force && pnpm release
+          publish: bash -c 'pnpm turbo build $TURBO_ARGS --force=true && pnpm release'
           # Workaround for https://github.com/changesets/changesets/issues/421
           version: pnpm version-packages
         env:


### PR DESCRIPTION
## Summary
- Wrap `publish` command in `bash -c` so `$TURBO_ARGS` is shell-expanded and `&&` works as a command separator
- Use explicit `--force=true` since Turbo's `--force` flag now accepts an optional value

## Context
The release workflow is [failing](https://github.com/clerk/javascript/actions/runs/22642935626/job/65623485729) because:

1. The `changesets/action` `publish` input doesn't run through a shell, so `$TURBO_ARGS` isn't expanded and `&&` isn't treated as a command separator
2. Turbo's `--force` flag now accepts an optional value (`true`/`false`), causing `&&` to be parsed as the flag's value

All other workflows use `run:` steps (which go through bash natively), so they aren't affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to ensure consistent build execution during the publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->