### PR TITLE
fix(ui): Don't show period toggle for default plans

### DIFF
--- a/.changeset/red-monkeys-deny.md
+++ b/.changeset/red-monkeys-deny.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix issue where monthly/annual toggle appeared on default free plans.

--- a/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
@@ -400,7 +400,7 @@ const PeriodToggle = ({
   planPeriod: BillingSubscriptionPlanPeriod;
   setPlanPeriod: (val: BillingSubscriptionPlanPeriod) => void;
 }) => {
-  if (plan.fee && plan.annualMonthlyFee) {
+  if (!plan.isDefault && plan.fee && plan.annualMonthlyFee) {
     return (
       <Box
         elementDescriptor={descriptors.pricingTableCardPeriodToggle}


### PR DESCRIPTION
## Description

This PR fixes an issue where the monthly/annual toggle was incorrectly shown for default free plans.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the monthly/annual pricing toggle was appearing on default free plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->