### PR TITLE
fix(clerk-js): Don't render switch button on default plans

### DIFF
--- a/.changeset/some-birds-know.md
+++ b/.changeset/some-birds-know.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix issue where "Manage Subscription" button appeared on default free plans.

--- a/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
+++ b/packages/clerk-js/src/ui/components/PricingTable/utils/pricing-footer-state.ts
@@ -38,7 +38,10 @@ const valueResolution = (params: UsePricingFooterStateParams): [boolean, boolean
   // Active subscription
   if (subscription.status === 'active') {
     const isCanceled = !!subscription.canceledAt;
-    const isSwitchingPaidPeriod = planPeriod !== subscription.planPeriod && Boolean(plan.annualMonthlyFee);
+    const isSwitchingPaidPeriod =
+      !subscription.plan.isDefault &&
+      planPeriod !== subscription.planPeriod &&
+      ((planPeriod === 'annual' && Boolean(plan.annualMonthlyFee)) || (planPeriod === 'month' && Boolean(plan.fee)));
     const isActiveFreeTrial = plan.freeTrialEnabled && subscription.isFreeTrial;
 
     if (isCanceled || isSwitchingPaidPeriod) {


### PR DESCRIPTION
## Description

This PR fixes an issue where a "Manage Subscription" button appeared on default free plans when another plan was switched to annual. This PR updates the logic to calculate whether a period switch is allowed by factoring in the `is_default` property of the subscription's plan.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
