### PR TITLE
chore(repo): Minimize old snapshot comments on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,36 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           reactions: heart
 
+      - name: Minimize previous snapshot comments
+        if: steps.version-packages.outputs.success == '1'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLERK_COOKIE_PAT }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const snapshotComments = comments.filter(
+              (comment) =>
+                comment.body?.includes('the snapshot version command generated the following package versions')
+            );
+
+            for (const comment of snapshotComments) {
+              await github.graphql(`
+                mutation MinimizeComment($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment {
+                      isMinimized
+                    }
+                  }
+                }
+              `, { id: comment.node_id });
+            }
+
       - name: Create snapshot release comment
         if: steps.version-packages.outputs.success == '1'
         uses: peter-evans/create-or-update-comment@v3.0.0


### PR DESCRIPTION
## Description

Added a new step to the snapshot-release workflow that automatically minimizes previous snapshot result comments when a new snapshot is posted. This keeps PR discussions cleaner by collapsing outdated snapshot results and keeping focus on the latest one.

The step:
- Fetches all comments on the PR
- Filters for snapshot result comments (identified by the unique marker text)
- Uses GitHub's GraphQL API to minimize each one with the OUTDATED classifier
- Runs before the new snapshot comment is created

## Type of change

- [x] 📖 Refactoring / dependency upgrade / documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved snapshot release workflow to automatically minimize and clean up previous snapshot release comments, streamlining release communication and enhancing clarity by reducing clutter in release discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->