### PR TITLE
fix(expo): seed Clerk activity ref on cold-start to fix MissingActivity (MOBILE-485)

### DIFF
--- a/.changeset/expo-mobile-485-cold-start-activity.md
+++ b/.changeset/expo-mobile-485-cold-start-activity.md
@@ -1,0 +1,7 @@
+---
+"@clerk/expo": patch
+---
+
+Fix `MissingActivity` error on cold-start Google sign-in / passkey flows. Previously, the first tap on "Sign in with Google" in `<AuthView />` failed with `Clerk error: Google sign-in cannot start: Credential Manager requires an active Activity context.` — the workaround was to background and foreground the app once before signing in.
+
+The Android bridge now calls `Clerk.attachActivity()` (added in clerk-android 1.0.16) at SDK initialization and on AuthView/UserProfile mount, so the current Activity is registered with the underlying SDK before any Credential Manager call. No app-side changes required; the fix is transparent on rebuild.

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -18,8 +18,8 @@ ext {
   credentialsVersion = "1.3.0"
   googleIdVersion = "1.1.1"
   kotlinxCoroutinesVersion = "1.7.3"
-  clerkAndroidApiVersion = "1.0.13"
-  clerkAndroidUiVersion = "1.0.13"
+  clerkAndroidApiVersion = "1.0.16"
+  clerkAndroidUiVersion = "1.0.16"
   composeVersion = "1.7.0"
   activityComposeVersion = "1.9.0"
   lifecycleVersion = "2.8.0"
@@ -111,6 +111,16 @@ dependencies {
   // Exclude kotlin-stdlib to prevent 2.3.0 from polluting the project
   // Exclude okhttp to prevent version conflict with React Native's okhttp
   implementation("com.clerk:clerk-android-ui:$clerkAndroidUiVersion") {
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
+    exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'
+  }
+  // clerk-android-telemetry has a transitive dep on the last released
+  // clerk-android-api. Pinning the api explicitly here keeps consumers
+  // compiling against the same version we ship the UI from.
+  implementation("com.clerk:clerk-android-api:$clerkAndroidApiVersion") {
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthExpoView.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthExpoView.kt
@@ -44,7 +44,14 @@ class ClerkAuthNativeView(context: Context) : FrameLayout(context) {
   var mode: String = "signInOrUp"
   var isDismissable: Boolean = true
 
-  private val activity: ComponentActivity? = findActivity(context)
+  private val activity: ComponentActivity? = findActivity(context).also {
+    // At cold start, ClerkExpoModule.configure() may run before React's
+    // host-resume sync — meaning getCurrentActivity() returns null there.
+    // This view's construction is a reliable second hook: we know the Activity
+    // is available (we just walked the context to find it) and we're about to
+    // render Google sign-in / passkey buttons that need it.
+    if (it != null) Clerk.attachActivity(it)
+  }
 
   // Per-view ViewModelStoreOwner so the AuthView's ViewModels (including its
   // navigation state) are scoped to THIS view instance, not the activity.

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
@@ -85,6 +85,16 @@ class ClerkExpoModule(reactContext: ReactApplicationContext) :
                     }
 
                     Clerk.initialize(reactApplicationContext, pubKey)
+                    // clerk-android registers ActivityLifecycleCallbacks during
+                    // initialize(), but in React Native MainActivity has already passed
+                    // onResume() by the time <ClerkProvider> mounts and we reach this
+                    // line, so the callbacks miss the initial activity. Without seeding,
+                    // the first Credential Manager call (Google sign-in / passkeys)
+                    // fails with MissingActivity until the user backgrounds and
+                    // foregrounds the app. getCurrentActivity() can be null here on
+                    // cold start before React's host-resume sync — AuthView and
+                    // UserProfile also call attachActivity() on mount as a backstop.
+                    getCurrentActivity()?.let { Clerk.attachActivity(it) }
                     // Theme loading is centralized here. ClerkViewFactory.configure()
                     // and ClerkUserProfileActivity.onCreate() only call Clerk.initialize()
                     // when Clerk is not yet initialized, so by the time they run


### PR DESCRIPTION
## Summary

Fixes [MOBILE-485](https://linear.app/clerk/issue/MOBILE-485/new-reproducible-bug-on-android-with-google-sign-in-in-authview).

**Customer-reported bug** ([T-57530](https://app.plain.com/), M2X Group, Business tier): on `@clerk/expo@3.2.x`, the first tap on "Sign in with Google" in `<AuthView />` after a cold launch silently fails. Logcat shows:

```
E/ClerkLog: Clerk error: Google sign-in cannot start: Credential Manager requires an active Activity context.
```

The workaround was to background and foreground the app once before signing in.

## Root cause

`clerk-android` tracks the current foreground `Activity` via `ActivityLifecycleCallbacks` registered inside `Clerk.initialize()`. The callbacks only fire on subsequent `onActivityCreated/Started/Resumed` events — they don't observe the host Activity's *current* state at the moment `initialize()` runs.

In React Native, `MainActivity` has already passed `onResume()` by the time `<ClerkProvider />` mounts and `configure()` runs, so when we call `Clerk.initialize()`, the just-registered callbacks miss the initial Activity. `Clerk.currentActivity` stays null until the next OS-driven resume cycle — which is why backgrounding and re-foregrounding the app "fixes" it.

## Fix

The proper fix lives in `clerk-android`: it now exposes a public `Clerk.attachActivity(activity)` API in [1.0.16](https://github.com/clerk/clerk-android/pull/614) for hosts that pass an Application-typed Context to `initialize()` but have a current Activity available.

This PR adopts that API at two reliable points:

1. **`ClerkExpoModule.configure()`** — right after `Clerk.initialize()`, calls `Clerk.attachActivity(getCurrentActivity())`. May be a no-op on cold start if React's host-resume sync hasn't fired yet, but covers the warm-init case.

2. **`ClerkAuthNativeView` constructor** — calls `Clerk.attachActivity()` with the Activity returned by `findActivity(context)`. This is the empirically-reliable backstop: by the time the AuthView is being constructed, the host Activity is unambiguously available.

Bumps `clerk-android-{api,ui}` to `1.0.16`. Also adds an explicit `clerk-android-api` dep — without it, telemetry's transitive pin on the prior release wins the version conflict and consumers end up on the older artifact (which doesn't have `attachActivity`).

## Test plan

- [x] Reproduced the bug first-hand on `@clerk/expo@3.2.7` against a Pixel 9 Pro emulator (Android 16). Cold-launch via `pm clear` + deep-link, tap Google as first action — `E/ClerkLog: Clerk error: Google sign-in cannot start: Credential Manager requires an active Activity context.` in logcat, silent failure on JS, stuck on AuthView.
- [x] Built `@clerk/expo` against this branch (consuming `clerk-android` 1.0.16 via local Maven), reran the same reproduction:
  - `I/CredentialManager: starting executeGetCredential` → `[GetGoogleIdOperation] Operation succeeded` → Google account picker opens, sign-in completes, lands on the Welcome screen.
  - No `MissingActivity` in logcat.
- [x] Re-ran the exact reproduction with the fix in place after a clean `pm clear` and force-stop — could not reproduce the error.

## Gating

This PR depends on [clerk/clerk-android#614](https://github.com/clerk/clerk-android/pull/614) shipping as `1.0.16`. The build will fail at the `clerk_expo:compileDebugKotlin` step until that release is published to Maven Central.