### PR TITLE
chore(backend): Rename `taskId` -> `agentTaskId`

### DIFF
--- a/.changeset/cute-places-wear.md
+++ b/.changeset/cute-places-wear.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Adds `agentTaskId` and deprecates `taskId` to Agent Tasks Create response.

--- a/packages/backend/src/api/__tests__/AgentTaskApi.test.ts
+++ b/packages/backend/src/api/__tests__/AgentTaskApi.test.ts
@@ -13,7 +13,8 @@ describe('AgentTaskAPI', () => {
   const mockAgentTaskResponse = {
     object: 'agent_task',
     agent_id: 'agent_123',
-    task_id: 'task_456',
+    task_id: 'agent_task_456',
+    agent_task_id: 'agent_task_456',
     url: 'https://example.com/agent-task',
   };
 
@@ -51,9 +52,9 @@ describe('AgentTaskAPI', () => {
         redirectUrl: 'https://example.com/callback',
         sessionMaxDurationInSeconds: 1800,
       });
-
       expect(response.agentId).toBe('agent_123');
-      expect(response.taskId).toBe('task_456');
+      expect(response.taskId).toBe('agent_task_456');
+      expect(response.agentTaskId).toBe('agent_task_456');
       expect(response.url).toBe('https://example.com/agent-task');
     });
 
@@ -90,7 +91,8 @@ describe('AgentTaskAPI', () => {
       });
 
       expect(response.agentId).toBe('agent_123');
-      expect(response.taskId).toBe('task_456');
+      expect(response.taskId).toBe('agent_task_456');
+      expect(response.agentTaskId).toBe('agent_task_456');
     });
   });
 });

--- a/packages/backend/src/api/resources/AgentTask.ts
+++ b/packages/backend/src/api/resources/AgentTask.ts
@@ -34,6 +34,7 @@ export class AgentTask {
    * @returns A new AgentTask instance
    */
   static fromJSON(data: AgentTaskJSON): AgentTask {
-    return new AgentTask(data.agent_id, data.agent_task_id, data.agent_task_id, data.url);
+    const agentTaskId = data.agent_task_id ?? data.task_id ?? '';
+    return new AgentTask(data.agent_id, agentTaskId, agentTaskId, data.url);
   }
 }

--- a/packages/backend/src/api/resources/AgentTask.ts
+++ b/packages/backend/src/api/resources/AgentTask.ts
@@ -14,8 +14,13 @@ export class AgentTask {
     readonly agentId: string,
     /**
      * A unique identifier for this agent task.
+     * @deprecated Use agentTaskId instead.
      */
     readonly taskId: string,
+    /**
+     * A unique identifier for this agent task.
+     */
+    readonly agentTaskId: string,
     /**
      * The FAPI URL that, when visited, creates a session for the user.
      */
@@ -29,6 +34,6 @@ export class AgentTask {
    * @returns A new AgentTask instance
    */
   static fromJSON(data: AgentTaskJSON): AgentTask {
-    return new AgentTask(data.agent_id, data.task_id, data.url);
+    return new AgentTask(data.agent_id, data.agent_task_id, data.agent_task_id, data.url);
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -517,6 +517,10 @@ export interface AgentTaskJSON extends ClerkResourceJSON {
   object: typeof ObjectType.AgentTask;
   agent_id: string;
   agent_task_id: string;
+  /**
+   * @deprecated Use `agent_task_id` instead.
+   */
+  task_id: string;
   url: string;
 }
 

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -516,7 +516,7 @@ export interface SignInTokenJSON extends ClerkResourceJSON {
 export interface AgentTaskJSON extends ClerkResourceJSON {
   object: typeof ObjectType.AgentTask;
   agent_id: string;
-  task_id: string;
+  agent_task_id: string;
   url: string;
 }
 


### PR DESCRIPTION
## Description

Added `agentTaskId`, and deprecated `taskId`.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include a new agentTaskId field for Agent Tasks.

* **Deprecations**
  * The taskId field is deprecated; migrate to agentTaskId for future compatibility.

* **Tests**
  * Updated tests to reflect the new response shape.

* **Chores**
  * Changelog updated for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->