### PR TITLE
fix(ci): Fix membership check for private members

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,10 +224,13 @@ jobs:
           github-token: ${{ secrets.CLERK_COOKIE_PAT }}
           script: |
             try {
-              await github.rest.orgs.checkMembershipForUser({
+              const { data } = await github.rest.orgs.getMembershipForUser({
                 org: 'clerk',
                 username: context.actor
               });
+              if (data.state !== 'active') {
+                core.setFailed(`@${context.actor} is not an active member of the Clerk organization`);
+              }
             } catch (e) {
               core.setFailed(`@${context.actor} is not a member of the Clerk organization`);
             }


### PR DESCRIPTION

## Description

Private members of the organization cannot be fetched with checkMembershipForUser unless the caller is an org admin. We want this job to also allow private members to run snapshot jobs. This PR also adds the requirement that the user is an active member.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow validation to enforce stricter membership verification during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->