### PR TITLE
chore(backend): Harden `joinPaths` against traversal

### DIFF
--- a/.changeset/dark-bars-wink.md
+++ b/.changeset/dark-bars-wink.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add path traversal protections in `joinPaths`

--- a/packages/backend/src/util/__tests__/path.test.ts
+++ b/packages/backend/src/util/__tests__/path.test.ts
@@ -38,4 +38,28 @@ describe('utils.joinPaths(...args)', () => {
   it('handles no input', () => {
     expect(joinPaths()).toBe('');
   });
+
+  it('rejects literal ".." segments', () => {
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '../../../users')).toThrow();
+    expect(() => joinPaths('/sessions', '..')).toThrow();
+  });
+
+  it('rejects "." segments', () => {
+    expect(() => joinPaths('foo/./bar')).toThrow();
+    expect(() => joinPaths('foo', '.', 'bar')).toThrow();
+    expect(() => joinPaths('foo', './', 'bar')).toThrow();
+  });
+
+  it('rejects percent-encoded dot segments', () => {
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2e%2e/users')).toThrow();
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2E%2E/users')).toThrow();
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '.%2E/users')).toThrow();
+    expect(() => joinPaths('foo', '%2e', 'bar')).toThrow();
+  });
+
+  it('allows legitimate URLs and ID-like segments', () => {
+    expect(joinPaths('https://api.clerk.com', 'v1', '/sessions/sess_abc/tokens/supabase')).toBe(
+      'https://api.clerk.com/v1/sessions/sess_abc/tokens/supabase',
+    );
+  });
 });

--- a/packages/backend/src/util/__tests__/path.test.ts
+++ b/packages/backend/src/util/__tests__/path.test.ts
@@ -79,6 +79,10 @@ describe('utils.joinPaths(...args)', () => {
     expect(() => joinPaths('foo', '%2e', 'bar')).toThrow();
   });
 
+  it('rejects too many layers of encoding', () => {
+    expect(() => joinPaths('foo', '%2525252525252525252525252541')).toThrow();
+  });
+
   it('allows legitimate URLs and ID-like segments', () => {
     expect(joinPaths('https://api.clerk.com', 'v1', '/sessions/sess_abc/tokens/supabase')).toBe(
       'https://api.clerk.com/v1/sessions/sess_abc/tokens/supabase',

--- a/packages/backend/src/util/__tests__/path.test.ts
+++ b/packages/backend/src/util/__tests__/path.test.ts
@@ -39,6 +39,26 @@ describe('utils.joinPaths(...args)', () => {
     expect(joinPaths()).toBe('');
   });
 
+  it('accepts "." and ".." within a segment (not entire segment)', () => {
+    // Dot not as an isolated path segment
+    expect(joinPaths('foo.bar', 'baz')).toBe('foo.bar/baz');
+    expect(joinPaths('foo..bar', 'baz')).toBe('foo..bar/baz');
+    expect(joinPaths('foo.', 'bar.')).toBe('foo./bar.');
+    expect(joinPaths('foo..', '..bar')).toBe('foo../..bar');
+    expect(joinPaths('foo..baz')).toBe('foo..baz');
+    expect(joinPaths('fo.o', 'ba..z')).toBe('fo.o/ba..z');
+  });
+
+  it('accepts "." and ".." inside query parameter or as value', () => {
+    // . and .. as values in query string should not be considered dot segments
+    expect(joinPaths('/api', 'users?filter=..')).toBe('/api/users?filter=..');
+    expect(joinPaths('/api', 'users?filter=.')).toBe('/api/users?filter=.');
+    expect(joinPaths('/v1', 'search?q=foo.bar..baz')).toBe('/v1/search?q=foo.bar..baz');
+    // . and .. within querystring, fragment, or a value
+    expect(joinPaths('/foo', '?bar=..&baz=.')).toBe('/foo/?bar=..&baz=.');
+    expect(joinPaths('/foo', '#frag..ment')).toBe('/foo/#frag..ment');
+  });
+
   it('rejects literal ".." segments', () => {
     expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '../../../users')).toThrow();
     expect(() => joinPaths('/sessions', '..')).toThrow();
@@ -54,6 +74,8 @@ describe('utils.joinPaths(...args)', () => {
     expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2e%2e/users')).toThrow();
     expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2E%2E/users')).toThrow();
     expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '.%2E/users')).toThrow();
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2e%2e%2fusers')).toThrow();
+    expect(() => joinPaths('/sessions', 'sess_abc', 'tokens', '%2e%2e%252fusers')).toThrow();
     expect(() => joinPaths('foo', '%2e', 'bar')).toThrow();
   });
 

--- a/packages/backend/src/util/path.ts
+++ b/packages/backend/src/util/path.ts
@@ -1,14 +1,18 @@
 const SEPARATOR = '/';
 const MULTIPLE_SEPARATOR_REGEX = new RegExp('(?<!:)' + SEPARATOR + '{1,}', 'g');
+const MAX_DECODES = 10;
 
 type PathString = string | null | undefined;
 
 function isDotSegment(segment: string): boolean {
   let candidate = segment;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i <= MAX_DECODES; i++) {
     // After decoding, check if any slash-separated part is a dot segment
     if (candidate.split(/[/\\]/).some(p => p === '.' || p === '..')) {
       return true;
+    }
+    if (i === MAX_DECODES) {
+      throw new Error(`joinPaths: too many layers of encoding in ${segment}`);
     }
     try {
       const next = decodeURIComponent(candidate);

--- a/packages/backend/src/util/path.ts
+++ b/packages/backend/src/util/path.ts
@@ -3,9 +3,27 @@ const MULTIPLE_SEPARATOR_REGEX = new RegExp('(?<!:)' + SEPARATOR + '{1,}', 'g');
 
 type PathString = string | null | undefined;
 
+function isDotSegment(segment: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    decoded = segment;
+  }
+  return decoded === '.' || decoded === '..';
+}
+
 export function joinPaths(...args: PathString[]): string {
-  return args
+  const result = args
     .filter(p => p)
     .join(SEPARATOR)
     .replace(MULTIPLE_SEPARATOR_REGEX, SEPARATOR);
+
+  for (const segment of result.split(SEPARATOR)) {
+    if (isDotSegment(segment)) {
+      throw new Error(`joinPaths: "." and ".." path segments are not allowed (received "${result}")`);
+    }
+  }
+
+  return result;
 }

--- a/packages/backend/src/util/path.ts
+++ b/packages/backend/src/util/path.ts
@@ -4,13 +4,23 @@ const MULTIPLE_SEPARATOR_REGEX = new RegExp('(?<!:)' + SEPARATOR + '{1,}', 'g');
 type PathString = string | null | undefined;
 
 function isDotSegment(segment: string): boolean {
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(segment);
-  } catch {
-    decoded = segment;
+  let candidate = segment;
+  for (let i = 0; i < 3; i++) {
+    // After decoding, check if any slash-separated part is a dot segment
+    if (candidate.split(/[/\\]/).some(p => p === '.' || p === '..')) {
+      return true;
+    }
+    try {
+      const next = decodeURIComponent(candidate);
+      if (next === candidate) {
+        break;
+      } // stable — no more encoding
+      candidate = next;
+    } catch {
+      break;
+    }
   }
-  return decoded === '.' || decoded === '..';
+  return false;
 }
 
 export function joinPaths(...args: PathString[]): string {


### PR DESCRIPTION
## Description

There is no immediate vulnerability but it could be possible that someone uses one of the functions that call `joinPath` in a way that accepts user input and allows traversal on the backend API. This adds protection to avoid this problem.

Fixes SDK-60

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
