### PR TITLE
ci(e2e): point mobile-e2e to clerkstage-with-native-components instance

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -10,9 +10,6 @@
 #
 # Test users are provisioned per-run via Clerk Backend API and deleted at
 # teardown — same pattern as /integration's createBapiUser.
-#
-# TODO(SDK team): confirm the instance-name slot to add inside
-# INTEGRATION_INSTANCE_KEYS for this workflow (placeholder: "expo-native").
 name: "Mobile e2e (@clerk/expo)"
 
 on:
@@ -28,8 +25,7 @@ on:
         default: "manual,skip"
 
 env:
-  # TODO(SDK team): replace with the canonical mobile-e2e instance name once confirmed.
-  EXPO_INSTANCE_NAME: expo-native
+  EXPO_INSTANCE_NAME: clerkstage-with-native-components
 
 concurrency:
   group: mobile-e2e-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Replaces the `EXPO_INSTANCE_NAME: expo-native` placeholder added in #8489 with the real instance name `clerkstage-with-native-components`, which now exists in the `INTEGRATION_INSTANCE_KEYS` GitHub Actions secret.
- Drops the two TODOs in the header/env comment

Without this, the manual `Mobile e2e (@clerk/expo)` workflow would fail at the "Resolve Clerk instance keys" step with `No entry 'expo-native' found in INTEGRATION_INSTANCE_KEYS`.

## Test plan
- [ ] Trigger the `Mobile e2e (@clerk/expo)` workflow from the Actions tab on `main` after this lands and confirm the "Resolve Clerk instance keys" step passes.