### PR TITLE
fix(repo): Add standalonePage tag for JSDoc comments

### DIFF
--- a/.typedoc/custom-router.mjs
+++ b/.typedoc/custom-router.mjs
@@ -2,6 +2,7 @@
 import { ReflectionKind } from 'typedoc';
 import { MemberRouter } from 'typedoc-plugin-markdown';
 
+import { isInlineModifierWithoutStandalonePage } from './standalone-page-tag.mjs';
 import { REFERENCE_OBJECT_PAGE_SYMBOLS } from './reference-objects.mjs';
 
 /** @type {Set<string>} */
@@ -58,15 +59,11 @@ class ClerkRouter extends MemberRouter {
         }
 
         /**
-         * `@inline` marks types that should be expanded at use sites, not documented as their own page.
+         * `@inline` marks types that should be expanded at use sites, not documented as their own page unless `@standalonePage` is also set (see `standalone-page-tag.mjs`).
          * TypeDoc still assigns `fullUrls` for exported aliases, so we also strip links in the theme's `referenceType` partial (`custom-theme.mjs`).
          */
         const model = page.model;
-        if (
-          model &&
-          'comment' in model &&
-          /** @type {{ comment?: import('typedoc').Comment | undefined }} */ (model).comment?.hasModifier('@inline')
-        ) {
+        if (model && isInlineModifierWithoutStandalonePage(/** @type {import('typedoc').Reflection} */ (model))) {
           return false;
         }
 

--- a/.typedoc/custom-theme.mjs
+++ b/.typedoc/custom-theme.mjs
@@ -11,6 +11,7 @@ import { removeLineBreaks } from '../node_modules/typedoc-plugin-markdown/dist/l
 import { TypeDeclarationVisibility } from '../node_modules/typedoc-plugin-markdown/dist/options/maps.js';
 
 import { applyTodoStrippingToComment } from './comment-utils.mjs';
+import { isInlineModifierWithoutStandalonePage } from './standalone-page-tag.mjs';
 import { REFERENCE_OBJECTS_LIST } from './reference-objects.mjs';
 
 export { REFERENCE_OBJECTS_LIST };
@@ -789,7 +790,7 @@ function renderMergedIntersectionDeclaration(ctx, model, opts, mergedChildren, s
   }
   if (model.comment) {
     md.push(
-      superPartials.comment(model.comment, {
+      ctx.partials.comment(model.comment, {
         headingLevel,
         showSummary: true,
         showTags: false,
@@ -808,7 +809,7 @@ function renderMergedIntersectionDeclaration(ctx, model, opts, mergedChildren, s
 
   if (model.comment) {
     md.push(
-      superPartials.comment(model.comment, {
+      ctx.partials.comment(model.comment, {
         headingLevel,
         showSummary: false,
         showTags: true,
@@ -1047,9 +1048,9 @@ class ClerkMarkdownThemeContext extends MarkdownThemeContext {
         );
       },
       /**
-       * Stock `comments.comment` prints every {@link Comment.modifierTags} as **`TitleCase`** before the summary.
-       * `@inline` / `@inlineType` are router/type hints only; `@experimental` is SDK-only guidance — none of these
-       * must appear in property tables or prose.
+       * Stock `comments.comment` prints every {@link Comment.modifierTags} as **`TitleCase`** before the summary
+       * (it does not consult `notRenderedTags`; that option only filters block tags). `@inline` / `@inlineType` are
+       * router/type hints; `@experimental` is SDK-only guidance — none of these must appear in property tables or prose.
        *
        * @param {import('typedoc').Comment} model
        * @param {Parameters<typeof superPartials.comment>[1]} [options]
@@ -1059,7 +1060,7 @@ class ClerkMarkdownThemeContext extends MarkdownThemeContext {
           return superPartials.comment.call(this, model, options);
         }
         const modelToRender = applyTodoStrippingToComment(model) ?? model;
-        const hidden = new Set(['@inline', '@inlineType', '@experimental']);
+        const hidden = new Set(['@inline', '@inlineType', '@experimental', '@standalonePage']);
         const modTags = Array.from(modelToRender.modifierTags ?? []);
         if (modTags.some(/** @param {string} t */ t => hidden.has(t))) {
           const clone = Object.assign(Object.create(Object.getPrototypeOf(modelToRender)), modelToRender, {
@@ -1076,12 +1077,12 @@ class ClerkMarkdownThemeContext extends MarkdownThemeContext {
        */
       declarationTitle: () => '',
       /**
-       * TypeDoc's default links every {@link ReferenceType} to a URL. Types marked `@inline` are expanded at use sites and (via the router) have no standalone page — linking produces broken relative `.mdx` paths in extracted method docs. Render the **aliased type** (RHS) so literals and unions show as `'phone_code'`, not `PhoneCodeStrategy`.
+       * TypeDoc's default links every {@link ReferenceType} to a URL. Types marked `@inline` are expanded at use sites and (via the router) have no standalone page — linking produces broken relative `.mdx` paths in extracted method docs. Render the **aliased type** (RHS) so literals and unions show as `'phone_code'`, not `PhoneCodeStrategy`, unless `@standalonePage` is set (`standalone-page-tag.mjs`).
        *
        * @param {import('typedoc').ReferenceType} model
        */
       referenceType: model => {
-        if (model.reflection?.comment?.hasModifier('@inline')) {
+        if (isInlineModifierWithoutStandalonePage(model.reflection)) {
           const decl = /** @type {import('typedoc').DeclarationReflection} */ (model.reflection);
           // Generic instantiation, e.g. `Fn<Args>` — let `someType` apply type arguments.
           if (model.typeArguments?.length) {

--- a/.typedoc/extract-methods.mjs
+++ b/.typedoc/extract-methods.mjs
@@ -32,6 +32,7 @@ import {
   applyRelativeLinkReplacements,
   stripReferenceObjectPropertiesSection,
 } from './custom-plugin.mjs';
+import { isInlineModifierWithoutStandalonePage } from './standalone-page-tag.mjs';
 import { prepareMarkdownRenderer } from './prepare-markdown-renderer.mjs';
 import { applyTodoStrippingToComment } from './comment-utils.mjs';
 import { REFERENCE_OBJECTS_LIST, REFERENCE_OBJECT_CONFIG } from './reference-objects.mjs';
@@ -1048,7 +1049,7 @@ function unwrapOptionalParamType(t) {
 
 /**
  * When TypeDoc renders a parameter type as a markdown link to another generated `.mdx` file, that type has a dedicated page — omit nested `param?.prop` rows so readers follow the type link instead.
- * `@inline` aliases are expanded by the theme and do not link to a standalone page.
+ * `@inline` aliases are expanded by the theme and do not link to a standalone page unless `@standalonePage` is set (`standalone-page-tag.mjs`).
  *
  * @param {import('typedoc').SomeType | undefined} t
  * @param {import('typedoc-plugin-markdown').MarkdownThemeContext} ctx
@@ -1060,7 +1061,7 @@ function parameterTypeLinksToStandaloneMdxPage(t, ctx) {
   }
   if (bare.type === 'reference') {
     const ref = /** @type {import('typedoc').ReferenceType} */ (bare);
-    if (ref.reflection?.comment?.hasModifier('@inline')) {
+    if (isInlineModifierWithoutStandalonePage(ref.reflection)) {
       return false;
     }
   }

--- a/.typedoc/standalone-page-tag.mjs
+++ b/.typedoc/standalone-page-tag.mjs
@@ -1,8 +1,7 @@
 // @ts-check
 
 /**
- * Modifier tag: keep a dedicated `.mdx` page even when `@inline` is present (TypeDoc + our router
- * otherwise drop inline-marked declarations; the theme also expands references instead of linking).
+ * Modifier tag: keep a dedicated `.mdx` page even when `@inline` is present (TypeDoc + our router otherwise drop inline-marked declarations; the theme also expands references instead of linking).
  */
 export const STANDALONE_PAGE_MODIFIER_TAG = '@standalonePage';
 

--- a/.typedoc/standalone-page-tag.mjs
+++ b/.typedoc/standalone-page-tag.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+
+/**
+ * Modifier tag: keep a dedicated `.mdx` page even when `@inline` is present (TypeDoc + our router
+ * otherwise drop inline-marked declarations; the theme also expands references instead of linking).
+ */
+export const STANDALONE_PAGE_MODIFIER_TAG = '@standalonePage';
+
+/**
+ * @param {import('typedoc').Reflection | undefined} reflection
+ * @returns {boolean} True when `@inline` should suppress a standalone page / force in-place expansion.
+ */
+export function isInlineModifierWithoutStandalonePage(reflection) {
+  const comment =
+    reflection && 'comment' in reflection
+      ? /** @type {{ comment?: import('typedoc').Comment | undefined }} */ (reflection).comment
+      : undefined;
+  if (!comment?.hasModifier('@inline')) {
+    return false;
+  }
+  if (comment.hasModifier(STANDALONE_PAGE_MODIFIER_TAG)) {
+    return false;
+  }
+  return true;
+}

--- a/packages/shared/src/react/hooks/createBillingPaginatedHook.tsx
+++ b/packages/shared/src/react/hooks/createBillingPaginatedHook.tsx
@@ -25,28 +25,28 @@ type BillingHookConfig<TResource extends ClerkResource, TParams extends PagesOrI
 
 /**
  * @interface
+ * @standalonePage
  */
-export interface HookParams
-  extends PaginatedHookConfig<
-    PagesOrInfiniteOptions & {
-      /**
-       * If `true`, a request will be triggered when the hook is mounted.
-       *
-       * @default true
-       */
-      enabled?: boolean;
-      /**
-       * On `cache` mode, no request will be triggered when the hook is mounted and the data will be fetched from the cache.
-       *
-       * @default undefined
-       *
-       * @hidden
-       *
-       * @experimental
-       */
-      __experimental_mode?: 'cache';
-    }
-  > {
+export interface HookParams extends PaginatedHookConfig<
+  PagesOrInfiniteOptions & {
+    /**
+     * If `true`, a request will be triggered when the hook is mounted.
+     *
+     * @default true
+     */
+    enabled?: boolean;
+    /**
+     * On `cache` mode, no request will be triggered when the hook is mounted and the data will be fetched from the cache.
+     *
+     * @default undefined
+     *
+     * @hidden
+     *
+     * @experimental
+     */
+    __experimental_mode?: 'cache';
+  }
+> {
   /**
    * Specifies whether to fetch for the current user or Organization.
    *

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -85,6 +85,7 @@ export type PaginatedResourcesWithDefault<T> = {
 
 /**
  * @inline
+ * @standalonePage
  */
 export type PaginatedHookConfig<T> = T & {
   /**

--- a/turbo.json
+++ b/turbo.json
@@ -345,7 +345,8 @@
         ".typedoc/reference-objects.mjs",
         ".typedoc/comment-utils.mjs",
         ".typedoc/extract-methods.mjs",
-        ".typedoc/extract-returns-and-params.mjs"
+        ".typedoc/extract-returns-and-params.mjs",
+        ".typedoc/standalone-page-tag.mjs"
       ],
       "outputs": [".typedoc/**"],
       "outputLogs": "new-only"

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -91,6 +91,8 @@ const config = {
     /** Parsed for router/theme; must not appear as a doc section (otherwise renders as **Inline**). */
     '@inline',
     '@inlineType',
+    /** Opts into a dedicated reference page despite `@inline` (see `.typedoc/standalone-page-tag.mjs`). */
+    '@standalonePage',
   ],
   packageOptions: {
     includeVersion: false,
@@ -114,11 +116,15 @@ const config = {
       /** Type-only / router hints; not user-facing prose (see `notRenderedTags`). */
       '@inline',
       '@inlineType',
+      /** With `@inline`, still emit a standalone `.mdx` page (see `.typedoc/standalone-page-tag.mjs`). */
+      '@standalonePage',
     ],
     /**
-     * Stops TypeDoc from generating standalone pages for inline types.
+     * Keep `@inline` / `@inlineType` / `@standalonePage` in the model so the custom router and theme can read them.
      */
-    excludeTags: OptionDefaults.excludeTags.filter(tag => tag !== '@inline' && tag !== '@inlineType'),
+    excludeTags: OptionDefaults.excludeTags.filter(
+      tag => tag !== '@inline' && tag !== '@inlineType' && tag !== '@standalonePage',
+    ),
     exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     readme: 'none',
     disableGit: true,


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

We were getting errors that certain files weren't being generated anymore. More information here: https://github.com/clerk/javascript/pull/8276#issuecomment-4425942784

This PR adds a `@standalonePage` tag that can be used in conjunction with the `@inline` tag to indicate to typedoc to still generate a dedicated page for that type, even though it is recognized as `@inline`. Using both of these tags means that the type will show up as inlined in a table, but will also still have a generated MDX file.
For example:
`HookParams` will be inlined in a table:
<img width="751" height="117" alt="Screenshot 2026-05-11 at 17 22 38" src="https://github.com/user-attachments/assets/981209de-765c-4f58-b7fd-e0454c322135" />
but will still get a generated `shared/hook-params.mdx` file that can then be used in the docs:
<img width="879" height="830" alt="Screenshot 2026-05-11 at 17 23 22" src="https://github.com/user-attachments/assets/31735508-2825-4df4-b6c6-f1e4448a2901" />


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
