### PR TITLE
chore(astro): TypeScript 6.0 compatibility

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -77,10 +77,10 @@
     "types.ts"
   ],
   "scripts": {
-    "build": "tsup --onSuccess \"pnpm build:dts\" && pnpm copy:components",
+    "build": "tsdown --onSuccess \"pnpm build:dts\" && pnpm copy:components",
     "build:dts": "tsc --emitDeclarationOnly --declaration",
     "copy:components": "rm -rf ./components && mkdir -p ./components/ && cp  -r ./src/astro-components/* ./components/ && cp ./src/types.ts ./",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/astro/tsdown.config.mts
+++ b/packages/astro/tsdown.config.mts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
-// @ts-ignore
-import { name, version } from './package.json';
+import pkgJson from './package.json' with { type: 'json' };
 
 export default defineConfig(overrideOptions => {
   const shouldPublish = !!overrideOptions.env?.publish;
@@ -23,10 +22,9 @@ export default defineConfig(overrideOptions => {
     minify: false,
     onSuccess: shouldPublish ? 'pnpm build:dts && pkglab pub --ping' : 'pnpm build:dts',
     define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
+      PACKAGE_NAME: `"${pkgJson.name}"`,
+      PACKAGE_VERSION: `"${pkgJson.version}"`,
     },
-    bundle: true,
     sourcemap: true,
     format: ['esm'],
     external: ['astro', 'react', 'react-dom', 'node:async_hooks', '#async-local-storage', 'astro:transitions/client'],


### PR DESCRIPTION
## Description

This PR updates `@clerk/astro` to be compatible with TypeScript 6.0 by migrating to tsdown.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
