### PR TITLE
feat(ui): Render seat limits in SubscriptionDetails

### DIFF
--- a/packages/ui/src/components/SubscriptionDetails/index.tsx
+++ b/packages/ui/src/components/SubscriptionDetails/index.tsx
@@ -616,7 +616,7 @@ const SubscriptionCard = ({ subscription }: { subscription: BillingSubscriptionI
                 size='md'
                 colorScheme='neutral'
               />
-              <Text localizationKey={localizationKeys('billing.subscriptionDetails.pastDueAt')} />
+              <Text localizationKey={localizationKeys('billing.seats')} />
             </Text>
           }
           value={


### PR DESCRIPTION
## Description

This PR updates the SubscriptionDetails component to render seat limits on plans that have them.

<img width="1806" height="2200" alt="image" src="https://github.com/user-attachments/assets/097ac318-f963-4ade-8b1a-0cdc187c1325" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
