### PR TITLE
feat(localizations): Add en-XA locale

### DIFF
--- a/.changeset/flat-pets-taste.md
+++ b/.changeset/flat-pets-taste.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': minor
+---
+
+Added en-XA locale to highlight unlocalized strings.

--- a/packages/localizations/src/en-XA.ts
+++ b/packages/localizations/src/en-XA.ts
@@ -1,0 +1,80 @@
+import type { LocalizationResource } from '@clerk/shared/types';
+
+import { enUS } from './en-US';
+
+const pseudoCharacterMap = {
+  a: 'å',
+  b: 'ƀ',
+  c: 'ç',
+  d: 'ð',
+  e: 'é',
+  f: 'ƒ',
+  g: 'ğ',
+  h: 'ħ',
+  i: 'ï',
+  j: 'ĵ',
+  k: 'ķ',
+  l: 'ľ',
+  m: 'ɱ',
+  n: 'ñ',
+  o: 'ø',
+  p: 'þ',
+  q: 'ʠ',
+  r: 'ř',
+  s: 'š',
+  t: 'ŧ',
+  u: 'ü',
+  v: 'ṽ',
+  w: 'ŵ',
+  x: 'ẋ',
+  y: 'ÿ',
+  z: 'ž',
+} as const;
+
+const pseudoCharacterMapWithUppercase = Object.fromEntries(
+  Object.entries(pseudoCharacterMap).flatMap(([source, target]) => [
+    [source, target],
+    [source.toUpperCase(), target.toLocaleUpperCase('en-US')],
+  ]),
+) as Record<string, string>;
+
+const tokenOrLetterPattern = /\{\{[^{}]*\}\}|\{[^{}]*\}|[a-zA-Z]/g;
+
+function pseudoLocalizeString(value: string): string {
+  return value.replace(tokenOrLetterPattern, segment => {
+    if (segment.startsWith('{')) {
+      return segment;
+    }
+
+    return pseudoCharacterMapWithUppercase[segment] ?? segment;
+  });
+}
+
+function pseudoLocalizeValue<T>(value: T): T {
+  if (typeof value === 'string') {
+    return pseudoLocalizeString(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => pseudoLocalizeValue(item)) as T;
+  }
+
+  if (value && typeof value === 'object') {
+    const localized: Record<string, unknown> = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      localized[key] = pseudoLocalizeValue(nestedValue);
+    }
+
+    return localized as T;
+  }
+
+  return value;
+}
+
+const enXAFromEnUS = pseudoLocalizeValue(enUS);
+
+export const enXA: LocalizationResource = {
+  ...enXAFromEnUS,
+  locale: 'en-XA',
+};

--- a/packages/localizations/src/index.ts
+++ b/packages/localizations/src/index.ts
@@ -9,6 +9,7 @@ export { deDE } from './de-DE';
 export { elGR } from './el-GR';
 export { enUS } from './en-US';
 export { enGB } from './en-GB';
+export { enXA } from './en-XA';
 export { esCR } from './es-CR';
 export { esES } from './es-ES';
 export { esMX } from './es-MX';


### PR DESCRIPTION
## Description

This PR introduces a `en-XA` locale which is derived from our `en-US` locale. Each string is transformed to use a different character in a deterministic way to help highlight portions of the UI that are not using our localization system.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new en-XA pseudo-localization locale to the localizations package. This specialized locale visually highlights untranslated and unlocalized strings within the application, enabling translators and developers to quickly identify content requiring localization attention and improving overall localization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->