### PR TITLE
fix(repo): Remove npm self-upgrade step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,6 @@ jobs:
           turbo-team: ""
           turbo-token: ""
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
-
       - name: Build release
         run: pnpm turbo build $TURBO_ARGS --force
 
@@ -184,9 +181,6 @@ jobs:
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           playwright-enabled: true # Must be present to enable caching on branched workflows
-
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Version packages for canary
         id: version-packages
@@ -329,9 +323,6 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           turbo-team: ${{ vars.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
-
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Extract snapshot name
         id: extract-snapshot-name


### PR DESCRIPTION
## Summary

- Removes the `npm install -g npm@latest` step from all three release jobs (production, canary, snapshot)
- This step was failing with `MODULE_NOT_FOUND: promise-retry` on GitHub Actions runners using Node.js 22, where the bundled npm corrupts its own module tree during self-upgrade
- The step is unnecessary — Node 22 ships with npm 10.x which already supports trusted publishing (provenance) since npm 9.5.0

Fixes the release failure in https://github.com/clerk/javascript/actions/runs/24053278304

## Test plan

- [ ] Verify the re-triggered release workflow passes without the npm upgrade step
- [ ] Confirm `NPM_CONFIG_PROVENANCE: true` still works with the bundled npm version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release workflow pipeline by removing a global npm upgrade step from release automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->