### PR TITLE
chore(ui): Gate `<ConfigureSSO />` based on organization system permission

### DIFF
--- a/.changeset/legal-numbers-fry.md
+++ b/.changeset/legal-numbers-fry.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Update `<ConfigureSSO />` in the context of organizations to only allow managing enterprise connections based on system permission

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -179,6 +179,10 @@ export const arSA: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'تواصل مع مسؤول مؤسستك للحصول على أذونات لإدارة الاتصالات المؤسسية.',
+      title: 'ليس لديك إذن لإدارة الاتصالات المؤسسية',
+    },
     navbar: {
       title: 'تكوين تسجيل الدخول الموحد (SSO)',
     },

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -179,6 +179,11 @@ export const beBY: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Звярніцеся да адміністратара вашай арганізацыі, каб атрымаць дазволы на кіраванне карпаратыўнымі падключэннямі.',
+      title: 'У вас няма дазволу на кіраванне карпаратыўнымі падключэннямі',
+    },
     navbar: {
       title: 'Налада адзінага ўваходу (SSO)',
     },

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -180,6 +180,11 @@ export const bgBG: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Свържете се с администратора на вашата организация, за да получите разрешения за управление на корпоративни връзки.',
+      title: 'Нямате разрешение да управлявате корпоративни връзки',
+    },
     navbar: {
       title: 'Конфигуриране на единен вход (SSO)',
     },

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -179,6 +179,10 @@ export const bnIN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'এন্টারপ্রাইজ সংযোগ পরিচালনার অনুমতি পেতে আপনার সংস্থার প্রশাসকের সাথে যোগাযোগ করুন।',
+      title: 'এন্টারপ্রাইজ সংযোগ পরিচালনার অনুমতি আপনার নেই',
+    },
     navbar: {
       title: 'একক সাইন-অন (SSO) কনফিগার করুন',
     },

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -186,6 +186,11 @@ export const caES: LocalizationResource = {
     year: 'Any',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        "Contacta amb l'administrador de la teva organització per obtenir permisos per gestionar connexions empresarials.",
+      title: 'No tens permís per gestionar connexions empresarials',
+    },
     navbar: {
       title: "Configura l'inici de sessió únic (SSO)",
     },

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -183,6 +183,10 @@ export const csCZ: LocalizationResource = {
     year: 'Rok',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Kontaktujte správce vaší organizace, abyste získali oprávnění ke správě podnikových připojení.',
+      title: 'Nemáte oprávnění ke správě podnikových připojení',
+    },
     navbar: {
       title: 'Nastavit jednotné přihlášení (SSO)',
     },

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -179,6 +179,11 @@ export const daDK: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Kontakt din organisations administrator for at få tilladelse til at administrere virksomhedsforbindelser.',
+      title: 'Du har ikke tilladelse til at administrere virksomhedsforbindelser',
+    },
     navbar: {
       title: 'Konfigurer single sign-on (SSO)',
     },

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -185,6 +185,11 @@ export const deDE: LocalizationResource = {
     year: 'Jahr',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Wenden Sie sich an Ihren Organisationsadministrator, um Berechtigungen zur Verwaltung von Enterprise-Verbindungen zu erhalten.',
+      title: 'Sie haben keine Berechtigung, Enterprise-Verbindungen zu verwalten',
+    },
     navbar: {
       title: 'Single Sign-On (SSO) konfigurieren',
     },

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -179,6 +179,11 @@ export const elGR: LocalizationResource = {
     year: 'έτος',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Επικοινωνήστε με τον διαχειριστή του οργανισμού σας για να αποκτήσετε άδειες διαχείρισης εταιρικών συνδέσεων.',
+      title: 'Δεν έχετε άδεια διαχείρισης εταιρικών συνδέσεων',
+    },
     navbar: {
       title: 'Διαμόρφωση Ενιαίας Σύνδεσης (SSO)',
     },

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -179,6 +179,11 @@ export const enGB: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contact your organisation administrator in order to have permissions to manage enterprise connections.',
+      title: 'You do not have permission to manage enterprise connections',
+    },
     navbar: {
       title: 'Configure Single Sign-On (SSO)',
     },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -201,6 +201,11 @@ export const enUS: LocalizationResource = {
     yearPerUnit: 'Year per {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contact your organization administrator in order to have permissions to manage enterprise connections.',
+      title: 'You do not have permission to manage enterprise connections',
+    },
     navbar: {
       title: 'Configure Single Sign-On (SSO)',
     },

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -179,6 +179,11 @@ export const esCR: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contacta al administrador de tu organización para obtener permisos para gestionar conexiones de empresa.',
+      title: 'No tenés permiso para gestionar conexiones de empresa',
+    },
     navbar: {
       title: 'Configurar inicio de sesión único (SSO)',
     },

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -185,6 +185,11 @@ export const esES: LocalizationResource = {
     year: 'Año',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contacte al administrador de su organización para obtener permisos para gestionar conexiones empresariales.',
+      title: 'No tiene permiso para gestionar conexiones empresariales',
+    },
     navbar: {
       title: 'Configurar inicio de sesión único (SSO)',
     },

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -180,6 +180,11 @@ export const esMX: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contacta al administrador de tu organización para obtener permisos para administrar conexiones de empresa.',
+      title: 'No tienes permiso para administrar conexiones de empresa',
+    },
     navbar: {
       title: 'Configurar inicio de sesión único (SSO)',
     },

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -179,6 +179,11 @@ export const esUY: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contactá al administrador de tu organización para obtener permisos para gestionar conexiones empresariales.',
+      title: 'No tenés permiso para gestionar conexiones empresariales',
+    },
     navbar: {
       title: 'Configurar inicio de sesión único (SSO)',
     },

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -184,6 +184,10 @@ export const faIR: LocalizationResource = {
     year: 'سال',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'برای دریافت مجوز مدیریت اتصالات سازمانی با مدیر سازمان خود تماس بگیرید.',
+      title: 'شما اجازه مدیریت اتصالات سازمانی را ندارید',
+    },
     navbar: {
       title: 'پیکربندی ورود یکپارچه (SSO)',
     },

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -207,6 +207,10 @@ export const fiFI: LocalizationResource = {
     yearPerUnit: 'Vuosi per {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Ota yhteyttä organisaatiosi järjestelmänvalvojaan saadaksesi oikeudet hallita yritysyhteyksiä.',
+      title: 'Sinulla ei ole oikeutta hallita yritysyhteyksiä',
+    },
     navbar: {
       title: 'Määritä kertakirjautuminen (SSO)',
     },

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -187,6 +187,11 @@ export const frFR: LocalizationResource = {
     year: 'An',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        "Contactez l'administrateur de votre organisation afin d'obtenir les permissions pour gérer les connexions d'entreprise.",
+      title: "Vous n'avez pas la permission de gérer les connexions d'entreprise",
+    },
     navbar: {
       title: "Configurer l'authentification unique (SSO)",
     },

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -179,6 +179,10 @@ export const heIL: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'פנה למנהל הארגון שלך כדי לקבל הרשאות לניהול חיבורים ארגוניים.',
+      title: 'אין לך הרשאה לנהל חיבורים ארגוניים',
+    },
     navbar: {
       title: 'הגדרת כניסה אחידה (SSO)',
     },

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -179,6 +179,11 @@ export const hiIN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'एंटरप्राइज़ कनेक्शन प्रबंधित करने की अनुमति प्राप्त करने के लिए अपने संगठन के व्यवस्थापक से संपर्क करें।',
+      title: 'आपके पास एंटरप्राइज़ कनेक्शन प्रबंधित करने की अनुमति नहीं है',
+    },
     navbar: {
       title: 'सिंगल साइन-ऑन (SSO) कॉन्फ़िगर करें',
     },

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -208,6 +208,11 @@ export const hrHR: LocalizationResource = {
     yearPerUnit: 'Godina po {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Obratite se administratoru vaše organizacije kako biste dobili dopuštenja za upravljanje poslovnim vezama.',
+      title: 'Nemate dopuštenje za upravljanje poslovnim vezama',
+    },
     navbar: {
       title: 'Konfiguriraj jedinstvenu prijavu (SSO)',
     },

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -208,6 +208,11 @@ export const huHU: LocalizationResource = {
     yearPerUnit: 'Év / {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Vegye fel a kapcsolatot szervezete adminisztrátorával, hogy jogosultságot kapjon a vállalati kapcsolatok kezelésére.',
+      title: 'Nincs jogosultsága vállalati kapcsolatok kezelésére',
+    },
     navbar: {
       title: 'Egyszeri bejelentkezés (SSO) beállítása',
     },

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -179,6 +179,10 @@ export const idID: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Hubungi administrator organisasi Anda untuk mendapatkan izin mengelola koneksi enterprise.',
+      title: 'Anda tidak memiliki izin untuk mengelola koneksi enterprise',
+    },
     navbar: {
       title: 'Konfigurasi Single Sign-On (SSO)',
     },

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -207,6 +207,11 @@ export const isIS: LocalizationResource = {
     yearPerUnit: 'Ár á {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Hafðu samband við stjórnanda fyrirtækisins þíns til að fá heimildir til að stjórna fyrirtækjatengingum.',
+      title: 'Þú hefur ekki heimild til að stjórna fyrirtækjatengingum',
+    },
     navbar: {
       title: 'Stilla einnar innskráningar (SSO)',
     },

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -185,6 +185,11 @@ export const itIT: LocalizationResource = {
     year: 'Anno',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        "Contatta l'amministratore della tua organizzazione per ottenere i permessi per gestire le connessioni aziendali.",
+      title: 'Non hai il permesso di gestire le connessioni aziendali',
+    },
     navbar: {
       title: 'Configura Single Sign-On (SSO)',
     },

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -190,6 +190,10 @@ export const jaJP: LocalizationResource = {
     year: '年',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'エンタープライズ接続を管理する権限を取得するには、組織の管理者にお問い合わせください。',
+      title: 'エンタープライズ接続を管理する権限がありません',
+    },
     navbar: {
       title: 'シングルサインオン（SSO）を設定',
     },

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -179,6 +179,10 @@ export const kkKZ: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Корпоративтік қосылыстарды басқару рұқсаттарын алу үшін ұйым әкімшісіне хабарласыңыз.',
+      title: 'Сізде корпоративтік қосылыстарды басқаруға рұқсат жоқ',
+    },
     navbar: {
       title: 'Бірыңғай кіруді конфигурациялау (SSO)',
     },

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -186,6 +186,10 @@ export const koKR: LocalizationResource = {
     year: '년',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: '엔터프라이즈 연결을 관리할 권한을 얻으려면 조직 관리자에게 문의하세요.',
+      title: '엔터프라이즈 연결을 관리할 권한이 없습니다',
+    },
     navbar: {
       title: '싱글 사인온(SSO) 구성',
     },

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -179,6 +179,10 @@ export const mnMN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Аж ахуйн нэгжийн холболтыг удирдах эрх авахын тулд байгууллагынхаа админтай холбогдоно уу.',
+      title: 'Танд аж ахуйн нэгжийн холболтыг удирдах эрх байхгүй байна',
+    },
     navbar: {
       title: 'Нэгдсэн нэвтрэлт (SSO) тохируулах',
     },

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -179,6 +179,10 @@ export const msMY: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Hubungi pentadbir organisasi anda untuk mendapatkan kebenaran mengurus sambungan perusahaan.',
+      title: 'Anda tidak mempunyai kebenaran untuk mengurus sambungan perusahaan',
+    },
     navbar: {
       title: 'Konfigurasi Log Masuk Tunggal (SSO)',
     },

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -208,6 +208,10 @@ export const nbNO: LocalizationResource = {
     yearPerUnit: 'År per {{unitName}}',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Kontakt organisasjonens administrator for å få tillatelser til å administrere bedriftstilkoblinger.',
+      title: 'Du har ikke tillatelse til å administrere bedriftstilkoblinger',
+    },
     navbar: {
       title: 'Konfigurer enkeltpålogging (SSO)',
     },

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -179,6 +179,11 @@ export const nlBE: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Neem contact op met de beheerder van uw organisatie om toestemming te krijgen voor het beheren van enterprise-verbindingen.',
+      title: 'U hebt geen toestemming om enterprise-verbindingen te beheren',
+    },
     navbar: {
       title: 'Single sign-on (SSO) configureren',
     },

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -179,6 +179,11 @@ export const nlNL: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Neem contact op met de beheerder van je organisatie om toestemming te krijgen voor het beheren van enterprise-verbindingen.',
+      title: 'Je hebt geen toestemming om enterprise-verbindingen te beheren',
+    },
     navbar: {
       title: 'Single sign-on (SSO) configureren',
     },

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -179,6 +179,11 @@ export const plPL: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Skontaktuj się z administratorem swojej organizacji, aby uzyskać uprawnienia do zarządzania połączeniami korporacyjnymi.',
+      title: 'Nie masz uprawnień do zarządzania połączeniami korporacyjnymi',
+    },
     navbar: {
       title: 'Skonfiguruj logowanie jednokrotne (SSO)',
     },

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -185,6 +185,11 @@ export const ptBR: LocalizationResource = {
     year: 'Ano',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Entre em contato com o administrador da sua organização para obter permissões para gerenciar conexões empresariais.',
+      title: 'Você não tem permissão para gerenciar conexões empresariais',
+    },
     navbar: {
       title: 'Configurar logon único (SSO)',
     },

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -187,6 +187,10 @@ export const ptPT: LocalizationResource = {
     year: 'Ano',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Contacte o administrador da sua organização para obter permissões para gerir ligações empresariais.',
+      title: 'Não tem permissão para gerir ligações empresariais',
+    },
     navbar: {
       title: 'Configurar autenticação única (SSO)',
     },

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -185,6 +185,11 @@ export const roRO: LocalizationResource = {
     year: 'An',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Contactați administratorul organizației dumneavoastră pentru a obține permisiuni de gestionare a conexiunilor de întreprindere.',
+      title: 'Nu aveți permisiunea să gestionați conexiunile de întreprindere',
+    },
     navbar: {
       title: 'Configurați autentificarea unică (SSO)',
     },

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -179,6 +179,11 @@ export const ruRU: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Обратитесь к администратору вашей организации, чтобы получить разрешения на управление корпоративными подключениями.',
+      title: 'У вас нет разрешения на управление корпоративными подключениями',
+    },
     navbar: {
       title: 'Настроить единый вход (SSO)',
     },

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -179,6 +179,11 @@ export const skSK: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Kontaktujte správcu vašej organizácie, aby ste získali oprávnenia na spravovanie podnikových pripojení.',
+      title: 'Nemáte oprávnenie spravovať podnikové pripojenia',
+    },
     navbar: {
       title: 'Nastaviť jednotné prihlasovanie (SSO)',
     },

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -179,6 +179,11 @@ export const srRS: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Kontaktirajte administratora vaše organizacije da biste dobili dozvole za upravljanje korporativnim vezama.',
+      title: 'Nemate dozvolu za upravljanje korporativnim vezama',
+    },
     navbar: {
       title: 'Konfiguriši jedinstvenu prijavu (SSO)',
     },

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -179,6 +179,10 @@ export const svSE: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Kontakta administratören för din organisation för att få behörighet att hantera företagsanslutningar.',
+      title: 'Du har inte behörighet att hantera företagsanslutningar',
+    },
     navbar: {
       title: 'Konfigurera enkel inloggning (SSO)',
     },

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -179,6 +179,10 @@ export const taIN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'நிறுவன இணைப்புகளை நிர்வகிக்க அனுமதிகளைப் பெற உங்கள் நிறுவனத்தின் நிர்வாகியைத் தொடர்பு கொள்ளவும்.',
+      title: 'நிறுவன இணைப்புகளை நிர்வகிக்க உங்களுக்கு அனுமதி இல்லை',
+    },
     navbar: {
       title: 'ஒற்றை உள்நுழைவை (SSO) உள்ளமை',
     },

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -179,6 +179,10 @@ export const teIN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'ఎంటర్‌ప్రైజ్ కనెక్షన్‌లను నిర్వహించడానికి అనుమతులు పొందడానికి మీ సంస్థ నిర్వాహకుడిని సంప్రదించండి.',
+      title: 'ఎంటర్‌ప్రైజ్ కనెక్షన్‌లను నిర్వహించడానికి మీకు అనుమతి లేదు',
+    },
     navbar: {
       title: 'సింగిల్ సైన్-ఆన్ (SSO) కాన్ఫిగర్ చేయండి',
     },

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -183,6 +183,10 @@ export const thTH: LocalizationResource = {
     year: 'ปี',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'ติดต่อผู้ดูแลระบบขององค์กรของคุณเพื่อขอสิทธิ์ในการจัดการการเชื่อมต่อระดับองค์กร',
+      title: 'คุณไม่มีสิทธิ์จัดการการเชื่อมต่อระดับองค์กร',
+    },
     navbar: {
       title: 'กำหนดค่าการลงชื่อเข้าใช้แบบครั้งเดียว (SSO)',
     },

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -179,6 +179,10 @@ export const trTR: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Kurumsal bağlantıları yönetme izinleri almak için organizasyonunuzun yöneticisiyle iletişime geçin.',
+      title: 'Kurumsal bağlantıları yönetme izniniz yok',
+    },
     navbar: {
       title: 'Tek Oturum Açmayı (SSO) Yapılandır',
     },

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -179,6 +179,11 @@ export const ukUA: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle:
+        'Зверніться до адміністратора вашої організації, щоб отримати дозвіл на керування корпоративними підключеннями.',
+      title: 'У вас немає дозволу на керування корпоративними підключеннями',
+    },
     navbar: {
       title: 'Налаштувати єдиний вхід (SSO)',
     },

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -183,6 +183,10 @@ export const viVN: LocalizationResource = {
     year: 'Năm',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: 'Liên hệ với quản trị viên tổ chức của bạn để có quyền quản lý các kết nối doanh nghiệp.',
+      title: 'Bạn không có quyền quản lý các kết nối doanh nghiệp',
+    },
     navbar: {
       title: 'Cấu hình đăng nhập một lần (SSO)',
     },

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -179,6 +179,10 @@ export const zhCN: LocalizationResource = {
     year: undefined,
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: '请联系您的组织管理员以获得管理企业连接的权限。',
+      title: '您无权管理企业连接',
+    },
     navbar: {
       title: '配置单点登录 (SSO)',
     },

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -185,6 +185,10 @@ export const zhTW: LocalizationResource = {
     year: '年',
   },
   configureSSO: {
+    missingManageEnterpriseConnectionsPermission: {
+      subtitle: '請聯絡您的組織管理員以取得管理企業連線的權限。',
+      title: '您沒有管理企業連線的權限',
+    },
     navbar: {
       title: '設定單一登入 (SSO)',
     },

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1296,6 +1296,10 @@ export type __internal_LocalizationResource = {
     navbar: {
       title: LocalizationValue;
     };
+    missingManageEnterpriseConnectionsPermission: {
+      title: LocalizationValue;
+      subtitle: LocalizationValue;
+    };
   };
   apiKeys: {
     formTitle: LocalizationValue;

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -67,11 +67,11 @@ const ConfigureSSOCardContent = () => {
   const { session } = useSession();
 
   const isPersonalWorkspace = !session?.lastActiveOrganizationId;
-  const hasManageEnterpriseConnectionsPermission = useProtect(
+  const canManageEnterpriseConnections = useProtect(
     has => isPersonalWorkspace || has({ permission: 'org:sys_enterprise_connections:manage' }),
   );
 
-  if (!hasManageEnterpriseConnectionsPermission) {
+  if (!canManageEnterpriseConnections) {
     return <MissingManageEnterpriseConnectionsOrganizationPermission />;
   }
 

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -14,6 +14,8 @@ import { ConfigureSSOFlowProvider } from './ConfigureSSOContext';
 import { ConfigureSSOHeader } from './ConfigureSSOHeader';
 import { ConfigureSSONavbar } from './ConfigureSSONavbar';
 import { ConfigureSSOSkeleton } from './ConfigureSSOSkeleton';
+import { ProfileCardFooter, ProfileCardHeader } from './elements/ProfileCard';
+import { Step } from './elements/Step';
 import { Wizard } from './elements/Wizard';
 import { ConfigureStep, ConfirmationStep, SelectProviderStep, TestConfigurationStep, VerifyDomainStep } from './steps';
 
@@ -113,32 +115,48 @@ const ConfigureSSOCardContent = () => {
 };
 
 const MissingManageEnterpriseConnectionsPermission = () => (
-  <Flex
-    align='center'
-    justify='center'
-    sx={t => ({ flex: 1, padding: t.space.$8 })}
-  >
-    <Col
-      align='center'
-      sx={t => ({ gap: t.space.$2, textAlign: 'center', maxWidth: t.sizes.$94 })}
-    >
-      <Icon
-        icon={ExclamationTriangle}
-        sx={t => ({ width: t.sizes.$8, height: t.sizes.$8, color: t.colors.$neutralAlpha600 })}
-      />
-      <Heading
-        localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.title')}
-        textVariant='h1'
-        sx={t => ({ fontSize: t.fontSizes.$lg })}
-      />
-      <Text
-        as='p'
-        variant='body'
-        colorScheme='secondary'
-        localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.subtitle')}
-      />
-    </Col>
-  </Flex>
+  <>
+    <Flex sx={t => ({ minHeight: t.sizes.$13, minWidth: '100%' })}>
+      <ProfileCardHeader />
+    </Flex>
+
+    <Step.Body>
+      <Step.Section
+        sx={{ flex: 1 }}
+        align='center'
+        justify='center'
+      >
+        <Flex
+          align='center'
+          justify='center'
+          sx={t => ({ flex: 1, padding: t.space.$8 })}
+        >
+          <Col
+            align='center'
+            sx={t => ({ gap: t.space.$2, textAlign: 'center', maxWidth: t.sizes.$94 })}
+          >
+            <Icon
+              icon={ExclamationTriangle}
+              sx={t => ({ width: t.sizes.$8, height: t.sizes.$8, color: t.colors.$neutralAlpha600 })}
+            />
+            <Heading
+              localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.title')}
+              textVariant='h1'
+              sx={t => ({ fontSize: t.fontSizes.$lg, textWrap: 'balance' })}
+            />
+            <Text
+              as='p'
+              variant='body'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.subtitle')}
+              sx={{ textWrap: 'balance' }}
+            />
+          </Col>
+        </Flex>
+      </Step.Section>
+    </Step.Body>
+    <ProfileCardFooter />
+  </>
 );
 
 const ConfigureSSOCardProtect = ({ children }: { children: React.ReactNode }) => {

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -52,7 +52,9 @@ const AuthenticatedContent = withCoreUserGuard(() => {
             flex: 1,
           })}
         >
-          <ConfigureSSOCardContent />
+          <ConfigureSSOCardProtect>
+            <ConfigureSSOCardContent />
+          </ConfigureSSOCardProtect>
         </Col>
       </ConfigureSSONavbar>
     </ProfileCard.Root>
@@ -64,16 +66,6 @@ const ConfigureSSOCardContent = () => {
 
   // Currently FAPI only supports one enterprise connection per user
   const enterpriseConnection = enterpriseConnections?.[0];
-  const { session } = useSession();
-
-  const isPersonalWorkspace = !session?.lastActiveOrganizationId;
-  const canManageEnterpriseConnections = useProtect(
-    has => isPersonalWorkspace || has({ permission: 'org:sys_enterprise_connections:manage' }),
-  );
-
-  if (!canManageEnterpriseConnections) {
-    return <MissingManageEnterpriseConnectionsOrganizationPermission />;
-  }
 
   if (isLoading && !enterpriseConnection) {
     return <ConfigureSSOSkeleton />;
@@ -120,7 +112,7 @@ const ConfigureSSOCardContent = () => {
   );
 };
 
-const MissingManageEnterpriseConnectionsOrganizationPermission = () => (
+const MissingManageEnterpriseConnectionsPermission = () => (
   <Flex
     align='center'
     justify='center'
@@ -148,6 +140,20 @@ const MissingManageEnterpriseConnectionsOrganizationPermission = () => (
     </Col>
   </Flex>
 );
+
+const ConfigureSSOCardProtect = ({ children }: { children: React.ReactNode }) => {
+  const { session } = useSession();
+  const isPersonalWorkspace = !session?.lastActiveOrganizationId;
+  const canManageEnterpriseConnections = useProtect(
+    has => isPersonalWorkspace || has({ permission: 'org:sys_enterprise_connections:manage' }),
+  );
+
+  if (!canManageEnterpriseConnections) {
+    return <MissingManageEnterpriseConnectionsPermission />;
+  }
+
+  return children;
+};
 
 export const ConfigureSSO: React.ComponentType<__experimental_ConfigureSSOProps> =
   withCardStateProvider(ConfigureSSOInternal);

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -2,9 +2,9 @@ import { __internal_useUserEnterpriseConnections, useSession } from '@clerk/shar
 import type { __experimental_ConfigureSSOProps } from '@clerk/shared/types';
 import React from 'react';
 
-import { Protect } from '@/common';
+import { useProtect } from '@/common';
 import { withCoreUserGuard } from '@/contexts';
-import { Col, descriptors, Flex, Flow, Heading, Icon, Text } from '@/customizables';
+import { Col, descriptors, Flex, Flow, Heading, Icon, localizationKeys, Text } from '@/customizables';
 import { withCardStateProvider } from '@/elements/contexts';
 import { ProfileCard } from '@/elements/ProfileCard';
 import { ExclamationTriangle } from '@/icons';
@@ -61,60 +61,61 @@ const AuthenticatedContent = withCoreUserGuard(() => {
 
 const ConfigureSSOCardContent = () => {
   const { data: enterpriseConnections, isLoading } = __internal_useUserEnterpriseConnections({ enabled: true });
+
   // Currently FAPI only supports one enterprise connection per user
   const enterpriseConnection = enterpriseConnections?.[0];
   const { session } = useSession();
 
-  // Initial-load gate at root — wizard never sees isLoading
+  const isPersonalWorkspace = !session?.lastActiveOrganizationId;
+  const hasManageEnterpriseConnectionsPermission = useProtect(
+    has => isPersonalWorkspace || has({ permission: 'org:sys_enterprise_connections:manage' }),
+  );
+
+  if (!hasManageEnterpriseConnectionsPermission) {
+    return <MissingManageEnterpriseConnectionsOrganizationPermission />;
+  }
+
   if (isLoading && !enterpriseConnection) {
     return <ConfigureSSOSkeleton />;
   }
 
-  const isPersonalWorkspace = !session?.lastActiveOrganizationId;
-
   return (
     <ConfigureSSOFlowProvider enterpriseConnection={enterpriseConnection}>
-      <Protect
-        // If the user has an active organization membership, they need to have the permission to manage enterprise connections
-        condition={has => !isPersonalWorkspace && has({ permission: 'org:sys_enterprise_connections:manage' })}
-        fallback={<MissingManageEnterpriseConnectionsOrganizationPermission />}
-      >
-        <Wizard>
-          <ConfigureSSOHeader />
+      <Wizard>
+        <ConfigureSSOHeader />
 
-          <Wizard.Step id='select-provider'>
-            <SelectProviderStep />
-          </Wizard.Step>
+        <Wizard.Step id='select-provider'>
+          <SelectProviderStep />
+        </Wizard.Step>
 
-          <Wizard.Step
-            id='verify-domain'
-            label='Verify domain'
-          >
-            <VerifyDomainStep />
-          </Wizard.Step>
+        <Wizard.Step
+          id='verify-domain'
+          label='Verify domain'
+        >
+          <VerifyDomainStep />
+        </Wizard.Step>
 
-          <Wizard.Step
-            id='configure'
-            label='Configure'
-          >
-            <ConfigureStep />
-          </Wizard.Step>
+        <Wizard.Step
+          id='configure'
+          label='Configure'
+        >
+          <ConfigureStep />
+        </Wizard.Step>
 
-          <Wizard.Step
-            id='test'
-            label='Test'
-          >
-            <TestConfigurationStep />
-          </Wizard.Step>
+        <Wizard.Step
+          id='test'
+          label='Test'
+        >
+          <TestConfigurationStep />
+        </Wizard.Step>
 
-          <Wizard.Step
-            id='confirmation'
-            label='Confirmation'
-          >
-            <ConfirmationStep />
-          </Wizard.Step>
-        </Wizard>
-      </Protect>
+        <Wizard.Step
+          id='confirmation'
+          label='Confirmation'
+        >
+          <ConfirmationStep />
+        </Wizard.Step>
+      </Wizard>
     </ConfigureSSOFlowProvider>
   );
 };
@@ -134,18 +135,16 @@ const MissingManageEnterpriseConnectionsOrganizationPermission = () => (
         sx={t => ({ width: t.sizes.$8, height: t.sizes.$8, color: t.colors.$neutralAlpha600 })}
       />
       <Heading
+        localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.title')}
         textVariant='h1'
         sx={t => ({ fontSize: t.fontSizes.$lg })}
-      >
-        You do not have permission to manage enterprise connections
-      </Heading>
+      />
       <Text
         as='p'
         variant='body'
         colorScheme='secondary'
-      >
-        Contact your organization administrator in order to have permissions to manage enterprise connections.
-      </Text>
+        localizationKey={localizationKeys('configureSSO.missingManageEnterpriseConnectionsPermission.subtitle')}
+      />
     </Col>
   </Flex>
 );

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -1,11 +1,13 @@
-import { __internal_useUserEnterpriseConnections } from '@clerk/shared/react';
+import { __internal_useUserEnterpriseConnections, useSession } from '@clerk/shared/react';
 import type { __experimental_ConfigureSSOProps } from '@clerk/shared/types';
 import React from 'react';
 
+import { Protect } from '@/common';
 import { withCoreUserGuard } from '@/contexts';
-import { Col, descriptors, Flow } from '@/customizables';
+import { Col, descriptors, Flex, Flow, Heading, Icon, Text } from '@/customizables';
 import { withCardStateProvider } from '@/elements/contexts';
 import { ProfileCard } from '@/elements/ProfileCard';
+import { ExclamationTriangle } from '@/icons';
 import { Route, Switch } from '@/router';
 
 import { ConfigureSSOFlowProvider } from './ConfigureSSOContext';
@@ -61,52 +63,92 @@ const ConfigureSSOCardContent = () => {
   const { data: enterpriseConnections, isLoading } = __internal_useUserEnterpriseConnections({ enabled: true });
   // Currently FAPI only supports one enterprise connection per user
   const enterpriseConnection = enterpriseConnections?.[0];
+  const { session } = useSession();
 
   // Initial-load gate at root — wizard never sees isLoading
   if (isLoading && !enterpriseConnection) {
     return <ConfigureSSOSkeleton />;
   }
 
+  const isPersonalWorkspace = !session?.lastActiveOrganizationId;
+
   return (
     <ConfigureSSOFlowProvider enterpriseConnection={enterpriseConnection}>
-      <Wizard>
-        <ConfigureSSOHeader />
+      <Protect
+        // If the user has an active organization membership, they need to have the permission to manage enterprise connections
+        condition={has => !isPersonalWorkspace && has({ permission: 'org:sys_enterprise_connections:manage' })}
+        fallback={<MissingManageEnterpriseConnectionsOrganizationPermission />}
+      >
+        <Wizard>
+          <ConfigureSSOHeader />
 
-        <Wizard.Step id='select-provider'>
-          <SelectProviderStep />
-        </Wizard.Step>
+          <Wizard.Step id='select-provider'>
+            <SelectProviderStep />
+          </Wizard.Step>
 
-        <Wizard.Step
-          id='verify-domain'
-          label='Verify domain'
-        >
-          <VerifyDomainStep />
-        </Wizard.Step>
+          <Wizard.Step
+            id='verify-domain'
+            label='Verify domain'
+          >
+            <VerifyDomainStep />
+          </Wizard.Step>
 
-        <Wizard.Step
-          id='configure'
-          label='Configure'
-        >
-          <ConfigureStep />
-        </Wizard.Step>
+          <Wizard.Step
+            id='configure'
+            label='Configure'
+          >
+            <ConfigureStep />
+          </Wizard.Step>
 
-        <Wizard.Step
-          id='test'
-          label='Test'
-        >
-          <TestConfigurationStep />
-        </Wizard.Step>
+          <Wizard.Step
+            id='test'
+            label='Test'
+          >
+            <TestConfigurationStep />
+          </Wizard.Step>
 
-        <Wizard.Step
-          id='confirmation'
-          label='Confirmation'
-        >
-          <ConfirmationStep />
-        </Wizard.Step>
-      </Wizard>
+          <Wizard.Step
+            id='confirmation'
+            label='Confirmation'
+          >
+            <ConfirmationStep />
+          </Wizard.Step>
+        </Wizard>
+      </Protect>
     </ConfigureSSOFlowProvider>
   );
 };
+
+const MissingManageEnterpriseConnectionsOrganizationPermission = () => (
+  <Flex
+    align='center'
+    justify='center'
+    sx={t => ({ flex: 1, padding: t.space.$8 })}
+  >
+    <Col
+      align='center'
+      sx={t => ({ gap: t.space.$2, textAlign: 'center', maxWidth: t.sizes.$94 })}
+    >
+      <Icon
+        icon={ExclamationTriangle}
+        sx={t => ({ width: t.sizes.$8, height: t.sizes.$8, color: t.colors.$neutralAlpha600 })}
+      />
+      <Heading
+        textVariant='h1'
+        sx={t => ({ fontSize: t.fontSizes.$lg })}
+      >
+        You do not have permission to manage enterprise connections
+      </Heading>
+      <Text
+        as='p'
+        variant='body'
+        colorScheme='secondary'
+      >
+        Contact your organization administrator in order to have permissions to manage enterprise connections.
+      </Text>
+    </Col>
+  </Flex>
+);
 
 export const ConfigureSSO: React.ComponentType<__experimental_ConfigureSSOProps> =
   withCardStateProvider(ConfigureSSOInternal);

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, waitFor } from '@/test/utils';
+
+import { ConfigureSSO } from '../ConfigureSSO';
+
+const { createFixtures } = bindCreateFixtures('ConfigureSSO');
+
+describe('ConfigureSSO', () => {
+  describe('within an organization', () => {
+    it('shows a warning if the active organization membership lacks the manage enterprise connections permission', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEnterpriseSso({ selfServeSso: true });
+        f.withEmailAddress();
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', permissions: [] }],
+        });
+      });
+
+      fixtures.clerk.user?.getEnterpriseConnections.mockResolvedValue([]);
+
+      const { findByText, queryByText } = render(<ConfigureSSO />, { wrapper });
+
+      await findByText(/you do not have permission to manage enterprise connections/i);
+      expect(queryByText(/contact your organization administrator in order to have permissions/i)).toBeInTheDocument();
+      expect(queryByText(/select provider/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the wizard when the active organization membership has the manage enterprise connections permission', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEnterpriseSso({ selfServeSso: true });
+        f.withEmailAddress();
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', permissions: ['org:sys_enterprise_connections:manage'] }],
+        });
+      });
+
+      fixtures.clerk.user?.getEnterpriseConnections.mockResolvedValue([]);
+
+      const { findByText, queryByText } = render(<ConfigureSSO />, { wrapper });
+
+      await waitFor(() => {
+        expect(queryByText(/you do not have permission to manage enterprise connections/i)).not.toBeInTheDocument();
+      });
+      await findByText(/select provider/i);
+    });
+  });
+
+  describe('in a personal workspace', () => {
+    it('renders the wizard without checking the manage enterprise connections permission', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEnterpriseSso({ selfServeSso: true });
+        f.withEmailAddress();
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+
+      fixtures.clerk.user?.getEnterpriseConnections.mockResolvedValue([]);
+
+      const { findByText, queryByText } = render(<ConfigureSSO />, { wrapper });
+
+      await findByText(/select provider/i);
+      expect(queryByText(/you do not have permission to manage enterprise connections/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/ConfigureSSO/elements/ProfileCard.tsx
+++ b/packages/ui/src/components/ConfigureSSO/elements/ProfileCard.tsx
@@ -9,6 +9,7 @@ export const ProfileCardHeader = (props: ProfileCardHeaderProps): JSX.Element =>
     elementDescriptor={descriptors.configureSSOHeader}
     {...props}
     sx={theme => ({
+      width: '100%',
       gap: theme.space.$2,
       padding: `${theme.space.$5}`,
       borderBottomWidth: theme.borderWidths.$normal,

--- a/packages/ui/src/test/fixture-helpers.ts
+++ b/packages/ui/src/test/fixture-helpers.ts
@@ -538,9 +538,9 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     };
   };
 
-  const withEnterpriseSso = () => {
+  const withEnterpriseSso = (opts?: { selfServeSso?: boolean }) => {
     us.saml = { enabled: true };
-    us.enterprise_sso = { enabled: true };
+    us.enterprise_sso = { enabled: true, self_serve_sso: opts?.selfServeSso ?? false };
   };
 
   const withBackupCode = (opts?: Partial<UserSettingsJSON['attributes']['backup_code']>) => {


### PR DESCRIPTION
## Description

Check against current user session, if it's outside of a personal workspace and doesn't have the system permission to manage enterprise connection.

<img width="938" height="777" alt="CleanShot 2026-05-11 at 17 33 06" src="https://github.com/user-attachments/assets/8afcfdf9-d8c1-488a-a3f1-9c9eae1cb651" />

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
