### PR TITLE
feat(ui): show management button for plans without base fee

### DIFF
--- a/.changeset/billing-manage-subscription-seat-based.md
+++ b/.changeset/billing-manage-subscription-seat-based.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": patch
+---
+
+Fix the Manage Subscription button in `<UserProfile />` / `<OrganizationProfile />` and the Cancel / Re-subscribe actions in `<SubscriptionDetails />` so they are shown for paid seat-based plans that have no base fee. A shared `isManageableSubscriptionItem` helper now drives both places, treating "free / unmanageable" as "the instance's default plan" instead of "the plan has no base fee".

--- a/packages/ui/src/components/SubscriptionDetails/index.tsx
+++ b/packages/ui/src/components/SubscriptionDetails/index.tsx
@@ -2,13 +2,13 @@ import { __internal_useOrganizationBase, useClerk } from '@clerk/shared/react';
 import type {
   __internal_CheckoutProps,
   __internal_SubscriptionDetailsProps,
-  BillingPlanResource,
   BillingSubscriptionItemResource,
 } from '@clerk/shared/types';
 import * as React from 'react';
 import { useCallback, useContext, useState } from 'react';
 
 import { Users } from '@/icons';
+import { common } from '@/styledSystem';
 import { useProtect } from '@/ui/common/Gate';
 import {
   SubscriptionDetailsContext,
@@ -19,6 +19,7 @@ import { CardAlert } from '@/ui/elements/Card/CardAlert';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Drawer, useDrawerContext } from '@/ui/elements/Drawer';
 import { LineItems } from '@/ui/elements/LineItems';
+import { isManageableSubscriptionItem } from '@/ui/utils/billingSubscription';
 import { handleError } from '@/ui/utils/errorHandler';
 import { formatDate } from '@/ui/utils/formatDate';
 
@@ -44,9 +45,6 @@ import {
   useLocalizations,
 } from '../../customizables';
 import { SubscriptionBadge } from '../Subscriptions/badge';
-import { common } from '@/styledSystem';
-
-const isFreePlan = (plan: BillingPlanResource) => !plan.hasBaseFee;
 
 // We cannot derive the state of confirmation modal from the existence subscription, as it will make the animation laggy when the confirmation closes.
 const SubscriptionForCancellationContext = React.createContext<{
@@ -376,14 +374,14 @@ const SubscriptionCardActions = ({ subscription }: { subscription: BillingSubscr
   const canOrgManageBilling = useProtect(has => has({ permission: 'org:sys_billing:manage' }));
   const canManageBilling = subscriberType === 'user' || canOrgManageBilling;
 
+  const isManageable = isManageableSubscriptionItem(subscription);
   const isSwitchable =
     ((subscription.planPeriod === 'month' && Boolean(subscription.plan.annualMonthlyFee)) ||
       (subscription.planPeriod === 'annual' && Boolean(subscription.plan.fee))) &&
     subscription.status !== 'past_due' &&
-    !subscription.plan.isDefault;
-  const isFree = isFreePlan(subscription.plan);
-  const isCancellable = subscription.canceledAt === null && !isFree;
-  const isReSubscribable = subscription.canceledAt !== null && !isFree;
+    isManageable;
+  const isCancellable = subscription.canceledAt === null && isManageable;
+  const isReSubscribable = subscription.canceledAt !== null && isManageable;
 
   const openCheckout = useCallback(
     (params?: __internal_CheckoutProps) => {

--- a/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
@@ -1,9 +1,10 @@
-import type { BillingPlanResource, BillingSubscriptionItemResource } from '@clerk/shared/types';
+import type { BillingSubscriptionItemResource } from '@clerk/shared/types';
 import { Fragment, useMemo } from 'react';
 
 import { useProtect } from '@/ui/common/Gate';
 import { ProfileSection } from '@/ui/elements/Section';
 import { common } from '@/ui/styledSystem';
+import { isManageableSubscriptionItem } from '@/ui/utils/billingSubscription';
 
 import {
   normalizeFormatted,
@@ -18,8 +19,6 @@ import { Col, Flex, Icon, localizationKeys, Span, Table, Tbody, Td, Text, Th, Th
 import { ArrowsUpDown, CogFilled, Plans, Plus, Users } from '../../icons';
 import { useRouter } from '../../router';
 import { SubscriptionBadge } from './badge';
-
-const isFreePlan = (plan: BillingPlanResource) => !plan.hasBaseFee;
 
 export function SubscriptionsList({
   title,
@@ -45,11 +44,12 @@ export function SubscriptionsList({
     (commerceSettings.billing.user.hasPaidPlans && subscriberType === 'user') ||
     (commerceSettings.billing.organization.hasPaidPlans && subscriberType === 'organization');
 
-  const hasActiveFreePlan = useMemo(() => {
-    return subscriptionItems.some(sub => isFreePlan(sub.plan) && sub.status === 'active');
-  }, [subscriptionItems]);
+  const hasManageableSubscription = useMemo(
+    () => subscriptionItems.some(isManageableSubscriptionItem),
+    [subscriptionItems],
+  );
 
-  const isManageButtonVisible = canManageBilling && !hasActiveFreePlan && subscriptionItems.length > 0;
+  const isManageButtonVisible = canManageBilling && hasManageableSubscription;
 
   const sortedSubscriptionItems = useMemo(
     () =>

--- a/packages/ui/src/utils/billingSubscription.ts
+++ b/packages/ui/src/utils/billingSubscription.ts
@@ -1,0 +1,16 @@
+import type { BillingSubscriptionItemResource } from '@clerk/shared/types';
+
+/**
+ * Returns `true` when a subscription item exposes at least one management
+ * action to the user (switch period, cancel, or re-subscribe).
+ *
+ * The only subscription a user cannot act on is the one backed by the
+ * instance's default plan, because every user is implicitly subscribed to it
+ * and cannot opt out.
+ *
+ * Intentionally not based on `plan.hasBaseFee`: a plan can have no base fee
+ * and still be a real paid subscription (e.g seat-based billing where the
+ * cost is driven entirely by a seat unit price).
+ */
+export const isManageableSubscriptionItem = (subscriptionItem: BillingSubscriptionItemResource): boolean =>
+  !subscriptionItem.plan.isDefault;


### PR DESCRIPTION
Today, the Manage Subscription button in <UserProfile /> / <OrganizationProfile />, and the Cancel / Re-subscribe actions inside <SubscriptionDetails />, are gated by !plan.hasBaseFee. That predicate was originally shorthand for "this is the free fallback plan, there's nothing the user can do with it". with seat-based billing, however, a plan can have no base fee and still be a real paid subscription (the cost comes entirely from the seat unit prices), so the UI was hiding actions users need

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
