### PR TITLE
chore(repo): Various release workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,28 +84,29 @@ jobs:
               const clerkUiVersion = require('./packages/ui/package.json').version;
               const nextjsVersion = require('./packages/nextjs/package.json').version;
 
-              github.rest.actions.createWorkflowDispatch({
-                owner: 'clerk',
-                repo: 'sdk-infra-workers',
-                workflow_id: 'update-pkg-versions.yml',
-                ref: 'main',
-                inputs: { clerkjsVersion, clerkUiVersion }
-              })
-
-              github.rest.actions.createWorkflowDispatch({
-                owner: 'clerk',
-                repo: 'dashboard',
-                workflow_id: 'prepare-nextjs-sdk-update.yml',
-                ref: 'main',
-                inputs: { version: nextjsVersion }
-              })
-
-              github.rest.actions.createWorkflowDispatch({
-                owner: 'clerk',
-                repo: 'clerk-docs',
-                workflow_id: 'typedoc.yml',
-                ref: 'main',
-              })
+              const dispatches = [
+                github.rest.actions.createWorkflowDispatch({
+                  owner: 'clerk',
+                  repo: 'sdk-infra-workers',
+                  workflow_id: 'update-pkg-versions.yml',
+                  ref: 'main',
+                  inputs: { clerkjsVersion, clerkUiVersion }
+                }),
+                github.rest.actions.createWorkflowDispatch({
+                  owner: 'clerk',
+                  repo: 'dashboard',
+                  workflow_id: 'prepare-nextjs-sdk-update.yml',
+                  ref: 'main',
+                  inputs: { version: nextjsVersion }
+                }),
+                github.rest.actions.createWorkflowDispatch({
+                  owner: 'clerk',
+                  repo: 'clerk-docs',
+                  workflow_id: 'typedoc.yml',
+                  ref: 'main',
+                }),
+              ];
+              await Promise.all(dispatches);
             } else{
               core.warning("Changeset in pre-mode should not prepare a ClerkJS production release")
             }
@@ -185,24 +186,30 @@ jobs:
             const clerkUiVersion = require('./packages/ui/package.json').version;
             const nextjsVersion = require('./packages/nextjs/package.json').version;
 
-            github.rest.actions.createWorkflowDispatch({
-              owner: 'clerk',
-              repo: 'sdk-infra-workers',
-              workflow_id: 'update-pkg-versions.yml',
-              ref: 'main',
-              inputs: { clerkjsVersion, clerkUiVersion, sourceCommit: context.sha }
-            })
+            const dispatches = [
+              github.rest.actions.createWorkflowDispatch({
+                owner: 'clerk',
+                repo: 'sdk-infra-workers',
+                workflow_id: 'update-pkg-versions.yml',
+                ref: 'main',
+                inputs: { clerkjsVersion, clerkUiVersion, sourceCommit: context.sha }
+              }),
+            ];
 
             if (nextjsVersion.includes('canary')) {
               console.log('clerk/nextjs changed, will notify clerk/accounts');
-              github.rest.actions.createWorkflowDispatch({
-                owner: 'clerk',
-                repo: 'accounts',
-                workflow_id: 'release-staging.yml',
-                ref: 'main',
-                inputs: { version: nextjsVersion }
-              })
+              dispatches.push(
+                github.rest.actions.createWorkflowDispatch({
+                  owner: 'clerk',
+                  repo: 'accounts',
+                  workflow_id: 'release-staging.yml',
+                  ref: 'main',
+                  inputs: { version: nextjsVersion }
+                }),
+              );
             }
+
+            await Promise.all(dispatches);
 
   snapshot-release:
     name: Snapshot release


### PR DESCRIPTION
## Description

Following #7915 there were many small pre-existing things to fix. Now that we went through a whole release loop with the new workflow and everything works fine I packaged the fixes in here.

1. Use the built-in `GITHUB_TOKEN` everywhere possible
2. Fix the bug in the PR freshness check
3. Use `pnpm` instead of `npm` / `npx` where relevant
4. Await workflow dispatches instead of fire-and-forget

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized GitHub Actions workflows with consolidated dispatch calls for improved CI/CD efficiency.
  * Updated build tooling in release workflows for consistency and reduced command overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->