### PR TITLE
feat(expo): add Expo SDK 56 support

### DIFF
--- a/.changeset/sdk-56-expo-support.md
+++ b/.changeset/sdk-56-expo-support.md
@@ -1,0 +1,6 @@
+---
+"@clerk/expo": minor
+"@clerk/expo-passkeys": minor
+---
+
+Adds support for Expo SDK 56, including the SDK 56 preview release line.

--- a/packages/expo-passkeys/package.json
+++ b/packages/expo-passkeys/package.json
@@ -38,7 +38,7 @@
     "expo": "~52.0.49"
   },
   "peerDependencies": {
-    "expo": ">=53 <55",
+    "expo": ">=53 <56 || >=56.0.0-preview.0 <57.0.0-0",
     "react": "catalog:peer-react",
     "react-native": "*"
   }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -136,7 +136,7 @@
   },
   "peerDependencies": {
     "@clerk/expo-passkeys": ">=0.0.6",
-    "expo": ">=53 <56",
+    "expo": ">=53 <56 || >=56.0.0-preview.0 <57.0.0-0",
     "expo-apple-authentication": ">=7.0.0",
     "expo-auth-session": ">=5",
     "expo-constants": ">=12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,7 +538,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       expo:
-        specifier: '>=53 <56'
+        specifier: '>=53 <56 || >=56.0.0-preview.0 <57.0.0-0'
         version: 54.0.23(@babel/core@7.29.0)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(bufferutil@4.1.0)(graphql@16.13.2)(react-native@0.85.2(@babel/core@7.29.0)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)
       react:
         specifier: 18.3.1


### PR DESCRIPTION
## Description

Adds Expo SDK 56 support for the Expo packages while keeping the diff limited to compatibility metadata:

- expands `@clerk/expo` and `@clerk/expo-passkeys` Expo peer ranges to accept SDK 56 preview and stable 56 releases while excluding SDK 57 preview and stable releases with `<57.0.0-0`;
- leaves the existing Expo-related dev dependency ranges unchanged, so this PR does not become an internal validation-runtime upgrade;
- keeps the package README prerequisite wording broad (`Expo 53 or later`);
- adds a changeset for both packages.

I did not find an existing issue or PR for Expo SDK 56 support. This follows the same package-scope pattern as prior Expo SDK support PRs, with the additional `@clerk/expo-passkeys` peer range update because that package was still capped below SDK 55.

Validation run:

- `pnpm install --lockfile-only --engine-strict=false --prefer-offline`
- `pnpm install --engine-strict=false`
- `pnpm dlx semver 56.0.0-preview.7 -r '>=53 <56 || >=56.0.0-preview.0 <57.0.0-0'`
- `pnpm dlx semver 56.0.0 -r '>=53 <56 || >=56.0.0-preview.0 <57.0.0-0'`
- verified `57.0.0-preview.1` and `57.0.0` are excluded by the same range
- `pnpm --filter @clerk/expo lint` exits 0; existing warnings remain
- `pnpm --filter @clerk/expo test`
- `pnpm --filter @clerk/expo build`
- `pnpm --filter @clerk/expo format:check`
- `pnpm --filter @clerk/expo-passkeys lint` exits 0; existing warnings remain
- `pnpm --filter @clerk/expo-passkeys build`
- `pnpm --filter @clerk/expo-passkeys format:check`
- `pnpm changeset status --since=upstream/main`
- `git diff --check`
- packed local tarballs for both packages, installed them into a minimal Expo SDK 56 fixture with `expo@56.0.0-preview.7`, `react@19.2.3`, `react-native@0.85.3`, and current SDK 56 Expo modules, then ran `pnpm --dir /tmp/clerk-expo-sdk56-fixture exec expo install --check`

Notes:

- I intentionally did not bump the packages' Expo dev dependencies. The public support contract is the peer range, and the existing optional Expo module peer ranges already accept the SDK 56 module versions.
- I did not run full root `pnpm test` / `pnpm build`; the PR is scoped to the Expo packages.
- I did not run native iOS/Android app builds. Expo SDK 56 is currently a preview line, so maintainers may still want device/build-farm validation before release.
- No JSDoc export changes were needed because this does not add or change public APIs.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports (not applicable: no package exports changed)
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated (not applicable: package README wording remains broad and no clerk-docs changes are required for peer metadata)

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
