### PR TITLE
fix(e2e): skip keyless dashboard tests in staging

### DIFF
--- a/integration/tests/next-quickstart-keyless.test.ts
+++ b/integration/tests/next-quickstart-keyless.test.ts
@@ -56,6 +56,7 @@ test.describe('Keyless mode @quickstart', () => {
   });
 
   test('Toggle collapse popover and claim.', async ({ page, context }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await testToggleCollapsePopoverAndClaim({ page, context, app, dashboardUrl, framework: 'nextjs' });
   });
 
@@ -63,6 +64,7 @@ test.describe('Keyless mode @quickstart', () => {
     page,
     context,
   }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await mockClaimedInstanceEnvironmentCall(page);
     const u = createTestUtils({ app, page, context });
     await u.page.goToAppHome();

--- a/integration/tests/react-router/keyless.test.ts
+++ b/integration/tests/react-router/keyless.test.ts
@@ -39,6 +39,7 @@ test.describe('Keyless mode @react-router', () => {
   });
 
   test('Toggle collapse popover and claim.', async ({ page, context }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await testToggleCollapsePopoverAndClaim({ page, context, app, dashboardUrl, framework: 'react-router' });
   });
 
@@ -46,6 +47,7 @@ test.describe('Keyless mode @react-router', () => {
     page,
     context,
   }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await testClaimedAppWithMissingKeys({ page, context, app, dashboardUrl });
   });
 

--- a/integration/tests/tanstack-start/keyless.test.ts
+++ b/integration/tests/tanstack-start/keyless.test.ts
@@ -39,6 +39,7 @@ test.describe('Keyless mode @react-router', () => {
   });
 
   test('Toggle collapse popover and claim.', async ({ page, context }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await testToggleCollapsePopoverAndClaim({ page, context, app, dashboardUrl, framework: 'react-router' });
   });
 
@@ -46,6 +47,7 @@ test.describe('Keyless mode @react-router', () => {
     page,
     context,
   }) => {
+    test.skip(process.env.E2E_STAGING === '1', 'Staging dashboard is behind Vercel SSO');
     await testClaimedAppWithMissingKeys({ page, context, app, dashboardUrl });
   });
 


### PR DESCRIPTION
## Summary
- Skip keyless tests that navigate to the staging dashboard in `E2E_STAGING` mode
- The staging dashboard (`dashboard.clerkstage.dev`) is behind Vercel SSO, so claim flow tests time out waiting for a Clerk sign-in page that never appears
- Only skips tests that open the dashboard (claim, missing keys); other keyless tests (redirect loop, env restart) still run in staging
- Uses Playwright's built-in `test.skip()` with reason, following existing patterns for framework/version skips

### Tests skipped in staging:
- `next-quickstart-keyless.test.ts` — "Toggle collapse popover and claim", "Lands on claimed application..."
- `react-router/keyless.test.ts` — same two tests  
- `tanstack-start/keyless.test.ts` — same two tests

## Test plan
- [x] Verified from CI traces that all 3 keyless failures navigate to `vercel.com/login` instead of `dashboard.clerkstage.dev/apps/claim/sign-in`
- [x] Non-dashboard keyless tests (redirect loop, env restart) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Two keyless authentication tests now conditionally skip execution in staging environment across multiple framework integrations (Next.js, React Router, and TanStack Start).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->