### PR TITLE
fix(expo): add appleSignIn option to config plugin to allow opting out

### DIFF
--- a/.changeset/fix-apple-signin-entitlement-opt-out.md
+++ b/.changeset/fix-apple-signin-entitlement-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Add `appleSignIn` option to the Expo config plugin. Setting `appleSignIn: false` prevents the Sign in with Apple entitlement from being added unconditionally, allowing apps that do not use Apple Sign In to opt out.

--- a/packages/expo/app.plugin.js
+++ b/packages/expo/app.plugin.js
@@ -613,8 +613,11 @@ const withClerkAppleSignIn = config => {
 };
 
 const withClerkExpo = (config, props = {}) => {
+  const { appleSignIn = true } = props;
   config = withClerkIOS(config);
-  config = withClerkAppleSignIn(config);
+  if (appleSignIn !== false) {
+    config = withClerkAppleSignIn(config);
+  }
   config = withClerkGoogleSignIn(config);
   config = withClerkAndroid(config);
   config = withClerkKeychainService(config, props);


### PR DESCRIPTION
## Summary

Fixes #8050

The `withClerkExpo` config plugin was unconditionally adding the `com.apple.developer.applesignin` entitlement to every app, even those that don't use Apple Sign In. This caused issues for apps that intentionally don't include Apple Sign In (e.g., apps targeting non-Apple platforms or apps that want to manage entitlements manually).

**Change:** Added an `appleSignIn` option to the plugin props that defaults to `true` for full backwards compatibility. Apps can opt out by passing `appleSignIn: false`.

**Usage:**
```js
// app.json
{
  "plugins": [
    ["@clerk/expo", { "appleSignIn": false }]
  ]
}
```

## Test plan
- [ ] Verify existing apps (no `appleSignIn` option) still get the entitlement added (backwards compat)
- [ ] Verify `appleSignIn: false` prevents the entitlement from being added
- [ ] Verify `appleSignIn: true` explicitly still adds the entitlement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional appleSignIn configuration option. When set to false, the Sign in with Apple entitlement will not be automatically included, enabling applications that do not use Apple Sign In to opt out from the entitlement. Defaults to true for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->