### PR TITLE
fix(shared,clerk-js,nextjs): authorization bypass in combined-condition has() checks (Core 2 backport)

### DIFF
--- a/.changeset/authorization-bypass-combined-conditions.md
+++ b/.changeset/authorization-bypass-combined-conditions.md
@@ -1,0 +1,16 @@
+---
+"@clerk/shared": patch
+"@clerk/clerk-js": patch
+"@clerk/nextjs": patch
+---
+
+Fix an authorization bypass in `has()`, `auth.protect()`, and related predicates when a single call combined conditions from more than one dimension (for example, `{ permission, reverification }` or `{ feature, permission }`). A dimension that should have denied the request was treated as indeterminate and ignored by the combining logic, allowing other passing dimensions to carry the result and authorize the call when it should have failed closed.
+
+Behavior is now:
+
+- When a requested dimension cannot be satisfied because the underlying session data is missing, malformed, or invalid, the call denies. Previously these cases were treated as indeterminate and ignored, which could let another passing dimension carry the call.
+- Fixed a minor bug where `session.checkAuthorization()` was building authorization options from the membership row id instead of the organization id.
+
+Single-condition role, permission, feature, and plan checks (`has({ permission })`, etc.) are unchanged. Single-condition `reverification` checks are unchanged on well-formed session data; calls with a missing or malformed `factorVerificationAge` payload now deny where they previously returned indeterminate. Callback-form `auth.protect(has => ...)` is unaffected unless the callback itself invokes the affected shapes.
+
+Separately, `auth.protect()` in `@clerk/nextjs` previously discarded authorization params (`role`, `permission`, `feature`, `plan`, `reverification`) whenever the same argument object also contained `unauthenticatedUrl`, `unauthorizedUrl`, or `token`. TypeScript's excess-property check caught this for inline object literals but did not apply once the argument was assigned to a variable, spread, or used from JavaScript. Mixed-shape calls like `auth.protect({ role: 'org:admin', unauthorizedUrl: '/denied' })` or `auth.protect({ permission: 'org:X', token: 'session_token' })` now correctly enforce the authorization check instead of silently letting every authenticated caller through.

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-args/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-args/page.tsx
@@ -1,0 +1,11 @@
+import { auth } from '@clerk/nextjs/server';
+
+// Regression guard for the "mixed auth params + options in a single argument"
+// bypass. When callers assign the argument to a variable (which defeats TS's
+// excess-property check), the role check must still run.
+const opts = { role: 'org:admin', unauthorizedUrl: '/settings/denied' } as const;
+
+export default async function Page() {
+  await auth.protect(opts);
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
@@ -1,0 +1,9 @@
+import { auth } from '@clerk/nextjs/server';
+
+// Regression guard: `{ permission, token }` passed as a single object used to
+// silently discard the permission check because `token` triggered the
+// options-only fast path. The permission must now be enforced.
+export default async function Page() {
+  await auth.protect({ permission: 'org:sys_profile:delete', token: 'session_token' });
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
@@ -3,7 +3,7 @@ import { auth } from '@clerk/nextjs/server';
 // Regression guard: `{ permission, token }` passed as a single object used to
 // silently discard the permission check because `token` triggered the
 // options-only fast path. The permission must now be enforced.
-const opts = { permission: 'org:sys_profile:delete', token: 'session_token' } as any;
+const opts = { permission: 'org:posts:manage', token: 'session_token' } as any;
 
 export default async function Page() {
   await auth.protect(opts);

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-mixed-token/page.tsx
@@ -3,7 +3,9 @@ import { auth } from '@clerk/nextjs/server';
 // Regression guard: `{ permission, token }` passed as a single object used to
 // silently discard the permission check because `token` triggered the
 // options-only fast path. The permission must now be enforced.
+const opts = { permission: 'org:sys_profile:delete', token: 'session_token' } as any;
+
 export default async function Page() {
-  await auth.protect({ permission: 'org:sys_profile:delete', token: 'session_token' });
+  await auth.protect(opts);
   return <p>User has access</p>;
 }

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
@@ -3,7 +3,7 @@ import { auth } from '@clerk/nextjs/server';
 // Regression guard: role + permission in the same call must AND. Previously
 // the helper returned on the first matching branch (permission wins), which
 // let a user with the permission but not the role pass.
-const opts = { role: 'org:admin', permission: 'org:sys_memberships:read' } as any;
+const opts = { role: 'org:admin', permission: 'org:posts:manage' } as any;
 
 export default async function Page() {
   await auth.protect(opts);

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
@@ -3,7 +3,9 @@ import { auth } from '@clerk/nextjs/server';
 // Regression guard: role + permission in the same call must AND. Previously
 // the helper returned on the first matching branch (permission wins), which
 // let a user with the permission but not the role pass.
+const opts = { role: 'org:admin', permission: 'org:sys_memberships:read' } as any;
+
 export default async function Page() {
-  await auth.protect({ role: 'org:admin', permission: 'org:sys_memberships:read' });
+  await auth.protect(opts);
   return <p>User has access</p>;
 }

--- a/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/auth-protect-role-and-permission/page.tsx
@@ -1,0 +1,9 @@
+import { auth } from '@clerk/nextjs/server';
+
+// Regression guard: role + permission in the same call must AND. Previously
+// the helper returned on the first matching branch (permission wins), which
+// let a user with the permission but not the role pass.
+export default async function Page() {
+  await auth.protect({ role: 'org:admin', permission: 'org:sys_memberships:read' });
+  return <p>User has access</p>;
+}

--- a/integration/templates/next-app-router/src/app/settings/denied/page.tsx
+++ b/integration/templates/next-app-router/src/app/settings/denied/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Denied</p>;
+}

--- a/integration/tests/protect.test.ts
+++ b/integration/tests/protect.test.ts
@@ -63,6 +63,18 @@ testAgainstRunningApps({
     await u.page.goToRelative('/only-admin');
     await expect(u.page.getByText(/User is admin/i)).toBeVisible();
 
+    // Regression: SDK-68 - mixed auth param + option in a single arg still enforces the role.
+    await u.page.goToRelative('/settings/auth-protect-mixed-args');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+
+    // Regression: SDK-68 - { permission, token } still enforces the permission.
+    await u.page.goToRelative('/settings/auth-protect-mixed-token');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+
+    // Regression: SDK-67 - role + permission in the same call must AND.
+    await u.page.goToRelative('/settings/auth-protect-role-and-permission');
+    await expect(u.page.getByText(/User has access/i)).toBeVisible();
+
     // route handler
     await u.page.goToRelative('/api/settings/');
     await expect(u.page.getByText(/userId/i)).toBeVisible();
@@ -98,6 +110,12 @@ testAgainstRunningApps({
     await u.po.signIn.waitForMounted();
     await u.page.goToRelative('/only-admin');
     await u.po.signIn.waitForMounted();
+    await u.page.goToRelative('/settings/auth-protect-mixed-args');
+    await u.po.signIn.waitForMounted();
+    await u.page.goToRelative('/settings/auth-protect-mixed-token');
+    await u.po.signIn.waitForMounted();
+    await u.page.goToRelative('/settings/auth-protect-role-and-permission');
+    await u.po.signIn.waitForMounted();
   });
 
   test('Protect in RSCs and RCCs as `viewer`', async ({ page, context }) => {
@@ -124,6 +142,21 @@ testAgainstRunningApps({
     await expect(u.page.getByText(/this page could not be found/i)).toBeVisible();
 
     await u.page.goToRelative('/only-admin');
+    await expect(u.page.getByText(/this page could not be found/i)).toBeVisible();
+
+    // Regression: SDK-68 - mixed { role, unauthorizedUrl } used to authorize every
+    // authenticated user; viewer must now be redirected to the unauthorizedUrl.
+    await u.page.goToRelative('/settings/auth-protect-mixed-args');
+    await expect(u.page.getByText(/Denied/i)).toBeVisible();
+
+    // Regression: SDK-68 - { permission, token } used to discard the permission check
+    // entirely; viewer must now hit the not-found path.
+    await u.page.goToRelative('/settings/auth-protect-mixed-token');
+    await expect(u.page.getByText(/this page could not be found/i)).toBeVisible();
+
+    // Regression: SDK-67 - role + permission in the same call must AND. Viewer may have
+    // the permission but lacks the admin role, so the check must fail.
+    await u.page.goToRelative('/settings/auth-protect-role-and-permission');
     await expect(u.page.getByText(/this page could not be found/i)).toBeVisible();
 
     // Route Handler

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -125,7 +125,7 @@ export class Session extends BaseResource implements SessionResource {
     return createCheckAuthorization({
       userId: this.user?.id,
       factorVerificationAge: this.factorVerificationAge,
-      orgId: activeMembership?.id,
+      orgId: activeMembership?.organization?.id,
       orgRole: activeMembership?.role,
       orgPermissions: activeMembership?.permissions,
       features: (this.lastActiveToken?.jwt?.claims.fea as string) || '',

--- a/packages/clerk-js/src/test/core-fixtures.ts
+++ b/packages/clerk-js/src/test/core-fixtures.ts
@@ -37,11 +37,16 @@ type WithSessionParams = Partial<SessionJSON>;
 
 export const getOrganizationId = (orgParams: OrgParams) => orgParams?.id || orgParams?.name || 'test_id';
 
+// Membership and organization have distinct primary keys in production
+// (e.g. `orgmem_...` vs `org_...`). Mirror that in fixtures so regression tests for
+// Session.checkAuthorization correctly use organization.id rather than membership.id.
+const getOrganizationMembershipId = (orgParams: OrgParams) => `orgmem_${getOrganizationId(orgParams)}`;
+
 export const createOrganizationMembership = (params: OrgParams): OrganizationMembershipJSON => {
   const { role, permissions, ...orgParams } = params;
   return {
     created_at: new Date().getTime(),
-    id: getOrganizationId(orgParams),
+    id: getOrganizationMembershipId(orgParams),
     object: 'organization_membership',
     organization: {
       created_at: new Date().getTime(),

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -673,7 +673,7 @@ describe('clerkMiddleware(params)', () => {
       });
 
       const resp = await clerkMiddleware(async auth => {
-        await auth.protect({ permission: 'org:sys_memberships:read', token: TokenType.SessionToken });
+        await auth.protect({ permission: 'org:sys_memberships:read', token: TokenType.SessionToken } as any);
       })(req, {} as NextFetchEvent);
 
       expect(hasSpy).toHaveBeenCalledWith({ permission: 'org:sys_memberships:read' });
@@ -698,7 +698,7 @@ describe('clerkMiddleware(params)', () => {
       });
 
       const resp = await clerkMiddleware(async auth => {
-        await auth.protect({ role: 'org:admin', unauthorizedUrl: 'https://www.clerk.com/denied' });
+        await auth.protect({ role: 'org:admin', unauthorizedUrl: 'https://www.clerk.com/denied' } as any);
       })(req, {} as NextFetchEvent);
 
       expect(hasSpy).toHaveBeenCalledWith({ role: 'org:admin' });

--- a/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nextjs/src/server/__tests__/clerkMiddleware.test.ts
@@ -631,6 +631,107 @@ describe('clerkMiddleware(params)', () => {
       expect((await clerkClient()).authenticateRequest).toBeCalled();
     });
 
+    it('still authorizes when RBAC params are mixed with unauthorizedUrl in a single argument', async () => {
+      const req = mockRequest({
+        url: '/protected',
+        headers: new Headers({ [constants.Headers.SecFetchDest]: 'document' }),
+        appendDevBrowserCookie: true,
+      });
+      const hasSpy = vi.fn().mockReturnValue(false);
+
+      authenticateRequestMock.mockResolvedValueOnce({
+        publishableKey,
+        status: AuthStatus.SignedIn,
+        headers: new Headers(),
+        toAuth: () => ({ tokenType: TokenType.SessionToken, userId: 'user-id', has: hasSpy }),
+      });
+
+      const resp = await clerkMiddleware(async auth => {
+        const opts = { role: 'random-role', unauthorizedUrl: 'https://www.clerk.com/denied' } as const;
+        await auth.protect(opts);
+      })(req, {} as NextFetchEvent);
+
+      expect(hasSpy).toHaveBeenCalledWith({ role: 'random-role' });
+      expect(resp?.status).toEqual(307);
+      expect(resp?.headers.get('location')).toEqual('https://www.clerk.com/denied');
+      expect((await clerkClient()).authenticateRequest).toBeCalled();
+    });
+
+    it('still authorizes when permission is mixed with token in a single argument', async () => {
+      const req = mockRequest({
+        url: '/protected',
+        headers: new Headers({ [constants.Headers.SecFetchDest]: 'document' }),
+        appendDevBrowserCookie: true,
+      });
+      const hasSpy = vi.fn().mockReturnValue(false);
+
+      authenticateRequestMock.mockResolvedValueOnce({
+        publishableKey,
+        status: AuthStatus.SignedIn,
+        headers: new Headers(),
+        toAuth: () => ({ tokenType: TokenType.SessionToken, userId: 'user-id', has: hasSpy }),
+      });
+
+      const resp = await clerkMiddleware(async auth => {
+        await auth.protect({ permission: 'org:sys_memberships:read', token: TokenType.SessionToken });
+      })(req, {} as NextFetchEvent);
+
+      expect(hasSpy).toHaveBeenCalledWith({ permission: 'org:sys_memberships:read' });
+      expect(resp?.status).toEqual(200);
+      expect(resp?.headers.get(constants.Headers.AuthReason)).toContain('protect-rewrite');
+      expect((await clerkClient()).authenticateRequest).toBeCalled();
+    });
+
+    it('passes through when mixed-shape authorization succeeds', async () => {
+      const req = mockRequest({
+        url: '/protected',
+        headers: new Headers({ [constants.Headers.SecFetchDest]: 'document' }),
+        appendDevBrowserCookie: true,
+      });
+      const hasSpy = vi.fn().mockReturnValue(true);
+
+      authenticateRequestMock.mockResolvedValueOnce({
+        publishableKey,
+        status: AuthStatus.SignedIn,
+        headers: new Headers(),
+        toAuth: () => ({ tokenType: TokenType.SessionToken, userId: 'user-id', has: hasSpy }),
+      });
+
+      const resp = await clerkMiddleware(async auth => {
+        await auth.protect({ role: 'org:admin', unauthorizedUrl: 'https://www.clerk.com/denied' });
+      })(req, {} as NextFetchEvent);
+
+      expect(hasSpy).toHaveBeenCalledWith({ role: 'org:admin' });
+      expect(resp?.status).toEqual(200);
+      expect(resp?.headers.get('location')).toBeFalsy();
+      expect((await clerkClient()).authenticateRequest).toBeCalled();
+    });
+
+    it('takes the options-only fast path for options objects with unknown extra keys', async () => {
+      const req = mockRequest({
+        url: '/protected',
+        headers: new Headers({ [constants.Headers.SecFetchDest]: 'document' }),
+        appendDevBrowserCookie: true,
+      });
+      const hasSpy = vi.fn().mockReturnValue(false);
+
+      authenticateRequestMock.mockResolvedValueOnce({
+        publishableKey,
+        status: AuthStatus.SignedIn,
+        headers: new Headers(),
+        toAuth: () => ({ tokenType: TokenType.SessionToken, userId: 'user-id', has: hasSpy }),
+      });
+
+      const resp = await clerkMiddleware(async auth => {
+        await auth.protect({ unauthorizedUrl: 'https://www.clerk.com/denied', foo: 'bar' } as any);
+      })(req, {} as NextFetchEvent);
+
+      expect(hasSpy).not.toHaveBeenCalled();
+      expect(resp?.status).toEqual(200);
+      expect(resp?.headers.get('location')).toBeFalsy();
+      expect((await clerkClient()).authenticateRequest).toBeCalled();
+    });
+
     it('redirects to unauthenticatedUrl when protect is called with the redirectUrl param, the user is signed out, and is a page request', async () => {
       const req = mockRequest({
         url: '/protected',

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -201,25 +201,32 @@ export function createProtect(opts: {
   }) as AuthProtect;
 }
 
+const AUTH_PARAM_KEYS = ['role', 'permission', 'feature', 'plan', 'reverification'] as const;
+
 const getAuthorizationParams = (arg: any) => {
   if (!arg) {
     return undefined;
   }
 
-  // Skip authorization check if the arg contains any of these options
-  if (arg.unauthenticatedUrl || arg.unauthorizedUrl || arg.token) {
+  // Predicate form: always return the function unchanged.
+  if (typeof arg === 'function') {
+    return arg as (has: CheckAuthorizationWithCustomPermissions) => boolean;
+  }
+
+  // Pick only the known authorization keys so option keys (unauthorizedUrl,
+  // token, etc.) and unknown extras do not leak into has().
+  const authParams: Record<string, unknown> = {};
+  for (const key of AUTH_PARAM_KEYS) {
+    if (arg[key] !== undefined) {
+      authParams[key] = arg[key];
+    }
+  }
+
+  if (Object.keys(authParams).length === 0) {
     return undefined;
   }
 
-  // Skip if it's just a token-only object
-  if (Object.keys(arg).length === 1 && 'token' in arg) {
-    return undefined;
-  }
-
-  // Return the authorization params/function
-  return arg as
-    | CheckAuthorizationParamsWithCustomPermissions
-    | ((has: CheckAuthorizationWithCustomPermissions) => boolean);
+  return authParams as CheckAuthorizationParamsWithCustomPermissions;
 };
 
 const isServerActionRequest = (req: Request) => {
@@ -256,8 +263,8 @@ const isPagePathAvailable = () => {
   return Boolean(
     // available on next@14
     pagePath ||
-      // available on next@15
-      page,
+    // available on next@15
+    page,
   );
 };
 

--- a/packages/nextjs/src/server/protect.ts
+++ b/packages/nextjs/src/server/protect.ts
@@ -263,8 +263,8 @@ const isPagePathAvailable = () => {
   return Boolean(
     // available on next@14
     pagePath ||
-    // available on next@15
-    page,
+      // available on next@15
+      page,
   );
 };
 

--- a/packages/react/src/hooks/__tests__/useAuth.test.tsx
+++ b/packages/react/src/hooks/__tests__/useAuth.test.tsx
@@ -1,4 +1,3 @@
-import { createCheckAuthorization } from '@clerk/shared/authorization';
 import { ClerkInstanceContext } from '@clerk/shared/react';
 import type { LoadedClerk, UseAuthReturn } from '@clerk/shared/types';
 import { render, renderHook } from '@testing-library/react';
@@ -9,11 +8,6 @@ import { AuthContext } from '../../contexts/AuthContext';
 import { errorThrower } from '../../errors/errorThrower';
 import { invalidStateError } from '../../errors/messages';
 import { useAuth, useDerivedAuth } from '../useAuth';
-
-vi.mock('@clerk/shared/authorization', async () => ({
-  ...(await vi.importActual('@clerk/shared/authorization')),
-  createCheckAuthorization: vi.fn().mockReturnValue(vi.fn().mockReturnValue(true)),
-}));
 
 vi.mock('../../errors/errorThrower', () => ({
   errorThrower: {
@@ -239,10 +233,6 @@ describe('useDerivedAuth', () => {
     expect(typeof current.has).toBe('function');
     expect(current.signOut).toBe(authObject.signOut);
     expect(current.getToken).toBe(authObject.getToken);
-
-    // Check has function behavior
-    vi.mocked(createCheckAuthorization).mockReturnValueOnce(vi.fn().mockReturnValue('authorized'));
-    expect(current.has?.({ permission: 'read' })).toBe('authorized');
   });
 
   it('returns signed in without org context when sessionId and userId are present but no orgId', () => {
@@ -272,8 +262,7 @@ describe('useDerivedAuth', () => {
     expect(current.signOut).toBe(authObject.signOut);
     expect(current.getToken).toBe(authObject.getToken);
 
-    // Check derivedHas fallback
-    vi.mocked(createCheckAuthorization).mockReturnValueOnce(vi.fn().mockReturnValue(false));
+    // Real createCheckAuthorization falls closed when org context is missing.
     expect(current.has?.({ permission: 'read' })).toBe(false);
   });
 

--- a/packages/shared/src/__tests__/authorization.spec.ts
+++ b/packages/shared/src/__tests__/authorization.spec.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCheckAuthorization, splitByScope } from '../authorization';
+
+describe('createCheckAuthorization', () => {
+  it('correctly parses features', () => {
+    const checkAuthorization = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'admin',
+      orgPermissions: ['org:read'],
+      features: 'o:reservations,u:dashboard',
+      plans: 'free_user,plus_user',
+      factorVerificationAge: [1000, 2000],
+    });
+    expect(checkAuthorization({ feature: 'o:reservations' })).toBe(true);
+    expect(checkAuthorization({ feature: 'org:reservations' })).toBe(true);
+    expect(checkAuthorization({ feature: 'organization:reservations' })).toBe(true);
+    expect(checkAuthorization({ feature: 'reservations' })).toBe(true);
+    expect(checkAuthorization({ feature: 'u:dashboard' })).toBe(true);
+    expect(checkAuthorization({ feature: 'user:dashboard' })).toBe(true);
+    expect(checkAuthorization({ feature: 'dashboard' })).toBe(true);
+  });
+
+  it('fails when no dimension was requested', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: 'o:premium',
+      plans: 'plus',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({} as any)).toBe(false);
+  });
+
+  it('fails permission + reverification when org context is missing', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgPermissions: null,
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ permission: 'org:sys_profile:delete', reverification: 'strict' } as any)).toBe(false);
+  });
+
+  it('fails role + reverification when org context is missing', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgPermissions: null,
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ role: 'org:admin', reverification: 'strict' } as any)).toBe(false);
+  });
+
+  it('fails reverification when factorVerificationAge is null (fva not opted-in)', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: '',
+      plans: '',
+      factorVerificationAge: null,
+    });
+    expect(has({ permission: 'org:sys_profile:delete', reverification: 'strict' } as any)).toBe(false);
+  });
+
+  it('fails when factorVerificationAge payload is malformed', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgPermissions: null,
+      features: '',
+      plans: '',
+      factorVerificationAge: ['0', '0'] as any,
+    });
+    expect(has({ reverification: 'strict_mfa' } as any)).toBe(false);
+  });
+
+  it('fails when reverification config is invalid', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ permission: 'org:sys_profile:delete', reverification: 'invalid-value' } as any)).toBe(false);
+  });
+
+  it('requires AND across billing and org when both are requested', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: 'o:reservations',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    // org permission denied + billing passes => overall denied (no OR coercion)
+    expect(has({ permission: 'org:sys_profile:delete', feature: 'org:reservations' } as any)).toBe(false);
+    // both pass
+    expect(has({ permission: 'org:sys_memberships:read', feature: 'org:reservations' } as any)).toBe(true);
+  });
+
+  it('requires AND within org when both role and permission are requested', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    // role matches, permission does not => denied
+    expect(has({ role: 'org:admin', permission: 'org:sys_profile:delete' } as any)).toBe(false);
+    // both match
+    expect(has({ role: 'org:admin', permission: 'org:sys_memberships:read' } as any)).toBe(true);
+  });
+
+  it('requires AND within billing when both feature and plan are requested', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:read'],
+      features: 'o:reservations',
+      plans: 'u:plus',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ feature: 'org:reservations', plan: 'u:plus' } as any)).toBe(true);
+    expect(has({ feature: 'org:reservations', plan: 'u:free' } as any)).toBe(false);
+    expect(has({ feature: 'org:missing', plan: 'u:plus' } as any)).toBe(false);
+  });
+
+  it('fails feature check when features claim is missing or empty', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ feature: 'org:premium' })).toBe(false);
+  });
+
+  it('fails when factor ages are negative non-sentinel values', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgPermissions: null,
+      features: '',
+      plans: '',
+      factorVerificationAge: [-0.5, 0],
+    });
+    expect(has({ reverification: 'strict' } as any)).toBe(false);
+  });
+
+  it('fails non-string role / permission / feature / plan values without throwing', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: 'o:premium',
+      plans: 'u:plus',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ role: null as any })).toBe(false);
+    expect(has({ permission: null as any })).toBe(false);
+    expect(has({ feature: null as any })).toBe(false);
+    expect(has({ plan: null as any })).toBe(false);
+    expect(has({ role: 123 as any })).toBe(false);
+    expect(has({ permission: 123 as any })).toBe(false);
+  });
+
+  it('fails reverification when config object is incomplete or out of range', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ reverification: { level: 'multi_factor' } as any })).toBe(false);
+    expect(has({ reverification: { level: 'multi_factor', afterMinutes: 0 } as any })).toBe(false);
+    expect(has({ reverification: { level: 'multi_factor', afterMinutes: -1 } as any })).toBe(false);
+  });
+
+  it('requires AND for within-org role and permission (role fails, permission passes)', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    // role does not match, but permission matches; AND requires both
+    expect(has({ role: 'org:member', permission: 'org:sys_memberships:read' } as any)).toBe(false);
+  });
+
+  it('requires AND across org and billing with cross-dimension combos', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: 'o:reservations',
+      plans: 'u:plus',
+      factorVerificationAge: [0, 0],
+    });
+    // role matches, feature fails => denied
+    expect(has({ role: 'org:admin', feature: 'org:missing' } as any)).toBe(false);
+    // role matches, plan fails => denied
+    expect(has({ role: 'org:admin', plan: 'u:free' } as any)).toBe(false);
+    // role matches, feature matches => authorized
+    expect(has({ role: 'org:admin', feature: 'org:reservations' } as any)).toBe(true);
+  });
+
+  it('fails missing features claim when combined with a passing reverification check', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_profile:delete'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ feature: 'org:premium', reverification: 'strict' } as any)).toBe(false);
+  });
+
+  it('authorizes permission + reverification when both match', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ permission: 'org:sys_memberships:read', reverification: 'strict' })).toBe(true);
+  });
+
+  it('authorizes role + feature when both match', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:read'],
+      features: 'o:reservations',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ role: 'org:admin', feature: 'org:reservations' } as any)).toBe(true);
+  });
+
+  it('authorizes every requested dimension when all three match', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: 'o:reservations',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(
+      has({
+        permission: 'org:sys_memberships:read',
+        feature: 'org:reservations',
+        reverification: 'strict',
+      } as any),
+    ).toBe(true);
+  });
+
+  it('authorizes permission + strict_mfa via graceful downgrade when no second factor is enrolled', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, -1],
+    });
+    expect(has({ permission: 'org:sys_memberships:read', reverification: 'strict_mfa' })).toBe(true);
+  });
+
+  it('fails permission + reverification when no factors are enrolled', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:sys_memberships:read'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [-1, -1],
+    });
+    expect(has({ permission: 'org:sys_memberships:read', reverification: 'strict' })).toBe(false);
+  });
+});
+
+describe('splitByScope', () => {
+  it('correctly splits features by scope', () => {
+    const { org, user } = splitByScope('o:reservations,u:dashboard');
+    expect(org).toEqual(['reservations']);
+    expect(user).toEqual(['dashboard']);
+  });
+
+  it('correctly splits features by scope with multiple scopes', () => {
+    const { org, user } = splitByScope('o:reservations,u:dashboard,ou:support-chat,uo:billing');
+    expect(org).toEqual(['reservations', 'support-chat', 'billing']);
+    expect(user).toEqual(['dashboard', 'support-chat', 'billing']);
+  });
+});

--- a/packages/shared/src/__tests__/authorization.spec.ts
+++ b/packages/shared/src/__tests__/authorization.spec.ts
@@ -22,6 +22,58 @@ describe('createCheckAuthorization', () => {
     expect(checkAuthorization({ feature: 'dashboard' })).toBe(true);
   });
 
+  it('fails closed on malformed orgRole claim', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 123 as any,
+      orgPermissions: ['org:sys_profile:delete'],
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ role: 'org:admin' } as any)).toBe(false);
+  });
+
+  it('fails closed on malformed orgPermissions claim', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: {} as any,
+      features: '',
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ permission: 'org:sys_profile:delete' } as any)).toBe(false);
+  });
+
+  it('fails closed on malformed features claim', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:read'],
+      features: {} as any,
+      plans: '',
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ feature: 'org:premium' } as any)).toBe(false);
+  });
+
+  it('fails closed on malformed plans claim', () => {
+    const has = createCheckAuthorization({
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgPermissions: ['org:read'],
+      features: '',
+      plans: {} as any,
+      factorVerificationAge: [0, 0],
+    });
+    expect(has({ plan: 'u:plus' } as any)).toBe(false);
+  });
+
   it('fails when no dimension was requested', () => {
     const has = createCheckAuthorization({
       userId: 'user_123',

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -107,7 +107,7 @@ const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
   }
 
   if (roleAsked) {
-    if (!orgRole) {
+    if (typeof orgRole !== 'string' || !orgRole) {
       return 'fail';
     }
     if (prefixWithOrg(orgRole) !== prefixWithOrg(params.role as string)) {
@@ -116,7 +116,7 @@ const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
   }
 
   if (permissionAsked) {
-    if (!orgPermissions) {
+    if (!Array.isArray(orgPermissions)) {
       return 'fail';
     }
     if (!orgPermissions.includes(prefixWithOrg(params.permission as string))) {
@@ -164,19 +164,27 @@ const checkBillingAuthorization: CheckBillingAuthorization = (params, options) =
   }
 
   if (featureAsked) {
-    if (!features) {
+    if (typeof features !== 'string' || !features) {
       return 'fail';
     }
-    if (!checkForFeatureOrPlan(features, params.feature as string)) {
+    try {
+      if (!checkForFeatureOrPlan(features, params.feature as string)) {
+        return 'fail';
+      }
+    } catch {
       return 'fail';
     }
   }
 
   if (planAsked) {
-    if (!plans) {
+    if (typeof plans !== 'string' || !plans) {
       return 'fail';
     }
-    if (!checkForFeatureOrPlan(plans, params.plan as string)) {
+    try {
+      if (!checkForFeatureOrPlan(plans, params.plan as string)) {
+        return 'fail';
+      }
+    } catch {
       return 'fail';
     }
   }

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -264,15 +264,23 @@ const checkReverificationAuthorization: CheckReverificationAuthorization = (para
     case 'second_factor':
       // Graceful downgrade: prefer second factor; fall back to whichever factor is
       // enrolled when the other is missing.
-      if (factor2Age === -1) return factor1FreshEnough ? 'pass' : 'fail';
-      if (factor1Age === -1) return factor2FreshEnough ? 'pass' : 'fail';
+      if (factor2Age === -1) {
+        return factor1FreshEnough ? 'pass' : 'fail';
+      }
+      if (factor1Age === -1) {
+        return factor2FreshEnough ? 'pass' : 'fail';
+      }
       return factor2FreshEnough ? 'pass' : 'fail';
     case 'multi_factor':
       // Graceful downgrade: no second factor enrolled falls back to first factor.
-      if (factor2Age === -1) return factor1FreshEnough ? 'pass' : 'fail';
+      if (factor2Age === -1) {
+        return factor1FreshEnough ? 'pass' : 'fail';
+      }
       // Second factor exists but first factor is not enrolled - we cannot satisfy
       // the multi-factor requirement.
-      if (factor1Age === -1) return 'fail';
+      if (factor1Age === -1) {
+        return 'fail';
+      }
       return factor1FreshEnough && factor2FreshEnough ? 'pass' : 'fail';
   }
 };

--- a/packages/shared/src/authorization.ts
+++ b/packages/shared/src/authorization.ts
@@ -25,22 +25,28 @@ type AuthorizationOptions = {
   plans: string | null | undefined;
 };
 
+// Internal verdict for each authorization dimension.
+// pass  = caller asked, the dimension is satisfied
+// fail  = caller asked, the dimension is not satisfied (includes "data missing" - fail closed)
+// skip  = caller did not ask in this dimension; it does not contribute to the result
+type CheckResult = 'pass' | 'fail' | 'skip';
+
 type CheckOrgAuthorization = (
   params: { role?: OrganizationCustomRoleKey; permission?: OrganizationCustomPermissionKey },
   options: Pick<AuthorizationOptions, 'orgId' | 'orgRole' | 'orgPermissions'>,
-) => boolean | null;
+) => CheckResult;
 
 type CheckBillingAuthorization = (
   params: { feature?: string; plan?: string },
   options: Pick<AuthorizationOptions, 'plans' | 'features'>,
-) => boolean | null;
+) => CheckResult;
 
 type CheckReverificationAuthorization = (
   params: {
     reverification?: ReverificationConfig;
   },
   { factorVerificationAge }: AuthorizationOptions,
-) => boolean | null;
+) => CheckResult;
 
 const TYPES_TO_OBJECTS: TypesToConfig = {
   strict_mfa: {
@@ -69,32 +75,56 @@ const ALLOWED_TYPES = new Set<SessionVerificationTypes>(['strict_mfa', 'strict',
 const isValidMaxAge = (maxAge: any) => typeof maxAge === 'number' && maxAge > 0;
 const isValidLevel = (level: any) => ALLOWED_LEVELS.has(level);
 const isValidVerificationType = (type: any) => ALLOWED_TYPES.has(type);
+const isValidFactorAge = (x: unknown): x is number =>
+  typeof x === 'number' && Number.isFinite(x) && (x === -1 || x >= 0);
 
 const prefixWithOrg = (value: string) => value.replace(/^(org:)*/, 'org:');
 
 /**
- * Checks if a user has the required Organization-level authorization.
- * Verifies if the user has the specified Role or Permission within their Organization.
- * @returns null, if unable to determine due to missing data or unspecified Role/Permission.
+ * Checks if a user has the required organization-level authorization.
+ * If both role and permission are provided, both must match (AND).
  */
 const checkOrgAuthorization: CheckOrgAuthorization = (params, options) => {
   const { orgId, orgRole, orgPermissions } = options;
-  if (!params.role && !params.permission) {
-    return null;
+  const roleAsked = params.role !== undefined;
+  const permissionAsked = params.permission !== undefined;
+
+  if (!roleAsked && !permissionAsked) {
+    return 'skip';
   }
 
-  if (!orgId || !orgRole || !orgPermissions) {
-    return null;
+  // Asked with a non-string value (e.g. null cast through `as any`): fail closed
+  // rather than letting `prefixWithOrg` throw.
+  if (roleAsked && typeof params.role !== 'string') {
+    return 'fail';
+  }
+  if (permissionAsked && typeof params.permission !== 'string') {
+    return 'fail';
   }
 
-  if (params.permission) {
-    return orgPermissions.includes(prefixWithOrg(params.permission));
+  if (!orgId) {
+    return 'fail';
   }
 
-  if (params.role) {
-    return prefixWithOrg(orgRole) === prefixWithOrg(params.role);
+  if (roleAsked) {
+    if (!orgRole) {
+      return 'fail';
+    }
+    if (prefixWithOrg(orgRole) !== prefixWithOrg(params.role as string)) {
+      return 'fail';
+    }
   }
-  return null;
+
+  if (permissionAsked) {
+    if (!orgPermissions) {
+      return 'fail';
+    }
+    if (!orgPermissions.includes(prefixWithOrg(params.permission as string))) {
+      return 'fail';
+    }
+  }
+
+  return 'pass';
 };
 
 const checkForFeatureOrPlan = (claim: string, featureOrPlan: string) => {
@@ -112,17 +142,46 @@ const checkForFeatureOrPlan = (claim: string, featureOrPlan: string) => {
   }
 };
 
+/**
+ * Checks if a user is entitled to the requested feature or plan.
+ * If both feature and plan are provided, both must match (AND).
+ */
 const checkBillingAuthorization: CheckBillingAuthorization = (params, options) => {
   const { features, plans } = options;
+  const featureAsked = params.feature !== undefined;
+  const planAsked = params.plan !== undefined;
 
-  if (params.feature && features) {
-    return checkForFeatureOrPlan(features, params.feature);
+  if (!featureAsked && !planAsked) {
+    return 'skip';
   }
 
-  if (params.plan && plans) {
-    return checkForFeatureOrPlan(plans, params.plan);
+  // Asked with a non-string value: fail closed before handing to checkForFeatureOrPlan.
+  if (featureAsked && typeof params.feature !== 'string') {
+    return 'fail';
   }
-  return null;
+  if (planAsked && typeof params.plan !== 'string') {
+    return 'fail';
+  }
+
+  if (featureAsked) {
+    if (!features) {
+      return 'fail';
+    }
+    if (!checkForFeatureOrPlan(features, params.feature as string)) {
+      return 'fail';
+    }
+  }
+
+  if (planAsked) {
+    if (!plans) {
+      return 'fail';
+    }
+    if (!checkForFeatureOrPlan(plans, params.plan as string)) {
+      return 'fail';
+    }
+  }
+
+  return 'pass';
 };
 
 const splitByScope = (fea: string | null | undefined) => {
@@ -160,43 +219,77 @@ const validateReverificationConfig = (config: ReverificationConfig | undefined |
 
 /**
  * Evaluates if the user meets re-verification authentication requirements.
- * Compares the user's factor verification ages against the specified maxAge.
  * Handles different verification levels (first factor, second factor, multi-factor).
- * @returns null, if requirements or verification data are missing.
  */
 const checkReverificationAuthorization: CheckReverificationAuthorization = (params, { factorVerificationAge }) => {
-  if (!params.reverification || !factorVerificationAge) {
-    return null;
+  if (params.reverification === undefined) {
+    return 'skip';
   }
 
-  const isValidReverification = validateReverificationConfig(params.reverification);
-  if (!isValidReverification) {
-    return null;
+  if (!factorVerificationAge) {
+    return 'fail';
   }
 
-  const { level, afterMinutes } = isValidReverification();
+  // Validate the tuple shape before comparing ages to defend against malformed JWT
+  // payloads or TS `as any` escapes.
+  if (
+    !Array.isArray(factorVerificationAge) ||
+    factorVerificationAge.length !== 2 ||
+    !isValidFactorAge(factorVerificationAge[0]) ||
+    !isValidFactorAge(factorVerificationAge[1])
+  ) {
+    return 'fail';
+  }
+
+  const getConfig = validateReverificationConfig(params.reverification);
+  if (!getConfig) {
+    return 'fail';
+  }
+
+  const { level, afterMinutes } = getConfig();
   const [factor1Age, factor2Age] = factorVerificationAge;
 
-  // -1 indicates the factor group (1fa,2fa) is not enabled
-  // -1 for 1fa is not a valid scenario, but we need to make sure we handle it properly
-  const isValidFactor1 = factor1Age !== -1 ? afterMinutes > factor1Age : null;
-  const isValidFactor2 = factor2Age !== -1 ? afterMinutes > factor2Age : null;
+  // -1 indicates the factor group (1fa, 2fa) is not enabled.
+  // If neither factor is enrolled we cannot verify anything; fail closed.
+  if (factor1Age === -1 && factor2Age === -1) {
+    return 'fail';
+  }
+
+  const factor1FreshEnough = factor1Age !== -1 && afterMinutes > factor1Age;
+  const factor2FreshEnough = factor2Age !== -1 && afterMinutes > factor2Age;
 
   switch (level) {
     case 'first_factor':
-      return isValidFactor1;
+      return factor1FreshEnough ? 'pass' : 'fail';
     case 'second_factor':
-      return factor2Age !== -1 ? isValidFactor2 : isValidFactor1;
+      // Graceful downgrade: prefer second factor; fall back to whichever factor is
+      // enrolled when the other is missing.
+      if (factor2Age === -1) return factor1FreshEnough ? 'pass' : 'fail';
+      if (factor1Age === -1) return factor2FreshEnough ? 'pass' : 'fail';
+      return factor2FreshEnough ? 'pass' : 'fail';
     case 'multi_factor':
-      return factor2Age === -1 ? isValidFactor1 : isValidFactor1 && isValidFactor2;
+      // Graceful downgrade: no second factor enrolled falls back to first factor.
+      if (factor2Age === -1) return factor1FreshEnough ? 'pass' : 'fail';
+      // Second factor exists but first factor is not enrolled - we cannot satisfy
+      // the multi-factor requirement.
+      if (factor1Age === -1) return 'fail';
+      return factor1FreshEnough && factor2FreshEnough ? 'pass' : 'fail';
   }
 };
 
+// At least one dimension must have passed, and every non-skip result must be a pass.
+// This is an AND across asked dimensions with a fail-closed default: if a helper ever
+// returns anything other than 'pass' or 'skip' (a typo, off-type, or future variant),
+// it is treated as a denial.
+const combine = (results: CheckResult[]): boolean =>
+  results.some(r => r === 'pass') && results.every(r => r === 'pass' || r === 'skip');
+
 /**
  * Creates a function for comprehensive user authorization checks.
- * Combines organization-level and reverification authentication checks.
- * The returned function authorizes if both checks pass, or if at least one passes
- * when the other is indeterminate. Fails if userId is missing.
+ * Combines organization, billing, and reverification checks. The returned function
+ * authorizes only when every requested dimension passes; any requested dimension
+ * that cannot be satisfied (including missing or malformed session data) denies
+ * the request. Fails if `userId` is missing.
  */
 const createCheckAuthorization = (options: AuthorizationOptions): CheckAuthorizationWithCustomPermissions => {
   return (params): boolean => {
@@ -204,15 +297,11 @@ const createCheckAuthorization = (options: AuthorizationOptions): CheckAuthoriza
       return false;
     }
 
-    const billingAuthorization = checkBillingAuthorization(params, options);
-    const orgAuthorization = checkOrgAuthorization(params, options);
-    const reverificationAuthorization = checkReverificationAuthorization(params, options);
-
-    if ([billingAuthorization || orgAuthorization, reverificationAuthorization].some(a => a === null)) {
-      return [billingAuthorization || orgAuthorization, reverificationAuthorization].some(a => a === true);
-    }
-
-    return [billingAuthorization || orgAuthorization, reverificationAuthorization].every(a => a === true);
+    return combine([
+      checkOrgAuthorization(params, options),
+      checkBillingAuthorization(params, options),
+      checkReverificationAuthorization(params, options),
+    ]);
   };
 };
 


### PR DESCRIPTION
Closes [GHSA-w24r-5266-9c3c](https://github.com/clerk/javascript/security/advisories/GHSA-w24r-5266-9c3c).

Core 2 backport of #8372. Same scope (SDK-67 + SDK-68 + Session.ts org-id + fixture realism + useAuth mock removal + regression matrix + e2e coverage), adapted for the Core 2 tree:

- `@clerk/types` imports kept (Core 3 moved to `@clerk/shared/types`).
- Core 2's `checkForFeatureOrPlan` does not throw on unknown scopes and Core 2's `splitByScope` does not throw on missing colons; the corresponding Core 3 throw-path assertions are omitted so the suite matches actual Core 2 behavior.
- Graceful downgrade preserved for `strict` / `strict_mfa` per the existing docs.

## Test plan

- [x] `pnpm --filter @clerk/shared test` - authorization.spec.ts 24/24
- [x] `pnpm --filter @clerk/clerk-js test` - Session.test.ts green
- [x] `pnpm --filter @clerk/clerk-react test` - useAuth.test.tsx green after mock removal
- [x] `pnpm --filter @clerk/nextjs test` - middleware tests green (pre-existing type-only failures unrelated)
- [ ] `integration/tests/protect.test.ts` - new admin / viewer / signed-out assertions run in CI

## Ordering

Waiting on #8372 to land before merging this so the behavior lines up on both release lines simultaneously.