### PR TITLE
fix(expo): pass Apple full name on transferable sign-up

### DIFF
--- a/.changeset/tender-toes-shake.md
+++ b/.changeset/tender-toes-shake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': minor
+---
+
+Fix `useSignInWithApple` transfer sign-up so `firstName` and `lastName` from the Apple credential (`fullName.givenName` / `fullName.familyName`) are passed to `signUp.create()`.

--- a/packages/expo/src/hooks/__tests__/useSignInWithApple.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSignInWithApple.test.ts
@@ -128,6 +128,7 @@ describe('useSignInWithApple', () => {
       const mockIdentityToken = 'mock-identity-token';
       mocks.signInAsync.mockResolvedValue({
         identityToken: mockIdentityToken,
+        fullName: { givenName: 'Jane', familyName: 'Doe' },
       });
 
       mockSignIn.create.mockResolvedValue(undefined);
@@ -152,8 +153,35 @@ describe('useSignInWithApple', () => {
       expect(mockSignUp.create).toHaveBeenCalledWith({
         transfer: true,
         unsafeMetadata: { source: 'test' },
+        firstName: 'Jane',
+        lastName: 'Doe',
       });
       expect(response.createdSessionId).toBe('new-user-session-id');
+    });
+
+    test('should omit name fields on transfer when Apple returns no fullName', async () => {
+      const mockIdentityToken = 'mock-identity-token';
+      mocks.signInAsync.mockResolvedValue({
+        identityToken: mockIdentityToken,
+      });
+
+      mockSignIn.create.mockResolvedValue(undefined);
+      mockSignIn.firstFactorVerification.status = 'transferable';
+
+      const mockSignUpWithSession = { ...mockSignUp, createdSessionId: 'new-user-session-id' };
+      mocks.useSignUp.mockReturnValue({
+        signUp: mockSignUpWithSession,
+        isLoaded: true,
+      });
+
+      const { result } = renderHook(() => useSignInWithApple());
+
+      await result.current.startAppleAuthenticationFlow();
+
+      expect(mockSignUp.create).toHaveBeenCalledWith({
+        transfer: true,
+        unsafeMetadata: undefined,
+      });
     });
 
     test('should handle user cancellation gracefully', async () => {

--- a/packages/expo/src/hooks/useSignInWithApple.ios.ts
+++ b/packages/expo/src/hooks/useSignInWithApple.ios.ts
@@ -116,10 +116,13 @@ export function useSignInWithApple() {
       const userNeedsToBeCreated = signIn.firstFactorVerification.status === 'transferable';
 
       if (userNeedsToBeCreated) {
-        // User doesn't exist - create a new SignUp with transfer
+        // User doesn't exist - create a new SignUp with transfer & name fields
+        const { givenName, familyName } = credential.fullName ?? {};
         await signUp.create({
           transfer: true,
           unsafeMetadata: startAppleAuthenticationFlowParams?.unsafeMetadata,
+          ...(givenName ? { firstName: givenName } : {}),
+          ...(familyName ? { lastName: familyName } : {}),
         });
 
         return {


### PR DESCRIPTION
## Description

useSignInWithApple on iOS was creating a signUp, but it never forwarded Apple’s fullName (givenName / familyName) into signUp.create(). For new users in the flow, first and last name were therefore missing in Clerk even when Apple returned them (notably on the first authorization, when Apple supplies the name).

If the user has a first name and last name requirement in their Clerk config, they'll need to query the user for a name after the OAuth flow is complete, and this violates Apple's App guidelines for publishing to the App Store.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
