### PR TITLE
docs(repo): Fix clerk-docs links in Typedoc output

### DIFF
--- a/.typedoc/custom-plugin.mjs
+++ b/.typedoc/custom-plugin.mjs
@@ -53,10 +53,10 @@ const LINK_REPLACEMENTS = [
   ['signed-in-session-resource', '/docs/reference/objects/session'],
   ['sign-in-resource', '/docs/reference/objects/sign-in'],
   ['sign-in-future-resource', '/docs/reference/objects/sign-in-future'],
-  ['sign-in-errors', '/docs/reference/javascript/types/errors'],
+  ['sign-in-errors', '/docs/reference/types/errors'],
   ['sign-up-resource', '/docs/reference/objects/sign-up'],
   ['sign-up-future-resource', '/docs/reference/objects/sign-up-future'],
-  ['sign-up-errors', '/docs/reference/javascript/types/errors'],
+  ['sign-up-errors', '/docs/reference/types/errors'],
   ['user-resource', '/docs/reference/objects/user'],
   ['session-status-claim', '/docs/reference/types/session-status'],
   ['user-organization-invitation-resource', '/docs/reference/types/user-organization-invitation'],
@@ -164,7 +164,7 @@ function getCatchAllReplacements() {
     {
       pattern: /(?<![\[\w`])`?((?:SignIn|SignUp)Errors)`?(?![\]\w`])/g,
       replace: (/** @type {string} */ _match, /** @type {string} */ type) =>
-        `[\`${type}\`](/docs/reference/javascript/types/errors)`,
+        `[\`${type}\`](/docs/reference/types/errors)`,
     },
     {
       pattern: /(?<![\[\w`])`?SignInFutureResource`?(?![\]\w`])/g,


### PR DESCRIPTION
## Description

Fixes clerk-docs links for Typedoc output after PR merge here: https://github.com/clerk/javascript/pull/8079. 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation link paths for error-related type references to reflect a streamlined documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->