### PR TITLE
feat(nextjs): add helpful error for incorrect auth import

### DIFF
--- a/.changeset/auth-import-error.md
+++ b/.changeset/auth-import-error.md
@@ -1,0 +1,7 @@
+---
+"@clerk/nextjs": patch
+---
+
+Improve developer experience for incorrect auth import
+
+Add helpful TypeScript error when importing `auth` from `@clerk/nextjs` instead of `@clerk/nextjs/server`. The error message shows exactly how to fix the import with a clear diff format and explains that `auth` is only available in server contexts.

--- a/.changeset/auth-import-error.md
+++ b/.changeset/auth-import-error.md
@@ -2,6 +2,4 @@
 "@clerk/nextjs": patch
 ---
 
-Improve developer experience for incorrect auth import
-
-Add helpful TypeScript error when importing `auth` from `@clerk/nextjs` instead of `@clerk/nextjs/server`. The error message shows exactly how to fix the import with a clear diff format and explains that `auth` is only available in server contexts.
+Add helpful TypeScript error for incorrect `auth` import path

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -84,13 +84,13 @@ export const Show = ComponentsModule.Show as ServerComponentsServerModuleTypes['
 
 /**
  * `auth` is not available from this import path.
- * 
+ *
  * **To fix this error:**
  * ```diff
  * - import { auth } from '@clerk/nextjs'
  * + import { auth } from '@clerk/nextjs/server'
  * ```
- * 
+ *
  * The `auth` function is only available in server-side contexts:
  * API Routes, Server Components, Server Actions, and Middleware.
  */

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -81,3 +81,17 @@ import type { ServerComponentsServerModuleTypes } from './components.server';
 
 export const ClerkProvider = ComponentsModule.ClerkProvider as ServerComponentsServerModuleTypes['ClerkProvider'];
 export const Show = ComponentsModule.Show as ServerComponentsServerModuleTypes['Show'];
+
+/**
+ * `auth` is not available from this import path.
+ * 
+ * **To fix this error:**
+ * ```diff
+ * - import { auth } from '@clerk/nextjs'
+ * + import { auth } from '@clerk/nextjs/server'
+ * ```
+ * 
+ * The `auth` function is only available in server-side contexts:
+ * API Routes, Server Components, Server Actions, and Middleware.
+ */
+export declare const auth: never;


### PR DESCRIPTION
## Summary

Improves developer experience when trying to import `auth` from the wrong path by adding a helpful TypeScript error.

## Changes

- Add `export declare const auth: never` to main index.ts
- Include clear JSDoc with diff format showing correct import path
- Explains that `auth` is only available in server-side contexts

## Developer Experience

**Before:**
```
'auth' is not exported from '@clerk/nextjs'
```

**After:**
TypeScript error with helpful JSDoc:
```diff
- import { auth } from '@clerk/nextjs'
+ import { auth } from '@clerk/nextjs/server'
```

🤖 Generated with [Claude Code](https://claude.ai/code)