### PR TITLE
fix(express): forward clockSkewInMs in clerkMiddleware

### DIFF
--- a/.changeset/red-pans-sing.md
+++ b/.changeset/red-pans-sing.md
@@ -1,0 +1,5 @@
+---
+"@clerk/express": patch
+---
+
+Forward `clockSkewInMs` from `clerkMiddleware()` to backend `authenticateRequest()`.

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -118,7 +118,7 @@ describe('clerkMiddleware', () => {
     });
 
     expect(authenticateRequestMock).toHaveBeenCalledWith(
-      expect.any(Request),
+      expect.any(Object),
       expect.objectContaining({
         clockSkewInMs: 12_345,
       }),

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -12,9 +12,9 @@ vi.mock('@clerk/backend/proxy', async () => {
   };
 });
 
+import { authenticateRequest } from '../authenticateRequest';
 import { clerkMiddleware } from '../clerkMiddleware';
 import { getAuth } from '../getAuth';
-import { authenticateRequest } from '../authenticateRequest';
 import { assertNoDebugHeaders, assertSignedOutDebugHeaders, runMiddleware, runMiddlewareOnPath } from './helpers';
 
 describe('clerkMiddleware', () => {

--- a/packages/express/src/__tests__/clerkMiddleware.test.ts
+++ b/packages/express/src/__tests__/clerkMiddleware.test.ts
@@ -14,6 +14,7 @@ vi.mock('@clerk/backend/proxy', async () => {
 
 import { clerkMiddleware } from '../clerkMiddleware';
 import { getAuth } from '../getAuth';
+import { authenticateRequest } from '../authenticateRequest';
 import { assertNoDebugHeaders, assertSignedOutDebugHeaders, runMiddleware, runMiddlewareOnPath } from './helpers';
 
 describe('clerkMiddleware', () => {
@@ -92,6 +93,36 @@ describe('clerkMiddleware', () => {
     );
 
     assertSignedOutDebugHeaders(response);
+  });
+
+  it('forwards clockSkewInMs to authenticateRequest', async () => {
+    const authenticateRequestMock = vi.fn().mockResolvedValue({});
+    const clerkClient = {
+      authenticateRequest: authenticateRequestMock,
+    } as any;
+
+    await authenticateRequest({
+      clerkClient,
+      request: {
+        method: 'GET',
+        url: '/',
+        headers: {
+          host: 'example.com',
+        },
+      } as Request,
+      options: {
+        publishableKey: 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k',
+        secretKey: 'sk_test_....',
+        clockSkewInMs: 12_345,
+      },
+    });
+
+    expect(authenticateRequestMock).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        clockSkewInMs: 12_345,
+      }),
+    );
   });
 
   it('throws error if clerkMiddleware is not executed before getAuth', async () => {

--- a/packages/express/src/authenticateRequest.ts
+++ b/packages/express/src/authenticateRequest.ts
@@ -24,7 +24,7 @@ import { incomingMessageToRequest, loadApiEnv, loadClientEnv, requestToProxyRequ
  */
 export const authenticateRequest = (opts: AuthenticateRequestParams) => {
   const { clerkClient, request, options } = opts;
-  const { jwtKey, authorizedParties, audience, acceptsToken } = options || {};
+  const { jwtKey, authorizedParties, audience, acceptsToken, clockSkewInMs } = options || {};
 
   const clerkRequest = createClerkRequest(incomingMessageToRequest(request));
   const env = { ...loadApiEnv(), ...loadClientEnv() };
@@ -55,6 +55,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     machineSecretKey,
     publishableKey,
     jwtKey,
+    clockSkewInMs,
     authorizedParties,
     proxyUrl,
     isSatellite,


### PR DESCRIPTION
## Description

This fixes an `@clerk/express` bug where `clockSkewInMs` was accepted by the middleware options type but not forwarded to backend `authenticateRequest()`.

The change explicitly passes `clockSkewInMs` through in the Express wrapper and adds a regression test to verify the option is forwarded.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Verification

- `pnpm turbo run test --filter=@clerk/express`
- `pnpm turbo run build --filter=@clerk/express`
