### PR TITLE
fix(expo-passkeys): Use new lib DOM types

### DIFF
--- a/packages/expo-passkeys/src/ClerkExpoPasskeys.types.ts
+++ b/packages/expo-passkeys/src/ClerkExpoPasskeys.types.ts
@@ -43,50 +43,14 @@ export type SerializedPublicKeyCredentialRequestOptions = Omit<
   challenge: string;
 };
 
-// The return type from the "get" native module.
-export interface AuthenticationResponseJSON {
-  id: string;
-  rawId: string;
-  response: AuthenticatorAssertionResponseJSON;
-  authenticatorAttachment?: AuthenticatorAttachment;
-  clientExtensionResults: AuthenticationExtensionsClientOutputs;
-  type: PublicKeyCredentialType;
-}
-
 // The serialized response of the native module "create" response to be send back to clerk
 export type PublicKeyCredentialWithAuthenticatorAttestationResponse =
   ClerkPublicKeyCredentialWithAuthenticatorAttestationResponse & {
     toJSON: () => any;
   };
 
-interface AuthenticatorAssertionResponseJSON {
-  clientDataJSON: string;
-  authenticatorData: string;
-  signature: string;
-  userHandle?: string;
-}
-
 // The serialized response of the native module "get" response to be send back to clerk
 export type PublicKeyCredentialWithAuthenticatorAssertionResponse =
   ClerkPublicKeyCredentialWithAuthenticatorAssertionResponse & {
     toJSON: () => any;
   };
-
-interface AuthenticatorAttestationResponseJSON {
-  clientDataJSON: string;
-  attestationObject: string;
-  authenticatorData?: string;
-  transports?: AuthenticatorTransportFuture[];
-  publicKeyAlgorithm?: COSEAlgorithmIdentifier;
-  publicKey?: string;
-}
-
-// The type is returned from from native module "create" response
-export interface RegistrationResponseJSON {
-  id: string;
-  rawId: string;
-  response: AuthenticatorAttestationResponseJSON;
-  authenticatorAttachment?: AuthenticatorAttachment;
-  clientExtensionResults: AuthenticationExtensionsClientOutputs;
-  type: PublicKeyCredentialType;
-}

--- a/packages/expo-passkeys/src/index.ts
+++ b/packages/expo-passkeys/src/index.ts
@@ -1,13 +1,11 @@
 import { Platform } from 'react-native';
 
 import type {
-  AuthenticationResponseJSON,
   CredentialReturn,
   PublicKeyCredentialCreationOptionsWithoutExtensions,
   PublicKeyCredentialRequestOptionsWithoutExtensions,
   PublicKeyCredentialWithAuthenticatorAssertionResponse,
   PublicKeyCredentialWithAuthenticatorAttestationResponse,
-  RegistrationResponseJSON,
   SerializedPublicKeyCredentialCreationOptions,
   SerializedPublicKeyCredentialRequestOptions,
 } from './ClerkExpoPasskeys.types';

--- a/packages/expo-passkeys/tsconfig.json
+++ b/packages/expo-passkeys/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationMap": false,
     "esModuleInterop": true,
@@ -20,7 +19,9 @@
     "skipLibCheck": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2019"
+    "target": "ES2019",
+    "types": ["node"],
+    "rootDir": "./src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description

Updates `expo-passkeys` to be compatible with TypeScript 6.0. Explicitly sets `rootDir`, pulls in the Node types, and replaces handwritten DOM types with their new official versions.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
