### PR TITLE
feat(backend): GET organization settings

### DIFF
--- a/.changeset/tiny-bobcats-train.md
+++ b/.changeset/tiny-bobcats-train.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add backend query to GET organization settings for an instance.

--- a/packages/backend/src/api/endpoints/InstanceApi.ts
+++ b/packages/backend/src/api/endpoints/InstanceApi.ts
@@ -91,6 +91,13 @@ export class InstanceAPI extends AbstractAPI {
     });
   }
 
+  public async getOrganizationSettings() {
+    return this.request<OrganizationSettings>({
+      method: 'GET',
+      path: joinPaths(basePath, 'organization_settings'),
+    });
+  }
+
   public async updateOrganizationSettings(params: UpdateOrganizationSettingsParams) {
     return this.request<OrganizationSettings>({
       method: 'PATCH',


### PR DESCRIPTION
## Description

We recently added this BAPI endpoint because agents expect it to exist; they want to GET organization settings before doing a PATCH. In this PR we add support to the Javascript SDK as well.

I didn't bother with unit tests here because it would just be a thin mock.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
