### PR TITLE
fix(e2e): unpin next.js to ^16.2.1 in cache-components template

### DIFF
--- a/integration/templates/next-cache-components/package.json
+++ b/integration/templates/next-cache-components/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^18.19.33",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "next": "^16.0.0",
+    "next": "^16.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.3"


### PR DESCRIPTION
## Description

Unpin Next.js from `16.1.6` to `^16.2.1` in the `next-cache-components` integration template. Next.js 16.2.1 includes a fix for the cached components issue that caused us to pin in the first place, so we can go back to a caret range and pick up future 16.x patches automatically.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed the Next.js dependency constraint to a semver-compatible range, allowing automatic adoption of compatible 16.x releases and easing minor/patch updates while preserving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->