### PR TITLE
fix(backend): TypeScript 6.0 compatibility

### DIFF
--- a/packages/backend/src/api/endpoints/JwtTemplatesApi.ts
+++ b/packages/backend/src/api/endpoints/JwtTemplatesApi.ts
@@ -1,5 +1,5 @@
 import type { ClerkPaginationRequest } from '@clerk/shared/types';
-import { joinPaths } from 'src/util/path';
+import { joinPaths } from '../../util/path';
 
 import type { DeletedObject, JwtTemplate } from '../resources';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';

--- a/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
+++ b/packages/backend/src/api/endpoints/WaitlistEntryApi.ts
@@ -1,5 +1,5 @@
 import type { ClerkPaginationRequest } from '@clerk/shared/types';
-import { joinPaths } from 'src/util/path';
+import { joinPaths } from '../../util/path';
 
 import type { DeletedObject } from '../resources/DeletedObject';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';

--- a/packages/backend/src/jwt/cryptoKeys.ts
+++ b/packages/backend/src/jwt/cryptoKeys.ts
@@ -3,7 +3,7 @@ import { isomorphicAtob } from '@clerk/shared/isomorphicAtob';
 import { runtime } from '../runtime';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8_import
-function pemToBuffer(secret: string): ArrayBuffer {
+function pemToBuffer(secret: string): Uint8Array<ArrayBuffer> {
   const trimmed = secret
     .replace(/-----BEGIN.*?-----/g, '')
     .replace(/-----END.*?-----/g, '')

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -28,7 +28,12 @@ export async function hasValidSignature(jwt: Jwt, key: JsonWebKey | string): Pro
   try {
     const cryptoKey = await importKey(key, algorithm, 'verify');
 
-    const verified = await runtime.crypto.subtle.verify(algorithm.name, cryptoKey, signature, data);
+    const verified = await runtime.crypto.subtle.verify(
+      algorithm.name,
+      cryptoKey,
+      signature as Uint8Array<ArrayBuffer>,
+      data,
+    );
     return { data: verified };
   } catch (error) {
     return {

--- a/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
+++ b/packages/backend/src/tokens/__tests__/getAuth.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, test } from 'vitest';
+import { expectTypeOf, test, describe } from 'vitest';
 
 import type { RedirectFun } from '../../createRedirect';
 import type { AuthObject, InvalidTokenAuthObject } from '../authObjects';

--- a/packages/backend/src/webhooks.ts
+++ b/packages/backend/src/webhooks.ts
@@ -1,6 +1,6 @@
 import { getEnvVariable } from '@clerk/shared/getEnvVariable';
-import { errorThrower } from 'src/util/shared';
 import { Webhook } from 'standardwebhooks';
+import { errorThrower } from './util/shared';
 
 import type { WebhookEvent } from './api/resources/Webhooks';
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,


### PR DESCRIPTION
## Description

This PR updates the `@clerk/backend` package to be compatible with TypeScript 6.0. It removes usage of `baseUrl`, replaces imports from `'src...` with relative paths, and casts a value from `Uint8Array<ArrayBufferLike>` to `Uint8Array<ArrayBuffer>`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
