### PR TITLE
fix(ui): remove back button from sign-in password compromised/pwned error screen

### DIFF
--- a/.changeset/pink-taxes-do.md
+++ b/.changeset/pink-taxes-do.md
@@ -1,0 +1,7 @@
+---
+'@clerk/ui': patch
+---
+
+Remove back button on the sign-in password compromised/pwned error screen.
+
+These errors are not recoverable by re-entering the password, so the back button led to a confusing dead end that would always take you back to the same error.

--- a/packages/ui/src/components/SignIn/SignInFactorOne.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOne.tsx
@@ -155,7 +155,8 @@ function SignInFactorOneInternal(): JSX.Element {
   }
 
   if (showAllStrategies || showForgotPasswordStrategies) {
-    const canGoBack = factorHasLocalStrategy(currentFactor);
+    // Password errors are not recoverable by re-entering the password, so we hide the back button
+    const canGoBack = factorHasLocalStrategy(currentFactor) && !passwordErrorCode;
 
     const toggle = showAllStrategies ? toggleAllStrategies : toggleForgotPasswordStrategies;
     const backHandler = () => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -303,57 +303,6 @@ describe('SignInFactorOne', () => {
         await screen.findByText('First, enter the code sent to your phone');
       });
 
-      it('entering a pwned password, then going back and clicking forgot password should result in the correct title', async () => {
-        const { wrapper, fixtures } = await createFixtures(f => {
-          f.withEmailAddress();
-          f.withPassword();
-          f.withPreferredSignInStrategy({ strategy: 'password' });
-          f.startSignInWithEmailAddress({
-            supportPassword: true,
-            supportEmailCode: true,
-            supportResetPassword: true,
-          });
-        });
-        fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
-
-        const errJSON = {
-          code: 'form_password_pwned',
-          long_message:
-            'Password has been found in an online data breach. For account safety, please reset your password.',
-          message: 'Password has been found in an online data breach. For account safety, please reset your password.',
-          meta: { param_name: 'password' },
-        };
-
-        fixtures.signIn.attemptFirstFactor.mockRejectedValueOnce(
-          new ClerkAPIResponseError('Error', {
-            data: [errJSON],
-            status: 422,
-          }),
-        );
-
-        const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.type(screen.getByLabelText('Password'), '123456');
-        await userEvent.click(screen.getByText('Continue'));
-
-        await screen.findByText('Password compromised');
-        await screen.findByText(
-          'This password has been found as part of a breach and can not be used, please reset your password.',
-        );
-        await screen.findByText('Or, sign in with another method');
-
-        // Go back
-        await userEvent.click(screen.getByText('Back'));
-
-        // Choose to reset password via "Forgot password" instead
-        await userEvent.click(screen.getByText(/Forgot password/i));
-        await screen.findByText('Forgot Password?');
-        expect(
-          screen.queryByText(
-            'This password has been found as part of a breach and can not be used, please reset your password.',
-          ),
-        ).not.toBeInTheDocument();
-      });
-
       it('using an compromised password should show the compromised password screen', async () => {
         const { wrapper, fixtures } = await createFixtures(f => {
           f.withEmailAddress();


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

These errors are not recoverable by re-entering the password, so the back button led to a confusing dead end that would always take you back to the same error.

Before:

<img width="427" height="582" alt="CleanShot 2026-04-09 at 16 24 16" src="https://github.com/user-attachments/assets/8c733369-41a6-49d6-b8eb-68558b46b7fd" />

After:

<img width="426" height="551" alt="CleanShot 2026-04-09 at 16 23 32" src="https://github.com/user-attachments/assets/c09269af-033d-4ee2-95cd-3e4dc0f93892" />

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
