### PR TITLE
fix(nextjs): declare dist/esm as ESM and split ./server by react-server condition

### DIFF
--- a/.changeset/nextjs-esm-type-module.md
+++ b/.changeset/nextjs-esm-type-module.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix ESM resolution under consumers with `"type": "module"`. The package now emits `dist/esm/package.json` with `"type": "module"`, so Node 22+ and tsx no longer treat bundled ESM output as CJS and named imports from `@clerk/nextjs/server` resolve correctly. Closes #8396.

--- a/.changeset/nextjs-rsc-server-only.md
+++ b/.changeset/nextjs-rsc-server-only.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Restore Next 15 prerender compatibility for pages that call `auth()` / `currentUser()`. The `./server` subpath now splits by the `react-server` export condition: app-router-only helpers live under the RSC condition, while the pages-router-safe surface (`getAuth`, `buildClerkProps`, `clerkMiddleware`, etc.) remains in the default condition. `server-only` is now imported statically in `auth.ts` / `currentUser.ts` — cleaner than the previous lazy-`require` and analyzable by webpack in both CJS and ESM module classifications.

--- a/packages/nextjs/package.esm.json
+++ b/packages/nextjs/package.esm.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "sideEffects": false,
   "imports": {
     "#components": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -31,7 +31,11 @@
       "require": "./dist/cjs/index.js"
     },
     "./server": {
-      "types": "./dist/types/server/index.d.ts",
+      "types": "./dist/types/server/index.rsc.d.ts",
+      "react-server": {
+        "import": "./dist/esm/server/index.rsc.js",
+        "require": "./dist/cjs/server/index.rsc.js"
+      },
       "import": "./dist/esm/server/index.js",
       "require": "./dist/cjs/server/index.js"
     },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -78,7 +78,7 @@
     "format": "node ../../scripts/format-package.mjs",
     "format:check": "node ../../scripts/format-package.mjs --check",
     "lint": "eslint src",
-    "lint:attw": "attw --pack . --profile node16 --ignore-rules unexpected-module-syntax",
+    "lint:attw": "attw --pack . --profile node16 --ignore-rules false-cjs",
     "lint:publint": "publint",
     "test": "vitest run",
     "test:watch": "vitest watch"

--- a/packages/nextjs/src/app-router/server/auth.ts
+++ b/packages/nextjs/src/app-router/server/auth.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { SessionAuthObject } from '@clerk/backend';
 import type { AuthOptions, GetAuthFnNoRequest, RedirectFun } from '@clerk/backend/internal';
 import { constants, createClerkRequest, createRedirect, TokenType } from '@clerk/backend/internal';
@@ -75,9 +77,6 @@ export type AuthFn = GetAuthFnNoRequest<SessionAuthWithRedirect, true> & {
  * - Requires [`clerkMiddleware()`](https://clerk.com/docs/reference/nextjs/clerk-middleware) to be configured.
  */
 export const auth: AuthFn = (async (options?: AuthOptions) => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('server-only');
-
   try {
     const request = await buildRequestLike();
 
@@ -158,9 +157,6 @@ export const auth: AuthFn = (async (options?: AuthOptions) => {
 }) as AuthFn;
 
 auth.protect = async (...args: any[]) => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('server-only');
-
   const request = await buildRequestLike();
   const requestedToken = args?.[0]?.token || args?.[1]?.token || TokenType.SessionToken;
   const authObject = await auth({ acceptsToken: requestedToken });

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { User } from '@clerk/backend';
 import type { PendingSessionOptions } from '@clerk/shared/types';
 
@@ -29,9 +31,6 @@ type CurrentUserOptions = PendingSessionOptions;
  * ```
  */
 export async function currentUser(opts?: CurrentUserOptions): Promise<User | null> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('server-only');
-
   try {
     const { userId } = await auth({ treatPendingAsSignedOut: opts?.treatPendingAsSignedOut });
     if (!userId) {

--- a/packages/nextjs/src/experimental.ts
+++ b/packages/nextjs/src/experimental.ts
@@ -1,3 +1,23 @@
 'use client';
 
-export * from '@clerk/react/experimental';
+export {
+  CheckoutButton,
+  PlanDetailsButton,
+  SubscriptionDetailsButton,
+  PaymentElementProvider,
+  usePaymentElement,
+  PaymentElement,
+  usePaymentAttempts,
+  useStatements,
+  usePaymentMethods,
+  usePlans,
+  useSubscription,
+  CheckoutProvider,
+  useCheckout,
+} from '@clerk/react/experimental';
+
+export type {
+  CheckoutButtonProps,
+  SubscriptionDetailsButtonProps,
+  PlanDetailsButtonProps,
+} from '@clerk/react/experimental';

--- a/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`/server public exports > default condition (pages-safe) should not include a breaking change 1`] = `
+exports[`/server public exports > default condition (pages-safe) > should not include a breaking change 1`] = `
 [
   "buildClerkProps",
   "clerkClient",
@@ -16,7 +16,7 @@ exports[`/server public exports > default condition (pages-safe) should not incl
 ]
 `;
 
-exports[`/server public exports > react-server condition should not include a breaking change 1`] = `
+exports[`/server public exports > react-server condition > should not include a breaking change 1`] = `
 [
   "auth",
   "buildClerkProps",

--- a/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/server/__tests__/__snapshots__/exports.test.ts.snap
@@ -1,6 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`/server public exports > should not include a breaking change 1`] = `
+exports[`/server public exports > default condition (pages-safe) should not include a breaking change 1`] = `
+[
+  "buildClerkProps",
+  "clerkClient",
+  "clerkFrontendApiProxy",
+  "clerkMiddleware",
+  "createClerkClient",
+  "createFrontendApiProxyHandlers",
+  "createRouteMatcher",
+  "getAuth",
+  "reverificationError",
+  "reverificationErrorResponse",
+  "verifyToken",
+]
+`;
+
+exports[`/server public exports > react-server condition should not include a breaking change 1`] = `
 [
   "auth",
   "buildClerkProps",

--- a/packages/nextjs/src/server/__tests__/exports.test.ts
+++ b/packages/nextjs/src/server/__tests__/exports.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
 
 import * as publicExports from '../index';
 import * as rscExports from '../index.rsc';

--- a/packages/nextjs/src/server/__tests__/exports.test.ts
+++ b/packages/nextjs/src/server/__tests__/exports.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import * as publicExports from '../index';
+import * as rscExports from '../index.rsc';
 
 describe('/server public exports', () => {
-  it('should not include a breaking change', () => {
-    expect(Object.keys(publicExports).sort()).toMatchSnapshot();
+  describe('default condition (pages-safe)', () => {
+    it('should not include a breaking change', () => {
+      expect(Object.keys(publicExports).sort()).toMatchSnapshot();
+    });
+  });
+
+  describe('react-server condition', () => {
+    it('should not include a breaking change', () => {
+      expect(Object.keys(rscExports).sort()).toMatchSnapshot();
+    });
   });
 });

--- a/packages/nextjs/src/server/index.rsc.ts
+++ b/packages/nextjs/src/server/index.rsc.ts
@@ -1,0 +1,14 @@
+/**
+ * RSC-layer entrypoint for `@clerk/nextjs/server`.
+ *
+ * Selected by the `react-server` export condition in `package.json`. Adds the
+ * app-router-only helpers (`auth`, `currentUser`) on top of the pages-safe
+ * surface exported from `./index`. Pulling those helpers here — rather than
+ * from `./index` directly — keeps pages-router consumers from transitively
+ * importing `server-only`, which throws under a non-RSC condition.
+ */
+
+export * from './index';
+
+export { auth } from '../app-router/server/auth';
+export { currentUser } from '../app-router/server/currentUser';

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -38,11 +38,14 @@ export type {
 
 /**
  * NextJS-specific exports
+ *
+ * NOTE: `auth` and `currentUser` are re-exported from `./index.rsc.ts` only,
+ * which is selected via the `react-server` export condition. Loading them
+ * outside the RSC layer (e.g. from pages-router code) would transitively
+ * import `server-only` and crash at module load.
  */
 export { getAuth } from './createGetAuth';
 export { buildClerkProps } from './buildClerkProps';
-export { auth } from '../app-router/server/auth';
-export { currentUser } from '../app-router/server/currentUser';
 export { clerkMiddleware } from './clerkMiddleware';
 export type { ClerkMiddlewareAuth, ClerkMiddlewareSessionAuthObject, ClerkMiddlewareOptions } from './clerkMiddleware';
 


### PR DESCRIPTION
## Summary

Two changes, landed together to keep Next 15 working while fixing native-Node ESM resolution of `@clerk/nextjs/server`:

1. **Declare `dist/esm` as ESM via a `type:module` sidecar.** `packages/nextjs/package.esm.json` now ships with `"type": "module"` so Node 22+ and `tsx` consumers under `"type": "module"` can import named exports from `@clerk/nextjs/server` without the `SyntaxError: does not provide an export named 'clerkClient'` reported in #8396.

2. **Split `./server` by the `react-server` condition and import `server-only` statically.** Under ESM classification webpack preserves `require('server-only')` as a raw Node runtime call, which resolves without the `react-server` condition and trips the client-only guard — that was the Next 15 prerender regression the sidecar alone introduced. The fix:
   - New entrypoint `packages/nextjs/src/server/index.rsc.ts` selected by the `react-server` export condition. It re-exports the pages-safe surface plus `auth` and `currentUser`.
   - `packages/nextjs/src/server/index.ts` keeps the pages-safe surface (`getAuth`, `buildClerkProps`, `clerkMiddleware`, etc.). Pages-router consumers never transitively load `auth.ts`.
   - `auth.ts` and `currentUser.ts` now `import 'server-only'` at the top of the file instead of calling `require('server-only')` lazily inside the function body. Analyzable by webpack in both CJS and ESM module classifications.

`lint:attw` swaps `unexpected-module-syntax` for `--ignore-rules false-cjs`: with `type: module` set, `unexpected-module-syntax` stops firing, but attw now flags `false-cjs` on every subpath because type declarations are still emitted as `.d.ts`. Splitting types to `.d.mts` is tracked as a separate follow-up.

Closes #8396

## Test plan

- [x] `pnpm --filter @clerk/nextjs build` succeeds — `dist/esm/package.json` contains `"type": "module"`, `dist/esm/server/index.rsc.js` is emitted.
- [x] `pnpm --filter @clerk/nextjs lint:attw` passes with the swapped ignore rule.
- [x] `pnpm --filter @clerk/nextjs lint:publint` passes (pre-existing warnings unchanged).
- [x] `pnpm --filter @clerk/nextjs test` — no new regressions. Snapshot test extended to cover both default and `react-server` surfaces of `./server`.
- [x] Reporter's exact #8396 repro (tsx + `import { clerkClient } from '@clerk/nextjs/server'` under `"type": "module"`) now prints `clerkClient typeof: function`.
- [x] Minimal Next 15.5.15 app with a server component that calls `await auth()` builds cleanly — previously failed with `Module "server-only" cannot be imported from a Client Component module`.
