### PR TITLE
fix(astro): Restore Cloudflare Pages compatibility broken by cloudflare:workers env

### DIFF
--- a/.changeset/fix-astro-cf-pages-env-fallback.md
+++ b/.changeset/fix-astro-cf-pages-env-fallback.md
@@ -1,0 +1,5 @@
+---
+"@clerk/astro": patch
+---
+
+Fix Cloudflare Pages compatibility by falling through to `locals.runtime.env` when `cloudflare:workers` env is missing the requested key

--- a/packages/astro/src/server/__tests__/get-safe-env.test.ts
+++ b/packages/astro/src/server/__tests__/get-safe-env.test.ts
@@ -136,6 +136,21 @@ describe('get-safe-env', () => {
       const env = getSafeEnv({ locals } as any);
       expect(env.sk).toBe('sk_from_cf_workers');
     });
+
+    it('falls back to locals.runtime.env when cloudflareEnv is missing the key (CF Pages)', async () => {
+      // On CF Pages, cloudflare:workers env may have bindings (D1, R2) but
+      // not dashboard secrets like CLERK_SECRET_KEY.
+      vi.doMock('cloudflare:workers', () => ({
+        env: { SOME_OTHER_BINDING: 'value' },
+      }));
+
+      const { initCloudflareEnv, getSafeEnv } = await import('../get-safe-env');
+      await initCloudflareEnv();
+
+      const locals = { runtime: { env: { CLERK_SECRET_KEY: 'sk_from_runtime' } } };
+      const env = getSafeEnv({ locals } as any);
+      expect(env.sk).toBe('sk_from_runtime');
+    });
   });
 });
 

--- a/packages/astro/src/server/get-safe-env.ts
+++ b/packages/astro/src/server/get-safe-env.ts
@@ -41,8 +41,13 @@ function getContextEnvVar(envVarName: keyof InternalEnv, contextOrLocals: Contex
   // Astro v6+ Cloudflare adapter: env from cloudflare:workers
   // Checked first to avoid the expensive try/catch on locals.runtime.env,
   // which throws on every call in Astro v6 Cloudflare environments.
+  // Falls through when the key is missing — on CF Pages (Astro v5),
+  // cloudflare:workers env may not include dashboard secrets.
   if (cloudflareEnv) {
-    return cloudflareEnv[envVarName];
+    const value = cloudflareEnv[envVarName];
+    if (value !== undefined) {
+      return value;
+    }
   }
 
   // Astro v4/v5 Cloudflare adapter: env is on locals.runtime.env


### PR DESCRIPTION
On Cloudflare Pages (Astro v5), `cloudflare:workers` env may be available but lack dashboard secrets (`CLERK_SECRET_KEY`, etc.) that are only present in the fetch handler's env param (`locals.runtime.env`).

The current code short-circuits on cloudflareEnv without checking whether the requested key actually exists, preventing the fallback chain from ever reaching `locals.runtime.env`. This causes all SSR pages to break with `[object Object]` responses.

Fix: check if the value is defined before returning from the cloudflareEnv branch, allowing the fallback to locals.runtime.env.

Follow-up fix to https://github.com/clerk/javascript/pull/7890

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment-variable fallback on Cloudflare Pages so required secrets are sourced from runtime fallbacks when the platform omits them.
* **Tests**
  * Added a test validating the fallback chain for env values on Cloudflare Pages.
* **Chores**
  * Added a changeset recording a patch release for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->