### PR TITLE
fix(ui): Default OAuthConsent org selection to last active organization

### DIFF
--- a/.changeset/oauth-consent-last-active-org.md
+++ b/.changeset/oauth-consent-last-active-org.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": patch
+---
+
+Default the organization selection in `<OAuthConsent />` to the user's last active organization, falling back to the first membership when it is not set or no longer available.

--- a/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
@@ -46,8 +46,11 @@ function _OAuthConsent() {
       }))
     : [];
 
+  const lastActiveOrgId = clerk.session?.lastActiveOrganizationId;
+  const defaultOrg = orgOptions.find(o => o.value === lastActiveOrgId)?.value ?? orgOptions[0]?.value ?? null;
+
   const [selectedOrg, setSelectedOrg] = useState<string | null>(null);
-  const effectiveOrg = selectedOrg ?? orgOptions[0]?.value ?? null;
+  const effectiveOrg = selectedOrg ?? defaultOrg;
 
   // onAllow and onDeny are always provided as a pair by the accounts portal.
   const hasContextCallbacks = Boolean(ctx.onAllow || ctx.onDeny);

--- a/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
+++ b/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
@@ -415,5 +415,87 @@ describe('OAuthConsent', () => {
         expect(form.querySelector('input[name="organization_id"]')).toBeNull();
       });
     });
+
+    it('defaults the selected org to session.lastActiveOrganizationId when it matches a membership', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withUser({
+          email_addresses: ['jane@example.com'],
+          organization_memberships: [
+            { id: 'org_1', name: 'Acme Corp' },
+            { id: 'org_2', name: 'Globex' },
+            { id: 'org_3', name: 'Initech' },
+          ],
+        });
+        f.withOrganizations();
+      });
+
+      fixtures.clerk.session.lastActiveOrganizationId = 'org_3';
+
+      props.setProps({ componentName: 'OAuthConsent', __internal_enableOrgSelection: true } as any);
+      mockOAuthApplication(fixtures.clerk, { getConsentInfo: vi.fn().mockResolvedValue(fakeConsentInfo) });
+
+      const { baseElement } = render(<OAuthConsent />, { wrapper });
+
+      await waitFor(() => {
+        const form = baseElement.querySelector('form[action*="/v1/me/oauth/consent/"]')!;
+        const hiddenInput = form.querySelector('input[name="organization_id"]') as HTMLInputElement | null;
+        expect(hiddenInput).not.toBeNull();
+        expect(hiddenInput!.value).toBe('org_3');
+      });
+    });
+
+    it('falls back to the first membership when lastActiveOrganizationId does not match any membership', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withUser({
+          email_addresses: ['jane@example.com'],
+          organization_memberships: [
+            { id: 'org_1', name: 'Acme Corp' },
+            { id: 'org_2', name: 'Globex' },
+          ],
+        });
+        f.withOrganizations();
+      });
+
+      fixtures.clerk.session.lastActiveOrganizationId = 'org_deleted';
+
+      props.setProps({ componentName: 'OAuthConsent', __internal_enableOrgSelection: true } as any);
+      mockOAuthApplication(fixtures.clerk, { getConsentInfo: vi.fn().mockResolvedValue(fakeConsentInfo) });
+
+      const { baseElement } = render(<OAuthConsent />, { wrapper });
+
+      await waitFor(() => {
+        const form = baseElement.querySelector('form[action*="/v1/me/oauth/consent/"]')!;
+        const hiddenInput = form.querySelector('input[name="organization_id"]') as HTMLInputElement | null;
+        expect(hiddenInput).not.toBeNull();
+        expect(hiddenInput!.value).toBe('org_1');
+      });
+    });
+
+    it('falls back to the first membership when lastActiveOrganizationId is null', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withUser({
+          email_addresses: ['jane@example.com'],
+          organization_memberships: [
+            { id: 'org_1', name: 'Acme Corp' },
+            { id: 'org_2', name: 'Globex' },
+          ],
+        });
+        f.withOrganizations();
+      });
+
+      fixtures.clerk.session.lastActiveOrganizationId = null;
+
+      props.setProps({ componentName: 'OAuthConsent', __internal_enableOrgSelection: true } as any);
+      mockOAuthApplication(fixtures.clerk, { getConsentInfo: vi.fn().mockResolvedValue(fakeConsentInfo) });
+
+      const { baseElement } = render(<OAuthConsent />, { wrapper });
+
+      await waitFor(() => {
+        const form = baseElement.querySelector('form[action*="/v1/me/oauth/consent/"]')!;
+        const hiddenInput = form.querySelector('input[name="organization_id"]') as HTMLInputElement | null;
+        expect(hiddenInput).not.toBeNull();
+        expect(hiddenInput!.value).toBe('org_1');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

The `<OAuthConsent />` org picker currently defaults to whichever org the API returns first. This change seeds the default from `clerk.session?.lastActiveOrganizationId` so users consent on behalf of the org they were most recently working in, falling back to the first membership when the last active org is null, doesn't match any membership, or was deleted. Read via the already-in-scope `useClerk()` (no new hook, no re-renders from `useSession`), and the existing render guards keep the no-memberships case unchanged.

Added three test cases covering the match, no-match, and null paths, plus a `@clerk/ui` patch changeset.

## Checklist

- [x] \`pnpm test\` runs as expected.
- [ ] \`pnpm build\` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: