### PR TITLE
chore(expo): TypeScript 6.0 compatibility

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -101,10 +101,10 @@
     "app.plugin.d.ts"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsdown",
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "clean": "rimraf ./dist",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/expo/src/polyfills/base64Polyfill.ts
+++ b/packages/expo/src/polyfills/base64Polyfill.ts
@@ -3,11 +3,11 @@ import { decode, encode } from 'base-64';
 import { isHermes } from '../utils';
 
 // See Default Expo 51 engine Hermes' issue: https://github.com/facebook/hermes/issues/1379
-if (!global.btoa || isHermes()) {
-  global.btoa = encode;
+if (!globalThis.btoa || isHermes()) {
+  globalThis.btoa = encode;
 }
 
 // See Default Expo 51 engine Hermes' issue: https://github.com/facebook/hermes/issues/1379
-if (!global.atob || isHermes()) {
-  global.atob = decode;
+if (!globalThis.atob || isHermes()) {
+  globalThis.atob = decode;
 }

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react-jsx",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/packages/expo/tsdown.config.mts
+++ b/packages/expo/tsdown.config.mts
@@ -1,9 +1,9 @@
-import type { Options } from 'tsup';
-import { defineConfig } from 'tsup';
+import type { Options } from 'tsdown';
+import { defineConfig } from 'tsdown';
 
-import { runAfterLast } from '../../scripts/utils';
-import { version as clerkJsVersion } from '../clerk-js/package.json';
-import { name, version } from './package.json';
+import { runAfterLast } from '../../scripts/utils.ts';
+import clerkJsPkgJson from '../clerk-js/package.json' with { type: 'json' };
+import pkgJson from './package.json' with { type: 'json' };
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
@@ -17,11 +17,10 @@ export default defineConfig(overrideOptions => {
     clean: true,
     minify: false,
     sourcemap: true,
-    legacyOutput: true,
     define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
-      JS_PACKAGE_VERSION: `"${clerkJsVersion}"`,
+      PACKAGE_NAME: `"${pkgJson.name}"`,
+      PACKAGE_VERSION: `"${pkgJson.version}"`,
+      JS_PACKAGE_VERSION: `"${clerkJsPkgJson.version}"`,
       __DEV__: `${isWatch}`,
     },
   };

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,4 +1,4 @@
-import type { Options } from 'tsup';
+import type { Options } from 'tsdown';
 
 export const runAfterLast =
   (commands: Array<string | false>) =>


### PR DESCRIPTION
## Description

This PR updates `@clerk/expo` to be compatible with TypeScript 6.0 by migrating to tsdown. It included updating the `lib` config to `es2019` from `es6` to support `Array.flat` and `Array.includes`, along with replacing instances of `global` with `globalThis`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
