### PR TITLE
fix(repo): Upgrade npm for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,6 @@ jobs:
           # turbo-team: ${{ vars.TURBO_TEAM }}
           # turbo-token: ${{ secrets.TURBO_TOKEN }}
 
-      - name: Configure npm for provenance
-        run: pnpm config set registry https://registry.npmjs.org/
-
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 
@@ -156,9 +153,6 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           playwright-enabled: true # Must be present to enable caching on branched workflows
-
-      - name: Configure npm for provenance
-        run: pnpm config set registry https://registry.npmjs.org/
 
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
@@ -275,9 +269,6 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
-
-      - name: Configure npm for provenance
-        run: pnpm config set registry https://registry.npmjs.org/
 
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
The move to trusted publishing in #7915 removed `NODE_AUTH_TOKEN` from release workflows, relying on OIDC-based auth instead. The canary release immediately failed with `ENEEDAUTH` on all 22 packages: https://github.com/clerk/javascript/actions/runs/22712191833/job/65852752638

The problem: `actions/setup-node` with `registry-url` writes `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`. When that env var isn't set, the default npm version on GitHub runners treats the empty token as "auth configured but invalid" and fails before attempting OIDC. A newer npm version handles this correctly by falling through to OIDC when the token is empty.

This adds `npm install -g npm@latest` before publishing in all three release jobs (release, canary, snapshot), matching the pattern used in other repos with trusted publishing.

## Test plan
- Merge and verify the canary release succeeds on the next push to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to upgrade npm to the latest version prior to publishing steps.
  * Applied this change consistently across all release jobs so publishing runs use the same npm runtime and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->