### PR TITLE
fix(repo): remove duplicate fastify turbo task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -219,11 +219,6 @@
       "inputs": ["integration/**"],
       "outputLogs": "new-only"
     },
-    "//#test:integration:fastify": {
-      "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS"],
-      "inputs": ["integration/**"],
-      "outputLogs": "new-only"
-    },
     "//#test:integration:hono": {
       "env": ["CLEANUP", "DEBUG", "E2E_*", "INTEGRATION_INSTANCE_KEYS", "INTEGRATION_STAGING_INSTANCE_KEYS"],
       "inputs": ["integration/**"],


### PR DESCRIPTION
Removes a duplicate `//#test:integration:fastify` definition in `turbo.json`. The duplicate silently overrode the first entry and dropped `INTEGRATION_STAGING_INSTANCE_KEYS` from the task's env.
