### PR TITLE
fix(shared,clerk-js): loosen @tanstack/query-core pin to caret range

### DIFF
--- a/.changeset/loosen-query-core-pin.md
+++ b/.changeset/loosen-query-core-pin.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/clerk-js': patch
+---
+
+Loosen `@tanstack/query-core` dependency from an exact pin to a caret range (`^5.90.16`) so it can dedupe with consumer-installed `@tanstack/react-query` versions. This avoids Vite `resolve.dedupe` resolution failures under Bun when two divergent copies of `query-core` end up nested instead of hoisted.

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -91,7 +91,7 @@
     "@solana/wallet-standard": "catalog:module-manager",
     "@stripe/stripe-js": "5.6.0",
     "@swc/helpers": "catalog:repo",
-    "@tanstack/query-core": "5.90.16",
+    "@tanstack/query-core": "^5.90.16",
     "@wallet-standard/core": "catalog:module-manager",
     "@zxcvbn-ts/core": "catalog:module-manager",
     "@zxcvbn-ts/language-common": "catalog:module-manager",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -140,7 +140,7 @@
     "test:coverage": "vitest --collectCoverage && open coverage/lcov-report/index.html"
   },
   "dependencies": {
-    "@tanstack/query-core": "5.90.16",
+    "@tanstack/query-core": "^5.90.16",
     "dequal": "2.0.3",
     "glob-to-regexp": "0.4.1",
     "js-cookie": "3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,7 +438,7 @@ importers:
         specifier: catalog:repo
         version: 0.5.21
       '@tanstack/query-core':
-        specifier: 5.90.16
+        specifier: ^5.90.16
         version: 5.90.16
       '@wallet-standard/core':
         specifier: catalog:module-manager
@@ -811,7 +811,7 @@ importers:
   packages/shared:
     dependencies:
       '@tanstack/query-core':
-        specifier: 5.90.16
+        specifier: ^5.90.16
         version: 5.90.16
       dequal:
         specifier: 2.0.3


### PR DESCRIPTION
## Summary

- Bumps `@tanstack/query-core` from an exact pin (`5.90.16`) to `^5.90.16` in `@clerk/shared` and `@clerk/clerk-js`
- Lets the dependency dedupe with consumer-installed `@tanstack/react-query` versions, which pin `query-core` to their exact same patch version

## Motivation

Vite's `resolve.dedupe` resolves modules from the project root's `node_modules/` only. Under Bun's content-addressable layout, transitive deps are hoisted to root only when they can be deduped to a single version across the dep graph. With our exact pin, any consumer whose `react-query` resolved to a different `query-core` patch (e.g. `5.100.x`) ended up with two nested copies, neither hoisted to root, so Vite's dedupe failed to resolve `@tanstack/query-core` and the app crashed.

This was reproducing intermittently in Lovable apps (TanStack Start + Bun, no lockfile). Each fresh install pulled the latest `react-query@5.x`, which pulled a `query-core` that didn't satisfy our exact `5.90.16`. The caret allows dedupe to land on whichever 5.x the consumer's react-query brings.

## Test plan

- [ ] CI green
- [ ] Reproduction in a Lovable-style app (TanStack Start + Bun, `saveTextLockfile = false`) resolves `@tanstack/query-core` cleanly under Vite `resolve.dedupe`