### PR TITLE
fix(e2e): remove outputFileTracingRoot from Next.js test templates

### DIFF
--- a/integration/templates/next-app-router/next.config.js
+++ b/integration/templates/next-app-router/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  outputFileTracingRoot: '/',
-};
+const nextConfig = {};
 
 module.exports = nextConfig;

--- a/integration/templates/next-cache-components/next.config.js
+++ b/integration/templates/next-cache-components/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  outputFileTracingRoot: '/',
   cacheComponents: true,
 };
 


### PR DESCRIPTION
## Summary
- Remove `outputFileTracingRoot: '/'` from `next-app-router` and `next-cache-components` integration test templates
- This setting caused Next.js build traces to glob the entire filesystem, hitting macOS `~/.Trash` (EPERM) and crashing the build locally
- CI (Linux) is unaffected since there's no permission-restricted `.Trash` directory

## Context
The setting was added in #5784 to allow Turbopack to resolve `pnpm link`ed dependencies outside the project root (test apps live in `/tmp/.temp_integration/` while linked deps are in the monorepo).

However, the long-running integration test apps use `next build` + `next start` (production mode), not `next dev --turbo`. The `outputFileTracingRoot` only affects the build trace step, which is informational in non-standalone mode — removing it has no effect on the build output or test behavior.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm run test:integration:generic` — 199 passed, no EPERM errors (previously crashed during build)
- [x] `pnpm run test:integration:cache-components` — builds and runs successfully
