### PR TITLE
fix(ci): switch Core 2 release to npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
           # turbo-team: ${{ vars.TURBO_TEAM }}
           # turbo-token: ${{ secrets.TURBO_TOKEN }}
 
+      - name: Upgrade npm for trusted publishing
+        run: npx npm@11 install -g npm@11
+
       - name: Build release
         run: pnpm turbo build $TURBO_ARGS --force
 
@@ -61,8 +64,7 @@ jobs:
           version: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.CLERK_COOKIE_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
           NPM_CONFIG_PROVENANCE: true
 
       - name: Trigger workflows on related repos


### PR DESCRIPTION
## Summary

- Switch Core 2 release workflow from `NPM_TOKEN` secret to npm trusted publishing (OIDC), matching the `main` branch workflow
- Add `npx npm@11 install -g npm@11` step required for trusted publishing
- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` env vars that reference an expired/revoked secret

The Core 2 release has been failing with `ENEEDAUTH` since April 5 because the `NPM_TOKEN` secret is no longer valid. The `main` branch workflow already uses trusted publishing successfully — this aligns Core 2 with that approach.

## Test plan

- [ ] Merge and verify the next Core 2 release publishes successfully
- [ ] Confirm published packages have provenance attestation
