### PR TITLE
fix(ci): add dependsOn to integration test turbo tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -202,106 +202,127 @@
       "outputs": []
     },
     "//#test:integration:ap-flows": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:generic": {
+      "dependsOn": ["@clerk/nextjs#build", "@clerk/react#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:express": {
+      "dependsOn": ["@clerk/express#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:hono": {
+      "dependsOn": ["@clerk/hono#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:nextjs": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:nextjs:canary": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:quickstart": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "VERCEL_AUTOMATION_BYPASS_SECRET"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:astro": {
+      "dependsOn": ["@clerk/astro#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:localhost": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "NODE_EXTRA_CA_CERTS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:sessions": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "DISABLE_WEB_SECURITY", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "NODE_EXTRA_CA_CERTS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:sessions:staging": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "DISABLE_WEB_SECURITY", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "NODE_EXTRA_CA_CERTS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:handshake": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "DISABLE_WEB_SECURITY", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "NODE_EXTRA_CA_CERTS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:handshake:staging": {
+      "dependsOn": ["@clerk/nextjs#build"],
       "env": ["CLEANUP", "DEBUG", "DISABLE_WEB_SECURITY", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "NODE_EXTRA_CA_CERTS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:expo-web": {
+      "dependsOn": ["@clerk/expo#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:tanstack-react-start": {
+      "dependsOn": ["@clerk/tanstack-react-start#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:vue": {
+      "dependsOn": ["@clerk/vue#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:nuxt": {
+      "dependsOn": ["@clerk/nuxt#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:react-router": {
+      "dependsOn": ["@clerk/react-router#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:billing": {
+      "dependsOn": ["@clerk/nextjs#build", "@clerk/vue#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:machine": {
+      "dependsOn": ["@clerk/express#build", "@clerk/backend#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
     "//#test:integration:custom": {
+      "dependsOn": ["@clerk/react#build"],
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
       "inputs": ["integration/**"],
       "outputLogs": "new-only"


### PR DESCRIPTION
## Summary
- Add `dependsOn` with the primary `@clerk/*` package build task to each integration test turbo task
- Each package's `build` task already uses `^build` for transitive deps, so this correctly captures source changes, dependency updates, and any package-level changes
- `inputs: ["integration/**"]` is kept for detecting test infrastructure changes (not part of any package)

**Before:** Integration tests only ran when `integration/` files changed. All "passing" CI runs on PRs that changed `@clerk/*` packages were actually skipped (`affected=0`, ~24s job duration) — the tests never executed.

**After:** Turbo's package-level change detection triggers integration tests when the relevant `@clerk/*` package (or any of its transitive dependencies) changes.

### Mapping
| Test | dependsOn |
|------|-----------|
| ap-flows, nextjs, nextjs:canary, quickstart, localhost, sessions, sessions:staging, handshake, handshake:staging | `@clerk/nextjs#build` |
| generic | `@clerk/nextjs#build`, `@clerk/react#build` |
| express | `@clerk/express#build` |
| hono | `@clerk/hono#build` |
| astro | `@clerk/astro#build` |
| expo-web | `@clerk/expo#build` |
| tanstack-react-start | `@clerk/tanstack-react-start#build` |
| vue | `@clerk/vue#build` |
| nuxt | `@clerk/nuxt#build` |
| react-router | `@clerk/react-router#build` |
| billing | `@clerk/nextjs#build`, `@clerk/vue#build` |
| machine | `@clerk/express#build`, `@clerk/backend#build` |
| custom | `@clerk/react#build` |

## Test plan
- [ ] CI integration tests are marked `affected=1` on PRs that change `@clerk/*` package source
- [ ] CI integration tests are still skipped on PRs that only change unrelated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system configuration to ensure proper ordering and dependency resolution during integration testing across multiple framework packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->