### PR TITLE
ci(repo): show release type in workflow run names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
-run-name: ${{ github.event_name == 'issue_comment' && format('Snapshot release by {0}', github.actor) || format('Release pipelines from {0}', github.ref_name) }}
+run-name: >-
+  ${{
+    github.event_name == 'issue_comment'
+      && format('[Snapshot] Release by {0}', github.actor)
+    || contains(github.event.head_commit.message, 'Version packages')
+      && format('[Production] Release from {0}', github.ref_name)
+    || format('[Canary] Release from {0}', github.ref_name)
+  }}
 
 on:
   push:


### PR DESCRIPTION
## Why

All push-triggered release runs show "Release pipelines from main", making it hard to tell at a glance whether a run was a production release or just a canary. You have to click into each run to find out.

## What changed

- Updated run-name to dynamically tag runs based on release type
- [Production] for Version Packages commits (stable releases via changesets)
- [Canary] for all other pushes to main
- [Snapshot] for !snapshot comment triggers
- Reformatted the expression across multiple lines for readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release naming convention with improved categorization and labeling to provide clearer identification of different release types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->