### PR TITLE
fix(clerk-js): Harden `useEnabledThirdPartyProviders` against missing sso data

### DIFF
--- a/.changeset/harden-social-provider-strategies.md
+++ b/.changeset/harden-social-provider-strategies.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/ui": patch
+---
+
+Guard against empty social provider strategies from FAPI to prevent crashes in `useEnabledThirdPartyProviders`

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -136,7 +136,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     }
 
     return Object.entries(this.social)
-      .filter(([, desc]) => desc.enabled && desc.authenticatable)
+      .filter(([, desc]) => desc.enabled && desc.authenticatable && desc.strategy)
       .map(([, desc]) => desc.strategy)
       .sort();
   }
@@ -157,7 +157,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     }
 
     return Object.entries(this.social)
-      .filter(([, desc]) => desc.enabled)
+      .filter(([, desc]) => desc.enabled && desc.strategy)
       .map(([, desc]) => desc.strategy)
       .sort();
   }

--- a/packages/ui/src/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/ui/src/hooks/useEnabledThirdPartyProviders.tsx
@@ -81,6 +81,7 @@ export const useEnabledThirdPartyProviders = () => {
   );
 
   allCustomOAuthProviders.forEach(s => {
+    if (!social[s]) return;
     const providerName = s.replace('oauth_', '') as OAuthProvider;
     providerToDisplayData[providerName] = {
       strategy: s,
@@ -90,6 +91,7 @@ export const useEnabledThirdPartyProviders = () => {
   });
 
   activeCustomSocialStrategies.forEach(s => {
+    if (!social[s]) return;
     const providerId = s.replace('oauth_', '') as OAuthProvider;
     strategyToDisplayData[s] = {
       id: providerId,


### PR DESCRIPTION
## Summary

- Filter out empty `strategy` values in `socialProviderStrategies` and `authenticatableSocialStrategies` getters in `UserSettings.ts`
- Guard `social[s]` access in both `forEach` loops in `useEnabledThirdPartyProviders.tsx` to prevent crashes when FAPI returns a social provider with an empty strategy

Fixes USER-4991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes in social authentication when empty provider strategies were received from the API.
  * Added safeguards to properly handle missing or invalid social provider data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->