### PR TITLE
fix(ci): Set registry for OIDC through pnpm config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
           # turbo-team: ${{ vars.TURBO_TEAM }}
           # turbo-token: ${{ secrets.TURBO_TOKEN }}
 
+      - name: Configure npm for provenance
+        run: pnpm config set registry https://registry.npmjs.org/
+
       - name: Build release
         run: pnpm turbo build $TURBO_ARGS --force
 
@@ -150,6 +153,9 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           playwright-enabled: true # Must be present to enable caching on branched workflows
+
+      - name: Configure npm for provenance
+        run: pnpm config set registry https://registry.npmjs.org/
 
       - name: Version packages for canary
         id: version-packages
@@ -263,6 +269,9 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
+
+      - name: Configure npm for provenance
+        run: pnpm config set registry https://registry.npmjs.org/
 
       - name: Extract snapshot name
         id: extract-snapshot-name


### PR DESCRIPTION
## Description

In #7990 I removed the `.npmrc` file but we still need the registry to be set. `pnpm config` will handle that in a way that should work with OIDC.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to ensure consistent npm registry setup across all release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->