### PR TITLE
fix(shared,expo-passkeys): Add docs URL to `passkey_invalid_rpID_or_domain` error

### DIFF
--- a/.changeset/whole-paws-unite.md
+++ b/.changeset/whole-paws-unite.md
@@ -1,0 +1,6 @@
+---
+'@clerk/expo-passkeys': patch
+'@clerk/shared': patch
+---
+
+Add docs URL to `passkey_invalid_rpID_or_domain` error

--- a/packages/expo-passkeys/src/utils.ts
+++ b/packages/expo-passkeys/src/utils.ts
@@ -94,7 +94,10 @@ export function mapNativeErrorToClerkWebAuthnErrorCode(
   }
 
   if (code === '1002') {
-    return new ClerkWebAuthnError(message, { code: 'passkey_invalid_rpID_or_domain' });
+    return new ClerkWebAuthnError(message, {
+      code: 'passkey_invalid_rpID_or_domain',
+      docsUrl: 'https://clerk.com/docs/deployments/overview#authentication-across-subdomains',
+    });
   }
 
   if (code === '1003' || code === 'CreateCredentialInterruptedException') {

--- a/packages/shared/src/errors/webAuthNError.ts
+++ b/packages/shared/src/errors/webAuthNError.ts
@@ -1,3 +1,4 @@
+import type { ClerkErrorParams } from './clerkError';
 import { ClerkRuntimeError } from './clerkRuntimeError';
 
 type ClerkWebAuthnErrorCode =
@@ -14,14 +15,16 @@ type ClerkWebAuthnErrorCode =
   | 'passkey_registration_cancelled'
   | 'passkey_registration_failed';
 
+type ClerkWebAuthnErrorOptions = Omit<ClerkErrorParams, 'message' | 'code'> & { code: ClerkWebAuthnErrorCode };
+
 export class ClerkWebAuthnError extends ClerkRuntimeError {
   /**
    * A unique code identifying the error, can be used for localization.
    */
   code: ClerkWebAuthnErrorCode;
 
-  constructor(message: string, { code }: { code: ClerkWebAuthnErrorCode }) {
-    super(message, { code });
-    this.code = code;
+  constructor(message: string, options: ClerkWebAuthnErrorOptions) {
+    super(message, options);
+    this.code = options.code;
   }
 }

--- a/packages/shared/src/internal/clerk-js/passkeys.ts
+++ b/packages/shared/src/internal/clerk-js/passkeys.ts
@@ -118,7 +118,10 @@ function handlePublicKeyError(error: Error): ClerkWebAuthnError | ClerkRuntimeEr
     return new ClerkWebAuthnError(error.message, { code: 'passkey_operation_aborted' });
   }
   if (error.name === 'SecurityError') {
-    return new ClerkWebAuthnError(error.message, { code: 'passkey_invalid_rpID_or_domain' });
+    return new ClerkWebAuthnError(error.message, {
+      code: 'passkey_invalid_rpID_or_domain',
+      docsUrl: 'https://clerk.com/docs/deployments/overview#authentication-across-subdomains',
+    });
   }
   return error;
 }


### PR DESCRIPTION
## Description

Adds a documentation link to the `passkey_invalid_rpID_or_domain` error, pointing users to https://clerk.com/docs/deployments/overview#authentication-across-subdomains explaining the issue.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Passkey error messages now include documentation links to help troubleshoot authentication issues related to domain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->