### PR TITLE
chore(express): TypeScript 6.0 compatibility

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -61,9 +61,9 @@
     "env.d.ts"
   ],
   "scripts": {
-    "build": "pnpm clean && tsup",
+    "build": "pnpm clean && tsdown",
     "clean": "rimraf ./dist",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/express/tsdown.config.mts
+++ b/packages/express/tsdown.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
-import { name, version } from './package.json';
+import pkgJson from './package.json' with { type: 'json' };
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
@@ -13,15 +13,14 @@ export default defineConfig(overrideOptions => {
       types: './src/types/index.ts',
     },
     format: ['cjs', 'esm'],
-    bundle: true,
     clean: true,
     minify: false,
     sourcemap: true,
     dts: true,
     onSuccess: shouldPublish ? 'pkglab pub --ping' : undefined,
     define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
+      PACKAGE_NAME: `"${pkgJson.name}"`,
+      PACKAGE_VERSION: `"${pkgJson.version}"`,
       __DEV__: `${isWatch}`,
     },
   };


### PR DESCRIPTION
## Description

This PR updates `@clerk/express` for compatibility with TypeScript 6.0 by migrating to tsdown.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
