### PR TITLE
chore(clerk-js): TypeScript 6.0 compatibility

### DIFF
--- a/packages/clerk-js/tsconfig.json
+++ b/packages/clerk-js/tsconfig.json
@@ -7,7 +7,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
-    "lib": ["dom", "dom.iterable", "es2021.intl"],
+    "lib": ["dom", "dom.iterable", "es2020", "es2021.intl"],
     "module": "esnext",
     "moduleResolution": "Bundler",
     "noEmit": true,
@@ -22,7 +22,9 @@
     "useUnknownInCatchVariables": false,
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "rootDir": "./src",
+    "types": ["@rspack/core/module", "cloudflare-turnstile"]
   },
   "include": ["src", "vitest.config.mts", "vitest.setup.mts", "../shared/internal/clerk-js/componentGuards.ts"]
 }


### PR DESCRIPTION
## Description

This PR updates `@clerk/clerk-js` to be compatible with TypeScript 6.0. It updates the `lib` config to include `es2020` to cover our use of APIs such as `Array.includes`, `Promise.finally`, `Promise.allSettled`, and others.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
