### PR TITLE
fix(vue): deprecate SignOutButton signOutOptions prop

### DIFF
--- a/.changeset/deprecate-vue-signout-options.md
+++ b/.changeset/deprecate-vue-signout-options.md
@@ -1,0 +1,5 @@
+---
+"@clerk/vue": patch
+---
+
+Deprecate the `signOutOptions` prop on `<SignOutButton />` in favor of top-level `redirectUrl` and `sessionId` props. The `signOutOptions` prop still works but now emits a deprecation warning.

--- a/packages/vue/src/components/SignOutButton.vue
+++ b/packages/vue/src/components/SignOutButton.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import { useAttrs, useSlots } from 'vue';
+import { deprecated } from '@clerk/shared/deprecated';
 import type { SignOutOptions } from '@clerk/shared/types';
 import { useClerk } from '../composables/useClerk';
 import { assertSingleChild, normalizeWithDefaultValue } from '../utils';
 
 interface SignOutButtonProps {
+  /**
+   * @deprecated Use the `redirectUrl` and `sessionId` props directly instead.
+   */
   signOutOptions?: SignOutOptions;
   sessionId?: string;
   redirectUrl?: string;
@@ -22,6 +26,10 @@ function getChildComponent() {
 }
 
 function clickHandler() {
+  if (props.signOutOptions) {
+    deprecated('SignOutButton `signOutOptions`', 'Use the `redirectUrl` and `sessionId` props directly instead.');
+  }
+
   const signOutOptions: SignOutOptions = {
     redirectUrl: props.signOutOptions?.redirectUrl ?? props.redirectUrl,
     sessionId: props.signOutOptions?.sessionId ?? props.sessionId,


### PR DESCRIPTION
## Summary

- Deprecates the `signOutOptions` prop on Vue's `<SignOutButton />` in favor of the existing flat `redirectUrl` and `sessionId` props
- Adds `@deprecated` JSDoc annotation and runtime deprecation warning via `deprecated()` helper
- `signOutOptions` still works (backwards compatible) but emits a console warning in development

Companion to #8147 (React). Vue already had the flat props — this just adds the deprecation notice.

## Test plan

- [x] Existing tests pass unchanged (52 tests)
- [x] `npx turbo build --filter=@clerk/vue` passes
- [x] `npx turbo test --filter=@clerk/vue` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Deprecated `signOutOptions` prop on `<SignOutButton />`. Use `redirectUrl` and `sessionId` props directly instead. The deprecated prop remains functional with a deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->