### PR TITLE
fix(e2e): parse E2E_WORKERS as number for playwright config

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -14,7 +14,7 @@ export const common: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 5 : 0,
   maxFailures: process.env.CI ? 5 : undefined,
-  workers: process.env.E2E_WORKERS || (process.env.CI ? '50%' : '70%'),
+  workers: process.env.E2E_WORKERS ? Number(process.env.E2E_WORKERS) : process.env.CI ? '50%' : '70%',
   use: {
     actionTimeout: 10_000,
     navigationTimeout: 30_000,


### PR DESCRIPTION
## Summary
- Fix `config.workers must be a number or percentage` error introduced in #8132
- Playwright doesn't accept numeric strings like `'2'` — needs `Number()` parsing
- This broke all staging E2E tests

## Test plan
- [x] `E2E_WORKERS=2 node -e "console.log(Number('2'))"` → `2` (number)
- [x] Without `E2E_WORKERS`, falls back to percentage strings as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved E2E test worker configuration to properly process environment variable values, ensuring correct type handling during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->