### PR TITLE
feat(tanstack): Pass Cloudflare Workers env context to getEnvVariable

### DIFF
--- a/.changeset/tanstack-cloudflare-env-context.md
+++ b/.changeset/tanstack-cloudflare-env-context.md
@@ -1,0 +1,7 @@
+---
+'@clerk/tanstack-react-start': patch
+---
+
+feat(tanstack): Pass Cloudflare Workers env context to getEnvVariable
+
+Adds `cloudflare:workers` module env resolution to the TanStack Start package, following the pattern used in `@clerk/react-router` where loader context is passed to `getEnvVariable()`. On Cloudflare Workers, `process.env` and `import.meta.env` are not available at runtime. This fix initializes the CF Workers env in `clerkMiddleware` and passes it through `commonEnvs()` → `getEnvVariable(name, context)` so `CLERK_SECRET_KEY` and other env vars are resolved correctly.

--- a/packages/tanstack-react-start/src/server/clerkMiddleware.ts
+++ b/packages/tanstack-react-start/src/server/clerkMiddleware.ts
@@ -7,6 +7,7 @@ import { createMiddleware } from '@tanstack/react-start';
 
 import { canUseKeyless } from '../utils/feature-flags';
 import { clerkClient } from './clerkClient';
+import { initCloudflareWorkerEnv } from './cloudflareEnv';
 import { resolveKeysWithKeylessFallback } from './keyless/utils';
 import { loadOptions } from './loadOptions';
 import type { ClerkMiddlewareOptions, ClerkMiddlewareOptionsCallback } from './types';
@@ -16,6 +17,9 @@ export const clerkMiddleware = (
   options?: ClerkMiddlewareOptions | ClerkMiddlewareOptionsCallback,
 ): AnyRequestMiddleware => {
   return createMiddleware().server(async ({ request, next }) => {
+    // Initialize Cloudflare Workers env if available (no-op on non-CF runtimes)
+    await initCloudflareWorkerEnv();
+
     const clerkRequest = createClerkRequest(patchRequest(request));
 
     // Resolve options: if function, call it with context object; otherwise use as-is

--- a/packages/tanstack-react-start/src/server/cloudflareEnv.ts
+++ b/packages/tanstack-react-start/src/server/cloudflareEnv.ts
@@ -1,0 +1,40 @@
+/**
+ * Attempts to resolve Cloudflare Worker environment variables.
+ *
+ * On Cloudflare Workers (e.g., TanStack Start with @cloudflare/vite-plugin),
+ * env vars are not available on `process.env` or `import.meta.env`. They are
+ * accessible via the `cloudflare:workers` module.
+ *
+ * Returns the env object if available, or undefined in non-CF environments.
+ * The result is cached after the first call.
+ *
+ * This follows the same pattern used in `@clerk/astro` (see PRs #7889, #8136),
+ * adapted for synchronous access after async initialization.
+ */
+
+let cachedEnv: Record<string, string> | null | undefined;
+
+/**
+ * Initialize the Cloudflare Workers env cache.
+ * Call this once at startup (e.g., in middleware) before reading env vars.
+ */
+export async function initCloudflareWorkerEnv(): Promise<void> {
+  if (cachedEnv !== undefined) {
+    return;
+  }
+  try {
+    const moduleName = 'cloudflare:workers';
+    const mod = await import(/* @vite-ignore */ moduleName);
+    cachedEnv = mod.env ?? null;
+  } catch {
+    cachedEnv = null;
+  }
+}
+
+/**
+ * Returns the cached Cloudflare Workers env, or undefined if not available.
+ * Must call `initCloudflareWorkerEnv()` first.
+ */
+export function getCloudflareWorkerEnv(): Record<string, string> | undefined {
+  return cachedEnv ?? undefined;
+}

--- a/packages/tanstack-react-start/src/server/constants.ts
+++ b/packages/tanstack-react-start/src/server/constants.ts
@@ -2,9 +2,13 @@ import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey
 import { getEnvVariable } from '@clerk/shared/getEnvVariable';
 
 import { getPublicEnvVariables } from '../utils/env';
+import { getCloudflareWorkerEnv } from './cloudflareEnv';
 
-export const commonEnvs = () => {
-  const publicEnvs = getPublicEnvVariables();
+export const commonEnvs = (context?: Record<string, any>) => {
+  // On Cloudflare Workers, resolve env from the runtime.
+  // Falls back to undefined on non-CF environments.
+  const cfEnv = context ?? getCloudflareWorkerEnv();
+  const publicEnvs = getPublicEnvVariables(cfEnv);
 
   return {
     // Public environment variables
@@ -23,17 +27,17 @@ export const commonEnvs = () => {
     TELEMETRY_DEBUG: publicEnvs.telemetryDebug,
 
     // Server-only environment variables
-    API_VERSION: getEnvVariable('CLERK_API_VERSION') || 'v1',
-    SECRET_KEY: getEnvVariable('CLERK_SECRET_KEY'),
-    MACHINE_SECRET_KEY: getEnvVariable('CLERK_MACHINE_SECRET_KEY'),
-    ENCRYPTION_KEY: getEnvVariable('CLERK_ENCRYPTION_KEY'),
-    CLERK_JWT_KEY: getEnvVariable('CLERK_JWT_KEY'),
-    API_URL: getEnvVariable('CLERK_API_URL') || apiUrlFromPublishableKey(publicEnvs.publishableKey),
+    API_VERSION: getEnvVariable('CLERK_API_VERSION', cfEnv) || 'v1',
+    SECRET_KEY: getEnvVariable('CLERK_SECRET_KEY', cfEnv),
+    MACHINE_SECRET_KEY: getEnvVariable('CLERK_MACHINE_SECRET_KEY', cfEnv),
+    ENCRYPTION_KEY: getEnvVariable('CLERK_ENCRYPTION_KEY', cfEnv),
+    CLERK_JWT_KEY: getEnvVariable('CLERK_JWT_KEY', cfEnv),
+    API_URL: getEnvVariable('CLERK_API_URL', cfEnv) || apiUrlFromPublishableKey(publicEnvs.publishableKey),
 
     SDK_METADATA: {
       name: PACKAGE_NAME,
       version: PACKAGE_VERSION,
-      environment: getEnvVariable('NODE_ENV'),
+      environment: getEnvVariable('NODE_ENV', cfEnv),
     },
   } as const;
 };

--- a/packages/tanstack-react-start/src/utils/env.ts
+++ b/packages/tanstack-react-start/src/utils/env.ts
@@ -1,9 +1,9 @@
 import { getEnvVariable } from '@clerk/shared/getEnvVariable';
 import { isTruthy } from '@clerk/shared/underscore';
 
-export const getPublicEnvVariables = () => {
+export const getPublicEnvVariables = (context?: Record<string, any>) => {
   const getValue = (name: string): string => {
-    return getEnvVariable(`VITE_${name}`) || getEnvVariable(name);
+    return getEnvVariable(`VITE_${name}`, context) || getEnvVariable(name, context);
   };
 
   return {


### PR DESCRIPTION
## Description

Alternative approach to #8196 — instead of adding `cloudflare:workers` support to the shared `getEnvVariable`, this PR fixes the issue at the **TanStack Start package level** by passing Cloudflare Workers env as context to `getEnvVariable()`, following the same pattern already used in `@clerk/react-router`.

Related issue: #8197

### Problem

On Cloudflare Workers, `@clerk/tanstack-react-start` calls `getEnvVariable('CLERK_SECRET_KEY')` **without a context parameter**:

```typescript
// packages/tanstack-react-start/src/server/constants.ts
SECRET_KEY: getEnvVariable('CLERK_SECRET_KEY'),  // no context!
```

Compare with `@clerk/react-router` which correctly passes context:
```typescript
// packages/react-router/src/server/loadOptions.ts
const secretKey = getEnvVariable('CLERK_SECRET_KEY', context);  // ✅ passes context
```

Without context, `getEnvVariable` cannot find env vars on CF Workers because `process.env` and `import.meta.env` are not available at runtime.

### Solution

1. **`cloudflareEnv.ts`** — New module that dynamically imports `cloudflare:workers` and caches the env object (same pattern as `@clerk/astro`'s `initCloudflareEnv`)
2. **`clerkMiddleware.ts`** — Calls `initCloudflareWorkerEnv()` at the start of the middleware (no-op on non-CF runtimes)
3. **`constants.ts`** — `commonEnvs()` now accepts optional context and passes it to all `getEnvVariable()` calls
4. **`utils/env.ts`** — `getPublicEnvVariables()` now accepts optional context

### How this differs from #8196

| Approach | PR #8196 (shared) | This PR (tanstack) |
|----------|-------------------|-------------------|
| Scope | All framework packages | TanStack Start only |
| Changes | `@clerk/shared` | `@clerk/tanstack-react-start` |
| Pattern | Auto-import `cloudflare:workers` in shared | Pass context like `@clerk/react-router` does |
| Risk | Lower — additive fallback | Lower — follows existing React Router pattern |

Both PRs solve the same problem. The Clerk team can choose which approach they prefer, or merge both for defense-in-depth.

## Checklist

- [x] Follows existing `@clerk/react-router` pattern for CF context passing
- [x] Safe on non-Cloudflare runtimes (init silently no-ops)
- [x] No breaking changes (context parameter is optional)

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare Workers environment variable resolution in TanStack React Start, enabling proper runtime access to secret keys and configuration values on Cloudflare Workers deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->