### PR TITLE
fix(ui): show claim CTA in EnableOrganizationsPrompt for keyless mode

### DIFF
--- a/.changeset/fix-keyless-orgs-enablement.md
+++ b/.changeset/fix-keyless-orgs-enablement.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix EnableOrganizationsPrompt in keyless mode: show "Claim your application" CTA instead of broken "Sign in to continue" when organizations are enabled on an unclaimed keyless app with no signed-in user.

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
@@ -48,10 +48,14 @@ describe('EnableOrganizationsPrompt success state', () => {
       expect(claimLink).toHaveAttribute('target', '_blank');
       expect(claimLink).toHaveAttribute('rel', 'noopener noreferrer');
 
-      // href should include the claim URL with return_url appended
+      // href should stay raw until the user clicks, then pick up return_url
       const href = claimLink.getAttribute('href')!;
       expect(href).toContain('dashboard.clerk.com/claim');
-      expect(href).toContain('return_url=');
+      expect(href).not.toContain('return_url=');
+
+      await claimLink.click();
+
+      expect(claimLink.getAttribute('href')).toContain('return_url=');
 
       // Should show "I'll do it later" button
       expect(screen.getByRole('button', { name: /i.ll do it later/i })).toBeInTheDocument();

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
@@ -98,7 +98,7 @@ describe('EnableOrganizationsPrompt success state', () => {
   });
 
   describe('unclaimed keyless, signed-in user', () => {
-    it('renders Continue button and preserves default org name', async () => {
+    it('renders claim CTA with Continue button and preserves default org name', async () => {
       const onSuccess = vi.fn();
       const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
       const mockGetMemberships = vi.fn().mockResolvedValue({
@@ -128,12 +128,16 @@ describe('EnableOrganizationsPrompt success state', () => {
       await enableButton.click();
 
       await vi.waitFor(() => {
-        expect(screen.getByText(/Organizations feature enabled/i)).toBeInTheDocument();
+        expect(screen.getByText(/Organizations are now enabled/i)).toBeInTheDocument();
       });
 
-      // Should show "Continue", not claim CTA
+      // Should show "Continue" button AND claim CTA
       expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
-      expect(screen.queryByText(/claim your application/i)).not.toBeInTheDocument();
+      const claimLink = screen.getByRole('link', { name: /claim your application/i });
+      expect(claimLink).toBeInTheDocument();
+
+      // Should NOT show dashboard link (unclaimed keyless can't access it)
+      expect(screen.queryByRole('link', { name: /dashboard/i })).not.toBeInTheDocument();
 
       // Should mention the default org name
       await vi.waitFor(() => {

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/__tests__/EnableOrganizationsPrompt.test.tsx
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, screen } from '@/test/utils';
+
+import { EnableOrganizationsPrompt } from '../index';
+
+const { createFixtures } = bindCreateFixtures('EnableOrganizationsPrompt' as any);
+
+describe('EnableOrganizationsPrompt success state', () => {
+  describe('unclaimed keyless, no user', () => {
+    it('renders claim CTA instead of sign-in button after enabling orgs', async () => {
+      const onSuccess = vi.fn();
+      const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
+
+      const { wrapper, fixtures } = await createFixtures();
+
+      // Set up keyless mode (both URLs required)
+      (fixtures.options as any).__internal_keyless_claimKeylessApplicationUrl =
+        'https://dashboard.clerk.com/claim?token=abc';
+      (fixtures.options as any).__internal_keyless_copyInstanceKeysUrl =
+        'https://dashboard.clerk.com/apps/app_123/instances/ins_456/api-keys';
+
+      // Mock the enable setting API call
+      fixtures.environment.__internal_enableEnvironmentSetting = mockEnableSetting;
+
+      render(
+        <EnableOrganizationsPrompt
+          caller='OrganizationSwitcher'
+          onSuccess={onSuccess}
+        />,
+        { wrapper },
+      );
+
+      // Click "Enable Organizations" to trigger the API call
+      const enableButton = screen.getByRole('button', { name: /enable organizations/i });
+      await enableButton.click();
+
+      // Wait for the success state to render
+      await vi.waitFor(() => {
+        expect(screen.getByText(/Organizations are now enabled/i)).toBeInTheDocument();
+      });
+
+      // Should show claim CTA as an anchor, not "Sign in to continue"
+      const claimLink = screen.getByRole('link', { name: /claim your application/i });
+      expect(claimLink).toBeInTheDocument();
+      expect(claimLink.tagName).toBe('A');
+      expect(claimLink).toHaveAttribute('target', '_blank');
+      expect(claimLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+      // href should include the claim URL with return_url appended
+      const href = claimLink.getAttribute('href')!;
+      expect(href).toContain('dashboard.clerk.com/claim');
+      expect(href).toContain('return_url=');
+
+      // Should show "I'll do it later" button
+      expect(screen.getByRole('button', { name: /i.ll do it later/i })).toBeInTheDocument();
+
+      // Should NOT show "Sign in to continue"
+      expect(screen.queryByText(/sign in to continue/i)).not.toBeInTheDocument();
+
+      // redirectToSignIn should NOT have been called
+      expect(fixtures.clerk.redirectToSignIn).not.toHaveBeenCalled();
+    });
+
+    it('"I\'ll do it later" calls onSuccess', async () => {
+      const onSuccess = vi.fn();
+      const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
+
+      const { wrapper, fixtures } = await createFixtures();
+
+      (fixtures.options as any).__internal_keyless_claimKeylessApplicationUrl =
+        'https://dashboard.clerk.com/claim?token=abc';
+      (fixtures.options as any).__internal_keyless_copyInstanceKeysUrl =
+        'https://dashboard.clerk.com/apps/app_123/instances/ins_456/api-keys';
+      fixtures.environment.__internal_enableEnvironmentSetting = mockEnableSetting;
+
+      render(
+        <EnableOrganizationsPrompt
+          caller='OrganizationSwitcher'
+          onSuccess={onSuccess}
+        />,
+        { wrapper },
+      );
+
+      const enableButton = screen.getByRole('button', { name: /enable organizations/i });
+      await enableButton.click();
+
+      await vi.waitFor(() => {
+        expect(screen.getByText(/Organizations are now enabled/i)).toBeInTheDocument();
+      });
+
+      const laterButton = screen.getByRole('button', { name: /i.ll do it later/i });
+      await laterButton.click();
+
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  describe('unclaimed keyless, signed-in user', () => {
+    it('renders Continue button and preserves default org name', async () => {
+      const onSuccess = vi.fn();
+      const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
+      const mockGetMemberships = vi.fn().mockResolvedValue({
+        data: [{ organization: { name: 'My Org' } }],
+      });
+
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+
+      (fixtures.options as any).__internal_keyless_claimKeylessApplicationUrl =
+        'https://dashboard.clerk.com/claim?token=abc';
+      (fixtures.options as any).__internal_keyless_copyInstanceKeysUrl =
+        'https://dashboard.clerk.com/apps/app_123/instances/ins_456/api-keys';
+      fixtures.environment.__internal_enableEnvironmentSetting = mockEnableSetting;
+      (fixtures.clerk.user as any).getOrganizationMemberships = mockGetMemberships;
+
+      render(
+        <EnableOrganizationsPrompt
+          caller='OrganizationSwitcher'
+          onSuccess={onSuccess}
+        />,
+        { wrapper },
+      );
+
+      const enableButton = screen.getByRole('button', { name: /enable organizations/i });
+      await enableButton.click();
+
+      await vi.waitFor(() => {
+        expect(screen.getByText(/Organizations feature enabled/i)).toBeInTheDocument();
+      });
+
+      // Should show "Continue", not claim CTA
+      expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+      expect(screen.queryByText(/claim your application/i)).not.toBeInTheDocument();
+
+      // Should mention the default org name
+      await vi.waitFor(() => {
+        expect(screen.getByText(/My Org/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('claimed keyless, no user', () => {
+    it('renders Sign in to continue button', async () => {
+      const onSuccess = vi.fn();
+      const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
+
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withClaimedAt(new Date().toISOString());
+      });
+
+      (fixtures.options as any).__internal_keyless_claimKeylessApplicationUrl =
+        'https://dashboard.clerk.com/claim?token=abc';
+      (fixtures.options as any).__internal_keyless_copyInstanceKeysUrl =
+        'https://dashboard.clerk.com/apps/app_123/instances/ins_456/api-keys';
+      fixtures.environment.__internal_enableEnvironmentSetting = mockEnableSetting;
+
+      render(
+        <EnableOrganizationsPrompt
+          caller='OrganizationSwitcher'
+          onSuccess={onSuccess}
+        />,
+        { wrapper },
+      );
+
+      const enableButton = screen.getByRole('button', { name: /enable organizations/i });
+      await enableButton.click();
+
+      await vi.waitFor(() => {
+        expect(screen.getByText(/Organizations feature enabled/i)).toBeInTheDocument();
+      });
+
+      // Should show "Sign in to continue", not claim CTA
+      expect(screen.getByRole('button', { name: /sign in to continue/i })).toBeInTheDocument();
+      expect(screen.queryByText(/claim your application/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('non-keyless, no user', () => {
+    it('renders Sign in to continue button', async () => {
+      const onSuccess = vi.fn();
+      const mockEnableSetting = vi.fn().mockResolvedValue(undefined);
+
+      const { wrapper, fixtures } = await createFixtures();
+
+      // No keyless URLs set — this is a regular dev instance
+      fixtures.environment.__internal_enableEnvironmentSetting = mockEnableSetting;
+
+      render(
+        <EnableOrganizationsPrompt
+          caller='OrganizationSwitcher'
+          onSuccess={onSuccess}
+        />,
+        { wrapper },
+      );
+
+      const enableButton = screen.getByRole('button', { name: /enable organizations/i });
+      await enableButton.click();
+
+      await vi.waitFor(() => {
+        expect(screen.getByText(/Organizations feature enabled/i)).toBeInTheDocument();
+      });
+
+      // Should show "Sign in to continue"
+      expect(screen.getByRole('button', { name: /sign in to continue/i })).toBeInTheDocument();
+      expect(screen.queryByText(/claim your application/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
@@ -4,7 +4,7 @@ import type { __internal_EnableOrganizationsPromptProps, EnableEnvironmentSettin
 import type { SerializedStyles } from '@emotion/react';
 // eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/react';
-import React, { forwardRef, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useId, useLayoutEffect, useRef, useState } from 'react';
 
 import { useEnvironment, useOptions } from '@/ui/contexts';
 import { Modal } from '@/ui/elements/Modal';
@@ -38,13 +38,6 @@ const EnableOrganizationsPromptInternal = ({
   const isKeyless = Boolean(claimUrl) && Boolean(copyKeysUrl);
   const isClaimed = environment.authConfig.claimedAt !== null;
   const showKeylessClaimPath = isEnabled && isKeyless && !isClaimed;
-
-  const claimUrlWithReturnUrl = useMemo(() => {
-    if (!showKeylessClaimPath || !claimUrl) return undefined;
-    const url = new URL(claimUrl);
-    url.searchParams.append('return_url', window.location.href);
-    return url.href;
-  }, [showKeylessClaimPath, claimUrl]);
 
   const isComponent = !caller.startsWith('use');
 
@@ -277,10 +270,15 @@ const EnableOrganizationsPromptInternal = ({
                     {clerk.user ? 'Continue' : 'I\u2019ll do it later'}
                   </PromptButton>
                   <Link
-                    href={claimUrlWithReturnUrl}
+                    href={claimUrl}
                     target='_blank'
                     rel='noopener noreferrer'
-                    onClick={() => {
+                    onClick={e => {
+                      if (claimUrl) {
+                        const url = new URL(claimUrl);
+                        url.searchParams.append('return_url', window.location.href);
+                        e.currentTarget.href = url.href;
+                      }
                       clerk.__internal_closeEnableOrganizationsPrompt?.();
                     }}
                     css={css`

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
@@ -4,9 +4,9 @@ import type { __internal_EnableOrganizationsPromptProps, EnableEnvironmentSettin
 import type { SerializedStyles } from '@emotion/react';
 // eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/react';
-import React, { forwardRef, useId, useLayoutEffect, useRef, useState } from 'react';
+import React, { forwardRef, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { useEnvironment } from '@/ui/contexts';
+import { useEnvironment, useOptions } from '@/ui/contexts';
 import { Modal } from '@/ui/elements/Modal';
 import { InternalThemeProvider } from '@/ui/styledSystem';
 
@@ -30,6 +30,21 @@ const EnableOrganizationsPromptInternal = ({
   const initialFocusRef = useRef<HTMLHeadingElement>(null);
   const environment = useEnvironment();
   const radioGroupLabelId = useId();
+
+  const options = useOptions();
+
+  const claimUrl = options.__internal_keyless_claimKeylessApplicationUrl;
+  const copyKeysUrl = options.__internal_keyless_copyInstanceKeysUrl;
+  const isKeyless = Boolean(claimUrl) && Boolean(copyKeysUrl);
+  const isClaimed = environment.authConfig.claimedAt !== null;
+  const showKeylessClaimPath = isEnabled && isKeyless && !isClaimed && !clerk.user;
+
+  const claimUrlWithReturnUrl = useMemo(() => {
+    if (!showKeylessClaimPath || !claimUrl) return undefined;
+    const url = new URL(claimUrl);
+    url.searchParams.append('return_url', window.location.href);
+    return url.href;
+  }, [showKeylessClaimPath, claimUrl]);
 
   const isComponent = !caller.startsWith('use');
 
@@ -131,17 +146,24 @@ const EnableOrganizationsPromptInternal = ({
                     `,
                   ]}
                 >
-                  {clerk.user && defaultOrganizationName
-                    ? `The Organizations feature has been enabled for your application. A default organization named "${defaultOrganizationName}" was created automatically. You can manage or rename it in your`
-                    : `The Organizations feature has been enabled for your application. You can manage it in your`}{' '}
-                  <Link
-                    href={organizationsDashboardUrl}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  >
-                    dashboard
-                  </Link>
-                  .
+                  {showKeylessClaimPath
+                    ? 'Organizations are now enabled! Claim your application to save this configuration and access the full dashboard.'
+                    : clerk.user && defaultOrganizationName
+                      ? `The Organizations feature has been enabled for your application. A default organization named "${defaultOrganizationName}" was created automatically. You can manage or rename it in your`
+                      : `The Organizations feature has been enabled for your application. You can manage it in your`}
+                  {!showKeylessClaimPath && (
+                    <>
+                      {' '}
+                      <Link
+                        href={organizationsDashboardUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        dashboard
+                      </Link>
+                      .
+                    </>
+                  )}
                 </p>
               ) : (
                 <>
@@ -242,19 +264,48 @@ const EnableOrganizationsPromptInternal = ({
             })}
           >
             {isEnabled ? (
-              <PromptButton
-                variant='solid'
-                onClick={() => {
-                  if (!clerk.user) {
-                    void clerk.redirectToSignIn();
-                    clerk.__internal_closeEnableOrganizationsPrompt?.();
-                  } else {
-                    onSuccess?.();
-                  }
-                }}
-              >
-                {clerk.user ? 'Continue' : 'Sign in to continue'}
-              </PromptButton>
+              showKeylessClaimPath ? (
+                <>
+                  <PromptButton
+                    variant='outline'
+                    onClick={() => {
+                      onSuccess?.();
+                    }}
+                  >
+                    I&apos;ll do it later
+                  </PromptButton>
+                  <Link
+                    href={claimUrlWithReturnUrl}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    onClick={() => {
+                      clerk.__internal_closeEnableOrganizationsPrompt?.();
+                    }}
+                    css={css`
+                      ${baseButtonStyles}
+                      ${buttonSolidStyles}
+                      color: #fde047;
+                      text-decoration: none;
+                    `}
+                  >
+                    Claim your application
+                  </Link>
+                </>
+              ) : (
+                <PromptButton
+                  variant='solid'
+                  onClick={() => {
+                    if (!clerk.user) {
+                      void clerk.redirectToSignIn();
+                      clerk.__internal_closeEnableOrganizationsPrompt?.();
+                    } else {
+                      onSuccess?.();
+                    }
+                  }}
+                >
+                  {clerk.user ? 'Continue' : 'Sign in to continue'}
+                </PromptButton>
+              )
             ) : (
               <>
                 <PromptButton

--- a/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
+++ b/packages/ui/src/components/devPrompts/EnableOrganizationsPrompt/index.tsx
@@ -37,7 +37,7 @@ const EnableOrganizationsPromptInternal = ({
   const copyKeysUrl = options.__internal_keyless_copyInstanceKeysUrl;
   const isKeyless = Boolean(claimUrl) && Boolean(copyKeysUrl);
   const isClaimed = environment.authConfig.claimedAt !== null;
-  const showKeylessClaimPath = isEnabled && isKeyless && !isClaimed && !clerk.user;
+  const showKeylessClaimPath = isEnabled && isKeyless && !isClaimed;
 
   const claimUrlWithReturnUrl = useMemo(() => {
     if (!showKeylessClaimPath || !claimUrl) return undefined;
@@ -147,7 +147,9 @@ const EnableOrganizationsPromptInternal = ({
                   ]}
                 >
                   {showKeylessClaimPath
-                    ? 'Organizations are now enabled! Claim your application to save this configuration and access the full dashboard.'
+                    ? defaultOrganizationName
+                      ? `Organizations are now enabled and a default organization named "${defaultOrganizationName}" was created. Claim your application to save this configuration and access the full dashboard.`
+                      : 'Organizations are now enabled! Claim your application to save this configuration and access the full dashboard.'
                     : clerk.user && defaultOrganizationName
                       ? `The Organizations feature has been enabled for your application. A default organization named "${defaultOrganizationName}" was created automatically. You can manage or rename it in your`
                       : `The Organizations feature has been enabled for your application. You can manage it in your`}
@@ -272,7 +274,7 @@ const EnableOrganizationsPromptInternal = ({
                       onSuccess?.();
                     }}
                   >
-                    I&apos;ll do it later
+                    {clerk.user ? 'Continue' : 'I\u2019ll do it later'}
                   </PromptButton>
                   <Link
                     href={claimUrlWithReturnUrl}

--- a/packages/ui/src/test/create-fixtures.tsx
+++ b/packages/ui/src/test/create-fixtures.tsx
@@ -107,6 +107,7 @@ const unboundCreateFixtures = (
         'PlanDetails',
         'Checkout',
         'KeylessPrompt',
+        'EnableOrganizationsPrompt',
       ];
       const contextWrappedChildren = !componentsWithoutContext.includes(componentName) ? (
         <ComponentContextProvider


### PR DESCRIPTION
## Summary

- Fixes the `EnableOrganizationsPrompt` success state in keyless mode: replaces the broken "Sign in to continue" path (which cannot reach a usable dashboard flow on an unclaimed keyless app) with a "Claim your application" anchor, plus a secondary action that delegates to `onSuccess`
- The keyless claim path now activates for any unclaimed keyless app when `isKeyless && !isClaimed`, including signed-in users, because the dashboard link is inaccessible until the app is claimed
- The real caller still reloads after the secondary action by passing `onSuccess: () => window.location.reload()` from `clerk-js`; the UI component keeps that behavior delegated to its caller instead of hardcoding reload itself
- Detection uses `useOptions()` and `useEnvironment()` already available in the component — no prop threading, no changes to `clerk-js`, shared types, or any SDK package beyond the existing caller contract

## Test plan

- [x] Release canary and verify in a keyless Next.js app:
  1. Mount `<OrganizationSwitcher />` without signing in
  2. Click "Enable Organizations"
  3. Success state should show "Claim your application" + "I'll do it later" (not "Sign in to continue")
- [x] Verify signed-in keyless user now sees "Continue" + "Claim your application" with the default org name
- [x] Verify claimed keyless app (no user) still sees "Sign in to continue"
- [x] Verify non-keyless dev instance still sees "Sign in to continue"
- [x] Unit tests: 5 new tests covering all 4 state scenarios (all passing)