### PR TITLE
fix(ci): Remove registry-url to fix OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
         uses: ./.github/actions/init
         with:
           playwright-enabled: true # Must be present to enable caching on branched workflows
-          registry-url: 'https://registry.npmjs.org'
           # turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           # turbo-team: ${{ vars.TURBO_TEAM }}
           # turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -151,7 +150,6 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           playwright-enabled: true # Must be present to enable caching on branched workflows
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Version packages for canary
         id: version-packages
@@ -265,7 +263,6 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Extract snapshot name
         id: extract-snapshot-name


### PR DESCRIPTION

## Description

Having registry-url triggers the creation of a .npmrc file and the theory is that is takes precedence over OIDC and the publishing process is looking for a non-existent `NPM_TOKEN` in that .npmrc file.


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release configuration by simplifying npm registry settings to use default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->