### PR TITLE
fix(shared): correct isValidBrowser/isBrowserOnline for React Native

### DIFF
--- a/.changeset/fix-gettoken-template-rn.md
+++ b/.changeset/fix-gettoken-template-rn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix `getToken({ template })` not working in React Native by correcting `isValidBrowser()` and `isBrowserOnline()` to return `true` in non-browser environments instead of `false`

--- a/packages/shared/src/__tests__/browser.spec.ts
+++ b/packages/shared/src/__tests__/browser.spec.ts
@@ -38,12 +38,12 @@ describe('isValidBrowser', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns false if not in browser', () => {
+  it('returns true if not in browser (assumes valid in non-browser environments like React Native)', () => {
     const windowSpy = vi.spyOn(global, 'window', 'get');
     // @ts-ignore - Test
     windowSpy.mockReturnValue(undefined);
 
-    expect(isValidBrowser()).toBe(false);
+    expect(isValidBrowser()).toBe(true);
   });
 
   it('returns true if in browser, navigator is not a bot, and webdriver is not enabled', () => {

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -57,7 +57,10 @@ export function userAgentIsRobot(userAgent: string): boolean {
 export function isValidBrowser(): boolean {
   const navigator = inBrowser() ? window?.navigator : null;
   if (!navigator) {
-    return false;
+    // Not in a browser environment (e.g. React Native, SSR).
+    // Return true so non-browser runtimes are not incorrectly
+    // treated as bots or automated browsers.
+    return true;
   }
   return !userAgentIsRobot(navigator?.userAgent) && !navigator?.webdriver;
 }
@@ -70,7 +73,10 @@ export function isValidBrowser(): boolean {
 export function isBrowserOnline(): boolean {
   const navigator = inBrowser() ? window?.navigator : null;
   if (!navigator) {
-    return false;
+    // Not in a browser environment (e.g. React Native, SSR).
+    // Assume online — RN has its own networking layer and the
+    // absence of browser APIs does not indicate offline status.
+    return true;
   }
 
   // navigator.onLine is the standard API and is reliable for detecting


### PR DESCRIPTION
## Summary

- `isValidBrowser()` and `isBrowserOnline()` in `@clerk/shared` were returning `false` when `window`/`navigator` are undefined (React Native environments)
- Core-3's token fetching checks these functions before making FAPI calls — returning `false` caused `getToken({ template: '...' })` to silently fail on React Native while `getToken()` (which reads from local cache) continued to work
- Fix: return `true` in non-browser environments since React Native has its own networking layer and should not be treated as a bot or offline

## Reported by
Bledar via Discord — `getToken({ template: 'one_hour_token' })` returns nothing on Expo after upgrading to latest Clerk

## Test plan
- [x] Updated existing `browser.spec.ts` test to verify `isValidBrowser()` returns `true` when window is undefined
- [x] All 983 tests in `@clerk/shared` pass
- [ ] Verify `getToken({ template })` works on React Native after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token retrieval with templates in React Native and other non-browser environments. Non-browser runtimes are now correctly recognized as valid execution contexts, ensuring template-based token operations function properly across React Native, server-side rendering, and similar platforms. This resolves compatibility issues that previously prevented proper authentication token management in these environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->