### PR TITLE
fix(expo): clear JWT from SecureStore on sign-out to prevent stale session errors

### DIFF
--- a/.changeset/fix-clear-jwt-on-signout.md
+++ b/.changeset/fix-clear-jwt-on-signout.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Clear JWT from SecureStore when signing out via native components (AuthView, UserButton) to prevent "session_exists" / "already signed in" errors on subsequent sign-in attempts.

--- a/packages/expo/src/native/UserButton.tsx
+++ b/packages/expo/src/native/UserButton.tsx
@@ -1,7 +1,9 @@
 import { useClerk, useUser } from '@clerk/react';
+import * as SecureStore from 'expo-secure-store';
 import { useEffect, useRef, useState } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+import { CLERK_CLIENT_JWT_KEY } from '../constants';
 import { ClerkExpoModule as ClerkExpo, isNativeSupported } from '../utils/native-module';
 
 // Raw result from native module (may vary by platform)
@@ -154,6 +156,9 @@ export function UserButton(_props: UserButtonProps) {
             console.warn('[UserButton] Native signOut error (may already be signed out):', e);
           }
         }
+
+        // Clear stale JWT from SecureStore to prevent "already signed in" errors
+        await SecureStore.deleteItemAsync(CLERK_CLIENT_JWT_KEY).catch(() => {});
 
         // Sign out from JS SDK to update isSignedIn state
         if (clerk?.signOut) {

--- a/packages/expo/src/provider/ClerkProvider.tsx
+++ b/packages/expo/src/provider/ClerkProvider.tsx
@@ -10,6 +10,7 @@ import { CLERK_CLIENT_JWT_KEY } from '../constants';
 import { useNativeAuthEvents } from '../hooks/useNativeAuthEvents';
 import NativeClerkModule from '../specs/NativeClerkModule';
 import { tokenCache as defaultTokenCache } from '../token-cache';
+import * as SecureStore from 'expo-secure-store';
 import { isNative, isWeb } from '../utils/runtime';
 import { getClerkInstance } from './singleton';
 import type { BuildClerkOptions } from './singleton/types';
@@ -254,6 +255,9 @@ export function ClerkProvider<TUi extends Ui = Ui>(props: ClerkProviderProps<TUi
           if (!isMountedRef.current) {
             return;
           }
+          // Clear the JWT from SecureStore before signing out to prevent
+          // "session_exists" / "already signed in" errors on the next sign-in attempt.
+          await SecureStore.deleteItemAsync(CLERK_CLIENT_JWT_KEY).catch(() => {});
           await clerkInstance.signOut();
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

Fixes "session_exists" / "already signed in" errors when users try to sign in again after signing out via native components (`<AuthView />`, `<UserButton />`).

When signing out, `clerk.signOut()` clears the Clerk JS SDK state but does NOT clear the JWT stored in `expo-secure-store`. On the next sign-in attempt, the stale JWT is sent with the FAPI request, causing the server to reject it with "session_exists" because it sees an active session.

The fix explicitly deletes the JWT from SecureStore before calling `clerk.signOut()` in both:
- `ClerkProvider.tsx` (native auth state sync for signedOut events)
- `UserButton.tsx` (sign-out after profile modal closes)

## Reported by

- Reddit user: https://www.reddit.com/r/expo/comments/1s0y8sv/clerk_expo_quickstart_not_working/
- Internal (Erwin, community SSO issue)

## Test plan

- [ ] Sign in via `<AuthView />`, sign out, sign in again (no "already signed in" error)
- [ ] Sign in via `<UserButton />` profile, sign out, sign in again (no error)
- [ ] Verify JWT is cleared from SecureStore after sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where signing out through native components would not properly clear authentication state, preventing re-sign-in errors (e.g., "already signed in" or "session exists" messages).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->