### PR TITLE
feat(shared): Add cloudflare:workers env fallback to getEnvVariable

### DIFF
--- a/.changeset/cloudflare-workers-env-fallback.md
+++ b/.changeset/cloudflare-workers-env-fallback.md
@@ -1,0 +1,9 @@
+---
+'@clerk/shared': patch
+---
+
+feat(shared): Add `cloudflare:workers` env fallback to `getEnvVariable`
+
+Adds `initCloudflareWorkersEnv()` and a `cloudflare:workers` module env check to the shared `getEnvVariable()` function. This allows Clerk to read environment variables (e.g., `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY`) directly from the Cloudflare Workers runtime environment, following the same pattern used in `@clerk/astro` (PRs #7889, #8136).
+
+This is needed for frameworks running on Cloudflare Workers (e.g., TanStack Start, Hono) where `process.env` and `import.meta.env` are not available at runtime, but `cloudflare:workers` module env is.

--- a/packages/shared/src/getEnvVariable.ts
+++ b/packages/shared/src/getEnvVariable.ts
@@ -9,6 +9,38 @@ const hasCloudflareContext = (context: any): context is CloudflareEnv => {
 };
 
 /**
+ * Cached env object from the `cloudflare:workers` module.
+ * - `undefined`: not yet attempted
+ * - `null`: attempted but not available (non-Cloudflare environment)
+ * - object: the env record from `cloudflare:workers`
+ */
+let cloudflareWorkersEnv: Record<string, string> | null | undefined;
+
+/**
+ * Attempts to import env from `cloudflare:workers` and caches the result.
+ * This is needed for Cloudflare Workers environments where env vars
+ * are not available on `process.env` or `import.meta.env` but are
+ * accessible via the `cloudflare:workers` module.
+ *
+ * Safe to call in non-Cloudflare environments — will silently no-op.
+ *
+ * This follows the same pattern used in `@clerk/astro` (see PR #7889, #8136).
+ */
+export async function initCloudflareWorkersEnv(): Promise<void> {
+  if (cloudflareWorkersEnv !== undefined) {
+    return;
+  }
+  try {
+    // Use a variable to prevent bundlers from resolving the module specifier
+    const moduleName = 'cloudflare:workers';
+    const mod = await import(/* @vite-ignore */ moduleName);
+    cloudflareWorkersEnv = mod.env;
+  } catch {
+    cloudflareWorkersEnv = null;
+  }
+}
+
+/**
  * Retrieves an environment variable across runtime environments.
  *
  * @param name - The environment variable name to retrieve.
@@ -26,11 +58,21 @@ export const getEnvVariable = (name: string, context?: Record<string, any>): str
     return import.meta.env[name];
   }
 
+  // Cloudflare Workers: env from `cloudflare:workers` module.
+  // Falls through when the key is missing — on CF Pages, dashboard
+  // secrets may not be present in the module env.
+  if (cloudflareWorkersEnv) {
+    const value = cloudflareWorkersEnv[name];
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
   if (hasCloudflareProxyContext(context)) {
     return context.cloudflare.env[name] || '';
   }
 
-  // Cloudflare
+  // Cloudflare context (e.g., from fetch handler env param)
   if (hasCloudflareContext(context)) {
     return context.env[name] || '';
   }
@@ -40,7 +82,7 @@ export const getEnvVariable = (name: string, context?: Record<string, any>): str
     return context[name];
   }
 
-  // Cloudflare workers
+  // Cloudflare workers globalThis fallback
   try {
     return globalThis[name as keyof typeof globalThis];
   } catch {


### PR DESCRIPTION
## Description

Add `initCloudflareWorkersEnv()` and a `cloudflare:workers` module env check to the shared `getEnvVariable()` function in `@clerk/shared`.

This allows Clerk to read environment variables (e.g., `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY`) directly from the Cloudflare Workers runtime environment, following the same pattern already used in `@clerk/astro` (PRs #7889, #8136).

### Problem

When using Clerk with frameworks running on Cloudflare Workers (e.g., TanStack Start, Hono), `process.env` and `import.meta.env` are not available at runtime. The current `getEnvVariable()` only falls back to `globalThis[name]` for Workers, which doesn't work because Worker env vars are not set as globals — they're passed via the fetch handler's `env` parameter or accessible via the `cloudflare:workers` module.

### Solution

- Add a cached `cloudflareWorkersEnv` variable (same pattern as `@clerk/astro`'s `get-safe-env.ts`)
- Add `initCloudflareWorkersEnv()` that dynamically imports `cloudflare:workers` and caches the env object
- Check `cloudflareWorkersEnv[name]` before falling through to context-based checks
- Falls through when the key is missing (e.g., on CF Pages where dashboard secrets may not be in the module env)
- Safe to call in non-Cloudflare environments — silently no-ops

### Why in `@clerk/shared`?

The Astro package has its own `get-safe-env.ts` with this pattern, but other framework packages (`@clerk/tanstack-react-start`, `@clerk/backend`) import `getEnvVariable` from `@clerk/shared`. Adding the `cloudflare:workers` fallback to the shared utility benefits all framework packages running on CF Workers without requiring per-package fixes.

## Checklist

- [x] `pnpm build` runs as expected (no breaking changes — new export is additive)
- [x] (If applicable) JSDoc comments have been added

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clerk environment variables can now be resolved from Cloudflare Workers runtime, enabling configuration of CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY in Cloudflare Workers environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->