### PR TITLE
fix(backend): Clock skew of 0 should not fall back

### DIFF
--- a/.changeset/wacky-dryers-hammer.md
+++ b/.changeset/wacky-dryers-hammer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+A clock skew of 0 will not fall back to the default value anymore.

--- a/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
+++ b/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
@@ -241,4 +241,32 @@ describe('verifyJwt(jwt, options)', () => {
     const { data } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
     expect(data).toEqual(mockJwtPayload);
   });
+
+  it('falls back to the default clock skew when clockSkewInMs is NaN', async () => {
+    vi.setSystemTime(new Date((mockJwtPayload.exp + 1) * 1000));
+    const inputVerifyJwtOptions = {
+      key: mockJwks.keys[0],
+      issuer: mockJwtPayload.iss,
+      authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+      clockSkewInMs: Number.NaN,
+    };
+    const { data } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
+    expect(data).toEqual(mockJwtPayload);
+
+    vi.setSystemTime(new Date((mockJwtPayload.exp + 60) * 1000));
+    const { errors: [error] = [] } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
+    expect(error?.message).toContain('JWT is expired');
+  });
+
+  it('falls back to the default clock skew when clockSkewInMs is Infinity', async () => {
+    vi.setSystemTime(new Date((mockJwtPayload.exp + 3600) * 1000));
+    const inputVerifyJwtOptions = {
+      key: mockJwks.keys[0],
+      issuer: mockJwtPayload.iss,
+      authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+      clockSkewInMs: Number.POSITIVE_INFINITY,
+    };
+    const { errors: [error] = [] } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
+    expect(error?.message).toContain('JWT is expired');
+  });
 });

--- a/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
+++ b/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
@@ -217,4 +217,28 @@ describe('verifyJwt(jwt, options)', () => {
     expect(error?.message).toContain('Invalid JWT type');
     expect(error?.message).toContain('Expected "at+jwt, application/at+jwt"');
   });
+
+  it('rejects an expired JWT when clockSkewInMs is explicitly 0', async () => {
+    vi.setSystemTime(new Date((mockJwtPayload.exp + 1) * 1000));
+    const inputVerifyJwtOptions = {
+      key: mockJwks.keys[0],
+      issuer: mockJwtPayload.iss,
+      authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+      clockSkewInMs: 0,
+    };
+    const { errors: [error] = [] } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('JWT is expired');
+  });
+
+  it('accepts a recently expired JWT within the default clock skew when clockSkewInMs is undefined', async () => {
+    vi.setSystemTime(new Date((mockJwtPayload.exp + 1) * 1000));
+    const inputVerifyJwtOptions = {
+      key: mockJwks.keys[0],
+      issuer: mockJwtPayload.iss,
+      authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+    };
+    const { data } = await verifyJwt(mockJwt, inputVerifyJwtOptions);
+    expect(data).toEqual(mockJwtPayload);
+  });
 });

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -131,7 +131,7 @@ export async function verifyJwt(
   options: VerifyJwtOptions,
 ): Promise<JwtReturnType<JwtPayload, TokenVerificationError>> {
   const { audience, authorizedParties, clockSkewInMs, key, headerType } = options;
-  const clockSkew = clockSkewInMs || DEFAULT_CLOCK_SKEW_IN_MS;
+  const clockSkew = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_IN_MS;
 
   const { data: decoded, errors } = decodeJwt(token);
   if (errors) {

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -131,7 +131,8 @@ export async function verifyJwt(
   options: VerifyJwtOptions,
 ): Promise<JwtReturnType<JwtPayload, TokenVerificationError>> {
   const { audience, authorizedParties, clockSkewInMs, key, headerType } = options;
-  const clockSkew = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_IN_MS;
+  const clockSkew =
+    typeof clockSkewInMs === 'number' && Number.isFinite(clockSkewInMs) ? clockSkewInMs : DEFAULT_CLOCK_SKEW_IN_MS;
 
   const { data: decoded, errors } = decodeJwt(token);
   if (errors) {


### PR DESCRIPTION
## Description

Because 0 is falsy the current code fell back to the default value when the clock skew was configured to 0. This changes the syntax to fall back on null-ish values which 0 is not.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
