### PR TITLE
refactor(nextjs): factor runHandlerWithRequestState out of baseNextMiddleware

### DIFF
--- a/.changeset/sdk-70-backend-bootstrap-state.md
+++ b/.changeset/sdk-70-backend-bootstrap-state.md
@@ -2,4 +2,4 @@
 '@clerk/backend': minor
 ---
 
-Add `createBootstrapSignedOutState` helper to `@clerk/backend/internal`. Returns a synthetic `UnauthenticatedState<'session_token'>` without requiring a publishable key or an `AuthenticateContext`. Intended for framework integrations that need to run authorization logic before real Clerk keys are available (e.g. the Next.js keyless bootstrap window).
+Add `createBootstrapSignedOutState` helper to `@clerk/backend/internal`. Returns a synthetic `UnauthenticatedState<'session_token'>` without requiring a publishable key or an `AuthenticateContext`. Intended for framework integrations that need to run authorization logic before real Clerk keys are available (e.g. the Next.js keyless bootstrap window). Accepts optional `signInUrl`, `signUpUrl`, `isSatellite`, `domain`, and `proxyUrl` so that `createRedirect`-driven flows (including cross-origin satellite sign-in with the `__clerk_status=needs-sync` handshake marker) behave correctly during bootstrap.

--- a/.changeset/sdk-70-backend-bootstrap-state.md
+++ b/.changeset/sdk-70-backend-bootstrap-state.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add `createBootstrapSignedOutState` helper to `@clerk/backend/internal`. Returns a synthetic `UnauthenticatedState<'session_token'>` without requiring a publishable key or an `AuthenticateContext`. Intended for framework integrations that need to run authorization logic before real Clerk keys are available (e.g. the Next.js keyless bootstrap window).

--- a/.changeset/sdk-70-middleware-refactor.md
+++ b/.changeset/sdk-70-middleware-refactor.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Refactor `clerkMiddleware` internals to factor the post-authentication pipeline (handler invocation, CSP, redirects, response decoration) into a private `runHandlerWithRequestState` helper. Pure refactor — no behavioral change.

--- a/packages/backend/src/__tests__/exports.test.ts
+++ b/packages/backend/src/__tests__/exports.test.ts
@@ -45,6 +45,7 @@ describe('subpath /internal exports', () => {
         "authenticatedMachineObject",
         "constants",
         "createAuthenticateRequest",
+        "createBootstrapSignedOutState",
         "createClerkRequest",
         "createRedirect",
         "debugRequestState",

--- a/packages/backend/src/internal.ts
+++ b/packages/backend/src/internal.ts
@@ -38,7 +38,7 @@ export {
   getAuthObjectForAcceptedToken,
 } from './tokens/authObjects';
 
-export { AuthStatus } from './tokens/authStatus';
+export { AuthStatus, createBootstrapSignedOutState } from './tokens/authStatus';
 export type {
   RequestState,
   SignedInState,

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -268,6 +268,52 @@ export function signedOutInvalidToken(): UnauthenticatedState<null> {
   });
 }
 
+type BootstrapSignedOutParams = {
+  signInUrl?: string;
+  signUpUrl?: string;
+  reason?: AuthReason;
+  message?: string;
+  headers?: Headers;
+};
+
+/**
+ * Returns a synthetic `UnauthenticatedState` without requiring a publishable key or an
+ * `AuthenticateContext`. Intended for framework integrations that need to run
+ * authorization logic for a request that arrived before real Clerk keys are available
+ * (e.g. the Next.js keyless bootstrap window). The returned state has
+ * `status: 'signed-out'` and `toAuth()` returns a standard signed-out session auth object.
+ *
+ * `signInUrl` / `signUpUrl` are carried through so that `redirectToSignIn` /
+ * `redirectToSignUp` can resolve to the application's own routes during bootstrap.
+ */
+export function createBootstrapSignedOutState({
+  signInUrl = '',
+  signUpUrl = '',
+  reason = AuthErrorReason.SessionTokenAndUATMissing,
+  message = '',
+  headers = new Headers(),
+}: BootstrapSignedOutParams = {}): UnauthenticatedState<SessionTokenType> {
+  return withDebugHeaders({
+    status: AuthStatus.SignedOut,
+    reason,
+    message,
+    proxyUrl: '',
+    publishableKey: '',
+    isSatellite: false,
+    domain: '',
+    signInUrl,
+    signUpUrl,
+    afterSignInUrl: '',
+    afterSignUpUrl: '',
+    isSignedIn: false,
+    isAuthenticated: false,
+    tokenType: TokenType.SessionToken,
+    toAuth: () => signedOutAuthObject({ status: AuthStatus.SignedOut, reason, message }),
+    headers,
+    token: null,
+  });
+}
+
 const withDebugHeaders = <T extends { headers: Headers; message?: string; reason?: AuthReason; status?: AuthStatus }>(
   requestState: T,
 ): T => {

--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -271,6 +271,9 @@ export function signedOutInvalidToken(): UnauthenticatedState<null> {
 type BootstrapSignedOutParams = {
   signInUrl?: string;
   signUpUrl?: string;
+  isSatellite?: boolean;
+  domain?: string;
+  proxyUrl?: string;
   reason?: AuthReason;
   message?: string;
   headers?: Headers;
@@ -285,10 +288,16 @@ type BootstrapSignedOutParams = {
  *
  * `signInUrl` / `signUpUrl` are carried through so that `redirectToSignIn` /
  * `redirectToSignUp` can resolve to the application's own routes during bootstrap.
+ * `isSatellite` / `domain` / `proxyUrl` are carried through so that cross-origin
+ * satellite redirects produced by `createRedirect` include the `__clerk_status=needs-sync`
+ * marker required for the return-trip handshake.
  */
 export function createBootstrapSignedOutState({
   signInUrl = '',
   signUpUrl = '',
+  isSatellite = false,
+  domain = '',
+  proxyUrl = '',
   reason = AuthErrorReason.SessionTokenAndUATMissing,
   message = '',
   headers = new Headers(),
@@ -297,10 +306,10 @@ export function createBootstrapSignedOutState({
     status: AuthStatus.SignedOut,
     reason,
     message,
-    proxyUrl: '',
+    proxyUrl,
     publishableKey: '',
-    isSatellite: false,
-    domain: '',
+    isSatellite,
+    domain,
     signInUrl,
     signUpUrl,
     afterSignInUrl: '',

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -1,4 +1,4 @@
-import type { AuthObject, ClerkClient } from '@clerk/backend';
+import type { AccountlessApplication, AuthObject, ClerkClient } from '@clerk/backend';
 import type {
   AuthenticatedState,
   AuthenticateRequestOptions,
@@ -31,6 +31,7 @@ import { NextResponse } from 'next/server';
 import type { AuthFn } from '../app-router/server/auth';
 import type { GetAuthOptions } from '../server/createGetAuth';
 import { isRedirect, serverRedirectWithAuth, setHeader } from '../utils';
+import type { Logger, LoggerNoCommit } from '../utils/debugLogger';
 import { withLogger } from '../utils/debugLogger';
 import { canUseKeyless } from '../utils/feature-flags';
 import { clerkClient } from './clerkClient';
@@ -216,114 +217,17 @@ export const clerkMiddleware = ((...args: unknown[]): NextMiddleware | NextMiddl
         createAuthenticateRequestOptions(clerkRequest, options),
       );
 
-      logger.debug('requestState', () => ({
-        status: requestState.status,
-        headers: JSON.stringify(Object.fromEntries(requestState.headers)),
-        reason: requestState.reason,
-      }));
-
-      const locationHeader = requestState.headers.get(constants.Headers.Location);
-      if (locationHeader) {
-        handleNetlifyCacheInDevInstance({
-          locationHeader,
-          requestStateHeaders: requestState.headers,
-          publishableKey: requestState.publishableKey,
-        });
-
-        const res = NextResponse.redirect(requestState.headers.get(constants.Headers.Location) || locationHeader);
-        requestState.headers.forEach((value, key) => {
-          if (key === constants.Headers.Location) {
-            return;
-          }
-          res.headers.append(key, value);
-        });
-        return res;
-      } else if (requestState.status === AuthStatus.Handshake) {
-        throw new Error('Clerk: handshake status without redirect');
-      }
-
-      const authObject = requestState.toAuth();
-      logger.debug('auth', () => ({ auth: authObject, debug: authObject.debug() }));
-
-      const redirectToSignIn = createMiddlewareRedirectToSignIn(clerkRequest);
-      const redirectToSignUp = createMiddlewareRedirectToSignUp(clerkRequest);
-      const protect = await createMiddlewareProtect(clerkRequest, authObject, redirectToSignIn);
-
-      const authHandler = createMiddlewareAuthHandler(requestState, redirectToSignIn, redirectToSignUp);
-      authHandler.protect = protect;
-
-      let handlerResult: Response = NextResponse.next();
-      try {
-        const userHandlerResult = await clerkMiddlewareRequestDataStorage.run(
-          clerkMiddlewareRequestDataStore,
-          async () => handler?.(authHandler, request, event),
-        );
-        handlerResult = userHandlerResult || handlerResult;
-      } catch (e: any) {
-        handlerResult = handleControlFlowErrors(e, clerkRequest, request, requestState);
-      }
-      if (options.contentSecurityPolicy) {
-        const { headers } = createContentSecurityPolicyHeaders(
-          (parsePublishableKey(publishableKey)?.frontendApi ?? '').replace('$', ''),
-          options.contentSecurityPolicy,
-        );
-
-        const cspRequestHeaders: Record<string, string> = {};
-        headers.forEach(([key, value]) => {
-          setHeader(handlerResult, key, value);
-          cspRequestHeaders[key] = value;
-        });
-
-        // Forward CSP headers as request headers so server components
-        // can access the nonce via headers()
-        setRequestHeadersOnNextResponse(handlerResult, clerkRequest, cspRequestHeaders);
-
-        logger.debug('Clerk generated CSP', () => ({
-          headers,
-        }));
-      }
-
-      // TODO @nikos: we need to make this more generic
-      // and move the logic in clerk/backend
-      if (requestState.headers) {
-        requestState.headers.forEach((value, key) => {
-          if (key === constants.Headers.ContentSecurityPolicy) {
-            logger.debug('Content-Security-Policy detected', () => ({
-              value,
-            }));
-          }
-          handlerResult.headers.append(key, value);
-        });
-      }
-
-      if (isRedirect(handlerResult)) {
-        logger.debug('handlerResult is redirect');
-        return serverRedirectWithAuth(clerkRequest, handlerResult, options);
-      }
-
-      if (options.debug) {
-        setRequestHeadersOnNextResponse(handlerResult, clerkRequest, { [constants.Headers.EnableDebug]: 'true' });
-      }
-
-      const keylessKeysForRequestData =
-        // Only pass keyless credentials when there are no explicit keys
-        secretKey === keyless?.secretKey
-          ? {
-              publishableKey: keyless?.publishableKey,
-              secretKey: keyless?.secretKey,
-            }
-          : {};
-
-      decorateRequest(
+      return runHandlerWithRequestState({
         clerkRequest,
-        handlerResult,
+        request,
+        event,
         requestState,
+        handler,
+        options,
         resolvedParams,
-        keylessKeysForRequestData,
-        authObject.tokenType === 'session_token' ? null : makeAuthObjectSerializable(authObject),
-      );
-
-      return handlerResult;
+        keyless,
+        logger,
+      });
     });
 
     const keylessMiddleware: NextMiddleware = async (request, event) => {
@@ -389,6 +293,152 @@ const parseHandlerAndOptions = (args: unknown[]) => {
     (args.length === 2 ? args[1] : typeof args[0] === 'function' ? {} : args[0]) || {},
   ] as [ClerkMiddlewareHandler | undefined, ClerkMiddlewareOptions | ClerkMiddlewareOptionsCallback];
 };
+
+type RunHandlerWithRequestStateArgs = {
+  clerkRequest: ClerkRequest;
+  request: NextMiddlewareRequestParam;
+  event: NextMiddlewareEvtParam;
+  requestState: RequestState<'session_token'>;
+  handler: ClerkMiddlewareHandler | undefined;
+  options: ClerkMiddlewareOptions & {
+    publishableKey: string;
+    secretKey: string;
+    signInUrl: string;
+    signUpUrl: string;
+  };
+  resolvedParams: ClerkMiddlewareOptions;
+  keyless: AccountlessApplication | undefined;
+  logger: LoggerNoCommit<Logger>;
+};
+
+/**
+ * Drives the post-authentication pipeline: handler invocation, CSP, redirects, header propagation,
+ * and response decoration. Accepts a pre-computed `requestState` so callers can supply either a
+ * real authentication result from `authenticateRequest()` or a synthetic signed-out state
+ * (e.g. during keyless bootstrap when no publishable key is available yet).
+ */
+async function runHandlerWithRequestState({
+  clerkRequest,
+  request,
+  event,
+  requestState,
+  handler,
+  options,
+  resolvedParams,
+  keyless,
+  logger,
+}: RunHandlerWithRequestStateArgs): Promise<Response> {
+  const { publishableKey, secretKey } = options;
+
+  logger.debug('requestState', () => ({
+    status: requestState.status,
+    headers: JSON.stringify(Object.fromEntries(requestState.headers)),
+    reason: requestState.reason,
+  }));
+
+  const locationHeader = requestState.headers.get(constants.Headers.Location);
+  if (locationHeader) {
+    handleNetlifyCacheInDevInstance({
+      locationHeader,
+      requestStateHeaders: requestState.headers,
+      publishableKey: requestState.publishableKey,
+    });
+
+    const res = NextResponse.redirect(requestState.headers.get(constants.Headers.Location) || locationHeader);
+    requestState.headers.forEach((value, key) => {
+      if (key === constants.Headers.Location) {
+        return;
+      }
+      res.headers.append(key, value);
+    });
+    return res;
+  } else if (requestState.status === AuthStatus.Handshake) {
+    throw new Error('Clerk: handshake status without redirect');
+  }
+
+  const authObject = requestState.toAuth();
+  logger.debug('auth', () => ({ auth: authObject, debug: authObject.debug() }));
+
+  const redirectToSignIn = createMiddlewareRedirectToSignIn(clerkRequest);
+  const redirectToSignUp = createMiddlewareRedirectToSignUp(clerkRequest);
+  const protect = await createMiddlewareProtect(clerkRequest, authObject, redirectToSignIn);
+
+  const authHandler = createMiddlewareAuthHandler(requestState, redirectToSignIn, redirectToSignUp);
+  authHandler.protect = protect;
+
+  let handlerResult: Response = NextResponse.next();
+  try {
+    const userHandlerResult = await clerkMiddlewareRequestDataStorage.run(
+      clerkMiddlewareRequestDataStore,
+      async () => handler?.(authHandler, request, event),
+    );
+    handlerResult = userHandlerResult || handlerResult;
+  } catch (e: any) {
+    handlerResult = handleControlFlowErrors(e, clerkRequest, request, requestState);
+  }
+  if (options.contentSecurityPolicy) {
+    const { headers } = createContentSecurityPolicyHeaders(
+      (parsePublishableKey(publishableKey)?.frontendApi ?? '').replace('$', ''),
+      options.contentSecurityPolicy,
+    );
+
+    const cspRequestHeaders: Record<string, string> = {};
+    headers.forEach(([key, value]) => {
+      setHeader(handlerResult, key, value);
+      cspRequestHeaders[key] = value;
+    });
+
+    // Forward CSP headers as request headers so server components
+    // can access the nonce via headers()
+    setRequestHeadersOnNextResponse(handlerResult, clerkRequest, cspRequestHeaders);
+
+    logger.debug('Clerk generated CSP', () => ({
+      headers,
+    }));
+  }
+
+  // TODO @nikos: we need to make this more generic
+  // and move the logic in clerk/backend
+  if (requestState.headers) {
+    requestState.headers.forEach((value, key) => {
+      if (key === constants.Headers.ContentSecurityPolicy) {
+        logger.debug('Content-Security-Policy detected', () => ({
+          value,
+        }));
+      }
+      handlerResult.headers.append(key, value);
+    });
+  }
+
+  if (isRedirect(handlerResult)) {
+    logger.debug('handlerResult is redirect');
+    return serverRedirectWithAuth(clerkRequest, handlerResult, options);
+  }
+
+  if (options.debug) {
+    setRequestHeadersOnNextResponse(handlerResult, clerkRequest, { [constants.Headers.EnableDebug]: 'true' });
+  }
+
+  const keylessKeysForRequestData =
+    // Only pass keyless credentials when there are no explicit keys
+    secretKey === keyless?.secretKey
+      ? {
+          publishableKey: keyless?.publishableKey,
+          secretKey: keyless?.secretKey,
+        }
+      : {};
+
+  decorateRequest(
+    clerkRequest,
+    handlerResult,
+    requestState,
+    resolvedParams,
+    keylessKeysForRequestData,
+    authObject.tokenType === 'session_token' ? null : makeAuthObjectSerializable(authObject),
+  );
+
+  return handlerResult;
+}
 
 const isKeylessSyncRequest = (request: NextMiddlewareRequestParam) =>
   request.nextUrl.pathname === '/clerk-sync-keyless';

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -368,9 +368,8 @@ async function runHandlerWithRequestState({
 
   let handlerResult: Response = NextResponse.next();
   try {
-    const userHandlerResult = await clerkMiddlewareRequestDataStorage.run(
-      clerkMiddlewareRequestDataStore,
-      async () => handler?.(authHandler, request, event),
+    const userHandlerResult = await clerkMiddlewareRequestDataStorage.run(clerkMiddlewareRequestDataStore, async () =>
+      handler?.(authHandler, request, event),
     );
     handlerResult = userHandlerResult || handlerResult;
   } catch (e: any) {


### PR DESCRIPTION
## Summary

Starting work on fixing the issue with keyless mode skipping middleware auth checks.

Groundwork for [SDK-70](https://linear.app/clerk/issue/SDK-70). Pure refactor — no behavioral change.

- **`@clerk/backend`** — exports a new `createBootstrapSignedOutState` helper from `@clerk/backend/internal`. Returns a synthetic `UnauthenticatedState<'session_token'>` without requiring a publishable key or an `AuthenticateContext`. Intended for framework integrations that need to run authorization logic before real Clerk keys are available (e.g. the Next.js keyless bootstrap window).
- **`@clerk/nextjs`** — factors the post-authentication pipeline inside `baseNextMiddleware` (handler invocation, CSP, redirects, response decoration) into a private `runHandlerWithRequestState` helper. The `authenticateRequest` call and subsequent pipeline now live in a single, testable unit, making it possible for a follow-up to feed a synthesized `RequestState` into the same pipeline when there's no real publishable key yet.

## Why split this PR?

The follow-up (SDK-70 proper) will flip `keylessMiddleware`'s no-key branch to synthesize a signed-out state and run the user's middleware handler, closing a middleware-bypass window during the keyless bootstrap. That change is small on its own — most of the work is the plumbing to route a non-`authenticateRequest`-produced `RequestState` through the same post-auth pipeline. Landing the plumbing first keeps the behavioral change's diff small and reviewable.

## Test plan

- [x] `pnpm turbo build --filter=@clerk/backend --filter=@clerk/nextjs` passes
- [x] `pnpm --filter=@clerk/backend test` — 1186/1186 pass (includes the updated `exports.test.ts` snapshot)
- [x] `pnpm --filter=@clerk/nextjs test` — 369 pass / 50 fail; all 50 failures are a pre-existing `AbortSignal`/`createClerkRequest` test-env issue that reproduces identically on `main` (unrelated to this refactor)
- [ ] Manual smoke: keyless bootstrap still works end-to-end (no behavioral change expected since both call sites in `baseNextMiddleware` were preserved)