### PR TITLE
fix(astro): normalize URL paths in createRouteMatcher [v1]

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clerk/astro",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Clerk SDK for Astro",
   "keywords": [
     "auth",

--- a/packages/astro/src/server/clerk-middleware.ts
+++ b/packages/astro/src/server/clerk-middleware.ts
@@ -15,6 +15,7 @@ import { clerkClient } from './clerk-client';
 import { createCurrentUser } from './current-user';
 import { getAuth } from './get-auth';
 import { getClientSafeEnv, getSafeEnv } from './get-safe-env';
+import { isMalformedURLError } from './route-matcher';
 import { serverRedirectWithAuth } from './server-redirect-with-auth';
 import type {
   AstroMiddleware,
@@ -365,6 +366,10 @@ const handleControlFlowErrors = (
   requestState: RequestState,
   context: AstroMiddlewareContextParam,
 ): Response => {
+  if (isMalformedURLError(e)) {
+    return new Response(null, { status: 400, statusText: 'Bad Request' });
+  }
+
   switch (e.message) {
     case CONTROL_FLOW_ERROR.REDIRECT_TO_SIGN_IN:
       return createRedirect({

--- a/packages/astro/src/server/route-matcher.ts
+++ b/packages/astro/src/server/route-matcher.ts
@@ -7,6 +7,45 @@ type RouteMatcherRoutes = Autocomplete<WithPathPatternWildcard>;
 
 export type RouteMatcherParam = Array<RegExp | RouteMatcherRoutes> | RegExp | RouteMatcherRoutes;
 
+export class MalformedURLError extends Error {
+  public readonly statusCode = 400;
+  public readonly cause?: unknown;
+
+  constructor(pathname: string, cause?: unknown) {
+    super(`Malformed encoding in URL path: ${pathname}`);
+    this.name = 'MalformedURLError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * String-based check for MalformedURLError that works across package bundles
+ * where `instanceof` would fail due to duplicate class identities.
+ */
+export function isMalformedURLError(e: unknown): e is MalformedURLError {
+  return e instanceof Error && e.name === 'MalformedURLError';
+}
+
+/**
+ * Normalizes a URL path for safe route matching.
+ *
+ * 1. Decodes percent-encoded unreserved characters using decodeURI (not
+ *    decodeURIComponent) so path-reserved delimiters like %2F, %3F, %23
+ *    are preserved — matching how framework routers interpret paths.
+ * 2. Collapses consecutive slashes (e.g. //api/admin → /api/admin) to
+ *    prevent bypass via extra slashes.
+ *
+ * @throws {MalformedURLError} if the path contains invalid percent-encoding
+ */
+const normalizePath = (pathname: string): string => {
+  try {
+    pathname = decodeURI(pathname);
+  } catch (e) {
+    throw new MalformedURLError(pathname, e);
+  }
+  return pathname.replace(/\/\/+/g, '/');
+};
+
 // TODO-SHARED: This can be moved to @clerk/shared as an identical implementation exists in @clerk/nextjs
 /**
  * Returns a function that accepts a `Request` object and returns whether the request matches the list of
@@ -19,7 +58,7 @@ export type RouteMatcherParam = Array<RegExp | RouteMatcherRoutes> | RegExp | Ro
 export const createRouteMatcher = (routes: RouteMatcherParam) => {
   const routePatterns = [routes || ''].flat().filter(Boolean);
   const matchers = precomputePathRegex(routePatterns);
-  return (req: Request) => matchers.some(matcher => matcher.test(new URL(req.url).pathname));
+  return (req: Request) => matchers.some(matcher => matcher.test(normalizePath(new URL(req.url).pathname)));
 };
 
 const precomputePathRegex = (patterns: Array<string | RegExp>) => {


### PR DESCRIPTION
Backport of the `createRouteMatcher` normalization to the `@clerk/astro` v1 line (1.5.6 → 1.5.7).

## Summary

- Adds `normalizePath` to astro's inline `route-matcher.ts`; `createRouteMatcher` now normalizes paths before matching, preventing route protection bypass via malformed or non-canonical paths
- Introduces `MalformedURLError` and `isMalformedURLError` helper for cross-bundle detection
- `clerkMiddleware` catches `MalformedURLError` and returns HTTP 400
- `decodeURI` (not `decodeURIComponent`) preserves reserved delimiters (`%2F`, `%3F`, `%23`)
- Collapses consecutive slashes (`//api/admin` → `/api/admin`)

## Release

Ships via the dispatched release workflow (not via merge). This PR is for review; base is pinned at the `@clerk/astro@1.5.6` commit so the diff shows only the fix.