### PR TITLE
fix(nextjs): normalize URL paths in createRouteMatcher [v5]

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clerk/nextjs",
-  "version": "5.7.5",
+  "version": "5.7.6",
   "description": "Clerk SDK for NextJS",
   "keywords": [
     "clerk",

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -162,6 +162,13 @@ const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
 
     logger.debug('Options debug', { ...options, beforeAuth: !!options.beforeAuth, afterAuth: !!options.afterAuth });
 
+    // Reject malformed percent-encoded paths before any matcher runs (GHSA-vqx2-fgx2-5wq9).
+    try {
+      decodeURI(nextRequest.nextUrl.pathname);
+    } catch {
+      return new NextResponse(null, { status: 400, statusText: 'Bad Request' });
+    }
+
     if (isIgnoredRoute(nextRequest)) {
       logger.debug({ isIgnoredRoute: true });
       if (isDevelopmentFromSecretKey(options.secretKey) && !options.ignoredRoutes) {

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -14,6 +14,7 @@ import { PUBLISHABLE_KEY, SECRET_KEY, SIGN_IN_URL, SIGN_UP_URL } from './constan
 import { errorThrower } from './errorThrower';
 import type { AuthProtect } from './protect';
 import { createProtect } from './protect';
+import { isMalformedURLError } from './routeMatcher';
 import type { NextMiddlewareEvtParam, NextMiddlewareRequestParam, NextMiddlewareReturn } from './types';
 import {
   assertKey,
@@ -255,6 +256,10 @@ const createMiddlewareProtect = (
 // This function handles the known errors thrown by the APIs described above,
 // and returns the appropriate response.
 const handleControlFlowErrors = (e: any, clerkRequest: ClerkRequest, requestState: RequestState): Response => {
+  if (isMalformedURLError(e)) {
+    return new NextResponse(null, { status: 400, statusText: 'Bad Request' });
+  }
+
   switch (e.message) {
     case CONTROL_FLOW_ERROR.FORCE_NOT_FOUND:
       // Rewrite to a bogus URL to force not found error

--- a/packages/nextjs/src/server/routeMatcher.ts
+++ b/packages/nextjs/src/server/routeMatcher.ts
@@ -14,6 +14,45 @@ export type RouteMatcherParam =
   | RouteMatcherWithNextTypedRoutes
   | ((req: NextRequest) => boolean);
 
+export class MalformedURLError extends Error {
+  public readonly statusCode = 400;
+  public readonly cause?: unknown;
+
+  constructor(pathname: string, cause?: unknown) {
+    super(`Malformed encoding in URL path: ${pathname}`);
+    this.name = 'MalformedURLError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * String-based check for MalformedURLError that works across package bundles
+ * where `instanceof` would fail due to duplicate class identities.
+ */
+export function isMalformedURLError(e: unknown): e is MalformedURLError {
+  return e instanceof Error && e.name === 'MalformedURLError';
+}
+
+/**
+ * Normalizes a URL path for safe route matching.
+ *
+ * 1. Decodes percent-encoded unreserved characters using decodeURI (not
+ *    decodeURIComponent) so path-reserved delimiters like %2F, %3F, %23
+ *    are preserved — matching how framework routers interpret paths.
+ * 2. Collapses consecutive slashes (e.g. //api/admin → /api/admin) to
+ *    prevent bypass via extra slashes.
+ *
+ * @throws {MalformedURLError} if the path contains invalid percent-encoding
+ */
+const normalizePath = (pathname: string): string => {
+  try {
+    pathname = decodeURI(pathname);
+  } catch (e) {
+    throw new MalformedURLError(pathname, e);
+  }
+  return pathname.replace(/\/\/+/g, '/');
+};
+
 /**
  * Returns a function that accepts a `Request` object and returns whether the request matches the list of
  * predefined routes that can be passed in as the first argument.
@@ -29,7 +68,7 @@ export const createRouteMatcher = (routes: RouteMatcherParam) => {
 
   const routePatterns = [routes || ''].flat().filter(Boolean);
   const matchers = precomputePathRegex(routePatterns);
-  return (req: NextRequest) => matchers.some(matcher => matcher.test(req.nextUrl.pathname));
+  return (req: NextRequest) => matchers.some(matcher => matcher.test(normalizePath(req.nextUrl.pathname)));
 };
 
 const precomputePathRegex = (patterns: Array<string | RegExp>) => {


### PR DESCRIPTION
Backport of the `createRouteMatcher` normalization to the `@clerk/nextjs` v5 line (5.7.5 → 5.7.6).

## Summary

- Adds `normalizePath` to nextjs's inline `routeMatcher.ts`; `createRouteMatcher` now normalizes paths before matching, preventing route protection bypass via malformed or non-canonical paths
- Introduces `MalformedURLError` and `isMalformedURLError` helper for cross-bundle detection
- `clerkMiddleware` catches `MalformedURLError` and returns HTTP 400
- Legacy `authMiddleware` validates the incoming path at handler entry (covers all matcher invocations regardless of pattern vs function)
- `decodeURI` (not `decodeURIComponent`) preserves reserved delimiters (`%2F`, `%3F`, `%23`)
- Collapses consecutive slashes (`//api/admin` → `/api/admin`)

## Release

Ships via the dispatched release workflow (not via merge). This PR is for review; base is pinned at the `@clerk/nextjs@5.7.5` commit so the diff shows only the fix.