### PR TITLE
fix(expo): prevent session loss on Expo JS reload

### DIFF
--- a/.changeset/fix-native-session-sync-reload.md
+++ b/.changeset/fix-native-session-sync-reload.md
@@ -1,0 +1,7 @@
+---
+'@clerk/expo': patch
+---
+
+Fix session loss on Expo JS reload (pressing R in dev)
+
+`NativeSessionSync` was calling native `signOut()` during the loading phase when `isSignedIn` is `undefined`. On a JS reload, the native module persists from the previous session, so `signOut()` revokes the session server-side and clears all keychain items, forcing the user to log in again. This adds an `isLoaded` guard so native `signOut()` is only called when Clerk has confirmed the user is actually signed out.

--- a/packages/expo/src/provider/ClerkProvider.tsx
+++ b/packages/expo/src/provider/ClerkProvider.tsx
@@ -70,7 +70,7 @@ function NativeSessionSync({
   publishableKey: string;
   tokenCache: TokenCache | undefined;
 }) {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth();
   const hasSyncedRef = useRef(false);
   // Use the provided tokenCache, falling back to the default SecureStore cache
   const effectiveTokenCache = tokenCache ?? defaultTokenCache;
@@ -79,15 +79,20 @@ function NativeSessionSync({
     if (!isSignedIn) {
       hasSyncedRef.current = false;
 
-      // Clear the native session so native components (UserButton, etc.)
-      // don't continue showing a signed-in state after JS-side sign out.
-      const ClerkExpo = NativeClerkModule;
-      if (ClerkExpo?.signOut) {
-        void ClerkExpo.signOut().catch((error: unknown) => {
-          if (__DEV__) {
-            console.warn('[NativeSessionSync] Failed to clear native session:', error);
-          }
-        });
+      // Only call native signOut when Clerk has fully loaded and confirmed
+      // the user is actually signed out. Without this check, a JS reload
+      // (e.g. pressing R in Expo) triggers signOut during the loading phase
+      // (when isSignedIn is undefined), which revokes the session server-side
+      // and clears all keychain items, forcing the user to log in again.
+      if (isLoaded) {
+        const ClerkExpo = NativeClerkModule;
+        if (ClerkExpo?.signOut) {
+          void ClerkExpo.signOut().catch((error: unknown) => {
+            if (__DEV__) {
+              console.warn('[NativeSessionSync] Failed to clear native session:', error);
+            }
+          });
+        }
       }
 
       return;
@@ -130,7 +135,7 @@ function NativeSessionSync({
     };
 
     void syncToNative();
-  }, [isSignedIn, publishableKey, effectiveTokenCache]);
+  }, [isSignedIn, isLoaded, publishableKey, effectiveTokenCache]);
 
   return null;
 }


### PR DESCRIPTION
## Description

Mirror of @souyahia's #8437 brought to the upstream repo so the integration tests (which are gated to non-fork PRs for secret access) can run. Same single-commit change, with original authorship preserved via cherry-pick.

Original PR: #8437
Original author: @souyahia (Samy Ouyahia <samy.ouyahia@mistral.ai>) — preserved as the commit author here.

### Bug

`NativeSessionSync` calls native `signOut()` whenever `isSignedIn` is falsy, including the brief loading window where it's `undefined`. On a JS reload (pressing R in Expo, or Metro bundle change), JS state resets but the native module persists, so `signOut()` goes through and:

- calls `Clerk.shared.auth.signOut(sessionId:)` → server-side session revoke
- calls `Clerk.clearAllKeychainItems()` → wipes native keychain entries

When Clerk JS finishes loading on the new bundle, `/v1/client` returns no session and the user is back on the sign-in screen. Confirmed reproducible on both iOS and Android, and on both the native `<AuthView />` flow and pure JS `useSignIn()` flow (since `<NativeSessionSync />` is mounted unconditionally for `isNative()` apps in `ClerkProvider`).

### Fix

Add an `isLoaded` guard so the native `signOut()` only runs when Clerk has fully loaded and confirmed the user is actually signed out — not during the loading phase where `isSignedIn === undefined`.

### Test plan

Verified end-to-end against `clerk-expo-quickstart/NativeComponentQuickstart`:

| Setup | Result |
| --- | --- |
| Buggy `@clerk/expo@3.1.8` (no guard), iOS sim, native `<AuthView />` | 1 reload → session lost ❌ |
| Buggy 3.1.8, iOS sim, JS-only `useSignIn` flow | 1 reload → session lost ❌ |
| This fix, iOS sim, native `<AuthView />` | 4 reloads → session persisted ✅ |
| This fix, Android emulator, native `<AuthView />` | 3 reloads → session persisted ✅ |