### PR TITLE
fix(e2e): use caret range for react in cache-components template

### DIFF
--- a/integration/templates/next-cache-components/package.json
+++ b/integration/templates/next-cache-components/package.json
@@ -14,8 +14,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "next": "^16.0.0-canary.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "^5.7.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Loosens `react` and `react-dom` from pinned `19.0.0` to `^19.0.0` in the `next-cache-components` integration test template
- Fixes `ERESOLVE` peer dependency conflict: `@clerk/nextjs` requires `react@"^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"` which doesn't include `19.0.0`

## Test plan

- [ ] `cache-components` integration tests pass in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version constraints for core React dependencies to allow compatible updates within the version 19 range, enabling access to minor improvements and bug fixes while preserving stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->