### PR TITLE
chore(localizations): Migrate to tsdown

### DIFF
--- a/packages/localizations/package.json
+++ b/packages/localizations/package.json
@@ -54,9 +54,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup --env.NODE_ENV production",
+    "build": "tsdown",
     "clean": "rimraf ./dist",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/localizations/tsconfig.json
+++ b/packages/localizations/tsconfig.json
@@ -13,7 +13,8 @@
     "declarationMap": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "tmp", "dist", "**/dist/**"]

--- a/packages/localizations/tsdown.config.mts
+++ b/packages/localizations/tsdown.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
 export default defineConfig(overrideOptions => {
   const shouldPublish = !!overrideOptions.env?.publish;
@@ -6,7 +6,6 @@ export default defineConfig(overrideOptions => {
   return {
     entry: ['src/*.ts'],
     format: ['cjs', 'esm'],
-    bundle: true,
     clean: true,
     minify: false,
     sourcemap: true,


### PR DESCRIPTION
## Description

This PR updates the tsconfig for `@clerk/localizations` to be compatible with TypeScript 6.0 by migrating to tsdown since using tsup with `dts: true` does not work with TypeScript 6.0 due to the forced usage of `baseUrl` in the generated configuration.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
