### PR TITLE
fix(ui): Ensure cssLayerName from appearance is preserved during updateProps

### DIFF
--- a/.changeset/fix-css-layer-name-update-props.md
+++ b/.changeset/fix-css-layer-name-update-props.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix `cssLayerName` from theme not being applied after initial mount. When `ClerkProvider` re-renders, the `updateProps` handler overwrote the extracted `cssLayerName` with the raw appearance object, causing Clerk's runtime CSS to not be wrapped in `@layer`. This broke Tailwind utility overrides when using themes like `shadcn` that set `cssLayerName: 'components'`.

--- a/packages/ui/src/Components.tsx
+++ b/packages/ui/src/Components.tsx
@@ -397,6 +397,11 @@ const Components = (props: ComponentsProps) => {
         }
       }
 
+      // Extract cssLayerName from theme if present and move it to appearance level
+      if (restProps.appearance) {
+        restProps = { ...restProps, appearance: extractCssLayerNameFromAppearance(restProps.appearance) };
+      }
+
       setState(s => ({ ...s, ...restProps, options: { ...s.options, ...restProps.options } }));
     };
 

--- a/packages/ui/src/utils/__tests__/extractCssLayerNameFromAppearance.test.ts
+++ b/packages/ui/src/utils/__tests__/extractCssLayerNameFromAppearance.test.ts
@@ -56,27 +56,7 @@ describe('extractCssLayerNameFromAppearance', () => {
     expect(extractCssLayerNameFromAppearance(undefined)).toBeUndefined();
   });
 
-  describe('Components.updateProps state merge', () => {
-    // This replicates the state merge in Components.tsx updateProps handler:
-    //   setState(s => ({ ...s, ...restProps, options: { ...s.options, ...restProps.options } }))
-    //
-    // When ClerkProvider re-renders, it calls __internal_updateProps({ appearance: { theme: shadcn } }).
-    // This arrives in updateProps as restProps = { appearance: { theme: shadcn } }.
-    // The bug: cssLayerName buried in theme is not promoted to appearance level,
-    // so StyleCacheProvider never wraps Clerk CSS in @layer.
-
-    function updatePropsStateMerge(currentState: Record<string, any>, restProps: Record<string, any>) {
-      // This is the exact logic from Components.tsx line 400 (without fix)
-      return { ...currentState, ...restProps, options: { ...currentState.options, ...restProps.options } };
-    }
-
-    function updatePropsStateMergeFixed(currentState: Record<string, any>, restProps: Record<string, any>) {
-      if (restProps.appearance) {
-        restProps = { ...restProps, appearance: extractCssLayerNameFromAppearance(restProps.appearance) };
-      }
-      return { ...currentState, ...restProps, options: { ...currentState.options, ...restProps.options } };
-    }
-
+  it('persists cssLayerName when appearance is re-extracted after an updateProps-style state merge', () => {
     const theme = {
       name: 'shadcn',
       cssLayerName: 'components',
@@ -85,25 +65,32 @@ describe('extractCssLayerNameFromAppearance', () => {
       __type: 'prebuilt_appearance' as const,
     };
 
-    const initialState = {
-      appearance: { theme, cssLayerName: 'components' }, // after mountComponentRenderer extraction
-      options: {},
+    // Initial mount: cssLayerName is extracted to appearance level
+    const initialAppearance = extractCssLayerNameFromAppearance({ theme });
+    expect(initialAppearance?.cssLayerName).toBe('components');
+
+    // ClerkProvider re-renders and sends raw appearance (cssLayerName only inside theme)
+    const rawAppearance = { theme };
+
+    // updateProps must re-extract before merging into state
+    const reExtracted = extractCssLayerNameFromAppearance(rawAppearance);
+    expect(reExtracted?.cssLayerName).toBe('components');
+  });
+
+  it('respects a new cssLayerName passed via updateProps', () => {
+    const theme = {
+      name: 'shadcn',
+      cssLayerName: 'components',
+      variables: {},
+      elements: {},
+      __type: 'prebuilt_appearance' as const,
     };
 
-    it('BUG: updateProps overwrites extracted cssLayerName with raw appearance from ClerkProvider', () => {
-      // ClerkProvider sends raw appearance (cssLayerName only inside theme, not at top level)
-      const restProps = { appearance: { theme } };
-      const newState = updatePropsStateMerge(initialState, restProps);
+    // User changes cssLayerName at the appearance level
+    const updatedAppearance = { theme, cssLayerName: 'utilities' };
+    const result = extractCssLayerNameFromAppearance(updatedAppearance);
 
-      // cssLayerName is lost — it's only inside theme, not at the appearance level
-      expect(newState.appearance.cssLayerName).toBeUndefined();
-    });
-
-    it('FIX: updateProps extracts cssLayerName from theme before merging into state', () => {
-      const restProps = { appearance: { theme } };
-      const newState = updatePropsStateMergeFixed(initialState, restProps);
-
-      expect(newState.appearance.cssLayerName).toBe('components');
-    });
+    // Explicit appearance-level cssLayerName takes precedence over theme
+    expect(result?.cssLayerName).toBe('utilities');
   });
 });

--- a/packages/ui/src/utils/__tests__/extractCssLayerNameFromAppearance.test.ts
+++ b/packages/ui/src/utils/__tests__/extractCssLayerNameFromAppearance.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractCssLayerNameFromAppearance } from '../extractCssLayerNameFromAppearance';
+
+describe('extractCssLayerNameFromAppearance', () => {
+  it('promotes cssLayerName from a single theme to the appearance level', () => {
+    const theme = {
+      name: 'shadcn',
+      cssLayerName: 'components',
+      variables: {},
+      elements: {},
+      __type: 'prebuilt_appearance' as const,
+    };
+
+    const result = extractCssLayerNameFromAppearance({ theme });
+
+    expect(result?.cssLayerName).toBe('components');
+  });
+
+  it('promotes cssLayerName from a theme array to the appearance level', () => {
+    const theme = {
+      name: 'shadcn',
+      cssLayerName: 'components',
+      variables: {},
+      elements: {},
+      __type: 'prebuilt_appearance' as const,
+    };
+
+    const result = extractCssLayerNameFromAppearance({ theme: [theme] });
+
+    expect(result?.cssLayerName).toBe('components');
+  });
+
+  it('preserves explicit cssLayerName on appearance over theme cssLayerName', () => {
+    const theme = {
+      name: 'shadcn',
+      cssLayerName: 'components',
+      variables: {},
+      elements: {},
+      __type: 'prebuilt_appearance' as const,
+    };
+
+    const result = extractCssLayerNameFromAppearance({ theme, cssLayerName: 'custom' });
+
+    expect(result?.cssLayerName).toBe('custom');
+  });
+
+  it('returns appearance unchanged when no theme is present', () => {
+    const appearance = { cssLayerName: 'custom' };
+    const result = extractCssLayerNameFromAppearance(appearance);
+
+    expect(result).toEqual(appearance);
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(extractCssLayerNameFromAppearance(undefined)).toBeUndefined();
+  });
+
+  describe('Components.updateProps state merge', () => {
+    // This replicates the state merge in Components.tsx updateProps handler:
+    //   setState(s => ({ ...s, ...restProps, options: { ...s.options, ...restProps.options } }))
+    //
+    // When ClerkProvider re-renders, it calls __internal_updateProps({ appearance: { theme: shadcn } }).
+    // This arrives in updateProps as restProps = { appearance: { theme: shadcn } }.
+    // The bug: cssLayerName buried in theme is not promoted to appearance level,
+    // so StyleCacheProvider never wraps Clerk CSS in @layer.
+
+    function updatePropsStateMerge(currentState: Record<string, any>, restProps: Record<string, any>) {
+      // This is the exact logic from Components.tsx line 400 (without fix)
+      return { ...currentState, ...restProps, options: { ...currentState.options, ...restProps.options } };
+    }
+
+    function updatePropsStateMergeFixed(currentState: Record<string, any>, restProps: Record<string, any>) {
+      if (restProps.appearance) {
+        restProps = { ...restProps, appearance: extractCssLayerNameFromAppearance(restProps.appearance) };
+      }
+      return { ...currentState, ...restProps, options: { ...currentState.options, ...restProps.options } };
+    }
+
+    const theme = {
+      name: 'shadcn',
+      cssLayerName: 'components',
+      variables: {},
+      elements: {},
+      __type: 'prebuilt_appearance' as const,
+    };
+
+    const initialState = {
+      appearance: { theme, cssLayerName: 'components' }, // after mountComponentRenderer extraction
+      options: {},
+    };
+
+    it('BUG: updateProps overwrites extracted cssLayerName with raw appearance from ClerkProvider', () => {
+      // ClerkProvider sends raw appearance (cssLayerName only inside theme, not at top level)
+      const restProps = { appearance: { theme } };
+      const newState = updatePropsStateMerge(initialState, restProps);
+
+      // cssLayerName is lost — it's only inside theme, not at the appearance level
+      expect(newState.appearance.cssLayerName).toBeUndefined();
+    });
+
+    it('FIX: updateProps extracts cssLayerName from theme before merging into state', () => {
+      const restProps = { appearance: { theme } };
+      const newState = updatePropsStateMergeFixed(initialState, restProps);
+
+      expect(newState.appearance.cssLayerName).toBe('components');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fix `cssLayerName` from theme not being applied after initial mount. When `ClerkProvider` re-renders, the `updateProps` handler overwrote the extracted `cssLayerName` with the raw appearance object, causing Clerk's runtime CSS to not be wrapped in `@layer`. This broke Tailwind utility overrides when using themes like `shadcn` that set `cssLayerName: 'components'`.

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
