### PR TITLE
fix(ci): always build packages in e2e-staging workflow

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -116,11 +116,10 @@ jobs:
           fi
           jq --version
 
-      # --- SDK from ref: build from source and publish to local registry ---
       - name: Build packages
-        if: ${{ steps.inputs.outputs.sdk-source == 'ref' }}
         run: pnpm turbo build $TURBO_ARGS --only
 
+      # --- SDK from ref: publish to local registry ---
       - name: Publish to local registry
         if: ${{ steps.inputs.outputs.sdk-source == 'ref' }}
         run: pkglab pub --force


### PR DESCRIPTION
## Summary

- Makes `pnpm turbo build` unconditional in the `e2e-staging` workflow
- With `sdk-source=latest`, the build step was skipped, but the test harness imports `@clerk/shared/keys` from the workspace — which requires built packages to resolve
- The build is needed for test infrastructure regardless of whether the SDK under test comes from npm or the local registry

## Test plan

- [ ] Trigger `e2e-staging` workflow via `workflow_dispatch` with `sdk-source=latest` and verify tests no longer fail with `Cannot find module` errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging workflow to ensure packages are built consistently during the CI/CD pipeline, regardless of build source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->