### PR TITLE
chore(ui): TypeScript 6.0 compatibility

### DIFF
--- a/packages/ui/src/elements/Menu.tsx
+++ b/packages/ui/src/elements/Menu.tsx
@@ -58,7 +58,6 @@ export const MenuTrigger = (props: MenuTriggerProps) => {
   }
 
   return cloneElement(children, {
-    // @ts-expect-error
     ref: reference,
     elementDescriptor: children.props.elementDescriptor || descriptors.menuButton,
     elementId: children.props.elementId || descriptors.menuButton.setId(elementId),

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -27,7 +27,8 @@
       // in order to make git merges easier
       // TODO: @nikos remove after v6 release
       "@/ui*": ["./src/*"]
-    }
+    },
+    "types": ["@rspack/core/module"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Description

This PR updates `@clerk/ui` to be compatible with TypeScript 6.0 by adding an explicit `"types": ["@rspack/core/module"]` to the tsconfig and removing a now unnecessary `@ts-expect-error` directive.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
