### PR TITLE
feat(ui): Add flush appearance option

### DIFF
--- a/.changeset/card-elevation-option.md
+++ b/.changeset/card-elevation-option.md
@@ -3,3 +3,5 @@
 ---
 
 Add `elevation` appearance option with `'raised'` (default) and `'flush'` values. When set to `flush`, card-based components render without border, box-shadow, border-radius, outer padding, and footer background, allowing them to sit flat against their container. Applies to `<SignIn />`, `<SignUp />`, `<Waitlist />`, `<CreateOrganization />`, `<OrganizationList />`, `<OAuthConsent />`, `<UserVerification />`, and session task components. Profile and popover components always render as raised. Modal components always render as raised regardless of this setting.
+
+The `cardBox` element exposes a `data-elevation="flush"` attribute when flush is active, giving className-based themes a hook to neutralize their card chrome via attribute selectors. The `shadcn` theme uses this hook to drop its `shadow-sm border` utilities under flush.

--- a/.changeset/card-elevation-option.md
+++ b/.changeset/card-elevation-option.md
@@ -1,0 +1,5 @@
+---
+"@clerk/ui": minor
+---
+
+Add `elevation` appearance option with `'raised'` (default) and `'flush'` values. When set to `flush`, card-based components render without border, box-shadow, border-radius, outer padding, and footer background, allowing them to sit flat against their container. Applies to `<SignIn />`, `<SignUp />`, `<Waitlist />`, `<CreateOrganization />`, `<OrganizationList />`, `<OAuthConsent />`, `<UserVerification />`, and session task components. Profile and popover components always render as raised. Modal components always render as raised regardless of this setting.

--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -281,12 +281,25 @@ function otherOptions() {
     localization: document.getElementById('localizationSelect') as HTMLSelectElement,
   };
 
+  const elevationSelect = document.getElementById('elevationSelect') as HTMLSelectElement;
+  const devWarningsToggle = document.getElementById('devWarningsToggle') as HTMLInputElement;
+
   Object.entries(otherOptionsInputs).forEach(([key, input]) => {
     const savedValue = sessionStorage.getItem(key);
     if (savedValue) {
       input.value = savedValue;
     }
   });
+
+  const savedElevation = sessionStorage.getItem('elevation');
+  if (savedElevation) {
+    elevationSelect.value = savedElevation;
+  }
+
+  const savedDevWarnings = sessionStorage.getItem('devWarnings');
+  if (savedDevWarnings !== null) {
+    devWarningsToggle.checked = savedDevWarnings === 'on';
+  }
 
   const updateOtherOptions = () => {
     void Clerk.__internal_updateProps({
@@ -304,16 +317,40 @@ function otherOptions() {
     });
   };
 
+  const updateAppearanceOptions = () => {
+    sessionStorage.setItem('elevation', elevationSelect.value);
+    sessionStorage.setItem('devWarnings', devWarningsToggle.checked ? 'on' : 'off');
+    const currentAppearance = Clerk.__internal_getOption('appearance') ?? {};
+    void Clerk.__internal_updateProps({
+      appearance: {
+        ...currentAppearance,
+        options: {
+          ...(currentAppearance as any).options,
+          elevation: elevationSelect.value as 'raised' | 'flush',
+          unsafe_disableDevelopmentModeWarnings: !devWarningsToggle.checked,
+        },
+      },
+    });
+  };
+
   Object.values(otherOptionsInputs).forEach(input => {
     input.addEventListener('change', updateOtherOptions);
   });
 
+  elevationSelect.addEventListener('change', updateAppearanceOptions);
+  devWarningsToggle.addEventListener('change', updateAppearanceOptions);
+
   resetOtherOptionsBtn?.addEventListener('click', () => {
     otherOptionsInputs.localization.value = 'enUS';
+    elevationSelect.value = 'raised';
+    devWarningsToggle.checked = true;
+    sessionStorage.removeItem('elevation');
+    sessionStorage.removeItem('devWarnings');
     updateOtherOptions();
+    updateAppearanceOptions();
   });
 
-  return { updateOtherOptions };
+  return { updateOtherOptions, updateAppearanceOptions };
 }
 
 const themes: Record<string, unknown> = {
@@ -411,7 +448,7 @@ void (async () => {
   const { updateVariables } = appearanceVariableOptions();
   const { updateTheme } = themeSelector();
   const { updatePreset } = presetSelector();
-  const { updateOtherOptions } = otherOptions();
+  const { updateOtherOptions, updateAppearanceOptions } = otherOptions();
 
   const sidebars = document.querySelectorAll('[data-sidebar]');
   document.addEventListener('keydown', e => {
@@ -540,6 +577,15 @@ void (async () => {
     const initialTheme = initialThemeName ? themes[initialThemeName] : undefined;
     const initialPresetName = sessionStorage.getItem('preset') ?? '';
     const initialPreset = initialPresetName ? presets[initialPresetName] : undefined;
+    const initialElevation = sessionStorage.getItem('elevation') as 'raised' | 'flush' | null;
+    const initialDevWarnings = sessionStorage.getItem('devWarnings');
+    const initialAppearanceOptions: Record<string, unknown> = {};
+    if (initialElevation) {
+      initialAppearanceOptions.elevation = initialElevation;
+    }
+    if (initialDevWarnings === 'off') {
+      initialAppearanceOptions.unsafe_disableDevelopmentModeWarnings = true;
+    }
 
     await Clerk.load({
       ...(componentControls.clerk.getProps() ?? {}),
@@ -549,6 +595,7 @@ void (async () => {
       appearance: {
         ...(initialTheme ? { theme: initialTheme } : {}),
         ...presetToAppearance(initialPreset),
+        ...(Object.keys(initialAppearanceOptions).length ? { options: initialAppearanceOptions } : {}),
       },
     });
     renderCurrentRoute();
@@ -560,6 +607,7 @@ void (async () => {
       updateVariables();
     }
     updateOtherOptions();
+    updateAppearanceOptions();
   } else {
     console.error(`Unknown route: "${route}".`);
   }

--- a/packages/clerk-js/sandbox/template.html
+++ b/packages/clerk-js/sandbox/template.html
@@ -33,7 +33,7 @@
       }
     </script>
   </head>
-  <body class="flex min-h-full flex-col overflow-x-hidden bg-gray-50 lg:has-[*[data-sidebar]:not(.hidden)]:px-72">
+  <body class="flex min-h-full flex-col overflow-x-hidden bg-white lg:has-[*[data-sidebar]:not(.hidden)]:px-72">
     <div
       data-sidebar
       class="fixed inset-y-0 left-0 w-72 overflow-y-auto border-r border-gray-100 bg-white px-2 py-4 max-lg:hidden"
@@ -435,6 +435,24 @@
         <label class="flex items-center justify-between border-t border-gray-100 py-2">
           <span class="font-mono text-xs">localization</span>
           <select id="localizationSelect"></select>
+        </label>
+        <label class="flex items-center justify-between border-t border-gray-100 py-2">
+          <span class="font-mono text-xs">elevation</span>
+          <select
+            id="elevationSelect"
+            class="text-sm"
+          >
+            <option value="raised">raised</option>
+            <option value="flush">flush</option>
+          </select>
+        </label>
+        <label class="flex items-center justify-between border-t border-gray-100 py-2">
+          <span class="font-mono text-xs">devWarnings</span>
+          <input
+            type="checkbox"
+            id="devWarningsToggle"
+            checked
+          />
         </label>
       </fieldset>
     </div>

--- a/packages/ui/src/customizables/AppearanceContext.tsx
+++ b/packages/ui/src/customizables/AppearanceContext.tsx
@@ -23,4 +23,4 @@ const AppearanceProvider = (props: AppearanceProviderProps) => {
   return <AppearanceContext.Provider value={ctxValue}>{props.children}</AppearanceContext.Provider>;
 };
 
-export { AppearanceProvider, useAppearance };
+export { AppearanceContext, AppearanceProvider, useAppearance };

--- a/packages/ui/src/customizables/__tests__/parseAppearance.test.tsx
+++ b/packages/ui/src/customizables/__tests__/parseAppearance.test.tsx
@@ -238,6 +238,7 @@ describe('AppearanceProvider options flows', () => {
             showOptionalFields: false,
             socialButtonsPlacement: 'bottom',
             socialButtonsVariant: 'iconButton',
+            elevation: 'flush',
           },
         }}
       >
@@ -255,6 +256,7 @@ describe('AppearanceProvider options flows', () => {
     expect(result.current.parsedOptions.showOptionalFields).toBe(false);
     expect(result.current.parsedOptions.socialButtonsPlacement).toBe('bottom');
     expect(result.current.parsedOptions.socialButtonsVariant).toBe('iconButton');
+    expect(result.current.parsedOptions.elevation).toBe('flush');
   });
 
   it('sets the parsedOptions correctly from the appearance prop', () => {
@@ -272,6 +274,7 @@ describe('AppearanceProvider options flows', () => {
             showOptionalFields: true,
             socialButtonsPlacement: 'top',
             socialButtonsVariant: 'blockButton',
+            elevation: 'flush',
           },
         }}
       >
@@ -289,6 +292,7 @@ describe('AppearanceProvider options flows', () => {
     expect(result.current.parsedOptions.showOptionalFields).toBe(true);
     expect(result.current.parsedOptions.socialButtonsPlacement).toBe('top');
     expect(result.current.parsedOptions.socialButtonsVariant).toBe('blockButton');
+    expect(result.current.parsedOptions.elevation).toBe('flush');
   });
 
   it('sets the parsedOptions correctly from the globalAppearance and appearance prop', () => {
@@ -306,6 +310,7 @@ describe('AppearanceProvider options flows', () => {
             showOptionalFields: false,
             socialButtonsPlacement: 'bottom',
             socialButtonsVariant: 'iconButton',
+            elevation: 'flush',
           },
         }}
         appearance={{
@@ -319,6 +324,7 @@ describe('AppearanceProvider options flows', () => {
             showOptionalFields: true,
             socialButtonsPlacement: 'top',
             socialButtonsVariant: 'blockButton',
+            elevation: 'raised',
           },
         }}
       >
@@ -336,6 +342,7 @@ describe('AppearanceProvider options flows', () => {
     expect(result.current.parsedOptions.showOptionalFields).toBe(true);
     expect(result.current.parsedOptions.socialButtonsPlacement).toBe('top');
     expect(result.current.parsedOptions.socialButtonsVariant).toBe('blockButton');
+    expect(result.current.parsedOptions.elevation).toBe('raised');
   });
 
   it('removes the base theme when simpleStyles is passed to globalAppearance', () => {

--- a/packages/ui/src/customizables/index.ts
+++ b/packages/ui/src/customizables/index.ts
@@ -6,7 +6,7 @@ import { makeResponsive } from './makeResponsive';
 import { sanitizeDomProps } from './sanitizeDomProps';
 
 export * from './Flow';
-export { AppearanceProvider, useAppearance } from './AppearanceContext';
+export { AppearanceContext, AppearanceProvider, useAppearance } from './AppearanceContext';
 export { descriptors } from './elementDescriptors';
 export { localizationKeys, useLocalizations } from '../localization';
 export type { LocalizationKey } from '../localization';

--- a/packages/ui/src/customizables/parseAppearance.ts
+++ b/packages/ui/src/customizables/parseAppearance.ts
@@ -52,6 +52,7 @@ const defaultOptions: ParsedOptions = {
   animations: true,
   unsafe_disableDevelopmentModeWarnings: false,
   autoFocus: true,
+  elevation: 'raised',
 };
 
 const defaultCaptchaOptions: ParsedCaptcha = {

--- a/packages/ui/src/elements/Card/CardClerkAndPagesTag.tsx
+++ b/packages/ui/src/elements/Card/CardClerkAndPagesTag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useEnvironment } from '../../contexts';
-import { Box, Col, Flex, Icon, Link, Text } from '../../customizables';
+import { Box, Col, descriptors, Flex, Icon, Link, Text } from '../../customizables';
 import { useDevMode } from '../../hooks/useDevMode';
 import { LogoMark } from '../../icons';
 import type { PropsOfComponent, ThemableCssProp } from '../../styledSystem';
@@ -28,6 +28,7 @@ export const CardClerkAndPagesTag = React.memo(
 
     return (
       <Box
+        elementDescriptor={descriptors.footerItem}
         sx={[
           {
             width: '100%',

--- a/packages/ui/src/elements/Card/CardRoot.tsx
+++ b/packages/ui/src/elements/Card/CardRoot.tsx
@@ -1,17 +1,91 @@
 import React from 'react';
 
-import { Col, descriptors, generateFlowPartClassname, useAppearance } from '../../customizables';
+import { AppearanceContext, Col, descriptors, generateFlowPartClassname, useAppearance } from '../../customizables';
 import type { ElementDescriptor } from '../../customizables/elementDescriptors';
 import type { PropsOfComponent } from '../../styledSystem';
 import { mqu } from '../../styledSystem';
 import { ApplicationLogo } from '../ApplicationLogo';
 import { useFlowMetadata } from '../contexts';
+import { ModalContext } from '../Modal';
+
+const FLUSH_ELEMENTS = {
+  cardBox: {
+    borderWidth: 0,
+    borderRadius: 0,
+    boxShadow: 'none',
+    overflow: 'visible',
+  },
+  card: {
+    borderWidth: 0,
+    borderRadius: 0,
+    boxShadow: 'none',
+    backgroundColor: 'transparent',
+    padding: 0,
+    marginBlockStart: 0,
+    marginInline: 0,
+  },
+  footer: {
+    background: 'transparent',
+  },
+  scrollBox: {
+    borderWidth: 0,
+    borderRadius: 0,
+    boxShadow: 'none',
+    backgroundColor: 'transparent',
+    marginBlock: 0,
+    marginInlineEnd: 0,
+  },
+  navbar: {
+    background: 'transparent',
+  },
+  navbarMobileMenuRow: {
+    background: 'transparent',
+  },
+};
 
 type CardRootProps = PropsOfComponent<typeof Col>;
 export const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>((props, ref) => {
   const { sx, children, ...rest } = props;
   const appearance = useAppearance();
   const flowMetadata = useFlowMetadata();
+
+  const rawModalCtx = React.useContext(ModalContext);
+  const isModal = rawModalCtx !== undefined;
+  const isFlush = appearance.parsedOptions.elevation === 'flush' && !isModal;
+
+  const augmentedAppearance = React.useMemo(() => {
+    if (!isFlush) {
+      return appearance;
+    }
+    const newParsedElements = [appearance.parsedElements[0], FLUSH_ELEMENTS, ...appearance.parsedElements.slice(1)];
+    return { ...appearance, parsedElements: newParsedElements };
+  }, [appearance, isFlush]);
+
+  const cardBox = (
+    <Col
+      elementDescriptor={[descriptors.cardBox, props.elementDescriptor as ElementDescriptor]}
+      className={generateFlowPartClassname(flowMetadata)}
+      ref={ref}
+      sx={[
+        t => ({
+          isolation: 'isolate',
+          maxWidth: `calc(100vw - ${t.sizes.$10})`,
+          width: t.sizes.$100,
+          borderWidth: t.borderWidths.$normal,
+          borderStyle: t.borderStyles.$solid,
+          borderColor: t.colors.$borderAlpha150,
+          borderRadius: t.radii.$xl,
+          color: t.colors.$colorForeground,
+          position: 'relative',
+          overflow: 'hidden',
+        }),
+        sx,
+      ]}
+      {...rest}
+    >
+      {children}
+    </Col>
+  );
 
   return (
     <>
@@ -25,33 +99,11 @@ export const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>((props, 
           })}
         />
       )}
-      <Col
-        elementDescriptor={[descriptors.cardBox, props.elementDescriptor as ElementDescriptor]}
-        className={generateFlowPartClassname(flowMetadata)}
-        ref={ref}
-        sx={[
-          t => ({
-            /**
-             * All components should create their own stack context
-             * https://developer.mozilla.org/en-US/docs/Web/CSS/isolation
-             */
-            isolation: 'isolate',
-            maxWidth: `calc(100vw - ${t.sizes.$10})`,
-            width: t.sizes.$100,
-            borderWidth: t.borderWidths.$normal,
-            borderStyle: t.borderStyles.$solid,
-            borderColor: t.colors.$borderAlpha150,
-            borderRadius: t.radii.$xl,
-            color: t.colors.$colorForeground,
-            position: 'relative',
-            overflow: 'hidden',
-          }),
-          sx,
-        ]}
-        {...rest}
-      >
-        {children}
-      </Col>
+      {isFlush ? (
+        <AppearanceContext.Provider value={{ value: augmentedAppearance }}>{cardBox}</AppearanceContext.Provider>
+      ) : (
+        cardBox
+      )}
     </>
   );
 });

--- a/packages/ui/src/elements/Card/CardRoot.tsx
+++ b/packages/ui/src/elements/Card/CardRoot.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 
 import { AppearanceContext, Col, descriptors, generateFlowPartClassname, useAppearance } from '../../customizables';
 import type { ElementDescriptor } from '../../customizables/elementDescriptors';
-import type { PropsOfComponent } from '../../styledSystem';
+import type { InternalTheme, PropsOfComponent } from '../../styledSystem';
 import { mqu } from '../../styledSystem';
 import { ApplicationLogo } from '../ApplicationLogo';
 import { useFlowMetadata } from '../contexts';
 import { ModalContext } from '../Modal';
 
-// Element style overrides for flush elevation. Injected into parsedElements at
+// Element style overrides for flush elevation. Resolved with the current theme
+// so values like `t.space.$4` are available, then injected into parsedElements at
 // index 1 (after baseTheme, before user overrides) via AppearanceContext so they
 // participate in the makeCustomizable cascade and can still be overridden by users.
-const FLUSH_ELEMENTS = {
+const getFlushElements = (t: InternalTheme) => ({
   cardBox: {
     borderWidth: 0,
     borderRadius: 0,
@@ -23,23 +24,25 @@ const FLUSH_ELEMENTS = {
     borderRadius: 0,
     boxShadow: 'none',
     backgroundColor: 'transparent',
-    padding: 0,
+    paddingInline: 0,
+    paddingBlock: 0,
     marginBlockStart: 0,
     marginInline: 0,
   },
   footer: {
     background: 'transparent',
-    marginTop: 0,
+    marginTop: t.space.$8,
     paddingTop: 0,
+    rowGap: t.space.$8,
     '>:first-of-type': {
-      paddingInline: 0,
+      padding: 0,
     },
     '>:not(:first-of-type)': {
       borderTopWidth: 0,
-      paddingInline: 0,
+      padding: 0,
     },
   },
-};
+});
 
 type CardRootProps = PropsOfComponent<typeof Col> & {
   /**
@@ -65,7 +68,8 @@ export const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>((props, 
     if (!isFlush) {
       return appearance;
     }
-    const newParsedElements = [appearance.parsedElements[0], FLUSH_ELEMENTS, ...appearance.parsedElements.slice(1)];
+    const flushElements = getFlushElements(appearance.parsedInternalTheme);
+    const newParsedElements = [appearance.parsedElements[0], flushElements, ...appearance.parsedElements.slice(1)];
     return { ...appearance, parsedElements: newParsedElements };
   }, [appearance, isFlush]);
 

--- a/packages/ui/src/elements/Card/CardRoot.tsx
+++ b/packages/ui/src/elements/Card/CardRoot.tsx
@@ -8,10 +8,7 @@ import { ApplicationLogo } from '../ApplicationLogo';
 import { useFlowMetadata } from '../contexts';
 import { ModalContext } from '../Modal';
 
-// Element style overrides for flush elevation. Resolved with the current theme
-// so values like `t.space.$4` are available, then injected into parsedElements at
-// index 1 (after baseTheme, before user overrides) via AppearanceContext so they
-// participate in the makeCustomizable cascade and can still be overridden by users.
+// Flush overrides injected into parsedElements after baseTheme but before user overrides.
 const getFlushElements = (t: InternalTheme) => ({
   cardBox: {
     borderWidth: 0,

--- a/packages/ui/src/elements/Card/CardRoot.tsx
+++ b/packages/ui/src/elements/Card/CardRoot.tsx
@@ -8,6 +8,9 @@ import { ApplicationLogo } from '../ApplicationLogo';
 import { useFlowMetadata } from '../contexts';
 import { ModalContext } from '../Modal';
 
+// Element style overrides for flush elevation. Injected into parsedElements at
+// index 1 (after baseTheme, before user overrides) via AppearanceContext so they
+// participate in the makeCustomizable cascade and can still be overridden by users.
 const FLUSH_ELEMENTS = {
   cardBox: {
     borderWidth: 0,
@@ -26,32 +29,37 @@ const FLUSH_ELEMENTS = {
   },
   footer: {
     background: 'transparent',
-  },
-  scrollBox: {
-    borderWidth: 0,
-    borderRadius: 0,
-    boxShadow: 'none',
-    backgroundColor: 'transparent',
-    marginBlock: 0,
-    marginInlineEnd: 0,
-  },
-  navbar: {
-    background: 'transparent',
-  },
-  navbarMobileMenuRow: {
-    background: 'transparent',
+    marginTop: 0,
+    paddingTop: 0,
+    '>:first-of-type': {
+      paddingInline: 0,
+    },
+    '>:not(:first-of-type)': {
+      borderTopWidth: 0,
+      paddingInline: 0,
+    },
   },
 };
 
-type CardRootProps = PropsOfComponent<typeof Col>;
+type CardRootProps = PropsOfComponent<typeof Col> & {
+  /**
+   * Override the visual elevation for this card instance.
+   * When omitted, falls back to `appearance.options.elevation` for page-mounted
+   * components, and `'raised'` for modals.
+   * Profile and popover card roots pass `'raised'` explicitly to opt out of flush.
+   */
+  elevation?: 'raised' | 'flush';
+};
 export const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>((props, ref) => {
-  const { sx, children, ...rest } = props;
+  const { sx, children, elevation: elevationProp, ...rest } = props;
   const appearance = useAppearance();
   const flowMetadata = useFlowMetadata();
 
   const rawModalCtx = React.useContext(ModalContext);
   const isModal = rawModalCtx !== undefined;
-  const isFlush = appearance.parsedOptions.elevation === 'flush' && !isModal;
+  // Explicit prop wins; modals always raised; otherwise use appearance option
+  const elevation = elevationProp ?? (isModal ? 'raised' : appearance.parsedOptions.elevation);
+  const isFlush = elevation === 'flush';
 
   const augmentedAppearance = React.useMemo(() => {
     if (!isFlush) {

--- a/packages/ui/src/elements/Card/CardRoot.tsx
+++ b/packages/ui/src/elements/Card/CardRoot.tsx
@@ -74,6 +74,7 @@ export const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>((props, 
       elementDescriptor={[descriptors.cardBox, props.elementDescriptor as ElementDescriptor]}
       className={generateFlowPartClassname(flowMetadata)}
       ref={ref}
+      data-elevation={isFlush ? 'flush' : undefined}
       sx={[
         t => ({
           isolation: 'isolate',

--- a/packages/ui/src/elements/Card/__tests__/CardRoot.test.tsx
+++ b/packages/ui/src/elements/Card/__tests__/CardRoot.test.tsx
@@ -1,0 +1,179 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AppearanceProvider, useAppearance } from '@/customizables';
+import type { ParsedAppearance } from '@/customizables/parseAppearance';
+import { FlowMetadataProvider } from '@/elements/contexts';
+import { ModalContext } from '@/elements/Modal';
+import { InternalThemeProvider } from '@/styledSystem';
+
+import { CardRoot } from '../CardRoot';
+
+let captured: ParsedAppearance;
+const AppearanceCapture = () => {
+  captured = useAppearance();
+  return null;
+};
+
+const hasFlushShape = (elements: ParsedAppearance['parsedElements']) =>
+  elements.some(el => el.cardBox?.boxShadow === 'none' && el.card?.backgroundColor === 'transparent');
+
+type RenderCardOptions = {
+  elevation?: 'raised' | 'flush';
+  globalAppearance?: Record<string, unknown>;
+  appearance?: Record<string, unknown>;
+  withModal?: boolean;
+};
+
+const renderCard = ({ elevation, globalAppearance, appearance, withModal }: RenderCardOptions = {}) => {
+  const card = (
+    <CardRoot elevation={elevation}>
+      <AppearanceCapture />
+    </CardRoot>
+  );
+
+  return render(
+    <AppearanceProvider
+      appearanceKey='signIn'
+      globalAppearance={globalAppearance as any}
+      appearance={appearance as any}
+    >
+      <InternalThemeProvider>
+        <FlowMetadataProvider flow='signIn'>
+          {withModal ? <ModalContext.Provider value={{ value: {} }}>{card}</ModalContext.Provider> : card}
+        </FlowMetadataProvider>
+      </InternalThemeProvider>
+    </AppearanceProvider>,
+  );
+};
+
+describe('CardRoot augmentedAppearance — raised (default)', () => {
+  beforeEach(() => {
+    captured = undefined as any;
+  });
+
+  it('children see original parsedElements when elevation is raised', () => {
+    renderCard();
+    expect(hasFlushShape(captured.parsedElements)).toBe(false);
+  });
+
+  it('explicit raised prop overrides flush option', () => {
+    renderCard({
+      elevation: 'raised',
+      appearance: { options: { elevation: 'flush' } },
+    });
+    expect(hasFlushShape(captured.parsedElements)).toBe(false);
+  });
+});
+
+describe('CardRoot augmentedAppearance — flush', () => {
+  beforeEach(() => {
+    captured = undefined as any;
+  });
+
+  it('flush overrides appear at index 1 after base theme', () => {
+    renderCard({ elevation: 'flush' });
+    expect(captured.parsedElements[1].cardBox?.boxShadow).toBe('none');
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+    expect(captured.parsedElements[1].footer?.paddingTop).toBe(0);
+  });
+
+  it('preserves parsedInternalTheme, parsedOptions, and parsedCaptcha through augmentation', () => {
+    renderCard({ elevation: 'raised' });
+    const { parsedInternalTheme: raisedTheme, parsedOptions: raisedOptions, parsedCaptcha: raisedCaptcha } = captured;
+
+    renderCard({ elevation: 'flush' });
+    expect(captured.parsedInternalTheme).toEqual(raisedTheme);
+    expect(captured.parsedOptions).toEqual(raisedOptions);
+    expect(captured.parsedCaptcha).toEqual(raisedCaptcha);
+  });
+
+  it('parsedElements length increases by 1 when flush is active', () => {
+    renderCard({ elevation: 'raised' });
+    const raisedLength = captured.parsedElements.length;
+
+    renderCard({ elevation: 'flush' });
+    expect(captured.parsedElements.length).toBe(raisedLength + 1);
+  });
+
+  it('user appearance.elements.card appears after flush overrides', () => {
+    renderCard({
+      elevation: 'flush',
+      appearance: { elements: { card: { backgroundColor: 'hotpink' } } },
+    });
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+    expect(captured.parsedElements[2].card?.backgroundColor).toBe('hotpink');
+  });
+
+  it('globalAppearance.elements appear after flush overrides', () => {
+    renderCard({
+      elevation: 'flush',
+      globalAppearance: { elements: { card: { backgroundColor: 'hotpink' } } },
+    });
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+    expect(captured.parsedElements[2].card?.backgroundColor).toBe('hotpink');
+  });
+
+  it('both global and component element layers are preserved in order after flush', () => {
+    renderCard({
+      elevation: 'flush',
+      globalAppearance: { elements: { card: { color: 'blue' } } },
+      appearance: { elements: { card: { color: 'red' } } },
+    });
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+    expect(captured.parsedElements[2].card?.color).toBe('blue');
+    expect(captured.parsedElements[3].card?.color).toBe('red');
+  });
+
+  it('elevation via appearance.options activates flush', () => {
+    renderCard({
+      appearance: { options: { elevation: 'flush' } },
+    });
+    expect(captured.parsedElements[1].cardBox?.boxShadow).toBe('none');
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+  });
+});
+
+describe('CardRoot elevation resolution priority', () => {
+  beforeEach(() => {
+    captured = undefined as any;
+  });
+
+  it('modal context forces raised even when option is flush', () => {
+    renderCard({
+      withModal: true,
+      appearance: { options: { elevation: 'flush' } },
+    });
+    expect(hasFlushShape(captured.parsedElements)).toBe(false);
+  });
+
+  it('explicit flush prop overrides modal context', () => {
+    renderCard({
+      elevation: 'flush',
+      withModal: true,
+    });
+    expect(captured.parsedElements[1].cardBox?.boxShadow).toBe('none');
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+  });
+});
+
+describe('CardRoot data-elevation attribute', () => {
+  it('data-elevation is absent when raised', () => {
+    const { container } = renderCard();
+    expect(container.querySelector('[data-elevation]')).toBeNull();
+  });
+
+  it('data-elevation is flush when elevation is flush', () => {
+    const { container } = renderCard({ elevation: 'flush' });
+    expect(container.querySelector('[data-elevation="flush"]')).not.toBeNull();
+  });
+
+  it('data-elevation is absent when modal forces raised', () => {
+    const { container } = renderCard({
+      withModal: true,
+      appearance: { options: { elevation: 'flush' } },
+    });
+    expect(container.querySelector('[data-elevation]')).toBeNull();
+  });
+});

--- a/packages/ui/src/elements/Card/__tests__/CardRoot.test.tsx
+++ b/packages/ui/src/elements/Card/__tests__/CardRoot.test.tsx
@@ -133,6 +133,33 @@ describe('CardRoot augmentedAppearance — flush', () => {
     expect(captured.parsedElements[1].cardBox?.boxShadow).toBe('none');
     expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
   });
+
+  it('user string classname elements are preserved after flush overrides', () => {
+    renderCard({
+      elevation: 'flush',
+      appearance: { elements: { card: 'my-custom-class' } },
+    });
+    expect(captured.parsedElements[1].card?.backgroundColor).toBe('transparent');
+    expect(captured.parsedElements[2].card).toBe('my-custom-class');
+  });
+
+  it('user footer overrides with nested selectors appear after flush footer', () => {
+    renderCard({
+      elevation: 'flush',
+      appearance: {
+        elements: {
+          footer: {
+            background: 'blue',
+            '>:first-of-type': { padding: '16px' },
+          },
+        },
+      },
+    });
+    expect(captured.parsedElements[1].footer?.background).toBe('transparent');
+    expect(captured.parsedElements[1].footer?.['>:first-of-type']?.padding).toBe(0);
+    expect(captured.parsedElements[2].footer?.background).toBe('blue');
+    expect(captured.parsedElements[2].footer?.['>:first-of-type']?.padding).toBe('16px');
+  });
 });
 
 describe('CardRoot elevation resolution priority', () => {

--- a/packages/ui/src/elements/PopoverCard.tsx
+++ b/packages/ui/src/elements/PopoverCard.tsx
@@ -28,6 +28,8 @@ const PopoverCardRoot = React.forwardRef<
         elementDescriptor={[descriptors.popoverBox, elementDescriptor as ElementDescriptor]}
         {...rest}
         ref={ref}
+        // Popover cards always render as raised — flush is scoped to simple card components
+        elevation='raised'
         sx={[
           t => ({
             width: t.sizes.$94,

--- a/packages/ui/src/elements/ProfileCard/ProfileCardRoot.tsx
+++ b/packages/ui/src/elements/ProfileCard/ProfileCardRoot.tsx
@@ -15,6 +15,8 @@ export const ProfileCardRoot = React.forwardRef<HTMLDivElement, PropsOfComponent
   return (
     <Card.Root
       ref={ref}
+      // Profile cards always render as raised — flush is scoped to simple card components
+      elevation='raised'
       sx={[
         t => ({
           width: t.sizes.$220,

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -1004,11 +1004,20 @@ export type Options = {
   autoFocus?: boolean;
 
   /**
-   * Controls the visual elevation of card components.
-   * `raised` preserves the default appearance with border, shadow, and padding.
-   * `flush` removes the card border, box-shadow, border-radius, outer padding, and footer background,
-   * making the component sit flat against its container.
-   * Only applies to page-mounted components — modals always use `raised`.
+   * Controls the visual elevation of card-based components.
+   *
+   * - `'raised'` (default) — the card renders with its border, box-shadow, border-radius, and padding.
+   * - `'flush'` — removes the card border, box-shadow, border-radius, outer padding, and footer
+   *   background so the component sits flat against its container.
+   *
+   * Applies to all card-based components including `<SignIn />`, `<SignUp />`,
+   * `<Waitlist />`, `<CreateOrganization />`, `<OrganizationList />`,
+   * `<OAuthConsent />`, `<UserVerification />`, and session task components.
+   *
+   * Does **not** affect profile components (`<UserProfile />`, `<OrganizationProfile />`)
+   * or popover components (`<UserButton />`, `<OrganizationSwitcher />`), which always render as raised.
+   *
+   * When a component is opened as a modal, it always renders as raised regardless of this setting.
    *
    * @default 'raised'
    */

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -1002,6 +1002,17 @@ export type Options = {
    * @default true
    */
   autoFocus?: boolean;
+
+  /**
+   * Controls the visual elevation of card components.
+   * `raised` preserves the default appearance with border, shadow, and padding.
+   * `flush` removes the card border, box-shadow, border-radius, outer padding, and footer background,
+   * making the component sit flat against its container.
+   * Only applies to page-mounted components — modals always use `raised`.
+   *
+   * @default 'raised'
+   */
+  elevation?: 'raised' | 'flush';
 };
 
 export type CaptchaAppearanceOptions = {

--- a/packages/ui/src/themes/shadcn.ts
+++ b/packages/ui/src/themes/shadcn.ts
@@ -25,7 +25,7 @@ export const shadcn = createTheme({
   },
   elements: {
     input: 'bg-transparent dark:bg-input/30',
-    cardBox: 'shadow-sm border',
+    cardBox: 'shadow-sm border data-[elevation=flush]:shadow-none data-[elevation=flush]:border-0',
     popoverBox: 'shadow-sm border',
     button: {
       '&[data-variant="solid"]::after': {


### PR DESCRIPTION
## Description

Introduce new `elevation` appearance option that allows rendering components "flush" on the page vs being wrapped in a card. Options include `raised|flush` with `raised` being the default for backwards compat.

Note this only applies to page-mounted components modals/popovers always use `raised`.

| Raised | Flush |
|--------|--------|
| <img width="1056" height="934" alt="Screenshot 2026-05-08 at 9 57 02 AM" src="https://github.com/user-attachments/assets/33a5c6cb-449d-4fcf-a5f7-588b084ba74e" /> | <img width="1000" height="945" alt="Screenshot 2026-05-08 at 9 57 33 AM" src="https://github.com/user-attachments/assets/e2c274d3-fa56-4781-89f2-e69243ee0e45" /> | 

Docs: https://github.com/clerk/clerk-docs/pull/3355

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
