### PR TITLE
fix(repo): prevent integration tests from installing Core 3 packages

### DIFF
--- a/verdaccio.install.yaml
+++ b/verdaccio.install.yaml
@@ -9,7 +9,6 @@ packages:
   '@clerk/*':
     access: $all
     publish: $all
-    proxy: npmjs
   '**':
     access: $all
     publish: $all


### PR DESCRIPTION
## Summary

- Remove `proxy: npmjs` from `@clerk/*` packages in `verdaccio.install.yaml` so integration tests only install locally published Core 2 packages instead of resolving higher Core 3 versions from the npm registry

## Context

After Core 3 was published to npm, the `release/core-2` integration tests started failing because:

1. CI publishes Core 2 packages (e.g. `@clerk/backend@2.33.0`) to a local Verdaccio registry
2. Verdaccio restarts with `verdaccio.install.yaml` which proxies `@clerk/*` to npmjs.org
3. Test apps install `@clerk/backend` — pnpm resolves Core 3 (`3.0.1`) from npm since it's a higher version than the locally published Core 2 (`2.33.0`)
4. All integration tests fail because they run Core 3 code against Core 2 test fixtures

The fix mirrors what `verdaccio.publish.yaml` already does — no npm proxy for `@clerk/*` scoped packages. Non-clerk dependencies continue to proxy to npm normally.

## Test plan

- [ ] Integration tests on this PR pass (they should install Core 2 packages from Verdaccio instead of Core 3 from npm)