### PR TITLE
chore(clerk-js,ui): Remove unused internal OAuthConsent prop

### DIFF
--- a/.changeset/four-wombats-clean.md
+++ b/.changeset/four-wombats-clean.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/ui": patch
+---
+
+Removed unused internal OAuthConsent prop.

--- a/.changeset/four-wombats-clean.md
+++ b/.changeset/four-wombats-clean.md
@@ -1,6 +1,6 @@
 ---
-"@clerk/clerk-js": patch
-"@clerk/ui": patch
+"@clerk/clerk-js": minor
+"@clerk/ui": minor
 ---
 
 Removed unused internal OAuthConsent prop.

--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -486,7 +486,6 @@ void (async () => {
           scopes,
           oauthClientId: 'Wg9fP2d0pSFXCZ1u',
           redirectUrl: searchParams.get('redirect_uri') ?? 'http://localhost:4000/oauth/callback',
-          __internal_enableOrgSelection: true,
         },
       );
     },

--- a/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
@@ -72,7 +72,7 @@ function _OAuthConsent() {
   const redirectUrl = ctx.redirectUrl ?? getRedirectUriFromSearch();
 
   const hasOrgReadScope = scopes.some(s => s.scope === USER_ORG_READ_SCOPE);
-  const orgSelectionEnabled = !!((hasOrgReadScope || ctx.enableOrgSelection) && organizationSettings.enabled);
+  const orgSelectionEnabled = !!(hasOrgReadScope && organizationSettings.enabled);
   const orgOptions = orgSelectionEnabled
     ? (user?.organizationMemberships ?? []).map(m => ({
         value: m.organization.id,

--- a/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
+++ b/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
@@ -390,25 +390,6 @@ describe('OAuthConsent', () => {
       });
     });
 
-    it('renders the org selector when __internal_enableOrgSelection is true (fallback for existing apps)', async () => {
-      const { wrapper, fixtures, props } = await createFixtures(f => {
-        f.withUser({
-          email_addresses: ['jane@example.com'],
-          organization_memberships: [{ id: 'org_1', name: 'Acme Corp' }],
-        });
-        f.withOrganizations();
-      });
-
-      props.setProps({ componentName: 'OAuthConsent', __internal_enableOrgSelection: true } as any);
-      mockOAuthApplication(fixtures.clerk, { getConsentInfo: vi.fn().mockResolvedValue(fakeConsentInfo) });
-
-      const { getByText } = render(<OAuthConsent />, { wrapper });
-
-      await waitFor(() => {
-        expect(getByText('Acme Corp')).toBeVisible();
-      });
-    });
-
     it('does not display user:org:read in the scopes list', async () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withUser({

--- a/packages/ui/src/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/ui/src/contexts/ClerkUIComponentsContext.tsx
@@ -142,7 +142,6 @@ export function ComponentContextProvider({
             onAllow: p.onAllow,
             onDeny: p.onDeny,
             appearance: p.appearance,
-            enableOrgSelection: (p as any).__internal_enableOrgSelection === true,
           }}
         >
           {children}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -225,11 +225,6 @@ export type OAuthConsentCtx = {
    * Customize the appearance of the component.
    */
   appearance?: ClerkAppearanceTheme;
-  /**
-   * When true, renders the organization picker and submits organization_id
-   * with the consent form. Internal use only, not exposed in the public prop type.
-   */
-  enableOrgSelection?: boolean;
 };
 
 export type SubscriptionDetailsCtx = __internal_SubscriptionDetailsProps & {


### PR DESCRIPTION
## Description

When we shipped CLI, we added an internal prop to render org selection when consenting in the dashboard. We've added a new scope and is already being used by dashboard (https://github.com/clerk/dashboard/pull/9149), so this prop can be safely removed.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
