### PR TITLE
fix(shared): improve single-session sign-in/sign-up dev warning wording

### DIFF
--- a/.changeset/single-session-warning-wording.md
+++ b/.changeset/single-session-warning-wording.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Improved the `cannot_render_single_session_enabled` dev warning to use friendlier wording. The message now clearly states that the behavior is expected and points developers to the Clerk Dashboard to enable multi-session mode if needed.

--- a/packages/shared/src/internal/clerk-js/__tests__/warnings.test.ts
+++ b/packages/shared/src/internal/clerk-js/__tests__/warnings.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { warnings } from '../warnings';
+
+describe('warnings', () => {
+  describe('cannotOpenSignInOrSignUp', () => {
+    it('explains that the behavior is expected', () => {
+      expect(warnings.cannotOpenSignInOrSignUp).toContain('expected behavior');
+    });
+
+    it('mentions single-session mode', () => {
+      expect(warnings.cannotOpenSignInOrSignUp).toContain('single-session mode');
+    });
+
+    it('mentions multi-session as the resolution', () => {
+      expect(warnings.cannotOpenSignInOrSignUp).toContain('multi-session mode');
+    });
+
+    it('includes the development notice', () => {
+      expect(warnings.cannotOpenSignInOrSignUp).toContain('This notice only appears in development');
+    });
+  });
+});

--- a/packages/shared/src/internal/clerk-js/warnings.ts
+++ b/packages/shared/src/internal/clerk-js/warnings.ts
@@ -53,7 +53,7 @@ const warnings = {
   cannotOpenCheckout:
     'The Checkout drawer cannot render unless a user is signed in. Since no user is signed in, this is no-op.',
   cannotOpenSignInOrSignUp:
-    'The SignIn or SignUp modals do not render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, this is no-op.',
+    'The <SignIn/> and <SignUp/> modals are hidden because a user is already signed in and this application is configured for single-session mode. This is expected behavior — no action is needed. To allow rendering while signed in, enable multi-session mode in your Clerk Dashboard.',
   cannotRenderAPIKeysComponent:
     'The <APIKeys/> component cannot be rendered when API keys is disabled. Since API keys is disabled, this is no-op.',
   cannotRenderAPIKeysComponentForOrgWhenUnauthorized:


### PR DESCRIPTION
## Summary
- The `cannot_render_single_session_enabled` dev warning previously used phrasing like "this is no-op" which made it look like something was broken
- Reworded to clearly state this is **expected behavior** when a user is already signed in under single-session mode, and points developers to the Dashboard to enable multi-session if that's what they want
- Before: `The SignIn or SignUp modals do not render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, this is no-op.`
- After: `The <SignIn/> and <SignUp/> modals are hidden because a user is already signed in and this application is configured for single-session mode. This is expected behavior — no action is needed. To allow rendering while signed in, enable multi-session mode in your Clerk Dashboard.`

Ref: SDK-66

## Test plan
- [x] Added `warnings.test.ts` verifying the warning contains key phrases ("expected behavior", "single-session mode", "multi-session mode", dev notice)
- [ ] Verify in dev mode that the warning renders with the updated wording when triggering `openSignIn`/`openSignUp` while signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)