### PR TITLE
test(e2e): verify account portal serves clerk-js v6

### DIFF
--- a/integration/tests/next-account-portal/clerk-ap-core-3-v6.test.ts
+++ b/integration/tests/next-account-portal/clerk-ap-core-3-v6.test.ts
@@ -4,7 +4,7 @@ import type { Application } from '../../models/application';
 import { appConfigs } from '../../presets';
 import type { FakeUser } from '../../testUtils';
 import { createTestUtils } from '../../testUtils';
-import { testHandshakeRecovery, testSignIn, testSignOut, testSignUp, testSSR } from './common';
+import { testAPClerkJsVersion, testHandshakeRecovery, testSignIn, testSignOut, testSignUp, testSSR } from './common';
 
 test.describe('Next with ClerkJS V6 <-> Account Portal Core 3 @ap-flows', () => {
   test.describe.configure({ mode: 'serial' });
@@ -25,6 +25,10 @@ test.describe('Next with ClerkJS V6 <-> Account Portal Core 3 @ap-flows', () => 
   test.afterAll(async () => {
     await fakeUser.deleteIfExists();
     await app.teardown();
+  });
+
+  test('AP serves clerk-js v6', async ({ page, context }) => {
+    await testAPClerkJsVersion({ app, page, context, fakeUser }, '6');
   });
 
   test('sign in', async ({ page, context }) => {

--- a/integration/tests/next-account-portal/common.ts
+++ b/integration/tests/next-account-portal/common.ts
@@ -226,6 +226,26 @@ export const testSignOut = async ({ app, page, context, fakeUser }: TestParams) 
   expect(apURL).toMatch(/\.accounts(stage\.dev|\.dev|\.stg)/);
 };
 
+export const testAPClerkJsVersion = async ({ app, page, context }: TestParams, expectedMajorVersion: string) => {
+  const u = createTestUtils({ app, page, context, useTestingToken: false });
+
+  await u.page.goToAppHome();
+  await u.page.waitForClerkJsLoaded();
+  await u.po.expect.toBeSignedOut();
+
+  // Navigate to the Account Portal
+  await u.page.getByRole('button', { name: /Sign in/i }).click();
+  await u.po.signIn.waitForMounted();
+
+  const accountPortalURL = page.url();
+  expect(accountPortalURL).toMatch(/\.accounts(stage\.dev|\.dev|\.stg)/);
+
+  // Verify the clerk-js version served by the Account Portal
+  const clerkVersion = await page.evaluate(() => window.Clerk?.version);
+  expect(clerkVersion).toBeDefined();
+  expect(clerkVersion).toMatch(new RegExp(`^${expectedMajorVersion}\\.`));
+};
+
 export const testHandshakeRecovery = async ({ app, page, context, fakeUser }: TestParams) => {
   const u = createTestUtils({ app, page, context, useTestingToken: false });
 


### PR DESCRIPTION
The AP E2E tests exercise sign-in/sign-up flows against staging Core 3 but never actually assert which clerk-js version the AP serves. If Core 3 started serving the wrong major version, these tests would still pass silently.

- Added `testAPClerkJsVersion` helper in `common.ts` that navigates to the AP, waits for clerk-js to mount, and checks `window.Clerk.version` starts with the expected major version
- Called from the v6 test file with expected major `'6'`
- The helper is reusable for other version checks (v5, v7) if needed

## Test plan

- [ ] CI passes (no new deps, just a new test case in the existing AP serial suite)
- [ ] Run the `@ap-flows` tagged tests against staging to confirm the version assertion passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test utilities for verifying Clerk JS version compatibility in Account Portal integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->