### PR TITLE
ci(expo): add manual mobile e2e workflow_dispatch

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   android:
     name: Android
-    runs-on: ubuntu-latest
+    runs-on: 'blacksmith-8vcpu-ubuntu-2204'
     timeout-minutes: 45
     defaults:
       run:

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,267 @@
+# Manual mobile e2e for @clerk/expo native components.
+# Clones clerk-expo-quickstart, builds the NativeComponentQuickstart app,
+# and runs Maestro flows on iOS simulator and Android emulator.
+#
+# Secrets:
+#   INTEGRATION_INSTANCE_KEYS — JSON map of named test instances
+#     ({ "<name>": { "pk": "pk_test_...", "sk": "sk_test_..." } }).
+#     Same secret used by /integration (Playwright). We read the entry named
+#     EXPO_INSTANCE_NAME (set in env: below).
+#
+# Test users are provisioned per-run via Clerk Backend API and deleted at
+# teardown — same pattern as /integration's createBapiUser.
+#
+# TODO(SDK team): confirm the instance-name slot to add inside
+# INTEGRATION_INSTANCE_KEYS for this workflow (placeholder: "expo-native").
+name: "Mobile e2e (@clerk/expo)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      quickstart_ref:
+        description: "clerk-expo-quickstart git ref (branch, tag, or SHA)"
+        required: false
+        default: "main"
+      exclude_tags:
+        description: "Maestro tags to exclude (comma-separated)"
+        required: false
+        default: "manual,skip"
+
+env:
+  # TODO(SDK team): replace with the canonical mobile-e2e instance name once confirmed.
+  EXPO_INSTANCE_NAME: expo-native
+
+concurrency:
+  group: mobile-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout @clerk/javascript
+        uses: actions/checkout@v4
+
+      - name: Checkout clerk-expo-quickstart
+        uses: actions/checkout@v4
+        with:
+          repository: clerk/clerk-expo-quickstart
+          ref: ${{ inputs.quickstart_ref }}
+          path: clerk-expo-quickstart
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install monorepo deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @clerk/expo
+        run: pnpm turbo build --filter=@clerk/expo...
+
+      - name: Install quickstart deps
+        working-directory: clerk-expo-quickstart/NativeComponentQuickstart
+        run: pnpm install
+
+      - name: Resolve Clerk instance keys
+        id: keys
+        env:
+          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+        run: |
+          if [ -z "$INTEGRATION_INSTANCE_KEYS" ]; then
+            echo "::error::INTEGRATION_INSTANCE_KEYS secret is not set"
+            exit 1
+          fi
+          pk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
+            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_INSTANCE_KEYS"
+            exit 1
+          }
+          sk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
+          echo "::add-mask::$sk"
+          echo "pk=$pk" >> "$GITHUB_OUTPUT"
+          echo "sk=$sk" >> "$GITHUB_OUTPUT"
+
+      - name: Write quickstart .env
+        working-directory: clerk-expo-quickstart/NativeComponentQuickstart
+        run: |
+          echo "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.keys.outputs.pk }}" > .env
+
+      - name: Provision test user via BAPI
+        id: user
+        env:
+          CLERK_SECRET_KEY: ${{ steps.keys.outputs.sk }}
+        run: |
+          email="ci-${GITHUB_RUN_ID}-${RANDOM}+clerk_test@clerkcookie.com"
+          password="ClerkCI!$(openssl rand -hex 8)Aa1"
+          response=$(curl -fsS -X POST https://api.clerk.com/v1/users \
+            -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"email_address\":[\"$email\"],\"password\":\"$password\"}")
+          user_id=$(echo "$response" | jq -er '.id')
+          echo "::add-mask::$password"
+          echo "email=$email" >> "$GITHUB_OUTPUT"
+          echo "password=$password" >> "$GITHUB_OUTPUT"
+          echo "user_id=$user_id" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Run Android e2e
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          CLERK_TEST_EMAIL: ${{ steps.user.outputs.email }}
+          CLERK_TEST_PASSWORD: ${{ steps.user.outputs.password }}
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          script: |
+            cd clerk-expo-quickstart/NativeComponentQuickstart
+            npx expo prebuild --clean
+            npx expo run:android --variant release --no-bundler
+            cd ../../integration-mobile
+            # Maestro doesn't auto-recurse into subdirectories; pass each flow explicitly.
+            find flows -type f -name "*.yaml" ! -path "*/common/*" -print0 | \
+              xargs -0 maestro test --exclude-tags "${{ inputs.exclude_tags }}"
+
+      - name: Upload Maestro artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-android
+          path: ~/.maestro/tests
+
+      - name: Cleanup test user
+        if: always() && steps.user.outputs.user_id != ''
+        env:
+          CLERK_SECRET_KEY: ${{ steps.keys.outputs.sk }}
+          USER_ID: ${{ steps.user.outputs.user_id }}
+        run: |
+          curl -fsS -X DELETE "https://api.clerk.com/v1/users/$USER_ID" \
+            -H "Authorization: Bearer $CLERK_SECRET_KEY" || true
+
+  ios:
+    name: iOS
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout @clerk/javascript
+        uses: actions/checkout@v4
+
+      - name: Checkout clerk-expo-quickstart
+        uses: actions/checkout@v4
+        with:
+          repository: clerk/clerk-expo-quickstart
+          ref: ${{ inputs.quickstart_ref }}
+          path: clerk-expo-quickstart
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install monorepo deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @clerk/expo
+        run: pnpm turbo build --filter=@clerk/expo...
+
+      - name: Install quickstart deps
+        working-directory: clerk-expo-quickstart/NativeComponentQuickstart
+        run: pnpm install
+
+      - name: Resolve Clerk instance keys
+        id: keys
+        env:
+          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+        run: |
+          if [ -z "$INTEGRATION_INSTANCE_KEYS" ]; then
+            echo "::error::INTEGRATION_INSTANCE_KEYS secret is not set"
+            exit 1
+          fi
+          pk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
+            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_INSTANCE_KEYS"
+            exit 1
+          }
+          sk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
+          echo "::add-mask::$sk"
+          echo "pk=$pk" >> "$GITHUB_OUTPUT"
+          echo "sk=$sk" >> "$GITHUB_OUTPUT"
+
+      - name: Write quickstart .env
+        working-directory: clerk-expo-quickstart/NativeComponentQuickstart
+        run: |
+          echo "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.keys.outputs.pk }}" > .env
+
+      - name: Provision test user via BAPI
+        id: user
+        env:
+          CLERK_SECRET_KEY: ${{ steps.keys.outputs.sk }}
+        run: |
+          email="ci-${GITHUB_RUN_ID}-${RANDOM}+clerk_test@clerkcookie.com"
+          password="ClerkCI!$(openssl rand -hex 8)Aa1"
+          response=$(curl -fsS -X POST https://api.clerk.com/v1/users \
+            -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"email_address\":[\"$email\"],\"password\":\"$password\"}")
+          user_id=$(echo "$response" | jq -er '.id')
+          echo "::add-mask::$password"
+          echo "email=$email" >> "$GITHUB_OUTPUT"
+          echo "password=$password" >> "$GITHUB_OUTPUT"
+          echo "user_id=$user_id" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: spm-${{ hashFiles('packages/expo/package.json') }}
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Build and run iOS e2e
+        env:
+          CLERK_TEST_EMAIL: ${{ steps.user.outputs.email }}
+          CLERK_TEST_PASSWORD: ${{ steps.user.outputs.password }}
+        run: |
+          cd clerk-expo-quickstart/NativeComponentQuickstart
+          npx expo prebuild --clean
+          npx expo run:ios --configuration Release --no-bundler
+          cd ../../integration-mobile
+          # Maestro doesn't auto-recurse into subdirectories; pass each flow explicitly.
+          find flows -type f -name "*.yaml" ! -path "*/common/*" -print0 | \
+            xargs -0 maestro test --exclude-tags "${{ inputs.exclude_tags }},androidOnly"
+
+      - name: Upload Maestro artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-ios
+          path: ~/.maestro/tests
+
+      - name: Cleanup test user
+        if: always() && steps.user.outputs.user_id != ''
+        env:
+          CLERK_SECRET_KEY: ${{ steps.keys.outputs.sk }}
+          USER_ID: ${{ steps.user.outputs.user_id }}
+        run: |
+          curl -fsS -X DELETE "https://api.clerk.com/v1/users/$USER_ID" \
+            -H "Authorization: Bearer $CLERK_SECRET_KEY" || true

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -126,6 +126,7 @@ jobs:
         env:
           CLERK_TEST_EMAIL: ${{ steps.user.outputs.email }}
           CLERK_TEST_PASSWORD: ${{ steps.user.outputs.password }}
+          EXCLUDE_TAGS: ${{ inputs.exclude_tags }}
         with:
           api-level: 34
           target: google_apis
@@ -137,7 +138,7 @@ jobs:
             cd ../../integration-mobile
             # Maestro doesn't auto-recurse into subdirectories; pass each flow explicitly.
             find flows -type f -name "*.yaml" ! -path "*/common/*" -print0 | \
-              xargs -0 maestro test --exclude-tags "${{ inputs.exclude_tags }}"
+              xargs -0 maestro test --exclude-tags "$EXCLUDE_TAGS"
 
       - name: Upload Maestro artifacts on failure
         if: failure()
@@ -241,6 +242,7 @@ jobs:
         env:
           CLERK_TEST_EMAIL: ${{ steps.user.outputs.email }}
           CLERK_TEST_PASSWORD: ${{ steps.user.outputs.password }}
+          EXCLUDE_TAGS: ${{ inputs.exclude_tags }}
         run: |
           cd clerk-expo-quickstart/NativeComponentQuickstart
           npx expo prebuild --clean
@@ -248,7 +250,7 @@ jobs:
           cd ../../integration-mobile
           # Maestro doesn't auto-recurse into subdirectories; pass each flow explicitly.
           find flows -type f -name "*.yaml" ! -path "*/common/*" -print0 | \
-            xargs -0 maestro test --exclude-tags "${{ inputs.exclude_tags }},androidOnly"
+            xargs -0 maestro test --exclude-tags "$EXCLUDE_TAGS,androidOnly"
 
       - name: Upload Maestro artifacts on failure
         if: failure()


### PR DESCRIPTION
## Summary

Splits the `mobile-e2e.yml` workflow file out of #8334 so it lands on `main` first.

`workflow_dispatch` only registers in the GitHub Actions UI once the workflow file is on the default branch. Landing this small PR first lets us dispatch the workflow against `chris/native-component-tests` and validate the full mobile e2e end-to-end before merging the larger PR.

The workflow itself is **manual-only**:
- Does not run on push, PR, or schedule.
- Triggered via Actions UI → "Run workflow" → "Mobile e2e (@clerk/expo)" or via `gh workflow run mobile-e2e.yml`.
- Reads the test instance keys from the existing `INTEGRATION_STAGING_INSTANCE_KEYS` repo secret (entry `clerkstage-with-native-components`, added separately by the SDK team).
- Provisions a per-run BAPI test user against the staging instance and cleans it up on teardown.

The test infrastructure that this workflow runs (Maestro flows under `integration-mobile/`, the new `packages/expo` unit tests, native Swift/Kotlin tests) lives in #8334 and will be merged separately.

## Test plan

- [ ] Merge this PR to `main`.
- [ ] SDK team adds the `clerkstage-with-native-components` entry to the `INTEGRATION_STAGING_INSTANCE_KEYS` repo secret (already in 1Password's `Shared/JS SDKs integration tests` note).
- [ ] Dispatch the workflow against `chris/native-component-tests` from the Actions UI; confirm both `Android` and `iOS` jobs come back green.
- [ ] Once green, mark #8334 ready for review.