### PR TITLE
fix(ui): Add missing noop methods to unsafeMetadata field in SignUpStart

### DIFF
--- a/.changeset/wild-insects-design.md
+++ b/.changeset/wild-insects-design.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": patch
+---
+
+Fixed unhandled TypeError when `unsafeMetadata` is passed to `<SignUp />`

--- a/packages/ui/src/components/SignUp/SignUpStart.tsx
+++ b/packages/ui/src/components/SignUp/SignUpStart.tsx
@@ -259,7 +259,15 @@ function SignUpStartInternal(): JSX.Element {
     }, [] as Array<FormControlState>);
 
     if (unsafeMetadata) {
-      fieldsToSubmit.push({ id: 'unsafeMetadata', value: unsafeMetadata } as any);
+      const noop = () => {};
+      fieldsToSubmit.push({
+        id: 'unsafeMetadata',
+        value: unsafeMetadata,
+        clearFeedback: noop,
+        setValue: noop,
+        onChange: noop,
+        setError: noop,
+      } as any);
     }
 
     if (fields.ticket || hasExistingSignUpWithTicket) {

--- a/packages/ui/src/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/ui/src/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -1,3 +1,4 @@
+import { ClerkAPIResponseError } from '@clerk/shared/error';
 import { OAUTH_PROVIDERS } from '@clerk/shared/oauth';
 import type { SignUpResource } from '@clerk/shared/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -450,6 +451,45 @@ describe('SignUpStart', () => {
           unsafeMetadata: { foo: 'bar', nested: { value: 123 } },
         }),
       );
+    });
+
+    it('does not throw when unsafeMetadata is set and signUp.create rejects with an API error', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withPassword();
+      });
+      fixtures.signUp.create.mockRejectedValueOnce(
+        new ClerkAPIResponseError('Error', {
+          data: [
+            {
+              code: 'form_password_pwned',
+              long_message: 'Password has been found in an online data breach.',
+              message: 'Password has been found in an online data breach.',
+              meta: { param_name: 'password' },
+            },
+          ],
+          status: 422,
+        }),
+      );
+      props.setProps({ unsafeMetadata: { foo: 'bar' } });
+
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { href: 'http://localhost/sign-up?__clerk_ticket=test_ticket' },
+      });
+      Object.defineProperty(window, 'history', {
+        writable: true,
+        value: { replaceState: vi.fn() },
+      });
+
+      render(
+        <CardStateProvider>
+          <SignUpStart />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      await waitFor(() => expect(fixtures.signUp.create).toHaveBeenCalled());
     });
 
     it('removes the ticket from the url when completing the sign up', async () => {

--- a/packages/ui/src/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/ui/src/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -453,45 +453,6 @@ describe('SignUpStart', () => {
       );
     });
 
-    it('does not throw when unsafeMetadata is set and signUp.create rejects with an API error', async () => {
-      const { wrapper, fixtures, props } = await createFixtures(f => {
-        f.withEmailAddress();
-        f.withPassword();
-      });
-      fixtures.signUp.create.mockRejectedValueOnce(
-        new ClerkAPIResponseError('Error', {
-          data: [
-            {
-              code: 'form_password_pwned',
-              long_message: 'Password has been found in an online data breach.',
-              message: 'Password has been found in an online data breach.',
-              meta: { param_name: 'password' },
-            },
-          ],
-          status: 422,
-        }),
-      );
-      props.setProps({ unsafeMetadata: { foo: 'bar' } });
-
-      Object.defineProperty(window, 'location', {
-        writable: true,
-        value: { href: 'http://localhost/sign-up?__clerk_ticket=test_ticket' },
-      });
-      Object.defineProperty(window, 'history', {
-        writable: true,
-        value: { replaceState: vi.fn() },
-      });
-
-      render(
-        <CardStateProvider>
-          <SignUpStart />
-        </CardStateProvider>,
-        { wrapper },
-      );
-
-      await waitFor(() => expect(fixtures.signUp.create).toHaveBeenCalled());
-    });
-
     it('removes the ticket from the url when completing the sign up', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withEmailAddress();
@@ -560,6 +521,59 @@ describe('SignUpStart', () => {
       );
 
       await waitFor(() => screen.getByText(/create your account/i));
+    });
+  });
+
+  describe('unsafeMetadata', () => {
+    it('does not throw when signUp.create rejects with an API error', async () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { href: 'http://localhost/sign-up' },
+      });
+
+      let unhandledError: unknown = null;
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledError = reason;
+      };
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withEmailAddress({ required: true });
+        f.withPassword({ required: true });
+      });
+      fixtures.signUp.create.mockRejectedValueOnce(
+        new ClerkAPIResponseError('Error', {
+          data: [
+            {
+              code: 'form_password_pwned',
+              long_message: 'Password has been found in an online data breach.',
+              message: 'Password has been found in an online data breach.',
+              meta: { param_name: 'password' },
+            },
+          ],
+          status: 422,
+        }),
+      );
+      props.setProps({ unsafeMetadata: { foo: 'bar' } });
+
+      const { userEvent } = render(
+        <CardStateProvider>
+          <SignUpStart />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      await userEvent.type(screen.getByLabelText(/email address/i), 'test@example.com');
+      await userEvent.type(screen.getByPlaceholderText(/create a password/i), 'password123');
+      await userEvent.click(screen.getByText(/continue/i));
+
+      await waitFor(() => expect(fixtures.signUp.create).toHaveBeenCalled());
+      await screen.findByTestId('form-feedback-error');
+      // Flush pending microtasks so any unhandled rejection event has a chance to fire.
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      process.off('unhandledRejection', onUnhandledRejection);
+      expect(unhandledError).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes `TypeError: e.clearFeedback is not a function` when `<SignUp unsafeMetadata={...} />` is used and a Clerk API error is thrown. The `unsafeMetadata` synthetic field pushed to `fieldsToSubmit` was missing `clearFeedback` and `setError` stubs, unlike every other synthetic field in the same function.

Fixes https://github.com/clerk/javascript/issues/8496 https://github.com/clerk/javascript/issues/3996

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
