### PR TITLE
chore(chrome-extension): TypeScript 6.0 compatibility

### DIFF
--- a/packages/chrome-extension/tsconfig.json
+++ b/packages/chrome-extension/tsconfig.json
@@ -17,7 +17,9 @@
     "declaration": true,
     "declarationDir": "dist/types",
     "declarationMap": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "rootDir": "./src",
+    "types": ["jest"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description

This PR updates `@clerk/chrome-extension` to be compatible with TypeScript 6.0.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
