### PR TITLE
chore(repo): Harden pnpm-workspace settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,5 +37,27 @@ minimumReleaseAgeExclude:
   - 'pkglab-*'
 
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # Their 4.x package was published with provenance and this
+  # triggers the policy because it's based on publish date and
+  # not semver.
+  - 'eslint-import-resolver-typescript@3.10.1'
+  # Same idea, their 7.1.x publish process is more "trustworthy"
+  - 'vite@6.4.1'
+  # Same idea, their 1.x publish process is more "trustworthy"
+  - 'axios@0.30.2'
+  # Same idea, their 7.x publish process is more "trustworthy"
+  - 'semver@5.7.2 || 6.3.1'
+  # Same idea, their 7.x publish process is more "trustworthy"
+  - 'undici@5.29.0 || 6.22.0'
+  # Same idea, their 2.x publish process is more "trustworthy"
+  - 'ua-parser-js@1.0.41'
+  # Same idea, their 10.x publish process is more "trustworthy"
+  - '@octokit/endpoint@9.0.6'
+  # They experimented with provenance for some earlier versions
+  # and then disabled it before re-enabling it again later.
+  - 'undici-types@6.21.0'
+  # Same here
+  - 'chokidar@4.0.3'
 
 blockExoticSubdeps: true


### PR DESCRIPTION
## Description

Supply chain hardening tips from https://pnpm.io/supply-chain-security

`blockExoticSubdeps`:  transitive dependencies must be resolved from a trusted source, such as the configured registry, local file paths, workspace links, or trusted GitHub repositories (node, bun, deno).

`trustPolicy`: pnpm will fail if a package's trust level has decreased compared to previous releases. For example, if a package was previously published by a trusted publisher but now only has provenance or no trust evidence, installation will fail. This helps prevent installing potentially compromised versions.

The challenge with `trustPolicy` is that when a version 1.x is developed in parallel with a 2.x but only 2.x has provenance / trusted publishing any updates in the 1.x line will be flagged as a trust downgrade before a "previous" (chronologically) package from the 2.x line was more trustworthy. This explains the list of exceptions in the `pnpm-workspace.yaml` file.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: pnpm config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace-level dependency resolution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->