### PR TITLE
fix(shared): Generate publishable keys with unpadded Base64 encoding to match backend output

### DIFF
--- a/.changeset/neat-keys-shine.md
+++ b/.changeset/neat-keys-shine.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Generate publishable keys with unpadded Base64 encoding to match backend output.

--- a/packages/shared/src/__tests__/keys.spec.ts
+++ b/packages/shared/src/__tests__/keys.spec.ts
@@ -14,9 +14,9 @@ import {
 
 describe('buildPublishableKey(frontendApi)', () => {
   const cases = [
-    ['fake-clerk-test.clerk.accounts.dev', 'pk_live_ZmFrZS1jbGVyay10ZXN0LmNsZXJrLmFjY291bnRzLmRldiQ='],
+    ['fake-clerk-test.clerk.accounts.dev', 'pk_live_ZmFrZS1jbGVyay10ZXN0LmNsZXJrLmFjY291bnRzLmRldiQ'],
     ['foo-bar-13.clerk.accounts.dev', 'pk_test_Zm9vLWJhci0xMy5jbGVyay5hY2NvdW50cy5kZXYk'],
-    ['clerk.boring.sawfly-91.lcl.dev', 'pk_test_Y2xlcmsuYm9yaW5nLnNhd2ZseS05MS5sY2wuZGV2JA=='],
+    ['clerk.boring.sawfly-91.lcl.dev', 'pk_test_Y2xlcmsuYm9yaW5nLnNhd2ZseS05MS5sY2wuZGV2JA'],
     ['clerk.boring.sawfly-91.lclclerk.com', 'pk_test_Y2xlcmsuYm9yaW5nLnNhd2ZseS05MS5sY2xjbGVyay5jb20k'],
   ];
 
@@ -36,7 +36,7 @@ describe('parsePublishableKey(key)', () => {
     ['', null],
     ['whatever', null],
     [
-      'pk_live_ZmFrZS1jbGVyay10ZXN0LmNsZXJrLmFjY291bnRzLmRldiQ=',
+      'pk_live_ZmFrZS1jbGVyay10ZXN0LmNsZXJrLmFjY291bnRzLmRldiQ',
       { instanceType: 'production', frontendApi: 'fake-clerk-test.clerk.accounts.dev' },
     ],
     [

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -30,17 +30,17 @@ const PUBLISHABLE_KEY_TEST_PREFIX = 'pk_test_';
 const PUBLISHABLE_FRONTEND_API_DEV_REGEX = /^(([a-z]+)-){2}([0-9]{1,2})\.clerk\.accounts([a-z.]*)(dev|com)$/i;
 
 /**
- * Converts a frontend API URL into a base64-encoded publishable key.
+ * Converts a frontend API URL into an unpadded base64-encoded publishable key.
  *
  * @param frontendApi - The frontend API URL (e.g., 'clerk.example.com').
- * @returns A base64-encoded publishable key with appropriate prefix (pk_live_ or pk_test_).
+ * @returns An unpadded base64-encoded publishable key with appropriate prefix (pk_live_ or pk_test_).
  */
 export function buildPublishableKey(frontendApi: string): string {
   const isDevKey =
     PUBLISHABLE_FRONTEND_API_DEV_REGEX.test(frontendApi) ||
     (frontendApi.startsWith('clerk.') && LEGACY_DEV_INSTANCE_SUFFIXES.some(s => frontendApi.endsWith(s)));
   const keyPrefix = isDevKey ? PUBLISHABLE_KEY_TEST_PREFIX : PUBLISHABLE_KEY_LIVE_PREFIX;
-  return `${keyPrefix}${isomorphicBtoa(`${frontendApi}$`)}`;
+  return `${keyPrefix}${isomorphicBtoa(`${frontendApi}$`).replace(/=+$/, '')}`;
 }
 
 /**


### PR DESCRIPTION
- **fix(buildPublishableKey): build unpadded key**
- **chore: changeset**

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
