### PR TITLE
fix(e2e): reduce playwright workers for staging to avoid FAPI rate limiting

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -213,6 +213,7 @@ jobs:
         env:
           E2E_DEBUG: '1'
           E2E_STAGING: '1'
+          E2E_WORKERS: '2'
           E2E_SDK_SOURCE: ${{ steps.inputs.outputs.sdk-source }}
           E2E_APP_CLERK_JS_DIR: ${{ runner.temp }}
           E2E_APP_CLERK_UI_DIR: ${{ runner.temp }}

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -14,7 +14,7 @@ export const common: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 5 : 0,
   maxFailures: process.env.CI ? 5 : undefined,
-  workers: process.env.CI ? '50%' : '70%',
+  workers: process.env.E2E_WORKERS || (process.env.CI ? '50%' : '70%'),
   use: {
     actionTimeout: 10_000,
     navigationTimeout: 30_000,


### PR DESCRIPTION
## Summary
- Add `E2E_WORKERS` env var support to playwright config, falling back to existing behavior
- Set `E2E_WORKERS=2` in the staging E2E workflow to reduce concurrent FAPI requests
- The `generic` suite runs 212 tests with 4 workers (50% of 8 vCPUs), each spawning long-running apps against the same staging instance — this causes "Too many requests" rate limiting on the staging FAPI
- Reducing to 2 workers halves the concurrent requests while keeping reasonable throughput

## Test plan
- [x] Verified `E2E_WORKERS` is respected by playwright config
- [x] Non-staging workflows unaffected (env var not set, falls back to `50%`/`70%`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure configuration by introducing configurable worker allocation for end-to-end tests, enabling more flexible resource management during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->