### PR TITLE
chore(react-router): TypeScript 6.0 compatibility

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -85,8 +85,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "dev": "tsup --watch",
+    "build": "tsdown",
+    "dev": "tsdown --watch",
     "dev:pub": "pnpm dev -- --env.publish",
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",

--- a/packages/react-router/src/client/ReactRouterClerkProvider.tsx
+++ b/packages/react-router/src/client/ReactRouterClerkProvider.tsx
@@ -11,8 +11,6 @@ import { ClerkReactRouterOptionsProvider } from './ReactRouterOptionsContext';
 import type { ClerkState, ReactRouterClerkProviderProps } from './types';
 import { useAwaitableNavigate } from './useAwaitableNavigate';
 
-export * from '@clerk/react';
-
 const SDK_METADATA = {
   name: PACKAGE_NAME,
   version: PACKAGE_VERSION,

--- a/packages/react-router/src/client/index.ts
+++ b/packages/react-router/src/client/index.ts
@@ -1,4 +1,3 @@
-export * from './ReactRouterClerkProvider';
+export { ClerkProvider } from './ReactRouterClerkProvider';
 export type { WithClerkState } from './types';
 export { SignIn, SignUp, OrganizationProfile, UserProfile } from './uiComponents';
-export { UNSAFE_PortalProvider } from '@clerk/react';

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -2,7 +2,8 @@ if (typeof window !== 'undefined' && typeof (window as any).global === 'undefine
   (window as any).global = window;
 }
 
-export * from './client';
+export * from '@clerk/react';
+export { ClerkProvider, SignIn, SignUp, OrganizationProfile, UserProfile, type WithClerkState } from './client';
 export { getToken } from '@clerk/shared/getToken';
 
 // Override Clerk React error thrower to show that errors come from @clerk/react-router

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "lib": ["es6", "dom"],
     "jsx": "react",
     "module": "ES2020",
@@ -20,7 +19,8 @@
     "allowJs": true,
     "target": "ES2019",
     "noEmitOnError": false,
-    "incremental": false
+    "incremental": false,
+    "rootDir": "./src"
   },
   "include": ["src"]
 }

--- a/packages/react-router/tsdown.config.ts
+++ b/packages/react-router/tsdown.config.ts
@@ -1,8 +1,7 @@
-import { esbuildPluginFilePathExtensions } from 'esbuild-plugin-file-path-extensions';
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
-import { version as clerkJsVersion } from '../clerk-js/package.json';
-import { name, version } from './package.json';
+import clerkJsPackage from '../clerk-js/package.json' with { type: 'json' };
+import pkgJson from './package.json' with { type: 'json' };
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
@@ -19,11 +18,10 @@ export default defineConfig(overrideOptions => {
     sourcemap: true,
     onSuccess: shouldPublish ? 'pkglab pub --ping' : undefined,
     define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
-      JS_PACKAGE_VERSION: `"${clerkJsVersion}"`,
+      PACKAGE_NAME: `"${pkgJson.name}"`,
+      PACKAGE_VERSION: `"${pkgJson.version}"`,
+      JS_PACKAGE_VERSION: `"${clerkJsPackage.version}"`,
       __DEV__: `${isWatch}`,
     },
-    esbuildPlugins: [esbuildPluginFilePathExtensions({ esmExtension: 'js' })],
   };
 });


### PR DESCRIPTION
## Description

Updates `@clerk/react-router` to be compatible with TypeScript 6.0 by moving to `tsdown` and modifying the exports to prevent the same collision issues solved in #8204 

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
