### PR TITLE
fix(ui): Factor in isDefault into isSwitchable

### DIFF
--- a/.changeset/witty-knives-ask.md
+++ b/.changeset/witty-knives-ask.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix issue where default plans offered the ability to switch to annual.

--- a/packages/ui/src/components/SubscriptionDetails/index.tsx
+++ b/packages/ui/src/components/SubscriptionDetails/index.tsx
@@ -375,8 +375,9 @@ const SubscriptionCardActions = ({ subscription }: { subscription: BillingSubscr
 
   const isSwitchable =
     ((subscription.planPeriod === 'month' && Boolean(subscription.plan.annualMonthlyFee)) ||
-      subscription.planPeriod === 'annual') &&
-    subscription.status !== 'past_due';
+      (subscription.planPeriod === 'annual' && Boolean(subscription.plan.fee))) &&
+    subscription.status !== 'past_due' &&
+    !subscription.plan.isDefault;
   const isFree = isFreePlan(subscription.plan);
   const isCancellable = subscription.canceledAt === null && !isFree;
   const isReSubscribable = subscription.canceledAt !== null && !isFree;


### PR DESCRIPTION
## Description

This PR fixes an issue where the `Switch to annual` button was being rendered for default plans.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted plan switching eligibility to prevent unintended changes for default and annual plans without active fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->