### PR TITLE
fix(e2e): reduce staging E2E concurrency to avoid rate limiting

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -64,6 +64,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         test-name:
           - 'sessions:staging'


### PR DESCRIPTION
## Summary
- Limit staging E2E matrix to 3 parallel jobs (was 9 unrestricted)
- Staging instances have stricter FAPI rate limits than production, causing "Too many requests" errors during concurrent sign-in flows
- Tests pass individually but fail when all 9 suites hit the same staging instance simultaneously

## Test plan
- [x] Confirmed locally: sign-in tests pass when run alone, fail with "Too many requests" when run concurrently
- [x] Error context from CI confirms rate limiting: `Too many requests. Please try again in a bit.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized staging environment test execution by implementing controlled parallelization limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->