### PR TITLE
fix(ui): anchor SignIn callback URLs to signInUrl across all flows

### DIFF
--- a/integration/tests/oauth-flows.test.ts
+++ b/integration/tests/oauth-flows.test.ts
@@ -217,6 +217,50 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withEmailCodes] })('oauth flo
   });
 });
 
+testAgainstRunningApps({ withEnv: [appConfigs.envs.withSignInOrUpFlow] })(
+  'oauth flows combined @nextjs',
+  ({ app }) => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.afterAll(async () => {
+      await app.teardown();
+    });
+
+    test('openSignIn OAuth in combined flow targets /sign-in#/create/sso-callback', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+
+      await u.page.goToRelative('/buttons');
+      await u.page.waitForClerkJsLoaded();
+      await u.po.expect.toBeSignedOut();
+
+      await u.page.evaluate(() => {
+        (window as any).Clerk.openSignIn({ forceRedirectUrl: '/protected' });
+      });
+      await u.po.signIn.waitForModal();
+
+      const signInPostPromise = page.waitForRequest(
+        req => req.method() === 'POST' && /\/v1\/client\/sign_ins(\?|$)/.test(req.url()),
+      );
+
+      await u.page.getByRole('button', { name: 'E2E OAuth Provider' }).click();
+
+      const signInPost = await signInPostPromise;
+      const body = new URLSearchParams(signInPost.postData() || '');
+      const redirectUrl = body.get('redirect_url');
+      expect(redirectUrl).toBeTruthy();
+
+      // Combined flow (CLERK_SIGN_UP_URL is unset in this env): the sso-callback must anchor to
+      // ClerkProvider.signInUrl and carry the combined-flow /create segment, since the
+      // create/sso-callback route is mounted under the SignIn tree — not SignUp.
+      const parsed = new URL(redirectUrl!);
+      const appOrigin = new URL(app.serverUrl).origin;
+      expect(parsed.origin).toBe(appOrigin);
+      expect(parsed.pathname).toBe('/sign-in');
+      expect(parsed.hash).toMatch(/^#\/create\/sso-callback/);
+    });
+  },
+);
+
 testAgainstRunningApps({ withPattern: ['react.vite.withLegalConsent'] })(
   'oauth popup with path-based routing @react',
   ({ app }) => {

--- a/packages/ui/src/contexts/components/SignIn.ts
+++ b/packages/ui/src/contexts/components/SignIn.ts
@@ -100,21 +100,20 @@ export const useSignInContext = (): SignInContextType => {
 
   const authQueryString = redirectUrls.toSearchParams().toString();
 
-  // For virtual routing (modal), ctx.signUpUrl contains the internal CLERK-ROUTER/VIRTUAL path,
-  // which is not valid as an OAuth redirect URL. For non-combined flow, use signInUrl as the base
-  // so the callback lands on the sign-in page (matching ClerkProvider.signInUrl).
-  const ssoCallbackBaseUrl = !isCombinedFlow && ctx.routing === 'virtual' ? signInUrl : signUpUrl;
-
+  // Callback routes owned by the SignIn tree are always SignIn-rooted — including the combined-flow
+  // branches mounted at `create/sso-callback` and `create/verify` under the SignIn component
+  // (packages/ui/src/components/SignIn/index.tsx). Anchor both callback URLs to signInUrl and let
+  // the endpoint carry the combined-flow affordance, instead of juggling bases per flow/routing.
   const emailLinkRedirectUrl = buildRedirectUrl({
     routing: ctx.routing,
-    baseUrl: ssoCallbackBaseUrl,
+    baseUrl: signInUrl,
     authQueryString,
     path: ctx.path,
     endpoint: isCombinedFlow ? '/create' + MAGIC_LINK_VERIFY_PATH_ROUTE : MAGIC_LINK_VERIFY_PATH_ROUTE,
   });
   const ssoCallbackUrl = buildRedirectUrl({
     routing: ctx.routing,
-    baseUrl: ssoCallbackBaseUrl,
+    baseUrl: signInUrl,
     authQueryString,
     path: ctx.path,
     endpoint: isCombinedFlow ? '/create' + SSO_CALLBACK_PATH_ROUTE : SSO_CALLBACK_PATH_ROUTE,


### PR DESCRIPTION
## Summary

Suggested addition to #8385. Anchors `ssoCallbackUrl` and `emailLinkRedirectUrl` in `useSignInContext` to `signInUrl` unconditionally, removing the conditional `ssoCallbackBaseUrl` local.

Callback routes owned by the SignIn tree are SignIn-rooted in every flow — including combined-flow, where `create/sso-callback` and `create/verify` are mounted under the **SignIn** component (`packages/ui/src/components/SignIn/index.tsx:97`), not SignUp. The combined-flow email-link redirect passed through `normalizedSignUpContext` (`packages/ui/src/components/SignIn/index.tsx:178`) and consumed by `SignUpEmailLinkCard.tsx:39` likewise resolves under SignIn's `create/...` routes.

The current `ssoCallbackBaseUrl = !isCombinedFlow && routing === 'virtual' ? signInUrl : signUpUrl` narrow guard leaves combined-flow + virtual routing anchored to `signUpUrl`, which for the SignInOrUp modal path (`CLERK_SIGN_UP_URL` unset) falls back to `displayConfig.signUpUrl` — still accounts-origin, so the reported bug isn't fully fixed for that path.

This change lets the endpoint carry the combined-flow affordance (`/create/sso-callback`, `/create/verify`) instead of juggling bases per flow/routing:

| case | endpoint | result |
| --- | --- | --- |
| non-combined, virtual | `/sso-callback` | `<signInUrl>#/sso-callback` |
| non-combined, path | `/sso-callback` | `<path>/sso-callback` |
| combined, virtual | `/create/sso-callback` | `<signInUrl>#/create/sso-callback` |
| combined, path | `/create/sso-callback` | `<path>/create/sso-callback` |

Adds a combined-flow e2e repro (`withSignInOrUpFlow`) asserting origin, `/sign-in` pathname, and `#/create/sso-callback` hash — mirrors the existing non-combined repro already on this branch.

## Test plan

- [ ] CI: `Integration Tests (nextjs, chrome, 15 & 16)` — both existing repro and new combined-flow repro pass
- [ ] No regressions in `sign-in-or-up-flow.test.ts`