### PR TITLE
ci(e2e): use INTEGRATION_STAGING_INSTANCE_KEYS for mobile-e2e workflow

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -3,10 +3,10 @@
 # and runs Maestro flows on iOS simulator and Android emulator.
 #
 # Secrets:
-#   INTEGRATION_INSTANCE_KEYS — JSON map of named test instances
+#   INTEGRATION_STAGING_INSTANCE_KEYS — JSON map of named staging test instances
 #     ({ "<name>": { "pk": "pk_test_...", "sk": "sk_test_..." } }).
-#     Same secret used by /integration (Playwright). We read the entry named
-#     EXPO_INSTANCE_NAME (set in env: below).
+#     Same secret used by /integration (Playwright) staging jobs. We read the
+#     entry named EXPO_INSTANCE_NAME (set in env: below).
 #
 # Test users are provisioned per-run via Clerk Backend API and deleted at
 # teardown — same pattern as /integration's createBapiUser.
@@ -69,17 +69,17 @@ jobs:
       - name: Resolve Clerk instance keys
         id: keys
         env:
-          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+          INTEGRATION_STAGING_INSTANCE_KEYS: ${{ secrets.INTEGRATION_STAGING_INSTANCE_KEYS }}
         run: |
-          if [ -z "$INTEGRATION_INSTANCE_KEYS" ]; then
-            echo "::error::INTEGRATION_INSTANCE_KEYS secret is not set"
+          if [ -z "$INTEGRATION_STAGING_INSTANCE_KEYS" ]; then
+            echo "::error::INTEGRATION_STAGING_INSTANCE_KEYS secret is not set"
             exit 1
           fi
-          pk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
-            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_INSTANCE_KEYS"
+          pk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
+            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_STAGING_INSTANCE_KEYS"
             exit 1
           }
-          sk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
+          sk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
           echo "::add-mask::$sk"
           echo "pk=$pk" >> "$GITHUB_OUTPUT"
           echo "sk=$sk" >> "$GITHUB_OUTPUT"
@@ -186,17 +186,17 @@ jobs:
       - name: Resolve Clerk instance keys
         id: keys
         env:
-          INTEGRATION_INSTANCE_KEYS: ${{ secrets.INTEGRATION_INSTANCE_KEYS }}
+          INTEGRATION_STAGING_INSTANCE_KEYS: ${{ secrets.INTEGRATION_STAGING_INSTANCE_KEYS }}
         run: |
-          if [ -z "$INTEGRATION_INSTANCE_KEYS" ]; then
-            echo "::error::INTEGRATION_INSTANCE_KEYS secret is not set"
+          if [ -z "$INTEGRATION_STAGING_INSTANCE_KEYS" ]; then
+            echo "::error::INTEGRATION_STAGING_INSTANCE_KEYS secret is not set"
             exit 1
           fi
-          pk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
-            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_INSTANCE_KEYS"
+          pk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
+            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_STAGING_INSTANCE_KEYS"
             exit 1
           }
-          sk=$(echo "$INTEGRATION_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
+          sk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
           echo "::add-mask::$sk"
           echo "pk=$pk" >> "$GITHUB_OUTPUT"
           echo "sk=$sk" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -70,19 +70,7 @@ jobs:
         id: keys
         env:
           INTEGRATION_STAGING_INSTANCE_KEYS: ${{ secrets.INTEGRATION_STAGING_INSTANCE_KEYS }}
-        run: |
-          if [ -z "$INTEGRATION_STAGING_INSTANCE_KEYS" ]; then
-            echo "::error::INTEGRATION_STAGING_INSTANCE_KEYS secret is not set"
-            exit 1
-          fi
-          pk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
-            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_STAGING_INSTANCE_KEYS"
-            exit 1
-          }
-          sk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
-          echo "::add-mask::$sk"
-          echo "pk=$pk" >> "$GITHUB_OUTPUT"
-          echo "sk=$sk" >> "$GITHUB_OUTPUT"
+        run: node scripts/resolve-instance-keys.mjs INTEGRATION_STAGING_INSTANCE_KEYS "$EXPO_INSTANCE_NAME"
 
       - name: Write quickstart .env
         working-directory: clerk-expo-quickstart/NativeComponentQuickstart
@@ -187,19 +175,7 @@ jobs:
         id: keys
         env:
           INTEGRATION_STAGING_INSTANCE_KEYS: ${{ secrets.INTEGRATION_STAGING_INSTANCE_KEYS }}
-        run: |
-          if [ -z "$INTEGRATION_STAGING_INSTANCE_KEYS" ]; then
-            echo "::error::INTEGRATION_STAGING_INSTANCE_KEYS secret is not set"
-            exit 1
-          fi
-          pk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].pk") || {
-            echo "::error::No entry '$EXPO_INSTANCE_NAME' found in INTEGRATION_STAGING_INSTANCE_KEYS"
-            exit 1
-          }
-          sk=$(echo "$INTEGRATION_STAGING_INSTANCE_KEYS" | jq -er ".[\"$EXPO_INSTANCE_NAME\"].sk")
-          echo "::add-mask::$sk"
-          echo "pk=$pk" >> "$GITHUB_OUTPUT"
-          echo "sk=$sk" >> "$GITHUB_OUTPUT"
+        run: node scripts/resolve-instance-keys.mjs INTEGRATION_STAGING_INSTANCE_KEYS "$EXPO_INSTANCE_NAME"
 
       - name: Write quickstart .env
         working-directory: clerk-expo-quickstart/NativeComponentQuickstart

--- a/scripts/resolve-instance-keys.mjs
+++ b/scripts/resolve-instance-keys.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * Resolves Clerk pk/sk for a named test instance from a JSON-encoded env var
+ * (e.g. INTEGRATION_INSTANCE_KEYS / INTEGRATION_STAGING_INSTANCE_KEYS).
+ *
+ * Usage:
+ *   node scripts/resolve-instance-keys.mjs <SECRET_ENV_VAR> <INSTANCE_NAME>
+ *
+ * Writes pk and sk as GitHub Actions step outputs to $GITHUB_OUTPUT and masks
+ * sk in the runner logs. Exits non-zero with a ::error:: annotation if the
+ * env var is missing, malformed, or doesn't contain the requested instance.
+ */
+
+import { appendFileSync } from 'node:fs';
+
+const fail = msg => {
+  console.error(`::error::${msg}`);
+  process.exit(1);
+};
+
+const [, , secretVar, instanceName] = process.argv;
+if (!secretVar || !instanceName) {
+  fail('Usage: resolve-instance-keys.mjs <SECRET_ENV_VAR> <INSTANCE_NAME>');
+}
+
+const raw = process.env[secretVar];
+if (!raw) fail(`${secretVar} secret is not set`);
+
+let parsed;
+try {
+  parsed = JSON.parse(raw);
+} catch (err) {
+  fail(`Failed to parse ${secretVar} as JSON: ${err.message}`);
+}
+
+if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  fail(`Expected ${secretVar} to be a JSON object of instance entries`);
+}
+
+const entry = parsed[instanceName];
+if (!entry) fail(`No entry '${instanceName}' found in ${secretVar}`);
+
+const { pk, sk } = entry;
+if (!pk) fail(`Entry '${instanceName}' in ${secretVar} is missing 'pk'`);
+if (!sk) fail(`Entry '${instanceName}' in ${secretVar} is missing 'sk'`);
+
+console.log(`::add-mask::${sk}`);
+
+const out = process.env.GITHUB_OUTPUT;
+if (out) appendFileSync(out, `pk=${pk}\nsk=${sk}\n`);


### PR DESCRIPTION
## Summary
- Switches the mobile-e2e workflow's "Resolve Clerk instance keys" step from reading `INTEGRATION_INSTANCE_KEYS` to `INTEGRATION_STAGING_INSTANCE_KEYS`.
- The `clerkstage-with-native-components` instance lives in the staging secret (same one `e2e-staging.yml` uses), not the production one.
- Updates header comment to match.

Without this, the manual run fails fast with `No entry 'clerkstage-with-native-components' found in INTEGRATION_INSTANCE_KEYS`.

## Test plan
- [ ] After merge, trigger `Mobile e2e (@clerk/expo)` from the Actions tab on `main` and confirm the "Resolve Clerk instance keys" step passes.