### PR TITLE
chore(fastify): TypeScript 6.0 compatibility

### DIFF
--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -60,9 +60,9 @@
     "webhooks"
   ],
   "scripts": {
-    "build": "tsup --env.NODE_ENV production",
+    "build": "tsdown --env.NODE_ENV production",
     "clean": "rimraf ./dist",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/fastify/tsdown.config.mts
+++ b/packages/fastify/tsdown.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
-import { name, version } from './package.json';
+import pkgJson from './package.json' with { type: 'json' };
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
@@ -13,15 +13,14 @@ export default defineConfig(overrideOptions => {
       types: './src/types/index.ts',
     },
     format: ['cjs', 'esm'],
-    bundle: true,
     clean: true,
     minify: false,
     sourcemap: true,
     dts: true,
     onSuccess: shouldPublish ? 'pkglab pub --ping' : undefined,
     define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
+      PACKAGE_NAME: `"${pkgJson.name}"`,
+      PACKAGE_VERSION: `"${pkgJson.version}"`,
       __DEV__: `${isWatch}`,
     },
   };


### PR DESCRIPTION
## Description

This PR updates the `@clerk/fastify` package to be compatible with TypeScript 6.0 by migrating to tsdown.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
