### PR TITLE
feat(headless): Add `headless` ui primitives package

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -1,0 +1,64 @@
+# @clerk/headless
+
+Headless UI primitives for Clerk's component library. These are unstyled, accessible React components built on [Floating UI](https://floating-ui.com/) that handle positioning, keyboard navigation, focus management, and ARIA attributes.
+
+This package is **internal** (`private: true`) and consumed by `@clerk/ui`. It exists as a separate package because `@clerk/ui` uses `@emotion/react` as its JSX source, which conflicts with the standard `react-jsx` transform these primitives require.
+
+## Primitives
+
+| Primitive    | Import                         | Description                                             |
+| ------------ | ------------------------------ | ------------------------------------------------------- |
+| Accordion    | `@clerk/headless/accordion`    | Expandable content sections with single/multiple mode   |
+| Autocomplete | `@clerk/headless/autocomplete` | Combobox input with filterable option list              |
+| Dialog       | `@clerk/headless/dialog`       | Modal dialog with focus trapping and scroll lock        |
+| Menu         | `@clerk/headless/menu`         | Dropdown and nested context menus with safe hover zones |
+| Popover      | `@clerk/headless/popover`      | Non-modal floating content triggered by click           |
+| Select       | `@clerk/headless/select`       | Dropdown select with typeahead and keyboard navigation  |
+| Tabs         | `@clerk/headless/tabs`         | Tab navigation with animated indicator                  |
+| Tooltip      | `@clerk/headless/tooltip`      | Hover/focus tooltip with configurable delay             |
+
+Shared utilities are available at `@clerk/headless/utils` (includes `renderElement` and `mergeProps`).
+
+Each primitive has its own README in `src/primitives/<name>/` with full API docs, props tables, keyboard navigation, and data attributes.
+
+## Usage
+
+```tsx
+import { Select } from '@clerk/headless/select';
+
+<Select>
+  <Select.Trigger>Choose...</Select.Trigger>
+  <Select.Positioner>
+    <Select.Popup>
+      <Select.Option
+        value='a'
+        label='Option A'
+      />
+      <Select.Option
+        value='b'
+        label='Option B'
+      />
+    </Select.Popup>
+  </Select.Positioner>
+</Select>;
+```
+
+All primitives follow the same compound component pattern. They emit zero styles — all visual styling is applied externally via `data-cl-*` attribute selectors.
+
+## Architecture
+
+- **Compound components** via `Object.assign` — each primitive is a single export with dot-accessed parts (`Select.Trigger`, `Select.Popup`, etc.)
+- **`renderElement`** — every part uses this instead of returning JSX directly, enabling consumer `render` prop overrides and automatic state-to-data-attribute mapping
+- **`data-cl-*` attributes** — structural (`data-cl-slot`), state (`data-cl-open`, `data-cl-selected`, `data-cl-active`), and animation lifecycle (`data-cl-starting-style`, `data-cl-ending-style`)
+- **CSS-driven animations** — the transition system uses `data-cl-*` attributes and the Web Animations API (`getAnimations().finished`) so all timing lives in CSS
+- **Floating UI** — positioning, interactions, focus management, dismiss handling, list navigation, and ARIA are all delegated to `@floating-ui/react`
+
+## Development
+
+```sh
+pnpm dev          # watch mode build
+pnpm build        # production build
+pnpm test         # run tests (vitest + playwright browser mode)
+```
+
+Tests run in a real Chromium browser via `@vitest/browser-playwright`, not jsdom.

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -6,16 +6,16 @@ This package is **internal** (`private: true`) and consumed by `@clerk/ui`. It e
 
 ## Primitives
 
-| Primitive    | Import                         | Description                                             |
-| ------------ | ------------------------------ | ------------------------------------------------------- |
-| Accordion    | `@clerk/headless/accordion`    | Expandable content sections with single/multiple mode   |
-| Autocomplete | `@clerk/headless/autocomplete` | Combobox input with filterable option list              |
-| Dialog       | `@clerk/headless/dialog`       | Modal dialog with focus trapping and scroll lock        |
-| Menu         | `@clerk/headless/menu`         | Dropdown and nested context menus with safe hover zones |
-| Popover      | `@clerk/headless/popover`      | Non-modal floating content triggered by click           |
-| Select       | `@clerk/headless/select`       | Dropdown select with typeahead and keyboard navigation  |
-| Tabs         | `@clerk/headless/tabs`         | Tab navigation with animated indicator                  |
-| Tooltip      | `@clerk/headless/tooltip`      | Hover/focus tooltip with configurable delay             |
+| Primitive    | Import                         | Description                                                   |
+| ------------ | ------------------------------ | ------------------------------------------------------------- |
+| Accordion    | `@clerk/headless/accordion`    | Expandable content sections with single/multiple mode         |
+| Autocomplete | `@clerk/headless/autocomplete` | Combobox input with filterable option list                    |
+| Dialog       | `@clerk/headless/dialog`       | Modal dialog with focus trapping and scroll lock              |
+| Menu         | `@clerk/headless/menu`         | Dropdown and nested context menus with safe hover zones       |
+| Popover      | `@clerk/headless/popover`      | Non-modal floating content triggered by click                 |
+| Select       | `@clerk/headless/select`       | Dropdown select with typeahead and keyboard navigation        |
+| Tabs         | `@clerk/headless/tabs`         | Tab navigation with animated indicator                        |
+| Tooltip      | `@clerk/headless/tooltip`      | Hover/focus tooltip with configurable delay and group support |
 
 Shared utilities are available at `@clerk/headless/utils` (includes `renderElement` and `mergeProps`).
 

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@clerk/headless",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./select": {
+      "import": "./dist/primitives/select/index.js",
+      "types": "./dist/primitives/select/index.d.ts"
+    },
+    "./menu": {
+      "import": "./dist/primitives/menu/index.js",
+      "types": "./dist/primitives/menu/index.d.ts"
+    },
+    "./dialog": {
+      "import": "./dist/primitives/dialog/index.js",
+      "types": "./dist/primitives/dialog/index.d.ts"
+    },
+    "./popover": {
+      "import": "./dist/primitives/popover/index.js",
+      "types": "./dist/primitives/popover/index.d.ts"
+    },
+    "./tooltip": {
+      "import": "./dist/primitives/tooltip/index.js",
+      "types": "./dist/primitives/tooltip/index.d.ts"
+    },
+    "./autocomplete": {
+      "import": "./dist/primitives/autocomplete/index.js",
+      "types": "./dist/primitives/autocomplete/index.d.ts"
+    },
+    "./tabs": {
+      "import": "./dist/primitives/tabs/index.js",
+      "types": "./dist/primitives/tabs/index.d.ts"
+    },
+    "./accordion": {
+      "import": "./dist/primitives/accordion/index.js",
+      "types": "./dist/primitives/accordion/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && vite build",
+    "dev": "vite build --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@floating-ui/react": "catalog:repo"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "catalog:react",
+    "@types/react-dom": "catalog:react",
+    "@vitest/browser": "4.1.4",
+    "@vitest/browser-playwright": "4.1.4",
+    "axe-core": "^4.11.3",
+    "playwright": "^1.59.1",
+    "react": "catalog:react",
+    "react-dom": "catalog:react",
+    "rolldown": "1.0.0-rc.15",
+    "typescript": "catalog:repo",
+    "vite": "^8.0.8",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "4.1.4",
+    "vitest-axe": "^0.1.0"
+  },
+  "peerDependencies": {
+    "react": "catalog:peer-react",
+    "react-dom": "catalog:peer-react"
+  }
+}

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -62,9 +62,8 @@
     "playwright": "^1.59.1",
     "react": "catalog:react",
     "react-dom": "catalog:react",
-    "rolldown": "1.0.0-rc.15",
     "typescript": "catalog:repo",
-    "vite": "^8.0.8",
+    "vite": "6.4.1",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "4.1.4",
     "vitest-axe": "^0.1.0"

--- a/packages/headless/src/hooks/use-animations-finished.test.ts
+++ b/packages/headless/src/hooks/use-animations-finished.test.ts
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRef, type RefObject } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAnimationsFinished } from './use-animations-finished';
+
+function createMockElement(
+  animations: Array<{ finished: Promise<void> }> = [],
+  attributes: Record<string, string> = {},
+): HTMLElement {
+  const el = document.createElement('div');
+  Object.entries(attributes).forEach(([k, v]) => el.setAttribute(k, v));
+  el.getAnimations = vi.fn(() => animations as unknown as Animation[]);
+  return el;
+}
+
+describe('useAnimationsFinished', () => {
+  it('fires callback immediately when ref.current is null', () => {
+    const ref = createRef<HTMLElement>() as RefObject<HTMLElement | null>;
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires callback immediately when getAnimations is not supported', () => {
+    const ref = { current: document.createElement('div') } as RefObject<HTMLElement | null>;
+    // Don't add getAnimations
+    delete (ref.current as unknown as Record<string, unknown>).getAnimations;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires callback immediately when no animations are running', () => {
+    const el = createMockElement([]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for all animations to finish before firing callback', async () => {
+    let resolveAnim!: () => void;
+    const animPromise = new Promise<void>(r => {
+      resolveAnim = r;
+    });
+    const el = createMockElement([{ finished: animPromise }]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+
+    expect(callback).not.toHaveBeenCalled();
+
+    // After animations finish, change getAnimations to return empty
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    await act(async () => resolveAnim());
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts previous pending wait when called again', async () => {
+    let resolveFirst!: () => void;
+    const firstAnim = new Promise<void>(r => {
+      resolveFirst = r;
+    });
+    const el = createMockElement([{ finished: firstAnim }]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const firstCallback = vi.fn();
+    act(() => result.current(firstCallback));
+
+    // Call again — should abort the first
+    const secondCallback = vi.fn();
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    act(() => result.current(secondCallback));
+
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+
+    // Resolve first animation — its callback should NOT fire
+    await act(async () => resolveFirst());
+    expect(firstCallback).not.toHaveBeenCalled();
+  });
+
+  it('re-checks animations when one is cancelled', async () => {
+    let rejectAnim!: () => void;
+    const cancelledAnim = new Promise<void>((_, reject) => {
+      rejectAnim = reject;
+    });
+    const el = createMockElement([{ finished: cancelledAnim }]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+
+    expect(callback).not.toHaveBeenCalled();
+
+    // Cancel the animation — hook should re-check and find no new animations
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    await act(async () => {
+      rejectAnim();
+      // Let microtask queue flush
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for starting-style attribute removal when open=true', async () => {
+    const el = createMockElement([], { 'data-cl-starting-style': '' });
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result } = renderHook(() => useAnimationsFinished(ref, true));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+
+    // Should not fire yet — waiting for attribute removal
+    expect(callback).not.toHaveBeenCalled();
+
+    // Remove the attribute — MutationObserver should fire
+    await act(async () => {
+      el.removeAttribute('data-cl-starting-style');
+      // MutationObserver is async; wait a tick
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up on unmount', () => {
+    let resolveAnim!: () => void;
+    const animPromise = new Promise<void>(r => {
+      resolveAnim = r;
+    });
+    const el = createMockElement([{ finished: animPromise }]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+
+    const { result, unmount } = renderHook(() => useAnimationsFinished(ref, false));
+
+    const callback = vi.fn();
+    act(() => result.current(callback));
+
+    // Unmount should abort
+    unmount();
+
+    // Resolve animation — callback should not fire because abort was called
+    resolveAnim();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/headless/src/hooks/use-animations-finished.ts
+++ b/packages/headless/src/hooks/use-animations-finished.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
+
+/**
+ * Returns a function that waits for all CSS animations/transitions on the
+ * referenced element to finish, then invokes a callback.
+ *
+ * Uses the Web Animations API (`element.getAnimations()` + `animation.finished`)
+ * so we're duration-agnostic — CSS owns all timing.
+ *
+ * When `open` is true, waits for `[data-cl-starting-style]` to be removed
+ * before polling animations. This avoids a race where `getAnimations()` returns
+ * an empty array before the enter transition has been registered.
+ *
+ * Each call aborts any pending wait from a previous call, so rapid open/close
+ * toggles don't leak stale callbacks.
+ */
+export function useAnimationsFinished(ref: RefObject<HTMLElement | null>, open: boolean) {
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return useCallback(
+    (callback: () => void) => {
+      const element = ref.current;
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const { signal } = controller;
+
+      if (!element || typeof element.getAnimations !== 'function') {
+        callback();
+        return;
+      }
+
+      const runCheck = () => {
+        if (signal.aborted) return;
+        const animations = element.getAnimations();
+        if (animations.length === 0) {
+          // Called synchronously (from useEffect or MutationObserver) —
+          // plain callback is fine, React will batch the state update.
+          callback();
+          return;
+        }
+        Promise.all(animations.map(a => a.finished))
+          .then(() => {
+            if (signal.aborted) return;
+            // Called from a microtask — flushSync forces synchronous unmount
+            // so there's no flash of the element in its final animated state.
+            flushSync(callback);
+          })
+          .catch(() => {
+            if (signal.aborted) return;
+            // An animation was cancelled. If new animations are running, wait
+            // for those instead; otherwise we're done.
+            const current = element.getAnimations();
+            if (current.length > 0) {
+              runCheck();
+            } else {
+              flushSync(callback);
+            }
+          });
+      };
+
+      if (open && element.hasAttribute('data-cl-starting-style')) {
+        const observer = new MutationObserver(() => {
+          if (!element.hasAttribute('data-cl-starting-style')) {
+            observer.disconnect();
+            runCheck();
+          }
+        });
+        observer.observe(element, {
+          attributes: true,
+          attributeFilter: ['data-cl-starting-style'],
+        });
+        signal.addEventListener('abort', () => observer.disconnect());
+        return;
+      }
+
+      runCheck();
+    },
+    [ref, open],
+  );
+}

--- a/packages/headless/src/hooks/use-controllable-state.test.ts
+++ b/packages/headless/src/hooks/use-controllable-state.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useControllableState } from './use-controllable-state';
+
+describe('useControllableState', () => {
+  describe('uncontrolled mode', () => {
+    it('uses defaultValue when controlled is undefined', () => {
+      const { result } = renderHook(() => useControllableState<string>(undefined, 'default'));
+      expect(result.current[0]).toBe('default');
+    });
+
+    it('updates internal state on setValue', () => {
+      const { result } = renderHook(() => useControllableState<string>(undefined, 'initial'));
+
+      act(() => result.current[1]('updated'));
+
+      expect(result.current[0]).toBe('updated');
+    });
+
+    it('calls onChange when value changes', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useControllableState<string>(undefined, 'initial', onChange));
+
+      act(() => result.current[1]('new'));
+
+      expect(onChange).toHaveBeenCalledWith('new');
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('uses controlled value over default', () => {
+      const { result } = renderHook(() => useControllableState<string>('controlled', 'default'));
+      expect(result.current[0]).toBe('controlled');
+    });
+
+    it('does not update internal state when controlled', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useControllableState<string>('controlled', 'default', onChange));
+
+      act(() => result.current[1]('new'));
+
+      // Value stays controlled
+      expect(result.current[0]).toBe('controlled');
+      // But onChange still fires
+      expect(onChange).toHaveBeenCalledWith('new');
+    });
+
+    it('reflects new controlled value on rerender', () => {
+      const { result, rerender } = renderHook(({ controlled }) => useControllableState(controlled, 'default'), {
+        initialProps: { controlled: 'a' as string | undefined },
+      });
+
+      expect(result.current[0]).toBe('a');
+
+      rerender({ controlled: 'b' });
+
+      expect(result.current[0]).toBe('b');
+    });
+  });
+
+  describe('switching modes', () => {
+    it('switches from uncontrolled to controlled', () => {
+      const { result, rerender } = renderHook(({ controlled }) => useControllableState(controlled, 'default'), {
+        initialProps: { controlled: undefined as string | undefined },
+      });
+
+      expect(result.current[0]).toBe('default');
+
+      rerender({ controlled: 'now-controlled' });
+
+      expect(result.current[0]).toBe('now-controlled');
+    });
+  });
+});

--- a/packages/headless/src/hooks/use-controllable-state.ts
+++ b/packages/headless/src/hooks/use-controllable-state.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Manages a value that can be either controlled (externally owned) or
+ * uncontrolled (internally owned). When `controlled` is `undefined`, the
+ * hook stores the value internally; otherwise it defers to the caller.
+ *
+ * `onChange` is always called on updates regardless of mode.
+ */
+export function useControllableState<T>(
+  controlled: T | undefined,
+  defaultValue: T,
+  onChange?: (value: T) => void,
+): [T, (value: T) => void] {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue);
+  const value = controlled !== undefined ? controlled : uncontrolled;
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on `controlled !== undefined` to avoid re-creating when the controlled value changes
+  const setValue = useCallback(
+    (next: T) => {
+      if (controlled === undefined) setUncontrolled(next);
+      onChange?.(next);
+    },
+    [controlled !== undefined, onChange],
+  );
+  return [value, setValue];
+}

--- a/packages/headless/src/hooks/use-floating-transition.test.ts
+++ b/packages/headless/src/hooks/use-floating-transition.test.ts
@@ -1,0 +1,202 @@
+import { act, renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFloatingTransition } from './use-floating-transition';
+
+describe('useFloatingTransition', () => {
+  let rafCallbacks: Array<FrameRequestCallback>;
+  let originalRaf: typeof requestAnimationFrame;
+  let originalCaf: typeof cancelAnimationFrame;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    originalRaf = globalThis.requestAnimationFrame;
+    originalCaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(cb => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    globalThis.cancelAnimationFrame = vi.fn(id => {
+      rafCallbacks[id - 1] = () => {};
+    });
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRaf;
+    globalThis.cancelAnimationFrame = originalCaf;
+  });
+
+  function flushRaf() {
+    const cbs = [...rafCallbacks];
+    rafCallbacks = [];
+    cbs.forEach(cb => cb(performance.now()));
+  }
+
+  function createElementRef(): RefObject<HTMLElement | null> {
+    const el = document.createElement('div');
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    return { current: el };
+  }
+
+  function createAnimatingRef() {
+    let resolveAnim!: () => void;
+    const animPromise = new Promise<void>(r => {
+      resolveAnim = r;
+    });
+    const el = document.createElement('div');
+    el.getAnimations = vi.fn(() => [{ finished: animPromise }] as unknown as Animation[]);
+    const ref = { current: el } as RefObject<HTMLElement | null>;
+    return { ref, el, resolveAnim };
+  }
+
+  it('returns mounted=false and empty transitionProps when closed', () => {
+    const ref = createElementRef();
+    const { result } = renderHook(() => useFloatingTransition({ open: false, ref }));
+
+    expect(result.current.mounted).toBe(false);
+    expect(result.current.transitionProps).toEqual({});
+  });
+
+  it('returns mounted=true with starting-style props on open', () => {
+    const ref = createElementRef();
+    const { result } = renderHook(() => useFloatingTransition({ open: true, ref }));
+
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionProps).toEqual({
+      'data-cl-open': '',
+      'data-cl-starting-style': '',
+      style: { transition: 'none' },
+    });
+  });
+
+  it('clears starting-style after first frame, keeps data-cl-open', () => {
+    const ref = createElementRef();
+    const { result } = renderHook(() => useFloatingTransition({ open: true, ref }));
+
+    act(() => flushRaf());
+
+    expect(result.current.transitionProps).toEqual({
+      'data-cl-open': '',
+    });
+  });
+
+  it('sets closing props while animations are running', async () => {
+    const { ref, el, resolveAnim } = createAnimatingRef();
+    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    rerender({ open: false });
+
+    // Wait for effect to run
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionProps).toEqual({
+      'data-cl-closed': '',
+      'data-cl-ending-style': '',
+    });
+
+    // Cleanup: resolve to prevent hanging
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    await act(async () => {
+      resolveAnim();
+      await new Promise(r => setTimeout(r, 0));
+    });
+  });
+
+  it('unmounts immediately when no animations are running', async () => {
+    const ref = createElementRef();
+    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    await act(async () => {
+      rerender({ open: false });
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.mounted).toBe(false);
+  });
+
+  it('stays mounted while animations are running', async () => {
+    const { ref, el, resolveAnim } = createAnimatingRef();
+
+    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    rerender({ open: false });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.mounted).toBe(true);
+
+    // Finish animation
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    await act(async () => {
+      resolveAnim();
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.mounted).toBe(false);
+  });
+
+  it('handles rapid open→close — unmounts after animations finish', async () => {
+    const ref = createElementRef();
+    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+      initialProps: { open: false },
+    });
+
+    // Open
+    rerender({ open: true });
+    expect(result.current.mounted).toBe(true);
+
+    // Immediately close — no animations, so unmount happens on effect flush
+    await act(async () => {
+      rerender({ open: false });
+      flushRaf();
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.mounted).toBe(false);
+  });
+
+  it('handles rapid close→open by cancelling exit', async () => {
+    const { ref, el, resolveAnim } = createAnimatingRef();
+    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    // Close — sets ending
+    rerender({ open: false });
+
+    // Immediately reopen before animations finish — element never unmounted,
+    // so the state machine goes straight back to open. The ending status
+    // persists briefly until the next rAF clears it.
+    rerender({ open: true });
+
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionProps['data-cl-open']).toBe('');
+
+    // After rAF, ending-style is cleared and we're in stable open state
+    act(() => flushRaf());
+    expect(result.current.transitionProps['data-cl-ending-style']).toBeUndefined();
+    expect(result.current.transitionProps['data-cl-open']).toBe('');
+
+    // Cleanup
+    el.getAnimations = vi.fn(() => [] as unknown as Animation[]);
+    await act(async () => {
+      resolveAnim();
+      await new Promise(r => setTimeout(r, 0));
+    });
+  });
+});

--- a/packages/headless/src/hooks/use-floating-transition.ts
+++ b/packages/headless/src/hooks/use-floating-transition.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { type CSSProperties, type RefObject, useEffect, useMemo } from 'react';
+import { useAnimationsFinished } from './use-animations-finished';
+import { type TransitionStatus, useTransitionStatus } from './use-transition-status';
+
+export interface UseFloatingTransitionOptions {
+  open: boolean;
+  ref: RefObject<HTMLElement | null>;
+}
+
+export interface TransitionProps {
+  'data-cl-open'?: '';
+  'data-cl-closed'?: '';
+  'data-cl-starting-style'?: '';
+  'data-cl-ending-style'?: '';
+  style?: CSSProperties;
+}
+
+export interface UseFloatingTransitionReturn {
+  mounted: boolean;
+  transitionStatus: TransitionStatus;
+  transitionProps: TransitionProps;
+}
+
+/**
+ * Base UI-style enter/exit animation lifecycle for Floating UI components.
+ *
+ * Returns:
+ * - `mounted`: whether the floating element should render. Gate your JSX on this.
+ * - `transitionProps`: spread onto the floating element. Exposes
+ *   `data-cl-open` / `data-cl-closed` / `data-cl-starting-style` /
+ *   `data-cl-ending-style` data attributes and an inline `transition: none` on
+ *   the first mount frame.
+ *
+ * Consumers drive all animation via CSS — no durations in JS. Works with CSS
+ * transitions (via `[data-cl-starting-style]` / `[data-cl-ending-style]`) and
+ * CSS keyframe animations (via `[data-cl-open]` / `[data-cl-closed]`).
+ */
+export function useFloatingTransition({ open, ref }: UseFloatingTransitionOptions): UseFloatingTransitionReturn {
+  const { mounted, transitionStatus, setMounted } = useTransitionStatus(open);
+  const runOnAnimationsFinished = useAnimationsFinished(ref, open);
+
+  useEffect(() => {
+    if (transitionStatus !== 'ending') return;
+    runOnAnimationsFinished(() => {
+      setMounted(false);
+    });
+  }, [transitionStatus, runOnAnimationsFinished, setMounted]);
+
+  const transitionProps = useMemo<TransitionProps>(() => {
+    const props: TransitionProps = {};
+    if (open) {
+      props['data-cl-open'] = '';
+    } else if (mounted) {
+      props['data-cl-closed'] = '';
+    }
+    if (transitionStatus === 'starting') {
+      props['data-cl-starting-style'] = '';
+      props.style = { transition: 'none' };
+    } else if (transitionStatus === 'ending') {
+      props['data-cl-ending-style'] = '';
+    }
+    return props;
+  }, [open, mounted, transitionStatus]);
+
+  return { mounted, transitionStatus, transitionProps };
+}

--- a/packages/headless/src/hooks/use-transition-status.test.ts
+++ b/packages/headless/src/hooks/use-transition-status.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTransitionStatus } from './use-transition-status';
+
+describe('useTransitionStatus', () => {
+  let rafCallbacks: Array<FrameRequestCallback>;
+  let originalRaf: typeof requestAnimationFrame;
+  let originalCaf: typeof cancelAnimationFrame;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    originalRaf = globalThis.requestAnimationFrame;
+    originalCaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(cb => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    globalThis.cancelAnimationFrame = vi.fn(id => {
+      rafCallbacks[id - 1] = () => {};
+    });
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRaf;
+    globalThis.cancelAnimationFrame = originalCaf;
+  });
+
+  function flushRaf() {
+    const cbs = [...rafCallbacks];
+    rafCallbacks = [];
+    cbs.forEach(cb => cb(performance.now()));
+  }
+
+  it('returns mounted=false and status=undefined when open=false', () => {
+    const { result } = renderHook(() => useTransitionStatus(false));
+    expect(result.current.mounted).toBe(false);
+    expect(result.current.transitionStatus).toBeUndefined();
+  });
+
+  it("returns mounted=true and status='starting' when open=true", () => {
+    const { result } = renderHook(() => useTransitionStatus(true));
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionStatus).toBe('starting');
+  });
+
+  it('synchronously sets mounted and starting when open flips true', () => {
+    const { result, rerender } = renderHook(({ open }) => useTransitionStatus(open), {
+      initialProps: { open: false },
+    });
+    expect(result.current.mounted).toBe(false);
+
+    rerender({ open: true });
+
+    // Both must be set in the same render — no intermediate frame
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionStatus).toBe('starting');
+  });
+
+  it('clears starting status after one rAF', () => {
+    const { result } = renderHook(() => useTransitionStatus(true));
+    expect(result.current.transitionStatus).toBe('starting');
+
+    act(() => flushRaf());
+
+    expect(result.current.transitionStatus).toBeUndefined();
+  });
+
+  it('sets ending status synchronously when open flips false', () => {
+    const { result, rerender } = renderHook(({ open }) => useTransitionStatus(open), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf()); // clear starting
+
+    rerender({ open: false });
+
+    expect(result.current.transitionStatus).toBe('ending');
+    expect(result.current.mounted).toBe(true);
+  });
+
+  it('stays mounted until setMounted(false) is called', () => {
+    const { result, rerender } = renderHook(({ open }) => useTransitionStatus(open), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    rerender({ open: false });
+    expect(result.current.mounted).toBe(true);
+
+    act(() => result.current.setMounted(false));
+    expect(result.current.mounted).toBe(false);
+  });
+
+  it('clears transitionStatus when unmounted', () => {
+    const { result, rerender } = renderHook(({ open }) => useTransitionStatus(open), {
+      initialProps: { open: true },
+    });
+    act(() => flushRaf());
+
+    rerender({ open: false });
+    expect(result.current.transitionStatus).toBe('ending');
+
+    act(() => result.current.setMounted(false));
+    expect(result.current.transitionStatus).toBeUndefined();
+  });
+
+  it('handles rapid open→close before rAF fires', () => {
+    const { result, rerender } = renderHook(({ open }) => useTransitionStatus(open), {
+      initialProps: { open: false },
+    });
+
+    // Open
+    rerender({ open: true });
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionStatus).toBe('starting');
+
+    // Close before rAF clears starting
+    rerender({ open: false });
+    expect(result.current.mounted).toBe(true);
+    expect(result.current.transitionStatus).toBe('ending');
+
+    // The rAF from opening should be cancelled, not interfere
+    act(() => flushRaf());
+    expect(result.current.transitionStatus).toBe('ending');
+  });
+});

--- a/packages/headless/src/hooks/use-transition-status.ts
+++ b/packages/headless/src/hooks/use-transition-status.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type TransitionStatus = 'starting' | 'ending' | undefined;
+
+/**
+ * Core state machine for enter/exit animations.
+ *
+ * Tracks whether a component should be in the DOM (`mounted`) and which
+ * animation phase it is in (`transitionStatus`).
+ *
+ * - When `open` becomes true: synchronously sets `mounted=true` and
+ *   `transitionStatus='starting'` during render so the first committed DOM
+ *   frame carries `[data-starting-style]`. One animation frame later, clears
+ *   the status so the CSS transition fires.
+ * - When `open` becomes false: synchronously sets `transitionStatus='ending'`.
+ *   The element stays mounted until the caller explicitly calls `setMounted(false)`
+ *   (typically after all CSS animations have finished).
+ */
+export function useTransitionStatus(open: boolean) {
+  const [mounted, setMounted] = useState(open);
+  const [transitionStatus, setTransitionStatus] = useState<TransitionStatus>(open ? 'starting' : undefined);
+
+  // Synchronous render-phase state updates. Running these during render (not in
+  // useEffect) guarantees the first committed DOM includes the right data
+  // attributes — critical for `[data-starting-style]` to be present on mount.
+  if (open && !mounted) {
+    setMounted(true);
+    setTransitionStatus('starting');
+  }
+  if (!open && mounted && transitionStatus !== 'ending') {
+    setTransitionStatus('ending');
+  }
+  if (!mounted && transitionStatus !== undefined) {
+    setTransitionStatus(undefined);
+  }
+
+  // After the browser has painted the 'starting' frame, remove it so the CSS
+  // transition fires toward the element's resting style.
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => {
+      setTransitionStatus(undefined);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  return { mounted, transitionStatus, setMounted };
+}

--- a/packages/headless/src/hooks/use-transition.test.ts
+++ b/packages/headless/src/hooks/use-transition.test.ts
@@ -1,9 +1,9 @@
 import { act, renderHook } from '@testing-library/react';
 import type { RefObject } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useFloatingTransition } from './use-floating-transition';
+import { useTransition } from './use-transition';
 
-describe('useFloatingTransition', () => {
+describe('useTransition', () => {
   let rafCallbacks: Array<FrameRequestCallback>;
   let originalRaf: typeof requestAnimationFrame;
   let originalCaf: typeof cancelAnimationFrame;
@@ -51,7 +51,7 @@ describe('useFloatingTransition', () => {
 
   it('returns mounted=false and empty transitionProps when closed', () => {
     const ref = createElementRef();
-    const { result } = renderHook(() => useFloatingTransition({ open: false, ref }));
+    const { result } = renderHook(() => useTransition({ open: false, ref }));
 
     expect(result.current.mounted).toBe(false);
     expect(result.current.transitionProps).toEqual({});
@@ -59,7 +59,7 @@ describe('useFloatingTransition', () => {
 
   it('returns mounted=true with starting-style props on open', () => {
     const ref = createElementRef();
-    const { result } = renderHook(() => useFloatingTransition({ open: true, ref }));
+    const { result } = renderHook(() => useTransition({ open: true, ref }));
 
     expect(result.current.mounted).toBe(true);
     expect(result.current.transitionProps).toEqual({
@@ -71,7 +71,7 @@ describe('useFloatingTransition', () => {
 
   it('clears starting-style after first frame, keeps data-cl-open', () => {
     const ref = createElementRef();
-    const { result } = renderHook(() => useFloatingTransition({ open: true, ref }));
+    const { result } = renderHook(() => useTransition({ open: true, ref }));
 
     act(() => flushRaf());
 
@@ -82,7 +82,7 @@ describe('useFloatingTransition', () => {
 
   it('sets closing props while animations are running', async () => {
     const { ref, el, resolveAnim } = createAnimatingRef();
-    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+    const { result, rerender } = renderHook(({ open }) => useTransition({ open, ref }), {
       initialProps: { open: true },
     });
     act(() => flushRaf());
@@ -110,7 +110,7 @@ describe('useFloatingTransition', () => {
 
   it('unmounts immediately when no animations are running', async () => {
     const ref = createElementRef();
-    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+    const { result, rerender } = renderHook(({ open }) => useTransition({ open, ref }), {
       initialProps: { open: true },
     });
     act(() => flushRaf());
@@ -126,7 +126,7 @@ describe('useFloatingTransition', () => {
   it('stays mounted while animations are running', async () => {
     const { ref, el, resolveAnim } = createAnimatingRef();
 
-    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+    const { result, rerender } = renderHook(({ open }) => useTransition({ open, ref }), {
       initialProps: { open: true },
     });
     act(() => flushRaf());
@@ -151,7 +151,7 @@ describe('useFloatingTransition', () => {
 
   it('handles rapid open→close — unmounts after animations finish', async () => {
     const ref = createElementRef();
-    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+    const { result, rerender } = renderHook(({ open }) => useTransition({ open, ref }), {
       initialProps: { open: false },
     });
 
@@ -171,7 +171,7 @@ describe('useFloatingTransition', () => {
 
   it('handles rapid close→open by cancelling exit', async () => {
     const { ref, el, resolveAnim } = createAnimatingRef();
-    const { result, rerender } = renderHook(({ open }) => useFloatingTransition({ open, ref }), {
+    const { result, rerender } = renderHook(({ open }) => useTransition({ open, ref }), {
       initialProps: { open: true },
     });
     act(() => flushRaf());

--- a/packages/headless/src/hooks/use-transition.ts
+++ b/packages/headless/src/hooks/use-transition.ts
@@ -4,7 +4,7 @@ import { type CSSProperties, type RefObject, useEffect, useMemo } from 'react';
 import { useAnimationsFinished } from './use-animations-finished';
 import { type TransitionStatus, useTransitionStatus } from './use-transition-status';
 
-export interface UseFloatingTransitionOptions {
+export interface UseTransitionOptions {
   open: boolean;
   ref: RefObject<HTMLElement | null>;
 }
@@ -17,18 +17,18 @@ export interface TransitionProps {
   style?: CSSProperties;
 }
 
-export interface UseFloatingTransitionReturn {
+export interface UseTransitionReturn {
   mounted: boolean;
   transitionStatus: TransitionStatus;
   transitionProps: TransitionProps;
 }
 
 /**
- * Base UI-style enter/exit animation lifecycle for Floating UI components.
+ * Enter/exit animation lifecycle hook.
  *
  * Returns:
- * - `mounted`: whether the floating element should render. Gate your JSX on this.
- * - `transitionProps`: spread onto the floating element. Exposes
+ * - `mounted`: whether the element should render. Gate your JSX on this.
+ * - `transitionProps`: spread onto the element. Exposes
  *   `data-cl-open` / `data-cl-closed` / `data-cl-starting-style` /
  *   `data-cl-ending-style` data attributes and an inline `transition: none` on
  *   the first mount frame.
@@ -37,7 +37,7 @@ export interface UseFloatingTransitionReturn {
  * transitions (via `[data-cl-starting-style]` / `[data-cl-ending-style]`) and
  * CSS keyframe animations (via `[data-cl-open]` / `[data-cl-closed]`).
  */
-export function useFloatingTransition({ open, ref }: UseFloatingTransitionOptions): UseFloatingTransitionReturn {
+export function useTransition({ open, ref }: UseTransitionOptions): UseTransitionReturn {
   const { mounted, transitionStatus, setMounted } = useTransitionStatus(open);
   const runOnAnimationsFinished = useAnimationsFinished(ref, open);
 

--- a/packages/headless/src/primitives/accordion/README.md
+++ b/packages/headless/src/primitives/accordion/README.md
@@ -1,0 +1,128 @@
+# Accordion
+
+A vertically stacked set of collapsible sections. Supports single or multiple open panels, keyboard navigation, and CSS-driven expand/collapse animations.
+
+## When to Use
+
+- FAQ sections, settings panels, or any UI where content should be shown/hidden in discrete sections.
+- When you need accessible expand/collapse with proper ARIA attributes and keyboard support.
+- Prefer Accordion over manual show/hide toggles — it handles focus management, ARIA, and animation lifecycle automatically.
+
+## Usage
+
+```tsx
+import { Accordion } from '@/primitives/accordion';
+
+<Accordion
+  type='single'
+  defaultValue={['item-1']}
+>
+  <Accordion.Item value='item-1'>
+    <Accordion.Header>
+      <Accordion.Trigger>Section 1</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Panel>Content for section 1</Accordion.Panel>
+  </Accordion.Item>
+  <Accordion.Item value='item-2'>
+    <Accordion.Header>
+      <Accordion.Trigger>Section 2</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Panel>Content for section 2</Accordion.Panel>
+  </Accordion.Item>
+</Accordion>;
+```
+
+### Controlled
+
+```tsx
+const [value, setValue] = useState<string[]>(['item-1']);
+
+<Accordion
+  value={value}
+  onValueChange={setValue}
+>
+  {/* ... */}
+</Accordion>;
+```
+
+## Parts
+
+| Part                | Default Element | Description                        |
+| ------------------- | --------------- | ---------------------------------- |
+| `Accordion`         | `<div>`         | Root wrapper, provides context     |
+| `Accordion.Item`    | `<div>`         | Wraps a single collapsible section |
+| `Accordion.Header`  | `<h3>`          | Heading wrapper for the trigger    |
+| `Accordion.Trigger` | `<button>`      | Clickable toggle for its panel     |
+| `Accordion.Panel`   | `<div>`         | Collapsible content area           |
+
+## Props
+
+### `Accordion` (root)
+
+| Prop            | Type                        | Default      | Description                               |
+| --------------- | --------------------------- | ------------ | ----------------------------------------- |
+| `value`         | `string[]`                  | —            | Controlled open items                     |
+| `defaultValue`  | `string[]`                  | `[]`         | Initial open items (uncontrolled)         |
+| `onValueChange` | `(value: string[]) => void` | —            | Called when open items change             |
+| `type`          | `"single" \| "multiple"`    | `"multiple"` | `"single"` enforces at most one open item |
+| `disabled`      | `boolean`                   | `false`      | Disables all items                        |
+
+### `Accordion.Item`
+
+| Prop       | Type      | Default       | Description                     |
+| ---------- | --------- | ------------- | ------------------------------- |
+| `value`    | `string`  | **required**  | Unique identifier for this item |
+| `disabled` | `boolean` | inherits root | Disables this specific item     |
+
+### `Accordion.Header`
+
+No additional props. Renders as `<h3>` by default.
+
+### `Accordion.Trigger`
+
+No additional props. Renders as `<button>` by default.
+
+### `Accordion.Panel`
+
+No additional props. Renders as `<div>` by default.
+
+All parts accept a `render` prop for polymorphic rendering and standard HTML attributes for their default element.
+
+## Keyboard Navigation
+
+| Key               | Action                         |
+| ----------------- | ------------------------------ |
+| `ArrowDown`       | Move focus to next trigger     |
+| `ArrowUp`         | Move focus to previous trigger |
+| `Enter` / `Space` | Toggle the focused item        |
+
+## Data Attributes
+
+| Attribute          | Applies To           | Description                                       |
+| ------------------ | -------------------- | ------------------------------------------------- |
+| `data-cl-slot`     | All parts            | Identifies each part (e.g. `"accordion-trigger"`) |
+| `data-cl-open`     | Item, Trigger, Panel | Present when the item is expanded                 |
+| `data-cl-closed`   | Item, Trigger, Panel | Present when the item is collapsed                |
+| `data-cl-disabled` | Item, Trigger        | Present when the item is disabled                 |
+
+## CSS Animation
+
+`Accordion.Panel` exposes a `--accordion-panel-height` CSS custom property set to the panel's `scrollHeight` in pixels. Use this for height-based expand/collapse animations:
+
+```css
+[data-cl-slot='accordion-panel'] {
+  overflow: hidden;
+  height: var(--accordion-panel-height);
+  transition: height 200ms ease;
+}
+[data-cl-slot='accordion-panel'][data-cl-closed] {
+  height: 0;
+}
+```
+
+The panel suppresses the enter animation on initial mount — only subsequent opens animate.
+
+## ARIA
+
+- Trigger: `aria-expanded`, `aria-controls` (pointing to its panel), `aria-disabled`
+- Panel: `role="region"`, `aria-labelledby` (pointing to its trigger)

--- a/packages/headless/src/primitives/accordion/README.md
+++ b/packages/headless/src/primitives/accordion/README.md
@@ -107,12 +107,12 @@ All parts accept a `render` prop for polymorphic rendering and standard HTML att
 
 ## CSS Animation
 
-`Accordion.Panel` exposes a `--accordion-panel-height` CSS custom property set to the panel's `scrollHeight` in pixels. Use this for height-based expand/collapse animations:
+`Accordion.Panel` exposes a `--cl-accordion-panel-height` CSS custom property set to the panel's `scrollHeight` in pixels. Use this for height-based expand/collapse animations:
 
 ```css
 [data-cl-slot='accordion-panel'] {
   overflow: hidden;
-  height: var(--accordion-panel-height);
+  height: var(--cl-accordion-panel-height);
   transition: height 200ms ease;
 }
 [data-cl-slot='accordion-panel'][data-cl-closed] {

--- a/packages/headless/src/primitives/accordion/accordion.test.tsx
+++ b/packages/headless/src/primitives/accordion/accordion.test.tsx
@@ -1,0 +1,419 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Accordion } from './accordion';
+
+afterEach(() => cleanup());
+
+function renderAccordion(props: Partial<React.ComponentProps<typeof Accordion>> = {}) {
+  return render(
+    <Accordion {...props}>
+      <Accordion.Item value='item1'>
+        <Accordion.Header>
+          <Accordion.Trigger>Section 1</Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel>Content 1</Accordion.Panel>
+      </Accordion.Item>
+      <Accordion.Item value='item2'>
+        <Accordion.Header>
+          <Accordion.Trigger>Section 2</Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel>Content 2</Accordion.Panel>
+      </Accordion.Item>
+      <Accordion.Item value='item3'>
+        <Accordion.Header>
+          <Accordion.Trigger>Section 3</Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel>Content 3</Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>,
+  );
+}
+
+describe('Accordion', () => {
+  describe('slot attributes', () => {
+    it('renders root with data-cl-slot', () => {
+      renderAccordion();
+      expect(document.querySelector('[data-cl-slot="accordion-root"]')).toBeInTheDocument();
+    });
+
+    it('renders items with data-cl-slot', () => {
+      renderAccordion();
+      const items = document.querySelectorAll('[data-cl-slot="accordion-item"]');
+      expect(items).toHaveLength(3);
+    });
+
+    it('renders headers with data-cl-slot', () => {
+      renderAccordion();
+      const headers = document.querySelectorAll('[data-cl-slot="accordion-header"]');
+      expect(headers).toHaveLength(3);
+    });
+
+    it('renders triggers with data-cl-slot', () => {
+      renderAccordion();
+      const triggers = document.querySelectorAll('[data-cl-slot="accordion-trigger"]');
+      expect(triggers).toHaveLength(3);
+    });
+
+    it('renders panels with data-cl-slot when open', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      expect(document.querySelector('[data-cl-slot="accordion-panel"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('expand/collapse', () => {
+    it('opens an item on trigger click', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+
+      const item = document.querySelectorAll('[data-cl-slot="accordion-item"]')[0];
+      expect(item).toHaveAttribute('data-cl-open', '');
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+    });
+
+    it('closes an open item on trigger click', async () => {
+      const user = userEvent.setup();
+      renderAccordion({ defaultValue: ['item1'] });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+
+      const item = document.querySelectorAll('[data-cl-slot="accordion-item"]')[0];
+      expect(item).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onValueChange when toggled', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      renderAccordion({ onValueChange });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+
+      expect(onValueChange).toHaveBeenCalledWith(['item1']);
+    });
+
+    it('allows multiple items open in multiple mode', async () => {
+      const user = userEvent.setup();
+      renderAccordion({ type: 'multiple' });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+      await user.click(screen.getByRole('button', { name: 'Section 2' }));
+
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    });
+
+    it('allows only one item open in single mode', async () => {
+      const user = userEvent.setup();
+      renderAccordion({ type: 'single' });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+      await user.click(screen.getByRole('button', { name: 'Section 2' }));
+
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('controlled value', () => {
+    it('respects controlled value prop', () => {
+      renderAccordion({ value: ['item2'] });
+
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    });
+
+    it('does not change when controlled', async () => {
+      const user = userEvent.setup();
+      renderAccordion({ value: [] });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('trigger has aria-expanded=false when closed', () => {
+      renderAccordion();
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('trigger has aria-expanded=true when open', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('trigger has aria-controls linked to panel id', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      const panel = document.querySelector('[data-cl-slot="accordion-panel"]');
+
+      expect(trigger).toHaveAttribute('aria-controls', panel?.getAttribute('id'));
+    });
+
+    it('panel has aria-labelledby linked to trigger id', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      const panel = document.querySelector('[data-cl-slot="accordion-panel"]');
+
+      expect(panel).toHaveAttribute('aria-labelledby', trigger.getAttribute('id'));
+    });
+
+    it('panel has role=region', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      expect(screen.getByRole('region')).toBeInTheDocument();
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('panel is not in DOM when closed', () => {
+      renderAccordion();
+      expect(document.querySelector('[data-cl-slot="accordion-panel"]')).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on panel when open', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const panel = document.querySelector('[data-cl-slot="accordion-panel"]');
+      expect(panel).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('does not apply starting-style on initially open panels', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const panel = document.querySelector('[data-cl-slot="accordion-panel"]');
+      expect(panel).not.toHaveAttribute('data-cl-starting-style');
+    });
+
+    it('sets --accordion-panel-height CSS variable on panel', () => {
+      renderAccordion({ defaultValue: ['item1'] });
+      const panel = document.querySelector('[data-cl-slot="accordion-panel"]') as HTMLElement;
+      // Verify the CSS variable is present in the style attribute
+      expect(panel.getAttribute('style')).toContain('--accordion-panel-height');
+    });
+  });
+
+  describe('disabled', () => {
+    it('disables all items when disabled on root', () => {
+      renderAccordion({ disabled: true });
+      const triggers = screen.getAllByRole('button');
+      triggers.forEach(trigger => {
+        expect(trigger).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    it('prevents toggle when disabled', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      renderAccordion({ disabled: true, onValueChange });
+
+      await user.click(screen.getByRole('button', { name: 'Section 1' }));
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('disables individual item', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Accordion onValueChange={onValueChange}>
+          <Accordion.Item
+            value='item1'
+            disabled
+          >
+            <Accordion.Header>
+              <Accordion.Trigger>Disabled</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value='item2'>
+            <Accordion.Header>
+              <Accordion.Trigger>Enabled</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 2</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Disabled' }));
+      expect(onValueChange).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Enabled' }));
+      expect(onValueChange).toHaveBeenCalledWith(['item2']);
+    });
+
+    it('applies data-cl-disabled on item and trigger', () => {
+      render(
+        <Accordion>
+          <Accordion.Item
+            value='item1'
+            disabled
+          >
+            <Accordion.Header>
+              <Accordion.Trigger>Disabled</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      );
+
+      const item = document.querySelector('[data-cl-slot="accordion-item"]');
+      const trigger = document.querySelector('[data-cl-slot="accordion-trigger"]');
+      expect(item).toHaveAttribute('data-cl-disabled', '');
+      expect(trigger).toHaveAttribute('data-cl-disabled', '');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('moves focus down with ArrowDown', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const triggers = screen.getAllByRole('button');
+      triggers[0].focus();
+      await user.keyboard('{ArrowDown}');
+
+      expect(triggers[1]).toHaveFocus();
+    });
+
+    it('moves focus up with ArrowUp', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const triggers = screen.getAllByRole('button');
+      triggers[1].focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(triggers[0]).toHaveFocus();
+    });
+
+    it('toggles item with Enter', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      trigger.focus();
+      await user.keyboard('{Enter}');
+
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+    });
+
+    it('toggles item with Space', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const trigger = screen.getByRole('button', { name: 'Section 1' });
+      trigger.focus();
+      await user.keyboard(' ');
+
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+    });
+
+    it('moves focus to first trigger with Home', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const triggers = screen.getAllByRole('button');
+      triggers[2].focus();
+      await user.keyboard('{Home}');
+
+      expect(triggers[0]).toHaveFocus();
+    });
+
+    it('moves focus to last trigger with End', async () => {
+      const user = userEvent.setup();
+      renderAccordion();
+
+      const triggers = screen.getAllByRole('button');
+      triggers[0].focus();
+      await user.keyboard('{End}');
+
+      expect(triggers[2]).toHaveFocus();
+    });
+
+    it('Home skips disabled triggers', async () => {
+      const user = userEvent.setup();
+      render(
+        <Accordion>
+          <Accordion.Item
+            value='item1'
+            disabled
+          >
+            <Accordion.Header>
+              <Accordion.Trigger>Section 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 1</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value='item2'>
+            <Accordion.Header>
+              <Accordion.Trigger>Section 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 2</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value='item3'>
+            <Accordion.Header>
+              <Accordion.Trigger>Section 3</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 3</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      );
+
+      const section3 = screen.getByRole('button', { name: 'Section 3' });
+      section3.focus();
+      await user.keyboard('{Home}');
+
+      expect(screen.getByRole('button', { name: 'Section 2' })).toHaveFocus();
+    });
+
+    it('End skips disabled triggers', async () => {
+      const user = userEvent.setup();
+      render(
+        <Accordion>
+          <Accordion.Item value='item1'>
+            <Accordion.Header>
+              <Accordion.Trigger>Section 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 1</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value='item2'>
+            <Accordion.Header>
+              <Accordion.Trigger>Section 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 2</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item
+            value='item3'
+            disabled
+          >
+            <Accordion.Header>
+              <Accordion.Trigger>Section 3</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>Content 3</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      );
+
+      const section1 = screen.getByRole('button', { name: 'Section 1' });
+      section1.focus();
+      await user.keyboard('{End}');
+
+      expect(screen.getByRole('button', { name: 'Section 2' })).toHaveFocus();
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when collapsed', async () => {
+      const { container } = renderAccordion();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when expanded', async () => {
+      const { container } = renderAccordion({ defaultValue: ['item1'] });
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/accordion/accordion.test.tsx
+++ b/packages/headless/src/primitives/accordion/accordion.test.tsx
@@ -188,11 +188,11 @@ describe('Accordion', () => {
       expect(panel).not.toHaveAttribute('data-cl-starting-style');
     });
 
-    it('sets --accordion-panel-height CSS variable on panel', () => {
+    it('sets --cl-accordion-panel-height CSS variable on panel', () => {
       renderAccordion({ defaultValue: ['item1'] });
       const panel = document.querySelector('[data-cl-slot="accordion-panel"]') as HTMLElement;
       // Verify the CSS variable is present in the style attribute
-      expect(panel.getAttribute('style')).toContain('--accordion-panel-height');
+      expect(panel.getAttribute('style')).toContain('--cl-accordion-panel-height');
     });
   });
 

--- a/packages/headless/src/primitives/accordion/accordion.tsx
+++ b/packages/headless/src/primitives/accordion/accordion.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { Composite, CompositeItem } from '@floating-ui/react';
+import React, {
+  createContext,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { useFloatingTransition } from '../../hooks/use-floating-transition';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface AccordionContextValue {
+  value: string[];
+  toggle: (itemValue: string) => void;
+  disabled: boolean;
+  accordionId: string;
+}
+
+const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+function useAccordionContext() {
+  const ctx = useContext(AccordionContext);
+  if (!ctx) {
+    throw new Error('Accordion compound components must be used within <Accordion>');
+  }
+  return ctx;
+}
+
+interface AccordionItemContextValue {
+  itemValue: string;
+  open: boolean;
+  disabled: boolean;
+  triggerId: string;
+  panelId: string;
+}
+
+const AccordionItemContext = createContext<AccordionItemContextValue | null>(null);
+
+function useAccordionItemContext() {
+  const ctx = useContext(AccordionItemContext);
+  if (!ctx) {
+    throw new Error('Accordion.Trigger/Header/Panel must be used within <Accordion.Item>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Accordion (root)
+// ---------------------------------------------------------------------------
+
+export interface AccordionProps extends ComponentProps<'div'> {
+  /** Controlled open items. */
+  value?: string[];
+  /** Initial open items (uncontrolled). */
+  defaultValue?: string[];
+  /** Called when open items change. */
+  onValueChange?: (value: string[]) => void;
+  /** When true, only one item can be open at a time. @default false */
+  type?: 'single' | 'multiple';
+  /** Disable all items. @default false */
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+function AccordionRoot(props: AccordionProps) {
+  const { render, type = 'multiple', disabled = false, children, ...otherProps } = props;
+
+  const [value, setValue] = useControllableState(props.value, props.defaultValue ?? [], props.onValueChange);
+
+  const accordionId = useId();
+
+  const toggle = useCallback(
+    (itemValue: string) => {
+      const isOpen = value.includes(itemValue);
+      if (isOpen) {
+        setValue(value.filter(v => v !== itemValue));
+      } else if (type === 'single') {
+        setValue([itemValue]);
+      } else {
+        setValue([...value, itemValue]);
+      }
+    },
+    [type, value, setValue],
+  );
+
+  const contextValue = useMemo<AccordionContextValue>(
+    () => ({ value, toggle, disabled, accordionId }),
+    [value, toggle, disabled, accordionId],
+  );
+
+  return (
+    <AccordionContext.Provider value={contextValue}>
+      <Composite
+        orientation='vertical'
+        render={(compositeProps: React.HTMLAttributes<HTMLElement>) => {
+          // aria-orientation is injected by Composite but is not valid on a
+          // generic <div> (no widget role). Strip it to avoid an axe violation.
+          const { 'aria-orientation': _ao, ...restCompositeProps } = compositeProps;
+
+          const defaultProps: Record<string, unknown> = {
+            'data-cl-slot': 'accordion-root',
+            onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+              if (event.key !== 'Home' && event.key !== 'End') return;
+              event.preventDefault();
+              const items = Array.from(
+                event.currentTarget.querySelectorAll<HTMLElement>('[data-cl-slot="accordion-trigger"]:not([disabled])'),
+              );
+              if (items.length === 0) return;
+              const target = event.key === 'Home' ? items[0] : items[items.length - 1];
+              target.focus();
+            },
+          };
+
+          const merged = mergeProps<'div'>(
+            defaultProps,
+            mergeProps<'div'>(otherProps, restCompositeProps as Record<string, unknown>),
+          );
+
+          return renderElement({
+            defaultTagName: 'div',
+            render,
+            props: merged,
+          })!;
+        }}
+      >
+        {children}
+      </Composite>
+    </AccordionContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Accordion.Item
+// ---------------------------------------------------------------------------
+
+export interface AccordionItemProps extends ComponentProps<'div'> {
+  /** Unique value identifying this item. */
+  value: string;
+  /** Disable this specific item. */
+  disabled?: boolean;
+}
+
+function AccordionItem(props: AccordionItemProps) {
+  const { render, value: itemValue, disabled: itemDisabled, ...otherProps } = props;
+  const ctx = useAccordionContext();
+
+  const open = ctx.value.includes(itemValue);
+  const disabled = itemDisabled ?? ctx.disabled;
+  const triggerId = `${ctx.accordionId}-trigger-${itemValue}`;
+  const panelId = `${ctx.accordionId}-panel-${itemValue}`;
+
+  const itemContextValue = useMemo<AccordionItemContextValue>(
+    () => ({ itemValue, open, disabled, triggerId, panelId }),
+    [itemValue, open, disabled, triggerId, panelId],
+  );
+
+  const state = { open, disabled };
+
+  const defaultProps = {
+    'data-cl-slot': 'accordion-item',
+  };
+
+  return (
+    <AccordionItemContext.Provider value={itemContextValue}>
+      {renderElement({
+        defaultTagName: 'div',
+        render,
+        state,
+        stateAttributesMapping: {
+          open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+          disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+        },
+        props: mergeProps<'div'>(defaultProps, otherProps),
+      })}
+    </AccordionItemContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Accordion.Header
+// ---------------------------------------------------------------------------
+
+export interface AccordionHeaderProps extends ComponentProps<'h3'> {}
+
+function AccordionHeader(props: AccordionHeaderProps) {
+  const { render, ...otherProps } = props;
+
+  const defaultProps = {
+    'data-cl-slot': 'accordion-header',
+  };
+
+  return renderElement({
+    defaultTagName: 'h3',
+    render,
+    props: mergeProps<'h3'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Accordion.Trigger
+// ---------------------------------------------------------------------------
+
+export interface AccordionTriggerProps extends ComponentProps<'button'> {}
+
+function AccordionTrigger(props: AccordionTriggerProps) {
+  const { render, children, ...otherProps } = props;
+  const ctx = useAccordionContext();
+  const { itemValue, open, disabled, triggerId, panelId } = useAccordionItemContext();
+
+  const state = { open, disabled };
+
+  return (
+    <CompositeItem
+      disabled={disabled}
+      render={(compositeProps: React.HTMLAttributes<HTMLElement>) => {
+        const defaultProps: Record<string, unknown> = {
+          'data-cl-slot': 'accordion-trigger',
+          id: triggerId,
+          type: 'button' as const,
+          'aria-expanded': open,
+          'aria-controls': panelId,
+          'aria-disabled': disabled || undefined,
+          onClick: () => {
+            if (!disabled) ctx.toggle(itemValue);
+          },
+        };
+
+        const merged = mergeProps<'button'>(
+          mergeProps<'button'>(defaultProps, otherProps),
+          compositeProps as Record<string, unknown>,
+        );
+
+        return renderElement({
+          defaultTagName: 'button',
+          render,
+          state,
+          stateAttributesMapping: {
+            open: (v: boolean): Record<string, string> | null =>
+              v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' },
+            disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+          },
+          props: merged,
+        })!;
+      }}
+    >
+      {children}
+    </CompositeItem>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Accordion.Panel
+// ---------------------------------------------------------------------------
+
+export interface AccordionPanelProps extends ComponentProps<'div'> {}
+
+function AccordionPanel(props: AccordionPanelProps) {
+  const { render, ...otherProps } = props;
+  const { open, triggerId, panelId } = useAccordionItemContext();
+
+  const panelRef = useRef<HTMLElement | null>(null);
+  const [height, setHeight] = useState<number | undefined>(undefined);
+
+  // Track whether open has ever transitioned from true→false.
+  // Until that happens, skip enter animations (prevents animate-on-load).
+  const hasBeenClosed = useRef(false);
+  if (!open) hasBeenClosed.current = true;
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: panelRef as RefObject<HTMLElement>,
+  });
+
+  // Measure the content height and keep it in sync via ResizeObserver
+  useLayoutEffect(() => {
+    if (!mounted) return;
+
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    // Measure scrollHeight of the panel's content
+    const measure = () => {
+      setHeight(panel.scrollHeight);
+    };
+
+    measure();
+
+    const ro = new ResizeObserver(measure);
+    // Observe children mutations that affect height
+    ro.observe(panel, { box: 'border-box' });
+
+    return () => ro.disconnect();
+  }, [mounted]);
+
+  const state = { open };
+
+  // Skip enter animation for panels that have never been closed
+  const effectiveTransitionProps = !hasBeenClosed.current
+    ? {
+        ...transitionProps,
+        'data-cl-starting-style': undefined,
+        style: undefined,
+      }
+    : transitionProps;
+
+  const defaultProps: Record<string, unknown> = {
+    'data-cl-slot': 'accordion-panel',
+    id: panelId,
+    role: 'region' as const,
+    'aria-labelledby': triggerId,
+    ref: panelRef,
+    ...effectiveTransitionProps,
+    style: {
+      '--accordion-panel-height': height != null ? `${height}px` : undefined,
+      ...effectiveTransitionProps.style,
+    },
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    enabled: mounted,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Accordion = Object.assign(AccordionRoot, {
+  Item: AccordionItem,
+  Header: AccordionHeader,
+  Trigger: AccordionTrigger,
+  Panel: AccordionPanel,
+});

--- a/packages/headless/src/primitives/accordion/accordion.tsx
+++ b/packages/headless/src/primitives/accordion/accordion.tsx
@@ -14,7 +14,7 @@ import React, {
   useState,
 } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { useFloatingTransition } from '../../hooks/use-floating-transition';
+import { useTransition } from '../../hooks/use-transition';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -278,7 +278,7 @@ function AccordionPanel(props: AccordionPanelProps) {
   const hasBeenClosed = useRef(false);
   if (!open) hasBeenClosed.current = true;
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: panelRef as RefObject<HTMLElement>,
   });
@@ -323,7 +323,7 @@ function AccordionPanel(props: AccordionPanelProps) {
     ref: panelRef,
     ...effectiveTransitionProps,
     style: {
-      '--accordion-panel-height': height != null ? `${height}px` : undefined,
+      '--cl-accordion-panel-height': height != null ? `${height}px` : undefined,
       ...effectiveTransitionProps.style,
     },
   };

--- a/packages/headless/src/primitives/accordion/index.ts
+++ b/packages/headless/src/primitives/accordion/index.ts
@@ -1,0 +1,8 @@
+export type {
+  AccordionHeaderProps,
+  AccordionItemProps,
+  AccordionPanelProps,
+  AccordionProps,
+  AccordionTriggerProps,
+} from './accordion';
+export { Accordion } from './accordion';

--- a/packages/headless/src/primitives/autocomplete/README.md
+++ b/packages/headless/src/primitives/autocomplete/README.md
@@ -1,0 +1,136 @@
+# Autocomplete
+
+A combobox input with a filterable dropdown list. Supports virtual focus (focus stays on the input), keyboard navigation, and controlled/uncontrolled input and selection values.
+
+## When to Use
+
+- Search inputs with suggestions, tag pickers, or any input that filters a list of options.
+- When the user needs to type to narrow down choices, unlike `Select` which is for picking from a static list.
+- When you need `aria-autocomplete` behavior with `aria-activedescendant` virtual focus.
+
+## Usage
+
+```tsx
+import { Autocomplete } from '@/primitives/autocomplete';
+
+const fruits = ['Apple', 'Banana', 'Cherry', 'Date'];
+
+function MyAutocomplete() {
+  const [inputValue, setInputValue] = useState('');
+  const filtered = fruits.filter(f => f.toLowerCase().includes(inputValue.toLowerCase()));
+
+  return (
+    <Autocomplete
+      inputValue={inputValue}
+      onInputValueChange={setInputValue}
+    >
+      <Autocomplete.Input placeholder='Search fruits...' />
+      <Autocomplete.Positioner>
+        <Autocomplete.Popup>
+          {filtered.map(fruit => (
+            <Autocomplete.Option
+              key={fruit}
+              value={fruit}
+              label={fruit}
+            />
+          ))}
+        </Autocomplete.Popup>
+      </Autocomplete.Positioner>
+    </Autocomplete>
+  );
+}
+```
+
+### Inline List (inside another floating element)
+
+Use `Autocomplete.List` instead of `Positioner + Popup` when nesting inside a Popover or Dialog. This skips the portal and floating positioning.
+
+```tsx
+<Autocomplete>
+  <Autocomplete.Input />
+  <Autocomplete.List>
+    <Autocomplete.Option value='one' />
+  </Autocomplete.List>
+</Autocomplete>
+```
+
+## Parts
+
+| Part                      | Default Element | Description                              |
+| ------------------------- | --------------- | ---------------------------------------- |
+| `Autocomplete`            | —               | Root context provider                    |
+| `Autocomplete.Input`      | `<input>`       | Text input that drives filtering         |
+| `Autocomplete.Positioner` | `<div>`         | Floating positioned container (portal)   |
+| `Autocomplete.Popup`      | `<div>`         | Visual wrapper for the option list       |
+| `Autocomplete.List`       | `<div>`         | Inline alternative to Positioner + Popup |
+| `Autocomplete.Option`     | `<div>`         | A selectable option                      |
+| `Autocomplete.Arrow`      | `<svg>`         | Optional floating arrow                  |
+
+## Props
+
+### `Autocomplete` (root)
+
+| Prop                 | Type                      | Default          | Description                           |
+| -------------------- | ------------------------- | ---------------- | ------------------------------------- |
+| `inputValue`         | `string`                  | —                | Controlled input text                 |
+| `defaultInputValue`  | `string`                  | `""`             | Initial input text (uncontrolled)     |
+| `onInputValueChange` | `(value: string) => void` | —                | Called when input text changes        |
+| `value`              | `string`                  | —                | Controlled selected value             |
+| `defaultValue`       | `string`                  | —                | Initial selected value (uncontrolled) |
+| `onValueChange`      | `(value: string) => void` | —                | Called when an option is selected     |
+| `open`               | `boolean`                 | —                | Controlled open state                 |
+| `defaultOpen`        | `boolean`                 | `false`          | Initial open state (uncontrolled)     |
+| `onOpenChange`       | `(open: boolean) => void` | —                | Called when open state changes        |
+| `placement`          | `Placement`               | `"bottom-start"` | Floating UI placement                 |
+| `sideOffset`         | `number`                  | `4`              | Gap between input and popup (px)      |
+
+### `Autocomplete.Option`
+
+| Prop       | Type      | Default               | Description                                          |
+| ---------- | --------- | --------------------- | ---------------------------------------------------- |
+| `value`    | `string`  | **required**          | The option's value                                   |
+| `label`    | `string`  | falls back to `value` | Display label, also used for input text on selection |
+| `disabled` | `boolean` | —                     | Prevents selection                                   |
+
+### `Autocomplete.Input`, `Autocomplete.Positioner`, `Autocomplete.Popup`, `Autocomplete.List`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+### `Autocomplete.Arrow`
+
+Accepts all `FloatingArrow` props. `ref` and `context` are injected automatically.
+
+## Keyboard Navigation
+
+| Key         | Action                                |
+| ----------- | ------------------------------------- |
+| `ArrowDown` | Move to next option                   |
+| `ArrowUp`   | Move to previous option               |
+| `Enter`     | Select the active option, close popup |
+| `Escape`    | Close the popup                       |
+
+Navigation loops and auto-scrolls the active option into view.
+
+## Data Attributes
+
+| Attribute                         | Applies To        | Description                                   |
+| --------------------------------- | ----------------- | --------------------------------------------- |
+| `data-cl-slot`                    | All parts         | Part identifier (e.g. `"autocomplete-input"`) |
+| `data-cl-open` / `data-cl-closed` | Input             | Popup open state                              |
+| `data-cl-selected`                | Option            | The currently selected option                 |
+| `data-cl-active`                  | Option            | The keyboard-highlighted option               |
+| `data-cl-disabled`                | Option            | Disabled option                               |
+| `data-cl-side`                    | Positioner, Arrow | Resolved placement side                       |
+
+## Open/Close Behavior
+
+- Typing a non-empty string opens the popup automatically.
+- Clearing the input closes the popup.
+- Clicking an option closes the popup and returns focus to the input.
+- Outside click and Escape close the popup.
+
+## ARIA
+
+- Input: `aria-autocomplete="list"`, `aria-activedescendant` (virtual focus)
+- Options: `role="option"`, `aria-selected`, `aria-disabled`
+- Focus manager: non-modal, `initialFocus={-1}` (focus stays on input)

--- a/packages/headless/src/primitives/autocomplete/README.md
+++ b/packages/headless/src/primitives/autocomplete/README.md
@@ -75,7 +75,8 @@ In this pattern, keep the outer `Popover` or `Dialog` as the source of truth for
 | ------------------------- | --------------- | ---------------------------------------- |
 | `Autocomplete`            | —               | Root context provider                    |
 | `Autocomplete.Input`      | `<input>`       | Text input that drives filtering         |
-| `Autocomplete.Positioner` | `<div>`         | Floating positioned container (portal)   |
+| `Autocomplete.Portal`     | —               | Portals children (accepts `root` prop)   |
+| `Autocomplete.Positioner` | `<div>`         | Floating positioned container            |
 | `Autocomplete.Popup`      | `<div>`         | Visual wrapper for the option list       |
 | `Autocomplete.List`       | `<div>`         | Inline alternative to Positioner + Popup |
 | `Autocomplete.Option`     | `<div>`         | A selectable option                      |

--- a/packages/headless/src/primitives/autocomplete/README.md
+++ b/packages/headless/src/primitives/autocomplete/README.md
@@ -43,16 +43,31 @@ function MyAutocomplete() {
 
 ### Inline List (inside another floating element)
 
-Use `Autocomplete.List` instead of `Positioner + Popup` when nesting inside a Popover or Dialog. This skips the portal and floating positioning.
+Use `Autocomplete.List` when the autocomplete input lives inside an outer floating surface such as a Popover or Dialog. In this mode, the outer primitive owns placement and dismissal for the overall panel, while `Autocomplete` still owns the combobox/listbox semantics between the input and the results list.
 
 ```tsx
-<Autocomplete>
-  <Autocomplete.Input />
-  <Autocomplete.List>
-    <Autocomplete.Option value='one' />
-  </Autocomplete.List>
-</Autocomplete>
+<Popover>
+  <Popover.Trigger>Pick a country</Popover.Trigger>
+  <Popover.Positioner>
+    <Popover.Popup>
+      <Autocomplete open>
+        <Autocomplete.Input
+          placeholder='Search countries...'
+          autoFocus
+        />
+        <Autocomplete.List>
+          <Autocomplete.Option
+            value='us'
+            label='United States'
+          />
+        </Autocomplete.List>
+      </Autocomplete>
+    </Popover.Popup>
+  </Popover.Positioner>
+</Popover>
 ```
+
+In this pattern, keep the outer `Popover` or `Dialog` as the source of truth for whether the panel is visible. `Autocomplete` should render the input and inline listbox inside that surface, and selecting an option can close the outer shell if desired.
 
 ## Parts
 

--- a/packages/headless/src/primitives/autocomplete/autocomplete.test.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.test.tsx
@@ -475,6 +475,29 @@ describe('Autocomplete', () => {
       expect(activeOption).toBeInTheDocument();
     });
 
+    it('links the input to the inline listbox with aria-controls', () => {
+      render(<InlineAutocomplete />);
+
+      const input = screen.getByRole('combobox');
+      const list = document.querySelector('[data-cl-slot="autocomplete-list"]');
+
+      expect(list).toHaveAttribute('id');
+      expect(input).toHaveAttribute('aria-controls', list?.getAttribute('id'));
+    });
+
+    it('updates aria-activedescendant during keyboard navigation', async () => {
+      const user = userEvent.setup();
+      render(<InlineAutocomplete />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(activeOption).toHaveAttribute('id');
+      expect(input).toHaveAttribute('aria-activedescendant', activeOption?.getAttribute('id'));
+    });
+
     it('selects option on Enter after arrow navigation', async () => {
       const onValueChange = vi.fn();
       const user = userEvent.setup();
@@ -577,9 +600,6 @@ describe('Autocomplete', () => {
                 value={selectedValue}
                 inputValue={inputValue}
                 onInputValueChange={setInputValue}
-                onOpenChange={open => {
-                  if (!open) setPopoverOpen(false);
-                }}
                 onValueChange={value => {
                   setSelectedValue(value);
                   setPopoverOpen(false);
@@ -615,6 +635,19 @@ describe('Autocomplete', () => {
 
       const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
       expect(options).toHaveLength(4);
+    });
+
+    it('wires the popover autocomplete input to the inline listbox', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      const input = screen.getByRole('combobox');
+      const list = document.querySelector('[data-cl-slot="autocomplete-list"]');
+
+      expect(list).toHaveAttribute('id');
+      expect(input).toHaveAttribute('aria-controls', list?.getAttribute('id'));
     });
 
     it('navigates options with arrow keys inside popover', async () => {
@@ -801,9 +834,6 @@ describe('Autocomplete', () => {
                 value={selectedValue}
                 inputValue={inputValue}
                 onInputValueChange={setInputValue}
-                onOpenChange={open => {
-                  if (!open) setPopoverOpen(false);
-                }}
                 onValueChange={value => {
                   setSelectedValue(value);
                   setPopoverOpen(false);
@@ -835,13 +865,57 @@ describe('Autocomplete', () => {
       const user = userEvent.setup();
       render(<AutocompleteInPopoverFull />);
 
-      await user.click(screen.getByText('Pick a fruit...'));
+      const trigger = screen.getByText('Pick a fruit...');
+      await user.click(trigger);
       expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]').length).toBeGreaterThan(0);
 
       await user.keyboard('{Escape}');
 
       // Popover should close — no options visible
       expect(document.querySelector('[data-cl-slot="autocomplete-option"]')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('focuses the input on open with an empty value', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      const input = screen.getByPlaceholderText('Search...') as HTMLInputElement;
+      expect(document.activeElement).toBe(input);
+      expect(input.value).toBe('');
+    });
+
+    it('keeps the input empty on open even when a selected item exists', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Cherry'));
+
+      await user.click(screen.getByText('Cherry'));
+
+      const input = screen.getByPlaceholderText('Search...') as HTMLInputElement;
+      expect(document.activeElement).toBe(input);
+      expect(input.value).toBe('');
+    });
+
+    it('marks the previously selected item as active on reopen while focus stays on the input', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Banana'));
+
+      await user.click(screen.getByText('Banana'));
+
+      const input = screen.getByPlaceholderText('Search...');
+      const active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+
+      expect(document.activeElement).toBe(input);
+      expect(active).toHaveTextContent('Banana');
+      expect(input).toHaveAttribute('aria-activedescendant', active?.getAttribute('id'));
     });
 
     it('clears input on reopen after Escape', async () => {
@@ -929,6 +1003,20 @@ describe('Autocomplete', () => {
 
       // Popover should close and trigger should show Banana
       expect(screen.getByText('Banana').closest('[data-cl-slot="popover-trigger"]')).toBeInTheDocument();
+    });
+
+    it('selects the highlighted item with Enter, closes the popover, and returns focus to the trigger', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      const trigger = screen.getByText('Pick a fruit...');
+      await user.click(trigger);
+      await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+      const updatedTrigger = screen.getByText('Banana');
+      expect(updatedTrigger.closest('[data-cl-slot="popover-trigger"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="autocomplete-option"]')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(updatedTrigger);
     });
 
     it('keeps focus on input during keyboard navigation', async () => {
@@ -1025,6 +1113,41 @@ describe('Autocomplete', () => {
 
       await user.click(screen.getByPlaceholderText('Search fruits...'));
       await user.keyboard('a');
+
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+
+    it('has no violations for the inline listbox inside a popover', async () => {
+      const user = userEvent.setup();
+      render(
+        <Popover defaultOpen>
+          <Popover.Trigger>Pick a fruit...</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Popover.Title>Fruit picker</Popover.Title>
+              <Autocomplete open>
+                <Autocomplete.Input
+                  placeholder='Search...'
+                  autoFocus
+                />
+                <Autocomplete.List>
+                  {fruits.map(f => (
+                    <Autocomplete.Option
+                      key={f.value}
+                      value={f.value}
+                      label={f.label}
+                    >
+                      {f.label}
+                    </Autocomplete.Option>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
 
       expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
     });

--- a/packages/headless/src/primitives/autocomplete/autocomplete.test.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.test.tsx
@@ -1,0 +1,1032 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Popover } from '../popover/popover';
+import { Autocomplete } from './autocomplete';
+
+afterEach(() => cleanup());
+
+const fruits = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+  { value: 'date', label: 'Date' },
+];
+
+function FilteredAutocomplete(
+  props: {
+    onValueChange?: (value: string) => void;
+    onInputValueChange?: (value: string) => void;
+    defaultInputValue?: string;
+  } = {},
+) {
+  const [inputValue, setInputValue] = useState(props.defaultInputValue ?? '');
+  const filtered = fruits.filter(f => f.label.toLowerCase().startsWith(inputValue.toLowerCase()));
+
+  return (
+    <Autocomplete
+      inputValue={inputValue}
+      onInputValueChange={v => {
+        setInputValue(v);
+        props.onInputValueChange?.(v);
+      }}
+      onValueChange={props.onValueChange}
+    >
+      <Autocomplete.Input placeholder='Search fruits...' />
+      <Autocomplete.Positioner>
+        <Autocomplete.Popup>
+          {filtered.map(f => (
+            <Autocomplete.Option
+              key={f.value}
+              value={f.value}
+              label={f.label}
+            >
+              {f.label}
+            </Autocomplete.Option>
+          ))}
+        </Autocomplete.Popup>
+      </Autocomplete.Positioner>
+    </Autocomplete>
+  );
+}
+
+function StaticAutocomplete(props: Partial<React.ComponentProps<typeof Autocomplete>> = {}) {
+  return (
+    <Autocomplete {...props}>
+      <Autocomplete.Input placeholder='Search fruits...' />
+      <Autocomplete.Positioner>
+        <Autocomplete.Popup>
+          {fruits.map(f => (
+            <Autocomplete.Option
+              key={f.value}
+              value={f.value}
+              label={f.label}
+            >
+              {f.label}
+            </Autocomplete.Option>
+          ))}
+        </Autocomplete.Popup>
+      </Autocomplete.Positioner>
+    </Autocomplete>
+  );
+}
+
+describe('Autocomplete', () => {
+  describe('slot attributes', () => {
+    it('renders input with data-cl-slot', () => {
+      render(<StaticAutocomplete />);
+      const input = screen.getByPlaceholderText('Search fruits...');
+      expect(input).toHaveAttribute('data-cl-slot', 'autocomplete-input');
+    });
+
+    it('renders all parts with correct slot attributes when open', () => {
+      render(<StaticAutocomplete defaultOpen />);
+
+      expect(document.querySelector('[data-cl-slot="autocomplete-positioner"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="autocomplete-popup"]')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]')).toHaveLength(4);
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens when user types', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+
+      expect(document.querySelector('[data-cl-slot="autocomplete-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes when input is cleared', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+
+      expect(document.querySelector('[data-cl-slot="autocomplete-popup"]')).toBeInTheDocument();
+
+      await user.clear(input);
+
+      expect(input).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+      await user.keyboard('{Escape}');
+
+      expect(input).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onOpenChange when toggled', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(<StaticAutocomplete onOpenChange={onOpenChange} />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('filtering', () => {
+    it('filters options based on input', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'ch');
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Cherry');
+    });
+
+    it('shows all matching options', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(1); // Only "Apple" starts with "a"
+    });
+  });
+
+  describe('selection', () => {
+    it('selects option on click', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete onValueChange={onValueChange} />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'b');
+      await user.click(screen.getByText('Banana'));
+
+      expect(onValueChange).toHaveBeenCalledWith('banana');
+    });
+
+    it('updates input value to label on selection', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...') as HTMLInputElement;
+      await user.type(input, 'b');
+      await user.click(screen.getByText('Banana'));
+
+      expect(input.value).toBe('Banana');
+    });
+
+    it('closes after selection', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'b');
+      await user.click(screen.getByText('Banana'));
+
+      expect(input).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('returns focus to input after click selection', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'b');
+      await user.click(screen.getByText('Banana'));
+
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('navigates options with arrow keys', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+
+    it('selects option on Enter', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete onValueChange={onValueChange} />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'b');
+      // activeIndex starts at 0 when typing opens the list
+      await user.keyboard('{Enter}');
+
+      expect(onValueChange).toHaveBeenCalledWith('banana');
+    });
+
+    it('updates input value on Enter selection', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...') as HTMLInputElement;
+      await user.type(input, 'b');
+      await user.keyboard('{Enter}');
+
+      expect(input.value).toBe('Banana');
+    });
+
+    it('focus stays on input during arrow navigation', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+      await user.keyboard('{ArrowDown}');
+
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  describe('option state attributes', () => {
+    it('marks active option with data-cl-active', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      await user.type(screen.getByPlaceholderText('Search fruits...'), 'a');
+
+      // First option is active by default (activeIndex starts at 0)
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[0]).toHaveAttribute('data-cl-active', '');
+    });
+
+    it('marks selected option with data-cl-selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <StaticAutocomplete
+          defaultValue='banana'
+          defaultOpen
+        />,
+      );
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[1]).toHaveAttribute('data-cl-selected', '');
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('input has role=combobox', () => {
+      render(<StaticAutocomplete />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('input has aria-autocomplete=list', () => {
+      render(<StaticAutocomplete />);
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    });
+
+    it('options have role=option', () => {
+      render(<StaticAutocomplete defaultOpen />);
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(4);
+    });
+
+    it('active option has aria-selected=true', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      await user.type(screen.getByPlaceholderText('Search fruits...'), 'a');
+
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('positioner is not rendered when closed', () => {
+      render(<StaticAutocomplete />);
+      expect(document.querySelector('[data-cl-slot="autocomplete-positioner"]')).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on popup when open', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      await user.type(screen.getByPlaceholderText('Search fruits...'), 'a');
+
+      const popup = document.querySelector('[data-cl-slot="autocomplete-popup"]');
+      expect(popup).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('positioner has data-cl-side', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      await user.type(screen.getByPlaceholderText('Search fruits...'), 'a');
+
+      const positioner = document.querySelector('[data-cl-slot="autocomplete-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side');
+    });
+  });
+
+  describe('disabled option', () => {
+    it('renders disabled option with data-cl-disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Autocomplete defaultOpen>
+          <Autocomplete.Input placeholder='Search...' />
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.Option
+                value='apple'
+                label='Apple'
+              >
+                Apple
+              </Autocomplete.Option>
+              <Autocomplete.Option
+                value='banana'
+                label='Banana'
+                disabled
+              >
+                Banana
+              </Autocomplete.Option>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete>,
+      );
+
+      const disabledOption = screen.getByText('Banana').closest('[data-cl-slot="autocomplete-option"]');
+      expect(disabledOption).toHaveAttribute('data-cl-disabled', '');
+      expect(disabledOption).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not select disabled option on click', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Autocomplete
+          onValueChange={onValueChange}
+          defaultOpen
+        >
+          <Autocomplete.Input placeholder='Search...' />
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.Option
+                value='apple'
+                label='Apple'
+              >
+                Apple
+              </Autocomplete.Option>
+              <Autocomplete.Option
+                value='banana'
+                label='Banana'
+                disabled
+              >
+                Banana
+              </Autocomplete.Option>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete>,
+      );
+
+      await user.click(screen.getByText('Banana'));
+
+      expect(onValueChange).not.toHaveBeenCalledWith('banana');
+    });
+  });
+
+  describe('Autocomplete.List (inline mode)', () => {
+    function InlineAutocomplete(props: { value?: string; onValueChange?: (value: string) => void } = {}) {
+      const [inputValue, setInputValue] = useState('');
+      const filtered = fruits.filter(f => f.label.toLowerCase().startsWith(inputValue.toLowerCase()));
+
+      return (
+        <Autocomplete
+          open
+          value={props.value}
+          inputValue={inputValue}
+          onInputValueChange={setInputValue}
+          onValueChange={props.onValueChange}
+        >
+          <Autocomplete.Input placeholder='Search fruits...' />
+          <Autocomplete.List data-testid='list'>
+            {filtered.map(f => (
+              <Autocomplete.Option
+                key={f.value}
+                value={f.value}
+                label={f.label}
+              >
+                {f.label}
+              </Autocomplete.Option>
+            ))}
+          </Autocomplete.List>
+        </Autocomplete>
+      );
+    }
+
+    it('renders options with data-cl-slot', () => {
+      render(<InlineAutocomplete />);
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(4);
+    });
+
+    it('renders list with data-cl-slot', () => {
+      render(<InlineAutocomplete />);
+      expect(document.querySelector('[data-cl-slot="autocomplete-list"]')).toBeInTheDocument();
+    });
+
+    it('marks selected option with data-cl-selected via controlled value', () => {
+      render(<InlineAutocomplete value='banana' />);
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[1]).toHaveAttribute('data-cl-selected', '');
+    });
+
+    it('selects option on click', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(<InlineAutocomplete onValueChange={onValueChange} />);
+
+      await user.click(screen.getByText('Banana'));
+
+      expect(onValueChange).toHaveBeenCalledWith('banana');
+    });
+
+    it('navigates options with arrow keys', async () => {
+      const user = userEvent.setup();
+      render(<InlineAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.click(input);
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+
+    it('selects option on Enter after arrow navigation', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(<InlineAutocomplete onValueChange={onValueChange} />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.click(input);
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      expect(onValueChange).toHaveBeenCalled();
+    });
+
+    it('filters options based on input', async () => {
+      const user = userEvent.setup();
+      render(<InlineAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'ch');
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Cherry');
+    });
+
+    it('preserves selected state after unmount and remount', () => {
+      const { unmount } = render(<InlineAutocomplete value='cherry' />);
+
+      let options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[2]).toHaveAttribute('data-cl-selected', '');
+
+      unmount();
+
+      render(<InlineAutocomplete value='cherry' />);
+
+      options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[2]).toHaveAttribute('data-cl-selected', '');
+    });
+
+    it('shows selected state after selecting then remounting', async () => {
+      function TestHarness() {
+        const [mounted, setMounted] = useState(true);
+        const [value, setValue] = useState<string | undefined>();
+
+        return (
+          <>
+            <button
+              type='button'
+              data-testid='toggle'
+              onClick={() => setMounted(m => !m)}
+            />
+            {mounted && (
+              <InlineAutocomplete
+                value={value}
+                onValueChange={setValue}
+              />
+            )}
+          </>
+        );
+      }
+
+      const user = userEvent.setup();
+      render(<TestHarness />);
+
+      // Select banana
+      await user.click(screen.getByText('Banana'));
+
+      // Unmount (simulates popover close)
+      await user.click(screen.getByTestId('toggle'));
+      expect(document.querySelector('[data-cl-slot="autocomplete-option"]')).not.toBeInTheDocument();
+
+      // Remount (simulates popover reopen)
+      await user.click(screen.getByTestId('toggle'));
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options[1]).toHaveAttribute('data-cl-selected', '');
+    });
+  });
+
+  describe('Autocomplete.List inside Popover', () => {
+    function AutocompleteInPopover() {
+      const [popoverOpen, setPopoverOpen] = useState(false);
+      const [selectedValue, setSelectedValue] = useState<string | undefined>();
+      const [inputValue, setInputValue] = useState('');
+      const selectedLabel = fruits.find(f => f.value === selectedValue)?.label;
+      const filtered = fruits.filter(f => f.label.toLowerCase().startsWith(inputValue.toLowerCase()));
+
+      return (
+        <Popover
+          open={popoverOpen}
+          onOpenChange={open => {
+            setPopoverOpen(open);
+            if (open) setInputValue('');
+          }}
+        >
+          <Popover.Trigger>{selectedLabel || 'Pick a fruit...'}</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Autocomplete
+                open={popoverOpen}
+                value={selectedValue}
+                inputValue={inputValue}
+                onInputValueChange={setInputValue}
+                onOpenChange={open => {
+                  if (!open) setPopoverOpen(false);
+                }}
+                onValueChange={value => {
+                  setSelectedValue(value);
+                  setPopoverOpen(false);
+                }}
+              >
+                <Autocomplete.Input
+                  placeholder='Search...'
+                  autoFocus
+                />
+                <Autocomplete.List>
+                  {filtered.map(f => (
+                    <Autocomplete.Option
+                      key={f.value}
+                      value={f.value}
+                      label={f.label}
+                    >
+                      {f.label}
+                    </Autocomplete.Option>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('renders options when popover is open', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(4);
+    });
+
+    it('navigates options with arrow keys inside popover', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      // Verify options rendered and input has focus
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options.length).toBeGreaterThan(0);
+
+      const input = screen.getByPlaceholderText('Search...');
+      expect(document.activeElement).toBe(input);
+
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+
+    it('selects option on click and updates trigger', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Banana'));
+
+      expect(screen.getByText('Banana')).toBeInTheDocument();
+      expect(screen.getByText('Banana').closest('[data-cl-slot="popover-trigger"]')).toBeInTheDocument();
+    });
+
+    it('shows data-cl-selected on previously selected option after reopen', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      // Open and select
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Cherry'));
+
+      // Reopen
+      await user.click(screen.getByText('Cherry'));
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      const cherryOption = Array.from(options).find(o => o.textContent === 'Cherry');
+      expect(cherryOption).toHaveAttribute('data-cl-selected', '');
+    });
+
+    it('selects option with Enter after arrow navigation inside popover', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopover />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      // Should have selected the first option
+      expect(screen.getByText('Apple').closest('[data-cl-slot="popover-trigger"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('scrolling', () => {
+    const manyFruits = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana' },
+      { value: 'cherry', label: 'Cherry' },
+      { value: 'date', label: 'Date' },
+      { value: 'elderberry', label: 'Elderberry' },
+      { value: 'fig', label: 'Fig' },
+      { value: 'grape', label: 'Grape' },
+      { value: 'honeydew', label: 'Honeydew' },
+    ];
+
+    function ScrollableAutocomplete({ defaultValue }: { defaultValue?: string }) {
+      const [popoverOpen, setPopoverOpen] = useState(false);
+      const [selectedValue, setSelectedValue] = useState<string | undefined>(defaultValue);
+      const [inputValue, setInputValue] = useState('');
+      const selectedLabel = manyFruits.find(f => f.value === selectedValue)?.label;
+      const filtered = manyFruits.filter(f => f.label.toLowerCase().startsWith(inputValue.toLowerCase()));
+
+      return (
+        <Popover
+          open={popoverOpen}
+          onOpenChange={open => {
+            setPopoverOpen(open);
+            if (open) setInputValue('');
+          }}
+        >
+          <Popover.Trigger>{selectedLabel || 'Pick a fruit...'}</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Autocomplete
+                open={popoverOpen}
+                value={selectedValue}
+                inputValue={inputValue}
+                onInputValueChange={setInputValue}
+                onValueChange={value => {
+                  setSelectedValue(value);
+                  setPopoverOpen(false);
+                }}
+              >
+                <Autocomplete.Input
+                  placeholder='Search...'
+                  autoFocus
+                />
+                <Autocomplete.List style={{ maxHeight: 80, overflowY: 'auto' }}>
+                  {filtered.map(f => (
+                    <Autocomplete.Option
+                      key={f.value}
+                      value={f.value}
+                      label={f.label}
+                    >
+                      {f.label}
+                    </Autocomplete.Option>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('sets active index on arrow key navigation', async () => {
+      const user = userEvent.setup();
+      render(<ScrollableAutocomplete />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+
+    it('selected item has data-cl-active on reopen', async () => {
+      const user = userEvent.setup();
+      render(<ScrollableAutocomplete />);
+
+      // Open and select "Grape" (6th item)
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Grape'));
+
+      // Reopen — trigger now shows "Grape"
+      await user.click(screen.getByText('Grape').closest('[data-cl-slot="popover-trigger"]')!);
+
+      // The selected option should be active
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      const grapeOption = Array.from(options).find(o => o.textContent === 'Grape');
+      expect(grapeOption).toHaveAttribute('data-cl-active', '');
+    });
+
+    it('selected item is active on open when defaultValue is set', async () => {
+      const user = userEvent.setup();
+      render(<ScrollableAutocomplete defaultValue='grape' />);
+
+      await user.click(screen.getByText('Grape'));
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      const grapeOption = Array.from(options).find(o => o.textContent === 'Grape');
+      expect(grapeOption).toHaveAttribute('data-cl-active', '');
+    });
+  });
+
+  describe('Autocomplete.List inside Popover — edge cases', () => {
+    function AutocompleteInPopoverFull() {
+      const [popoverOpen, setPopoverOpen] = useState(false);
+      const [selectedValue, setSelectedValue] = useState<string | undefined>();
+      const [inputValue, setInputValue] = useState('');
+      const selectedLabel = fruits.find(f => f.value === selectedValue)?.label;
+      const filtered = fruits.filter(f => f.label.toLowerCase().startsWith(inputValue.toLowerCase()));
+
+      return (
+        <Popover
+          open={popoverOpen}
+          onOpenChange={open => {
+            setPopoverOpen(open);
+            if (open) setInputValue('');
+          }}
+        >
+          <Popover.Trigger>{selectedLabel || 'Pick a fruit...'}</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Autocomplete
+                open={popoverOpen}
+                value={selectedValue}
+                inputValue={inputValue}
+                onInputValueChange={setInputValue}
+                onOpenChange={open => {
+                  if (!open) setPopoverOpen(false);
+                }}
+                onValueChange={value => {
+                  setSelectedValue(value);
+                  setPopoverOpen(false);
+                }}
+              >
+                <Autocomplete.Input
+                  placeholder='Search...'
+                  autoFocus
+                />
+                <Autocomplete.List>
+                  {filtered.map(f => (
+                    <Autocomplete.Option
+                      key={f.value}
+                      value={f.value}
+                      label={f.label}
+                    >
+                      {f.label}
+                    </Autocomplete.Option>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('closes popover on Escape key', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]').length).toBeGreaterThan(0);
+
+      await user.keyboard('{Escape}');
+
+      // Popover should close — no options visible
+      expect(document.querySelector('[data-cl-slot="autocomplete-option"]')).not.toBeInTheDocument();
+    });
+
+    it('clears input on reopen after Escape', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      const input = screen.getByPlaceholderText('Search...');
+      await user.type(input, 'ch');
+
+      // Should be filtered to Cherry only
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]')).toHaveLength(1);
+
+      await user.keyboard('{Escape}');
+
+      // Reopen
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      // Input should be cleared, all options visible
+      const newInput = screen.getByPlaceholderText('Search...');
+      expect((newInput as HTMLInputElement).value).toBe('');
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]')).toHaveLength(4);
+    });
+
+    it('navigates all options with repeated ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      await user.keyboard('{ArrowDown}');
+      let active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Apple');
+
+      await user.keyboard('{ArrowDown}');
+      active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Banana');
+
+      await user.keyboard('{ArrowDown}');
+      active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Cherry');
+
+      await user.keyboard('{ArrowDown}');
+      active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Date');
+    });
+
+    it('loops navigation with ArrowDown past last option', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      // Navigate past all 4 options to loop back
+      await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}');
+      const active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Apple');
+    });
+
+    it('navigates with ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      // ArrowUp from no active item should go to last item (loop)
+      await user.keyboard('{ArrowUp}');
+      const active = document.querySelector('[data-cl-slot="autocomplete-option"][data-cl-active]');
+      expect(active).toHaveTextContent('Date');
+    });
+
+    it('selects with Enter after filtering and navigating', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      const input = screen.getByPlaceholderText('Search...');
+      await user.type(input, 'b');
+
+      // Only Banana should be shown, activeIndex should be 0
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]')).toHaveLength(1);
+
+      await user.keyboard('{Enter}');
+
+      // Popover should close and trigger should show Banana
+      expect(screen.getByText('Banana').closest('[data-cl-slot="popover-trigger"]')).toBeInTheDocument();
+    });
+
+    it('keeps focus on input during keyboard navigation', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      const input = screen.getByPlaceholderText('Search...');
+
+      await user.keyboard('{ArrowDown}{ArrowDown}');
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('can type to filter after arrow navigation', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+
+      // Navigate first
+      await user.keyboard('{ArrowDown}{ArrowDown}');
+
+      // Then type to filter
+      const input = screen.getByPlaceholderText('Search...');
+      await user.type(input, 'd');
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Date');
+    });
+
+    it('reopen after selection shows all options with empty input', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      // Select Cherry
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Cherry'));
+
+      // Reopen
+      await user.click(screen.getByText('Cherry'));
+
+      // Input should be empty, all options should show
+      const input = screen.getByPlaceholderText('Search...');
+      expect((input as HTMLInputElement).value).toBe('');
+      expect(document.querySelectorAll('[data-cl-slot="autocomplete-option"]')).toHaveLength(4);
+    });
+
+    it('selected option retains data-cl-selected on reopen', async () => {
+      const user = userEvent.setup();
+      render(<AutocompleteInPopoverFull />);
+
+      await user.click(screen.getByText('Pick a fruit...'));
+      await user.click(screen.getByText('Banana'));
+
+      // Reopen
+      await user.click(screen.getByText('Banana'));
+
+      const options = document.querySelectorAll('[data-cl-slot="autocomplete-option"]');
+      const bananaOption = Array.from(options).find(o => o.textContent === 'Banana');
+      expect(bananaOption).toHaveAttribute('data-cl-selected', '');
+    });
+  });
+
+  describe('input state attributes', () => {
+    it('input has data-cl-open when list is visible', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      await user.type(input, 'a');
+
+      expect(input).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('input has data-cl-closed when list is hidden', () => {
+      render(<FilteredAutocomplete />);
+
+      const input = screen.getByPlaceholderText('Search fruits...');
+      expect(input).toHaveAttribute('data-cl-closed', '');
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = render(<FilteredAutocomplete />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      const user = userEvent.setup();
+      render(<FilteredAutocomplete />);
+
+      await user.click(screen.getByPlaceholderText('Search fruits...'));
+      await user.keyboard('a');
+
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/autocomplete/autocomplete.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.tsx
@@ -165,7 +165,10 @@ function AutocompleteInner(props: AutocompleteProps) {
       flip({ padding: 5 }),
       size({
         apply({ rects, availableHeight, elements }) {
-          // Skip in List mode — only apply auto-sizing in Positioner mode
+          // Autocomplete supports two floating targets: Positioner (portal mode)
+          // and List (inline mode). Both call refs.setFloating, but only
+          // Positioner should be auto-sized. Skip when the floating element is
+          // the inline List.
           if (elements.floating.getAttribute('data-cl-slot') !== 'autocomplete-positioner') return;
           Object.assign(elements.floating.style, {
             width: `${rects.reference.width}px`,

--- a/packages/headless/src/primitives/autocomplete/autocomplete.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.tsx
@@ -1,0 +1,566 @@
+'use client';
+
+import {
+  arrow,
+  autoUpdate,
+  type ExtendedRefs,
+  FloatingArrow,
+  type FloatingContext,
+  FloatingFocusManager,
+  FloatingList,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  flip,
+  offset,
+  type Placement,
+  type ReferenceType,
+  size,
+  type UseInteractionsReturn,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useInteractions,
+  useListItem,
+  useListNavigation,
+  useRole,
+} from '@floating-ui/react';
+import {
+  type CSSProperties,
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface AutocompleteContextValue {
+  open: boolean;
+  inputValue: string;
+  selectedValue: string | undefined;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  getItemProps: UseInteractionsReturn['getItemProps'];
+  activeIndex: number | null;
+  selectedIndex: number | null;
+  elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  labelsRef: React.MutableRefObject<Array<string | null>>;
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  arrowRef: React.MutableRefObject<SVGSVGElement | null>;
+  valuesByIndexRef: React.MutableRefObject<Map<number, string>>;
+  handleSelect: (value: string, index: number, label: string) => void;
+  handleInputChange: (value: string) => void;
+  registerSelectedIndex: (index: number, value: string) => void;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+}
+
+const AutocompleteContext = createContext<AutocompleteContextValue | null>(null);
+
+function useAutocompleteContext() {
+  const ctx = useContext(AutocompleteContext);
+  if (!ctx) {
+    throw new Error('Autocomplete compound components must be used within <Autocomplete>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete (root)
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteProps {
+  /** Controlled input text. */
+  inputValue?: string;
+  defaultInputValue?: string;
+  onInputValueChange?: (value: string) => void;
+  /** Controlled selected value. */
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placement?: Placement;
+  sideOffset?: number;
+  children: ReactNode;
+}
+
+function AutocompleteInner(props: AutocompleteProps) {
+  const { placement: placementProp = 'bottom-start', sideOffset = 4, children } = props;
+
+  const nodeId = useFloatingNodeId();
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const [inputValue, setInputValue] = useControllableState(
+    props.inputValue,
+    props.defaultInputValue ?? '',
+    props.onInputValueChange,
+  );
+
+  const [selectedValue, setSelectedValue] = useControllableState<string | undefined>(
+    props.value,
+    props.defaultValue,
+    props.onValueChange as ((value: string | undefined) => void) | undefined,
+  );
+
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const elementsRef = useRef<Array<HTMLElement | null>>([]);
+  const labelsRef = useRef<Array<string | null>>([]);
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+  const valuesByIndexRef = useRef<Map<number, string>>(new Map());
+  const registerSelectedIndex = useCallback(
+    (index: number, value: string) => {
+      if (value === selectedValue) {
+        setSelectedIndex(index);
+      }
+    },
+    [selectedValue],
+  );
+
+  // When open transitions to true, sync activeIndex to selectedIndex.
+  // Supplements useListNavigation's built-in sync for timing edge cases.
+  const previousOpenRef = useRef(open);
+  useEffect(() => {
+    if (open && !previousOpenRef.current && selectedIndex != null) {
+      setActiveIndex(selectedIndex);
+    }
+    previousOpenRef.current = open;
+  }, [open, selectedIndex]);
+
+  const {
+    refs,
+    floatingStyles,
+    context: floatingContext,
+    placement,
+  } = useFloating<HTMLInputElement>({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: placementProp,
+    middleware: [
+      offset(sideOffset),
+      flip({ padding: 5 }),
+      size({
+        apply({ rects, availableHeight, elements }) {
+          // Skip in List mode — only apply auto-sizing in Positioner mode
+          if (elements.floating.getAttribute('data-cl-slot') !== 'autocomplete-positioner') return;
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+        padding: 5,
+      }),
+      arrow({ element: arrowRef }),
+      floatingCssVars({ sideOffset }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const dismiss = useDismiss(floatingContext);
+  const role = useRole(floatingContext, { role: 'listbox' });
+  const listNav = useListNavigation(floatingContext, {
+    listRef: elementsRef,
+    activeIndex,
+    selectedIndex,
+    onNavigate: setActiveIndex,
+    virtual: true,
+    loop: true,
+    scrollItemIntoView: true,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([dismiss, role, listNav]);
+
+  const handleSelect = useCallback(
+    (value: string, index: number, label: string) => {
+      setSelectedValue(value);
+      setSelectedIndex(index);
+      setInputValue(label);
+      setActiveIndex(null);
+      setOpen(false);
+    },
+    [setSelectedValue, setInputValue, setOpen],
+  );
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInputValue(value);
+      if (value) {
+        setOpen(true);
+        setActiveIndex(0);
+      } else {
+        setOpen(false);
+        setActiveIndex(null);
+      }
+    },
+    [setInputValue, setOpen],
+  );
+
+  const contextValue = useMemo<AutocompleteContextValue>(
+    () => ({
+      open,
+      inputValue,
+      selectedValue,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      selectedIndex,
+      elementsRef,
+      labelsRef,
+      popupRef,
+      arrowRef,
+      valuesByIndexRef,
+      handleSelect,
+      handleInputChange,
+      registerSelectedIndex,
+      mounted,
+      transitionProps,
+    }),
+    [
+      open,
+      inputValue,
+      selectedValue,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      selectedIndex,
+      handleSelect,
+      handleInputChange,
+      registerSelectedIndex,
+      mounted,
+      transitionProps,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <AutocompleteContext.Provider value={contextValue}>{children}</AutocompleteContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function AutocompleteRoot(props: AutocompleteProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <AutocompleteInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <AutocompleteInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Input
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteInputProps extends ComponentProps<'input'> {}
+
+function AutocompleteInput(props: AutocompleteInputProps) {
+  const { render, ...otherProps } = props;
+  const {
+    open,
+    inputValue,
+    activeIndex,
+    refs,
+    getReferenceProps,
+    handleInputChange,
+    handleSelect,
+    labelsRef,
+    valuesByIndexRef,
+  } = useAutocompleteContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    'data-cl-slot': 'autocomplete-input',
+    ...(getReferenceProps({
+      ref: refs.setReference,
+      value: inputValue,
+      'aria-autocomplete': 'list' as const,
+      onChange(event: React.ChangeEvent<HTMLInputElement>) {
+        handleInputChange(event.target.value);
+      },
+      onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+        if (event.key === 'Enter' && activeIndex != null) {
+          const value = valuesByIndexRef.current.get(activeIndex);
+          const label = labelsRef.current[activeIndex];
+          if (value != null) {
+            event.preventDefault();
+            handleSelect(value, activeIndex, label ?? value);
+          }
+        }
+      },
+    }) as React.ComponentPropsWithRef<'input'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'input',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'input'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Portal
+// ---------------------------------------------------------------------------
+
+export interface AutocompletePortalProps {
+  children: ReactNode;
+}
+
+function AutocompletePortal(props: AutocompletePortalProps) {
+  const { mounted } = useAutocompleteContext();
+  if (!mounted) return null;
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Positioner
+// ---------------------------------------------------------------------------
+
+export interface AutocompletePositionerProps extends ComponentProps<'div'> {}
+
+function AutocompletePositioner(props: AutocompletePositionerProps) {
+  const { render, ...otherProps } = props;
+  const { mounted, floatingContext, refs, floatingStyles, placement, getFloatingProps, elementsRef, labelsRef } =
+    useAutocompleteContext();
+
+  const side = placement.split('-')[0];
+
+  const defaultProps = {
+    'data-cl-slot': 'autocomplete-positioner',
+    'data-cl-side': side,
+    ref: refs.setFloating,
+    style: floatingStyles,
+    ...(getFloatingProps() as React.ComponentPropsWithRef<'div'>),
+  };
+
+  return (
+    <FloatingFocusManager
+      context={floatingContext}
+      initialFocus={-1}
+      visuallyHiddenDismiss
+      modal={false}
+    >
+      <FloatingList
+        elementsRef={elementsRef}
+        labelsRef={labelsRef}
+      >
+        {renderElement({
+          defaultTagName: 'div',
+          render,
+          enabled: mounted,
+          props: mergeProps<'div'>(defaultProps, otherProps),
+        })}
+      </FloatingList>
+    </FloatingFocusManager>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Popup
+// ---------------------------------------------------------------------------
+
+export interface AutocompletePopupProps extends ComponentProps<'div'> {}
+
+function AutocompletePopup(props: AutocompletePopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, transitionProps } = useAutocompleteContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'autocomplete-popup',
+    ref: popupRef,
+    ...transitionProps,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Option
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteOptionProps extends ComponentProps<'div'> {
+  value: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+function AutocompleteOption(props: AutocompleteOptionProps) {
+  const { render, value, label, disabled, ...otherProps } = props;
+  const { activeIndex, selectedValue, getItemProps, handleSelect, valuesByIndexRef, registerSelectedIndex, refs } =
+    useAutocompleteContext();
+
+  const id = useId();
+  const displayLabel = label ?? value;
+  const { ref: itemRef, index } = useListItem({ label: displayLabel });
+
+  const isSelected = selectedValue === value;
+  const isActive = activeIndex === index;
+
+  // Register value for index-based lookup (used by Enter key on input)
+  useEffect(() => {
+    valuesByIndexRef.current.set(index, value);
+    registerSelectedIndex(index, value);
+    return () => {
+      valuesByIndexRef.current.delete(index);
+    };
+  }, [index, value, valuesByIndexRef, registerSelectedIndex]);
+
+  const state = {
+    selected: isSelected,
+    active: isActive,
+    disabled: !!disabled,
+  };
+
+  const defaultProps = {
+    'data-cl-slot': 'autocomplete-option',
+    id,
+    ref: itemRef,
+    role: 'option' as const,
+    'aria-selected': isActive,
+    'aria-disabled': disabled || undefined,
+    ...(getItemProps({
+      onClick() {
+        if (!disabled) {
+          handleSelect(value, index, displayLabel);
+          (refs.domReference.current as HTMLElement | null)?.focus();
+        }
+      },
+    }) as React.ComponentPropsWithRef<'div'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    state,
+    stateAttributesMapping: {
+      selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+      active: (v: boolean) => (v ? { 'data-cl-active': '' } : null),
+      disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+    },
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.Arrow
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteArrowProps extends React.ComponentPropsWithRef<typeof FloatingArrow> {}
+
+function AutocompleteArrowComponent(props: AutocompleteArrowProps) {
+  const { floatingContext, arrowRef, placement } = useAutocompleteContext();
+  const side = placement.split('-')[0];
+
+  return (
+    <FloatingArrow
+      data-cl-slot='autocomplete-arrow'
+      data-cl-side={side}
+      {...props}
+      ref={arrowRef}
+      context={floatingContext}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete.List
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteListProps extends ComponentProps<'div'> {}
+
+/**
+ * Inline list wrapper that provides FloatingList context without portal or
+ * positioning. Use this instead of Positioner + Popup when the Autocomplete
+ * is rendered inside another floating element (e.g. a Popover).
+ */
+function AutocompleteList(props: AutocompleteListProps) {
+  const { render, ...otherProps } = props;
+  const { elementsRef, labelsRef, refs } = useAutocompleteContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'autocomplete-list',
+    role: 'listbox' as const,
+    ref: refs.setFloating,
+  };
+
+  return (
+    <FloatingList
+      elementsRef={elementsRef}
+      labelsRef={labelsRef}
+    >
+      {
+        renderElement({
+          defaultTagName: 'div',
+          render,
+          props: mergeProps<'div'>(defaultProps, otherProps),
+        })!
+      }
+    </FloatingList>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Autocomplete = Object.assign(AutocompleteRoot, {
+  Input: AutocompleteInput,
+  Portal: AutocompletePortal,
+  Positioner: AutocompletePositioner,
+  Popup: AutocompletePopup,
+  List: AutocompleteList,
+  Option: AutocompleteOption,
+  Arrow: AutocompleteArrowComponent,
+});

--- a/packages/headless/src/primitives/autocomplete/autocomplete.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.tsx
@@ -40,8 +40,8 @@ import {
 } from 'react';
 
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
-import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
+import { cssVars } from '../../utils/css-vars';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -180,12 +180,12 @@ function AutocompleteInner(props: AutocompleteProps) {
         padding: 5,
       }),
       arrow({ element: arrowRef }),
-      floatingCssVars({ sideOffset }),
+      cssVars({ sideOffset }),
     ],
     whileElementsMounted: autoUpdate,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -365,12 +365,13 @@ function AutocompleteInput(props: AutocompleteInputProps) {
 
 export interface AutocompletePortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function AutocompletePortal(props: AutocompletePortalProps) {
   const { mounted } = useAutocompleteContext();
   if (!mounted) return null;
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return <FloatingPortal root={props.root}>{props.children}</FloatingPortal>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/headless/src/primitives/autocomplete/autocomplete.tsx
+++ b/packages/headless/src/primitives/autocomplete/autocomplete.tsx
@@ -66,6 +66,7 @@ interface AutocompleteContextValue {
   popupRef: React.RefObject<HTMLDivElement | null>;
   arrowRef: React.MutableRefObject<SVGSVGElement | null>;
   valuesByIndexRef: React.MutableRefObject<Map<number, string>>;
+  setInlineMode: React.Dispatch<React.SetStateAction<boolean>>;
   handleSelect: (value: string, index: number, label: string) => void;
   handleInputChange: (value: string) => void;
   registerSelectedIndex: (index: number, value: string) => void;
@@ -125,6 +126,7 @@ function AutocompleteInner(props: AutocompleteProps) {
 
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [inlineMode, setInlineMode] = useState(false);
 
   const elementsRef = useRef<Array<HTMLElement | null>>([]);
   const labelsRef = useRef<Array<string | null>>([]);
@@ -188,7 +190,14 @@ function AutocompleteInner(props: AutocompleteProps) {
     ref: popupRef,
   });
 
-  const dismiss = useDismiss(floatingContext);
+  const dismiss = useDismiss(floatingContext, {
+    escapeKey: !inlineMode,
+    outsidePress: !inlineMode,
+    bubbles: {
+      escapeKey: inlineMode,
+      outsidePress: inlineMode,
+    },
+  });
   const role = useRole(floatingContext, { role: 'listbox' });
   const listNav = useListNavigation(floatingContext, {
     listRef: elementsRef,
@@ -246,6 +255,7 @@ function AutocompleteInner(props: AutocompleteProps) {
       popupRef,
       arrowRef,
       valuesByIndexRef,
+      setInlineMode,
       handleSelect,
       handleInputChange,
       registerSelectedIndex,
@@ -530,12 +540,17 @@ export interface AutocompleteListProps extends ComponentProps<'div'> {}
  */
 function AutocompleteList(props: AutocompleteListProps) {
   const { render, ...otherProps } = props;
-  const { elementsRef, labelsRef, refs } = useAutocompleteContext();
+  const { elementsRef, labelsRef, refs, getFloatingProps, setInlineMode } = useAutocompleteContext();
+
+  useEffect(() => {
+    setInlineMode(true);
+    return () => setInlineMode(false);
+  }, [setInlineMode]);
 
   const defaultProps = {
     'data-cl-slot': 'autocomplete-list',
-    role: 'listbox' as const,
     ref: refs.setFloating,
+    ...(getFloatingProps() as React.ComponentPropsWithRef<'div'>),
   };
 
   return (

--- a/packages/headless/src/primitives/autocomplete/index.ts
+++ b/packages/headless/src/primitives/autocomplete/index.ts
@@ -1,0 +1,11 @@
+export type {
+  AutocompleteArrowProps,
+  AutocompleteInputProps,
+  AutocompleteListProps,
+  AutocompleteOptionProps,
+  AutocompletePopupProps,
+  AutocompletePortalProps,
+  AutocompletePositionerProps,
+  AutocompleteProps,
+} from './autocomplete';
+export { Autocomplete } from './autocomplete';

--- a/packages/headless/src/primitives/dialog/README.md
+++ b/packages/headless/src/primitives/dialog/README.md
@@ -1,0 +1,104 @@
+# Dialog
+
+A modal or non-modal dialog overlay. Handles focus trapping, scroll locking, ARIA labeling, and enter/exit animations.
+
+## When to Use
+
+- Confirmations, alerts, forms, or any content that requires user attention before continuing.
+- When you need focus trapping and scroll lock (modal behavior).
+- Prefer Dialog over Popover when the content is not anchored to a trigger element and should appear centered/overlaid.
+
+## Usage
+
+```tsx
+import { Dialog } from '@/primitives/dialog';
+
+<Dialog>
+  <Dialog.Trigger>Open Dialog</Dialog.Trigger>
+  <Dialog.Backdrop>
+    <Dialog.Popup>
+      <Dialog.Title>Confirm Action</Dialog.Title>
+      <Dialog.Description>Are you sure you want to proceed?</Dialog.Description>
+      <Dialog.Close>Cancel</Dialog.Close>
+    </Dialog.Popup>
+  </Dialog.Backdrop>
+</Dialog>;
+```
+
+### Controlled
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Dialog
+  open={open}
+  onOpenChange={setOpen}
+>
+  {/* ... */}
+</Dialog>;
+```
+
+### Non-modal
+
+```tsx
+<Dialog modal={false}>{/* Focus is not trapped, page remains interactive */}</Dialog>
+```
+
+## Parts
+
+| Part                 | Default Element | Description                                     |
+| -------------------- | --------------- | ----------------------------------------------- |
+| `Dialog`             | —               | Root context provider                           |
+| `Dialog.Trigger`     | `<button>`      | Opens/closes the dialog on click                |
+| `Dialog.Backdrop`    | `<div>`         | Overlay + portal + focus manager host           |
+| `Dialog.Popup`       | `<div>`         | The dialog content container                    |
+| `Dialog.Title`       | `<h2>`          | Dialog heading, wired to `aria-labelledby`      |
+| `Dialog.Description` | `<p>`           | Dialog description, wired to `aria-describedby` |
+| `Dialog.Close`       | `<button>`      | Closes the dialog on click                      |
+
+## Props
+
+### `Dialog` (root)
+
+| Prop           | Type                      | Default | Description                             |
+| -------------- | ------------------------- | ------- | --------------------------------------- |
+| `open`         | `boolean`                 | —       | Controlled open state                   |
+| `defaultOpen`  | `boolean`                 | `false` | Initial open state (uncontrolled)       |
+| `onOpenChange` | `(open: boolean) => void` | —       | Called when open state changes          |
+| `modal`        | `boolean`                 | `true`  | Traps focus and blocks page interaction |
+
+### `Dialog.Backdrop`
+
+| Prop         | Type      | Default | Description                     |
+| ------------ | --------- | ------- | ------------------------------- |
+| `lockScroll` | `boolean` | `true`  | Prevents body scroll while open |
+
+### `Dialog.Trigger`, `Dialog.Popup`, `Dialog.Title`, `Dialog.Description`, `Dialog.Close`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+## Keyboard
+
+| Key      | Action                                      |
+| -------- | ------------------------------------------- |
+| `Escape` | Closes the dialog                           |
+| `Tab`    | Cycles focus within the dialog (modal mode) |
+
+## Data Attributes
+
+| Attribute                         | Applies To        | Description                             |
+| --------------------------------- | ----------------- | --------------------------------------- |
+| `data-cl-slot`                    | All parts         | Part identifier (e.g. `"dialog-popup"`) |
+| `data-cl-open` / `data-cl-closed` | Trigger, Backdrop | Open state                              |
+
+## Important Notes
+
+- **`Dialog.Popup` must be a child of `Dialog.Backdrop`.** The backdrop hosts the portal, overlay, and focus manager — the popup alone does not handle these.
+- **Title and Description are optional but recommended.** If omitted, `aria-labelledby` / `aria-describedby` are simply absent from the popup.
+- **Nested dialogs are supported.** The `FloatingTree` pattern handles nesting automatically.
+- **No positioning middleware.** Dialogs are centered via CSS, not Floating UI positioning.
+
+## ARIA
+
+- Popup: `role="dialog"`, `aria-labelledby` (from Title), `aria-describedby` (from Description)
+- Trigger: `aria-expanded`, `aria-haspopup="dialog"`, `aria-controls`

--- a/packages/headless/src/primitives/dialog/README.md
+++ b/packages/headless/src/primitives/dialog/README.md
@@ -50,7 +50,8 @@ const [open, setOpen] = useState(false);
 | -------------------- | --------------- | ----------------------------------------------- |
 | `Dialog`             | —               | Root context provider                           |
 | `Dialog.Trigger`     | `<button>`      | Opens/closes the dialog on click                |
-| `Dialog.Backdrop`    | `<div>`         | Overlay + portal + focus manager host           |
+| `Dialog.Portal`      | —               | Portals children (defaults to `document.body`)  |
+| `Dialog.Backdrop`    | `<div>`         | Overlay + focus manager host                    |
 | `Dialog.Popup`       | `<div>`         | The dialog content container                    |
 | `Dialog.Title`       | `<h2>`          | Dialog heading, wired to `aria-labelledby`      |
 | `Dialog.Description` | `<p>`           | Dialog description, wired to `aria-describedby` |
@@ -67,11 +68,19 @@ const [open, setOpen] = useState(false);
 | `onOpenChange` | `(open: boolean) => void` | —       | Called when open state changes          |
 | `modal`        | `boolean`                 | `true`  | Traps focus and blocks page interaction |
 
+### `Dialog.Portal`
+
+| Prop   | Type                                                          | Default         | Description                      |
+| ------ | ------------------------------------------------------------- | --------------- | -------------------------------- |
+| `root` | `HTMLElement \| null \| React.RefObject<HTMLElement \| null>` | `document.body` | Container element to portal into |
+
+When `root` is provided, the dialog is "scoped" to that container: `Dialog.Backdrop` skips `FloatingOverlay` (no fixed positioning or scroll lock), and consumers handle positioning via CSS on the container.
+
 ### `Dialog.Backdrop`
 
-| Prop         | Type      | Default | Description                     |
-| ------------ | --------- | ------- | ------------------------------- |
-| `lockScroll` | `boolean` | `true`  | Prevents body scroll while open |
+| Prop         | Type      | Default | Description                                           |
+| ------------ | --------- | ------- | ----------------------------------------------------- |
+| `lockScroll` | `boolean` | `true`  | Prevents body scroll while open (skipped when scoped) |
 
 ### `Dialog.Trigger`, `Dialog.Popup`, `Dialog.Title`, `Dialog.Description`, `Dialog.Close`
 

--- a/packages/headless/src/primitives/dialog/dialog.test.tsx
+++ b/packages/headless/src/primitives/dialog/dialog.test.tsx
@@ -1,0 +1,260 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Dialog } from './dialog';
+
+afterEach(() => cleanup());
+
+function renderDialog(props: Partial<React.ComponentProps<typeof Dialog>> = {}) {
+  return render(
+    <Dialog {...props}>
+      <Dialog.Trigger>Open dialog</Dialog.Trigger>
+      <Dialog.Backdrop>
+        <Dialog.Popup>
+          <Dialog.Title>Dialog Title</Dialog.Title>
+          <Dialog.Description>Some dialog description</Dialog.Description>
+          <p>Dialog body content</p>
+          <Dialog.Close>Close</Dialog.Close>
+        </Dialog.Popup>
+      </Dialog.Backdrop>
+    </Dialog>,
+  );
+}
+
+describe('Dialog', () => {
+  describe('slot attributes', () => {
+    it('renders trigger with data-cl-slot', () => {
+      renderDialog();
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      expect(trigger).toHaveAttribute('data-cl-slot', 'dialog-trigger');
+    });
+
+    it('renders all parts with correct slot attributes when open', () => {
+      renderDialog({ defaultOpen: true });
+
+      expect(document.querySelector('[data-cl-slot="dialog-backdrop"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="dialog-popup"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="dialog-title"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="dialog-description"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="dialog-close"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens on trigger click', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('data-cl-open', '');
+      expect(document.querySelector('[data-cl-slot="dialog-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      renderDialog({ defaultOpen: true });
+
+      await user.keyboard('{Escape}');
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes via Close button', async () => {
+      const user = userEvent.setup();
+      renderDialog({ defaultOpen: true });
+
+      const closeBtn = screen.getByRole('button', { name: 'Close' });
+      await user.click(closeBtn);
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onOpenChange when toggled', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      renderDialog({ onOpenChange });
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      await user.click(trigger);
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('controlled open', () => {
+    it('respects controlled open prop', () => {
+      renderDialog({ open: true });
+
+      expect(document.querySelector('[data-cl-slot="dialog-popup"]')).toBeInTheDocument();
+    });
+
+    it('does not open when controlled open is false', async () => {
+      const user = userEvent.setup();
+      renderDialog({ open: false });
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(document.querySelector('[data-cl-slot="dialog-popup"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('popup has aria-labelledby linked to title', () => {
+      renderDialog({ defaultOpen: true });
+
+      const title = document.querySelector('[data-cl-slot="dialog-title"]');
+      const popup = document.querySelector('[data-cl-slot="dialog-popup"]');
+
+      expect(title).toHaveAttribute('id');
+      expect(popup).toHaveAttribute('aria-labelledby', title?.getAttribute('id'));
+    });
+
+    it('popup has aria-describedby linked to description', () => {
+      renderDialog({ defaultOpen: true });
+
+      const desc = document.querySelector('[data-cl-slot="dialog-description"]');
+      const popup = document.querySelector('[data-cl-slot="dialog-popup"]');
+
+      expect(desc).toHaveAttribute('id');
+      expect(popup).toHaveAttribute('aria-describedby', desc?.getAttribute('id'));
+    });
+
+    it('popup has role=dialog', () => {
+      renderDialog({ defaultOpen: true });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('backdrop is not rendered when closed', () => {
+      renderDialog();
+      expect(document.querySelector('[data-cl-slot="dialog-backdrop"]')).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on popup when open', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      const popup = document.querySelector('[data-cl-slot="dialog-popup"]');
+      expect(popup).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('applies data-cl-open on backdrop when open', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      const backdrop = document.querySelector('[data-cl-slot="dialog-backdrop"]');
+      expect(backdrop).toHaveAttribute('data-cl-open', '');
+    });
+  });
+
+  describe('content rendering', () => {
+    it('renders children content when open', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(screen.getByText('Dialog body content')).toBeInTheDocument();
+      expect(screen.getByText('Dialog Title')).toBeInTheDocument();
+      expect(screen.getByText('Some dialog description')).toBeInTheDocument();
+    });
+
+    it('does not render content when closed', () => {
+      renderDialog();
+      expect(screen.queryByText('Dialog body content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('trigger state attributes', () => {
+    it('trigger has data-cl-closed when dialog is hidden', () => {
+      renderDialog();
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('trigger has data-cl-open when dialog is visible', () => {
+      renderDialog({ defaultOpen: true });
+      // When modal is open, trigger's container gets aria-hidden, so use querySelector
+      const trigger = document.querySelector('[data-cl-slot="dialog-trigger"]');
+      expect(trigger).toHaveAttribute('data-cl-open', '');
+    });
+  });
+
+  describe('modal behavior', () => {
+    it('defaults to modal=true', () => {
+      renderDialog({ defaultOpen: true });
+      // Modal dialog should have role=dialog (already tested)
+      // Focus should be trapped inside the dialog
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('focus management', () => {
+    it('moves focus into dialog on open', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+      // FloatingFocusManager schedules focus via requestAnimationFrame
+      await new Promise(r => requestAnimationFrame(r));
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    it('returns focus to trigger on close via Escape', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      await user.click(trigger);
+      await user.keyboard('{Escape}');
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('returns focus to trigger on close via Close button', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const trigger = screen.getByRole('button', { name: 'Open dialog' });
+      await user.click(trigger);
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = renderDialog();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      renderDialog({ defaultOpen: true });
+      // aria-command-name: FloatingFocusManager injects focus guard spans
+      // with role="button" but no label — this is internal to floating-ui
+      expect(
+        await axe(document.body, {
+          rules: {
+            region: { enabled: false },
+            'aria-command-name': { enabled: false },
+          },
+        }),
+      ).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/dialog/dialog.tsx
+++ b/packages/headless/src/primitives/dialog/dialog.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import {
+  type ExtendedRefs,
+  type FloatingContext,
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingOverlay,
+  FloatingPortal,
+  FloatingTree,
+  type ReferenceType,
+  type UseInteractionsReturn,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface DialogContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  modal: boolean;
+  labelId: string | undefined;
+  descriptionId: string | undefined;
+  setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+function useDialogContext() {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('Dialog compound components must be used within <Dialog>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog (root)
+// ---------------------------------------------------------------------------
+
+export interface DialogProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** When true, the dialog traps focus and blocks interaction with the rest of the page. Default: true */
+  modal?: boolean;
+  children: ReactNode;
+}
+
+function DialogInner(props: DialogProps) {
+  const nodeId = useFloatingNodeId();
+  const { modal = true, children } = props;
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const [labelId, setLabelId] = useState<string | undefined>();
+  const [descriptionId, setDescriptionId] = useState<string | undefined>();
+
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const { refs, context: floatingContext } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const click = useClick(floatingContext);
+  const dismiss = useDismiss(floatingContext, {
+    outsidePressEvent: 'mousedown',
+  });
+  const role = useRole(floatingContext);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role]);
+
+  const contextValue = useMemo<DialogContextValue>(
+    () => ({
+      open,
+      setOpen,
+      floatingContext,
+      refs,
+      getReferenceProps,
+      getFloatingProps,
+      popupRef,
+      modal,
+      labelId,
+      descriptionId,
+      setLabelId,
+      setDescriptionId,
+      mounted,
+      transitionProps,
+    }),
+    [
+      open,
+      setOpen,
+      floatingContext,
+      refs,
+      getReferenceProps,
+      getFloatingProps,
+      modal,
+      labelId,
+      descriptionId,
+      mounted,
+      transitionProps,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <DialogContext.Provider value={contextValue}>{children}</DialogContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function DialogRoot(props: DialogProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <DialogInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <DialogInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Trigger
+// ---------------------------------------------------------------------------
+
+export interface DialogTriggerProps extends ComponentProps<'button'> {}
+
+function DialogTrigger(props: DialogTriggerProps) {
+  const { render, ...otherProps } = props;
+  const { open, refs, getReferenceProps } = useDialogContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'dialog-trigger',
+    ref: refs.setReference,
+    ...(getReferenceProps() as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Portal
+// ---------------------------------------------------------------------------
+
+export interface DialogPortalProps {
+  children: ReactNode;
+}
+
+function DialogPortal(props: DialogPortalProps) {
+  const { mounted } = useDialogContext();
+
+  if (!mounted) return null;
+
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Backdrop
+// ---------------------------------------------------------------------------
+
+export interface DialogBackdropProps extends ComponentProps<'div'> {
+  /** When true, locks body scroll while the dialog is open. Default: true */
+  lockScroll?: boolean;
+}
+
+function DialogBackdrop(props: DialogBackdropProps) {
+  const { render, lockScroll = true, ...otherProps } = props;
+  const { open, mounted, transitionProps } = useDialogContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    'data-cl-slot': 'dialog-backdrop',
+    ...transitionProps,
+  } as React.ComponentPropsWithRef<'div'>;
+
+  const backdropElement = renderElement({
+    defaultTagName: 'div',
+    render,
+    enabled: mounted,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+
+  return <FloatingOverlay lockScroll={lockScroll}>{backdropElement}</FloatingOverlay>;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Popup
+// ---------------------------------------------------------------------------
+
+export interface DialogPopupProps extends ComponentProps<'div'> {}
+
+function DialogPopup(props: DialogPopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, refs, getFloatingProps, floatingContext, modal, labelId, descriptionId, transitionProps } =
+    useDialogContext();
+
+  const combinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      (popupRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      refs.setFloating(node);
+    },
+    [popupRef, refs],
+  );
+
+  const defaultProps = {
+    'data-cl-slot': 'dialog-popup',
+    ref: combinedRef,
+    'aria-labelledby': labelId,
+    'aria-describedby': descriptionId,
+    ...(getFloatingProps() as React.ComponentPropsWithRef<'div'>),
+    ...transitionProps,
+  };
+
+  return (
+    <FloatingFocusManager
+      context={floatingContext}
+      modal={modal}
+    >
+      {renderElement({
+        defaultTagName: 'div',
+        render,
+        props: mergeProps<'div'>(defaultProps, otherProps),
+      })}
+    </FloatingFocusManager>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Title
+// ---------------------------------------------------------------------------
+
+export interface DialogTitleProps extends ComponentProps<'h2'> {}
+
+function DialogTitle(props: DialogTitleProps) {
+  const { render, ...otherProps } = props;
+  const { setLabelId } = useDialogContext();
+  const id = useId();
+
+  useLayoutEffect(() => {
+    setLabelId(id);
+    return () => setLabelId(undefined);
+  }, [id, setLabelId]);
+
+  const defaultProps = {
+    'data-cl-slot': 'dialog-title',
+    id,
+  };
+
+  return renderElement({
+    defaultTagName: 'h2',
+    render,
+    props: mergeProps<'h2'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Description
+// ---------------------------------------------------------------------------
+
+export interface DialogDescriptionProps extends ComponentProps<'p'> {}
+
+function DialogDescription(props: DialogDescriptionProps) {
+  const { render, ...otherProps } = props;
+  const { setDescriptionId } = useDialogContext();
+  const id = useId();
+
+  useLayoutEffect(() => {
+    setDescriptionId(id);
+    return () => setDescriptionId(undefined);
+  }, [id, setDescriptionId]);
+
+  const defaultProps = {
+    'data-cl-slot': 'dialog-description',
+    id,
+  };
+
+  return renderElement({
+    defaultTagName: 'p',
+    render,
+    props: mergeProps<'p'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dialog.Close
+// ---------------------------------------------------------------------------
+
+export interface DialogCloseProps extends ComponentProps<'button'> {}
+
+function DialogClose(props: DialogCloseProps) {
+  const { render, ...otherProps } = props;
+  const { setOpen } = useDialogContext();
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'dialog-close',
+    onClick() {
+      setOpen(false);
+    },
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Dialog = Object.assign(DialogRoot, {
+  Trigger: DialogTrigger,
+  Portal: DialogPortal,
+  Backdrop: DialogBackdrop,
+  Popup: DialogPopup,
+  Title: DialogTitle,
+  Description: DialogDescription,
+  Close: DialogClose,
+});

--- a/packages/headless/src/primitives/dialog/dialog.tsx
+++ b/packages/headless/src/primitives/dialog/dialog.tsx
@@ -21,7 +21,7 @@ import {
 } from '@floating-ui/react';
 import { createContext, type ReactNode, useContext, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -46,6 +46,7 @@ interface DialogContextValue {
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
+const DialogScopedContext = createContext(false);
 
 function useDialogContext() {
   const ctx = useContext(DialogContext);
@@ -85,7 +86,7 @@ function DialogInner(props: DialogProps) {
     onOpenChange: setOpen,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -187,14 +188,20 @@ function DialogTrigger(props: DialogTriggerProps) {
 
 export interface DialogPortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function DialogPortal(props: DialogPortalProps) {
   const { mounted } = useDialogContext();
+  const isScoped = props.root != null;
 
   if (!mounted) return null;
 
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return (
+    <FloatingPortal root={props.root}>
+      <DialogScopedContext.Provider value={isScoped}>{props.children}</DialogScopedContext.Provider>
+    </FloatingPortal>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +216,7 @@ export interface DialogBackdropProps extends ComponentProps<'div'> {
 function DialogBackdrop(props: DialogBackdropProps) {
   const { render, lockScroll = true, ...otherProps } = props;
   const { open, mounted, transitionProps } = useDialogContext();
+  const scoped = useContext(DialogScopedContext);
 
   const state = { open };
 
@@ -227,6 +235,12 @@ function DialogBackdrop(props: DialogBackdropProps) {
     },
     props: mergeProps<'div'>(defaultProps, otherProps),
   });
+
+  // When scoped to a container (Dialog.Portal has a root), skip FloatingOverlay
+  // which uses position:fixed. CSS on the backdrop element handles positioning.
+  if (scoped) {
+    return backdropElement;
+  }
 
   return <FloatingOverlay lockScroll={lockScroll}>{backdropElement}</FloatingOverlay>;
 }

--- a/packages/headless/src/primitives/dialog/dialog.tsx
+++ b/packages/headless/src/primitives/dialog/dialog.tsx
@@ -16,19 +16,10 @@ import {
   useFloatingNodeId,
   useFloatingParentNodeId,
   useInteractions,
+  useMergeRefs,
   useRole,
 } from '@floating-ui/react';
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { createContext, type ReactNode, useContext, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
 import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
@@ -251,13 +242,7 @@ function DialogPopup(props: DialogPopupProps) {
   const { popupRef, refs, getFloatingProps, floatingContext, modal, labelId, descriptionId, transitionProps } =
     useDialogContext();
 
-  const combinedRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      (popupRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-      refs.setFloating(node);
-    },
-    [popupRef, refs],
-  );
+  const combinedRef = useMergeRefs([popupRef, refs.setFloating]);
 
   const defaultProps = {
     'data-cl-slot': 'dialog-popup',

--- a/packages/headless/src/primitives/dialog/index.ts
+++ b/packages/headless/src/primitives/dialog/index.ts
@@ -1,0 +1,11 @@
+export type {
+  DialogBackdropProps,
+  DialogCloseProps,
+  DialogDescriptionProps,
+  DialogPopupProps,
+  DialogPortalProps,
+  DialogProps,
+  DialogTitleProps,
+  DialogTriggerProps,
+} from './dialog';
+export { Dialog } from './dialog';

--- a/packages/headless/src/primitives/menu/README.md
+++ b/packages/headless/src/primitives/menu/README.md
@@ -1,0 +1,156 @@
+# Menu
+
+A dropdown menu with keyboard navigation, typeahead, and nested submenu support. Handles ARIA roles, safe hover zones for submenus, and tree-level close-on-click.
+
+## When to Use
+
+- Action menus, context menus, dropdown menus attached to a button trigger.
+- When you need nested submenus with safe pointer zones between trigger and submenu.
+- Prefer Menu over Popover when the content is a list of actions/commands rather than arbitrary content.
+
+## Usage
+
+```tsx
+import { Menu } from '@/primitives/menu';
+
+<Menu>
+  <Menu.Trigger>Actions</Menu.Trigger>
+  <Menu.Positioner>
+    <Menu.Popup>
+      <Menu.Item
+        label='Edit'
+        onClick={() => handleEdit()}
+      />
+      <Menu.Item
+        label='Duplicate'
+        onClick={() => handleDuplicate()}
+      />
+      <Menu.Separator />
+      <Menu.Item
+        label='Delete'
+        onClick={() => handleDelete()}
+      />
+    </Menu.Popup>
+  </Menu.Positioner>
+</Menu>;
+```
+
+### Nested Submenus
+
+Nest a `<Menu>` inside a parent `<Menu>` — the nested trigger automatically renders as a `menuitem` and opens on hover with a safe polygon zone.
+
+```tsx
+<Menu>
+  <Menu.Trigger>Actions</Menu.Trigger>
+  <Menu.Positioner>
+    <Menu.Popup>
+      <Menu.Item label='Edit' />
+      <Menu>
+        <Menu.Trigger>Share</Menu.Trigger>
+        <Menu.Positioner>
+          <Menu.Popup>
+            <Menu.Item label='Copy Link' />
+            <Menu.Item label='Email' />
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu>
+    </Menu.Popup>
+  </Menu.Positioner>
+</Menu>
+```
+
+### Controlled
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Menu
+  open={open}
+  onOpenChange={setOpen}
+>
+  {/* ... */}
+</Menu>;
+```
+
+## Parts
+
+| Part              | Default Element | Description                            |
+| ----------------- | --------------- | -------------------------------------- |
+| `Menu`            | —               | Root context provider                  |
+| `Menu.Trigger`    | `<button>`      | Opens/closes the menu                  |
+| `Menu.Positioner` | `<div>`         | Floating positioned container (portal) |
+| `Menu.Popup`      | `<div>`         | Visual wrapper for menu items          |
+| `Menu.Item`       | `<button>`      | A menu action item                     |
+| `Menu.Separator`  | `<div>`         | Visual divider between items           |
+| `Menu.Arrow`      | `<svg>`         | Optional floating arrow                |
+
+## Props
+
+### `Menu` (root)
+
+| Prop           | Type                      | Default                                           | Description                        |
+| -------------- | ------------------------- | ------------------------------------------------- | ---------------------------------- |
+| `open`         | `boolean`                 | —                                                 | Controlled open state              |
+| `defaultOpen`  | `boolean`                 | `false`                                           | Initial open state (uncontrolled)  |
+| `onOpenChange` | `(open: boolean) => void` | —                                                 | Called when open state changes     |
+| `placement`    | `Placement`               | `"bottom-start"` (root), `"right-start"` (nested) | Floating UI placement              |
+| `sideOffset`   | `number`                  | `4` (root), `0` (nested)                          | Gap between trigger and popup (px) |
+
+### `Menu.Item`
+
+| Prop           | Type      | Default      | Description                                            |
+| -------------- | --------- | ------------ | ------------------------------------------------------ |
+| `label`        | `string`  | **required** | Item text, also used for typeahead matching            |
+| `disabled`     | `boolean` | —            | Prevents click handler, keeps item focusable           |
+| `closeOnClick` | `boolean` | `true`       | Whether clicking this item closes the entire menu tree |
+
+### `Menu.Trigger`, `Menu.Positioner`, `Menu.Popup`, `Menu.Separator`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+### `Menu.Arrow`
+
+Accepts all `FloatingArrow` props. `ref` and `context` are injected automatically.
+
+## Keyboard Navigation
+
+| Key               | Action                                 |
+| ----------------- | -------------------------------------- |
+| `ArrowDown`       | Move to next item                      |
+| `ArrowUp`         | Move to previous item                  |
+| `ArrowRight`      | Open nested submenu                    |
+| `ArrowLeft`       | Close nested submenu, return to parent |
+| `Enter` / `Space` | Activate the focused item              |
+| `Escape`          | Close the current menu level           |
+| Type a character  | Jump to matching item (typeahead)      |
+
+## Data Attributes
+
+| Attribute                         | Applies To        | Description                          |
+| --------------------------------- | ----------------- | ------------------------------------ |
+| `data-cl-slot`                    | All parts         | Part identifier (e.g. `"menu-item"`) |
+| `data-cl-open` / `data-cl-closed` | Trigger           | Menu open state                      |
+| `data-cl-active`                  | Item              | Keyboard-focused item                |
+| `data-cl-disabled`                | Item              | Disabled item                        |
+| `data-cl-side`                    | Positioner, Arrow | Resolved placement side              |
+
+## Nested Menu Behavior
+
+- Nested menus open on hover (75ms delay) with a `safePolygon` safe zone.
+- Only one sibling submenu can be open at a time.
+- Clicking any item with `closeOnClick={true}` (default) closes the entire menu tree via a tree event.
+- `Escape` closes the innermost menu first, bubbling up through the tree.
+
+## Important Notes
+
+- **No built-in animations.** The positioner simply mounts/unmounts. Use `data-cl-open`/`data-cl-closed` for CSS-driven transitions.
+- **Disabled items use `aria-disabled`, not `disabled`.** They remain focusable for keyboard users.
+- **`label` is required on `Menu.Item`** — it drives typeahead matching. Disabled items are excluded from typeahead.
+
+## ARIA
+
+- Popup: `role="menu"`
+- Item: `role="menuitem"`, `aria-disabled`
+- Separator: `role="separator"`
+- Trigger: `aria-expanded`, `aria-haspopup="menu"`, `aria-controls`
+- Nested trigger: `role="menuitem"` (instead of button)

--- a/packages/headless/src/primitives/menu/README.md
+++ b/packages/headless/src/primitives/menu/README.md
@@ -78,7 +78,8 @@ const [open, setOpen] = useState(false);
 | ----------------- | --------------- | -------------------------------------- |
 | `Menu`            | —               | Root context provider                  |
 | `Menu.Trigger`    | `<button>`      | Opens/closes the menu                  |
-| `Menu.Positioner` | `<div>`         | Floating positioned container (portal) |
+| `Menu.Portal`     | —               | Portals children (accepts `root` prop) |
+| `Menu.Positioner` | `<div>`         | Floating positioned container          |
 | `Menu.Popup`      | `<div>`         | Visual wrapper for menu items          |
 | `Menu.Item`       | `<button>`      | A menu action item                     |
 | `Menu.Separator`  | `<div>`         | Visual divider between items           |

--- a/packages/headless/src/primitives/menu/index.ts
+++ b/packages/headless/src/primitives/menu/index.ts
@@ -1,0 +1,10 @@
+export type {
+  MenuArrowProps,
+  MenuItemProps,
+  MenuPopupProps,
+  MenuPositionerProps,
+  MenuProps,
+  MenuSeparatorProps,
+  MenuTriggerProps,
+} from './menu';
+export { Menu } from './menu';

--- a/packages/headless/src/primitives/menu/menu.test.tsx
+++ b/packages/headless/src/primitives/menu/menu.test.tsx
@@ -1,0 +1,673 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Menu } from './menu';
+
+afterEach(() => cleanup());
+
+describe('Menu', () => {
+  describe('slot attributes', () => {
+    it('renders trigger with data-cl-slot', () => {
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-slot', 'menu-trigger');
+    });
+
+    it('renders all parts with correct slot attributes when open', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Separator />
+              <Menu.Item label='Paste'>Paste</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(document.querySelector('[data-cl-slot="menu-positioner"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="menu-popup"]')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-cl-slot="menu-item"]')).toHaveLength(2);
+      expect(document.querySelector('[data-cl-slot="menu-separator"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens on trigger click', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getByText('Cut')).toBeInTheDocument();
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('closes on trigger click when open', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.keyboard('{Escape}');
+
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes when item is clicked', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Cut'
+                onClick={onClick}
+              >
+                Cut
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Cut'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('does not close on item click when closeOnClick=false', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Toggle'
+                closeOnClick={false}
+              >
+                Toggle
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Toggle'));
+
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('calls onOpenChange', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Menu onOpenChange={onOpenChange}>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('item interaction', () => {
+    it('fires onClick on item click', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Cut'
+                onClick={onClick}
+              >
+                Cut
+              </Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Cut'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('items are buttons with role=menuitem', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      const item = screen.getByText('Cut');
+      expect(item.tagName).toBe('BUTTON');
+      expect(item).toHaveAttribute('role', 'menuitem');
+    });
+  });
+
+  describe('disabled items', () => {
+    it('marks disabled item with data-cl-disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Cut'
+                disabled
+              >
+                Cut
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(document.querySelector('[data-cl-slot="menu-item"]')).toHaveAttribute('data-cl-disabled', '');
+    });
+
+    it('disabled item has aria-disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Cut'
+                disabled
+              >
+                Cut
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(document.querySelector('[data-cl-slot="menu-item"]')).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not close menu when clicking disabled item', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item
+                label='Cut'
+                disabled
+              >
+                Cut
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Cut'));
+
+      expect(screen.getByText('Actions')).toHaveAttribute('data-cl-open', '');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('navigates items with ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await new Promise(r => requestAnimationFrame(r));
+      await user.keyboard('{ArrowDown}');
+
+      expect(screen.getByText('Cut')).toHaveAttribute('data-cl-active', '');
+    });
+
+    it('navigates items with ArrowUp from last to first', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await new Promise(r => requestAnimationFrame(r));
+      await user.keyboard('{ArrowDown}{ArrowUp}');
+
+      expect(screen.getByText('Cut')).toHaveAttribute('data-cl-active', '');
+    });
+
+    it('Home moves to first item', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+              <Menu.Item label='Paste'>Paste</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await new Promise(r => requestAnimationFrame(r));
+      await user.keyboard('{ArrowDown}{ArrowDown}{Home}');
+
+      expect(screen.getByText('Cut')).toHaveAttribute('data-cl-active', '');
+    });
+
+    it('End moves to last item', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+              <Menu.Item label='Paste'>Paste</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await new Promise(r => requestAnimationFrame(r));
+      await user.keyboard('{End}');
+
+      expect(screen.getByText('Paste')).toHaveAttribute('data-cl-active', '');
+    });
+  });
+
+  describe('focus management', () => {
+    it('returns focus to trigger on close via Escape', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.keyboard('{Escape}');
+
+      expect(document.activeElement).toBe(screen.getByText('Actions'));
+    });
+
+    it('returns focus to trigger on item click', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+      await user.click(screen.getByText('Cut'));
+
+      expect(document.activeElement).toBe(screen.getByText('Actions'));
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('trigger has aria-expanded', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      expect(screen.getByText('Actions')).toHaveAttribute('aria-expanded', 'false');
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getByText('Actions')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('popup has role=menu', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('trigger has aria-haspopup', () => {
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+      expect(screen.getByText('Actions')).toHaveAttribute('aria-haspopup');
+    });
+
+    it('items have role=menuitem', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+    });
+
+    it('separator has role=separator', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Separator />
+              <Menu.Item label='Paste'>Paste</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+  });
+
+  describe('nested menus', () => {
+    it('renders submenu trigger as menuitem', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu>
+                <Menu.Trigger>Share</Menu.Trigger>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.Item label='Email'>Email</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      const shareTrigger = screen.getByText('Share');
+      expect(shareTrigger).toHaveAttribute('role', 'menuitem');
+      expect(shareTrigger).toHaveAttribute('data-cl-slot', 'menu-trigger');
+    });
+
+    it('opens submenu via controlled open prop', () => {
+      render(
+        <Menu defaultOpen>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu defaultOpen>
+                <Menu.Trigger>Share</Menu.Trigger>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.Item label='Email'>Email</Menu.Item>
+                    <Menu.Item label='Slack'>Slack</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      expect(screen.getByText('Email')).toBeInTheDocument();
+      expect(screen.getByText('Slack')).toBeInTheDocument();
+    });
+
+    it('submenu items close all menus on click', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Menu defaultOpen>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu defaultOpen>
+                <Menu.Trigger>Share</Menu.Trigger>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.Item
+                      label='Email'
+                      onClick={onClick}
+                    >
+                      Email
+                    </Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Email'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('positioner', () => {
+    it('not rendered when closed', () => {
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      expect(document.querySelector('[data-cl-slot="menu-positioner"]')).not.toBeInTheDocument();
+    });
+
+    it('has data-cl-side when open', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(document.querySelector('[data-cl-slot="menu-positioner"]')).toHaveAttribute('data-cl-side');
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <Menu.Trigger>Actions</Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item label='Cut'>Cut</Menu.Item>
+              <Menu.Item label='Copy'>Copy</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu>,
+      );
+
+      await user.click(screen.getByText('Actions'));
+
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/menu/menu.tsx
+++ b/packages/headless/src/primitives/menu/menu.tsx
@@ -43,8 +43,8 @@ import {
   useState,
 } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
-import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
+import { cssVars } from '../../utils/css-vars';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -134,12 +134,12 @@ function MenuInner(props: MenuProps) {
       flip(),
       shift({ padding: 5 }),
       arrow({ element: arrowRef }),
-      floatingCssVars({ sideOffset: resolvedOffset }),
+      cssVars({ sideOffset: resolvedOffset }),
     ],
     whileElementsMounted: autoUpdate,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -317,12 +317,13 @@ function MenuTrigger(props: MenuTriggerProps) {
 
 export interface MenuPortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function MenuPortal(props: MenuPortalProps) {
   const { mounted } = useMenuContext();
   if (!mounted) return null;
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return <FloatingPortal root={props.root}>{props.children}</FloatingPortal>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/headless/src/primitives/menu/menu.tsx
+++ b/packages/headless/src/primitives/menu/menu.tsx
@@ -1,0 +1,542 @@
+'use client';
+
+import {
+  arrow,
+  autoUpdate,
+  type ExtendedRefs,
+  FloatingArrow,
+  type FloatingContext,
+  FloatingFocusManager,
+  FloatingList,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  flip,
+  offset,
+  type Placement,
+  type ReferenceType,
+  safePolygon,
+  shift,
+  type UseInteractionsReturn,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useFloatingTree,
+  useHover,
+  useInteractions,
+  useListItem,
+  useListNavigation,
+  useMergeRefs,
+  useRole,
+  useTypeahead,
+} from '@floating-ui/react';
+import {
+  type CSSProperties,
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface MenuContextValue {
+  open: boolean;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  getItemProps: UseInteractionsReturn['getItemProps'];
+  activeIndex: number | null;
+  setActiveIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  labelsRef: React.MutableRefObject<Array<string | null>>;
+  arrowRef: React.MutableRefObject<SVGSVGElement | null>;
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  isNested: boolean;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+  setHasFocusInside: React.Dispatch<React.SetStateAction<boolean>>;
+  parentContext: MenuContextValue | null;
+}
+
+const MenuContext = createContext<MenuContextValue | null>(null);
+
+function useMenuContext() {
+  const ctx = useContext(MenuContext);
+  if (!ctx) {
+    throw new Error('Menu compound components must be used within <Menu>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Menu (root)
+// ---------------------------------------------------------------------------
+
+export interface MenuProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placement?: Placement;
+  sideOffset?: number;
+  children: ReactNode;
+}
+
+function MenuInner(props: MenuProps) {
+  const { placement: placementProp, sideOffset, children } = props;
+
+  const parentContext = useContext(MenuContext);
+  const tree = useFloatingTree();
+  const nodeId = useFloatingNodeId();
+  const parentId = useFloatingParentNodeId();
+  const isNested = parentId != null;
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const [hasFocusInside, setHasFocusInside] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const elementsRef = useRef<Array<HTMLElement | null>>([]);
+  const labelsRef = useRef<Array<string | null>>([]);
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const resolvedPlacement = placementProp ?? (isNested ? 'right-start' : 'bottom-start');
+  const resolvedOffset = sideOffset ?? (isNested ? 0 : 4);
+
+  const {
+    refs,
+    floatingStyles,
+    context: floatingContext,
+    placement,
+  } = useFloating<HTMLButtonElement>({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: resolvedPlacement,
+    middleware: [
+      offset({
+        mainAxis: resolvedOffset,
+        alignmentAxis: isNested ? -4 : 0,
+      }),
+      flip(),
+      shift({ padding: 5 }),
+      arrow({ element: arrowRef }),
+      floatingCssVars({ sideOffset: resolvedOffset }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const hover = useHover(floatingContext, {
+    enabled: isNested,
+    delay: { open: 75 },
+    handleClose: safePolygon({ blockPointerEvents: true }),
+  });
+  const click = useClick(floatingContext, {
+    event: 'mousedown',
+    toggle: !isNested,
+    ignoreMouse: isNested,
+  });
+  const role = useRole(floatingContext, { role: 'menu' });
+  const dismiss = useDismiss(floatingContext, { bubbles: true });
+  const listNavigation = useListNavigation(floatingContext, {
+    listRef: elementsRef,
+    activeIndex,
+    nested: isNested,
+    onNavigate: setActiveIndex,
+  });
+  const typeahead = useTypeahead(floatingContext, {
+    listRef: labelsRef,
+    onMatch: open ? setActiveIndex : undefined,
+    activeIndex,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    hover,
+    click,
+    role,
+    dismiss,
+    listNavigation,
+    typeahead,
+  ]);
+
+  // Close all menus when an item is clicked anywhere in the tree
+  useEffect(() => {
+    if (!tree) return;
+
+    function handleTreeClick() {
+      setOpen(false);
+    }
+
+    function onSubMenuOpen(event: { nodeId: string; parentId: string }) {
+      if (event.nodeId !== nodeId && event.parentId === parentId) {
+        setOpen(false);
+      }
+    }
+
+    tree.events.on('click', handleTreeClick);
+    tree.events.on('menuopen', onSubMenuOpen);
+
+    return () => {
+      tree.events.off('click', handleTreeClick);
+      tree.events.off('menuopen', onSubMenuOpen);
+    };
+  }, [tree, nodeId, parentId, setOpen]);
+
+  useEffect(() => {
+    if (open && tree) {
+      tree.events.emit('menuopen', { parentId, nodeId });
+    }
+  }, [tree, open, nodeId, parentId]);
+
+  const contextValue = useMemo<MenuContextValue>(
+    () => ({
+      open,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      setActiveIndex,
+      elementsRef,
+      labelsRef,
+      arrowRef,
+      popupRef,
+      isNested,
+      mounted,
+      transitionProps,
+      setHasFocusInside,
+      parentContext,
+    }),
+    [
+      open,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      isNested,
+      mounted,
+      transitionProps,
+      parentContext,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <MenuContext.Provider value={contextValue}>{children}</MenuContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function MenuRoot(props: MenuProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <MenuInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <MenuInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Trigger
+// ---------------------------------------------------------------------------
+
+export interface MenuTriggerProps extends ComponentProps<'button'> {}
+
+function MenuTrigger(props: MenuTriggerProps) {
+  const { render, ref: consumerRef, ...otherProps } = props;
+  const { open, isNested, refs, getReferenceProps, parentContext, setHasFocusInside } = useMenuContext();
+
+  const item = useListItem();
+
+  const mergedRef = useMergeRefs([refs.setReference, isNested ? item.ref : null, consumerRef ?? null]);
+
+  const state = { open };
+
+  let referenceProps: Record<string, unknown>;
+
+  if (isNested && parentContext) {
+    referenceProps = getReferenceProps(
+      parentContext.getItemProps({
+        onFocus() {
+          setHasFocusInside(false);
+          parentContext.setHasFocusInside(true);
+        },
+      }) as React.HTMLProps<HTMLElement>,
+    );
+  } else {
+    referenceProps = getReferenceProps();
+  }
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'menu-trigger',
+    ref: mergedRef,
+    ...(isNested && {
+      role: 'menuitem' as const,
+      tabIndex: parentContext?.activeIndex === item.index ? 0 : -1,
+    }),
+    ...(referenceProps as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Portal
+// ---------------------------------------------------------------------------
+
+export interface MenuPortalProps {
+  children: ReactNode;
+}
+
+function MenuPortal(props: MenuPortalProps) {
+  const { mounted } = useMenuContext();
+  if (!mounted) return null;
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Positioner
+// ---------------------------------------------------------------------------
+
+export interface MenuPositionerProps extends ComponentProps<'div'> {}
+
+function MenuPositioner(props: MenuPositionerProps) {
+  const { render, ...otherProps } = props;
+  const {
+    mounted,
+    floatingContext,
+    refs,
+    floatingStyles,
+    placement,
+    getFloatingProps,
+    elementsRef,
+    labelsRef,
+    isNested,
+    setActiveIndex,
+  } = useMenuContext();
+
+  const side = placement.split('-')[0];
+
+  const defaultProps = {
+    'data-cl-slot': 'menu-positioner',
+    'data-cl-side': side,
+    ref: refs.setFloating,
+    style: floatingStyles,
+    ...(getFloatingProps({
+      onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+        if (event.key === 'Home' || event.key === 'End') {
+          event.preventDefault();
+          const items = elementsRef.current;
+          if (event.key === 'Home') {
+            const firstEnabled = items.findIndex(el => el != null && !el.hasAttribute('aria-disabled'));
+            if (firstEnabled !== -1) setActiveIndex(firstEnabled);
+          } else {
+            for (let i = items.length - 1; i >= 0; i--) {
+              if (items[i] != null && !items[i]!.hasAttribute('aria-disabled')) {
+                setActiveIndex(i);
+                break;
+              }
+            }
+          }
+        }
+      },
+    }) as React.ComponentPropsWithRef<'div'>),
+  };
+
+  const element = renderElement({
+    defaultTagName: 'div',
+    render,
+    enabled: mounted,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+
+  return (
+    <FloatingFocusManager
+      context={floatingContext}
+      modal={false}
+      initialFocus={isNested ? -1 : 0}
+      returnFocus={!isNested}
+    >
+      <FloatingList
+        elementsRef={elementsRef}
+        labelsRef={labelsRef}
+      >
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- element is guaranteed non-null when mounted */}
+        {element!}
+      </FloatingList>
+    </FloatingFocusManager>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Popup
+// ---------------------------------------------------------------------------
+
+export interface MenuPopupProps extends ComponentProps<'div'> {}
+
+function MenuPopup(props: MenuPopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, transitionProps } = useMenuContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'menu-popup',
+    ref: popupRef,
+    ...transitionProps,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Item
+// ---------------------------------------------------------------------------
+
+export interface MenuItemProps extends ComponentProps<'button'> {
+  label: string;
+  disabled?: boolean;
+  closeOnClick?: boolean;
+}
+
+function MenuItem(props: MenuItemProps) {
+  const { render, label, disabled, closeOnClick = true, ...otherProps } = props;
+  const { activeIndex, getItemProps, setHasFocusInside } = useMenuContext();
+  const tree = useFloatingTree();
+  const item = useListItem({ label: disabled ? null : label });
+  const isActive = item.index === activeIndex;
+
+  const state = {
+    active: isActive,
+    disabled: !!disabled,
+  };
+
+  const defaultProps = {
+    'data-cl-slot': 'menu-item',
+    type: 'button' as const,
+    ref: item.ref,
+    role: 'menuitem' as const,
+    tabIndex: isActive ? 0 : -1,
+    ...(disabled && { 'aria-disabled': true as const }),
+    ...(getItemProps({
+      onClick() {
+        if (!disabled && closeOnClick) {
+          tree?.events.emit('click');
+        }
+      },
+      onFocus() {
+        setHasFocusInside(true);
+      },
+    }) as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      active: (v: boolean) => (v ? { 'data-cl-active': '' } : null),
+      disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Separator
+// ---------------------------------------------------------------------------
+
+export interface MenuSeparatorProps extends ComponentProps<'div'> {}
+
+function MenuSeparator(props: MenuSeparatorProps) {
+  const { render, ...otherProps } = props;
+
+  const defaultProps = {
+    'data-cl-slot': 'menu-separator',
+    role: 'separator' as const,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Menu.Arrow
+// ---------------------------------------------------------------------------
+
+export interface MenuArrowProps extends React.ComponentPropsWithRef<typeof FloatingArrow> {}
+
+function MenuArrowComponent(props: MenuArrowProps) {
+  const { floatingContext, arrowRef, placement } = useMenuContext();
+  const side = placement.split('-')[0];
+
+  return (
+    <FloatingArrow
+      data-cl-slot='menu-arrow'
+      data-cl-side={side}
+      {...props}
+      ref={arrowRef}
+      context={floatingContext}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Menu = Object.assign(MenuRoot, {
+  Trigger: MenuTrigger,
+  Portal: MenuPortal,
+  Positioner: MenuPositioner,
+  Popup: MenuPopup,
+  Item: MenuItem,
+  Separator: MenuSeparator,
+  Arrow: MenuArrowComponent,
+});

--- a/packages/headless/src/primitives/menu/menu.tsx
+++ b/packages/headless/src/primitives/menu/menu.tsx
@@ -69,7 +69,6 @@ interface MenuContextValue {
   isNested: boolean;
   mounted: boolean;
   transitionProps: TransitionProps;
-  setHasFocusInside: React.Dispatch<React.SetStateAction<boolean>>;
   parentContext: MenuContextValue | null;
 }
 
@@ -107,7 +106,6 @@ function MenuInner(props: MenuProps) {
 
   const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
 
-  const [hasFocusInside, setHasFocusInside] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   const elementsRef = useRef<Array<HTMLElement | null>>([]);
@@ -227,7 +225,6 @@ function MenuInner(props: MenuProps) {
       isNested,
       mounted,
       transitionProps,
-      setHasFocusInside,
       parentContext,
     }),
     [
@@ -276,7 +273,7 @@ export interface MenuTriggerProps extends ComponentProps<'button'> {}
 
 function MenuTrigger(props: MenuTriggerProps) {
   const { render, ref: consumerRef, ...otherProps } = props;
-  const { open, isNested, refs, getReferenceProps, parentContext, setHasFocusInside } = useMenuContext();
+  const { open, isNested, refs, getReferenceProps, parentContext } = useMenuContext();
 
   const item = useListItem();
 
@@ -287,14 +284,7 @@ function MenuTrigger(props: MenuTriggerProps) {
   let referenceProps: Record<string, unknown>;
 
   if (isNested && parentContext) {
-    referenceProps = getReferenceProps(
-      parentContext.getItemProps({
-        onFocus() {
-          setHasFocusInside(false);
-          parentContext.setHasFocusInside(true);
-        },
-      }) as React.HTMLProps<HTMLElement>,
-    );
+    referenceProps = getReferenceProps(parentContext.getItemProps() as React.HTMLProps<HTMLElement>);
   } else {
     referenceProps = getReferenceProps();
   }
@@ -444,7 +434,7 @@ export interface MenuItemProps extends ComponentProps<'button'> {
 
 function MenuItem(props: MenuItemProps) {
   const { render, label, disabled, closeOnClick = true, ...otherProps } = props;
-  const { activeIndex, getItemProps, setHasFocusInside } = useMenuContext();
+  const { activeIndex, getItemProps } = useMenuContext();
   const tree = useFloatingTree();
   const item = useListItem({ label: disabled ? null : label });
   const isActive = item.index === activeIndex;
@@ -466,9 +456,6 @@ function MenuItem(props: MenuItemProps) {
         if (!disabled && closeOnClick) {
           tree?.events.emit('click');
         }
-      },
-      onFocus() {
-        setHasFocusInside(true);
       },
     }) as React.ComponentPropsWithRef<'button'>),
   };

--- a/packages/headless/src/primitives/popover/README.md
+++ b/packages/headless/src/primitives/popover/README.md
@@ -51,7 +51,8 @@ const [open, setOpen] = useState(false);
 | --------------------- | --------------- | ---------------------------------------- |
 | `Popover`             | —               | Root context provider                    |
 | `Popover.Trigger`     | `<button>`      | Toggles the popover on click             |
-| `Popover.Positioner`  | `<div>`         | Floating positioned container (portal)   |
+| `Popover.Portal`      | —               | Portals children (accepts `root` prop)   |
+| `Popover.Positioner`  | `<div>`         | Floating positioned container            |
 | `Popover.Popup`       | `<div>`         | Visual content wrapper                   |
 | `Popover.Arrow`       | `<svg>`         | Optional floating arrow                  |
 | `Popover.Title`       | `<h2>`          | Heading, wired to `aria-labelledby`      |

--- a/packages/headless/src/primitives/popover/README.md
+++ b/packages/headless/src/primitives/popover/README.md
@@ -1,0 +1,110 @@
+# Popover
+
+A floating panel anchored to a trigger element. Supports focus management, ARIA labeling, and enter/exit animations.
+
+## When to Use
+
+- Rich content panels, filter dropdowns, or any non-modal floating content anchored to a trigger.
+- When content includes interactive elements (inputs, buttons) — unlike Tooltip which is display-only.
+- Prefer Popover over Dialog when the content should be anchored to a specific element and the page should remain interactive by default.
+
+## Usage
+
+```tsx
+import { Popover } from '@/primitives/popover';
+
+<Popover>
+  <Popover.Trigger>Settings</Popover.Trigger>
+  <Popover.Positioner>
+    <Popover.Popup>
+      <Popover.Title>Preferences</Popover.Title>
+      <Popover.Description>Adjust your settings below.</Popover.Description>
+      {/* Interactive content here */}
+      <Popover.Close>Done</Popover.Close>
+    </Popover.Popup>
+  </Popover.Positioner>
+</Popover>;
+```
+
+### Controlled
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Popover
+  open={open}
+  onOpenChange={setOpen}
+>
+  {/* ... */}
+</Popover>;
+```
+
+### Modal Mode
+
+```tsx
+<Popover modal>{/* Focus is trapped within the popover */}</Popover>
+```
+
+## Parts
+
+| Part                  | Default Element | Description                              |
+| --------------------- | --------------- | ---------------------------------------- |
+| `Popover`             | —               | Root context provider                    |
+| `Popover.Trigger`     | `<button>`      | Toggles the popover on click             |
+| `Popover.Positioner`  | `<div>`         | Floating positioned container (portal)   |
+| `Popover.Popup`       | `<div>`         | Visual content wrapper                   |
+| `Popover.Arrow`       | `<svg>`         | Optional floating arrow                  |
+| `Popover.Title`       | `<h2>`          | Heading, wired to `aria-labelledby`      |
+| `Popover.Description` | `<p>`           | Description, wired to `aria-describedby` |
+| `Popover.Close`       | `<button>`      | Closes the popover on click              |
+
+## Props
+
+### `Popover` (root)
+
+| Prop           | Type                      | Default    | Description                        |
+| -------------- | ------------------------- | ---------- | ---------------------------------- |
+| `open`         | `boolean`                 | —          | Controlled open state              |
+| `defaultOpen`  | `boolean`                 | `false`    | Initial open state (uncontrolled)  |
+| `onOpenChange` | `(open: boolean) => void` | —          | Called when open state changes     |
+| `placement`    | `Placement`               | `"bottom"` | Floating UI placement              |
+| `sideOffset`   | `number`                  | `4`        | Gap between trigger and popup (px) |
+| `modal`        | `boolean`                 | `false`    | Traps focus within the popover     |
+
+### `Popover.Trigger`, `Popover.Positioner`, `Popover.Popup`, `Popover.Title`, `Popover.Description`, `Popover.Close`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+### `Popover.Arrow`
+
+Accepts all `FloatingArrow` props. `ref` and `context` are injected automatically.
+
+## Keyboard
+
+| Key      | Action                                                               |
+| -------- | -------------------------------------------------------------------- |
+| `Escape` | Closes the popover                                                   |
+| `Tab`    | Cycles focus within popover (modal mode) or moves freely (non-modal) |
+
+## Data Attributes
+
+| Attribute                         | Applies To        | Description                              |
+| --------------------------------- | ----------------- | ---------------------------------------- |
+| `data-cl-slot`                    | All parts         | Part identifier (e.g. `"popover-popup"`) |
+| `data-cl-open` / `data-cl-closed` | Trigger           | Open state                               |
+| `data-cl-side`                    | Positioner, Arrow | Resolved placement side                  |
+
+## Positioning
+
+Middleware stack: `offset` -> `flip` -> `shift` -> `arrow` -> CSS vars. The popup auto-repositions on scroll and resize via `autoUpdate`. Cross-axis flipping is enabled only when using an aligned placement (e.g. `"bottom-start"`).
+
+## Important Notes
+
+- **Title and Description are optional but recommended.** They wire `aria-labelledby` and `aria-describedby` to the positioner. If omitted, those attributes are simply absent.
+- **Non-modal by default.** Unlike Dialog, the page remains interactive behind the popover. Set `modal={true}` for a stricter focus trap.
+- **Nested popovers are supported.** The `FloatingTree` pattern handles nesting automatically.
+
+## ARIA
+
+- Positioner: `role="dialog"`, `aria-labelledby` (from Title), `aria-describedby` (from Description)
+- Trigger: `aria-expanded`, `aria-haspopup="dialog"`, `aria-controls`

--- a/packages/headless/src/primitives/popover/index.ts
+++ b/packages/headless/src/primitives/popover/index.ts
@@ -1,0 +1,12 @@
+export type {
+  PopoverArrowProps,
+  PopoverCloseProps,
+  PopoverDescriptionProps,
+  PopoverPopupProps,
+  PopoverPortalProps,
+  PopoverPositionerProps,
+  PopoverProps,
+  PopoverTitleProps,
+  PopoverTriggerProps,
+} from './popover';
+export { Popover } from './popover';

--- a/packages/headless/src/primitives/popover/popover.test.tsx
+++ b/packages/headless/src/primitives/popover/popover.test.tsx
@@ -1,0 +1,259 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Popover } from './popover';
+
+afterEach(() => cleanup());
+
+function renderPopover(props: Partial<React.ComponentProps<typeof Popover>> = {}) {
+  return render(
+    <Popover {...props}>
+      <Popover.Trigger>Open popover</Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Popup>
+          <Popover.Title>Popover Title</Popover.Title>
+          <Popover.Description>Some description</Popover.Description>
+          <p>Popover content</p>
+          <Popover.Close>Close</Popover.Close>
+        </Popover.Popup>
+      </Popover.Positioner>
+    </Popover>,
+  );
+}
+
+describe('Popover', () => {
+  describe('slot attributes', () => {
+    it('renders trigger with data-cl-slot', () => {
+      renderPopover();
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      expect(trigger).toHaveAttribute('data-cl-slot', 'popover-trigger');
+    });
+
+    it('renders all parts with correct slot attributes when open', () => {
+      renderPopover({ defaultOpen: true });
+
+      expect(document.querySelector('[data-cl-slot="popover-positioner"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="popover-popup"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="popover-title"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="popover-description"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="popover-close"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens on trigger click', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('data-cl-open', '');
+      expect(document.querySelector('[data-cl-slot="popover-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes on trigger click when open', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      await user.click(trigger);
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      renderPopover({ defaultOpen: true });
+
+      await user.keyboard('{Escape}');
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('closes via Close button', async () => {
+      const user = userEvent.setup();
+      renderPopover({ defaultOpen: true });
+
+      const closeBtn = screen.getByRole('button', { name: 'Close' });
+      await user.click(closeBtn);
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onOpenChange when toggled', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      renderPopover({ onOpenChange });
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      await user.click(trigger);
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it('closes on outside click', async () => {
+      const user = userEvent.setup();
+      renderPopover({ defaultOpen: true });
+
+      expect(document.querySelector('[data-cl-slot="popover-popup"]')).toBeInTheDocument();
+
+      await user.click(document.body);
+
+      expect(document.querySelector('[data-cl-slot="popover-popup"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('controlled open', () => {
+    it('respects controlled open prop', () => {
+      renderPopover({ open: true });
+
+      expect(document.querySelector('[data-cl-slot="popover-positioner"]')).toBeInTheDocument();
+    });
+
+    it('does not open when controlled open is false', async () => {
+      const user = userEvent.setup();
+      renderPopover({ open: false });
+
+      await user.click(screen.getByRole('button', { name: 'Open popover' }));
+
+      expect(document.querySelector('[data-cl-slot="popover-positioner"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('positioner has aria-labelledby linked to title', () => {
+      renderPopover({ defaultOpen: true });
+
+      const title = document.querySelector('[data-cl-slot="popover-title"]');
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+
+      expect(title).toHaveAttribute('id');
+      expect(positioner).toHaveAttribute('aria-labelledby', title?.getAttribute('id'));
+    });
+
+    it('positioner has aria-describedby linked to description', () => {
+      renderPopover({ defaultOpen: true });
+
+      const desc = document.querySelector('[data-cl-slot="popover-description"]');
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+
+      expect(desc).toHaveAttribute('id');
+      expect(positioner).toHaveAttribute('aria-describedby', desc?.getAttribute('id'));
+    });
+
+    it('trigger has role=button', () => {
+      renderPopover();
+      expect(screen.getByRole('button', { name: 'Open popover' })).toBeInTheDocument();
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('positioner is not rendered when closed', () => {
+      renderPopover();
+      expect(document.querySelector('[data-cl-slot="popover-positioner"]')).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on popup when open', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button', { name: 'Open popover' }));
+
+      const popup = document.querySelector('[data-cl-slot="popover-popup"]');
+      expect(popup).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('positioner has data-cl-side', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button', { name: 'Open popover' }));
+
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side');
+    });
+  });
+
+  describe('content rendering', () => {
+    it('renders children content when open', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button', { name: 'Open popover' }));
+
+      expect(screen.getByText('Popover content')).toBeInTheDocument();
+      expect(screen.getByText('Popover Title')).toBeInTheDocument();
+      expect(screen.getByText('Some description')).toBeInTheDocument();
+    });
+  });
+
+  describe('placement', () => {
+    it('accepts custom placement', () => {
+      renderPopover({ defaultOpen: true, placement: 'top-start' });
+
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side', 'top');
+    });
+
+    it('defaults to bottom placement', () => {
+      renderPopover({ defaultOpen: true });
+
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side', 'bottom');
+    });
+  });
+
+  describe('focus management', () => {
+    it('moves focus into popover on open', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button', { name: 'Open popover' }));
+      // FloatingFocusManager schedules focus via requestAnimationFrame
+      await new Promise(r => requestAnimationFrame(r));
+
+      const positioner = document.querySelector('[data-cl-slot="popover-positioner"]');
+      expect(positioner?.contains(document.activeElement)).toBe(true);
+    });
+
+    it('returns focus to trigger on close via Escape', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      await user.click(trigger);
+      await user.keyboard('{Escape}');
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('returns focus to trigger on close via Close button', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      const trigger = screen.getByRole('button', { name: 'Open popover' });
+      await user.click(trigger);
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = renderPopover();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      renderPopover({ defaultOpen: true });
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/popover/popover.tsx
+++ b/packages/headless/src/primitives/popover/popover.tsx
@@ -1,0 +1,418 @@
+'use client';
+
+import {
+  arrow,
+  autoUpdate,
+  type ExtendedRefs,
+  FloatingArrow,
+  type FloatingContext,
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  flip,
+  offset,
+  type Placement,
+  type ReferenceType,
+  shift,
+  type UseInteractionsReturn,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import {
+  type CSSProperties,
+  createContext,
+  type ReactNode,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface PopoverContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  arrowRef: React.MutableRefObject<SVGSVGElement | null>;
+  modal: boolean;
+  labelId: string | undefined;
+  descriptionId: string | undefined;
+  setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+}
+
+const PopoverContext = createContext<PopoverContextValue | null>(null);
+
+function usePopoverContext() {
+  const ctx = useContext(PopoverContext);
+  if (!ctx) {
+    throw new Error('Popover compound components must be used within <Popover>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Popover (root)
+// ---------------------------------------------------------------------------
+
+export interface PopoverProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placement?: Placement;
+  sideOffset?: number;
+  modal?: boolean;
+  children: ReactNode;
+}
+
+function PopoverInner(props: PopoverProps) {
+  const nodeId = useFloatingNodeId();
+  const { placement: placementProp = 'bottom', sideOffset = 4, modal = false, children } = props;
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const [labelId, setLabelId] = useState<string | undefined>();
+  const [descriptionId, setDescriptionId] = useState<string | undefined>();
+
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    refs,
+    floatingStyles,
+    context: floatingContext,
+    placement,
+  } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: placementProp,
+    middleware: [
+      offset(sideOffset),
+      flip({
+        crossAxis: placementProp.includes('-'),
+        fallbackAxisSideDirection: 'end',
+        padding: 5,
+      }),
+      shift({ padding: 5 }),
+      arrow({ element: arrowRef }),
+      floatingCssVars({ sideOffset }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const click = useClick(floatingContext);
+  const dismiss = useDismiss(floatingContext);
+  const role = useRole(floatingContext);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role]);
+
+  const contextValue = useMemo<PopoverContextValue>(
+    () => ({
+      open,
+      setOpen,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      popupRef,
+      arrowRef,
+      modal,
+      labelId,
+      descriptionId,
+      setLabelId,
+      setDescriptionId,
+      mounted,
+      transitionProps,
+    }),
+    [
+      open,
+      setOpen,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      modal,
+      labelId,
+      descriptionId,
+      mounted,
+      transitionProps,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <PopoverContext.Provider value={contextValue}>{children}</PopoverContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function PopoverRoot(props: PopoverProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <PopoverInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <PopoverInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Trigger
+// ---------------------------------------------------------------------------
+
+export interface PopoverTriggerProps extends ComponentProps<'button'> {}
+
+function PopoverTrigger(props: PopoverTriggerProps) {
+  const { render, ...otherProps } = props;
+  const { open, refs, getReferenceProps } = usePopoverContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'popover-trigger',
+    ref: refs.setReference,
+    ...(getReferenceProps() as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Portal
+// ---------------------------------------------------------------------------
+
+export interface PopoverPortalProps {
+  children: ReactNode;
+}
+
+function PopoverPortal(props: PopoverPortalProps) {
+  const { mounted } = usePopoverContext();
+  if (!mounted) return null;
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Positioner
+// ---------------------------------------------------------------------------
+
+export interface PopoverPositionerProps extends ComponentProps<'div'> {}
+
+function PopoverPositioner(props: PopoverPositionerProps) {
+  const { render, ...otherProps } = props;
+  const { mounted, floatingContext, refs, floatingStyles, placement, getFloatingProps, modal, labelId, descriptionId } =
+    usePopoverContext();
+
+  const side = placement.split('-')[0];
+
+  const defaultProps = {
+    'data-cl-slot': 'popover-positioner',
+    'data-cl-side': side,
+    ref: refs.setFloating,
+    style: floatingStyles,
+    'aria-labelledby': labelId,
+    'aria-describedby': descriptionId,
+    ...(getFloatingProps() as React.ComponentPropsWithRef<'div'>),
+  };
+
+  const element = renderElement({
+    defaultTagName: 'div',
+    render,
+    enabled: mounted,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+
+  return (
+    <FloatingFocusManager
+      context={floatingContext}
+      modal={modal}
+    >
+      {element!}
+    </FloatingFocusManager>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Popup
+// ---------------------------------------------------------------------------
+
+export interface PopoverPopupProps extends ComponentProps<'div'> {}
+
+function PopoverPopup(props: PopoverPopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, transitionProps } = usePopoverContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'popover-popup',
+    ref: popupRef,
+    ...transitionProps,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Arrow
+// ---------------------------------------------------------------------------
+
+export interface PopoverArrowProps extends React.ComponentPropsWithRef<typeof FloatingArrow> {}
+
+function PopoverArrowComponent(props: PopoverArrowProps) {
+  const { floatingContext, arrowRef, placement } = usePopoverContext();
+  const side = placement.split('-')[0];
+
+  return (
+    <FloatingArrow
+      data-cl-slot='popover-arrow'
+      data-cl-side={side}
+      {...props}
+      ref={arrowRef}
+      context={floatingContext}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Title
+// ---------------------------------------------------------------------------
+
+export interface PopoverTitleProps extends ComponentProps<'h2'> {}
+
+function PopoverTitle(props: PopoverTitleProps) {
+  const { render, ...otherProps } = props;
+  const { setLabelId } = usePopoverContext();
+  const id = useId();
+
+  useLayoutEffect(() => {
+    setLabelId(id);
+    return () => setLabelId(undefined);
+  }, [id, setLabelId]);
+
+  const defaultProps = {
+    'data-cl-slot': 'popover-title',
+    id,
+  };
+
+  return renderElement({
+    defaultTagName: 'h2',
+    render,
+    props: mergeProps<'h2'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Description
+// ---------------------------------------------------------------------------
+
+export interface PopoverDescriptionProps extends ComponentProps<'p'> {}
+
+function PopoverDescription(props: PopoverDescriptionProps) {
+  const { render, ...otherProps } = props;
+  const { setDescriptionId } = usePopoverContext();
+  const id = useId();
+
+  useLayoutEffect(() => {
+    setDescriptionId(id);
+    return () => setDescriptionId(undefined);
+  }, [id, setDescriptionId]);
+
+  const defaultProps = {
+    'data-cl-slot': 'popover-description',
+    id,
+  };
+
+  return renderElement({
+    defaultTagName: 'p',
+    render,
+    props: mergeProps<'p'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Popover.Close
+// ---------------------------------------------------------------------------
+
+export interface PopoverCloseProps extends ComponentProps<'button'> {}
+
+function PopoverClose(props: PopoverCloseProps) {
+  const { render, ...otherProps } = props;
+  const { setOpen } = usePopoverContext();
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'popover-close',
+    onClick() {
+      setOpen(false);
+    },
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Popover = Object.assign(PopoverRoot, {
+  Trigger: PopoverTrigger,
+  Portal: PopoverPortal,
+  Positioner: PopoverPositioner,
+  Popup: PopoverPopup,
+  Arrow: PopoverArrowComponent,
+  Title: PopoverTitle,
+  Description: PopoverDescription,
+  Close: PopoverClose,
+});

--- a/packages/headless/src/primitives/popover/popover.tsx
+++ b/packages/headless/src/primitives/popover/popover.tsx
@@ -36,8 +36,8 @@ import {
   useState,
 } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
-import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
+import { cssVars } from '../../utils/css-vars';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -119,12 +119,12 @@ function PopoverInner(props: PopoverProps) {
       }),
       shift({ padding: 5 }),
       arrow({ element: arrowRef }),
-      floatingCssVars({ sideOffset }),
+      cssVars({ sideOffset }),
     ],
     whileElementsMounted: autoUpdate,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -229,12 +229,13 @@ function PopoverTrigger(props: PopoverTriggerProps) {
 
 export interface PopoverPortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function PopoverPortal(props: PopoverPortalProps) {
   const { mounted } = usePopoverContext();
   if (!mounted) return null;
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return <FloatingPortal root={props.root}>{props.children}</FloatingPortal>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/headless/src/primitives/select/README.md
+++ b/packages/headless/src/primitives/select/README.md
@@ -1,0 +1,162 @@
+# Select
+
+A dropdown select component with keyboard navigation, typeahead, and optional item-to-trigger alignment. Replaces native `<select>` with a fully styled, accessible alternative.
+
+## When to Use
+
+- Picking a single value from a predefined list of options.
+- When you need typeahead, keyboard navigation, and full styling control.
+- Prefer Select over Autocomplete when the user should choose from a fixed list without typing to filter.
+
+## Usage
+
+```tsx
+import { Select } from '@/primitives/select';
+
+<Select>
+  <Select.Trigger>
+    <Select.Value placeholder='Choose a fruit...' />
+  </Select.Trigger>
+  <Select.Positioner>
+    <Select.Popup>
+      <Select.Option
+        value='apple'
+        label='Apple'
+      />
+      <Select.Option
+        value='banana'
+        label='Banana'
+      />
+      <Select.Option
+        value='cherry'
+        label='Cherry'
+      />
+    </Select.Popup>
+  </Select.Positioner>
+</Select>;
+```
+
+### Controlled
+
+```tsx
+const [value, setValue] = useState('apple');
+
+<Select
+  value={value}
+  onValueChange={setValue}
+>
+  {/* ... */}
+</Select>;
+```
+
+### With `items` for SSR label resolution
+
+The `items` prop allows label resolution before options mount (useful for server rendering or deferred lists):
+
+```tsx
+const items = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+];
+
+<Select
+  items={items}
+  defaultValue='apple'
+>
+  {/* Select.Value will display "Apple" even before Options mount */}
+</Select>;
+```
+
+### Disable item-to-trigger alignment
+
+By default, the selected option visually aligns with the trigger. Disable this for standard dropdown positioning:
+
+```tsx
+<Select alignItemWithTrigger={false}>{/* Uses standard Floating UI positioning */}</Select>
+```
+
+## Parts
+
+| Part                | Default Element | Description                                |
+| ------------------- | --------------- | ------------------------------------------ |
+| `Select`            | —               | Root context provider                      |
+| `Select.Trigger`    | `<button>`      | Toggles the dropdown on click              |
+| `Select.Value`      | `<span>`        | Displays the selected label or placeholder |
+| `Select.Positioner` | `<div>`         | Floating positioned container (portal)     |
+| `Select.Popup`      | `<div>`         | Visual wrapper for the option list         |
+| `Select.Option`     | `<button>`      | A selectable option                        |
+| `Select.Arrow`      | `<svg>`         | Optional floating arrow                    |
+
+## Props
+
+### `Select` (root)
+
+| Prop                   | Type                      | Default          | Description                                                        |
+| ---------------------- | ------------------------- | ---------------- | ------------------------------------------------------------------ |
+| `value`                | `string`                  | —                | Controlled selected value                                          |
+| `defaultValue`         | `string`                  | —                | Initial selected value (uncontrolled)                              |
+| `onValueChange`        | `(value: string) => void` | —                | Called when selection changes                                      |
+| `open`                 | `boolean`                 | —                | Controlled open state                                              |
+| `defaultOpen`          | `boolean`                 | `false`          | Initial open state (uncontrolled)                                  |
+| `onOpenChange`         | `(open: boolean) => void` | —                | Called when open state changes                                     |
+| `items`                | `SelectItem[]`            | —                | `{ label, value }` pairs for label resolution before options mount |
+| `alignItemWithTrigger` | `boolean`                 | `true`           | Visually align selected option over the trigger                    |
+| `placement`            | `Placement`               | `"bottom-start"` | Floating UI placement                                              |
+| `sideOffset`           | `number`                  | `4`              | Gap between trigger and popup (px)                                 |
+
+### `Select.Value`
+
+| Prop          | Type        | Default | Description                     |
+| ------------- | ----------- | ------- | ------------------------------- |
+| `placeholder` | `ReactNode` | —       | Shown when no value is selected |
+
+### `Select.Option`
+
+| Prop       | Type      | Default               | Description                            |
+| ---------- | --------- | --------------------- | -------------------------------------- |
+| `value`    | `string`  | **required**          | The option's value                     |
+| `label`    | `string`  | falls back to `value` | Display label, also used for typeahead |
+| `disabled` | `boolean` | —                     | Prevents selection                     |
+
+### `Select.Trigger`, `Select.Positioner`, `Select.Popup`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+### `Select.Arrow`
+
+Accepts all `FloatingArrow` props. `ref` and `context` are injected automatically.
+
+## Keyboard Navigation
+
+| Key               | Action                                |
+| ----------------- | ------------------------------------- |
+| `ArrowDown`       | Move to next option                   |
+| `ArrowUp`         | Move to previous option               |
+| `Enter` / `Space` | Select the active option, close popup |
+| `Escape`          | Close the popup                       |
+| Type a character  | Jump to matching option (typeahead)   |
+
+Typeahead also works while the popup is closed — it changes the selected value directly.
+
+## Data Attributes
+
+| Attribute                         | Applies To | Description                              |
+| --------------------------------- | ---------- | ---------------------------------------- |
+| `data-cl-slot`                    | All parts  | Part identifier (e.g. `"select-option"`) |
+| `data-cl-open` / `data-cl-closed` | Trigger    | Popup open state                         |
+| `data-cl-selected`                | Option     | The currently selected option            |
+| `data-cl-active`                  | Option     | The keyboard-highlighted option          |
+| `data-cl-disabled`                | Option     | Disabled option                          |
+| `data-cl-side`                    | Positioner | Resolved placement side                  |
+
+## Important Notes
+
+- **`label` on `Select.Option`** drives both display in `Select.Value` and typeahead matching. If omitted, `value` is used for both.
+- **`items` prop** is only for label resolution — it does not control which options render. You still render `Select.Option` children yourself.
+- **Disabled options** can still receive keyboard focus but cannot be selected.
+
+## ARIA
+
+- Popup: `role="listbox"`
+- Option: `role="option"`, `aria-selected`, `aria-disabled`
+- Trigger: `aria-expanded`, `aria-haspopup="listbox"`, `aria-controls`

--- a/packages/headless/src/primitives/select/README.md
+++ b/packages/headless/src/primitives/select/README.md
@@ -82,7 +82,8 @@ By default, the selected option visually aligns with the trigger. Disable this f
 | `Select`            | —               | Root context provider                      |
 | `Select.Trigger`    | `<button>`      | Toggles the dropdown on click              |
 | `Select.Value`      | `<span>`        | Displays the selected label or placeholder |
-| `Select.Positioner` | `<div>`         | Floating positioned container (portal)     |
+| `Select.Portal`     | —               | Portals children (accepts `root` prop)     |
+| `Select.Positioner` | `<div>`         | Floating positioned container              |
 | `Select.Popup`      | `<div>`         | Visual wrapper for the option list         |
 | `Select.Option`     | `<button>`      | A selectable option                        |
 | `Select.Arrow`      | `<svg>`         | Optional floating arrow                    |

--- a/packages/headless/src/primitives/select/index.ts
+++ b/packages/headless/src/primitives/select/index.ts
@@ -1,0 +1,12 @@
+export type {
+  SelectArrowProps,
+  SelectItem,
+  SelectOptionProps,
+  SelectPopupProps,
+  SelectPortalProps,
+  SelectPositionerProps,
+  SelectProps,
+  SelectTriggerProps,
+  SelectValueProps,
+} from './select';
+export { Select } from './select';

--- a/packages/headless/src/primitives/select/select.test.tsx
+++ b/packages/headless/src/primitives/select/select.test.tsx
@@ -213,6 +213,114 @@ describe('Select', () => {
       const activeOption = document.querySelector('[data-cl-slot="select-option"][data-cl-active]');
       expect(activeOption).toBeInTheDocument();
     });
+
+    it('scrolls options into view on arrow key navigation', async () => {
+      const manyItems = Array.from({ length: 20 }, (_, i) => ({
+        label: `Item ${i + 1}`,
+        value: `item-${i + 1}`,
+      }));
+
+      const user = userEvent.setup();
+      render(
+        <Select
+          items={manyItems}
+          alignItemWithTrigger={false}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <div style={{ maxHeight: '100px', overflow: 'auto' }}>
+                {manyItems.map(({ label, value }) => (
+                  <Select.Option
+                    key={value}
+                    value={value}
+                    label={label}
+                  >
+                    {label}
+                  </Select.Option>
+                ))}
+              </div>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+
+      // Navigate down through many items to force scrolling
+      for (let i = 0; i < 15; i++) {
+        await user.keyboard('{ArrowDown}');
+      }
+
+      const activeOption = document.querySelector('[data-cl-slot="select-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+
+      // The active item should be visible within its scroll container
+      const scrollContainer = activeOption!.closest('div[style]') as HTMLElement;
+      const optionRect = activeOption!.getBoundingClientRect();
+      const containerRect = scrollContainer.getBoundingClientRect();
+
+      expect(optionRect.bottom).toBeLessThanOrEqual(containerRect.bottom + 1);
+      expect(optionRect.top).toBeGreaterThanOrEqual(containerRect.top - 1);
+    });
+
+    it('scrolls selected item into view when reopening', async () => {
+      const manyItems = Array.from({ length: 20 }, (_, i) => ({
+        label: `Item ${i + 1}`,
+        value: `item-${i + 1}`,
+      }));
+
+      const user = userEvent.setup();
+      render(
+        <Select
+          items={manyItems}
+          alignItemWithTrigger={false}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <div style={{ maxHeight: '100px', overflow: 'auto' }}>
+                {manyItems.map(({ label, value }) => (
+                  <Select.Option
+                    key={value}
+                    value={value}
+                    label={label}
+                  >
+                    {label}
+                  </Select.Option>
+                ))}
+              </div>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+
+      // Open, navigate to item near the bottom, select it
+      await user.click(trigger);
+      for (let i = 0; i < 15; i++) {
+        await user.keyboard('{ArrowDown}');
+      }
+      await user.keyboard('{Enter}');
+
+      // Reopen — the selected item should be scrolled into view
+      await user.click(trigger);
+
+      const selectedOption = document.querySelector('[data-cl-slot="select-option"][data-cl-selected]');
+      expect(selectedOption).toBeInTheDocument();
+
+      const scrollContainer = selectedOption!.closest('div[style]') as HTMLElement;
+      const optionRect = selectedOption!.getBoundingClientRect();
+      const containerRect = scrollContainer.getBoundingClientRect();
+
+      expect(optionRect.bottom).toBeLessThanOrEqual(containerRect.bottom + 1);
+      expect(optionRect.top).toBeGreaterThanOrEqual(containerRect.top - 1);
+    });
   });
 
   describe('option state attributes', () => {

--- a/packages/headless/src/primitives/select/select.test.tsx
+++ b/packages/headless/src/primitives/select/select.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { axe } from '../../test-utils/axe';
@@ -522,6 +522,97 @@ describe('Select', () => {
       const positioner = document.querySelector('[data-cl-slot="select-positioner"]') as HTMLElement;
       // Standard Floating UI positioning uses position: absolute with transform
       expect(positioner.style.position).toBe('absolute');
+    });
+
+    const manyItems: SelectItem[] = Array.from({ length: 20 }, (_, i) => ({
+      label: `Item ${i + 1}`,
+      value: `item-${i + 1}`,
+    }));
+
+    it('aligns selected item with trigger vertically', async () => {
+      render(
+        <Select
+          items={manyItems}
+          defaultOpen
+          defaultValue='item-10'
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              {manyItems.map(({ label, value }) => (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  label={label}
+                >
+                  {label}
+                </Select.Option>
+              ))}
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      const selectedOption = document.querySelector('[data-cl-slot="select-option"][data-cl-selected]');
+      expect(selectedOption).toBeInTheDocument();
+
+      const triggerRect = trigger.getBoundingClientRect();
+      const selectedRect = selectedOption!.getBoundingClientRect();
+
+      // The selected item should be positioned near the trigger's vertical position
+      expect(Math.abs(selectedRect.top - triggerRect.top)).toBeLessThan(50);
+    });
+
+    it('repositions when ancestor scrolls', async () => {
+      const user = userEvent.setup();
+      render(
+        <div
+          data-testid='scroll-container'
+          style={{ height: '200px', overflow: 'auto', paddingTop: '300px' }}
+        >
+          <Select
+            items={manyItems}
+            defaultValue='item-5'
+          >
+            <Select.Trigger>
+              <Select.Value placeholder='Pick...' />
+            </Select.Trigger>
+            <Select.Positioner>
+              <Select.Popup>
+                {manyItems.map(({ label, value }) => (
+                  <Select.Option
+                    key={value}
+                    value={value}
+                    label={label}
+                  >
+                    {label}
+                  </Select.Option>
+                ))}
+              </Select.Popup>
+            </Select.Positioner>
+          </Select>
+          <div style={{ height: '500px' }} />
+        </div>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]') as HTMLElement;
+      const initialTop = positioner.getBoundingClientRect().top;
+
+      // Scroll the container
+      const scrollContainer = screen.getByTestId('scroll-container');
+      scrollContainer.scrollTop = 100;
+      scrollContainer.dispatchEvent(new Event('scroll'));
+
+      // autoUpdate repositions on scroll — wait for the update
+      await waitFor(() => {
+        const newTop = positioner.getBoundingClientRect().top;
+        expect(newTop).not.toBe(initialTop);
+      });
     });
   });
 

--- a/packages/headless/src/primitives/select/select.test.tsx
+++ b/packages/headless/src/primitives/select/select.test.tsx
@@ -1,0 +1,504 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Select, type SelectItem } from './select';
+
+afterEach(() => cleanup());
+
+const fruits: SelectItem[] = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+];
+
+function renderSelect(props: Partial<React.ComponentProps<typeof Select>> = {}) {
+  const { children, ...rest } = props as Record<string, unknown>;
+  return render(
+    <Select
+      items={fruits}
+      alignItemWithTrigger={false}
+      {...rest}
+    >
+      <Select.Trigger>
+        <Select.Value placeholder='Pick a fruit...' />
+      </Select.Trigger>
+      <Select.Positioner>
+        <Select.Popup>
+          {fruits.map(({ label, value }) => (
+            <Select.Option
+              key={value}
+              value={value}
+              label={label}
+            >
+              {label}
+            </Select.Option>
+          ))}
+        </Select.Popup>
+      </Select.Positioner>
+    </Select>,
+  );
+}
+
+describe('Select', () => {
+  describe('slot attributes', () => {
+    it('renders trigger with data-cl-slot', () => {
+      renderSelect();
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('data-cl-slot', 'select-trigger');
+    });
+
+    it('renders value with data-cl-slot', () => {
+      renderSelect();
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value).toBeInTheDocument();
+    });
+
+    it('renders all parts with correct slot attributes when open', () => {
+      renderSelect({ defaultOpen: true });
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      const popup = document.querySelector('[data-cl-slot="select-popup"]');
+      const options = document.querySelectorAll('[data-cl-slot="select-option"]');
+
+      expect(positioner).toBeInTheDocument();
+      expect(popup).toBeInTheDocument();
+      expect(options).toHaveLength(3);
+    });
+  });
+
+  describe('items prop and label resolution', () => {
+    it('shows placeholder when no value is selected', () => {
+      renderSelect();
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toBe('Pick a fruit...');
+    });
+
+    it('resolves label from items before options mount', () => {
+      renderSelect({ defaultValue: 'banana' });
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toBe('Banana');
+    });
+
+    it('resolves label for controlled value from items', () => {
+      renderSelect({ value: 'cherry' });
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toBe('Cherry');
+    });
+
+    it('falls back to raw value when no items provided', () => {
+      render(
+        <Select
+          defaultValue='banana'
+          alignItemWithTrigger={false}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Option
+                value='banana'
+                label='Banana'
+              >
+                Banana
+              </Select.Option>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toBe('banana');
+    });
+
+    it('updates label after selection via option registry', async () => {
+      const user = userEvent.setup();
+      // No items prop — labels only known once options mount
+      render(
+        <Select alignItemWithTrigger={false}>
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Option
+                value='x'
+                label='Special Item'
+              >
+                Special Item
+              </Select.Option>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Special Item'));
+
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toBe('Special Item');
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens on trigger click', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('data-cl-open', '');
+      expect(document.querySelector('[data-cl-slot="select-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      renderSelect({ defaultOpen: true });
+
+      await user.keyboard('{Escape}');
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onOpenChange when toggled', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      renderSelect({ onOpenChange });
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('selection', () => {
+    it('selects option on click', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      renderSelect({ onValueChange });
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+
+      const option = screen.getByText('Banana');
+      await user.click(option);
+
+      expect(onValueChange).toHaveBeenCalledWith('banana');
+    });
+
+    it('displays selected label in Value after selection', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Cherry'));
+
+      const value = document.querySelector('[data-cl-slot="select-value"]');
+      expect(value?.textContent).toContain('Cherry');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('navigates options with arrow keys', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="select-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+  });
+
+  describe('option state attributes', () => {
+    it('marks selected option with data-cl-selected', () => {
+      renderSelect({ defaultValue: 'banana', defaultOpen: true });
+
+      const options = document.querySelectorAll('[data-cl-slot="select-option"]');
+      expect(options[1]).toHaveAttribute('data-cl-selected', '');
+    });
+
+    it('marks active option with data-cl-active', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{ArrowDown}');
+
+      const activeOption = document.querySelector('[data-cl-slot="select-option"][data-cl-active]');
+      expect(activeOption).toBeInTheDocument();
+    });
+  });
+
+  describe('disabled option', () => {
+    it('renders disabled option with data-cl-disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Select alignItemWithTrigger={false}>
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Option
+                value='apple'
+                label='Apple'
+              >
+                Apple
+              </Select.Option>
+              <Select.Option
+                value='banana'
+                label='Banana'
+                disabled
+              >
+                Banana
+              </Select.Option>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+
+      const disabledOption = screen.getByText('Banana').closest("[data-cl-slot='select-option']");
+      expect(disabledOption).toHaveAttribute('data-cl-disabled', '');
+      expect(disabledOption).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not select disabled option on click', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Select
+          onValueChange={onValueChange}
+          alignItemWithTrigger={false}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Option
+                value='apple'
+                label='Apple'
+              >
+                Apple
+              </Select.Option>
+              <Select.Option
+                value='banana'
+                label='Banana'
+                disabled
+              >
+                Banana
+              </Select.Option>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Banana'));
+
+      expect(onValueChange).not.toHaveBeenCalledWith('banana');
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('options have role=option', () => {
+      renderSelect({ defaultOpen: true });
+
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(3);
+    });
+
+    it('selected option has aria-selected=true', () => {
+      renderSelect({ defaultValue: 'apple', defaultOpen: true });
+
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveAttribute('aria-selected', 'true');
+      expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('positioner is not rendered when closed', () => {
+      renderSelect();
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      expect(positioner).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on popup when open', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      await user.click(screen.getByRole('combobox'));
+
+      const popup = document.querySelector('[data-cl-slot="select-popup"]');
+      expect(popup).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('positioner has data-cl-side', async () => {
+      const user = userEvent.setup();
+      renderSelect();
+
+      await user.click(screen.getByRole('combobox'));
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side');
+    });
+  });
+
+  describe('controlled open', () => {
+    it('respects controlled open prop', () => {
+      renderSelect({ open: true });
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      expect(positioner).toBeInTheDocument();
+    });
+
+    it('does not open when controlled open is false', async () => {
+      const user = userEvent.setup();
+      renderSelect({ open: false });
+
+      await user.click(screen.getByRole('combobox'));
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      expect(positioner).not.toBeInTheDocument();
+    });
+  });
+
+  describe('alignItemWithTrigger', () => {
+    it('defaults to true', () => {
+      // Render without explicitly setting alignItemWithTrigger
+      render(
+        <Select
+          items={fruits}
+          defaultOpen
+          defaultValue='banana'
+        >
+          <Select.Trigger>
+            <Select.Value placeholder='Pick...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              {fruits.map(({ label, value }) => (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  label={label}
+                >
+                  {label}
+                </Select.Option>
+              ))}
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+
+      // The positioner should render (alignItemWithTrigger doesn't prevent rendering)
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]');
+      expect(positioner).toBeInTheDocument();
+    });
+
+    it('uses standard floating styles when disabled', async () => {
+      const user = userEvent.setup();
+      renderSelect({ alignItemWithTrigger: false });
+
+      await user.click(screen.getByRole('combobox'));
+
+      const positioner = document.querySelector('[data-cl-slot="select-positioner"]') as HTMLElement;
+      // Standard Floating UI positioning uses position: absolute with transform
+      expect(positioner.style.position).toBe('absolute');
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = render(
+        <Select
+          items={fruits}
+          alignItemWithTrigger={false}
+        >
+          <Select.Trigger aria-label='Fruit'>
+            <Select.Value placeholder='Pick a fruit...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              {fruits.map(({ label, value }) => (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  label={label}
+                >
+                  {label}
+                </Select.Option>
+              ))}
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      render(
+        <Select
+          items={fruits}
+          alignItemWithTrigger={false}
+          defaultOpen
+        >
+          <Select.Trigger aria-label='Fruit'>
+            <Select.Value placeholder='Pick a fruit...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              {fruits.map(({ label, value }) => (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  label={label}
+                >
+                  {label}
+                </Select.Option>
+              ))}
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+
+    it('has no violations with a selected value', async () => {
+      const { container } = render(
+        <Select
+          items={fruits}
+          alignItemWithTrigger={false}
+          defaultValue='banana'
+        >
+          <Select.Trigger aria-label='Fruit'>
+            <Select.Value placeholder='Pick a fruit...' />
+          </Select.Trigger>
+          <Select.Positioner>
+            <Select.Popup>
+              {fruits.map(({ label, value }) => (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  label={label}
+                >
+                  {label}
+                </Select.Option>
+              ))}
+            </Select.Popup>
+          </Select.Positioner>
+        </Select>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/select/select.tsx
+++ b/packages/headless/src/primitives/select/select.tsx
@@ -44,8 +44,8 @@ import {
   useState,
 } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
-import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
+import { cssVars } from '../../utils/css-vars';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -235,12 +235,12 @@ function SelectInner(props: SelectProps) {
       }),
       ...(!alignProp ? [arrow({ element: arrowRef })] : []),
       ...(alignProp ? [alignSelectedItem(selectedItemRef)] : []),
-      floatingCssVars({ sideOffset }),
+      cssVars({ sideOffset }),
     ],
     whileElementsMounted: autoUpdate,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -424,12 +424,13 @@ function SelectValue(props: SelectValueProps) {
 
 export interface SelectPortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function SelectPortal(props: SelectPortalProps) {
   const { mounted } = useSelectContext();
   if (!mounted) return null;
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return <FloatingPortal root={props.root}>{props.children}</FloatingPortal>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/headless/src/primitives/select/select.tsx
+++ b/packages/headless/src/primitives/select/select.tsx
@@ -12,6 +12,7 @@ import {
   FloatingPortal,
   FloatingTree,
   flip,
+  type Middleware,
   offset,
   type Placement,
   type ReferenceType,
@@ -38,7 +39,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -77,6 +77,45 @@ function resolveLabel(
   if (label) return label;
   // 3. fallback to raw value
   return value;
+}
+
+// ---------------------------------------------------------------------------
+// alignSelectedItem middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom floating-ui middleware that positions the floating element so the
+ * selected item overlays the reference (trigger), like a native `<select>`.
+ * Running as middleware means it automatically re-runs on scroll/resize via
+ * `autoUpdate`, preventing drift.
+ */
+function alignSelectedItem(selectedItemRef: RefObject<HTMLElement | null>): Middleware {
+  return {
+    name: 'alignSelectedItem',
+    fn({ elements }) {
+      const selectedEl = selectedItemRef.current;
+      if (!selectedEl) return {};
+
+      const floatingRect = elements.floating.getBoundingClientRect();
+      const selectedRect = selectedEl.getBoundingClientRect();
+      const referenceRect = (elements.reference as HTMLElement).getBoundingClientRect();
+
+      // How far the selected item is from the top of the floating element
+      const itemOffsetInPopup = selectedRect.top - floatingRect.top;
+
+      // Position so the selected item sits at the same Y as the trigger
+      const desiredTop = referenceRect.top - itemOffsetInPopup;
+
+      // Clamp to viewport with 8px padding
+      const viewportHeight = window.innerHeight;
+      const clampedTop = Math.max(8, Math.min(desiredTop, viewportHeight - floatingRect.height - 8));
+
+      return {
+        x: referenceRect.left,
+        y: clampedTop,
+      };
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -185,9 +224,8 @@ function SelectInner(props: SelectProps) {
     onOpenChange: setOpen,
     placement: placementProp,
     middleware: [
-      offset(sideOffset),
-      flip(),
-      shift({ padding: 5 }),
+      offset(alignProp ? 0 : sideOffset),
+      ...(!alignProp ? [flip(), shift({ padding: 5 })] : []),
       size({
         apply({ availableHeight, elements }) {
           Object.assign(elements.floating.style, {
@@ -195,7 +233,8 @@ function SelectInner(props: SelectProps) {
           });
         },
       }),
-      arrow({ element: arrowRef }),
+      ...(!alignProp ? [arrow({ element: arrowRef })] : []),
+      ...(alignProp ? [alignSelectedItem(selectedItemRef)] : []),
       floatingCssVars({ sideOffset }),
     ],
     whileElementsMounted: autoUpdate,
@@ -402,7 +441,6 @@ export interface SelectPositionerProps extends ComponentProps<'div'> {}
 function SelectPositioner(props: SelectPositionerProps) {
   const { render, ...otherProps } = props;
   const {
-    open,
     mounted,
     floatingContext,
     refs,
@@ -411,61 +449,16 @@ function SelectPositioner(props: SelectPositionerProps) {
     getFloatingProps,
     elementsRef,
     labelsRef,
-    selectedItemRef,
-    alignItemWithTrigger,
     setActiveIndex,
   } = useSelectContext();
 
-  const [alignOffset, setAlignOffset] = useState<CSSProperties | null>(null);
-
-  // alignItemWithTrigger: compute the vertical offset so the selected item
-  // text overlays the trigger. Runs after the popup has rendered.
-  useLayoutEffect(() => {
-    if (!open || !mounted || !alignItemWithTrigger) {
-      setAlignOffset(null);
-      return;
-    }
-
-    const triggerEl = refs.domReference.current as HTMLElement | null;
-    const floatingEl = refs.floating.current;
-    const selectedEl = selectedItemRef.current;
-
-    if (!triggerEl || !floatingEl || !selectedEl) {
-      setAlignOffset(null);
-      return;
-    }
-
-    const triggerRect = triggerEl.getBoundingClientRect();
-    const floatingRect = floatingEl.getBoundingClientRect();
-    const selectedRect = selectedEl.getBoundingClientRect();
-
-    // How far the selected item is from the top of the floating element
-    const itemOffsetInPopup = selectedRect.top - floatingRect.top;
-
-    // We want the selected item to sit at the same Y as the trigger
-    const desiredTop = triggerRect.top - itemOffsetInPopup;
-
-    // Clamp to viewport
-    const viewportHeight = window.innerHeight;
-    const clampedTop = Math.max(8, Math.min(desiredTop, viewportHeight - floatingRect.height - 8));
-
-    setAlignOffset({
-      position: 'fixed',
-      top: clampedTop,
-      left: triggerRect.left,
-      minWidth: triggerRect.width,
-    });
-  }, [open, mounted, alignItemWithTrigger, refs, selectedItemRef]);
-
   const side = placement.split('-')[0];
-
-  const positionStyle = alignOffset ?? floatingStyles;
 
   const defaultProps = {
     'data-cl-slot': 'select-positioner',
     'data-cl-side': side,
     ref: refs.setFloating,
-    style: positionStyle,
+    style: floatingStyles,
     ...(getFloatingProps({
       onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
         if (event.key === 'Home' || event.key === 'End') {

--- a/packages/headless/src/primitives/select/select.tsx
+++ b/packages/headless/src/primitives/select/select.tsx
@@ -1,0 +1,640 @@
+'use client';
+
+import {
+  arrow,
+  autoUpdate,
+  type ExtendedRefs,
+  FloatingArrow,
+  type FloatingContext,
+  FloatingFocusManager,
+  FloatingList,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  flip,
+  offset,
+  type Placement,
+  type ReferenceType,
+  size,
+  type UseInteractionsReturn,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useInteractions,
+  useListItem,
+  useListNavigation,
+  useRole,
+  useTypeahead,
+} from '@floating-ui/react';
+import {
+  type CSSProperties,
+  createContext,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SelectItem {
+  label: string;
+  value: string;
+}
+
+// ---------------------------------------------------------------------------
+// Label resolution
+// ---------------------------------------------------------------------------
+
+function resolveLabel(
+  value: string | undefined,
+  items: SelectItem[] | undefined,
+  valueToLabelRef: React.MutableRefObject<Map<string, string>>,
+): string | null {
+  if (value === undefined) return null;
+  // 1. items prop (available before options mount)
+  if (items) {
+    const item = items.find(i => i.value === value);
+    if (item) return item.label;
+  }
+  // 2. runtime registry (populated after options mount)
+  const label = valueToLabelRef.current.get(value);
+  if (label) return label;
+  // 3. fallback to raw value
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface SelectContextValue {
+  open: boolean;
+  items: SelectItem[] | undefined;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  getItemProps: UseInteractionsReturn['getItemProps'];
+  activeIndex: number | null;
+  setActiveIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  selectedIndex: number | null;
+  selectedValue: string | undefined;
+  selectedLabel: string | null;
+  elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  labelsRef: React.MutableRefObject<Array<string | null>>;
+  popupRef: RefObject<HTMLDivElement | null>;
+  arrowRef: React.MutableRefObject<SVGSVGElement | null>;
+  valueToLabelRef: React.MutableRefObject<Map<string, string>>;
+  selectedItemRef: React.MutableRefObject<HTMLElement | null>;
+  alignItemWithTrigger: boolean;
+  handleSelect: (value: string, index: number) => void;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+}
+
+const SelectContext = createContext<SelectContextValue | null>(null);
+
+function useSelectContext() {
+  const ctx = useContext(SelectContext);
+  if (!ctx) {
+    throw new Error('Select compound components must be used within <Select>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Select (root)
+// ---------------------------------------------------------------------------
+
+export interface SelectProps {
+  /** Array of `{ label, value }` items for label resolution before options mount. */
+  items?: SelectItem[];
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * When true, the popup is positioned so the selected item overlays the
+   * trigger — like a native `<select>`. Defaults to `true`.
+   */
+  alignItemWithTrigger?: boolean;
+  placement?: Placement;
+  sideOffset?: number;
+  children: ReactNode;
+}
+
+function SelectInner(props: SelectProps) {
+  const {
+    items,
+    alignItemWithTrigger: alignProp = true,
+    placement: placementProp = 'bottom-start',
+    sideOffset = 4,
+    children,
+  } = props;
+
+  const nodeId = useFloatingNodeId();
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const [selectedValue, setSelectedValue] = useControllableState<string | undefined>(
+    props.value,
+    props.defaultValue,
+    props.onValueChange as ((value: string | undefined) => void) | undefined,
+  );
+
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  // Label captured at selection time — survives option unmount
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const elementsRef = useRef<Array<HTMLElement | null>>([]);
+  const labelsRef = useRef<Array<string | null>>([]);
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+  const valueToLabelRef = useRef<Map<string, string>>(new Map());
+  const selectedItemRef = useRef<HTMLElement | null>(null);
+
+  const {
+    refs,
+    floatingStyles,
+    context: floatingContext,
+    placement,
+  } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: placementProp,
+    middleware: [
+      offset(sideOffset),
+      flip(),
+      size({
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+      }),
+      arrow({ element: arrowRef }),
+      floatingCssVars({ sideOffset }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const handleSelect = useCallback(
+    (value: string, index: number) => {
+      setSelectedValue(value);
+      setSelectedIndex(index);
+      setSelectedLabel(valueToLabelRef.current.get(value) ?? value);
+      setOpen(false);
+    },
+    [setSelectedValue, setOpen],
+  );
+
+  const handleTypeaheadMatch = useCallback(
+    (index: number | null) => {
+      if (open) {
+        setActiveIndex(index);
+      } else if (index !== null) {
+        setSelectedIndex(index);
+      }
+    },
+    [open],
+  );
+
+  const click = useClick(floatingContext);
+  const dismiss = useDismiss(floatingContext);
+  const role = useRole(floatingContext, { role: 'listbox' });
+  const listNav = useListNavigation(floatingContext, {
+    listRef: elementsRef,
+    activeIndex,
+    selectedIndex,
+    onNavigate: setActiveIndex,
+    loop: true,
+  });
+  const typeahead = useTypeahead(floatingContext, {
+    listRef: labelsRef,
+    activeIndex,
+    selectedIndex,
+    onMatch: handleTypeaheadMatch,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    click,
+    dismiss,
+    role,
+    listNav,
+    typeahead,
+  ]);
+
+  const contextValue = useMemo<SelectContextValue>(
+    () => ({
+      open,
+      items,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      setActiveIndex,
+      selectedIndex,
+      selectedValue,
+      selectedLabel,
+      elementsRef,
+      labelsRef,
+      popupRef,
+      arrowRef,
+      valueToLabelRef,
+      selectedItemRef,
+      alignItemWithTrigger: alignProp,
+      handleSelect,
+      mounted,
+      transitionProps,
+    }),
+    [
+      open,
+      items,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      getItemProps,
+      activeIndex,
+      setActiveIndex,
+      selectedIndex,
+      selectedValue,
+      selectedLabel,
+      alignProp,
+      handleSelect,
+      mounted,
+      transitionProps,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <SelectContext.Provider value={contextValue}>{children}</SelectContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function SelectRoot(props: SelectProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <SelectInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <SelectInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Select.Trigger
+// ---------------------------------------------------------------------------
+
+export interface SelectTriggerProps extends ComponentProps<'button'> {}
+
+function SelectTrigger(props: SelectTriggerProps) {
+  const { render, ...otherProps } = props;
+  const { open, refs, getReferenceProps } = useSelectContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'select-trigger',
+    ref: refs.setReference,
+    ...(getReferenceProps() as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Select.Value
+// ---------------------------------------------------------------------------
+
+export interface SelectValueProps extends ComponentProps<'span'> {
+  placeholder?: ReactNode;
+}
+
+function SelectValue(props: SelectValueProps) {
+  const { render, placeholder, ...otherProps } = props;
+  const { selectedValue, selectedLabel, items, valueToLabelRef } = useSelectContext();
+
+  const displayText =
+    selectedValue !== undefined ? (selectedLabel ?? resolveLabel(selectedValue, items, valueToLabelRef)) : placeholder;
+
+  const defaultProps = {
+    'data-cl-slot': 'select-value',
+    children: displayText,
+  };
+
+  return renderElement({
+    defaultTagName: 'span',
+    render,
+    props: mergeProps<'span'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Select.Portal
+// ---------------------------------------------------------------------------
+
+export interface SelectPortalProps {
+  children: ReactNode;
+}
+
+function SelectPortal(props: SelectPortalProps) {
+  const { mounted } = useSelectContext();
+  if (!mounted) return null;
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Select.Positioner
+// ---------------------------------------------------------------------------
+
+export interface SelectPositionerProps extends ComponentProps<'div'> {}
+
+function SelectPositioner(props: SelectPositionerProps) {
+  const { render, ...otherProps } = props;
+  const {
+    open,
+    mounted,
+    floatingContext,
+    refs,
+    floatingStyles,
+    placement,
+    getFloatingProps,
+    elementsRef,
+    labelsRef,
+    selectedItemRef,
+    alignItemWithTrigger,
+    setActiveIndex,
+  } = useSelectContext();
+
+  const [alignOffset, setAlignOffset] = useState<CSSProperties | null>(null);
+
+  // alignItemWithTrigger: compute the vertical offset so the selected item
+  // text overlays the trigger. Runs after the popup has rendered.
+  useLayoutEffect(() => {
+    if (!open || !mounted || !alignItemWithTrigger) {
+      setAlignOffset(null);
+      return;
+    }
+
+    const triggerEl = refs.domReference.current as HTMLElement | null;
+    const floatingEl = refs.floating.current;
+    const selectedEl = selectedItemRef.current;
+
+    if (!triggerEl || !floatingEl || !selectedEl) {
+      setAlignOffset(null);
+      return;
+    }
+
+    const triggerRect = triggerEl.getBoundingClientRect();
+    const floatingRect = floatingEl.getBoundingClientRect();
+    const selectedRect = selectedEl.getBoundingClientRect();
+
+    // How far the selected item is from the top of the floating element
+    const itemOffsetInPopup = selectedRect.top - floatingRect.top;
+
+    // We want the selected item to sit at the same Y as the trigger
+    const desiredTop = triggerRect.top - itemOffsetInPopup;
+
+    // Clamp to viewport
+    const viewportHeight = window.innerHeight;
+    const clampedTop = Math.max(8, Math.min(desiredTop, viewportHeight - floatingRect.height - 8));
+
+    setAlignOffset({
+      position: 'fixed',
+      top: clampedTop,
+      left: triggerRect.left,
+      minWidth: triggerRect.width,
+    });
+  }, [open, mounted, alignItemWithTrigger, refs, selectedItemRef]);
+
+  const side = placement.split('-')[0];
+
+  const positionStyle = alignOffset ?? floatingStyles;
+
+  const defaultProps = {
+    'data-cl-slot': 'select-positioner',
+    'data-cl-side': side,
+    ref: refs.setFloating,
+    style: positionStyle,
+    ...(getFloatingProps({
+      onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+        if (event.key === 'Home' || event.key === 'End') {
+          event.preventDefault();
+          const items = elementsRef.current;
+          if (event.key === 'Home') {
+            const firstEnabled = items.findIndex(el => el != null && !el.hasAttribute('aria-disabled'));
+            if (firstEnabled !== -1) setActiveIndex(firstEnabled);
+          } else {
+            for (let i = items.length - 1; i >= 0; i--) {
+              if (items[i] != null && !items[i]!.hasAttribute('aria-disabled')) {
+                setActiveIndex(i);
+                break;
+              }
+            }
+          }
+        }
+      },
+    }) as React.ComponentPropsWithRef<'div'>),
+  };
+
+  return (
+    <FloatingFocusManager
+      context={floatingContext}
+      modal={false}
+    >
+      <FloatingList
+        elementsRef={elementsRef}
+        labelsRef={labelsRef}
+      >
+        {renderElement({
+          defaultTagName: 'div',
+          render,
+          enabled: mounted,
+          props: mergeProps<'div'>(defaultProps, otherProps),
+        })}
+      </FloatingList>
+    </FloatingFocusManager>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Select.Popup
+// ---------------------------------------------------------------------------
+
+export interface SelectPopupProps extends ComponentProps<'div'> {}
+
+function SelectPopup(props: SelectPopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, transitionProps } = useSelectContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'select-popup',
+    ref: popupRef,
+    ...transitionProps,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Select.Option
+// ---------------------------------------------------------------------------
+
+export interface SelectOptionProps extends ComponentProps<'button'> {
+  value: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+function SelectOption(props: SelectOptionProps) {
+  const { render, value, label, disabled, ...otherProps } = props;
+  const { activeIndex, selectedValue, getItemProps, handleSelect, valueToLabelRef, selectedItemRef } =
+    useSelectContext();
+
+  const displayLabel = label ?? value;
+  const { ref: itemRef, index } = useListItem({ label: displayLabel });
+
+  const isSelected = selectedValue === value;
+  const isActive = activeIndex === index;
+
+  // Register value→label mapping for Select.Value display
+  useEffect(() => {
+    valueToLabelRef.current.set(value, displayLabel);
+    return () => {
+      valueToLabelRef.current.delete(value);
+    };
+  }, [value, displayLabel, valueToLabelRef]);
+
+  // Track the selected item element for alignItemWithTrigger
+  const combinedRef = useCallback(
+    (node: HTMLElement | null) => {
+      // Forward to FloatingList's ref
+      if (typeof itemRef === 'function') {
+        itemRef(node);
+      }
+      // Track selected item
+      if (isSelected) {
+        selectedItemRef.current = node;
+      }
+    },
+    [itemRef, isSelected, selectedItemRef],
+  );
+
+  const state = {
+    selected: isSelected,
+    active: isActive,
+    disabled: !!disabled,
+  };
+
+  const defaultProps = {
+    'data-cl-slot': 'select-option',
+    ref: combinedRef,
+    role: 'option' as const,
+    'aria-selected': isSelected,
+    'aria-disabled': disabled || undefined,
+    tabIndex: isActive ? 0 : -1,
+    ...(getItemProps({
+      onClick() {
+        if (!disabled) handleSelect(value, index);
+      },
+    }) as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+      active: (v: boolean) => (v ? { 'data-cl-active': '' } : null),
+      disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Select.Arrow
+// ---------------------------------------------------------------------------
+
+export interface SelectArrowProps extends React.ComponentPropsWithRef<typeof FloatingArrow> {}
+
+function SelectArrowComponent(props: SelectArrowProps) {
+  const { floatingContext, arrowRef, placement } = useSelectContext();
+  const side = placement.split('-')[0];
+
+  return (
+    <FloatingArrow
+      data-cl-slot='select-arrow'
+      data-cl-side={side}
+      {...props}
+      ref={arrowRef}
+      context={floatingContext}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Select = Object.assign(SelectRoot, {
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Portal: SelectPortal,
+  Positioner: SelectPositioner,
+  Popup: SelectPopup,
+  Option: SelectOption,
+  Arrow: SelectArrowComponent,
+});

--- a/packages/headless/src/primitives/select/select.tsx
+++ b/packages/headless/src/primitives/select/select.tsx
@@ -15,6 +15,7 @@ import {
   offset,
   type Placement,
   type ReferenceType,
+  shift,
   size,
   type UseInteractionsReturn,
   useClick,
@@ -25,6 +26,7 @@ import {
   useInteractions,
   useListItem,
   useListNavigation,
+  useMergeRefs,
   useRole,
   useTypeahead,
 } from '@floating-ui/react';
@@ -185,6 +187,7 @@ function SelectInner(props: SelectProps) {
     middleware: [
       offset(sideOffset),
       flip(),
+      shift({ padding: 5 }),
       size({
         apply({ availableHeight, elements }) {
           Object.assign(elements.floating.style, {
@@ -557,19 +560,7 @@ function SelectOption(props: SelectOptionProps) {
   }, [value, displayLabel, valueToLabelRef]);
 
   // Track the selected item element for alignItemWithTrigger
-  const combinedRef = useCallback(
-    (node: HTMLElement | null) => {
-      // Forward to FloatingList's ref
-      if (typeof itemRef === 'function') {
-        itemRef(node);
-      }
-      // Track selected item
-      if (isSelected) {
-        selectedItemRef.current = node;
-      }
-    },
-    [itemRef, isSelected, selectedItemRef],
-  );
+  const combinedRef = useMergeRefs([itemRef, isSelected ? selectedItemRef : null]);
 
   const state = {
     selected: isSelected,

--- a/packages/headless/src/primitives/tabs/README.md
+++ b/packages/headless/src/primitives/tabs/README.md
@@ -1,0 +1,151 @@
+# Tabs
+
+A tabbed interface with automatic or manual activation, keyboard navigation, and an animated indicator. Panels are shown/hidden via the HTML `hidden` attribute (not unmounted).
+
+## When to Use
+
+- Switching between views or content sections within the same page area.
+- When you need accessible tab navigation with `role="tablist"` / `role="tab"` / `role="tabpanel"`.
+- Prefer Tabs over Accordion when content sections are mutually exclusive and should feel like parallel views.
+
+## Usage
+
+```tsx
+import { Tabs } from '@/primitives/tabs';
+
+<Tabs defaultValue='tab1'>
+  <Tabs.List>
+    <Tabs.Tab value='tab1'>Account</Tabs.Tab>
+    <Tabs.Tab value='tab2'>Security</Tabs.Tab>
+    <Tabs.Tab value='tab3'>Notifications</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value='tab1'>Account settings content</Tabs.Panel>
+  <Tabs.Panel value='tab2'>Security settings content</Tabs.Panel>
+  <Tabs.Panel value='tab3'>Notification preferences content</Tabs.Panel>
+</Tabs>;
+```
+
+### Controlled
+
+```tsx
+const [value, setValue] = useState('tab1');
+
+<Tabs
+  value={value}
+  onValueChange={setValue}
+>
+  {/* ... */}
+</Tabs>;
+```
+
+### Manual Activation
+
+By default, arrowing to a tab immediately activates it. Use `activationMode="manual"` to require Enter/Space:
+
+```tsx
+<Tabs activationMode='manual'>{/* Arrow keys move focus, Enter/Space activates */}</Tabs>
+```
+
+### Vertical Orientation
+
+```tsx
+<Tabs orientation='vertical'>{/* Arrow Up/Down navigates instead of Left/Right */}</Tabs>
+```
+
+## Parts
+
+| Part             | Default Element | Description                                |
+| ---------------- | --------------- | ------------------------------------------ |
+| `Tabs`           | —               | Root context provider                      |
+| `Tabs.List`      | `<div>`         | Container for tabs (`role="tablist"`)      |
+| `Tabs.Tab`       | `<button>`      | A tab trigger (`role="tab"`)               |
+| `Tabs.Panel`     | `<div>`         | Content panel (`role="tabpanel"`)          |
+| `Tabs.Indicator` | `<span>`        | Animated indicator tracking the active tab |
+
+## Props
+
+### `Tabs` (root)
+
+| Prop             | Type                         | Default        | Description                               |
+| ---------------- | ---------------------------- | -------------- | ----------------------------------------- |
+| `value`          | `string`                     | —              | Controlled active tab                     |
+| `defaultValue`   | `string`                     | `""`           | Initial active tab (uncontrolled)         |
+| `onValueChange`  | `(value: string) => void`    | —              | Called when active tab changes            |
+| `orientation`    | `"horizontal" \| "vertical"` | `"horizontal"` | Arrow key direction                       |
+| `activationMode` | `"automatic" \| "manual"`    | `"automatic"`  | Whether focus activates a tab immediately |
+
+### `Tabs.Tab`
+
+| Prop       | Type      | Default      | Description                                                |
+| ---------- | --------- | ------------ | ---------------------------------------------------------- |
+| `value`    | `string`  | **required** | Unique tab identifier, must match a Panel's `value`        |
+| `disabled` | `boolean` | —            | Disables the tab (uses `aria-disabled`, remains focusable) |
+
+### `Tabs.Panel`
+
+| Prop    | Type     | Default      | Description                |
+| ------- | -------- | ------------ | -------------------------- |
+| `value` | `string` | **required** | Must match a Tab's `value` |
+
+### `Tabs.List`, `Tabs.Indicator`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+## Keyboard Navigation
+
+| Key               | Action (horizontal)        | Action (vertical)          |
+| ----------------- | -------------------------- | -------------------------- |
+| `ArrowRight`      | Next tab                   | —                          |
+| `ArrowLeft`       | Previous tab               | —                          |
+| `ArrowDown`       | —                          | Next tab                   |
+| `ArrowUp`         | —                          | Previous tab               |
+| `Enter` / `Space` | Activate tab (manual mode) | Activate tab (manual mode) |
+
+## Data Attributes
+
+| Attribute          | Applies To | Description                         |
+| ------------------ | ---------- | ----------------------------------- |
+| `data-cl-slot`     | All parts  | Part identifier (e.g. `"tabs-tab"`) |
+| `data-cl-selected` | Tab        | Active tab                          |
+| `data-cl-disabled` | Tab        | Disabled tab                        |
+| `data-cl-hidden`   | Panel      | Inactive panel                      |
+
+## Indicator CSS Variables
+
+`Tabs.Indicator` exposes CSS custom properties for positioning and sizing:
+
+| CSS Variable   | Description                        |
+| -------------- | ---------------------------------- |
+| `--tab-left`   | Left offset of the active tab (px) |
+| `--tab-width`  | Width of the active tab (px)       |
+| `--tab-top`    | Top offset of the active tab (px)  |
+| `--tab-height` | Height of the active tab (px)      |
+
+Use these to animate the indicator:
+
+```css
+[data-cl-slot='tabs-indicator'] {
+  position: absolute;
+  left: var(--tab-left);
+  width: var(--tab-width);
+  transition:
+    left 200ms ease,
+    width 200ms ease;
+}
+```
+
+The initial render suppresses the transition to prevent the indicator from animating from `0,0`.
+
+## Important Notes
+
+- **`Tabs.List` must have `position: relative`** in your CSS for the indicator to position correctly.
+- **Panels use the `hidden` attribute** — they stay in the DOM but are hidden when inactive. This preserves state in inactive panels.
+- **Disabled tabs use `aria-disabled`**, not the native `disabled` attribute, keeping them focusable for keyboard users.
+- **Indicator is `aria-hidden`** — it's purely decorative.
+
+## ARIA
+
+- List: `role="tablist"`
+- Tab: `role="tab"`, `aria-selected`, `aria-controls` (pointing to its panel), `aria-disabled`
+- Panel: `role="tabpanel"`, `aria-labelledby` (pointing to its tab), `tabIndex={0}`

--- a/packages/headless/src/primitives/tabs/README.md
+++ b/packages/headless/src/primitives/tabs/README.md
@@ -55,13 +55,14 @@ By default, arrowing to a tab immediately activates it. Use `activationMode="man
 
 ## Parts
 
-| Part             | Default Element | Description                                |
-| ---------------- | --------------- | ------------------------------------------ |
-| `Tabs`           | —               | Root context provider                      |
-| `Tabs.List`      | `<div>`         | Container for tabs (`role="tablist"`)      |
-| `Tabs.Tab`       | `<button>`      | A tab trigger (`role="tab"`)               |
-| `Tabs.Panel`     | `<div>`         | Content panel (`role="tabpanel"`)          |
-| `Tabs.Indicator` | `<span>`        | Animated indicator tracking the active tab |
+| Part             | Default Element | Description                                        |
+| ---------------- | --------------- | -------------------------------------------------- |
+| `Tabs`           | —               | Root context provider                              |
+| `Tabs.List`      | `<div>`         | Container for tabs (`role="tablist"`)              |
+| `Tabs.Tab`       | `<button>`      | A tab trigger inside `Tabs.List` (`role="tab"`)    |
+| `Tabs.Trigger`   | `<button>`      | Standalone tab trigger for use outside `Tabs.List` |
+| `Tabs.Panel`     | `<div>`         | Content panel (`role="tabpanel"`)                  |
+| `Tabs.Indicator` | `<span>`        | Animated indicator tracking the active tab         |
 
 ## Props
 
@@ -82,11 +83,21 @@ By default, arrowing to a tab immediately activates it. Use `activationMode="man
 | `value`    | `string`  | **required** | Unique tab identifier, must match a Panel's `value`        |
 | `disabled` | `boolean` | —            | Disables the tab (uses `aria-disabled`, remains focusable) |
 
+### `Tabs.Trigger`
+
+A standalone tab button for use outside `Tabs.List`. Unlike `Tabs.Tab`, it does not participate in roving tabindex keyboard navigation — it's a plain button with `onClick`.
+
+| Prop       | Type      | Default      | Description                                  |
+| ---------- | --------- | ------------ | -------------------------------------------- |
+| `value`    | `string`  | **required** | Tab identifier, must match a Panel's `value` |
+| `disabled` | `boolean` | —            | Disables the trigger                         |
+
 ### `Tabs.Panel`
 
-| Prop    | Type     | Default      | Description                |
-| ------- | -------- | ------------ | -------------------------- |
-| `value` | `string` | **required** | Must match a Tab's `value` |
+| Prop               | Type      | Default      | Description                                                         |
+| ------------------ | --------- | ------------ | ------------------------------------------------------------------- |
+| `value`            | `string`  | **required** | Must match a Tab's `value`                                          |
+| `shouldForceMount` | `boolean` | —            | When true, keeps the panel in layout flow instead of using `hidden` |
 
 ### `Tabs.List`, `Tabs.Indicator`
 
@@ -104,31 +115,37 @@ No additional props beyond standard HTML attributes and the `render` prop.
 
 ## Data Attributes
 
-| Attribute          | Applies To | Description                         |
-| ------------------ | ---------- | ----------------------------------- |
-| `data-cl-slot`     | All parts  | Part identifier (e.g. `"tabs-tab"`) |
-| `data-cl-selected` | Tab        | Active tab                          |
-| `data-cl-disabled` | Tab        | Disabled tab                        |
-| `data-cl-hidden`   | Panel      | Inactive panel                      |
+| Attribute                | Applies To   | Description                                           |
+| ------------------------ | ------------ | ----------------------------------------------------- |
+| `data-cl-slot`           | All parts    | Part identifier (e.g. `"tabs-tab"`, `"tabs-trigger"`) |
+| `data-cl-selected`       | Tab, Trigger | Active tab                                            |
+| `data-cl-disabled`       | Tab, Trigger | Disabled tab                                          |
+| `data-cl-hidden`         | Panel        | Inactive panel                                        |
+| `data-cl-open`           | Panel        | Selected panel (when `shouldForceMount`)              |
+| `data-cl-closed`         | Panel        | Deselected panel (when `shouldForceMount`)            |
+| `data-cl-starting-style` | Panel        | Enter animation frame (when `shouldForceMount`)       |
+| `data-cl-ending-style`   | Panel        | Exit animation frame (when `shouldForceMount`)        |
 
-## Indicator CSS Variables
+## CSS Variables
+
+### Indicator
 
 `Tabs.Indicator` exposes CSS custom properties for positioning and sizing:
 
-| CSS Variable   | Description                        |
-| -------------- | ---------------------------------- |
-| `--tab-left`   | Left offset of the active tab (px) |
-| `--tab-width`  | Width of the active tab (px)       |
-| `--tab-top`    | Top offset of the active tab (px)  |
-| `--tab-height` | Height of the active tab (px)      |
+| CSS Variable      | Description                        |
+| ----------------- | ---------------------------------- |
+| `--cl-tab-left`   | Left offset of the active tab (px) |
+| `--cl-tab-width`  | Width of the active tab (px)       |
+| `--cl-tab-top`    | Top offset of the active tab (px)  |
+| `--cl-tab-height` | Height of the active tab (px)      |
 
 Use these to animate the indicator:
 
 ```css
 [data-cl-slot='tabs-indicator'] {
   position: absolute;
-  left: var(--tab-left);
-  width: var(--tab-width);
+  left: var(--cl-tab-left);
+  width: var(--cl-tab-width);
   transition:
     left 200ms ease,
     width 200ms ease;
@@ -137,10 +154,41 @@ Use these to animate the indicator:
 
 The initial render suppresses the transition to prevent the indicator from animating from `0,0`.
 
+### Panel (with `shouldForceMount`)
+
+When `shouldForceMount` is set, panels expose a direction variable for directional animations:
+
+| CSS Variable                    | Description                                                    |
+| ------------------------------- | -------------------------------------------------------------- |
+| `--cl-tab-transition-direction` | `"1"` when navigating forward, `"-1"` when navigating backward |
+
+Use this to drive directional slide animations:
+
+```css
+[data-cl-slot='tabs-panel'] {
+  --_direction: var(--cl-tab-transition-direction, 1);
+  transition:
+    opacity 200ms,
+    translate 200ms;
+}
+[data-cl-slot='tabs-panel'][data-cl-starting-style],
+[data-cl-slot='tabs-panel'][data-cl-ending-style] {
+  opacity: 0;
+}
+[data-cl-slot='tabs-panel'][data-cl-starting-style] {
+  translate: calc(var(--_direction) * 8px) 0;
+}
+[data-cl-slot='tabs-panel'][data-cl-ending-style] {
+  translate: calc(var(--_direction) * -8px) 0;
+}
+```
+
 ## Important Notes
 
 - **`Tabs.List` must have `position: relative`** in your CSS for the indicator to position correctly.
-- **Panels use the `hidden` attribute** — they stay in the DOM but are hidden when inactive. This preserves state in inactive panels.
+- **Panels use the `hidden` attribute** by default — they stay in the DOM but are hidden when inactive. This preserves state in inactive panels.
+- **`shouldForceMount` panels** stay in layout flow with `inert` on inactive panels. This enables CSS enter/exit animations between tabs. The initially-selected panel appears instantly (no enter animation on page load).
+- **`Tabs.Trigger` vs `Tabs.Tab`**: Use `Tabs.Tab` inside `Tabs.List` for keyboard-navigable tabs with roving tabindex. Use `Tabs.Trigger` for standalone tab buttons placed anywhere in the tree (e.g., in a sidebar).
 - **Disabled tabs use `aria-disabled`**, not the native `disabled` attribute, keeping them focusable for keyboard users.
 - **Indicator is `aria-hidden`** — it's purely decorative.
 

--- a/packages/headless/src/primitives/tabs/index.ts
+++ b/packages/headless/src/primitives/tabs/index.ts
@@ -1,2 +1,9 @@
-export type { TabsIndicatorProps, TabsListProps, TabsPanelProps, TabsProps, TabsTabProps } from './tabs';
+export type {
+  TabsIndicatorProps,
+  TabsListProps,
+  TabsPanelProps,
+  TabsProps,
+  TabsTabProps,
+  TabsTriggerProps,
+} from './tabs';
 export { Tabs } from './tabs';

--- a/packages/headless/src/primitives/tabs/index.ts
+++ b/packages/headless/src/primitives/tabs/index.ts
@@ -1,0 +1,2 @@
+export type { TabsIndicatorProps, TabsListProps, TabsPanelProps, TabsProps, TabsTabProps } from './tabs';
+export { Tabs } from './tabs';

--- a/packages/headless/src/primitives/tabs/tabs.test.tsx
+++ b/packages/headless/src/primitives/tabs/tabs.test.tsx
@@ -376,12 +376,12 @@ describe('Tabs', () => {
       expect(indicator).toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('sets --tab-width and --tab-left CSS vars', () => {
+    it('sets --cl-tab-width and --cl-tab-left CSS vars', () => {
       renderWithIndicator();
       const indicator = screen.getByTestId('indicator');
       // In a real browser, getBoundingClientRect returns actual measurements
-      expect(indicator.style.getPropertyValue('--tab-width')).toBeTruthy();
-      expect(indicator.style.getPropertyValue('--tab-left')).toBeTruthy();
+      expect(indicator.style.getPropertyValue('--cl-tab-width')).toBeTruthy();
+      expect(indicator.style.getPropertyValue('--cl-tab-left')).toBeTruthy();
     });
 
     it('updates position when tab changes', async () => {
@@ -395,7 +395,7 @@ describe('Tabs', () => {
 
       // Verify the effect ran and style properties are set
       expect(indicator.style.position).toBe('absolute');
-      expect(indicator.style.getPropertyValue('--tab-width')).toBeDefined();
+      expect(indicator.style.getPropertyValue('--cl-tab-width')).toBeDefined();
     });
 
     it('skips transition on initial render', () => {

--- a/packages/headless/src/primitives/tabs/tabs.test.tsx
+++ b/packages/headless/src/primitives/tabs/tabs.test.tsx
@@ -1,0 +1,456 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Tabs } from './tabs';
+
+afterEach(() => cleanup());
+
+function renderTabs(props: Partial<React.ComponentProps<typeof Tabs>> = {}) {
+  return render(
+    <Tabs
+      defaultValue='tab1'
+      {...props}
+    >
+      <Tabs.List>
+        <Tabs.Tab value='tab1'>Account</Tabs.Tab>
+        <Tabs.Tab value='tab2'>Settings</Tabs.Tab>
+        <Tabs.Tab value='tab3'>Billing</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel value='tab1'>Account content</Tabs.Panel>
+      <Tabs.Panel value='tab2'>Settings content</Tabs.Panel>
+      <Tabs.Panel value='tab3'>Billing content</Tabs.Panel>
+    </Tabs>,
+  );
+}
+
+describe('Tabs', () => {
+  describe('slot attributes', () => {
+    it('renders list with data-cl-slot', () => {
+      renderTabs();
+      expect(document.querySelector('[data-cl-slot="tabs-list"]')).toBeInTheDocument();
+    });
+
+    it('renders tabs with data-cl-slot', () => {
+      renderTabs();
+      const tabs = document.querySelectorAll('[data-cl-slot="tabs-tab"]');
+      expect(tabs).toHaveLength(3);
+    });
+
+    it('renders panels with data-cl-slot', () => {
+      renderTabs();
+      const panels = document.querySelectorAll('[data-cl-slot="tabs-panel"]');
+      expect(panels).toHaveLength(3);
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('list has role=tablist', () => {
+      renderTabs();
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
+    });
+
+    it('list has aria-orientation', () => {
+      renderTabs();
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'horizontal');
+    });
+
+    it('vertical orientation sets aria-orientation', () => {
+      renderTabs({ orientation: 'vertical' });
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
+    it('tabs have role=tab', () => {
+      renderTabs();
+      expect(screen.getAllByRole('tab')).toHaveLength(3);
+    });
+
+    it('selected tab has aria-selected=true', () => {
+      renderTabs();
+      expect(screen.getByText('Account')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('panels have role=tabpanel', () => {
+      renderTabs();
+      // Only the selected panel is visible
+      expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+    });
+
+    it('tab has aria-controls linking to panel', () => {
+      renderTabs();
+      const tab = screen.getByText('Account');
+      const panelId = tab.getAttribute('aria-controls');
+      expect(panelId).toBeTruthy();
+      expect(document.getElementById(panelId!)).toHaveTextContent('Account content');
+    });
+
+    it('panel has aria-labelledby linking to tab', () => {
+      renderTabs();
+      const panel = screen.getByRole('tabpanel');
+      const tabId = panel.getAttribute('aria-labelledby');
+      expect(tabId).toBeTruthy();
+      expect(document.getElementById(tabId!)).toHaveTextContent('Account');
+    });
+  });
+
+  describe('selection', () => {
+    it('shows selected panel content', () => {
+      renderTabs();
+      expect(screen.getByText('Account content')).toBeVisible();
+      expect(screen.getByText('Settings content')).not.toBeVisible();
+    });
+
+    it('selects tab on click', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Settings'));
+
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Settings content')).toBeVisible();
+    });
+
+    it('marks selected tab with data-cl-selected', () => {
+      renderTabs();
+      expect(screen.getByText('Account')).toHaveAttribute('data-cl-selected', '');
+      expect(screen.getByText('Settings').hasAttribute('data-cl-selected')).toBe(false);
+    });
+
+    it('calls onValueChange on selection', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      renderTabs({ onValueChange });
+
+      await user.click(screen.getByText('Settings'));
+
+      expect(onValueChange).toHaveBeenCalledWith('tab2');
+    });
+  });
+
+  describe('controlled value', () => {
+    it('respects controlled value prop', () => {
+      renderTabs({ value: 'tab2' });
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Settings content')).toBeVisible();
+    });
+
+    it('does not change internally when controlled', async () => {
+      const user = userEvent.setup();
+      renderTabs({ value: 'tab1' });
+
+      await user.click(screen.getByText('Settings'));
+
+      // Still on tab1 since controlled
+      expect(screen.getByText('Account')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('keyboard navigation — automatic activation', () => {
+    it('moves focus with ArrowRight', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowRight}');
+
+      expect(document.activeElement).toBe(screen.getByText('Settings'));
+      // Automatic mode: focus triggers selection
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('moves focus with ArrowLeft', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Settings'));
+      await user.keyboard('{ArrowLeft}');
+
+      expect(document.activeElement).toBe(screen.getByText('Account'));
+    });
+
+    it('wraps around at the end (loop)', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Billing'));
+      await user.keyboard('{ArrowRight}');
+
+      expect(document.activeElement).toBe(screen.getByText('Account'));
+    });
+
+    it('wraps around at the start', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowLeft}');
+
+      expect(document.activeElement).toBe(screen.getByText('Billing'));
+    });
+
+    it('uses ArrowDown/ArrowUp for vertical orientation', async () => {
+      const user = userEvent.setup();
+      renderTabs({ orientation: 'vertical' });
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowDown}');
+
+      expect(document.activeElement).toBe(screen.getByText('Settings'));
+    });
+
+    it('moves focus to first tab with Home', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Billing'));
+      await user.keyboard('{Home}');
+
+      expect(document.activeElement).toBe(screen.getByText('Account'));
+    });
+
+    it('moves focus to last tab with End', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{End}');
+
+      expect(document.activeElement).toBe(screen.getByText('Billing'));
+    });
+
+    it('Tab key moves focus from tab to panel', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Account'));
+      await user.tab();
+
+      const panel = screen.getByRole('tabpanel');
+      expect(document.activeElement).toBe(panel);
+    });
+
+    it('Home skips disabled tabs', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tabs defaultValue='tab3'>
+          <Tabs.List>
+            <Tabs.Tab
+              value='tab1'
+              disabled
+            >
+              First
+            </Tabs.Tab>
+            <Tabs.Tab value='tab2'>Second</Tabs.Tab>
+            <Tabs.Tab value='tab3'>Third</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value='tab1'>Panel 1</Tabs.Panel>
+          <Tabs.Panel value='tab2'>Panel 2</Tabs.Panel>
+          <Tabs.Panel value='tab3'>Panel 3</Tabs.Panel>
+        </Tabs>,
+      );
+
+      await user.click(screen.getByText('Third'));
+      await user.keyboard('{Home}');
+
+      expect(document.activeElement).toBe(screen.getByText('Second'));
+    });
+  });
+
+  describe('keyboard navigation — manual activation', () => {
+    it('moves focus without selecting', async () => {
+      const user = userEvent.setup();
+      renderTabs({ activationMode: 'manual' });
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowRight}');
+
+      expect(document.activeElement).toBe(screen.getByText('Settings'));
+      // Manual mode: focus does NOT select
+      expect(screen.getByText('Account')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('selects on Enter', async () => {
+      const user = userEvent.setup();
+      renderTabs({ activationMode: 'manual' });
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowRight}{Enter}');
+
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('selects on Space', async () => {
+      const user = userEvent.setup();
+      renderTabs({ activationMode: 'manual' });
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowRight} ');
+
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('disabled tab', () => {
+    function renderWithDisabled() {
+      return render(
+        <Tabs defaultValue='tab1'>
+          <Tabs.List>
+            <Tabs.Tab value='tab1'>Account</Tabs.Tab>
+            <Tabs.Tab
+              value='tab2'
+              disabled
+            >
+              Settings
+            </Tabs.Tab>
+            <Tabs.Tab value='tab3'>Billing</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value='tab1'>Account content</Tabs.Panel>
+          <Tabs.Panel value='tab2'>Settings content</Tabs.Panel>
+          <Tabs.Panel value='tab3'>Billing content</Tabs.Panel>
+        </Tabs>,
+      );
+    }
+
+    it('disabled tab has data-cl-disabled', () => {
+      renderWithDisabled();
+      expect(screen.getByText('Settings')).toHaveAttribute('data-cl-disabled', '');
+    });
+
+    it('disabled tab has aria-disabled', () => {
+      renderWithDisabled();
+      expect(screen.getByText('Settings')).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('skips disabled tab during keyboard navigation', async () => {
+      const user = userEvent.setup();
+      renderWithDisabled();
+
+      await user.click(screen.getByText('Account'));
+      await user.keyboard('{ArrowRight}');
+
+      // Should skip Settings (disabled) and land on Billing
+      expect(document.activeElement).toBe(screen.getByText('Billing'));
+    });
+
+    it('does not select disabled tab on click', async () => {
+      const user = userEvent.setup();
+      renderWithDisabled();
+
+      await user.click(screen.getByText('Settings'));
+
+      expect(screen.getByText('Account')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('Tabs.Indicator', () => {
+    function renderWithIndicator() {
+      return render(
+        <Tabs defaultValue='tab1'>
+          <Tabs.List style={{ position: 'relative' }}>
+            <Tabs.Tab value='tab1'>Account</Tabs.Tab>
+            <Tabs.Tab value='tab2'>Settings</Tabs.Tab>
+            <Tabs.Indicator data-testid='indicator' />
+          </Tabs.List>
+          <Tabs.Panel value='tab1'>Account content</Tabs.Panel>
+          <Tabs.Panel value='tab2'>Settings content</Tabs.Panel>
+        </Tabs>,
+      );
+    }
+
+    it('renders with data-cl-slot', () => {
+      renderWithIndicator();
+      expect(document.querySelector('[data-cl-slot="tabs-indicator"]')).toBeInTheDocument();
+    });
+
+    it('has position absolute', () => {
+      renderWithIndicator();
+      const indicator = screen.getByTestId('indicator');
+      expect(indicator.style.position).toBe('absolute');
+    });
+
+    it('has aria-hidden', () => {
+      renderWithIndicator();
+      const indicator = screen.getByTestId('indicator');
+      expect(indicator).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('sets --tab-width and --tab-left CSS vars', () => {
+      renderWithIndicator();
+      const indicator = screen.getByTestId('indicator');
+      // In a real browser, getBoundingClientRect returns actual measurements
+      expect(indicator.style.getPropertyValue('--tab-width')).toBeTruthy();
+      expect(indicator.style.getPropertyValue('--tab-left')).toBeTruthy();
+    });
+
+    it('updates position when tab changes', async () => {
+      const user = userEvent.setup();
+      renderWithIndicator();
+
+      const indicator = screen.getByTestId('indicator');
+      const initialLeft = indicator.style.left;
+
+      await user.click(screen.getByText('Settings'));
+
+      // Verify the effect ran and style properties are set
+      expect(indicator.style.position).toBe('absolute');
+      expect(indicator.style.getPropertyValue('--tab-width')).toBeDefined();
+    });
+
+    it('skips transition on initial render', () => {
+      renderWithIndicator();
+      const indicator = screen.getByTestId('indicator');
+      expect(indicator.style.transition).toBe('none');
+    });
+  });
+
+  describe('panel visibility', () => {
+    it('hides non-selected panels with hidden attribute', () => {
+      renderTabs();
+      const panels = document.querySelectorAll('[data-cl-slot="tabs-panel"]');
+      const visible = Array.from(panels).filter(p => !p.hasAttribute('hidden'));
+      const hidden = Array.from(panels).filter(p => p.hasAttribute('hidden'));
+
+      expect(visible).toHaveLength(1);
+      expect(hidden).toHaveLength(2);
+    });
+
+    it('non-selected panels have data-cl-hidden', () => {
+      renderTabs();
+      const panels = document.querySelectorAll('[data-cl-slot="tabs-panel"][data-cl-hidden]');
+      expect(panels).toHaveLength(2);
+    });
+  });
+
+  describe('roving tabindex', () => {
+    it('selected tab has tabIndex=0, others have tabIndex=-1', () => {
+      renderTabs();
+      expect(screen.getByText('Account')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByText('Settings')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByText('Billing')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('tabIndex updates when selection changes', async () => {
+      const user = userEvent.setup();
+      renderTabs();
+
+      await user.click(screen.getByText('Settings'));
+
+      expect(screen.getByText('Account')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByText('Settings')).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations', async () => {
+      const { container } = renderTabs();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations with vertical orientation', async () => {
+      const { container } = renderTabs({ orientation: 'vertical' });
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/tabs/tabs.tsx
+++ b/packages/headless/src/primitives/tabs/tabs.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
+import { useTransition } from '../../hooks/use-transition';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -29,6 +30,7 @@ interface TabsContextValue {
   registerTab: (value: string, element: HTMLElement | null) => void;
   getTabElement: (value: string) => HTMLElement | null;
   listRef: React.RefObject<HTMLElement | null>;
+  direction: 1 | -1;
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null);
@@ -57,15 +59,22 @@ export interface TabsProps {
 function TabsRoot(props: TabsProps) {
   const { orientation = 'horizontal', activationMode = 'automatic', children } = props;
 
-  const [value, setValue] = useControllableState(props.value, props.defaultValue ?? '', props.onValueChange);
+  const [value, setValueRaw] = useControllableState(props.value, props.defaultValue ?? '', props.onValueChange);
 
+  const [direction, setDirection] = useState<1 | -1>(1);
   const tabsId = useId();
   const tabElementsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const tabOrderRef = useRef<string[]>([]);
   const listRef = useRef<HTMLElement | null>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   const registerTab = useCallback((tabValue: string, element: HTMLElement | null) => {
     if (element) {
       tabElementsRef.current.set(tabValue, element);
+      if (!tabOrderRef.current.includes(tabValue)) {
+        tabOrderRef.current.push(tabValue);
+      }
     } else {
       tabElementsRef.current.delete(tabValue);
     }
@@ -74,6 +83,18 @@ function TabsRoot(props: TabsProps) {
   const getTabElement = useCallback((tabValue: string) => {
     return tabElementsRef.current.get(tabValue) ?? null;
   }, []);
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      const prevIndex = tabOrderRef.current.indexOf(valueRef.current);
+      const nextIndex = tabOrderRef.current.indexOf(newValue);
+      if (prevIndex !== -1 && nextIndex !== -1) {
+        setDirection(nextIndex > prevIndex ? 1 : -1);
+      }
+      setValueRaw(newValue);
+    },
+    [setValueRaw],
+  );
 
   const contextValue = useMemo<TabsContextValue>(
     () => ({
@@ -85,8 +106,9 @@ function TabsRoot(props: TabsProps) {
       registerTab,
       getTabElement,
       listRef,
+      direction,
     }),
-    [value, setValue, orientation, activationMode, tabsId, registerTab, getTabElement],
+    [value, setValue, orientation, activationMode, tabsId, registerTab, getTabElement, direction],
   );
 
   return <TabsContext.Provider value={contextValue}>{children}</TabsContext.Provider>;
@@ -226,15 +248,34 @@ function TabsTab(props: TabsTabProps) {
 
 export interface TabsPanelProps extends ComponentProps<'div'> {
   value: string;
+  /** When true, removes `hidden` so the panel stays in layout flow. */
+  shouldForceMount?: boolean;
 }
 
 function TabsPanel(props: TabsPanelProps) {
-  const { render, value: panelValue, ...otherProps } = props;
-  const { value: selectedValue, tabsId } = useTabsContext();
+  const { render, value: panelValue, shouldForceMount, ...otherProps } = props;
+  const { value: selectedValue, tabsId, direction } = useTabsContext();
 
   const isSelected = selectedValue === panelValue;
   const tabId = `${tabsId}-tab-${panelValue}`;
   const panelId = `${tabsId}-panel-${panelValue}`;
+
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const { transitionProps } = useTransition({
+    open: isSelected,
+    ref: panelRef,
+  });
+
+  // Suppress enter animation on initial mount so the initially-selected panel
+  // appears instantly. After the panel has been deselected once, subsequent
+  // selections will animate normally. Matches the Accordion pattern.
+  const hasBeenDeselected = useRef(false);
+  if (!isSelected) hasBeenDeselected.current = true;
+
+  const effectiveTransitionProps =
+    shouldForceMount && !hasBeenDeselected.current
+      ? { ...transitionProps, 'data-cl-starting-style': undefined, style: undefined }
+      : transitionProps;
 
   const state = { hidden: !isSelected };
 
@@ -244,7 +285,15 @@ function TabsPanel(props: TabsPanelProps) {
     role: 'tabpanel' as const,
     'aria-labelledby': tabId,
     tabIndex: 0,
-    hidden: !isSelected || undefined,
+    inert: !isSelected || undefined,
+    hidden: !isSelected && !shouldForceMount ? true : undefined,
+    ...(shouldForceMount
+      ? {
+          ref: panelRef,
+          ...effectiveTransitionProps,
+          style: { ...effectiveTransitionProps.style, ['--cl-tab-transition-direction' as string]: String(direction) },
+        }
+      : {}),
   };
 
   return renderElement({
@@ -255,6 +304,60 @@ function TabsPanel(props: TabsPanelProps) {
       hidden: (v: boolean) => (v ? { 'data-cl-hidden': '' } : null),
     },
     props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tabs.Trigger
+// ---------------------------------------------------------------------------
+
+export interface TabsTriggerProps extends ComponentProps<'button'> {
+  value: string;
+  disabled?: boolean;
+}
+
+function TabsTrigger(props: TabsTriggerProps) {
+  const { render, value: tabValue, disabled, ...otherProps } = props;
+  const { value: selectedValue, setValue, tabsId, registerTab } = useTabsContext();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const isSelected = selectedValue === tabValue;
+  const tabId = `${tabsId}-tab-${tabValue}`;
+  const panelId = `${tabsId}-panel-${tabValue}`;
+
+  useLayoutEffect(() => {
+    registerTab(tabValue, triggerRef.current);
+    return () => registerTab(tabValue, null);
+  }, [tabValue, registerTab]);
+
+  const state = {
+    selected: isSelected,
+    disabled: !!disabled,
+  };
+
+  const defaultProps = {
+    'data-cl-slot': 'tabs-trigger',
+    ref: triggerRef,
+    id: tabId,
+    role: 'tab' as const,
+    type: 'button' as const,
+    'aria-selected': isSelected,
+    'aria-controls': panelId,
+    'aria-disabled': disabled || undefined,
+    onClick: () => {
+      if (!disabled) setValue(tabValue);
+    },
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+      disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
   });
 }
 
@@ -299,10 +402,10 @@ function TabsIndicator(props: TabsIndicatorProps) {
         position: 'absolute',
         left: newRect.left,
         width: newRect.width,
-        ['--tab-left' as string]: `${newRect.left}px`,
-        ['--tab-width' as string]: `${newRect.width}px`,
-        ['--tab-top' as string]: `${newRect.top}px`,
-        ['--tab-height' as string]: `${newRect.height}px`,
+        ['--cl-tab-left' as string]: `${newRect.left}px`,
+        ['--cl-tab-width' as string]: `${newRect.width}px`,
+        ['--cl-tab-top' as string]: `${newRect.top}px`,
+        ['--cl-tab-height' as string]: `${newRect.height}px`,
         ...(prev == null ? { transition: 'none' } : {}),
       });
     } else {
@@ -310,10 +413,10 @@ function TabsIndicator(props: TabsIndicatorProps) {
         position: 'absolute',
         top: newRect.top,
         height: newRect.height,
-        ['--tab-left' as string]: `${newRect.left}px`,
-        ['--tab-width' as string]: `${newRect.width}px`,
-        ['--tab-top' as string]: `${newRect.top}px`,
-        ['--tab-height' as string]: `${newRect.height}px`,
+        ['--cl-tab-left' as string]: `${newRect.left}px`,
+        ['--cl-tab-width' as string]: `${newRect.width}px`,
+        ['--cl-tab-top' as string]: `${newRect.top}px`,
+        ['--cl-tab-height' as string]: `${newRect.height}px`,
         ...(prev == null ? { transition: 'none' } : {}),
       });
     }
@@ -339,6 +442,7 @@ function TabsIndicator(props: TabsIndicatorProps) {
 export const Tabs = Object.assign(TabsRoot, {
   List: TabsList,
   Tab: TabsTab,
+  Trigger: TabsTrigger,
   Panel: TabsPanel,
   Indicator: TabsIndicator,
 });

--- a/packages/headless/src/primitives/tabs/tabs.tsx
+++ b/packages/headless/src/primitives/tabs/tabs.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import { Composite, CompositeItem } from '@floating-ui/react';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+  orientation: 'horizontal' | 'vertical';
+  activationMode: 'automatic' | 'manual';
+  tabsId: string;
+  registerTab: (value: string, element: HTMLElement | null) => void;
+  getTabElement: (value: string) => HTMLElement | null;
+  listRef: React.RefObject<HTMLElement | null>;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext() {
+  const ctx = useContext(TabsContext);
+  if (!ctx) {
+    throw new Error('Tabs compound components must be used within <Tabs>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tabs (root)
+// ---------------------------------------------------------------------------
+
+export interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  activationMode?: 'automatic' | 'manual';
+  children: ReactNode;
+}
+
+function TabsRoot(props: TabsProps) {
+  const { orientation = 'horizontal', activationMode = 'automatic', children } = props;
+
+  const [value, setValue] = useControllableState(props.value, props.defaultValue ?? '', props.onValueChange);
+
+  const tabsId = useId();
+  const tabElementsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const listRef = useRef<HTMLElement | null>(null);
+
+  const registerTab = useCallback((tabValue: string, element: HTMLElement | null) => {
+    if (element) {
+      tabElementsRef.current.set(tabValue, element);
+    } else {
+      tabElementsRef.current.delete(tabValue);
+    }
+  }, []);
+
+  const getTabElement = useCallback((tabValue: string) => {
+    return tabElementsRef.current.get(tabValue) ?? null;
+  }, []);
+
+  const contextValue = useMemo<TabsContextValue>(
+    () => ({
+      value,
+      setValue,
+      orientation,
+      activationMode,
+      tabsId,
+      registerTab,
+      getTabElement,
+      listRef,
+    }),
+    [value, setValue, orientation, activationMode, tabsId, registerTab, getTabElement],
+  );
+
+  return <TabsContext.Provider value={contextValue}>{children}</TabsContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Tabs.List
+// ---------------------------------------------------------------------------
+
+export interface TabsListProps extends ComponentProps<'div'> {}
+
+function TabsList(props: TabsListProps) {
+  const { render, children, ...otherProps } = props;
+  const { orientation, listRef } = useTabsContext();
+
+  return (
+    <Composite
+      ref={listRef}
+      orientation={orientation}
+      render={(compositeProps: React.HTMLAttributes<HTMLElement>) => {
+        const defaultProps: Record<string, unknown> = {
+          'data-cl-slot': 'tabs-list',
+          role: 'tablist' as const,
+          onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+            if (event.key !== 'Home' && event.key !== 'End') return;
+            event.preventDefault();
+            const items = Array.from(event.currentTarget.querySelectorAll<HTMLElement>('[role="tab"]:not([disabled])'));
+            if (items.length === 0) return;
+            const target = event.key === 'Home' ? items[0] : items[items.length - 1];
+            target.focus();
+          },
+        };
+
+        const merged = mergeProps<'div'>(
+          defaultProps,
+          mergeProps<'div'>(otherProps, compositeProps as Record<string, unknown>),
+        );
+
+        return renderElement({
+          defaultTagName: 'div',
+          render,
+          props: merged,
+        })!;
+      }}
+    >
+      {children}
+    </Composite>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tabs.Tab
+// ---------------------------------------------------------------------------
+
+export interface TabsTabProps extends ComponentProps<'button'> {
+  value: string;
+  disabled?: boolean;
+}
+
+function TabsTab(props: TabsTabProps) {
+  const { render, value: tabValue, disabled, children, ...otherProps } = props;
+  const { value: selectedValue, setValue, activationMode, tabsId, registerTab } = useTabsContext();
+
+  const isSelected = selectedValue === tabValue;
+  const tabId = `${tabsId}-tab-${tabValue}`;
+  const panelId = `${tabsId}-panel-${tabValue}`;
+  const internalRef = useRef<HTMLButtonElement | null>(null);
+
+  useLayoutEffect(() => {
+    registerTab(tabValue, internalRef.current);
+    return () => registerTab(tabValue, null);
+  }, [tabValue, registerTab]);
+
+  const state = {
+    selected: isSelected,
+    disabled: !!disabled,
+  };
+
+  return (
+    <CompositeItem
+      ref={internalRef}
+      disabled={disabled}
+      render={(compositeProps: React.HTMLAttributes<HTMLElement>) => {
+        const defaultProps: Record<string, unknown> = {
+          'data-cl-slot': 'tabs-tab',
+          id: tabId,
+          role: 'tab' as const,
+          type: 'button' as const,
+          'aria-selected': isSelected,
+          'aria-controls': panelId,
+          'aria-disabled': disabled || undefined,
+        };
+
+        if (activationMode === 'automatic') {
+          defaultProps.onFocus = (event: React.FocusEvent<HTMLButtonElement>) => {
+            if (!disabled) setValue(tabValue);
+          };
+        } else {
+          defaultProps.onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+            if (!disabled) setValue(tabValue);
+          };
+          defaultProps.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
+              event.preventDefault();
+              setValue(tabValue);
+            }
+          };
+        }
+
+        // Merge: defaultProps first, then consumer props, then composite props last
+        // (composite needs to win on tabIndex, data-active, onFocus, ref)
+        const merged = mergeProps<'button'>(
+          mergeProps<'button'>(defaultProps as Record<string, unknown>, otherProps),
+          compositeProps as Record<string, unknown>,
+        );
+
+        return renderElement({
+          defaultTagName: 'button',
+          render,
+          state,
+          stateAttributesMapping: {
+            selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+            disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+          },
+          props: merged,
+        })!;
+      }}
+    >
+      {children}
+    </CompositeItem>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tabs.Panel
+// ---------------------------------------------------------------------------
+
+export interface TabsPanelProps extends ComponentProps<'div'> {
+  value: string;
+}
+
+function TabsPanel(props: TabsPanelProps) {
+  const { render, value: panelValue, ...otherProps } = props;
+  const { value: selectedValue, tabsId } = useTabsContext();
+
+  const isSelected = selectedValue === panelValue;
+  const tabId = `${tabsId}-tab-${panelValue}`;
+  const panelId = `${tabsId}-panel-${panelValue}`;
+
+  const state = { hidden: !isSelected };
+
+  const defaultProps = {
+    'data-cl-slot': 'tabs-panel',
+    id: panelId,
+    role: 'tabpanel' as const,
+    'aria-labelledby': tabId,
+    tabIndex: 0,
+    hidden: !isSelected || undefined,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    state,
+    stateAttributesMapping: {
+      hidden: (v: boolean) => (v ? { 'data-cl-hidden': '' } : null),
+    },
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tabs.Indicator
+// ---------------------------------------------------------------------------
+
+export interface TabsIndicatorProps extends ComponentProps<'span'> {}
+
+function TabsIndicator(props: TabsIndicatorProps) {
+  const { render, ...otherProps } = props;
+  const { value, getTabElement, orientation, listRef } = useTabsContext();
+
+  const [style, setStyle] = useState<React.CSSProperties>({});
+  const previousRectRef = useRef<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const el = getTabElement(value);
+    const list = listRef.current;
+    if (!el || !list) return;
+
+    const tabRect = el.getBoundingClientRect();
+    const listRect = list.getBoundingClientRect();
+
+    const newRect = {
+      left: tabRect.left - listRect.left,
+      top: tabRect.top - listRect.top,
+      width: tabRect.width,
+      height: tabRect.height,
+    };
+
+    const prev = previousRectRef.current;
+    previousRectRef.current = newRect;
+
+    if (orientation === 'horizontal') {
+      setStyle({
+        position: 'absolute',
+        left: newRect.left,
+        width: newRect.width,
+        ['--tab-left' as string]: `${newRect.left}px`,
+        ['--tab-width' as string]: `${newRect.width}px`,
+        ['--tab-top' as string]: `${newRect.top}px`,
+        ['--tab-height' as string]: `${newRect.height}px`,
+        ...(prev == null ? { transition: 'none' } : {}),
+      });
+    } else {
+      setStyle({
+        position: 'absolute',
+        top: newRect.top,
+        height: newRect.height,
+        ['--tab-left' as string]: `${newRect.left}px`,
+        ['--tab-width' as string]: `${newRect.width}px`,
+        ['--tab-top' as string]: `${newRect.top}px`,
+        ['--tab-height' as string]: `${newRect.height}px`,
+        ...(prev == null ? { transition: 'none' } : {}),
+      });
+    }
+  }, [value, getTabElement, orientation, listRef]);
+
+  const defaultProps = {
+    'data-cl-slot': 'tabs-indicator',
+    'aria-hidden': true as const,
+    style,
+  };
+
+  return renderElement({
+    defaultTagName: 'span',
+    render,
+    props: mergeProps<'span'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Tabs = Object.assign(TabsRoot, {
+  List: TabsList,
+  Tab: TabsTab,
+  Panel: TabsPanel,
+  Indicator: TabsIndicator,
+});

--- a/packages/headless/src/primitives/tooltip/README.md
+++ b/packages/headless/src/primitives/tooltip/README.md
@@ -1,0 +1,114 @@
+# Tooltip
+
+A floating label that appears on hover or focus. Non-interactive, used for supplementary descriptions. No focus trapping — tooltips never receive focus.
+
+## When to Use
+
+- Describing icon buttons, truncated text, or any element that benefits from a short label.
+- When the content is display-only (no interactive elements inside).
+- Prefer Tooltip over Popover when the content is a simple text label that should appear on hover/focus and disappear immediately.
+
+## Usage
+
+```tsx
+import { Tooltip } from '@/primitives/tooltip';
+
+<Tooltip>
+  <Tooltip.Trigger>
+    <IconButton aria-label='Settings' />
+  </Tooltip.Trigger>
+  <Tooltip.Positioner>
+    <Tooltip.Popup>
+      Settings
+      <Tooltip.Arrow />
+    </Tooltip.Popup>
+  </Tooltip.Positioner>
+</Tooltip>;
+```
+
+### Controlled
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Tooltip
+  open={open}
+  onOpenChange={setOpen}
+>
+  {/* ... */}
+</Tooltip>;
+```
+
+### Custom Delay
+
+```tsx
+<Tooltip
+  delay={500}
+  closeDelay={100}
+>
+  {/* Opens after 500ms hover, closes 100ms after leaving */}
+</Tooltip>
+```
+
+## Parts
+
+| Part                 | Default Element | Description                                      |
+| -------------------- | --------------- | ------------------------------------------------ |
+| `Tooltip`            | —               | Root context provider                            |
+| `Tooltip.Trigger`    | `<button>`      | Element that triggers the tooltip on hover/focus |
+| `Tooltip.Positioner` | `<div>`         | Floating positioned container (portal)           |
+| `Tooltip.Popup`      | `<div>`         | The visible tooltip content                      |
+| `Tooltip.Arrow`      | `<svg>`         | Optional arrow pointing at the trigger           |
+
+## Props
+
+### `Tooltip` (root)
+
+| Prop           | Type                      | Default | Description                          |
+| -------------- | ------------------------- | ------- | ------------------------------------ |
+| `open`         | `boolean`                 | —       | Controlled open state                |
+| `defaultOpen`  | `boolean`                 | `false` | Initial open state (uncontrolled)    |
+| `onOpenChange` | `(open: boolean) => void` | —       | Called when open state changes       |
+| `placement`    | `Placement`               | `"top"` | Floating UI placement                |
+| `sideOffset`   | `number`                  | `4`     | Gap between trigger and tooltip (px) |
+| `delay`        | `number`                  | `200`   | Hover open delay (ms)                |
+| `closeDelay`   | `number`                  | `0`     | Hover close delay (ms)               |
+
+### `Tooltip.Trigger`, `Tooltip.Positioner`, `Tooltip.Popup`
+
+No additional props beyond standard HTML attributes and the `render` prop.
+
+### `Tooltip.Arrow`
+
+Accepts all `FloatingArrow` props. `ref` and `context` are injected automatically.
+
+## Open/Close Behavior
+
+- **Hover**: Opens after `delay` ms, closes after `closeDelay` ms.
+- **Focus**: Opens on keyboard focus (`:focus-visible`), closes on blur.
+- **Dismiss**: Closes on Escape key.
+- **No click handling** — tooltips are triggered by hover and focus only.
+
+## Data Attributes
+
+| Attribute                         | Applies To        | Description                              |
+| --------------------------------- | ----------------- | ---------------------------------------- |
+| `data-cl-slot`                    | All parts         | Part identifier (e.g. `"tooltip-popup"`) |
+| `data-cl-open` / `data-cl-closed` | Trigger           | Open state                               |
+| `data-cl-side`                    | Positioner, Arrow | Resolved placement side                  |
+
+## Positioning
+
+Middleware stack: `offset` -> `flip` -> `shift` -> `arrow` -> CSS vars. Repositions automatically on scroll/resize via `autoUpdate`.
+
+## Important Notes
+
+- **No `FloatingFocusManager`** — tooltips do not receive or trap focus. This is correct per ARIA guidelines.
+- **Nested tooltips are supported** via `FloatingTree`.
+- **`Tooltip.Trigger` wraps its child** — if your trigger is already a button, the `render` prop can forward props to it instead of wrapping.
+- **For tooltip clusters** (e.g. toolbar buttons), consider adding `FloatingDelayGroup` support for instant switching between tooltips.
+
+## ARIA
+
+- Popup: `role="tooltip"`
+- Trigger: `aria-describedby` (pointing to the tooltip)

--- a/packages/headless/src/primitives/tooltip/README.md
+++ b/packages/headless/src/primitives/tooltip/README.md
@@ -56,7 +56,8 @@ const [open, setOpen] = useState(false);
 | -------------------- | --------------- | ------------------------------------------------ |
 | `Tooltip`            | —               | Root context provider                            |
 | `Tooltip.Trigger`    | `<button>`      | Element that triggers the tooltip on hover/focus |
-| `Tooltip.Positioner` | `<div>`         | Floating positioned container (portal)           |
+| `Tooltip.Portal`     | —               | Portals children (accepts `root` prop)           |
+| `Tooltip.Positioner` | `<div>`         | Floating positioned container                    |
 | `Tooltip.Popup`      | `<div>`         | The visible tooltip content                      |
 | `Tooltip.Arrow`      | `<svg>`         | Optional arrow pointing at the trigger           |
 

--- a/packages/headless/src/primitives/tooltip/index.ts
+++ b/packages/headless/src/primitives/tooltip/index.ts
@@ -1,5 +1,6 @@
 export type {
   TooltipArrowProps,
+  TooltipGroupProps,
   TooltipPopupProps,
   TooltipPortalProps,
   TooltipPositionerProps,

--- a/packages/headless/src/primitives/tooltip/index.ts
+++ b/packages/headless/src/primitives/tooltip/index.ts
@@ -1,0 +1,9 @@
+export type {
+  TooltipArrowProps,
+  TooltipPopupProps,
+  TooltipPortalProps,
+  TooltipPositionerProps,
+  TooltipProps,
+  TooltipTriggerProps,
+} from './tooltip';
+export { Tooltip } from './tooltip';

--- a/packages/headless/src/primitives/tooltip/tooltip.test.tsx
+++ b/packages/headless/src/primitives/tooltip/tooltip.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { axe } from '../../test-utils/axe';
@@ -239,6 +239,71 @@ describe('Tooltip', () => {
     it('has no violations when open', async () => {
       renderTooltip({ defaultOpen: true });
       expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+  });
+
+  describe('Tooltip.Group', () => {
+    function renderTooltipGroup() {
+      return render(
+        <Tooltip.Group delay={{ open: 0, close: 0 }}>
+          <Tooltip delay={0}>
+            <Tooltip.Trigger>Button A</Tooltip.Trigger>
+            <Tooltip.Positioner>
+              <Tooltip.Popup>Tooltip A</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip>
+          <Tooltip delay={0}>
+            <Tooltip.Trigger>Button B</Tooltip.Trigger>
+            <Tooltip.Positioner>
+              <Tooltip.Popup>Tooltip B</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip>
+        </Tooltip.Group>,
+      );
+    }
+
+    it('renders grouped tooltips', async () => {
+      renderTooltipGroup();
+
+      expect(screen.getByRole('button', { name: 'Button A' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Button B' })).toBeInTheDocument();
+    });
+
+    it('opens tooltip within a group on hover', async () => {
+      const user = userEvent.setup();
+      renderTooltipGroup();
+
+      const triggerA = screen.getByRole('button', { name: 'Button A' });
+      await user.hover(triggerA);
+
+      await waitFor(() => {
+        expect(screen.getByText('Tooltip A')).toBeInTheDocument();
+      });
+    });
+
+    it('switches between grouped tooltips without full delay', async () => {
+      const user = userEvent.setup();
+      renderTooltipGroup();
+
+      const triggerA = screen.getByRole('button', { name: 'Button A' });
+      const triggerB = screen.getByRole('button', { name: 'Button B' });
+
+      // Open first tooltip (wait for it to appear)
+      await user.hover(triggerA);
+      await waitFor(() => {
+        expect(screen.getByText('Tooltip A')).toBeInTheDocument();
+      });
+
+      // Move to second tooltip — group instant phase should show it quickly
+      await user.unhover(triggerA);
+      await user.hover(triggerB);
+
+      await waitFor(() => {
+        expect(screen.getByText('Tooltip B')).toBeInTheDocument();
+      });
+
+      // First tooltip should no longer be visible
+      expect(screen.queryByText('Tooltip A')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/headless/src/primitives/tooltip/tooltip.test.tsx
+++ b/packages/headless/src/primitives/tooltip/tooltip.test.tsx
@@ -1,0 +1,244 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { axe } from '../../test-utils/axe';
+import { Tooltip } from './tooltip';
+
+afterEach(() => cleanup());
+
+function renderTooltip(props: Partial<React.ComponentProps<typeof Tooltip>> = {}) {
+  return render(
+    <Tooltip
+      delay={0}
+      {...props}
+    >
+      <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+      <Tooltip.Positioner>
+        <Tooltip.Popup>Tooltip content</Tooltip.Popup>
+      </Tooltip.Positioner>
+    </Tooltip>,
+  );
+}
+
+describe('Tooltip', () => {
+  describe('slot attributes', () => {
+    it('renders trigger with data-cl-slot', () => {
+      renderTooltip();
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      expect(trigger).toHaveAttribute('data-cl-slot', 'tooltip-trigger');
+    });
+
+    it('renders all parts with correct slot attributes when open', () => {
+      renderTooltip({ defaultOpen: true });
+
+      expect(document.querySelector('[data-cl-slot="tooltip-positioner"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-cl-slot="tooltip-popup"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('open/close', () => {
+    it('opens on hover', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      expect(document.querySelector('[data-cl-slot="tooltip-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes on unhover', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      expect(document.querySelector('[data-cl-slot="tooltip-popup"]')).toBeInTheDocument();
+
+      await user.unhover(trigger);
+
+      const triggerEl = screen.getByRole('button', { name: 'Hover me' });
+      expect(triggerEl).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('opens on focus', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await act(async () => {
+        trigger.focus();
+      });
+
+      expect(document.querySelector('[data-cl-slot="tooltip-popup"]')).toBeInTheDocument();
+    });
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup();
+      renderTooltip({ defaultOpen: true });
+
+      await user.keyboard('{Escape}');
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+
+    it('calls onOpenChange when toggled', async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      renderTooltip({ onOpenChange });
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('controlled open', () => {
+    it('respects controlled open prop', () => {
+      renderTooltip({ open: true });
+
+      expect(document.querySelector('[data-cl-slot="tooltip-positioner"]')).toBeInTheDocument();
+    });
+
+    it('does not open when controlled open is false', async () => {
+      const user = userEvent.setup();
+      renderTooltip({ open: false });
+
+      await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+
+      expect(document.querySelector('[data-cl-slot="tooltip-positioner"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('trigger has tooltip role association', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      // aria-describedby must reference the tooltip positioner's id
+      const positioner = document.querySelector('[data-cl-slot="tooltip-positioner"]');
+      expect(positioner).toBeInTheDocument();
+      const positionerId = positioner!.getAttribute('id');
+      expect(positionerId).toBeTruthy();
+      expect(trigger.getAttribute('aria-describedby')).toBe(positionerId);
+    });
+
+    it('tooltip content has role=tooltip', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+
+    it('focus stays on trigger when tooltip is open', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      expect(document.querySelector('[data-cl-slot="tooltip-popup"]')).toBeInTheDocument();
+      // Tooltip must not steal focus — active element should not be inside the tooltip
+      const popup = document.querySelector('[data-cl-slot="tooltip-popup"]');
+      expect(popup).not.toContainElement(document.activeElement as HTMLElement);
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('positioner is not rendered when closed', () => {
+      renderTooltip();
+      expect(document.querySelector('[data-cl-slot="tooltip-positioner"]')).not.toBeInTheDocument();
+    });
+
+    it('applies data-cl-open on popup when open', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+
+      const popup = document.querySelector('[data-cl-slot="tooltip-popup"]');
+      expect(popup).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('positioner has data-cl-side', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+
+      const positioner = document.querySelector('[data-cl-slot="tooltip-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side');
+    });
+  });
+
+  describe('placement', () => {
+    it('accepts custom placement', () => {
+      renderTooltip({ defaultOpen: true, placement: 'bottom-end' });
+
+      const positioner = document.querySelector('[data-cl-slot="tooltip-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side', 'bottom');
+    });
+
+    it('defaults to top placement', () => {
+      renderTooltip({ defaultOpen: true });
+
+      const positioner = document.querySelector('[data-cl-slot="tooltip-positioner"]');
+      expect(positioner).toHaveAttribute('data-cl-side', 'top');
+    });
+  });
+
+  describe('trigger state attributes', () => {
+    it('trigger has data-cl-open when tooltip is visible', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      await user.hover(trigger);
+
+      expect(trigger).toHaveAttribute('data-cl-open', '');
+    });
+
+    it('trigger has data-cl-closed when tooltip is hidden', () => {
+      renderTooltip();
+
+      const trigger = screen.getByRole('button', { name: 'Hover me' });
+      expect(trigger).toHaveAttribute('data-cl-closed', '');
+    });
+  });
+
+  describe('content rendering', () => {
+    it('renders children content when open', async () => {
+      const user = userEvent.setup();
+      renderTooltip();
+
+      await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+
+      expect(screen.getByText('Tooltip content')).toBeInTheDocument();
+    });
+
+    it('does not render content when closed', () => {
+      renderTooltip();
+      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility (axe)', () => {
+    it('has no violations when closed', async () => {
+      const { container } = renderTooltip();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('has no violations when open', async () => {
+      renderTooltip({ defaultOpen: true });
+      expect(await axe(document.body, { rules: { region: { enabled: false } } })).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/headless/src/primitives/tooltip/tooltip.tsx
+++ b/packages/headless/src/primitives/tooltip/tooltip.tsx
@@ -6,6 +6,7 @@ import {
   type ExtendedRefs,
   FloatingArrow,
   type FloatingContext,
+  FloatingDelayGroup,
   FloatingNode,
   FloatingPortal,
   FloatingTree,
@@ -15,6 +16,7 @@ import {
   type ReferenceType,
   shift,
   type UseInteractionsReturn,
+  useDelayGroup,
   useDismiss,
   useFloating,
   useFloatingNodeId,
@@ -113,6 +115,10 @@ function TooltipInner(props: TooltipProps) {
     open,
     ref: popupRef,
   });
+
+  // Integrate with FloatingDelayGroup when inside a Tooltip.Group.
+  // Safe to call unconditionally — no-op without a parent provider.
+  useDelayGroup(floatingContext, { id: nodeId });
 
   const hover = useHover(floatingContext, {
     move: false,
@@ -289,6 +295,30 @@ function TooltipArrowComponent(props: TooltipArrowProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Tooltip.Group
+// ---------------------------------------------------------------------------
+
+export interface TooltipGroupProps {
+  /** Shared delay config for grouped tooltips. Default: { open: 200, close: 100 } */
+  delay?: number | { open?: number; close?: number };
+  /** Time in ms before the group resets to non-instant phase. Default: 300 */
+  timeoutMs?: number;
+  children: ReactNode;
+}
+
+function TooltipGroupRoot(props: TooltipGroupProps) {
+  const { delay = { open: 200, close: 100 }, timeoutMs = 300, children } = props;
+  return (
+    <FloatingDelayGroup
+      delay={delay}
+      timeoutMs={timeoutMs}
+    >
+      {children}
+    </FloatingDelayGroup>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Compound export
 // ---------------------------------------------------------------------------
 
@@ -298,4 +328,5 @@ export const Tooltip = Object.assign(TooltipRoot, {
   Positioner: TooltipPositioner,
   Popup: TooltipPopup,
   Arrow: TooltipArrowComponent,
+  Group: TooltipGroupRoot,
 });

--- a/packages/headless/src/primitives/tooltip/tooltip.tsx
+++ b/packages/headless/src/primitives/tooltip/tooltip.tsx
@@ -28,8 +28,8 @@ import {
 } from '@floating-ui/react';
 import { type CSSProperties, createContext, type ReactNode, useContext, useMemo, useRef } from 'react';
 import { useControllableState } from '../../hooks/use-controllable-state';
-import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
-import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type TransitionProps, useTransition } from '../../hooks/use-transition';
+import { cssVars } from '../../utils/css-vars';
 import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
 
 // ---------------------------------------------------------------------------
@@ -106,12 +106,12 @@ function TooltipInner(props: TooltipProps) {
       }),
       shift({ padding: 5 }),
       arrow({ element: arrowRef }),
-      floatingCssVars({ sideOffset }),
+      cssVars({ sideOffset }),
     ],
     whileElementsMounted: autoUpdate,
   });
 
-  const { mounted, transitionProps } = useFloatingTransition({
+  const { mounted, transitionProps } = useTransition({
     open,
     ref: popupRef,
   });
@@ -214,12 +214,13 @@ function TooltipTrigger(props: TooltipTriggerProps) {
 
 export interface TooltipPortalProps {
   children: ReactNode;
+  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
 }
 
 function TooltipPortal(props: TooltipPortalProps) {
   const { mounted } = useTooltipContext();
   if (!mounted) return null;
-  return <FloatingPortal>{props.children}</FloatingPortal>;
+  return <FloatingPortal root={props.root}>{props.children}</FloatingPortal>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/headless/src/primitives/tooltip/tooltip.tsx
+++ b/packages/headless/src/primitives/tooltip/tooltip.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import {
+  arrow,
+  autoUpdate,
+  type ExtendedRefs,
+  FloatingArrow,
+  type FloatingContext,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  flip,
+  offset,
+  type Placement,
+  type ReferenceType,
+  shift,
+  type UseInteractionsReturn,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import { type CSSProperties, createContext, type ReactNode, useContext, useMemo, useRef } from 'react';
+import { useControllableState } from '../../hooks/use-controllable-state';
+import { type TransitionProps, useFloatingTransition } from '../../hooks/use-floating-transition';
+import { floatingCssVars } from '../../utils/floating-css-vars';
+import { type ComponentProps, mergeProps, renderElement } from '../../utils/render-element';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface TooltipContextValue {
+  open: boolean;
+  floatingContext: FloatingContext;
+  refs: ExtendedRefs<ReferenceType>;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  getReferenceProps: UseInteractionsReturn['getReferenceProps'];
+  getFloatingProps: UseInteractionsReturn['getFloatingProps'];
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  arrowRef: React.MutableRefObject<SVGSVGElement | null>;
+  mounted: boolean;
+  transitionProps: TransitionProps;
+}
+
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+
+function useTooltipContext() {
+  const ctx = useContext(TooltipContext);
+  if (!ctx) {
+    throw new Error('Tooltip compound components must be used within <Tooltip>');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip (root)
+// ---------------------------------------------------------------------------
+
+export interface TooltipProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placement?: Placement;
+  sideOffset?: number;
+  /** Delay in ms before the tooltip opens on hover. Default: 200 */
+  delay?: number;
+  /** Delay in ms before the tooltip closes on hover out. Default: 0 */
+  closeDelay?: number;
+  children: ReactNode;
+}
+
+function TooltipInner(props: TooltipProps) {
+  const nodeId = useFloatingNodeId();
+
+  const { placement: placementProp = 'top', sideOffset = 4, delay = 200, closeDelay = 0, children } = props;
+
+  const [open, setOpen] = useControllableState(props.open, props.defaultOpen ?? false, props.onOpenChange);
+
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    refs,
+    floatingStyles,
+    context: floatingContext,
+    placement,
+  } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: placementProp,
+    middleware: [
+      offset(sideOffset),
+      flip({
+        crossAxis: placementProp.includes('-'),
+        fallbackAxisSideDirection: 'start',
+        padding: 5,
+      }),
+      shift({ padding: 5 }),
+      arrow({ element: arrowRef }),
+      floatingCssVars({ sideOffset }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { mounted, transitionProps } = useFloatingTransition({
+    open,
+    ref: popupRef,
+  });
+
+  const hover = useHover(floatingContext, {
+    move: false,
+    delay: { open: delay, close: closeDelay },
+  });
+  const focus = useFocus(floatingContext);
+  const dismiss = useDismiss(floatingContext);
+  const role = useRole(floatingContext, { role: 'tooltip' });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, dismiss, role]);
+
+  const contextValue = useMemo<TooltipContextValue>(
+    () => ({
+      open,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      popupRef,
+      arrowRef,
+      mounted,
+      transitionProps,
+    }),
+    [
+      open,
+      floatingContext,
+      refs,
+      floatingStyles,
+      placement,
+      getReferenceProps,
+      getFloatingProps,
+      mounted,
+      transitionProps,
+    ],
+  );
+
+  return (
+    <FloatingNode id={nodeId}>
+      <TooltipContext.Provider value={contextValue}>{children}</TooltipContext.Provider>
+    </FloatingNode>
+  );
+}
+
+function TooltipRoot(props: TooltipProps) {
+  const parentId = useFloatingParentNodeId();
+
+  if (parentId === null) {
+    return (
+      <FloatingTree>
+        <TooltipInner {...props} />
+      </FloatingTree>
+    );
+  }
+
+  return <TooltipInner {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip.Trigger
+// ---------------------------------------------------------------------------
+
+export interface TooltipTriggerProps extends ComponentProps<'button'> {}
+
+function TooltipTrigger(props: TooltipTriggerProps) {
+  const { render, ...otherProps } = props;
+  const { open, refs, getReferenceProps } = useTooltipContext();
+
+  const state = { open };
+
+  const defaultProps = {
+    type: 'button' as const,
+    'data-cl-slot': 'tooltip-trigger',
+    ref: refs.setReference,
+    ...(getReferenceProps() as React.ComponentPropsWithRef<'button'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'button',
+    render,
+    state,
+    stateAttributesMapping: {
+      open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+    },
+    props: mergeProps<'button'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip.Portal
+// ---------------------------------------------------------------------------
+
+export interface TooltipPortalProps {
+  children: ReactNode;
+}
+
+function TooltipPortal(props: TooltipPortalProps) {
+  const { mounted } = useTooltipContext();
+  if (!mounted) return null;
+  return <FloatingPortal>{props.children}</FloatingPortal>;
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip.Positioner
+// ---------------------------------------------------------------------------
+
+export interface TooltipPositionerProps extends ComponentProps<'div'> {}
+
+function TooltipPositioner(props: TooltipPositionerProps) {
+  const { render, ...otherProps } = props;
+  const { mounted, refs, floatingStyles, placement, getFloatingProps } = useTooltipContext();
+
+  const side = placement.split('-')[0];
+
+  const defaultProps = {
+    'data-cl-slot': 'tooltip-positioner',
+    'data-cl-side': side,
+    ref: refs.setFloating,
+    style: floatingStyles,
+    ...(getFloatingProps() as React.ComponentPropsWithRef<'div'>),
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    enabled: mounted,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip.Popup
+// ---------------------------------------------------------------------------
+
+export interface TooltipPopupProps extends ComponentProps<'div'> {}
+
+function TooltipPopup(props: TooltipPopupProps) {
+  const { render, ...otherProps } = props;
+  const { popupRef, transitionProps } = useTooltipContext();
+
+  const defaultProps = {
+    'data-cl-slot': 'tooltip-popup',
+    ref: popupRef,
+    ...transitionProps,
+  };
+
+  return renderElement({
+    defaultTagName: 'div',
+    render,
+    props: mergeProps<'div'>(defaultProps, otherProps),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip.Arrow
+// ---------------------------------------------------------------------------
+
+export interface TooltipArrowProps extends React.ComponentPropsWithRef<typeof FloatingArrow> {}
+
+function TooltipArrowComponent(props: TooltipArrowProps) {
+  const { floatingContext, arrowRef, placement } = useTooltipContext();
+  const side = placement.split('-')[0];
+
+  return (
+    <FloatingArrow
+      data-cl-slot='tooltip-arrow'
+      data-cl-side={side}
+      {...props}
+      ref={arrowRef}
+      context={floatingContext}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Tooltip = Object.assign(TooltipRoot, {
+  Trigger: TooltipTrigger,
+  Portal: TooltipPortal,
+  Positioner: TooltipPositioner,
+  Popup: TooltipPopup,
+  Arrow: TooltipArrowComponent,
+});

--- a/packages/headless/src/test-utils/axe.ts
+++ b/packages/headless/src/test-utils/axe.ts
@@ -1,0 +1,8 @@
+import axeCore from 'axe-core';
+export { toHaveNoViolations } from 'vitest-axe/matchers';
+
+type AxeOptions = Parameters<typeof axeCore.run>[1];
+
+export async function axe(container: Element, options?: AxeOptions): Promise<axeCore.AxeResults> {
+  return axeCore.run(container, options ?? {});
+}

--- a/packages/headless/src/utils/css-vars.test.ts
+++ b/packages/headless/src/utils/css-vars.test.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareState } from '@floating-ui/react';
 import { describe, expect, it, vi } from 'vitest';
-import { floatingCssVars } from './floating-css-vars';
+import { cssVars } from './css-vars';
 
 // Build a minimal MiddlewareState mock for testing the middleware fn
 function createMockState(
@@ -80,15 +80,15 @@ function getVars(state: MiddlewareState): Map<string, string> {
   return new Map(calls.map(([name, value]) => [name, value]));
 }
 
-describe('floatingCssVars middleware', () => {
-  it("has name 'floatingCssVars'", () => {
-    const mw = floatingCssVars();
-    expect(mw.name).toBe('floatingCssVars');
+describe('cssVars middleware', () => {
+  it("has name 'cssVars'", () => {
+    const mw = cssVars();
+    expect(mw.name).toBe('cssVars');
   });
 
-  describe('--anchor-width and --anchor-height', () => {
+  describe('--cl-anchor-width and --cl-anchor-height', () => {
     it('sets anchor dimensions from reference rects', async () => {
-      const mw = floatingCssVars();
+      const mw = cssVars();
       const state = createMockState({
         referenceWidth: 120,
         referenceHeight: 36,
@@ -96,12 +96,12 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--anchor-width')).toBe('120px');
-      expect(vars.get('--anchor-height')).toBe('36px');
+      expect(vars.get('--cl-anchor-width')).toBe('120px');
+      expect(vars.get('--cl-anchor-height')).toBe('36px');
     });
 
     it('handles zero-size reference', async () => {
-      const mw = floatingCssVars();
+      const mw = cssVars();
       const state = createMockState({
         referenceWidth: 0,
         referenceHeight: 0,
@@ -109,14 +109,14 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--anchor-width')).toBe('0px');
-      expect(vars.get('--anchor-height')).toBe('0px');
+      expect(vars.get('--cl-anchor-width')).toBe('0px');
+      expect(vars.get('--cl-anchor-height')).toBe('0px');
     });
   });
 
-  describe('--available-width and --available-height', () => {
+  describe('--cl-available-width and --cl-available-height', () => {
     it('sets available dimensions as CSS vars', async () => {
-      const mw = floatingCssVars();
+      const mw = cssVars();
       const state = createMockState({
         floatingWidth: 200,
         floatingHeight: 150,
@@ -125,16 +125,16 @@ describe('floatingCssVars middleware', () => {
 
       const vars = getVars(state);
       // Values are set (exact numbers depend on detectOverflow's padding)
-      expect(vars.has('--available-width')).toBe(true);
-      expect(vars.has('--available-height')).toBe(true);
-      expect(vars.get('--available-width')).toMatch(/^\d+px$/);
-      expect(vars.get('--available-height')).toMatch(/^\d+px$/);
+      expect(vars.has('--cl-available-width')).toBe(true);
+      expect(vars.has('--cl-available-height')).toBe(true);
+      expect(vars.get('--cl-available-width')).toMatch(/^\d+px$/);
+      expect(vars.get('--cl-available-height')).toMatch(/^\d+px$/);
     });
   });
 
-  describe('--transform-origin', () => {
+  describe('--cl-transform-origin', () => {
     it('centers on anchor when no arrow (bottom)', async () => {
-      const mw = floatingCssVars({ sideOffset: 8 });
+      const mw = cssVars({ sideOffset: 8 });
       // Reference: x=0, width=100 → center at 50. Floating: x=0.
       // transformX = 0 + 100/2 - 0 = 50
       const state = createMockState({
@@ -144,11 +144,11 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--transform-origin')).toBe('50px -8px');
+      expect(vars.get('--cl-transform-origin')).toBe('50px -8px');
     });
 
     it('centers on anchor when no arrow (top)', async () => {
-      const mw = floatingCssVars({ sideOffset: 4 });
+      const mw = cssVars({ sideOffset: 4 });
       const state = createMockState({
         placement: 'top',
         referenceWidth: 100,
@@ -156,11 +156,11 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--transform-origin')).toBe('50px calc(100% + 4px)');
+      expect(vars.get('--cl-transform-origin')).toBe('50px calc(100% + 4px)');
     });
 
     it('centers on anchor when no arrow (left)', async () => {
-      const mw = floatingCssVars({ sideOffset: 6 });
+      const mw = cssVars({ sideOffset: 6 });
       const state = createMockState({
         placement: 'left',
         referenceHeight: 40,
@@ -169,11 +169,11 @@ describe('floatingCssVars middleware', () => {
 
       const vars = getVars(state);
       // transformY = 0 + 40/2 - 0 = 20
-      expect(vars.get('--transform-origin')).toBe('calc(100% + 6px) 20px');
+      expect(vars.get('--cl-transform-origin')).toBe('calc(100% + 6px) 20px');
     });
 
     it('centers on anchor when no arrow (right)', async () => {
-      const mw = floatingCssVars({ sideOffset: 6 });
+      const mw = cssVars({ sideOffset: 6 });
       const state = createMockState({
         placement: 'right',
         referenceHeight: 40,
@@ -181,11 +181,11 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--transform-origin')).toBe('-6px 20px');
+      expect(vars.get('--cl-transform-origin')).toBe('-6px 20px');
     });
 
     it('handles alignment variants (e.g. bottom-start)', async () => {
-      const mw = floatingCssVars({ sideOffset: 4 });
+      const mw = cssVars({ sideOffset: 4 });
       const state = createMockState({
         placement: 'bottom-start',
         referenceWidth: 100,
@@ -194,11 +194,11 @@ describe('floatingCssVars middleware', () => {
 
       const vars = getVars(state);
       // Side is still "bottom", centers on anchor
-      expect(vars.get('--transform-origin')).toBe('50px -4px');
+      expect(vars.get('--cl-transform-origin')).toBe('50px -4px');
     });
 
     it('uses arrow position when arrow is present', async () => {
-      const mw = floatingCssVars({ sideOffset: 4 });
+      const mw = cssVars({ sideOffset: 4 });
       const state = createMockState({
         placement: 'bottom',
         arrowX: 50,
@@ -208,11 +208,11 @@ describe('floatingCssVars middleware', () => {
 
       const vars = getVars(state);
       // transformX = arrowX + arrowWidth/2 = 50 + 6 = 56
-      expect(vars.get('--transform-origin')).toBe('56px -4px');
+      expect(vars.get('--cl-transform-origin')).toBe('56px -4px');
     });
 
     it('uses arrow Y position on left/right placement', async () => {
-      const mw = floatingCssVars({ sideOffset: 4 });
+      const mw = cssVars({ sideOffset: 4 });
       const state = createMockState({
         placement: 'right',
         arrowY: 30,
@@ -222,11 +222,11 @@ describe('floatingCssVars middleware', () => {
 
       const vars = getVars(state);
       // transformY = arrowY + arrowHeight/2 = 30 + 5 = 35
-      expect(vars.get('--transform-origin')).toBe('-4px 35px');
+      expect(vars.get('--cl-transform-origin')).toBe('-4px 35px');
     });
 
     it('defaults sideOffset to 0 when not provided', async () => {
-      const mw = floatingCssVars();
+      const mw = cssVars();
       const state = createMockState({
         placement: 'bottom',
         referenceWidth: 100,
@@ -234,13 +234,13 @@ describe('floatingCssVars middleware', () => {
       await mw.fn(state);
 
       const vars = getVars(state);
-      expect(vars.get('--transform-origin')).toBe('50px 0px');
+      expect(vars.get('--cl-transform-origin')).toBe('50px 0px');
     });
   });
 
   describe('return value', () => {
     it('returns empty object (no position changes)', async () => {
-      const mw = floatingCssVars();
+      const mw = cssVars();
       const state = createMockState();
       const result = await mw.fn(state);
       expect(result).toEqual({});
@@ -249,7 +249,7 @@ describe('floatingCssVars middleware', () => {
 
   describe('all five CSS vars are set', () => {
     it('sets exactly 5 CSS custom properties', async () => {
-      const mw = floatingCssVars({ sideOffset: 4 });
+      const mw = cssVars({ sideOffset: 4 });
       const state = createMockState({ placement: 'bottom' });
       await mw.fn(state);
 
@@ -258,11 +258,11 @@ describe('floatingCssVars middleware', () => {
       const varNames = calls.map(([name]) => name);
 
       expect(varNames).toEqual([
-        '--anchor-width',
-        '--anchor-height',
-        '--available-width',
-        '--available-height',
-        '--transform-origin',
+        '--cl-anchor-width',
+        '--cl-anchor-height',
+        '--cl-available-width',
+        '--cl-available-height',
+        '--cl-transform-origin',
       ]);
     });
   });

--- a/packages/headless/src/utils/css-vars.ts
+++ b/packages/headless/src/utils/css-vars.ts
@@ -1,27 +1,27 @@
 import { detectOverflow, type Middleware } from '@floating-ui/react';
 
 /**
- * Floating UI middleware that sets CSS custom properties on the floating element:
+ * Positioning middleware that sets CSS custom properties on the floating element:
  *
- * - `--anchor-width`      – reference element width (px)
- * - `--anchor-height`     – reference element height (px)
- * - `--available-width`   – available width between anchor and viewport edge (px)
- * - `--available-height`  – available height between anchor and viewport edge (px)
- * - `--transform-origin`  – CSS transform-origin pointing back toward the anchor
+ * - `--cl-anchor-width`      – reference element width (px)
+ * - `--cl-anchor-height`     – reference element height (px)
+ * - `--cl-available-width`   – available width between anchor and viewport edge (px)
+ * - `--cl-available-height`  – available height between anchor and viewport edge (px)
+ * - `--cl-transform-origin`  – CSS transform-origin pointing back toward the anchor
  *
  * Place **after** `arrow()` so arrow position data is available for transform-origin.
  */
-export function floatingCssVars(opts?: { sideOffset?: number }): Middleware {
+export function cssVars(opts?: { sideOffset?: number }): Middleware {
   return {
-    name: 'floatingCssVars',
+    name: 'cssVars',
     async fn(state) {
       const { elements, rects, middlewareData, placement } = state;
       const style = elements.floating.style;
       const sideOffset = opts?.sideOffset ?? 0;
 
       // Anchor dimensions
-      style.setProperty('--anchor-width', `${rects.reference.width}px`);
-      style.setProperty('--anchor-height', `${rects.reference.height}px`);
+      style.setProperty('--cl-anchor-width', `${rects.reference.width}px`);
+      style.setProperty('--cl-anchor-height', `${rects.reference.height}px`);
 
       // Available space
       const overflow = await detectOverflow(state, { padding: 5 });
@@ -41,8 +41,8 @@ export function floatingCssVars(opts?: { sideOffset?: number }): Middleware {
             ? rects.floating.width - overflow.right
             : rects.floating.width - Math.max(overflow.left, 0) - Math.max(overflow.right, 0);
 
-      style.setProperty('--available-width', `${availableWidth}px`);
-      style.setProperty('--available-height', `${availableHeight}px`);
+      style.setProperty('--cl-available-width', `${availableWidth}px`);
+      style.setProperty('--cl-available-height', `${availableHeight}px`);
 
       // Transform origin — points back toward the anchor
       const arrowEl = elements.floating.querySelector("[data-cl-slot$='-arrow']") as HTMLElement | null;
@@ -68,7 +68,7 @@ export function floatingCssVars(opts?: { sideOffset?: number }): Middleware {
         right: `${-sideOffset}px ${transformY}px`,
       };
 
-      style.setProperty('--transform-origin', originMap[side]);
+      style.setProperty('--cl-transform-origin', originMap[side]);
 
       return {};
     },

--- a/packages/headless/src/utils/floating-css-vars.test.ts
+++ b/packages/headless/src/utils/floating-css-vars.test.ts
@@ -1,0 +1,269 @@
+import type { MiddlewareState } from '@floating-ui/react';
+import { describe, expect, it, vi } from 'vitest';
+import { floatingCssVars } from './floating-css-vars';
+
+// Build a minimal MiddlewareState mock for testing the middleware fn
+function createMockState(
+  overrides: {
+    placement?: string;
+    referenceWidth?: number;
+    referenceHeight?: number;
+    floatingWidth?: number;
+    floatingHeight?: number;
+    arrowX?: number;
+    arrowY?: number;
+    arrowElWidth?: number;
+    arrowElHeight?: number;
+    overflow?: { top: number; right: number; bottom: number; left: number };
+  } = {},
+): MiddlewareState {
+  const {
+    placement = 'bottom',
+    referenceWidth = 100,
+    referenceHeight = 40,
+    floatingWidth = 200,
+    floatingHeight = 150,
+    arrowX,
+    arrowY,
+    arrowElWidth = 0,
+    arrowElHeight = 0,
+    overflow = { top: 0, right: 0, bottom: 0, left: 0 },
+  } = overrides;
+
+  const style = {
+    setProperty: vi.fn(),
+  };
+
+  // Mock arrow element inside floating
+  const arrowEl = arrowElWidth || arrowElHeight ? { clientWidth: arrowElWidth, clientHeight: arrowElHeight } : null;
+
+  const floating = {
+    style,
+    querySelector: vi.fn(() => arrowEl),
+  } as unknown as HTMLElement;
+
+  return {
+    placement,
+    elements: {
+      floating,
+      reference: document.createElement('div'),
+    },
+    rects: {
+      reference: { width: referenceWidth, height: referenceHeight, x: 0, y: 0 },
+      floating: { width: floatingWidth, height: floatingHeight, x: 0, y: 0 },
+    },
+    middlewareData: {
+      arrow: arrowX != null || arrowY != null ? { x: arrowX ?? 0, y: arrowY ?? 0, centerOffset: 0 } : {},
+    },
+    platform: {
+      getElementRects: vi.fn(),
+      getDimensions: vi.fn(),
+      getClippingRect: vi.fn(async () => ({
+        width: 1024,
+        height: 768,
+        x: 0,
+        y: 0,
+      })),
+      convertOffsetParentRelativeRectToViewportRelativeRect: vi.fn(async ({ rect }: { rect: unknown }) => rect),
+    },
+    x: 0,
+    y: 0,
+    initialPlacement: placement,
+    strategy: 'absolute',
+  } as unknown as MiddlewareState;
+}
+
+// Helper to extract setProperty calls into a map
+function getVars(state: MiddlewareState): Map<string, string> {
+  const style = (state.elements.floating as HTMLElement).style;
+  const calls = (style.setProperty as ReturnType<typeof vi.fn>).mock.calls as [string, string][];
+  return new Map(calls.map(([name, value]) => [name, value]));
+}
+
+describe('floatingCssVars middleware', () => {
+  it("has name 'floatingCssVars'", () => {
+    const mw = floatingCssVars();
+    expect(mw.name).toBe('floatingCssVars');
+  });
+
+  describe('--anchor-width and --anchor-height', () => {
+    it('sets anchor dimensions from reference rects', async () => {
+      const mw = floatingCssVars();
+      const state = createMockState({
+        referenceWidth: 120,
+        referenceHeight: 36,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--anchor-width')).toBe('120px');
+      expect(vars.get('--anchor-height')).toBe('36px');
+    });
+
+    it('handles zero-size reference', async () => {
+      const mw = floatingCssVars();
+      const state = createMockState({
+        referenceWidth: 0,
+        referenceHeight: 0,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--anchor-width')).toBe('0px');
+      expect(vars.get('--anchor-height')).toBe('0px');
+    });
+  });
+
+  describe('--available-width and --available-height', () => {
+    it('sets available dimensions as CSS vars', async () => {
+      const mw = floatingCssVars();
+      const state = createMockState({
+        floatingWidth: 200,
+        floatingHeight: 150,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      // Values are set (exact numbers depend on detectOverflow's padding)
+      expect(vars.has('--available-width')).toBe(true);
+      expect(vars.has('--available-height')).toBe(true);
+      expect(vars.get('--available-width')).toMatch(/^\d+px$/);
+      expect(vars.get('--available-height')).toMatch(/^\d+px$/);
+    });
+  });
+
+  describe('--transform-origin', () => {
+    it('centers on anchor when no arrow (bottom)', async () => {
+      const mw = floatingCssVars({ sideOffset: 8 });
+      // Reference: x=0, width=100 → center at 50. Floating: x=0.
+      // transformX = 0 + 100/2 - 0 = 50
+      const state = createMockState({
+        placement: 'bottom',
+        referenceWidth: 100,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--transform-origin')).toBe('50px -8px');
+    });
+
+    it('centers on anchor when no arrow (top)', async () => {
+      const mw = floatingCssVars({ sideOffset: 4 });
+      const state = createMockState({
+        placement: 'top',
+        referenceWidth: 100,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--transform-origin')).toBe('50px calc(100% + 4px)');
+    });
+
+    it('centers on anchor when no arrow (left)', async () => {
+      const mw = floatingCssVars({ sideOffset: 6 });
+      const state = createMockState({
+        placement: 'left',
+        referenceHeight: 40,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      // transformY = 0 + 40/2 - 0 = 20
+      expect(vars.get('--transform-origin')).toBe('calc(100% + 6px) 20px');
+    });
+
+    it('centers on anchor when no arrow (right)', async () => {
+      const mw = floatingCssVars({ sideOffset: 6 });
+      const state = createMockState({
+        placement: 'right',
+        referenceHeight: 40,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--transform-origin')).toBe('-6px 20px');
+    });
+
+    it('handles alignment variants (e.g. bottom-start)', async () => {
+      const mw = floatingCssVars({ sideOffset: 4 });
+      const state = createMockState({
+        placement: 'bottom-start',
+        referenceWidth: 100,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      // Side is still "bottom", centers on anchor
+      expect(vars.get('--transform-origin')).toBe('50px -4px');
+    });
+
+    it('uses arrow position when arrow is present', async () => {
+      const mw = floatingCssVars({ sideOffset: 4 });
+      const state = createMockState({
+        placement: 'bottom',
+        arrowX: 50,
+        arrowElWidth: 12,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      // transformX = arrowX + arrowWidth/2 = 50 + 6 = 56
+      expect(vars.get('--transform-origin')).toBe('56px -4px');
+    });
+
+    it('uses arrow Y position on left/right placement', async () => {
+      const mw = floatingCssVars({ sideOffset: 4 });
+      const state = createMockState({
+        placement: 'right',
+        arrowY: 30,
+        arrowElHeight: 10,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      // transformY = arrowY + arrowHeight/2 = 30 + 5 = 35
+      expect(vars.get('--transform-origin')).toBe('-4px 35px');
+    });
+
+    it('defaults sideOffset to 0 when not provided', async () => {
+      const mw = floatingCssVars();
+      const state = createMockState({
+        placement: 'bottom',
+        referenceWidth: 100,
+      });
+      await mw.fn(state);
+
+      const vars = getVars(state);
+      expect(vars.get('--transform-origin')).toBe('50px 0px');
+    });
+  });
+
+  describe('return value', () => {
+    it('returns empty object (no position changes)', async () => {
+      const mw = floatingCssVars();
+      const state = createMockState();
+      const result = await mw.fn(state);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('all five CSS vars are set', () => {
+    it('sets exactly 5 CSS custom properties', async () => {
+      const mw = floatingCssVars({ sideOffset: 4 });
+      const state = createMockState({ placement: 'bottom' });
+      await mw.fn(state);
+
+      const style = state.elements.floating.style;
+      const calls = (style.setProperty as ReturnType<typeof vi.fn>).mock.calls as [string, string][];
+      const varNames = calls.map(([name]) => name);
+
+      expect(varNames).toEqual([
+        '--anchor-width',
+        '--anchor-height',
+        '--available-width',
+        '--available-height',
+        '--transform-origin',
+      ]);
+    });
+  });
+});

--- a/packages/headless/src/utils/floating-css-vars.ts
+++ b/packages/headless/src/utils/floating-css-vars.ts
@@ -1,0 +1,76 @@
+import { detectOverflow, type Middleware } from '@floating-ui/react';
+
+/**
+ * Floating UI middleware that sets CSS custom properties on the floating element:
+ *
+ * - `--anchor-width`      – reference element width (px)
+ * - `--anchor-height`     – reference element height (px)
+ * - `--available-width`   – available width between anchor and viewport edge (px)
+ * - `--available-height`  – available height between anchor and viewport edge (px)
+ * - `--transform-origin`  – CSS transform-origin pointing back toward the anchor
+ *
+ * Place **after** `arrow()` so arrow position data is available for transform-origin.
+ */
+export function floatingCssVars(opts?: { sideOffset?: number }): Middleware {
+  return {
+    name: 'floatingCssVars',
+    async fn(state) {
+      const { elements, rects, middlewareData, placement } = state;
+      const style = elements.floating.style;
+      const sideOffset = opts?.sideOffset ?? 0;
+
+      // Anchor dimensions
+      style.setProperty('--anchor-width', `${rects.reference.width}px`);
+      style.setProperty('--anchor-height', `${rects.reference.height}px`);
+
+      // Available space
+      const overflow = await detectOverflow(state, { padding: 5 });
+      const side = placement.split('-')[0] as 'top' | 'bottom' | 'left' | 'right';
+
+      const availableHeight =
+        side === 'top'
+          ? rects.floating.height - overflow.top
+          : side === 'bottom'
+            ? rects.floating.height - overflow.bottom
+            : rects.floating.height - Math.max(overflow.top, 0) - Math.max(overflow.bottom, 0);
+
+      const availableWidth =
+        side === 'left'
+          ? rects.floating.width - overflow.left
+          : side === 'right'
+            ? rects.floating.width - overflow.right
+            : rects.floating.width - Math.max(overflow.left, 0) - Math.max(overflow.right, 0);
+
+      style.setProperty('--available-width', `${availableWidth}px`);
+      style.setProperty('--available-height', `${availableHeight}px`);
+
+      // Transform origin — points back toward the anchor
+      const arrowEl = elements.floating.querySelector("[data-cl-slot$='-arrow']") as HTMLElement | null;
+
+      let transformX: number;
+      let transformY: number;
+
+      if (arrowEl) {
+        const arrowX = middlewareData.arrow?.x ?? 0;
+        const arrowY = middlewareData.arrow?.y ?? 0;
+        transformX = arrowX + arrowEl.clientWidth / 2;
+        transformY = arrowY + arrowEl.clientHeight / 2;
+      } else {
+        // No arrow — use the anchor's center relative to the floating element
+        transformX = rects.reference.x + rects.reference.width / 2 - state.x;
+        transformY = rects.reference.y + rects.reference.height / 2 - state.y;
+      }
+
+      const originMap: Record<string, string> = {
+        top: `${transformX}px calc(100% + ${sideOffset}px)`,
+        bottom: `${transformX}px ${-sideOffset}px`,
+        left: `calc(100% + ${sideOffset}px) ${transformY}px`,
+        right: `${-sideOffset}px ${transformY}px`,
+      };
+
+      style.setProperty('--transform-origin', originMap[side]);
+
+      return {};
+    },
+  };
+}

--- a/packages/headless/src/utils/floating-tree.test.tsx
+++ b/packages/headless/src/utils/floating-tree.test.tsx
@@ -1,0 +1,235 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Dialog } from '../primitives/dialog/dialog';
+import { Popover } from '../primitives/popover/popover';
+import { Select } from '../primitives/select/select';
+import { Tooltip } from '../primitives/tooltip/tooltip';
+
+afterEach(() => {
+  cleanup();
+});
+
+const fruits = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+];
+
+describe('FloatingTree integration', () => {
+  describe('Select inside Popover', () => {
+    function SelectInPopover() {
+      return (
+        <Popover>
+          <Popover.Trigger>Open Popover</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Popover.Title>Pick a fruit</Popover.Title>
+              <Select>
+                <Select.Trigger>
+                  <Select.Value placeholder='Choose...' />
+                </Select.Trigger>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {fruits.map(f => (
+                      <Select.Option
+                        key={f.value}
+                        value={f.value}
+                        label={f.label}
+                      >
+                        {f.label}
+                      </Select.Option>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('popover stays open when select dropdown opens', async () => {
+      const user = userEvent.setup();
+      render(<SelectInPopover />);
+
+      await user.click(screen.getByText('Open Popover'));
+      expect(screen.getByText('Pick a fruit')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Choose...'));
+
+      // Popover should still be open
+      expect(screen.getByText('Pick a fruit')).toBeInTheDocument();
+      // Select dropdown should be visible
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    it('popover stays open when clicking select option', async () => {
+      const user = userEvent.setup();
+      render(<SelectInPopover />);
+
+      await user.click(screen.getByText('Open Popover'));
+      await user.click(screen.getByText('Choose...'));
+      await user.click(screen.getByText('Banana'));
+
+      // Popover should still be open after selecting
+      expect(screen.getByText('Pick a fruit')).toBeInTheDocument();
+    });
+  });
+
+  describe('Select inside Dialog', () => {
+    function SelectInDialog() {
+      return (
+        <Dialog>
+          <Dialog.Trigger>Open Dialog</Dialog.Trigger>
+          <Dialog.Backdrop>
+            <Dialog.Popup>
+              <Dialog.Title>Select a fruit</Dialog.Title>
+              <Select>
+                <Select.Trigger>
+                  <Select.Value placeholder='Choose...' />
+                </Select.Trigger>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {fruits.map(f => (
+                      <Select.Option
+                        key={f.value}
+                        value={f.value}
+                        label={f.label}
+                      >
+                        {f.label}
+                      </Select.Option>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select>
+            </Dialog.Popup>
+          </Dialog.Backdrop>
+        </Dialog>
+      );
+    }
+
+    it('dialog stays open when select dropdown opens', async () => {
+      const user = userEvent.setup();
+      render(<SelectInDialog />);
+
+      await user.click(screen.getByText('Open Dialog'));
+      expect(screen.getByText('Select a fruit')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Choose...'));
+
+      // Dialog should still be open
+      expect(screen.getByText('Select a fruit')).toBeInTheDocument();
+      // Select options visible
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+  });
+
+  describe('Popover inside Popover', () => {
+    function NestedPopover() {
+      return (
+        <Popover>
+          <Popover.Trigger>Outer</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Popover.Title>Outer Content</Popover.Title>
+              <Popover>
+                <Popover.Trigger>Inner</Popover.Trigger>
+                <Popover.Positioner>
+                  <Popover.Popup>
+                    <Popover.Title>Inner Content</Popover.Title>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('outer popover stays open when inner popover opens', async () => {
+      const user = userEvent.setup();
+      render(<NestedPopover />);
+
+      await user.click(screen.getByText('Outer'));
+      expect(screen.getByText('Outer Content')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Inner'));
+
+      // Both should be visible
+      expect(screen.getByText('Outer Content')).toBeInTheDocument();
+      expect(screen.getByText('Inner Content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Tooltip inside Popover', () => {
+    function TooltipInPopover() {
+      return (
+        <Popover>
+          <Popover.Trigger>Open Popover</Popover.Trigger>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Popover.Title>Content</Popover.Title>
+              <Tooltip>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Positioner>
+                  <Tooltip.Popup>Tooltip text</Tooltip.Popup>
+                </Tooltip.Positioner>
+              </Tooltip>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover>
+      );
+    }
+
+    it('popover stays open when tooltip trigger is hovered', async () => {
+      const user = userEvent.setup();
+      render(<TooltipInPopover />);
+
+      await user.click(screen.getByText('Open Popover'));
+      expect(screen.getByText('Content')).toBeInTheDocument();
+
+      await user.hover(screen.getByText('Hover me'));
+
+      // Popover should remain open
+      expect(screen.getByText('Content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Popover inside Dialog', () => {
+    function PopoverInDialog() {
+      return (
+        <Dialog>
+          <Dialog.Trigger>Open Dialog</Dialog.Trigger>
+          <Dialog.Backdrop>
+            <Dialog.Popup>
+              <Dialog.Title>Dialog Content</Dialog.Title>
+              <Popover>
+                <Popover.Trigger>Open Popover</Popover.Trigger>
+                <Popover.Positioner>
+                  <Popover.Popup>
+                    <Popover.Title>Popover Content</Popover.Title>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover>
+            </Dialog.Popup>
+          </Dialog.Backdrop>
+        </Dialog>
+      );
+    }
+
+    it('dialog stays open when popover opens inside it', async () => {
+      const user = userEvent.setup();
+      render(<PopoverInDialog />);
+
+      await user.click(screen.getByText('Open Dialog'));
+      expect(screen.getByText('Dialog Content')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Open Popover'));
+
+      // Both should be visible
+      expect(screen.getByText('Dialog Content')).toBeInTheDocument();
+      expect(screen.getByText('Popover Content')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/headless/src/utils/index.ts
+++ b/packages/headless/src/utils/index.ts
@@ -1,2 +1,2 @@
-export { floatingCssVars } from './floating-css-vars';
+export { cssVars } from './css-vars';
 export { type ComponentProps, mergeProps, type RenderProp, renderElement } from './render-element';

--- a/packages/headless/src/utils/index.ts
+++ b/packages/headless/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { floatingCssVars } from './floating-css-vars';
+export { type ComponentProps, mergeProps, type RenderProp, renderElement } from './render-element';

--- a/packages/headless/src/utils/render-element.test.tsx
+++ b/packages/headless/src/utils/render-element.test.tsx
@@ -1,0 +1,225 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mergeProps, renderElement } from './render-element';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('mergeProps', () => {
+  it('merges two plain objects', () => {
+    const result = mergeProps<'div'>({ id: 'a', 'data-x': '1' }, { 'data-y': '2' });
+    expect(result).toEqual({ id: 'a', 'data-x': '1', 'data-y': '2' });
+  });
+
+  it('second argument overrides first for plain props', () => {
+    const result = mergeProps<'div'>({ id: 'a' }, { id: 'b' });
+    expect(result.id).toBe('b');
+  });
+
+  it('chains event handlers', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const result = mergeProps<'button'>({ onClick: first }, { onClick: second });
+
+    (result.onClick as Function)();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('shallow-merges style objects', () => {
+    const result = mergeProps<'div'>(
+      { style: { color: 'red', fontSize: 14 } },
+      { style: { color: 'blue', padding: 8 } },
+    );
+    expect(result.style).toEqual({
+      color: 'blue',
+      fontSize: 14,
+      padding: 8,
+    });
+  });
+
+  it('concatenates className', () => {
+    const result = mergeProps<'div'>({ className: 'base' }, { className: 'extra' });
+    expect(result.className).toBe('base extra');
+  });
+
+  it('does not chain non-event-handler functions', () => {
+    const ref1 = vi.fn();
+    const ref2 = vi.fn();
+    const result = mergeProps<'div'>({ ref: ref1 }, { ref: ref2 });
+    // ref is not an event handler (doesn't match /^on[A-Z]/), so it's overwritten
+    expect(result.ref).toBe(ref2);
+  });
+});
+
+describe('renderElement', () => {
+  it('renders default tag when no render prop', () => {
+    const element = renderElement({
+      defaultTagName: 'span',
+      props: { 'data-testid': 'test', children: 'hello' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el.tagName).toBe('SPAN');
+    expect(el).toHaveTextContent('hello');
+  });
+
+  it('renders custom element via render prop (element)', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      render: <section />,
+      props: { 'data-testid': 'test', children: 'content' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el.tagName).toBe('SECTION');
+  });
+
+  it('renders via render function', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      render: props => <article {...props} />,
+      props: { 'data-testid': 'test', children: 'content' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el.tagName).toBe('ARTICLE');
+  });
+
+  it('returns null when enabled is false', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      enabled: false,
+      props: { children: 'hidden' },
+    });
+
+    expect(element).toBeNull();
+  });
+
+  it('renders when enabled is true', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      enabled: true,
+      props: { 'data-testid': 'test', children: 'visible' },
+    });
+
+    render(element!);
+
+    expect(screen.getByTestId('test')).toBeInTheDocument();
+  });
+
+  it('applies state attributes via stateAttributesMapping', () => {
+    const element = renderElement({
+      defaultTagName: 'button',
+      state: { open: true },
+      stateAttributesMapping: {
+        open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+      },
+      props: { 'data-testid': 'test' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el).toHaveAttribute('data-cl-open', '');
+    expect(el).not.toHaveAttribute('data-cl-closed');
+  });
+
+  it('applies false state attributes via stateAttributesMapping', () => {
+    const element = renderElement({
+      defaultTagName: 'button',
+      state: { open: false },
+      stateAttributesMapping: {
+        open: (v: boolean): Record<string, string> | null => (v ? { 'data-cl-open': '' } : { 'data-cl-closed': '' }),
+      },
+      props: { 'data-testid': 'test' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el).toHaveAttribute('data-cl-closed', '');
+    expect(el).not.toHaveAttribute('data-cl-open');
+  });
+
+  it('skips null return from stateAttributesMapping', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      state: { selected: false },
+      stateAttributesMapping: {
+        selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+      },
+      props: { 'data-testid': 'test' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el).not.toHaveAttribute('data-cl-selected');
+  });
+
+  it('merges multiple state attribute mappings', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      state: { selected: true, active: true, disabled: false },
+      stateAttributesMapping: {
+        selected: (v: boolean) => (v ? { 'data-cl-selected': '' } : null),
+        active: (v: boolean) => (v ? { 'data-cl-active': '' } : null),
+        disabled: (v: boolean) => (v ? { 'data-cl-disabled': '' } : null),
+      },
+      props: { 'data-testid': 'test' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el).toHaveAttribute('data-cl-selected', '');
+    expect(el).toHaveAttribute('data-cl-active', '');
+    expect(el).not.toHaveAttribute('data-cl-disabled');
+  });
+
+  it('state attributes override props', () => {
+    const element = renderElement({
+      defaultTagName: 'div',
+      state: { open: true },
+      stateAttributesMapping: {
+        open: () => ({ 'data-cl-open': '' }),
+      },
+      props: { 'data-testid': 'test', 'data-cl-open': 'should-be-overridden' },
+    });
+
+    render(element!);
+
+    const el = screen.getByTestId('test');
+    expect(el).toHaveAttribute('data-cl-open', '');
+  });
+
+  it('passes computed props to render function', () => {
+    const renderFn = vi.fn(props => <div {...props} />);
+
+    renderElement({
+      defaultTagName: 'div',
+      render: renderFn,
+      state: { open: true },
+      stateAttributesMapping: {
+        open: (v: boolean) => (v ? { 'data-cl-open': '' } : null),
+      },
+      props: { id: 'test' },
+    });
+
+    expect(renderFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'test',
+        'data-cl-open': '',
+      }),
+    );
+  });
+});

--- a/packages/headless/src/utils/render-element.tsx
+++ b/packages/headless/src/utils/render-element.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A render prop: either a JSX element to clone, or a function that receives
+ * computed HTML props and returns a JSX element.
+ */
+export type RenderProp<Props = React.HTMLAttributes<HTMLElement>> =
+  | React.ReactElement
+  | ((props: Props) => React.ReactElement);
+
+/**
+ * Props accepted by any primitive part. Extends the native props for `Tag`
+ * and adds the optional `render` escape hatch.
+ */
+export type ComponentProps<Tag extends keyof React.JSX.IntrinsicElements> = React.ComponentPropsWithRef<Tag> & {
+  render?: RenderProp;
+};
+
+/**
+ * Maps state keys to functions that return data-attribute objects (or null).
+ */
+type StateAttributesMapping<S> = {
+  [K in keyof S]?: (value: S[K]) => Record<string, string> | null;
+};
+
+// ---------------------------------------------------------------------------
+// mergeProps
+// ---------------------------------------------------------------------------
+
+type PropsInput<Tag extends keyof React.JSX.IntrinsicElements> =
+  | React.ComponentPropsWithRef<Tag>
+  | Record<string, unknown>;
+
+/**
+ * Merges two props objects. Event handlers are chained (both fire),
+ * `style` is shallow-merged, `className` is concatenated, and
+ * everything else is overwritten by the second argument.
+ */
+export function mergeProps<Tag extends keyof React.JSX.IntrinsicElements>(
+  a: PropsInput<Tag>,
+  b: PropsInput<Tag>,
+): Record<string, unknown>;
+export function mergeProps(a: Record<string, unknown>, b: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...a };
+
+  for (const key of Object.keys(b)) {
+    const bVal = b[key];
+
+    if (
+      key.charCodeAt(0) === 111 /* o */ &&
+      key.charCodeAt(1) === 110 /* n */ &&
+      key.charCodeAt(2) >= 65 /* A */ &&
+      key.charCodeAt(2) <= 90 /* Z */ &&
+      typeof a[key] === 'function' &&
+      typeof bVal === 'function'
+    ) {
+      // Chain event handlers — internal fires first, consumer fires second
+      const aHandler = a[key] as (...args: unknown[]) => void;
+      const bHandler = bVal as (...args: unknown[]) => void;
+      merged[key] = (...args: unknown[]) => {
+        aHandler(...args);
+        bHandler(...args);
+      };
+    } else if (key === 'style' && a.style && bVal) {
+      merged.style = { ...(a.style as object), ...(bVal as object) };
+    } else if (key === 'className' && a.className && bVal) {
+      merged.className = `${a.className} ${bVal}`;
+    } else {
+      merged[key] = bVal;
+    }
+  }
+
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
+// renderElement
+// ---------------------------------------------------------------------------
+
+interface RenderElementParams<
+  Tag extends keyof React.JSX.IntrinsicElements,
+  State extends Record<string, unknown> = Record<string, never>,
+> {
+  /** Fallback HTML tag when `render` is not provided. */
+  defaultTagName: Tag;
+  /** Render prop from the consumer. */
+  render?: RenderProp;
+  /** When false, returns null (used by Positioners gated on `mounted`). */
+  enabled?: boolean;
+  /** State object. Keys are mapped to data attributes via `stateAttributesMapping`. */
+  state?: State;
+  /** Custom mapping from state keys to data-attribute objects. */
+  stateAttributesMapping?: StateAttributesMapping<State>;
+  /** Merged props to spread onto the element. */
+  props?: Record<string, unknown>;
+}
+
+/**
+ * Renders a primitive part element with render-prop support, conditional
+ * rendering, and state-to-data-attribute mapping.
+ */
+export function renderElement<
+  Tag extends keyof React.JSX.IntrinsicElements,
+  State extends Record<string, unknown> = Record<string, never>,
+>(params: RenderElementParams<Tag, State>): React.ReactElement | null {
+  const { defaultTagName, render, enabled = true, state, stateAttributesMapping, props } = params;
+
+  if (!enabled) return null;
+
+  // Build data attributes from state
+  let dataAttrs: Record<string, string> = {};
+  if (state && stateAttributesMapping) {
+    for (const key of Object.keys(stateAttributesMapping) as Array<keyof State>) {
+      const mapper = stateAttributesMapping[key];
+      if (mapper) {
+        const attrs = mapper(state[key]);
+        if (attrs) {
+          dataAttrs = { ...dataAttrs, ...attrs };
+        }
+      }
+    }
+  }
+
+  const computedProps = { ...props, ...dataAttrs };
+
+  if (typeof render === 'function') {
+    return render(computedProps as React.HTMLAttributes<HTMLElement>);
+  }
+
+  if (render) {
+    return React.cloneElement(render, computedProps);
+  }
+
+  return React.createElement(defaultTagName, computedProps);
+}

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "noUnusedLocals": true,
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "module": "preserve",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx",
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/headless/vite.config.ts
+++ b/packages/headless/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  plugins: [
+    dts({
+      tsconfigPath: './tsconfig.json',
+      exclude: ['**/*.test.ts', '**/*.test.tsx'],
+    }),
+  ],
+  build: {
+    lib: {
+      entry: {
+        'primitives/select/index': 'src/primitives/select/index.ts',
+        'primitives/menu/index': 'src/primitives/menu/index.ts',
+        'primitives/dialog/index': 'src/primitives/dialog/index.ts',
+        'primitives/popover/index': 'src/primitives/popover/index.ts',
+        'primitives/tooltip/index': 'src/primitives/tooltip/index.ts',
+        'primitives/autocomplete/index': 'src/primitives/autocomplete/index.ts',
+        'primitives/tabs/index': 'src/primitives/tabs/index.ts',
+        'primitives/accordion/index': 'src/primitives/accordion/index.ts',
+        'utils/index': 'src/utils/index.ts',
+        'hooks/use-controllable-state': 'src/hooks/use-controllable-state.ts',
+        'hooks/use-floating-transition': 'src/hooks/use-floating-transition.ts',
+        'hooks/use-transition-status': 'src/hooks/use-transition-status.ts',
+        'hooks/use-animations-finished': 'src/hooks/use-animations-finished.ts',
+      },
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime', '@floating-ui/react'],
+    },
+    sourcemap: true,
+  },
+});

--- a/packages/headless/vite.config.ts
+++ b/packages/headless/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
         'primitives/accordion/index': 'src/primitives/accordion/index.ts',
         'utils/index': 'src/utils/index.ts',
         'hooks/use-controllable-state': 'src/hooks/use-controllable-state.ts',
-        'hooks/use-floating-transition': 'src/hooks/use-floating-transition.ts',
+        'hooks/use-transition': 'src/hooks/use-transition.ts',
         'hooks/use-transition-status': 'src/hooks/use-transition-status.ts',
         'hooks/use-animations-finished': 'src/hooks/use-animations-finished.ts',
       },

--- a/packages/headless/vitest.config.ts
+++ b/packages/headless/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 export default defineConfig({
+  optimizeDeps: {
+    include: ['react/jsx-dev-runtime'],
+  },
   test: {
     browser: {
       enabled: true,

--- a/packages/headless/vitest.config.ts
+++ b/packages/headless/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }],
+    },
+    setupFiles: ['./vitest.setup.ts'],
+    css: { modules: { classNameStrategy: 'non-scoped' } },
+  },
+});

--- a/packages/headless/vitest.setup.ts
+++ b/packages/headless/vitest.setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/vitest';
+import { toHaveNoViolations } from './src/test-utils/axe';
+import { expect } from 'vitest';
+
+expect.extend({ toHaveNoViolations });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -98,7 +98,7 @@
     "@clerk/shared": "workspace:^",
     "@emotion/cache": "11.11.0",
     "@emotion/react": "11.11.1",
-    "@floating-ui/react": "0.27.12",
+    "@floating-ui/react": "catalog:repo",
     "@formkit/auto-animate": "^0.8.2",
     "@solana/wallet-adapter-base": "catalog:module-manager",
     "@solana/wallet-adapter-react": "catalog:module-manager",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ catalogs:
       specifier: 18.3.7
       version: 18.3.7
   repo:
+    '@floating-ui/react':
+      specifier: 0.27.12
+      version: 0.27.12
     '@swc/helpers':
       specifier: 0.5.21
       version: 0.5.21
@@ -151,10 +154,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.7.0(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.7.0(vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -292,7 +295,7 @@ importers:
         version: 0.15.7(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(typescript@5.8.3)(vue-tsc@3.1.4(typescript@5.8.3))
       tsup:
         specifier: catalog:repo
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3)
+        version: 8.5.1(@microsoft/api-extractor@7.58.6(@types/node@22.19.17))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3)
       turbo:
         specifier: ^2.5.4
         version: 2.6.0
@@ -316,7 +319,7 @@ importers:
         version: 8.3.2
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       zx:
         specifier: catalog:repo
         version: 8.8.5
@@ -341,7 +344,7 @@ importers:
         version: link:../ui
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@25.6.0)(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3)
+        version: 5.18.1(@types/node@25.6.0)(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.3)
 
   packages/backend:
     dependencies:
@@ -363,7 +366,7 @@ importers:
         version: 1.0.2
       msw:
         specifier: 2.11.6
-        version: 2.11.6(@types/node@25.6.0)(typescript@5.8.3)
+        version: 2.11.6(@types/node@25.6.0)(typescript@5.9.3)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -372,7 +375,7 @@ importers:
         version: 9.0.2
       vitest-environment-miniflare:
         specifier: 2.14.4
-        version: 2.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 2.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.4)
 
   packages/chrome-extension:
     dependencies:
@@ -415,22 +418,22 @@ importers:
     dependencies:
       '@base-org/account':
         specifier: catalog:module-manager
-        version: 2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@clerk/shared':
         specifier: workspace:^
         version: link:../shared
       '@coinbase/wallet-sdk':
         specifier: catalog:module-manager
-        version: 4.3.7(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 4.3.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-base':
         specifier: catalog:module-manager
-        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: catalog:module-manager
-        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
+        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
       '@solana/wallet-standard':
         specifier: catalog:module-manager
-        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
       '@stripe/stripe-js':
         specifier: 5.6.0
         version: 5.6.0
@@ -650,6 +653,67 @@ importers:
         specifier: ^5.8.5
         version: 5.8.5
 
+  packages/headless:
+    dependencies:
+      '@floating-ui/react':
+        specifier: catalog:repo
+        version: 0.27.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: catalog:react
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: catalog:react
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitest/browser':
+        specifier: 4.1.4
+        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright':
+        specifier: 4.1.4
+        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      axe-core:
+        specifier: ^4.11.3
+        version: 4.11.3
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+      rolldown:
+        specifier: 1.0.0-beta.47
+        version: 1.0.0-beta.47
+      typescript:
+        specifier: catalog:repo
+        version: 5.8.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^4.5.4
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest:
+        specifier: 4.1.4
+        version: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.4)
+
   packages/hono:
     dependencies:
       '@clerk/backend':
@@ -676,7 +740,7 @@ importers:
         version: link:../shared
       msw:
         specifier: 2.11.3
-        version: 2.11.3(@types/node@25.6.0)(typescript@5.8.3)
+        version: 2.11.3(@types/node@25.6.0)(typescript@5.9.3)
       next:
         specifier: '>=15.0.0'
         version: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -738,7 +802,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: ^4.1.2
-        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
+        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
       typescript:
         specifier: catalog:repo
         version: 5.8.3
@@ -834,19 +898,19 @@ importers:
     devDependencies:
       '@base-org/account':
         specifier: catalog:module-manager
-        version: 2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk':
         specifier: catalog:module-manager
-        version: 4.3.7(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 4.3.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-base':
         specifier: catalog:module-manager
-        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: catalog:module-manager
-        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
+        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
       '@solana/wallet-standard':
         specifier: catalog:module-manager
-        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
       '@stripe/react-stripe-js':
         specifier: 3.1.1
         version: 3.1.1(@stripe/stripe-js@5.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -901,7 +965,7 @@ importers:
         version: 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-start':
         specifier: 1.157.16
-        version: 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
+        version: 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
       esbuild-plugin-file-path-extensions:
         specifier: ^2.1.4
         version: 2.1.4
@@ -940,20 +1004,20 @@ importers:
         specifier: 11.11.1
         version: 11.11.1(@types/react@18.3.28)(react@18.3.1)
       '@floating-ui/react':
-        specifier: 0.27.12
+        specifier: catalog:repo
         version: 0.27.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@formkit/auto-animate':
         specifier: ^0.8.2
         version: 0.8.4
       '@solana/wallet-adapter-base':
         specifier: catalog:module-manager
-        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: catalog:module-manager
-        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
+        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
       '@solana/wallet-standard':
         specifier: catalog:module-manager
-        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+        version: 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
       '@swc/helpers':
         specifier: catalog:repo
         version: 0.5.21
@@ -999,7 +1063,7 @@ importers:
         version: 1.6.2(react-refresh@0.17.0)
       '@svgr/rollup':
         specifier: ^8.1.0
-        version: 8.1.0(rollup@4.53.1)(typescript@5.8.3)
+        version: 8.1.0(rollup@4.53.1)(typescript@5.9.3)
       '@svgr/webpack':
         specifier: ^6.5.1
         version: 6.5.1
@@ -1017,7 +1081,7 @@ importers:
         version: 10.2.5
       tsdown:
         specifier: catalog:repo
-        version: 0.15.7(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(typescript@5.8.3)(vue-tsc@3.1.4(typescript@5.8.3))
+        version: 0.15.7(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@3.1.4(typescript@5.9.3))
       webpack-merge:
         specifier: ^5.10.0
         version: 5.10.0
@@ -1082,22 +1146,22 @@ importers:
         version: link:../ui
       '@testing-library/vue':
         specifier: ^8.1.0
-        version: 8.1.0(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.8.3))
+        version: 8.1.0(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
-        version: 5.2.4(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+        version: 5.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue.ts/tsx-auto-props':
         specifier: ^0.6.0
-        version: 0.6.0(magicast@0.3.5)(rollup@4.53.1)(typescript@5.8.3)(vue@3.5.32(typescript@5.8.3))
+        version: 0.6.0(magicast@0.3.5)(rollup@4.53.1)(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))
       unplugin-vue:
         specifier: 7.0.8
-        version: 7.0.8(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(ms@2.1.3)(terser@5.46.1)(tsx@4.20.6)(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3)
+        version: 7.0.8(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(ms@2.1.3)(terser@5.46.1)(tsx@4.20.6)(vue@3.5.32(typescript@5.9.3))(yaml@2.8.3)
       vue:
         specifier: catalog:repo
-        version: 3.5.32(typescript@5.8.3)
+        version: 3.5.32(typescript@5.9.3)
       vue-tsc:
         specifier: ^3.2.4
-        version: 3.2.4(typescript@5.8.3)
+        version: 3.2.4(typescript@5.9.3)
 
 packages:
 
@@ -1920,6 +1984,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
@@ -3178,6 +3245,19 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
+
+  '@microsoft/api-extractor@7.58.6':
+    resolution: {integrity: sha512-+F7lTCwIuGapTDJpkTj2GnHYozqDbqLAmCsySX58PBaMt0cB28zPO9gOG7LijMXpqCkSGwSPh1k1rqvJUc9mzg==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.18.1':
+    resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
   '@miniflare/cache@2.14.4':
     resolution: {integrity: sha512-ayzdjhcj+4mjydbNK7ZGDpIXNliDbQY4GPcY2KrYw0v1OSUdj5kZUkygD09fqoGRfAks0d91VelkyRsAXX8FQA==}
@@ -4512,6 +4592,36 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/problem-matcher@0.2.1':
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
+  '@rushstack/terminal@0.23.0':
+    resolution: {integrity: sha512-7FfI9irLqnBDxCvMEXdEXLDjaouZsGbKkeGfmW8IOn8aYi7DV9aaXaEQHCcVxWMvEDOkuTf4y6RMDgIY5CFuUQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.3.8':
+    resolution: {integrity: sha512-vKL4fVR2TdnMdCmlP71nZUzbNANOYlR7NfN+J/YL9UIvicDIEB+ZtH38LcJECOZUwHia8C5Mg98kc4kPt/ev5w==}
+
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -4715,6 +4825,9 @@ packages:
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@stripe/react-stripe-js@3.1.1':
     resolution: {integrity: sha512-+JzYFgUivVD7koqYV7LmLlt9edDMAwKH7XhZAHFQMo7NeRC+6D2JmQGzp9tygWerzwttwFLlExGp4rAOvD6l9g==}
@@ -5008,6 +5121,21 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: 18.3.1
+      react-dom: 18.3.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -5030,6 +5158,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -5505,6 +5636,17 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
+  '@vitest/browser-playwright@4.1.4':
+    resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.4
+
+  '@vitest/browser@4.1.4':
+    resolution: {integrity: sha512-TrNaY/yVOwxtrxNsDUC/wQ56xSwplpytTeRAqF/197xV/ZddxxulBsxR6TrhVMyniJmp9in8d5u0AcDaNRY30w==}
+    peerDependencies:
+      vitest: 4.1.4
+
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
     peerDependencies:
@@ -5517,6 +5659,9 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
@@ -5528,20 +5673,46 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@volar/language-core@2.1.6':
     resolution: {integrity: sha512-pAlMCGX/HatBSiDFMdMyqUshkbwWbLxpN/RL7HCQDOo2gYBE+uS+nanosLc1qR6pTQ/U8q00xt8bdrrAFPSC0A==}
@@ -5619,6 +5790,9 @@ packages:
   '@vue/compiler-ssr@3.5.32':
     resolution: {integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==}
 
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
@@ -5635,6 +5809,14 @@ packages:
 
   '@vue/language-core@2.0.7':
     resolution: {integrity: sha512-Vh1yZX3XmYjn9yYLkjU8DN6L0ceBtEcapqiyclHne8guG84IaTzqtvizZB1Yfxm3h6m7EIvjerLO5fvOZO6IIQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-core@2.2.0':
+    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -5856,6 +6038,14 @@ packages:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -5882,6 +6072,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  alien-signals@0.4.14:
+    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
   alien-signals@2.0.6:
     resolution: {integrity: sha512-P3TxJSe31bUHBiblg59oU1PpaWPtmxF9GhJ/cB7OkgJ0qN/ifFSKUI25/v8ZhsT+lIG6ac8DpTOplXxORX6F3Q==}
@@ -6145,8 +6338,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axe-core@4.11.0:
-    resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
   axios@0.30.2:
@@ -6563,6 +6756,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -6865,6 +7062,9 @@ packages:
   compare-urls@2.0.0:
     resolution: {integrity: sha512-eCJcWn2OYFEIqbm70ta7LQowJOOZZqq1a2YbbFCFI1uwSvj+TWMwXVn7vPR1ceFNcAIt5RSTDbwdlX82gYLTkA==}
     engines: {node: '>=6'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
@@ -7717,6 +7917,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -8042,6 +8245,10 @@ packages:
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   expo-apple-authentication@7.2.4:
@@ -9072,6 +9279,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -9558,6 +9769,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
@@ -9749,6 +9963,9 @@ packages:
   knitwork@1.2.0:
     resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   lan-network@0.1.7:
     resolution: {integrity: sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==}
     hasBin: true
@@ -9791,6 +10008,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.27.0:
     resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
     engines: {node: '>= 12.0.0'}
@@ -9799,6 +10022,12 @@ packages:
 
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -9815,6 +10044,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.27.0:
     resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
     engines: {node: '>= 12.0.0'}
@@ -9823,6 +10058,12 @@ packages:
 
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -9839,6 +10080,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.27.0:
     resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
     engines: {node: '>= 12.0.0'}
@@ -9848,6 +10095,13 @@ packages:
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -9867,6 +10121,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
@@ -9876,6 +10137,13 @@ packages:
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -9895,6 +10163,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
     engines: {node: '>= 12.0.0'}
@@ -9903,6 +10178,12 @@ packages:
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -9919,12 +10200,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.27.0:
     resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
     engines: {node: '>= 12.0.0'}
 
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
@@ -10003,6 +10294,9 @@ packages:
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -10574,6 +10868,10 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -10985,6 +11283,9 @@ packages:
     peerDependenciesMeta:
       ms:
         optional: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -11453,8 +11754,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.56.1:
     resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11469,6 +11780,10 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
@@ -12800,6 +13115,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -13197,12 +13515,20 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -13518,6 +13844,11 @@ packages:
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -13936,6 +14267,15 @@ packages:
       vue-tsc:
         optional: true
 
+  vite-plugin-dts@4.5.4:
+    resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
+    peerDependencies:
+      typescript: '*'
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vite-plugin-inspect@11.3.3:
     resolution: {integrity: sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==}
     engines: {node: '>=14'}
@@ -14032,6 +14372,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.0.9:
+    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.1:
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
@@ -14039,6 +14422,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest-chrome@0.1.0:
     resolution: {integrity: sha512-Bs1uywAolbc46h2tcaETQyFMTnOHjSA85iH10Zoe8ZMEl/71nuSdxs3z+KMxVZtN88TEgWicnl5vmbDO1OhoEw==}
@@ -14070,6 +14458,47 @@ packages:
       '@types/node':
         optional: true
       '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -15637,15 +16066,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@base-org/account@2.0.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.38.6(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.38.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -15658,6 +16087,8 @@ snapshots:
       - zod
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@blazediff/core@1.9.1': {}
 
   '@braidai/lang@1.1.2': {}
 
@@ -15833,13 +16264,13 @@ snapshots:
 
   '@cloudflare/workers-types@4.20251107.0': {}
 
-  '@coinbase/wallet-sdk@4.3.7(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@coinbase/wallet-sdk@4.3.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.8.0
       clsx: 1.2.1
       eventemitter3: 5.0.4
       preact: 10.27.2
-      viem: 2.38.6(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.38.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -17396,6 +17827,69 @@ snapshots:
       - encoding
       - supports-color
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@22.19.17)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@microsoft/api-extractor-model@7.33.8(@types/node@25.6.0)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.58.6(@types/node@22.19.17)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@22.19.17)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.17)
+      '@rushstack/ts-command-line': 5.3.8(@types/node@22.19.17)
+      diff: 8.0.3
+      minimatch: 10.2.3
+      resolve: 1.22.11
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@microsoft/api-extractor@7.58.6(@types/node@25.6.0)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.6.0)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@25.6.0)
+      '@rushstack/ts-command-line': 5.3.8(@types/node@25.6.0)
+      diff: 8.0.3
+      minimatch: 10.2.3
+      resolve: 1.22.11
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.18.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      ajv: 8.18.0
+      jju: 1.4.0
+      resolve: 1.22.11
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@miniflare/cache@2.14.4':
     dependencies:
       '@miniflare/core': 2.14.4
@@ -17682,11 +18176,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.1.0(magicast@0.5.1)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@nuxt/devtools-kit@3.1.0(magicast@0.5.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       execa: 8.0.1
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
@@ -17701,12 +18195,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.4
 
-  '@nuxt/devtools@3.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@nuxt/devtools@3.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.0(magicast@0.5.1)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@nuxt/devtools-kit': 3.1.0(magicast@0.5.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@nuxt/devtools-wizard': 3.1.0
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
-      '@vue/devtools-core': 8.0.3(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      '@vue/devtools-core': 8.0.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@vue/devtools-kit': 8.0.3
       birpc: 2.7.0
       consola: 3.4.2
@@ -17731,9 +18225,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
-      vite-plugin-vue-tracer: 1.1.3(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite-plugin-vue-tracer: 1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       which: 5.0.0
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -17819,7 +18313,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(rolldown@1.0.0-beta.47)(typescript@5.8.3)':
+  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(rolldown@1.0.0-beta.47)(typescript@5.8.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
@@ -17837,7 +18331,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.12.9(idb-keyval@6.2.1)(rolldown@1.0.0-beta.47)
-      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
+      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -17908,12 +18402,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@4.2.1(@types/node@25.6.0)(eslint@9.31.0(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(vue-tsc@3.2.4(typescript@5.8.3))(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.2.1(@types/node@25.6.0)(eslint@9.31.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(vue-tsc@3.2.4(typescript@5.8.3))(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.1)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       autoprefixer: 10.4.21(postcss@8.5.10)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.10)
@@ -17928,7 +18422,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
+      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.10
@@ -17937,9 +18431,9 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-node: 5.0.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-plugin-checker: 0.11.0(eslint@9.31.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-node: 5.0.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-plugin-checker: 0.11.0(eslint@9.31.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))
       vue: 3.5.32(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -19073,6 +19567,83 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@rushstack/node-core-library@5.23.1(@types/node@22.19.17)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.2
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 22.19.17
+    optional: true
+
+  '@rushstack/node-core-library@5.23.1(@types/node@25.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.2
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
+    optional: true
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.11
+
+  '@rushstack/terminal@0.23.0(@types/node@22.19.17)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@22.19.17)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 22.19.17
+    optional: true
+
+  '@rushstack/terminal@0.23.0(@types/node@25.6.0)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.6.0)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@rushstack/ts-command-line@5.3.8(@types/node@22.19.17)':
+    dependencies:
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.17)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@rushstack/ts-command-line@5.3.8(@types/node@25.6.0)':
+    dependencies:
+      '@rushstack/terminal': 0.23.0(@types/node@25.6.0)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.7.0':
@@ -19161,10 +19732,10 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       js-base64: 3.7.8
     transitivePeerDependencies:
@@ -19174,10 +19745,10 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/wallet-standard': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
+      '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/wallet-standard': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
       js-base64: 3.7.8
@@ -19190,13 +19761,13 @@ snapshots:
       - react
       - typescript
 
-  '@solana-mobile/wallet-adapter-mobile@2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)':
+  '@solana-mobile/wallet-adapter-mobile@2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
-      '@solana-mobile/wallet-standard-mobile': 0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
+      '@solana-mobile/wallet-standard-mobile': 0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-features': 1.3.0
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       js-base64: 3.7.8
     optionalDependencies:
       '@react-native-async-storage/async-storage': 1.24.0(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))
@@ -19206,9 +19777,9 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-mobile/wallet-standard-mobile@0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)':
+  '@solana-mobile/wallet-standard-mobile@0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
       '@wallet-standard/base': 1.1.0
@@ -19228,62 +19799,62 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@solana/codecs-core@2.3.0(typescript@5.8.3)':
+  '@solana/codecs-core@2.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@solana/codecs-core@4.0.0(typescript@5.8.3)':
+  '@solana/codecs-core@4.0.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 4.0.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@solana/codecs-numbers@2.3.0(typescript@5.8.3)':
+  '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.8.3)
-      '@solana/errors': 2.3.0(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@solana/codecs-numbers@4.0.0(typescript@5.8.3)':
+  '@solana/codecs-numbers@4.0.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 4.0.0(typescript@5.8.3)
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 4.0.0(typescript@5.9.3)
+      '@solana/errors': 4.0.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@solana/codecs-strings@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/codecs-strings@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 4.0.0(typescript@5.8.3)
-      '@solana/codecs-numbers': 4.0.0(typescript@5.8.3)
-      '@solana/errors': 4.0.0(typescript@5.8.3)
+      '@solana/codecs-core': 4.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 4.0.0(typescript@5.9.3)
+      '@solana/errors': 4.0.0(typescript@5.9.3)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  '@solana/errors@2.3.0(typescript@5.8.3)':
+  '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  '@solana/errors@4.0.0(typescript@5.8.3)':
+  '@solana/errors@4.0.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.1
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  '@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+  '@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-standard-features': 1.3.0
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       eventemitter3: 5.0.4
 
-  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)':
+  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@solana-mobile/wallet-adapter-mobile': 2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.8.3)
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana-mobile/wallet-adapter-mobile': 2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.9.3)
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 18.3.1
     transitivePeerDependencies:
       - bs58
@@ -19312,36 +19883,36 @@ snapshots:
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
 
-  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)':
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)':
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       '@wallet-standard/wallet': 1.1.0
       bs58: 5.0.0
 
-  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)':
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       '@wallet-standard/wallet': 1.1.0
       bs58: 6.0.0
 
-  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
+  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       react: 18.3.1
@@ -19349,10 +19920,10 @@ snapshots:
       - '@solana/web3.js'
       - bs58
 
-  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
+  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       react: 18.3.1
@@ -19360,53 +19931,53 @@ snapshots:
       - '@solana/web3.js'
       - bs58
 
-  '@solana/wallet-standard-wallet-adapter@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
+  '@solana/wallet-standard-wallet-adapter@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
     dependencies:
-      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)
-      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@solana/wallet-adapter-base'
       - '@solana/web3.js'
       - bs58
       - react
 
-  '@solana/wallet-standard-wallet-adapter@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
+  '@solana/wallet-standard-wallet-adapter@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
     dependencies:
-      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
-      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@solana/wallet-adapter-base'
       - '@solana/web3.js'
       - bs58
       - react
 
-  '@solana/wallet-standard@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
-    dependencies:
-      '@solana/wallet-standard-core': 1.1.2
-      '@solana/wallet-standard-wallet-adapter': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@solana/wallet-adapter-base'
-      - '@solana/web3.js'
-      - bs58
-      - react
-
-  '@solana/wallet-standard@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
+  '@solana/wallet-standard@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)':
     dependencies:
       '@solana/wallet-standard-core': 1.1.2
-      '@solana/wallet-standard-wallet-adapter': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+      '@solana/wallet-standard-wallet-adapter': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@solana/wallet-adapter-base'
       - '@solana/web3.js'
       - bs58
       - react
 
-  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@solana/wallet-standard@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)':
+    dependencies:
+      '@solana/wallet-standard-core': 1.1.2
+      '@solana/wallet-standard-wallet-adapter': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@solana/wallet-adapter-base'
+      - '@solana/web3.js'
+      - bs58
+      - react
+
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@5.8.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
       agentkeepalive: 4.6.0
       bn.js: 5.2.3
       borsh: 0.7.0
@@ -19426,6 +19997,8 @@ snapshots:
   '@speed-highlight/core@1.2.12': {}
 
   '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@stripe/react-stripe-js@3.1.1(@stripe/stripe-js@5.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19526,12 +20099,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/core@8.1.0(typescript@5.8.3)':
+  '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.5
       '@svgr/babel-preset': 8.1.0(@babel/core@7.28.5)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -19557,11 +20130,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@svgr/babel-preset': 8.1.0(@babel/core@7.28.5)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -19574,16 +20147,16 @@ snapshots:
       deepmerge: 4.3.1
       svgo: 2.8.0
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/rollup@8.1.0(rollup@4.53.1)(typescript@5.8.3)':
+  '@svgr/rollup@8.1.0(rollup@4.53.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.5)
@@ -19591,9 +20164,9 @@ snapshots:
       '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@rollup/pluginutils': 5.3.0(rollup@4.53.1)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -19657,19 +20230,19 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
+  '@tanstack/react-start@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
     dependencies:
       '@tanstack/react-router': 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-start-client': 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-start-server': 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-utils': 1.154.7
       '@tanstack/start-client-core': 1.157.16
-      '@tanstack/start-plugin-core': 1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
+      '@tanstack/start-plugin-core': 1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
       '@tanstack/start-server-core': 1.157.16
       pathe: 2.0.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - crossws
@@ -19707,7 +20280,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
+  '@tanstack/router-plugin@1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
@@ -19725,7 +20298,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       webpack: 5.102.1(esbuild@0.27.7)
     transitivePeerDependencies:
       - supports-color
@@ -19753,7 +20326,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.154.7': {}
 
-  '@tanstack/start-plugin-core@1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
+  '@tanstack/start-plugin-core@1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -19761,7 +20334,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.157.16
       '@tanstack/router-generator': 1.157.16
-      '@tanstack/router-plugin': 1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
+      '@tanstack/router-plugin': 1.157.16(@tanstack/react-router@1.157.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.1(esbuild@0.27.7))
       '@tanstack/router-utils': 1.154.7
       '@tanstack/start-client-core': 1.157.16
       '@tanstack/start-server-core': 1.157.16
@@ -19772,8 +20345,8 @@ snapshots:
       srvx: 0.10.1
       tinyglobby: 0.2.15
       ufo: 1.6.3
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitefu: 1.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -19845,16 +20418,26 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.8.3))':
+  '@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 9.3.4
       '@vue/test-utils': 2.4.6
-      vue: 3.5.32(typescript@5.8.3)
+      vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.32
 
@@ -19864,6 +20447,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -20357,7 +20942,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -20365,34 +20950,96 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.5)
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.8.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/browser-playwright@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser-playwright@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -20407,7 +21054,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -20419,27 +21066,49 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.6(@types/node@22.19.17)(typescript@5.8.3)
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.6(@types/node@25.6.0)(typescript@5.8.3)
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.6(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -20447,9 +21116,21 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -20457,11 +21138,19 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
+  '@vitest/spy@4.1.4': {}
+
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.1.6':
     dependencies:
@@ -20519,24 +21208,24 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue.ts/language@0.6.0(rollup@4.53.1)(typescript@5.8.3)':
+  '@vue.ts/language@0.6.0(rollup@4.53.1)(typescript@5.9.3)':
     dependencies:
       '@volar/typescript': 2.1.6
       '@vue.ts/common': 0.6.0(rollup@4.53.1)
-      '@vue/language-core': 2.0.7(typescript@5.8.3)
+      '@vue/language-core': 2.0.7(typescript@5.9.3)
     transitivePeerDependencies:
       - rollup
       - typescript
 
-  '@vue.ts/tsx-auto-props@0.6.0(magicast@0.3.5)(rollup@4.53.1)(typescript@5.8.3)(vue@3.5.32(typescript@5.8.3))':
+  '@vue.ts/tsx-auto-props@0.6.0(magicast@0.3.5)(rollup@4.53.1)(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 3.20.1(magicast@0.3.5)
       '@vue.ts/common': 0.6.0(rollup@4.53.1)
-      '@vue.ts/language': 0.6.0(rollup@4.53.1)(typescript@5.8.3)
+      '@vue.ts/language': 0.6.0(rollup@4.53.1)(typescript@5.9.3)
       magic-string: 0.30.21
-      typescript: 5.8.3
+      typescript: 5.9.3
       unplugin: 1.16.1
-      vue: 3.5.32(typescript@5.8.3)
+      vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -20600,16 +21289,21 @@ snapshots:
       '@vue/compiler-dom': 3.5.32
       '@vue/shared': 3.5.32
 
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@8.0.3(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vue/devtools-core@8.0.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 8.0.3
       '@vue/devtools-shared': 8.0.3
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite-hot-client: 2.1.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       vue: 3.5.32(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
@@ -20628,7 +21322,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@2.0.7(typescript@5.8.3)':
+  '@vue/language-core@2.0.7(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.1.6
       '@vue/compiler-dom': 3.5.32
@@ -20637,6 +21331,19 @@ snapshots:
       minimatch: 9.0.9
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/language-core@2.2.0(typescript@5.8.3)':
+    dependencies:
+      '@volar/language-core': 2.4.27
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.32
+      alien-signals: 0.4.14
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.8.3
 
@@ -20651,6 +21358,19 @@ snapshots:
       picomatch: 4.0.4
     optionalDependencies:
       typescript: 5.8.3
+    optional: true
+
+  '@vue/language-core@3.1.4(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.23
+      '@vue/compiler-dom': 3.5.32
+      '@vue/shared': 3.5.32
+      alien-signals: 3.1.2
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      typescript: 5.9.3
     optional: true
 
   '@vue/language-core@3.2.4':
@@ -20684,6 +21404,12 @@ snapshots:
       '@vue/compiler-ssr': 3.5.32
       '@vue/shared': 3.5.32
       vue: 3.5.32(typescript@5.8.3)
+
+  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.32
+      '@vue/shared': 3.5.32
+      vue: 3.5.32(typescript@5.9.3)
 
   '@vue/shared@3.5.32': {}
 
@@ -20813,14 +21539,14 @@ snapshots:
 
   abbrev@3.0.1: {}
 
-  abitype@1.1.0(typescript@5.8.3)(zod@3.25.76):
+  abitype@1.1.0(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.1.1(typescript@5.8.3)(zod@3.25.76):
+  abitype@1.1.1(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
       zod: 3.25.76
 
   abort-controller@3.0.0:
@@ -20878,6 +21604,10 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -20904,6 +21634,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@0.4.14: {}
 
   alien-signals@2.0.6: {}
 
@@ -21137,7 +21869,7 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  astro@5.18.1(@types/node@25.6.0)(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3):
+  astro@5.18.1(@types/node@25.6.0)(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.6
@@ -21188,20 +21920,20 @@ snapshots:
       svgo: 4.0.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.8.3)
+      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.3
       unist-util-visit: 5.0.0
       unstorage: 1.17.4(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -21276,7 +22008,7 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axe-core@4.11.0: {}
+  axe-core@4.11.3: {}
 
   axios@0.30.2:
     dependencies:
@@ -21842,6 +22574,8 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -22128,6 +22862,8 @@ snapshots:
     dependencies:
       normalize-url: 2.0.1
 
+  compare-versions@6.1.1: {}
+
   compatx@0.2.0: {}
 
   component-emitter@1.3.1: {}
@@ -22304,14 +23040,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.8.3):
+  cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   cosmiconfig@9.0.1(typescript@5.8.3):
     dependencies:
@@ -23074,6 +23810,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -23273,7 +24011,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.11.0
+      axe-core: 4.11.3
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
@@ -23554,6 +24292,8 @@ snapshots:
   expect-type@0.20.0: {}
 
   expect-type@1.2.2: {}
+
+  expect-type@1.3.0: {}
 
   expo-apple-authentication@7.2.4(expo@54.0.23(@babel/core@7.28.5)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(bufferutil@4.1.0)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10))(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10)):
     dependencies:
@@ -24846,6 +25586,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-lazy@4.0.0: {}
+
   import-meta-resolve@4.2.0: {}
 
   impound@1.0.0:
@@ -25339,6 +26081,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jju@1.4.0: {}
+
   joi@17.13.3:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -25596,6 +26340,8 @@ snapshots:
 
   knitwork@1.2.0: {}
 
+  kolorist@1.8.0: {}
+
   lan-network@0.1.7: {}
 
   language-subtag-registry@0.3.23: {}
@@ -25638,10 +26384,16 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.27.0:
     optional: true
 
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.27.0:
@@ -25650,10 +26402,16 @@ snapshots:
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.27.0:
     optional: true
 
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.27.0:
@@ -25662,10 +26420,16 @@ snapshots:
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.27.0:
@@ -25674,10 +26438,16 @@ snapshots:
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.27.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.27.0:
@@ -25686,16 +26456,25 @@ snapshots:
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.27.0:
@@ -25728,6 +26507,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@2.1.0: {}
 
@@ -25835,6 +26630,8 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -26794,6 +27591,10 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -26878,7 +27679,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.11.3(@types/node@25.6.0)(typescript@5.8.3):
+  msw@2.11.3(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -26900,7 +27701,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -26952,6 +27753,32 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.20(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.0.2
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 4.41.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -27265,16 +28092,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3):
+  nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.2.1(magicast@0.5.1)
       '@nuxt/cli': 3.30.0(magicast@0.5.1)
-      '@nuxt/devtools': 3.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      '@nuxt/devtools': 3.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(rolldown@1.0.0-beta.47)(typescript@5.8.3)
+      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(rolldown@1.0.0-beta.47)(typescript@5.8.3)
       '@nuxt/schema': 4.2.1
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.2.1(@types/node@25.6.0)(eslint@9.31.0(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(vue-tsc@3.2.4(typescript@5.8.3))(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3)
+      '@nuxt/vite-builder': 4.2.1(@types/node@25.6.0)(eslint@9.31.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.32)(bufferutil@4.1.0)(db0@0.3.4)(eslint@9.31.0(jiti@2.6.1))(idb-keyval@6.2.1)(ioredis@5.8.2)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3))(yaml@2.8.3))(optionator@0.9.4)(rolldown@1.0.0-beta.47)(rollup@4.53.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.8.3)(vue-tsc@3.2.4(typescript@5.8.3))(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3)
       '@unhead/vue': 2.0.19(vue@3.5.32(typescript@5.8.3))
       '@vue/shared': 3.5.32
       c12: 3.3.1(magicast@0.5.1)
@@ -27457,6 +28284,8 @@ snapshots:
     optionalDependencies:
       ms: 2.1.3
 
+  obug@2.1.1: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -27571,21 +28400,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.8.3)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@5.8.3)(zod@3.25.76)
+      abitype: 1.1.1(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.6(typescript@5.8.3)(zod@3.25.76):
+  ox@0.9.6(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -27593,10 +28422,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@5.8.3)(zod@3.25.76)
+      abitype: 1.1.1(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
@@ -27958,9 +28787,17 @@ snapshots:
 
   playwright-core@1.56.1: {}
 
+  playwright-core@1.59.1: {}
+
   playwright@1.56.1:
     dependencies:
       playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -27973,6 +28810,8 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@5.0.0: {}
+
+  pngjs@7.0.0: {}
 
   portfinder@1.0.38:
     dependencies:
@@ -28839,6 +29678,25 @@ snapshots:
       - oxc-resolver
       - supports-color
 
+  rolldown-plugin-dts@0.16.12(rolldown@1.0.0-beta.47)(typescript@5.9.3)(vue-tsc@3.1.4(typescript@5.9.3)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      ast-kit: 2.2.0
+      birpc: 2.7.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dts-resolver: 2.1.2
+      get-tsconfig: 4.13.0
+      magic-string: 0.30.21
+      rolldown: 1.0.0-beta.47
+    optionalDependencies:
+      typescript: 5.9.3
+      vue-tsc: 3.1.4(typescript@5.9.3)
+    transitivePeerDependencies:
+      - oxc-resolver
+      - supports-color
+
   rolldown@1.0.0-beta.47:
     dependencies:
       '@oxc-project/types': 0.96.0
@@ -29513,6 +30371,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.1.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -29947,9 +30807,16 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -30018,9 +30885,9 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6(typescript@5.8.3):
+  tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -30056,11 +30923,38 @@ snapshots:
       - supports-color
       - vue-tsc
 
+  tsdown@0.15.7(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(typescript@5.9.3)(vue-tsc@3.1.4(typescript@5.9.3)):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 4.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 8.0.3
+      empathic: 2.0.0
+      hookable: 5.5.3
+      rolldown: 1.0.0-beta.47
+      rolldown-plugin-dts: 0.16.12(rolldown@1.0.0-beta.47)(typescript@5.9.3)(vue-tsc@3.1.4(typescript@5.9.3))
+      semver: 7.7.4
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig: 7.4.0
+    optionalDependencies:
+      '@arethetypeswrong/core': 0.18.2
+      publint: 0.3.18
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - supports-color
+      - vue-tsc
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.58.6(@types/node@22.19.17))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -30080,6 +30974,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      '@microsoft/api-extractor': 7.58.6(@types/node@22.19.17)
       postcss: 8.5.10
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -30238,6 +31133,8 @@ snapshots:
   typescript@5.6.1-rc: {}
 
   typescript@5.8.3: {}
+
+  typescript@5.9.3: {}
 
   ua-parser-js@1.0.41: {}
 
@@ -30454,15 +31351,15 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue@7.0.8(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(ms@2.1.3)(terser@5.46.1)(tsx@4.20.6)(vue@3.5.32(typescript@5.8.3))(yaml@2.8.3):
+  unplugin-vue@7.0.8(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(ms@2.1.3)(terser@5.46.1)(tsx@4.20.6)(vue@3.5.32(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@vue/reactivity': 3.5.32
       obug: 2.0.0(ms@2.1.3)
       unplugin: 2.3.10
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.8.3)
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -30629,40 +31526,40 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.38.6(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.38.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.8.3)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.9.6(typescript@5.8.3)(zod@3.25.76)
+      ox: 0.9.6(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
 
-  vite-dev-rpc@1.1.0(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-dev-rpc@1.1.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       birpc: 2.7.0
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-hot-client: 2.1.0(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
 
-  vite-hot-client@2.1.0(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-hot-client@2.1.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -30677,13 +31574,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite-node@5.0.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -30698,28 +31595,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@5.0.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-plugin-checker@0.11.0(eslint@9.31.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3)):
+  vite-plugin-checker@0.11.0(eslint@9.31.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.8.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -30728,7 +31604,7 @@ snapshots:
       picomatch: 4.0.4
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.31.0(jiti@2.6.1)
@@ -30737,7 +31613,26 @@ snapshots:
       typescript: 5.8.3
       vue-tsc: 3.2.4(typescript@5.8.3)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+    dependencies:
+      '@microsoft/api-extractor': 7.58.6(@types/node@25.6.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.53.1)
+      '@volar/typescript': 2.4.27
+      '@vue/language-core': 2.2.0(typescript@5.8.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.8.3
+    optionalDependencies:
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -30747,24 +31642,24 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-dev-rpc: 1.1.0(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
     optionalDependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.1.3(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3)):
+  vite-plugin-vue-tracer@1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.8.3)
 
-  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -30776,12 +31671,12 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
+      lightningcss: 1.32.0
       terser: 5.46.1
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -30793,12 +31688,12 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
+      lightningcss: 1.32.0
       terser: 5.46.1
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -30810,40 +31705,82 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
+      lightningcss: 1.32.0
       terser: 5.46.1
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-beta.47
+      tinyglobby: 0.2.16
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      '@types/node': 22.19.17
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.1
+      tsx: 4.20.6
+      yaml: 2.8.3
 
-  vitefu@1.1.1(vite@7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-beta.47
+      tinyglobby: 0.2.16
     optionalDependencies:
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.1
+      tsx: 4.20.6
+      yaml: 2.8.3
+
+  vitefu@1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+
+  vitefu@1.1.1(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+
+  vitest-axe@0.1.0(vitest@4.1.4):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.3
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
 
   vitest-chrome@0.1.0:
     dependencies:
       '@types/chrome': 0.0.114
 
-  vitest-environment-miniflare@2.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest-environment-miniflare@2.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.4):
     dependencies:
       '@miniflare/queues': 2.14.4
       '@miniflare/runner-vm': 2.14.4
       '@miniflare/shared': 2.14.4
       '@miniflare/shared-test-environment': 2.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       undici: 5.28.4
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -30861,8 +31798,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -30883,49 +31820,69 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vitest@4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
-      expect-type: 1.2.2
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      tinyrainbow: 3.1.0
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
-      '@types/debug': 4.1.12
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/coverage-v8': 3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       jsdom: 27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/coverage-v8': 3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      jsdom: 27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - msw
 
   vlq@1.0.1: {}
 
@@ -30956,11 +31913,25 @@ snapshots:
       typescript: 5.8.3
     optional: true
 
+  vue-tsc@3.1.4(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.23
+      '@vue/language-core': 3.1.4(typescript@5.9.3)
+      typescript: 5.9.3
+    optional: true
+
   vue-tsc@3.2.4(typescript@5.8.3):
     dependencies:
       '@volar/typescript': 2.4.27
       '@vue/language-core': 3.2.4
       typescript: 5.8.3
+    optional: true
+
+  vue-tsc@3.2.4(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.27
+      '@vue/language-core': 3.2.4
+      typescript: 5.9.3
 
   vue@3.5.32(typescript@5.8.3):
     dependencies:
@@ -30971,6 +31942,16 @@ snapshots:
       '@vue/shared': 3.5.32
     optionalDependencies:
       typescript: 5.8.3
+
+  vue@3.5.32(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-sfc': 3.5.32
+      '@vue/runtime-dom': 3.5.32
+      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@5.9.3))
+      '@vue/shared': 3.5.32
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -31440,9 +32421,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
       zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,10 +679,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitest/browser':
         specifier: 4.1.4
-        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 4.1.4
-        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
       axe-core:
         specifier: ^4.11.3
         version: 4.11.3
@@ -695,21 +695,18 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
-      rolldown:
-        specifier: 1.0.0-beta.47
-        version: 1.0.0-beta.47
       typescript:
         specifier: catalog:repo
         version: 5.8.3
       vite:
-        specifier: ^8.0.8
-        version: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+        specifier: 6.4.1
+        version: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.4)
@@ -20977,13 +20974,13 @@ snapshots:
       vite: 7.2.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.8.3)
 
-  '@vitest/browser-playwright@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -21004,16 +21001,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -21075,23 +21072,23 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.6(@types/node@22.19.17)(typescript@5.8.3)
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.6(@types/node@25.6.0)(typescript@5.8.3)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
@@ -31559,7 +31556,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -31613,7 +31610,7 @@ snapshots:
       typescript: 5.8.3
       vue-tsc: 3.2.4(typescript@5.8.3)
 
-  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.53.1)(typescript@5.8.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.58.6(@types/node@25.6.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.53.1)
@@ -31626,7 +31623,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.8.3
     optionalDependencies:
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -31659,16 +31656,16 @@ snapshots:
       vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.8.3)
 
-  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.53.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -31676,16 +31673,16 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.53.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.19.17
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -31758,7 +31755,7 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
 
   vitest-chrome@0.1.0:
     dependencies:
@@ -31780,7 +31777,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -31798,7 +31795,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -31820,10 +31817,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest@4.1.4(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)))(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -31840,13 +31837,13 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
-      '@vitest/browser-playwright': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(bufferutil@4.1.0)(msw@2.11.6(@types/node@25.6.0)(typescript@5.8.3))(playwright@1.59.1)(utf-8-validate@5.0.10)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8': 3.2.4(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.11.6(@types/node@22.19.17)(typescript@5.8.3))(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))
       jsdom: 27.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalogs:
     react: 18.3.1
     react-dom: 18.3.1
   repo:
+    '@floating-ui/react': 0.27.12
     '@swc/helpers': 0.5.21
     core-js: 3.47.0
     rolldown: 1.0.0-beta.47


### PR DESCRIPTION
## Description

- New internal (private: true) package: unstyled, accessible React compound components built on Floating UI
- 8 primitives: Accordion, Autocomplete, Dialog, Menu, Popover, Select, Tabs, Tooltip
- Shared renderElement util enabling consumer render prop overrides + automatic state-to-data-cl-* attribute mapping
- CSS-driven animation system using Web Animations API (getAnimations().finished)
- All tests run in real Chromium via @vitest/browser-playwright

### Why a separate package

@clerk/ui uses @emotion/react as its JSX source, which conflicts with the standard react-jsx transform these primitives need. Splitting them out avoids the transform conflict.

### Architecture

- Compound components via Object.assign (Select.Trigger, Select.Popup, etc.)
- Positioning/interactions/focus/ARIA delegated to @floating-ui/react
- Zero emitted styles — consumers style via data-cl-* attribute selectors

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
