### PR TITLE
fix(ui): Render Card background in PricingTable when plan has seat features

### DIFF
--- a/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
@@ -155,6 +155,7 @@ function Card(props: CardProps) {
   }, [isSignedIn, canManageBilling, organization, subscriberType, plan]);
 
   const hasFeatures = plan.features.length > 0;
+  const hasSeatFeatures = !!getSeatUnitPrice(plan);
 
   const { shouldShowFooter, shouldShowFooterNotice } = getPricingFooterState({
     subscription,
@@ -213,8 +214,8 @@ function Card(props: CardProps) {
               flexDirection: 'column',
               flex: '1',
               padding: isCompact ? t.space.$3 : t.space.$4,
-              backgroundColor: hasFeatures ? t.colors.$colorBackground : 'transparent',
-              borderTopWidth: hasFeatures ? t.borderWidths.$normal : 0,
+              backgroundColor: hasFeatures || hasSeatFeatures ? t.colors.$colorBackground : 'transparent',
+              borderTopWidth: hasFeatures || hasSeatFeatures ? t.borderWidths.$normal : 0,
               borderTopStyle: t.borderStyles.$solid,
               borderTopColor: t.colors.$borderAlpha150,
             })}


### PR DESCRIPTION
## Description

This PR updates the Plan Card rendered in the PricingTable component to render a background when a plan contains no features but has a seat-based feature (such as seat limits or seat costs).

<img width="2272" height="2428" alt="CleanShot 2026-03-26 at 14 10 49@2x" src="https://github.com/user-attachments/assets/22a2cb57-935b-4361-8356-3ad4c8b7c83d" />

<img width="1240" height="1302" alt="CleanShot 2026-03-26 at 14 17 09@2x" src="https://github.com/user-attachments/assets/284b72ad-9e96-48eb-b0bf-f88aa324fa6f" />



## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
