### PR TITLE
chore(tanstack-react-start): Remove beta warning in README

### DIFF
--- a/.changeset/spotty-schools-burn.md
+++ b/.changeset/spotty-schools-burn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/tanstack-react-start': patch
+---
+
+Removed beta warning in README

--- a/packages/tanstack-react-start/README.md
+++ b/packages/tanstack-react-start/README.md
@@ -29,8 +29,6 @@
 
 [Clerk](https://clerk.com/?utm_source=github&utm_medium=clerk_tanstack_react_start) is the easiest way to add authentication and user management to your Tanstack Start application. Add sign up, sign in, and profile management to your application in minutes.
 
-> [!WARNING] > `@clerk/tanstack-react-start` is currently in beta. It's not recommended to use it in production just yet, but it would be much appreciated if you give it a try.
-
 ### Prerequisites
 
 - TanStack Start `^1.157.0` or later


### PR DESCRIPTION
## Description

We already released v1 of `@clerk/tanstack-react-start` as part of Core 3

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed beta notice from package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->