### PR TITLE
feat(ui): Add composite, button, and text components

### DIFF
--- a/packages/ui/src/ceramic/button.tsx
+++ b/packages/ui/src/ceramic/button.tsx
@@ -1,9 +1,11 @@
-import { style, variants } from './variants';
+import * as React from 'react';
+
+import { Composite, type RenderProp } from './composite';
+import { type StyleRule, type VariantProps, style, variants } from './variants';
 
 export const buttonStyles = variants({
   base: style(theme => ({
     appearance: 'none',
-    boxSizing: 'border-box',
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
@@ -16,8 +18,6 @@ export const buttonStyles = variants({
     fontFamily: theme.fontFamilies.sans,
     border: 'none',
     outline: 'none',
-    margin: 0,
-    paddingBlock: 0,
     paddingInline: theme.spacing[3],
     cursor: 'pointer',
     textDecoration: 'none',
@@ -55,7 +55,7 @@ export const buttonStyles = variants({
     },
   })),
   variants: {
-    variant: {
+    color: {
       primary: style(theme => ({
         background: theme.colors.purple[700],
         color: theme.colors.white,
@@ -73,7 +73,34 @@ export const buttonStyles = variants({
     },
   },
   defaultVariants: {
-    variant: 'primary',
+    color: 'primary',
     fullWidth: false,
   },
 });
+
+type ButtonVariantProps = VariantProps<typeof buttonStyles>;
+
+type ButtonProps = ButtonVariantProps & {
+  render?: RenderProp;
+  sx?: StyleRule;
+};
+
+export const Button = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & ButtonProps>(
+  function Button(props, forwardedRef) {
+    const { render = <button type='button' />, color, fullWidth, sx, ...domProps } = props;
+
+    const combinedSx: StyleRule = theme => ({
+      ...(buttonStyles({ color, fullWidth }) as any)(theme),
+      ...(typeof sx === 'function' ? sx(theme) : sx),
+    });
+
+    return (
+      <Composite
+        render={render}
+        sx={combinedSx}
+        ref={forwardedRef}
+        {...domProps}
+      />
+    );
+  },
+);

--- a/packages/ui/src/ceramic/button.tsx
+++ b/packages/ui/src/ceramic/button.tsx
@@ -89,15 +89,10 @@ export const Button = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>
   function Button(props, forwardedRef) {
     const { render = <button type='button' />, color, fullWidth, sx, ...domProps } = props;
 
-    const combinedSx: StyleRule = theme => ({
-      ...(buttonStyles({ color, fullWidth }) as any)(theme),
-      ...(typeof sx === 'function' ? sx(theme) : sx),
-    });
-
     return (
       <Composite
         render={render}
-        sx={combinedSx}
+        sx={[buttonStyles({ color, fullWidth }), sx]}
         ref={forwardedRef}
         {...domProps}
       />

--- a/packages/ui/src/ceramic/composite.tsx
+++ b/packages/ui/src/ceramic/composite.tsx
@@ -14,6 +14,8 @@ const compositeStyles = variants({
 
 export type RenderProp = React.JSX.Element | ((props: React.HTMLAttributes<HTMLElement>) => React.JSX.Element);
 
+type SxArray = (StyleRule | undefined | null | false)[];
+
 function renderJsx(render: RenderProp | undefined, computedProps: React.HTMLAttributes<HTMLElement>) {
   if (typeof render === 'function') {
     return render(computedProps);
@@ -26,19 +28,20 @@ function renderJsx(render: RenderProp | undefined, computedProps: React.HTMLAttr
 
 interface CompositeProps {
   render?: RenderProp;
-  sx?: StyleRule;
+  sx?: StyleRule | SxArray;
 }
 
 export const Composite = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & CompositeProps>(
   function Composite(props, forwardedRef) {
     const { render, sx, ...domProps } = props;
     const renderElementProps = render && typeof render !== 'function' ? render.props : {};
+    const sxEntries = Array.isArray(sx) ? sx : [sx];
 
     const computedProps = {
       ...domProps,
       ...renderElementProps,
       ref: forwardedRef,
-      css: [compositeStyles({}), sx as Interpolation<Theme>],
+      css: [compositeStyles({}), ...sxEntries] as Interpolation<Theme>[],
     };
 
     return renderJsx(render, computedProps);

--- a/packages/ui/src/ceramic/composite.tsx
+++ b/packages/ui/src/ceramic/composite.tsx
@@ -1,0 +1,46 @@
+// eslint-disable-next-line no-restricted-imports
+import { type Interpolation, type Theme, jsx } from '@emotion/react';
+import * as React from 'react';
+
+import { type StyleRule, style, variants } from './variants';
+
+const compositeStyles = variants({
+  base: style(() => ({
+    boxSizing: 'border-box',
+    margin: 0,
+    padding: 0,
+  })),
+});
+
+export type RenderProp = React.JSX.Element | ((props: React.HTMLAttributes<HTMLElement>) => React.JSX.Element);
+
+function renderJsx(render: RenderProp | undefined, computedProps: React.HTMLAttributes<HTMLElement>) {
+  if (typeof render === 'function') {
+    return render(computedProps);
+  }
+  if (render) {
+    return jsx(render.type, { ...render.props, ...computedProps });
+  }
+  return jsx('div', computedProps);
+}
+
+interface CompositeProps {
+  render?: RenderProp;
+  sx?: StyleRule;
+}
+
+export const Composite = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & CompositeProps>(
+  function Composite(props, forwardedRef) {
+    const { render, sx, ...domProps } = props;
+    const renderElementProps = render && typeof render !== 'function' ? render.props : {};
+
+    const computedProps = {
+      ...domProps,
+      ...renderElementProps,
+      ref: forwardedRef,
+      css: [compositeStyles({}), sx as Interpolation<Theme>],
+    };
+
+    return renderJsx(render, computedProps);
+  },
+);

--- a/packages/ui/src/ceramic/text.tsx
+++ b/packages/ui/src/ceramic/text.tsx
@@ -1,4 +1,7 @@
-import { style, variants } from './variants';
+import * as React from 'react';
+
+import { Composite, type RenderProp } from './composite';
+import { type StyleRule, type VariantProps, style, variants } from './variants';
 
 export const textStyles = variants({
   base: style(theme => ({
@@ -46,3 +49,30 @@ export const textStyles = variants({
     font: 'sans',
   },
 });
+
+type TextVariantProps = VariantProps<typeof textStyles>;
+
+type TextProps = TextVariantProps & {
+  render?: RenderProp;
+  sx?: StyleRule;
+};
+
+export const Text = React.forwardRef<HTMLElement, Omit<React.HTMLProps<HTMLElement>, 'color'> & TextProps>(
+  function Text(props, forwardedRef) {
+    const { render = <p />, variant, color, font, sx, ...domProps } = props;
+
+    const combinedSx: StyleRule = theme => ({
+      ...(textStyles({ variant, color, font }) as any)(theme),
+      ...(typeof sx === 'function' ? sx(theme) : sx),
+    });
+
+    return (
+      <Composite
+        render={render}
+        sx={combinedSx}
+        ref={forwardedRef}
+        {...domProps}
+      />
+    );
+  },
+);

--- a/packages/ui/src/ceramic/text.tsx
+++ b/packages/ui/src/ceramic/text.tsx
@@ -61,15 +61,10 @@ export const Text = React.forwardRef<HTMLElement, Omit<React.HTMLProps<HTMLEleme
   function Text(props, forwardedRef) {
     const { render = <p />, variant, color, font, sx, ...domProps } = props;
 
-    const combinedSx: StyleRule = theme => ({
-      ...(textStyles({ variant, color, font }) as any)(theme),
-      ...(typeof sx === 'function' ? sx(theme) : sx),
-    });
-
     return (
       <Composite
         render={render}
-        sx={combinedSx}
+        sx={[textStyles({ variant, color, font }), sx]}
         ref={forwardedRef}
         {...domProps}
       />

--- a/packages/ui/src/ceramic/variants.ts
+++ b/packages/ui/src/ceramic/variants.ts
@@ -1,6 +1,4 @@
 import { fastDeepMergeAndReplace } from '@clerk/shared/utils';
-// eslint-disable-next-line no-restricted-imports
-import type { Interpolation, Theme } from '@emotion/react';
 
 import { type CeramicTheme } from './theme';
 
@@ -143,9 +141,8 @@ function conditionMatches(
 export function variants<T>(config: VariantsConfig<T>) {
   const { base, variants: variantDefinitions = {} as T, defaultVariants = {}, compoundVariants = [] } = config;
 
-  return (props: ConfigVariants<T> = {}): Interpolation<Theme> => {
-    return ((theme: Theme) => {
-      const ceramicTheme = theme as unknown as CeramicTheme;
+  return (props: ConfigVariants<T> = {}): StyleFunction => {
+    return (ceramicTheme: CeramicTheme) => {
       const computedStyles: CSSObject = {};
       const variantDefs = variantDefinitions as Record<string, Record<string, StyleRule>>;
 
@@ -178,6 +175,6 @@ export function variants<T>(config: VariantsConfig<T>) {
       }
 
       return computedStyles;
-    }) as unknown as Interpolation<Theme>;
+    };
   };
 }

--- a/packages/ui/src/ceramic/variants.ts
+++ b/packages/ui/src/ceramic/variants.ts
@@ -4,10 +4,10 @@ import type { Interpolation, Theme } from '@emotion/react';
 
 import { type CeramicTheme } from './theme';
 
-type CSSObject = Record<string, any>;
+export type CSSObject = Record<string, any>;
 // StyleFunction uses CeramicTheme to provide proper typing for theme parameter
-type StyleFunction = (theme: CeramicTheme) => CSSObject;
-type StyleRule = CSSObject | StyleFunction;
+export type StyleFunction = (theme: CeramicTheme) => CSSObject;
+export type StyleRule = CSSObject | StyleFunction;
 
 // Convert string literal "true" | "false" to boolean (CVA's StringToBoolean)
 type StringToBoolean<T> = T extends 'true' | 'false' ? boolean : T;


### PR DESCRIPTION
## Description

Introduces a small component primitives layer on top of the ceramic design system. All components require CeramicThemeProvider in the tree.

### Composite — base primitive. Handles render-prop polymorphism, CSS reset, and sx styling. Everything else builds on this.

```tsx
// defaults to <div>
<Composite sx={t => ({ color: t.colors.primary })} />

// render any element
<Composite render={<section />} sx={{ display: 'flex' }} />

// render function for full prop control
<Composite render={props => <MyEl {...props} />} />
```

### Text — typography variants on top of Composite

```tsx
<Text>body copy</Text>                              // <p>, body-2, default color
<Text render={<h1 />} variant="heading-1" />        // <h1>
<Text variant="label-3" color="muted" />
<Text font="mono" sx={t => ({ letterSpacing: t.spacing[1] })} />
```

### Button — button variants on top of Composite

```tsx
<Button>primary</Button>
<Button color="secondary" fullWidth />
<Button render={<a href="/x" />}>link button</Button>  // <a> with button styles
<Button sx={t => ({ borderRadius: t.spacing[3] })} />
```

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
