### PR TITLE
feat(ui,shared,localizations): Add test step for `<ConfigureSSO />`

### DIFF
--- a/.changeset/three-ducks-hang.md
+++ b/.changeset/three-ducks-hang.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Add test step for `<__experimental_ConfigureSSO />`

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -274,6 +274,23 @@ export const enUS: LocalizationResource = {
         subtitle: "Contact the application's administrator to get access through the existing connection.",
       },
     },
+    testConfigurationStep: {
+      title: 'Test your SSO connection',
+      subtitle: 'Authenticate using the test SSO URL to verify you configured the connection correctly.',
+      testUrl: {
+        title: 'Test your SSO URL',
+        subtitle: 'Generate and copy a test SSO URL to authenticate with.',
+        actionLabel__copy: 'Copy test URL',
+      },
+      testResults: {
+        title: 'Test results',
+        actionLabel__refresh: 'Refresh',
+        polling: 'Waiting for the test run to complete…',
+        status__success: 'Success',
+        status__failed: 'Failed',
+        status__pending: 'Pending',
+      },
+    },
     configureStep: {
       spFields: {
         acsUrl: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -292,6 +292,49 @@ export const enUS: LocalizationResource = {
       },
       testRunDetails: {
         title: 'Test run',
+        runDetails: {
+          sectionTitle: 'Run details',
+          timestamp: 'Timestamp',
+          status: 'Status',
+          errorCode: 'Error code',
+          fullMessage: 'Full message',
+          actionLabel__copy: 'Copy message',
+          actionLabel__copied: 'Copied',
+        },
+        howToFix: {
+          sectionTitle: 'How to fix',
+          actionLabel__viewDocumentation: 'View documentation',
+          generic:
+            'There is no specific guidance for this error. Refer to the documentation for general troubleshooting tips.',
+          saml_user_attribute_missing: {
+            intro: 'To fix this error, follow these steps:',
+            step1: "Access your identity provider's configuration dashboard.",
+            step2: "Navigate to your application's SAML settings or attribute mapping configuration.",
+            step3: "Ensure that the 'mail' attribute is properly mapped to the user's email address field.",
+          },
+          saml_response_relaystate_missing: {
+            description:
+              'Check that your identity provider is correctly returning the RelayState parameter that was sent in the original request.',
+          },
+          saml_email_address_domain_mismatch: {
+            description:
+              'Verify that the user is signing in with an email address that matches one of the allowed domains for this connection. If you need to add additional domains, update the allowed domains in your connection settings.',
+          },
+          oauth_access_denied: {
+            description:
+              "This error occurs when the user clicked Cancel or Deny on the OAuth provider's authorization screen, or the provider rejected the authorization request. Verify that the OAuth application credentials (Client ID and Client Secret) are correctly configured.",
+          },
+          oauth_token_exchange_error: {
+            description:
+              "Verify that your OAuth application's Client ID and Client Secret are correctly configured and match the credentials from your OAuth provider's dashboard.",
+          },
+          oauth_fetch_user_error: {
+            intro: 'To fix this error, follow these steps:',
+            step1:
+              'Verify that the OAuth scopes configured in your connection settings include the necessary permissions to read user profile information.',
+            step2: 'Ensure that the user info endpoint URL is correctly configured.',
+          },
+        },
       },
     },
     configureStep: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -290,6 +290,9 @@ export const enUS: LocalizationResource = {
         status__failed: 'Failed',
         status__pending: 'Pending',
       },
+      testRunDetails: {
+        title: 'Test run',
+      },
     },
     configureStep: {
       spFields: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -301,11 +301,14 @@ export const enUS: LocalizationResource = {
           actionLabel__copy: 'Copy message',
           actionLabel__copied: 'Copied',
         },
+        parsedUserInfo: {
+          sectionTitle: 'Parsed user info',
+          email: 'Email',
+          firstName: 'First name',
+        },
         howToFix: {
           sectionTitle: 'How to fix',
           actionLabel__viewDocumentation: 'View documentation',
-          generic:
-            'There is no specific guidance for this error. Refer to the documentation for general troubleshooting tips.',
           saml_user_attribute_missing: {
             intro: 'To fix this error, follow these steps:',
             step1: "Access your identity provider's configuration dashboard.",

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -277,6 +277,8 @@ export const enUS: LocalizationResource = {
     testConfigurationStep: {
       title: 'Test your SSO connection',
       subtitle: 'Authenticate using the test SSO URL to verify you configured the connection correctly.',
+      error__noSuccessfulTestRun:
+        'You need at least one successful test run before you can continue. Generate a test SSO URL and complete the sign-in flow.',
       testUrl: {
         title: 'Test your SSO URL',
         subtitle: 'Generate and copy a test SSO URL to authenticate with.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -284,7 +284,7 @@ export const enUS: LocalizationResource = {
       },
       testResults: {
         title: 'Test results',
-        actionLabel__refresh: 'Refresh',
+        actionLabel__refresh: 'Refresh logs',
         polling: 'Waiting for the test run to complete…',
         status__success: 'Success',
         status__failed: 'Failed',

--- a/packages/shared/src/react/hooks/index.ts
+++ b/packages/shared/src/react/hooks/index.ts
@@ -38,6 +38,11 @@ export type {
   UseUserEnterpriseConnectionsParams,
   UseUserEnterpriseConnectionsReturn,
 } from './useUserEnterpriseConnections';
+export { __internal_useEnterpriseConnectionTestRuns } from './useEnterpriseConnectionTestRuns';
+export type {
+  UseEnterpriseConnectionTestRunsParams,
+  UseEnterpriseConnectionTestRunsReturn,
+} from './useEnterpriseConnectionTestRuns';
 
 export { useUserBase as __internal_useUserBase } from './base/useUserBase';
 export { useClientBase as __internal_useClientBase } from './base/useClientBase';

--- a/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.shared.ts
+++ b/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.shared.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+
+import type { GetEnterpriseConnectionTestRunsParams } from '../../types/enterpriseConnectionTestRun';
+import { INTERNAL_STABLE_KEYS } from '../stable-keys';
+import { createCacheKeys } from './createCacheKeys';
+
+/**
+ * @internal
+ */
+export function useEnterpriseConnectionTestRunsCacheKeys(params: {
+  userId: string | null;
+  enterpriseConnectionId: string | null;
+  args: GetEnterpriseConnectionTestRunsParams;
+}) {
+  const { userId, enterpriseConnectionId, args } = params;
+  return useMemo(() => {
+    return createCacheKeys({
+      stablePrefix: INTERNAL_STABLE_KEYS.ENTERPRISE_CONNECTION_TEST_RUNS_KEY,
+      authenticated: Boolean(userId),
+      tracked: {
+        userId: userId ?? null,
+        enterpriseConnectionId: enterpriseConnectionId ?? null,
+      },
+      untracked: {
+        args,
+      },
+    });
+    // The args object is intentionally serialized via the consumer to keep stability.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, enterpriseConnectionId, JSON.stringify(args)]);
+}

--- a/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
+++ b/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
@@ -37,24 +37,16 @@ export type UseEnterpriseConnectionTestRunsParams = {
 
 export type UseEnterpriseConnectionTestRunsReturn = {
   data: EnterpriseConnectionTestRunResource[] | undefined;
-  /** Convenience accessor for the most recent run (i.e. `data[0]`). */
-  latest: EnterpriseConnectionTestRunResource | undefined;
   totalCount: number | undefined;
   error: Error | null;
   isLoading: boolean;
   isFetching: boolean;
   /**
-   * `true` while the hook is actively polling for the first record to appear.
-   * Becomes `true` once `revalidate()` is called against an empty list and
-   * flips back to `false` permanently as soon as the response contains at
-   * least one record.
+   * `true` while the hook is actively polling for the first record to appear
    */
   isPolling: boolean;
   /**
-   * Force a refetch and (if the list is currently empty) arm polling. Once any
-   * record has been observed in the response, polling is disabled for the rest
-   * of this hook instance's lifetime — subsequent `revalidate()` calls just
-   * trigger a single refetch.
+   * Force a refetch and (if the list is currently empty) arm polling
    */
   revalidate: () => Promise<void>;
 };
@@ -102,8 +94,6 @@ function useEnterpriseConnectionTestRuns(
       }
       return user?.getEnterpriseConnectionTestRuns(enterpriseConnectionId, fetchParams);
     },
-    enabled: queryEnabled,
-    refetchIntervalInBackground: false,
     refetchInterval: q => {
       if (!shouldPoll) {
         return false;
@@ -112,6 +102,8 @@ function useEnterpriseConnectionTestRuns(
       const hasRows = (q.state.data?.data?.length ?? 0) > 0;
       return hasRows ? false : pollIntervalMs;
     },
+    enabled: queryEnabled,
+    refetchIntervalInBackground: false,
   });
 
   const hasRows = (query.data?.data?.length ?? 0) > 0;
@@ -135,7 +127,6 @@ function useEnterpriseConnectionTestRuns(
 
   return {
     data: query.data?.data,
-    latest: query.data?.data?.[0],
     totalCount: query.data?.total_count,
     error: query.error ?? null,
     isLoading: query.isLoading,

--- a/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
+++ b/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
@@ -103,6 +103,7 @@ function useEnterpriseConnectionTestRuns(
       return user?.getEnterpriseConnectionTestRuns(enterpriseConnectionId, fetchParams);
     },
     enabled: queryEnabled,
+    refetchIntervalInBackground: false,
     refetchInterval: q => {
       if (!shouldPoll) {
         return false;

--- a/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
+++ b/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type {
+  EnterpriseConnectionTestRunResource,
+  GetEnterpriseConnectionTestRunsParams,
+} from '../../types/enterpriseConnectionTestRun';
+import { useClerkInstanceContext } from '../contexts';
+import { useClerkQueryClient } from '../query/use-clerk-query-client';
+import { useClerkQuery } from '../query/useQuery';
+import { useUserBase } from './base/useUserBase';
+import { useClearQueriesOnSignOut } from './useClearQueriesOnSignOut';
+import { useEnterpriseConnectionTestRunsCacheKeys } from './useEnterpriseConnectionTestRuns.shared';
+
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+export type UseEnterpriseConnectionTestRunsParams = {
+  enterpriseConnectionId: string | null;
+  /**
+   * Pass-through fetch parameters (pagination, status filter).
+   * Defaults to `{ initialPage: 1, pageSize: 10 }`.
+   */
+  params?: GetEnterpriseConnectionTestRunsParams;
+  /**
+   * Polling interval (ms) applied between `revalidate()` and the moment the
+   * first record arrives in the response.
+   *
+   * @default 2000
+   */
+  pollIntervalMs?: number;
+  /**
+   * If `false`, the hook is dormant — no fetch, no polling.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+};
+
+export type UseEnterpriseConnectionTestRunsReturn = {
+  data: EnterpriseConnectionTestRunResource[] | undefined;
+  /** Convenience accessor for the most recent run (i.e. `data[0]`). */
+  latest: EnterpriseConnectionTestRunResource | undefined;
+  totalCount: number | undefined;
+  error: Error | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  /**
+   * `true` while the hook is actively polling for the first record to appear.
+   * Becomes `true` once `revalidate()` is called against an empty list and
+   * flips back to `false` permanently as soon as the response contains at
+   * least one record.
+   */
+  isPolling: boolean;
+  /**
+   * Force a refetch and (if the list is currently empty) arm polling. Once any
+   * record has been observed in the response, polling is disabled for the rest
+   * of this hook instance's lifetime — subsequent `revalidate()` calls just
+   * trigger a single refetch.
+   */
+  revalidate: () => Promise<void>;
+};
+
+/**
+ * Subscribes to the list of enterprise-connection test runs for the signed-in user
+ *
+ * @internal
+ */
+function useEnterpriseConnectionTestRuns(
+  params: UseEnterpriseConnectionTestRunsParams,
+): UseEnterpriseConnectionTestRunsReturn {
+  const {
+    enterpriseConnectionId,
+    params: fetchParams = { initialPage: 1, pageSize: 10 },
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    enabled = true,
+  } = params;
+
+  const clerk = useClerkInstanceContext();
+  const user = useUserBase();
+  const [queryClient] = useClerkQueryClient();
+
+  const { queryKey, stableKey, authenticated } = useEnterpriseConnectionTestRunsCacheKeys({
+    userId: user?.id ?? null,
+    enterpriseConnectionId,
+    args: fetchParams,
+  });
+
+  useClearQueriesOnSignOut({
+    isSignedOut: user === null,
+    authenticated,
+    stableKeys: stableKey,
+  });
+
+  const queryEnabled = enabled && clerk.loaded && Boolean(user) && Boolean(enterpriseConnectionId);
+
+  const [shouldPoll, setShouldPoll] = useState(false);
+
+  const query = useClerkQuery({
+    queryKey,
+    queryFn: () => {
+      if (!enterpriseConnectionId) {
+        throw new Error('enterpriseConnectionId is required to fetch test runs');
+      }
+      return user?.getEnterpriseConnectionTestRuns(enterpriseConnectionId, fetchParams);
+    },
+    enabled: queryEnabled,
+    refetchInterval: q => {
+      if (!shouldPoll) {
+        return false;
+      }
+
+      const hasRows = (q.state.data?.data?.length ?? 0) > 0;
+      return hasRows ? false : pollIntervalMs;
+    },
+  });
+
+  const hasRows = (query.data?.data?.length ?? 0) > 0;
+
+  useEffect(() => {
+    if (shouldPoll && hasRows) {
+      setShouldPoll(false);
+    }
+  }, [shouldPoll, hasRows]);
+
+  const revalidate = useCallback(async () => {
+    // Only arm polling when there is nothing in the list yet — once any record
+    // has been seen, this is a one-shot refetch.
+    if (!hasRows) {
+      setShouldPoll(true);
+    }
+    await queryClient.invalidateQueries({ queryKey: [stableKey] });
+  }, [queryClient, stableKey, hasRows]);
+
+  const isPolling = queryEnabled && shouldPoll && !hasRows;
+
+  return {
+    data: query.data?.data,
+    latest: query.data?.data?.[0],
+    totalCount: query.data?.total_count,
+    error: query.error ?? null,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isPolling,
+    revalidate,
+  };
+}
+
+export { useEnterpriseConnectionTestRuns as __internal_useEnterpriseConnectionTestRuns };

--- a/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
+++ b/packages/shared/src/react/hooks/useEnterpriseConnectionTestRuns.tsx
@@ -70,7 +70,7 @@ function useEnterpriseConnectionTestRuns(
   const user = useUserBase();
   const [queryClient] = useClerkQueryClient();
 
-  const { queryKey, stableKey, authenticated } = useEnterpriseConnectionTestRunsCacheKeys({
+  const { queryKey, invalidationKey, stableKey, authenticated } = useEnterpriseConnectionTestRunsCacheKeys({
     userId: user?.id ?? null,
     enterpriseConnectionId,
     args: fetchParams,
@@ -120,8 +120,8 @@ function useEnterpriseConnectionTestRuns(
     if (!hasRows) {
       setShouldPoll(true);
     }
-    await queryClient.invalidateQueries({ queryKey: [stableKey] });
-  }, [queryClient, stableKey, hasRows]);
+    await queryClient.invalidateQueries({ queryKey: invalidationKey });
+  }, [queryClient, invalidationKey, hasRows]);
 
   const isPolling = queryEnabled && shouldPoll && !hasRows;
 

--- a/packages/shared/src/react/stable-keys.ts
+++ b/packages/shared/src/react/stable-keys.ts
@@ -73,12 +73,14 @@ const PAYMENT_ATTEMPT_KEY = 'billing-payment-attempt';
 const BILLING_PLANS_KEY = 'billing-plan';
 const BILLING_STATEMENTS_KEY = 'billing-statement';
 const USER_ENTERPRISE_CONNECTIONS_KEY = 'userEnterpriseConnections';
+const ENTERPRISE_CONNECTION_TEST_RUNS_KEY = 'enterpriseConnectionTestRuns';
 
 export const INTERNAL_STABLE_KEYS = {
   PAYMENT_ATTEMPT_KEY,
   BILLING_PLANS_KEY,
   BILLING_STATEMENTS_KEY,
   USER_ENTERPRISE_CONNECTIONS_KEY,
+  ENTERPRISE_CONNECTION_TEST_RUNS_KEY,
 } as const;
 
 export type __internal_ResourceCacheStableKey = (typeof INTERNAL_STABLE_KEYS)[keyof typeof INTERNAL_STABLE_KEYS];

--- a/packages/shared/src/types/elementIds.ts
+++ b/packages/shared/src/types/elementIds.ts
@@ -57,7 +57,9 @@ export type ProfileSectionId =
   | 'ssoDomain'
   | 'ssoConfiguration'
   | 'configureAgain'
-  | 'resetSso';
+  | 'resetSso'
+  | 'testSsoUrl'
+  | 'testResults';
 export type ProfilePageId = 'account' | 'security' | 'organizationGeneral' | 'organizationMembers' | 'billing';
 
 export type UserPreviewId = 'userButton' | 'personalWorkspace';

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1365,10 +1365,14 @@ export type __internal_LocalizationResource = {
           actionLabel__copy: LocalizationValue;
           actionLabel__copied: LocalizationValue;
         };
+        parsedUserInfo: {
+          sectionTitle: LocalizationValue;
+          email: LocalizationValue;
+          firstName: LocalizationValue;
+        };
         howToFix: {
           sectionTitle: LocalizationValue;
           actionLabel__viewDocumentation: LocalizationValue;
-          generic: LocalizationValue;
           saml_user_attribute_missing: {
             intro: LocalizationValue;
             step1: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1341,6 +1341,7 @@ export type __internal_LocalizationResource = {
     testConfigurationStep: {
       title: LocalizationValue;
       subtitle: LocalizationValue;
+      error__noSuccessfulTestRun: LocalizationValue;
       testUrl: {
         title: LocalizationValue;
         subtitle: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1338,6 +1338,23 @@ export type __internal_LocalizationResource = {
         subtitle: LocalizationValue;
       };
     };
+    testConfigurationStep: {
+      title: LocalizationValue;
+      subtitle: LocalizationValue;
+      testUrl: {
+        title: LocalizationValue;
+        subtitle: LocalizationValue;
+        actionLabel__copy: LocalizationValue;
+      };
+      testResults: {
+        title: LocalizationValue;
+        actionLabel__refresh: LocalizationValue;
+        polling: LocalizationValue;
+        status__success: LocalizationValue;
+        status__failed: LocalizationValue;
+        status__pending: LocalizationValue;
+      };
+    };
     configureStep: {
       spFields: {
         acsUrl: {

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1354,6 +1354,9 @@ export type __internal_LocalizationResource = {
         status__failed: LocalizationValue;
         status__pending: LocalizationValue;
       };
+      testRunDetails: {
+        title: LocalizationValue;
+      };
     };
     configureStep: {
       spFields: {

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1356,6 +1356,43 @@ export type __internal_LocalizationResource = {
       };
       testRunDetails: {
         title: LocalizationValue;
+        runDetails: {
+          sectionTitle: LocalizationValue;
+          timestamp: LocalizationValue;
+          status: LocalizationValue;
+          errorCode: LocalizationValue;
+          fullMessage: LocalizationValue;
+          actionLabel__copy: LocalizationValue;
+          actionLabel__copied: LocalizationValue;
+        };
+        howToFix: {
+          sectionTitle: LocalizationValue;
+          actionLabel__viewDocumentation: LocalizationValue;
+          generic: LocalizationValue;
+          saml_user_attribute_missing: {
+            intro: LocalizationValue;
+            step1: LocalizationValue;
+            step2: LocalizationValue;
+            step3: LocalizationValue;
+          };
+          saml_response_relaystate_missing: {
+            description: LocalizationValue;
+          };
+          saml_email_address_domain_mismatch: {
+            description: LocalizationValue;
+          };
+          oauth_access_denied: {
+            description: LocalizationValue;
+          };
+          oauth_token_exchange_error: {
+            description: LocalizationValue;
+          };
+          oauth_fetch_user_error: {
+            intro: LocalizationValue;
+            step1: LocalizationValue;
+            step2: LocalizationValue;
+          };
+        };
       };
     };
     configureStep: {

--- a/packages/ui/src/components/APIKeys/APIKeys.tsx
+++ b/packages/ui/src/components/APIKeys/APIKeys.tsx
@@ -208,7 +208,6 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
         />
       </Action.Root>
 
-      {/* here reference to paginated table for test runs */}
       <APIKeysTable
         rows={apiKeys}
         isLoading={isLoading}

--- a/packages/ui/src/components/APIKeys/APIKeys.tsx
+++ b/packages/ui/src/components/APIKeys/APIKeys.tsx
@@ -1,6 +1,6 @@
 import { isClerkAPIResponseError } from '@clerk/shared/error';
 import { isOrganizationId } from '@clerk/shared/internal/clerk-js/organization';
-import { __internal_useOrganizationBase, useAPIKeys, useClerk, useUser } from '@clerk/shared/react';
+import { useAPIKeys, __internal_useOrganizationBase, useClerk, useUser } from '@clerk/shared/react';
 import type { APIKeyResource } from '@clerk/shared/types';
 import { lazy, useState } from 'react';
 
@@ -22,9 +22,9 @@ import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { InputWithIcon } from '@/ui/elements/InputWithIcon';
 import { Pagination } from '@/ui/elements/Pagination';
 import { useDebounce } from '@/ui/hooks';
+import { handleError } from '@/ui/utils/errorHandler';
 import { MagnifyingGlass } from '@/ui/icons';
 import { mqu } from '@/ui/styledSystem';
-import { handleError } from '@/ui/utils/errorHandler';
 
 import { APIKeysTable } from './ApiKeysTable';
 import type { OnCreateParams } from './CreateAPIKeyForm';

--- a/packages/ui/src/components/APIKeys/APIKeys.tsx
+++ b/packages/ui/src/components/APIKeys/APIKeys.tsx
@@ -1,6 +1,6 @@
 import { isClerkAPIResponseError } from '@clerk/shared/error';
 import { isOrganizationId } from '@clerk/shared/internal/clerk-js/organization';
-import { useAPIKeys, __internal_useOrganizationBase, useClerk, useUser } from '@clerk/shared/react';
+import { __internal_useOrganizationBase, useAPIKeys, useClerk, useUser } from '@clerk/shared/react';
 import type { APIKeyResource } from '@clerk/shared/types';
 import { lazy, useState } from 'react';
 
@@ -22,9 +22,9 @@ import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { InputWithIcon } from '@/ui/elements/InputWithIcon';
 import { Pagination } from '@/ui/elements/Pagination';
 import { useDebounce } from '@/ui/hooks';
-import { handleError } from '@/ui/utils/errorHandler';
 import { MagnifyingGlass } from '@/ui/icons';
 import { mqu } from '@/ui/styledSystem';
+import { handleError } from '@/ui/utils/errorHandler';
 
 import { APIKeysTable } from './ApiKeysTable';
 import type { OnCreateParams } from './CreateAPIKeyForm';
@@ -208,6 +208,7 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
         />
       </Action.Root>
 
+      {/* here reference to paginated table for test runs */}
       <APIKeysTable
         rows={apiKeys}
         isLoading={isLoading}

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -55,7 +55,7 @@ const AuthenticatedContent = withCoreUserGuard(() => {
           })}
         >
           <ConfigureSSOCardProtect>
-            <ConfigureSSOCardContent />
+            <ConfigureSSOCardContent contentRef={contentRef} />
           </ConfigureSSOCardProtect>
         </Col>
       </ConfigureSSONavbar>
@@ -63,7 +63,7 @@ const AuthenticatedContent = withCoreUserGuard(() => {
   );
 });
 
-const ConfigureSSOCardContent = () => {
+const ConfigureSSOCardContent = ({ contentRef }: { contentRef: React.RefObject<HTMLDivElement> }) => {
   const { data: enterpriseConnections, isLoading } = __internal_useUserEnterpriseConnections({ enabled: true });
 
   // Currently FAPI only supports one enterprise connection per user
@@ -74,7 +74,10 @@ const ConfigureSSOCardContent = () => {
   }
 
   return (
-    <ConfigureSSOProvider enterpriseConnection={enterpriseConnection}>
+    <ConfigureSSOProvider
+      enterpriseConnection={enterpriseConnection}
+      contentRef={contentRef}
+    >
       <ConfigureSSOSteps />
     </ConfigureSSOProvider>
   );

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -24,10 +24,15 @@ export interface ConfigureSSOData {
    * connection has been created.
    */
   setProvider: (provider: ProviderType) => void;
+  /**
+   * Ref to the scrollable content container of the wizard.
+   */
+  contentRef: React.RefObject<HTMLDivElement>;
 }
 
 interface ConfigureSSOProviderProps {
   enterpriseConnection: EnterpriseConnectionResource | undefined;
+  contentRef: React.RefObject<HTMLDivElement>;
 }
 
 const ConfigureSSOContext = React.createContext<ConfigureSSOData | null>(null);
@@ -35,6 +40,7 @@ ConfigureSSOContext.displayName = 'ConfigureSSOContext';
 
 export const ConfigureSSOProvider = ({
   enterpriseConnection,
+  contentRef,
   children,
 }: PropsWithChildren<ConfigureSSOProviderProps>): JSX.Element => {
   const [provider, setProvider] = React.useState<ProviderType | undefined>(
@@ -49,8 +55,9 @@ export const ConfigureSSOProvider = ({
       enterpriseConnection,
       provider,
       setProvider,
+      contentRef,
     }),
-    [initialStepId, enterpriseConnection, provider],
+    [initialStepId, enterpriseConnection, provider, contentRef],
   );
 
   return <ConfigureSSOContext.Provider value={value}>{children}</ConfigureSSOContext.Provider>;

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -281,6 +281,7 @@ const TestResultsTable = ({
   onPageChange,
 }: TestResultsTableProps): JSX.Element => {
   const { t } = useLocalizations();
+  const { contentRef } = useConfigureSSO();
   const [selectedTestRun, setSelectedTestRun] = useState<EnterpriseConnectionTestRunResource | null>(null);
 
   const drawerTitle =
@@ -423,6 +424,8 @@ const TestResultsTable = ({
             setSelectedTestRun(null);
           }
         }}
+        strategy='absolute'
+        portalProps={{ root: contentRef }}
       >
         <Drawer.Overlay />
         <Drawer.Content>

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -381,7 +381,64 @@ const TestRunDetailsBody = ({ testRun }: { testRun: EnterpriseConnectionTestRunR
       {testRun.status === 'failed' && failedLog?.message ? <FullMessageBlock message={failedLog.message} /> : null}
 
       {testRun.status === 'failed' ? <TestRunHowToFixSection errorCode={failedLog?.code} /> : null}
+
+      {testRun.status === 'success' ? <ParsedUserInfoSection parsedUserInfo={testRun.parsedUserInfo} /> : null}
     </Drawer.Body>
+  );
+};
+
+const ParsedUserInfoSection = ({
+  parsedUserInfo,
+}: {
+  parsedUserInfo: EnterpriseConnectionTestRunResource['parsedUserInfo'];
+}): JSX.Element | null => {
+  if (!parsedUserInfo?.emailAddress && !parsedUserInfo?.firstName) {
+    return null;
+  }
+
+  return (
+    <Flex
+      direction='col'
+      gap={3}
+      sx={t => ({
+        borderTopWidth: t.borderWidths.$normal,
+        borderTopStyle: t.borderStyles.$solid,
+        borderTopColor: t.colors.$borderAlpha100,
+        paddingTop: t.space.$4,
+      })}
+    >
+      <Heading
+        as='h3'
+        textVariant='h3'
+        localizationKey={localizationKeys(
+          'configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.sectionTitle',
+        )}
+      />
+
+      <LineItems.Root>
+        {parsedUserInfo.emailAddress ? (
+          <LineItems.Group>
+            <LineItems.Title
+              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.email')}
+            />
+            <LineItems.Description>
+              <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.emailAddress}</Text>
+            </LineItems.Description>
+          </LineItems.Group>
+        ) : null}
+
+        {parsedUserInfo.firstName ? (
+          <LineItems.Group>
+            <LineItems.Title
+              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.firstName')}
+            />
+            <LineItems.Description>
+              <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.firstName}</Text>
+            </LineItems.Description>
+          </LineItems.Group>
+        ) : null}
+      </LineItems.Root>
+    </Flex>
   );
 };
 

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -1,12 +1,17 @@
 import { __internal_useEnterpriseConnectionTestRuns, useUser } from '@clerk/shared/react/index';
 import type { EnterpriseConnectionTestRunResource } from '@clerk/shared/types';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
+import type { LocalizationKey } from '@/customizables';
 import {
   Badge,
   Box,
   Button,
+  Dd,
   descriptors,
+  Dl,
+  Dt,
   Flex,
   Flow,
   Heading,
@@ -25,7 +30,6 @@ import {
 import { useCardState } from '@/elements/contexts';
 import { Drawer } from '@/elements/Drawer';
 import { IconButton } from '@/elements/IconButton';
-import { LineItems } from '@/elements/LineItems';
 import { Pagination } from '@/elements/Pagination';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
@@ -154,14 +158,14 @@ export const TestConfigurationStep = (): JSX.Element => {
             >
               <TestResultsTable
                 rows={testRuns ?? []}
-                isLoading={areTestRunsLoading}
-                onTestRunCreated={handleTestRunCreated}
                 isPolling={isPolling}
+                isLoading={areTestRunsLoading}
                 page={currentPage}
                 pageCount={pageCount}
                 pageSize={TEST_RUNS_PAGE_SIZE}
                 totalCount={totalCount ?? 0}
                 onPageChange={setCurrentPage}
+                onTestRunCreated={handleTestRunCreated}
               />
             </ProfileSection.Root>
           </Step.Section>
@@ -459,6 +463,34 @@ const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRu
   );
 };
 
+const DetailRow = ({ title, children }: { title: LocalizationKey; children: ReactNode }): JSX.Element => (
+  <Box
+    as='div'
+    sx={t => ({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+      gap: t.space.$2,
+    })}
+  >
+    <Dt
+      localizationKey={title}
+      sx={t => ({
+        color: t.colors.$colorForeground,
+        ...common.textVariants(t).subtitle,
+      })}
+    />
+    <Dd
+      sx={t => ({
+        display: 'grid',
+        justifyContent: 'end',
+        color: t.colors.$colorForeground,
+      })}
+    >
+      {children}
+    </Dd>
+  </Box>
+);
+
 const TestRunDetailsBody = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element => {
   const formatted = useTestRunFormattedTimestamp(testRun);
   const failedLog = testRun.status === 'failed' ? testRun.logs?.[0] : null;
@@ -480,47 +512,34 @@ const TestRunDetailsBody = ({ testRun }: { testRun: EnterpriseConnectionTestRunR
         localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.sectionTitle')}
       />
 
-      <LineItems.Root>
+      <Dl sx={t => ({ display: 'grid', gridRowGap: t.space.$2 })}>
         {formatted ? (
-          <LineItems.Group>
-            <LineItems.Title
-              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.timestamp')}
-            />
-            <LineItems.Description>
-              <Flex
-                gap={2}
-                align='baseline'
-                sx={{ whiteSpace: 'nowrap' }}
-              >
-                <Text>{formatted.time}</Text>
-                <Text colorScheme='secondary'>{formatted.day}</Text>
-              </Flex>
-            </LineItems.Description>
-          </LineItems.Group>
+          <DetailRow title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.timestamp')}>
+            <Flex
+              gap={2}
+              align='baseline'
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              <Text>{formatted.time}</Text>
+              <Text colorScheme='secondary'>{formatted.day}</Text>
+            </Flex>
+          </DetailRow>
         ) : null}
 
         {testRun.status === 'failed' ? (
           failedLog?.code ? (
-            <LineItems.Group>
-              <LineItems.Title
-                title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.errorCode')}
-              />
-              <LineItems.Description>
-                <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{failedLog.code}</Text>
-              </LineItems.Description>
-            </LineItems.Group>
+            <DetailRow
+              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.errorCode')}
+            >
+              <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{failedLog.code}</Text>
+            </DetailRow>
           ) : null
         ) : (
-          <LineItems.Group>
-            <LineItems.Title
-              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.status')}
-            />
-            <LineItems.Description>
-              <TestRunStatusCell testRun={testRun} />
-            </LineItems.Description>
-          </LineItems.Group>
+          <DetailRow title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.status')}>
+            <TestRunStatusCell testRun={testRun} />
+          </DetailRow>
         )}
-      </LineItems.Root>
+      </Dl>
 
       {testRun.status === 'failed' && failedLog?.message ? <FullMessageBlock message={failedLog.message} /> : null}
 
@@ -559,29 +578,21 @@ const ParsedUserInfoSection = ({
         )}
       />
 
-      <LineItems.Root>
+      <Dl sx={t => ({ display: 'grid', gridRowGap: t.space.$2 })}>
         {parsedUserInfo.emailAddress ? (
-          <LineItems.Group>
-            <LineItems.Title
-              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.email')}
-            />
-            <LineItems.Description>
-              <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.emailAddress}</Text>
-            </LineItems.Description>
-          </LineItems.Group>
+          <DetailRow title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.email')}>
+            <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.emailAddress}</Text>
+          </DetailRow>
         ) : null}
 
         {parsedUserInfo.firstName ? (
-          <LineItems.Group>
-            <LineItems.Title
-              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.firstName')}
-            />
-            <LineItems.Description>
-              <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.firstName}</Text>
-            </LineItems.Description>
-          </LineItems.Group>
+          <DetailRow
+            title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.parsedUserInfo.firstName')}
+          >
+            <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{parsedUserInfo.firstName}</Text>
+          </DetailRow>
         ) : null}
-      </LineItems.Root>
+      </Dl>
     </Flex>
   );
 };
@@ -694,7 +705,6 @@ const TestRunStatusCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunRe
 };
 
 type CopyTestUrlButtonProps = {
-  /** Called once a new test run has been created and copied to the clipboard, with the generated test URL. */
   onTestRunCreated?: (testUrl: string) => void;
 };
 
@@ -719,7 +729,7 @@ const CopyTestUrlButton = ({ onTestRunCreated }: CopyTestUrlButtonProps): JSX.El
       .createEnterpriseConnectionTestRun(enterpriseConnection.id)
       .then(({ url }) => {
         setTestUrl(url);
-        onCopy(url);
+        onCopy();
         onTestRunCreated?.(url);
       })
       .catch(err => handleError(err as Error, [], card.setError))

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -4,10 +4,12 @@ import { useState } from 'react';
 
 import {
   Badge,
+  Box,
   Button,
   descriptors,
   Flex,
   Flow,
+  Heading,
   Icon,
   localizationKeys,
   Spinner,
@@ -22,6 +24,8 @@ import {
 } from '@/customizables';
 import { useCardState } from '@/elements/contexts';
 import { Drawer } from '@/elements/Drawer';
+import { IconButton } from '@/elements/IconButton';
+import { LineItems } from '@/elements/LineItems';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy, RotateLeftRight } from '@/icons';
@@ -31,9 +35,10 @@ import { handleError } from '@/utils/errorHandler';
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
+import { TestRunHowToFixSection } from './TestRunHowToFixSection';
 
 export const TestConfigurationStep = (): JSX.Element => {
-  const { goNext, goPrev, isLastStep } = useWizard();
+  const { goNext, goPrev } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
 
   const {
@@ -274,22 +279,29 @@ const TestResultsTable = ({ rows, isLoading, isPolling, onTestRunCreated }: Test
         <Drawer.Overlay />
         <Drawer.Content>
           <Drawer.Header title={drawerTitle} />
-          <Drawer.Body>{null}</Drawer.Body>
+          {selectedTestRun ? <TestRunDetailsBody testRun={selectedTestRun} /> : null}
         </Drawer.Content>
       </Drawer.Root>
     </>
   );
 };
 
-const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element | null => {
+const useTestRunFormattedTimestamp = (testRun: EnterpriseConnectionTestRunResource) => {
   const { locale } = useLocalizations();
-
   if (!testRun.createdAt) {
     return null;
   }
-
   const time = new Intl.DateTimeFormat(locale, { timeStyle: 'medium' }).format(testRun.createdAt);
   const day = new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(testRun.createdAt);
+
+  return { time, day };
+};
+
+const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element | null => {
+  const formatted = useTestRunFormattedTimestamp(testRun);
+  if (!formatted) {
+    return null;
+  }
 
   return (
     <Flex
@@ -297,8 +309,136 @@ const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRu
       align='baseline'
       sx={{ whiteSpace: 'nowrap' }}
     >
-      <Text>{time}</Text>
-      <Text colorScheme='secondary'>{day}</Text>
+      <Text>{formatted.time}</Text>
+      <Text colorScheme='secondary'>{formatted.day}</Text>
+    </Flex>
+  );
+};
+
+const TestRunDetailsBody = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element => {
+  const formatted = useTestRunFormattedTimestamp(testRun);
+  const failedLog = testRun.status === 'failed' ? testRun.logs?.[0] : null;
+
+  return (
+    <Drawer.Body
+      sx={t => ({
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        overflowY: 'auto',
+        padding: t.space.$4,
+        gap: t.space.$4,
+      })}
+    >
+      <Heading
+        as='h3'
+        textVariant='h3'
+        localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.sectionTitle')}
+      />
+
+      <LineItems.Root>
+        {formatted ? (
+          <LineItems.Group>
+            <LineItems.Title
+              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.timestamp')}
+            />
+            <LineItems.Description>
+              <Flex
+                gap={2}
+                align='baseline'
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                <Text>{formatted.time}</Text>
+                <Text colorScheme='secondary'>{formatted.day}</Text>
+              </Flex>
+            </LineItems.Description>
+          </LineItems.Group>
+        ) : null}
+
+        {testRun.status === 'failed' ? (
+          failedLog?.code ? (
+            <LineItems.Group>
+              <LineItems.Title
+                title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.errorCode')}
+              />
+              <LineItems.Description>
+                <Text sx={t => ({ fontFamily: t.fonts.$mono })}>{failedLog.code}</Text>
+              </LineItems.Description>
+            </LineItems.Group>
+          ) : null
+        ) : (
+          <LineItems.Group>
+            <LineItems.Title
+              title={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.status')}
+            />
+            <LineItems.Description>
+              <TestRunStatusCell testRun={testRun} />
+            </LineItems.Description>
+          </LineItems.Group>
+        )}
+      </LineItems.Root>
+
+      {testRun.status === 'failed' && failedLog?.message ? <FullMessageBlock message={failedLog.message} /> : null}
+
+      {testRun.status === 'failed' ? <TestRunHowToFixSection errorCode={failedLog?.code} /> : null}
+    </Drawer.Body>
+  );
+};
+
+const FullMessageBlock = ({ message }: { message: string }): JSX.Element => {
+  const { t } = useLocalizations();
+  const { onCopy, hasCopied } = useClipboard(message);
+  const copyLabel = t(
+    localizationKeys(
+      hasCopied
+        ? 'configureSSO.testConfigurationStep.testRunDetails.runDetails.actionLabel__copied'
+        : 'configureSSO.testConfigurationStep.testRunDetails.runDetails.actionLabel__copy',
+    ),
+  );
+
+  return (
+    <Flex
+      direction='col'
+      gap={2}
+    >
+      <Flex
+        justify='between'
+        align='center'
+        gap={4}
+      >
+        <Text
+          colorScheme='secondary'
+          localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.runDetails.fullMessage')}
+        />
+        <IconButton
+          variant='ghost'
+          colorScheme='neutral'
+          size='xs'
+          icon={hasCopied ? Check : Copy}
+          aria-label={copyLabel}
+          onClick={() => onCopy()}
+        />
+      </Flex>
+      <Box
+        as='pre'
+        sx={t => ({
+          margin: 0,
+          padding: t.space.$3,
+          backgroundColor: t.colors.$colorBackground,
+          borderWidth: t.borderWidths.$normal,
+          borderStyle: t.borderStyles.$solid,
+          borderColor: t.colors.$borderAlpha150,
+          borderRadius: t.radii.$md,
+          boxShadow: t.shadows.$cardContentShadow,
+          fontFamily: t.fonts.$mono,
+          fontSize: t.fontSizes.$sm,
+          color: t.colors.$colorForeground,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        })}
+      >
+        {message}
+      </Box>
     </Flex>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -26,6 +26,7 @@ import { useCardState } from '@/elements/contexts';
 import { Drawer } from '@/elements/Drawer';
 import { IconButton } from '@/elements/IconButton';
 import { LineItems } from '@/elements/LineItems';
+import { Pagination } from '@/elements/Pagination';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy, RotateLeftRight } from '@/icons';
@@ -37,24 +38,31 @@ import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
 import { TestRunHowToFixSection } from './TestRunHowToFixSection';
 
+const TEST_RUNS_PAGE_SIZE = 5;
+
 export const TestConfigurationStep = (): JSX.Element => {
   const { goNext, goPrev } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
 
+  const [currentPage, setCurrentPage] = useState(1);
+
   const {
     data: testRuns,
     latest,
+    totalCount,
     isLoading: areTestRunsLoading,
     isPolling,
     revalidate: revalidateTestRuns,
   } = __internal_useEnterpriseConnectionTestRuns({
     enterpriseConnectionId: enterpriseConnection?.id ?? null,
-    params: { initialPage: 1, pageSize: 10 },
+    params: { initialPage: currentPage, pageSize: TEST_RUNS_PAGE_SIZE },
   });
 
   const hasSuccessfulTestRun = latest?.status === 'success';
+  const pageCount = totalCount ? Math.ceil(totalCount / TEST_RUNS_PAGE_SIZE) : 0;
 
   const handleTestRunCreated = () => {
+    setCurrentPage(1);
     void revalidateTestRuns();
   };
 
@@ -149,6 +157,11 @@ export const TestConfigurationStep = (): JSX.Element => {
                 isLoading={areTestRunsLoading}
                 onTestRunCreated={handleTestRunCreated}
                 isPolling={isPolling}
+                page={currentPage}
+                pageCount={pageCount}
+                pageSize={TEST_RUNS_PAGE_SIZE}
+                totalCount={totalCount ?? 0}
+                onPageChange={setCurrentPage}
               />
             </ProfileSection.Root>
           </Step.Section>
@@ -171,9 +184,24 @@ type TestResultsTableProps = {
   isLoading: boolean;
   isPolling: boolean;
   onTestRunCreated?: (testUrl: string) => void;
+  page: number;
+  pageCount: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
 };
 
-const TestResultsTable = ({ rows, isLoading, isPolling, onTestRunCreated }: TestResultsTableProps): JSX.Element => {
+const TestResultsTable = ({
+  rows,
+  isLoading,
+  isPolling,
+  onTestRunCreated,
+  page,
+  pageCount,
+  pageSize,
+  totalCount,
+  onPageChange,
+}: TestResultsTableProps): JSX.Element => {
   const { t } = useLocalizations();
   const [selectedTestRun, setSelectedTestRun] = useState<EnterpriseConnectionTestRunResource | null>(null);
 
@@ -267,6 +295,20 @@ const TestResultsTable = ({ rows, isLoading, isPolling, onTestRunCreated }: Test
           </Tbody>
         </Table>
       </Flex>
+
+      {pageCount > 1 ? (
+        <Pagination
+          page={Math.min(page, pageCount)}
+          count={pageCount}
+          onChange={onPageChange}
+          siblingCount={1}
+          rowInfo={{
+            allRowsCount: totalCount,
+            startingRow: totalCount > 0 ? Math.max(0, (page - 1) * pageSize) + 1 : 0,
+            endingRow: Math.min(page * pageSize, totalCount),
+          }}
+        />
+      ) : null}
 
       <Drawer.Root
         open={selectedTestRun !== null}

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -732,7 +732,7 @@ const CopyTestUrlButton = ({ onTestRunCreated }: CopyTestUrlButtonProps): JSX.El
       .createEnterpriseConnectionTestRun(enterpriseConnection.id)
       .then(({ url }) => {
         setTestUrl(url);
-        onCopy();
+        onCopy(url);
         onTestRunCreated?.(url);
       })
       .catch(err => handleError(err as Error, [], card.setError))

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -1,4 +1,8 @@
-import { descriptors, Flow, Text } from '@/customizables';
+import { descriptors, Flex, Flow, Icon, Spinner, Table, Tbody, Td, Text, Tr } from '@/customizables';
+import { ProfileSection } from '@/elements/Section';
+import { useClipboard } from '@/hooks';
+import { Check, Copy } from '@/icons';
+import { mqu } from '@/styledSystem';
 
 import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
@@ -25,11 +29,51 @@ export const TestConfigurationStep = (): JSX.Element => {
               borderBottomColor: theme.colors.$borderAlpha100,
             })}
           >
-            <Text>Test your SSO URL</Text>
+            <ProfileSection.Root
+              title='Test your SSO URL'
+              id='testSsoUrl'
+              centered={false}
+              sx={t => ({
+                borderTopWidth: 0,
+                paddingTop: 0,
+                paddingBottom: 0,
+                flexDirection: 'column-reverse',
+                gap: t.space.$2,
+              })}
+            >
+              <Text colorScheme='secondary'>
+                Authenticate using the test SSO URL to verify you configured the connection correctly.
+              </Text>
+              <ProfileSection.Item
+                id='testSsoUrl'
+                sx={{ paddingInlineStart: 0 }}
+              >
+                <CopyTestUrlButton
+                  url=''
+                  isLoading={false}
+                />
+              </ProfileSection.Item>
+            </ProfileSection.Root>
           </Step.Section>
 
           <Step.Section>
-            <Text>Your test results</Text>
+            <ProfileSection.Root
+              title='Your test results'
+              id='testResults'
+              centered={false}
+              sx={t => ({
+                borderTopWidth: 0,
+                paddingTop: 0,
+                paddingBottom: 0,
+                flexDirection: 'column-reverse',
+                gap: t.space.$2,
+              })}
+            >
+              <TestResultsTable
+                rows={[]}
+                isLoading
+              />
+            </ProfileSection.Root>
           </Step.Section>
         </Step.Body>
 
@@ -45,5 +89,87 @@ export const TestConfigurationStep = (): JSX.Element => {
         </Step.Footer>
       </Step>
     </Flow.Part>
+  );
+};
+
+type TestResultRow = {
+  id: string;
+};
+
+const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoading: boolean }): JSX.Element => {
+  return (
+    <Flex sx={t => ({ width: '100%', [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 } })}>
+      <Table sx={t => ({ background: t.colors.$colorBackground })}>
+        <Tbody>
+          {isLoading ? (
+            <Tr>
+              <Td>
+                <Flex
+                  direction='col'
+                  align='center'
+                  gap={2}
+                  sx={t => ({ padding: `${t.space.$10} 0` })}
+                >
+                  <Spinner
+                    colorScheme='primary'
+                    elementDescriptor={descriptors.spinner}
+                  />
+                  <Text colorScheme='secondary'>loading logs</Text>
+                </Flex>
+              </Td>
+            </Tr>
+          ) : !rows.length ? (
+            <EmptyTestResultsRow />
+          ) : (
+            rows.map(row => (
+              <Tr key={row.id}>
+                <Td>{row.id}</Td>
+              </Tr>
+            ))
+          )}
+        </Tbody>
+      </Table>
+    </Flex>
+  );
+};
+
+const EmptyTestResultsRow = (): JSX.Element => {
+  return (
+    <Tr>
+      <Td>
+        <Text
+          colorScheme='secondary'
+          sx={t => ({ display: 'block', textAlign: 'center', padding: `${t.space.$10} 0` })}
+        >
+          No test results yet
+        </Text>
+      </Td>
+    </Tr>
+  );
+};
+
+const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean }): JSX.Element => {
+  const { onCopy, hasCopied } = useClipboard(url);
+
+  return (
+    <ProfileSection.Button
+      id='testSsoUrl'
+      variant='outline'
+      size='sm'
+      isDisabled={!url}
+      isLoading={isLoading}
+      loadingText='Generating test URL…'
+      onClick={onCopy}
+      sx={t => ({
+        gap: t.space.$1x5,
+        alignSelf: 'flex-start',
+      })}
+    >
+      <Icon
+        icon={hasCopied ? Check : Copy}
+        size='sm'
+      />
+      {hasCopied ? 'Copied' : 'Copy test URL'}
+    </ProfileSection.Button>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -7,7 +7,7 @@ export const TestConfigurationStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
 
   return (
-    <Flow.Part part='test-sso'>
+    <Flow.Part part='testSso'>
       <Step
         elementDescriptor={descriptors.configureSSOStep}
         elementId={descriptors.configureSSOStep.setId('test')}

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -1,4 +1,17 @@
-import { descriptors, Flex, Flow, Icon, Spinner, Table, Tbody, Td, Text, Tr } from '@/customizables';
+import {
+  descriptors,
+  Flex,
+  Flow,
+  Icon,
+  localizationKeys,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Tr,
+  useLocalizations,
+} from '@/customizables';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy } from '@/icons';
@@ -17,8 +30,8 @@ export const TestConfigurationStep = (): JSX.Element => {
         elementId={descriptors.configureSSOStep.setId('test')}
       >
         <Step.Header
-          title='Test your SSO connection'
-          description='Test your SSO configuration to verify you can successfully authenticate via your identity provider'
+          title={localizationKeys('configureSSO.testConfigurationStep.title')}
+          description={localizationKeys('configureSSO.testConfigurationStep.subtitle')}
         />
 
         <Step.Body>
@@ -30,7 +43,7 @@ export const TestConfigurationStep = (): JSX.Element => {
             })}
           >
             <ProfileSection.Root
-              title='Test your SSO URL'
+              title={localizationKeys('configureSSO.testConfigurationStep.testUrl.title')}
               id='testSsoUrl'
               centered={false}
               sx={t => ({
@@ -38,12 +51,13 @@ export const TestConfigurationStep = (): JSX.Element => {
                 paddingTop: 0,
                 paddingBottom: 0,
                 flexDirection: 'column-reverse',
-                gap: t.space.$2,
+                gap: t.space.$1,
               })}
             >
-              <Text colorScheme='secondary'>
-                Authenticate using the test SSO URL to verify you configured the connection correctly.
-              </Text>
+              <Text
+                colorScheme='secondary'
+                localizationKey={localizationKeys('configureSSO.testConfigurationStep.testUrl.subtitle')}
+              />
               <ProfileSection.Item
                 id='testSsoUrl'
                 sx={{ paddingInlineStart: 0 }}
@@ -58,7 +72,7 @@ export const TestConfigurationStep = (): JSX.Element => {
 
           <Step.Section>
             <ProfileSection.Root
-              title='Your test results'
+              title={localizationKeys('configureSSO.testConfigurationStep.testResults.title')}
               id='testResults'
               centered={false}
               sx={t => ({
@@ -114,7 +128,10 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
                     colorScheme='primary'
                     elementDescriptor={descriptors.spinner}
                   />
-                  <Text colorScheme='secondary'>loading logs</Text>
+                  <Text
+                    colorScheme='secondary'
+                    localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.loading')}
+                  />
                 </Flex>
               </Td>
             </Tr>
@@ -139,10 +156,9 @@ const EmptyTestResultsRow = (): JSX.Element => {
       <Td>
         <Text
           colorScheme='secondary'
+          localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.empty')}
           sx={t => ({ display: 'block', textAlign: 'center', padding: `${t.space.$10} 0` })}
-        >
-          No test results yet
-        </Text>
+        />
       </Td>
     </Tr>
   );
@@ -150,6 +166,7 @@ const EmptyTestResultsRow = (): JSX.Element => {
 
 const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean }): JSX.Element => {
   const { onCopy, hasCopied } = useClipboard(url);
+  const { t } = useLocalizations();
 
   return (
     <ProfileSection.Button
@@ -158,7 +175,7 @@ const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean
       size='sm'
       isDisabled={!url}
       isLoading={isLoading}
-      loadingText='Generating test URL…'
+      loadingText={t(localizationKeys('configureSSO.testConfigurationStep.testUrl.actionLabel__loading'))}
       onClick={onCopy}
       sx={t => ({
         gap: t.space.$1x5,
@@ -169,7 +186,14 @@ const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean
         icon={hasCopied ? Check : Copy}
         size='sm'
       />
-      {hasCopied ? 'Copied' : 'Copy test URL'}
+      <Text
+        as='span'
+        localizationKey={localizationKeys(
+          hasCopied
+            ? 'configureSSO.testConfigurationStep.testUrl.actionLabel__copied'
+            : 'configureSSO.testConfigurationStep.testUrl.actionLabel__copy',
+        )}
+      />
     </ProfileSection.Button>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -1,4 +1,8 @@
+import { useUser } from '@clerk/shared/react/index';
+import { useState } from 'react';
+
 import {
+  Button,
   descriptors,
   Flex,
   Flow,
@@ -12,11 +16,14 @@ import {
   Tr,
   useLocalizations,
 } from '@/customizables';
+import { useCardState } from '@/elements/contexts';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy } from '@/icons';
 import { mqu } from '@/styledSystem';
+import { handleError } from '@/utils/errorHandler';
 
+import { useConfigureSSOFlow } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
 
@@ -62,15 +69,12 @@ export const TestConfigurationStep = (): JSX.Element => {
                 id='testSsoUrl'
                 sx={{ paddingInlineStart: 0 }}
               >
-                <CopyTestUrlButton
-                  url=''
-                  isLoading={false}
-                />
+                <CopyTestUrlButton />
               </ProfileSection.Item>
             </ProfileSection.Root>
           </Step.Section>
 
-          <Step.Section>
+          <Step.Section sx={{ flex: 1, minHeight: 0 }}>
             <ProfileSection.Root
               title={localizationKeys('configureSSO.testConfigurationStep.testResults.title')}
               id='testResults'
@@ -81,21 +85,26 @@ export const TestConfigurationStep = (): JSX.Element => {
                 paddingBottom: 0,
                 flexDirection: 'column-reverse',
                 gap: t.space.$2,
+                flex: 1,
+                minHeight: 0,
+                '& > *:first-of-type': {
+                  flex: 1,
+                  minHeight: 0,
+                },
               })}
             >
               <TestResultsTable
                 rows={[]}
-                isLoading
+                // When test run has been created and we're waiting for the results, we show a loading state
+                isLoading={false}
               />
             </ProfileSection.Root>
           </Step.Section>
         </Step.Body>
 
         <Step.Footer>
-          <Step.Footer.Previous
-            onClick={() => goPrev()}
-            isDisabled={isFirstStep}
-          />
+          <Step.Footer.Previous onClick={() => goPrev()} />
+          {/* TODO - Only allow to continue if the test run has been created and there's at least one successful result */}
           <Step.Footer.Continue
             onClick={() => goNext()}
             isDisabled={isLastStep}
@@ -112,8 +121,18 @@ type TestResultRow = {
 
 const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoading: boolean }): JSX.Element => {
   return (
-    <Flex sx={t => ({ width: '100%', [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 } })}>
-      <Table sx={t => ({ background: t.colors.$colorBackground })}>
+    <Flex
+      sx={t => ({
+        width: '100%',
+        flex: 1,
+        minHeight: 0,
+        [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 },
+      })}
+    >
+      <Table
+        tableHeadVisuallyHidden
+        sx={t => ({ background: t.colors.$colorBackground, height: '100%' })}
+      >
         <Tbody>
           {isLoading ? (
             <Tr>
@@ -136,7 +155,17 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
               </Td>
             </Tr>
           ) : !rows.length ? (
-            <EmptyTestResultsRow />
+            <Tr>
+              <Td>
+                <Flex
+                  align='center'
+                  justify='center'
+                  sx={t => ({ padding: `${t.space.$10} 0`, flex: 1 })}
+                >
+                  <CopyTestUrlButton />
+                </Flex>
+              </Td>
+            </Tr>
           ) : (
             rows.map(row => (
               <Tr key={row.id}>
@@ -150,36 +179,45 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
   );
 };
 
-const EmptyTestResultsRow = (): JSX.Element => {
-  return (
-    <Tr>
-      <Td>
-        <Text
-          colorScheme='secondary'
-          localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.empty')}
-          sx={t => ({ display: 'block', textAlign: 'center', padding: `${t.space.$10} 0` })}
-        />
-      </Td>
-    </Tr>
-  );
-};
-
-const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean }): JSX.Element => {
-  const { onCopy, hasCopied } = useClipboard(url);
+const CopyTestUrlButton = (): JSX.Element => {
   const { t } = useLocalizations();
+  const { user } = useUser();
+  const card = useCardState();
+  const { enterpriseConnection } = useConfigureSSOFlow();
+
+  const [testUrl, setTestUrl] = useState('');
+  const [isCreatingTestRun, setIsCreatingTestRun] = useState(false);
+  const { onCopy, hasCopied } = useClipboard(testUrl);
+
+  const createTestRun = () => {
+    if (!user || !enterpriseConnection) {
+      return;
+    }
+
+    setIsCreatingTestRun(true);
+
+    user
+      .createEnterpriseConnectionTestRun(enterpriseConnection.id)
+      .then(({ url }) => {
+        setTestUrl(url);
+        onCopy();
+      })
+      .catch(err => handleError(err as Error, [], card.setError))
+      .finally(() => setIsCreatingTestRun(false));
+  };
 
   return (
-    <ProfileSection.Button
+    <Button
       id='testSsoUrl'
-      variant='outline'
-      size='sm'
-      isDisabled={!url}
-      isLoading={isLoading}
-      loadingText={t(localizationKeys('configureSSO.testConfigurationStep.testUrl.actionLabel__loading'))}
-      onClick={onCopy}
+      variant='bordered'
+      colorScheme='secondary'
+      size='xs'
+      onClick={createTestRun}
+      isDisabled={isCreatingTestRun}
+      isLoading={isCreatingTestRun}
+      loadingText={t(localizationKeys('configureSSO.testConfigurationStep.testUrl.actionLabel__copy'))}
       sx={t => ({
         gap: t.space.$1x5,
-        alignSelf: 'flex-start',
       })}
     >
       <Icon
@@ -188,12 +226,8 @@ const CopyTestUrlButton = ({ url, isLoading }: { url: string; isLoading: boolean
       />
       <Text
         as='span'
-        localizationKey={localizationKeys(
-          hasCopied
-            ? 'configureSSO.testConfigurationStep.testUrl.actionLabel__copied'
-            : 'configureSSO.testConfigurationStep.testUrl.actionLabel__copy',
-        )}
+        localizationKey={localizationKeys('configureSSO.testConfigurationStep.testUrl.actionLabel__copy')}
       />
-    </ProfileSection.Button>
+    </Button>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -30,7 +30,7 @@ import { Pagination } from '@/elements/Pagination';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy, RotateLeftRight } from '@/icons';
-import { mqu } from '@/styledSystem';
+import { common, mqu } from '@/styledSystem';
 import { handleError } from '@/utils/errorHandler';
 
 import { useConfigureSSO } from '../ConfigureSSOContext';
@@ -39,16 +39,17 @@ import { useWizard } from '../elements/Wizard';
 import { TestRunHowToFixSection } from './TestRunHowToFixSection';
 
 const TEST_RUNS_PAGE_SIZE = 5;
+const TEST_RESULTS_TABLE_COLUMN_COUNT = 3;
 
 export const TestConfigurationStep = (): JSX.Element => {
   const { goNext, goPrev } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
+  const card = useCardState();
 
   const [currentPage, setCurrentPage] = useState(1);
 
   const {
     data: testRuns,
-    latest,
     totalCount,
     isLoading: areTestRunsLoading,
     isPolling,
@@ -58,7 +59,6 @@ export const TestConfigurationStep = (): JSX.Element => {
     params: { initialPage: currentPage, pageSize: TEST_RUNS_PAGE_SIZE },
   });
 
-  const hasSuccessfulTestRun = latest?.status === 'success';
   const pageCount = totalCount ? Math.ceil(totalCount / TEST_RUNS_PAGE_SIZE) : 0;
 
   const handleTestRunCreated = () => {
@@ -167,15 +167,89 @@ export const TestConfigurationStep = (): JSX.Element => {
           </Step.Section>
         </Step.Body>
 
+        {card.error ? (
+          <Box
+            sx={t => ({
+              flexShrink: 0,
+              paddingInline: t.space.$5,
+              paddingBlock: t.space.$3,
+              borderTopWidth: t.borderWidths.$normal,
+              borderTopStyle: t.borderStyles.$solid,
+              borderTopColor: t.colors.$borderAlpha100,
+            })}
+          >
+            <Text
+              as='p'
+              variant='body'
+              sx={t => ({ color: t.colors.$danger500, fontSize: t.fontSizes.$sm })}
+            >
+              {card.error}
+            </Text>
+          </Box>
+        ) : null}
+
         <Step.Footer>
           <Step.Footer.Previous onClick={() => goPrev()} />
-          <Step.Footer.Continue
-            onClick={() => goNext()}
-            isDisabled={!hasSuccessfulTestRun || enterpriseConnection?.active}
+          <ContinueTestSsoStepButton
+            enterpriseConnectionId={enterpriseConnection?.id}
+            isConnectionActive={enterpriseConnection?.active}
+            onContinue={() => void goNext()}
           />
         </Step.Footer>
       </Step>
     </Flow.Part>
+  );
+};
+
+type ContinueTestSsoStepButtonProps = {
+  enterpriseConnectionId: string | undefined;
+  isConnectionActive: boolean | undefined;
+  onContinue: () => void;
+};
+
+const ContinueTestSsoStepButton = ({
+  enterpriseConnectionId,
+  isConnectionActive,
+  onContinue,
+}: ContinueTestSsoStepButtonProps): JSX.Element => {
+  const { user } = useUser();
+  const { t } = useLocalizations();
+  const card = useCardState();
+  const [isValidating, setIsValidating] = useState(false);
+
+  const handleContinue = async () => {
+    if (!user || !enterpriseConnectionId) {
+      return;
+    }
+
+    setIsValidating(true);
+    card.setError(undefined);
+
+    try {
+      const result = await user.getEnterpriseConnectionTestRuns(enterpriseConnectionId, {
+        initialPage: 1,
+        pageSize: 1,
+        status: ['success'],
+      });
+
+      if (result.data.length > 0) {
+        onContinue();
+      } else {
+        card.setError(t(localizationKeys('configureSSO.testConfigurationStep.error__noSuccessfulTestRun')));
+      }
+    } catch (err) {
+      handleError(err as Error, [], card.setError);
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  return (
+    <Step.Footer.Continue
+      onClick={() => void handleContinue()}
+      isLoading={isValidating}
+      isDisabled={!enterpriseConnectionId || isConnectionActive}
+    />
   );
 };
 
@@ -214,27 +288,53 @@ const TestResultsTable = ({
   return (
     <>
       <Flex
+        direction='col'
         sx={t => ({
           width: '100%',
+          flex: '0 1 auto',
           minHeight: 0,
+          overflowY: 'auto',
+          borderWidth: t.borderWidths.$normal,
+          borderStyle: t.borderStyles.$solid,
+          borderColor: t.colors.$borderAlpha150,
+          borderRadius: t.radii.$lg,
+          ...common.unstyledScrollbar(t),
           [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 },
         })}
       >
         <Table
           tableHeadVisuallyHidden={!rows.length}
-          sx={t => ({ background: t.colors.$colorBackground, height: '100%' })}
+          sx={t => ({
+            background: t.colors.$colorBackground,
+            '&&': {
+              border: 'none',
+              borderRadius: 0,
+            },
+          })}
         >
           <Thead>
             <Tr>
-              <Th>Timestamp</Th>
-              <Th>Details</Th>
-              <Th>Status</Th>
+              <Th
+                localizationKey={localizationKeys(
+                  'configureSSO.testConfigurationStep.testRunDetails.runDetails.timestamp',
+                )}
+              />
+              <Th
+                localizationKey={localizationKeys(
+                  'configureSSO.testConfigurationStep.testRunDetails.runDetails.sectionTitle',
+                )}
+              />
+              <Th
+                localizationKey={localizationKeys(
+                  'configureSSO.testConfigurationStep.testRunDetails.runDetails.status',
+                )}
+              />
             </Tr>
           </Thead>
           <Tbody>
             {isLoading || isPolling ? (
               <Tr>
-                <Td>
+                <Td colSpan={TEST_RESULTS_TABLE_COLUMN_COUNT}>
                   <Flex
                     direction='col'
                     align='center'
@@ -258,7 +358,7 @@ const TestResultsTable = ({
               </Tr>
             ) : !rows.length ? (
               <Tr>
-                <Td>
+                <Td colSpan={TEST_RESULTS_TABLE_COLUMN_COUNT}>
                   <Flex
                     align='center'
                     justify='center'
@@ -297,17 +397,19 @@ const TestResultsTable = ({
       </Flex>
 
       {pageCount > 1 ? (
-        <Pagination
-          page={Math.min(page, pageCount)}
-          count={pageCount}
-          onChange={onPageChange}
-          siblingCount={1}
-          rowInfo={{
-            allRowsCount: totalCount,
-            startingRow: totalCount > 0 ? Math.max(0, (page - 1) * pageSize) + 1 : 0,
-            endingRow: Math.min(page * pageSize, totalCount),
-          }}
-        />
+        <Box sx={{ flexShrink: 0 }}>
+          <Pagination
+            page={Math.min(page, pageCount)}
+            count={pageCount}
+            onChange={onPageChange}
+            siblingCount={1}
+            rowInfo={{
+              allRowsCount: totalCount,
+              startingRow: totalCount > 0 ? Math.max(0, (page - 1) * pageSize) + 1 : 0,
+              endingRow: Math.min(page * pageSize, totalCount),
+            }}
+          />
+        </Box>
       ) : null}
 
       <Drawer.Root
@@ -617,7 +719,7 @@ const CopyTestUrlButton = ({ onTestRunCreated }: CopyTestUrlButtonProps): JSX.El
       .createEnterpriseConnectionTestRun(enterpriseConnection.id)
       .then(({ url }) => {
         setTestUrl(url);
-        onCopy();
+        onCopy(url);
         onTestRunCreated?.(url);
       })
       .catch(err => handleError(err as Error, [], card.setError))

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -1,7 +1,9 @@
-import { useUser } from '@clerk/shared/react/index';
+import { __internal_useEnterpriseConnectionTestRuns, useUser } from '@clerk/shared/react/index';
+import type { EnterpriseConnectionTestRunResource } from '@clerk/shared/types';
 import { useState } from 'react';
 
 import {
+  Badge,
   Button,
   descriptors,
   Flex,
@@ -13,22 +15,42 @@ import {
   Tbody,
   Td,
   Text,
+  Th,
+  Thead,
   Tr,
   useLocalizations,
 } from '@/customizables';
 import { useCardState } from '@/elements/contexts';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
-import { Check, Copy } from '@/icons';
+import { Check, Copy, RotateLeftRight } from '@/icons';
 import { mqu } from '@/styledSystem';
 import { handleError } from '@/utils/errorHandler';
 
-import { useConfigureSSOFlow } from '../ConfigureSSOContext';
+import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
 
 export const TestConfigurationStep = (): JSX.Element => {
-  const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
+  const { goNext, goPrev, isLastStep } = useWizard();
+  const { enterpriseConnection } = useConfigureSSO();
+
+  const {
+    data: testRuns,
+    latest,
+    isLoading: areTestRunsLoading,
+    isPolling,
+    revalidate: revalidateTestRuns,
+  } = __internal_useEnterpriseConnectionTestRuns({
+    enterpriseConnectionId: enterpriseConnection?.id ?? null,
+    params: { initialPage: 1, pageSize: 10 },
+  });
+
+  const hasSuccessfulTestRun = latest?.status === 'success';
+
+  const handleTestRunCreated = () => {
+    revalidateTestRuns();
+  };
 
   return (
     <Flow.Part part='testSso'>
@@ -69,7 +91,30 @@ export const TestConfigurationStep = (): JSX.Element => {
                 id='testSsoUrl'
                 sx={{ paddingInlineStart: 0 }}
               >
-                <CopyTestUrlButton />
+                <Flex gap={2}>
+                  <CopyTestUrlButton onTestRunCreated={handleTestRunCreated} />
+
+                  <Button
+                    variant='bordered'
+                    colorScheme='secondary'
+                    size='xs'
+                    onClick={() => void revalidateTestRuns()}
+                    isDisabled={areTestRunsLoading}
+                    sx={t => ({ gap: t.space.$1x5 })}
+                  >
+                    <Icon
+                      icon={RotateLeftRight}
+                      size='sm'
+                      colorScheme='neutral'
+                    />
+                    <Text
+                      as='span'
+                      localizationKey={localizationKeys(
+                        'configureSSO.testConfigurationStep.testResults.actionLabel__refresh',
+                      )}
+                    />
+                  </Button>
+                </Flex>
               </ProfileSection.Item>
             </ProfileSection.Root>
           </Step.Section>
@@ -94,9 +139,10 @@ export const TestConfigurationStep = (): JSX.Element => {
               })}
             >
               <TestResultsTable
-                rows={[]}
-                // When test run has been created and we're waiting for the results, we show a loading state
-                isLoading={false}
+                rows={testRuns ?? []}
+                isLoading={areTestRunsLoading}
+                onTestRunCreated={handleTestRunCreated}
+                isPolling={isPolling}
               />
             </ProfileSection.Root>
           </Step.Section>
@@ -104,10 +150,9 @@ export const TestConfigurationStep = (): JSX.Element => {
 
         <Step.Footer>
           <Step.Footer.Previous onClick={() => goPrev()} />
-          {/* TODO - Only allow to continue if the test run has been created and there's at least one successful result */}
           <Step.Footer.Continue
             onClick={() => goNext()}
-            isDisabled={isLastStep}
+            isDisabled={isLastStep || !hasSuccessfulTestRun}
           />
         </Step.Footer>
       </Step>
@@ -115,26 +160,35 @@ export const TestConfigurationStep = (): JSX.Element => {
   );
 };
 
-type TestResultRow = {
-  id: string;
+type TestResultsTableProps = {
+  rows: EnterpriseConnectionTestRunResource[];
+  isLoading: boolean;
+  isPolling: boolean;
+  onTestRunCreated?: (testUrl: string) => void;
 };
 
-const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoading: boolean }): JSX.Element => {
+const TestResultsTable = ({ rows, isLoading, isPolling, onTestRunCreated }: TestResultsTableProps): JSX.Element => {
   return (
     <Flex
       sx={t => ({
         width: '100%',
-        flex: 1,
         minHeight: 0,
         [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 },
       })}
     >
       <Table
-        tableHeadVisuallyHidden
+        tableHeadVisuallyHidden={!rows.length}
         sx={t => ({ background: t.colors.$colorBackground, height: '100%' })}
       >
+        <Thead>
+          <Tr>
+            <Th>Timestamp</Th>
+            <Th>Details</Th>
+            <Th>Status</Th>
+          </Tr>
+        </Thead>
         <Tbody>
-          {isLoading ? (
+          {isLoading || isPolling ? (
             <Tr>
               <Td>
                 <Flex
@@ -149,7 +203,9 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
                   />
                   <Text
                     colorScheme='secondary'
-                    localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.loading')}
+                    localizationKey={
+                      isPolling ? localizationKeys('configureSSO.testConfigurationStep.testResults.polling') : undefined
+                    }
                   />
                 </Flex>
               </Td>
@@ -162,14 +218,22 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
                   justify='center'
                   sx={t => ({ padding: `${t.space.$10} 0`, flex: 1 })}
                 >
-                  <CopyTestUrlButton />
+                  <CopyTestUrlButton onTestRunCreated={onTestRunCreated} />
                 </Flex>
               </Td>
             </Tr>
           ) : (
             rows.map(row => (
               <Tr key={row.id}>
-                <Td>{row.id}</Td>
+                <Td>
+                  <TestRunTimestampCell testRun={row} />
+                </Td>
+                <Td>
+                  <TestRunDetailsCell testRun={row} />
+                </Td>
+                <Td>
+                  <TestRunStatusCell testRun={row} />
+                </Td>
               </Tr>
             ))
           )}
@@ -179,11 +243,87 @@ const TestResultsTable = ({ rows, isLoading }: { rows: TestResultRow[]; isLoadin
   );
 };
 
-const CopyTestUrlButton = (): JSX.Element => {
+const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element | null => {
+  const { locale } = useLocalizations();
+
+  if (!testRun.createdAt) {
+    return null;
+  }
+
+  const time = new Intl.DateTimeFormat(locale, { timeStyle: 'medium' }).format(testRun.createdAt);
+  const day = new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(testRun.createdAt);
+
+  return (
+    <Flex
+      gap={2}
+      align='baseline'
+      sx={t => ({ whiteSpace: 'nowrap' })}
+    >
+      <Text>{time}</Text>
+      <Text colorScheme='secondary'>{day}</Text>
+    </Flex>
+  );
+};
+
+const TestRunDetailsCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element | null => {
+  if (testRun.status === 'pending') {
+    return (
+      <Flex sx={t => ({ fontFamily: t.fonts.$mono })}>
+        <Text>-</Text>
+      </Flex>
+    );
+  }
+
+  if (testRun.status === 'success') {
+    return (
+      <Flex sx={t => ({ fontFamily: t.fonts.$mono })}>
+        <Text>{testRun.parsedUserInfo?.emailAddress}</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex sx={t => ({ fontFamily: t.fonts.$mono })}>
+      <Text>{testRun.logs?.[0]?.shortMessage}</Text>
+    </Flex>
+  );
+};
+
+const TestRunStatusCell = ({ testRun }: { testRun: EnterpriseConnectionTestRunResource }): JSX.Element => {
+  if (testRun.status === 'success') {
+    return (
+      <Badge
+        colorScheme='success'
+        localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.status__success')}
+      />
+    );
+  }
+  if (testRun.status === 'failed') {
+    return (
+      <Badge
+        colorScheme='danger'
+        localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.status__failed')}
+      />
+    );
+  }
+  return (
+    <Badge
+      colorScheme='warning'
+      localizationKey={localizationKeys('configureSSO.testConfigurationStep.testResults.status__pending')}
+    />
+  );
+};
+
+type CopyTestUrlButtonProps = {
+  /** Called once a new test run has been created and copied to the clipboard, with the generated test URL. */
+  onTestRunCreated?: (testUrl: string) => void;
+};
+
+const CopyTestUrlButton = ({ onTestRunCreated }: CopyTestUrlButtonProps): JSX.Element => {
   const { t } = useLocalizations();
   const { user } = useUser();
   const card = useCardState();
-  const { enterpriseConnection } = useConfigureSSOFlow();
+  const { enterpriseConnection } = useConfigureSSO();
 
   const [testUrl, setTestUrl] = useState('');
   const [isCreatingTestRun, setIsCreatingTestRun] = useState(false);
@@ -201,6 +341,7 @@ const CopyTestUrlButton = (): JSX.Element => {
       .then(({ url }) => {
         setTestUrl(url);
         onCopy();
+        onTestRunCreated?.(url);
       })
       .catch(err => handleError(err as Error, [], card.setError))
       .finally(() => setIsCreatingTestRun(false));
@@ -223,6 +364,7 @@ const CopyTestUrlButton = (): JSX.Element => {
       <Icon
         icon={hasCopied ? Check : Copy}
         size='sm'
+        colorScheme='neutral'
       />
       <Text
         as='span'

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -21,6 +21,7 @@ import {
   useLocalizations,
 } from '@/customizables';
 import { useCardState } from '@/elements/contexts';
+import { Drawer } from '@/elements/Drawer';
 import { ProfileSection } from '@/elements/Section';
 import { useClipboard } from '@/hooks';
 import { Check, Copy, RotateLeftRight } from '@/icons';
@@ -49,7 +50,7 @@ export const TestConfigurationStep = (): JSX.Element => {
   const hasSuccessfulTestRun = latest?.status === 'success';
 
   const handleTestRunCreated = () => {
-    revalidateTestRuns();
+    void revalidateTestRuns();
   };
 
   return (
@@ -152,7 +153,7 @@ export const TestConfigurationStep = (): JSX.Element => {
           <Step.Footer.Previous onClick={() => goPrev()} />
           <Step.Footer.Continue
             onClick={() => goNext()}
-            isDisabled={isLastStep || !hasSuccessfulTestRun}
+            isDisabled={!hasSuccessfulTestRun || enterpriseConnection?.active}
           />
         </Step.Footer>
       </Step>
@@ -168,78 +169,115 @@ type TestResultsTableProps = {
 };
 
 const TestResultsTable = ({ rows, isLoading, isPolling, onTestRunCreated }: TestResultsTableProps): JSX.Element => {
+  const { t } = useLocalizations();
+  const [selectedTestRun, setSelectedTestRun] = useState<EnterpriseConnectionTestRunResource | null>(null);
+
+  const drawerTitle =
+    selectedTestRun?.status === 'failed'
+      ? selectedTestRun.logs?.[0]?.shortMessage ||
+        t(localizationKeys('configureSSO.testConfigurationStep.testRunDetails.title'))
+      : t(localizationKeys('configureSSO.testConfigurationStep.testRunDetails.title'));
+
   return (
-    <Flex
-      sx={t => ({
-        width: '100%',
-        minHeight: 0,
-        [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 },
-      })}
-    >
-      <Table
-        tableHeadVisuallyHidden={!rows.length}
-        sx={t => ({ background: t.colors.$colorBackground, height: '100%' })}
+    <>
+      <Flex
+        sx={t => ({
+          width: '100%',
+          minHeight: 0,
+          [mqu.sm]: { overflowX: 'auto', padding: t.space.$0x25 },
+        })}
       >
-        <Thead>
-          <Tr>
-            <Th>Timestamp</Th>
-            <Th>Details</Th>
-            <Th>Status</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {isLoading || isPolling ? (
+        <Table
+          tableHeadVisuallyHidden={!rows.length}
+          sx={t => ({ background: t.colors.$colorBackground, height: '100%' })}
+        >
+          <Thead>
             <Tr>
-              <Td>
-                <Flex
-                  direction='col'
-                  align='center'
-                  gap={2}
-                  sx={t => ({ padding: `${t.space.$10} 0` })}
-                >
-                  <Spinner
-                    colorScheme='primary'
-                    elementDescriptor={descriptors.spinner}
-                  />
-                  <Text
-                    colorScheme='secondary'
-                    localizationKey={
-                      isPolling ? localizationKeys('configureSSO.testConfigurationStep.testResults.polling') : undefined
-                    }
-                  />
-                </Flex>
-              </Td>
+              <Th>Timestamp</Th>
+              <Th>Details</Th>
+              <Th>Status</Th>
             </Tr>
-          ) : !rows.length ? (
-            <Tr>
-              <Td>
-                <Flex
-                  align='center'
-                  justify='center'
-                  sx={t => ({ padding: `${t.space.$10} 0`, flex: 1 })}
-                >
-                  <CopyTestUrlButton onTestRunCreated={onTestRunCreated} />
-                </Flex>
-              </Td>
-            </Tr>
-          ) : (
-            rows.map(row => (
-              <Tr key={row.id}>
+          </Thead>
+          <Tbody>
+            {isLoading || isPolling ? (
+              <Tr>
                 <Td>
-                  <TestRunTimestampCell testRun={row} />
-                </Td>
-                <Td>
-                  <TestRunDetailsCell testRun={row} />
-                </Td>
-                <Td>
-                  <TestRunStatusCell testRun={row} />
+                  <Flex
+                    direction='col'
+                    align='center'
+                    gap={2}
+                    sx={t => ({ padding: `${t.space.$10} 0` })}
+                  >
+                    <Spinner
+                      colorScheme='primary'
+                      elementDescriptor={descriptors.spinner}
+                    />
+                    <Text
+                      colorScheme='secondary'
+                      localizationKey={
+                        isPolling
+                          ? localizationKeys('configureSSO.testConfigurationStep.testResults.polling')
+                          : undefined
+                      }
+                    />
+                  </Flex>
                 </Td>
               </Tr>
-            ))
-          )}
-        </Tbody>
-      </Table>
-    </Flex>
+            ) : !rows.length ? (
+              <Tr>
+                <Td>
+                  <Flex
+                    align='center'
+                    justify='center'
+                    sx={t => ({ padding: `${t.space.$10} 0`, flex: 1 })}
+                  >
+                    <CopyTestUrlButton onTestRunCreated={onTestRunCreated} />
+                  </Flex>
+                </Td>
+              </Tr>
+            ) : (
+              rows.map(row => (
+                <Tr
+                  key={row.id}
+                  onClick={() => setSelectedTestRun(row)}
+                  sx={t => ({
+                    cursor: 'pointer',
+                    '&:hover > td': {
+                      backgroundColor: t.colors.$neutralAlpha50,
+                    },
+                  })}
+                >
+                  <Td>
+                    <TestRunTimestampCell testRun={row} />
+                  </Td>
+                  <Td>
+                    <TestRunDetailsCell testRun={row} />
+                  </Td>
+                  <Td>
+                    <TestRunStatusCell testRun={row} />
+                  </Td>
+                </Tr>
+              ))
+            )}
+          </Tbody>
+        </Table>
+      </Flex>
+
+      <Drawer.Root
+        open={selectedTestRun !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setSelectedTestRun(null);
+          }
+        }}
+      >
+        <Drawer.Overlay />
+        <Drawer.Content>
+          <Drawer.Header title={drawerTitle} />
+          <Drawer.Body>{null}</Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
+    </>
   );
 };
 
@@ -257,7 +295,7 @@ const TestRunTimestampCell = ({ testRun }: { testRun: EnterpriseConnectionTestRu
     <Flex
       gap={2}
       align='baseline'
-      sx={t => ({ whiteSpace: 'nowrap' })}
+      sx={{ whiteSpace: 'nowrap' }}
     >
       <Text>{time}</Text>
       <Text colorScheme='secondary'>{day}</Text>

--- a/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
@@ -1,0 +1,193 @@
+import { Box, Flex, Heading, Icon, Link, localizationKeys, Span, Text } from '@/customizables';
+import { ArrowRightIcon } from '@/icons';
+
+import type { LocalizationKey } from '../../../localization';
+
+const DOCS_BASE_URL = 'https://clerk.com/docs/guides/organizations/add-members/sso';
+
+type HowToFixContent =
+  | { kind: 'description'; descriptionKey: LocalizationKey }
+  | { kind: 'steps'; introKey?: LocalizationKey; stepKeys: LocalizationKey[] };
+
+const HOW_TO_FIX_BY_ERROR_CODE: Record<string, HowToFixContent> = {
+  saml_user_attribute_missing: {
+    kind: 'steps',
+    introKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_user_attribute_missing.intro',
+    ),
+    stepKeys: [
+      localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_user_attribute_missing.step1'),
+      localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_user_attribute_missing.step2'),
+      localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_user_attribute_missing.step3'),
+    ],
+  },
+  saml_response_relaystate_missing: {
+    kind: 'description',
+    descriptionKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_response_relaystate_missing.description',
+    ),
+  },
+  saml_email_address_domain_mismatch: {
+    kind: 'description',
+    descriptionKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.saml_email_address_domain_mismatch.description',
+    ),
+  },
+  oauth_access_denied: {
+    kind: 'description',
+    descriptionKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.oauth_access_denied.description',
+    ),
+  },
+  oauth_token_exchange_error: {
+    kind: 'description',
+    descriptionKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.oauth_token_exchange_error.description',
+    ),
+  },
+  oauth_fetch_user_error: {
+    kind: 'steps',
+    introKey: localizationKeys(
+      'configureSSO.testConfigurationStep.testRunDetails.howToFix.oauth_fetch_user_error.intro',
+    ),
+    stepKeys: [
+      localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.oauth_fetch_user_error.step1'),
+      localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.oauth_fetch_user_error.step2'),
+    ],
+  },
+};
+
+type TestRunHowToFixSectionProps = {
+  errorCode: string | undefined;
+};
+
+export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProps): JSX.Element | null => {
+  if (!errorCode) {
+    return null;
+  }
+
+  const content = HOW_TO_FIX_BY_ERROR_CODE[errorCode];
+  const docsHref = `${DOCS_BASE_URL}#${errorCode.replaceAll('_', '-')}`;
+
+  return (
+    <Flex
+      direction='col'
+      gap={3}
+      sx={t => ({
+        borderTopWidth: t.borderWidths.$normal,
+        borderTopStyle: t.borderStyles.$solid,
+        borderTopColor: t.colors.$borderAlpha100,
+        paddingTop: t.space.$4,
+      })}
+    >
+      <Heading
+        as='h3'
+        textVariant='h3'
+        localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.sectionTitle')}
+      />
+
+      <Box
+        sx={t => ({
+          padding: t.space.$3,
+          backgroundColor: t.colors.$colorBackground,
+          borderWidth: t.borderWidths.$normal,
+          borderStyle: t.borderStyles.$solid,
+          borderColor: t.colors.$borderAlpha150,
+          borderRadius: t.radii.$md,
+          boxShadow: t.shadows.$cardContentShadow,
+        })}
+      >
+        {content ? (
+          <HowToFixContent content={content} />
+        ) : (
+          <Text
+            colorScheme='secondary'
+            localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.generic')}
+          />
+        )}
+      </Box>
+
+      <Link
+        href={docsHref}
+        target='_blank'
+        rel='noopener noreferrer'
+        sx={t => ({
+          alignSelf: 'flex-start',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: t.space.$1x5,
+          paddingBlock: t.space.$1,
+          paddingInline: t.space.$3,
+          borderRadius: t.radii.$md,
+          borderWidth: t.borderWidths.$normal,
+          borderStyle: t.borderStyles.$solid,
+          borderColor: t.colors.$borderAlpha150,
+          color: t.colors.$colorForeground,
+          fontSize: t.fontSizes.$sm,
+          fontWeight: t.fontWeights.$medium,
+          textDecoration: 'none',
+          '&:hover': { backgroundColor: t.colors.$neutralAlpha50, textDecoration: 'none' },
+        })}
+      >
+        <Span
+          localizationKey={localizationKeys(
+            'configureSSO.testConfigurationStep.testRunDetails.howToFix.actionLabel__viewDocumentation',
+          )}
+        />
+        <Icon
+          icon={ArrowRightIcon}
+          size='sm'
+        />
+      </Link>
+    </Flex>
+  );
+};
+
+const HowToFixContent = ({ content }: { content: HowToFixContent }): JSX.Element => {
+  if (content.kind === 'description') {
+    return (
+      <Text
+        colorScheme='secondary'
+        localizationKey={content.descriptionKey}
+      />
+    );
+  }
+
+  return (
+    <Flex
+      direction='col'
+      gap={2}
+    >
+      {content.introKey ? (
+        <Text
+          colorScheme='secondary'
+          localizationKey={content.introKey}
+        />
+      ) : null}
+      <Box
+        as='ol'
+        sx={t => ({
+          margin: 0,
+          paddingInlineStart: t.space.$5,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: t.space.$1,
+        })}
+      >
+        {content.stepKeys.map((stepKey, idx) => (
+          <Box
+            key={idx}
+            as='li'
+            sx={t => ({ color: t.colors.$colorMutedForeground })}
+          >
+            <Text
+              as='span'
+              colorScheme='secondary'
+              localizationKey={stepKey}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Flex>
+  );
+};

--- a/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
@@ -66,8 +66,6 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
     return null;
   }
 
-  errorCode = 'saml_user_attribute_missing';
-
   const content = HOW_TO_FIX_BY_ERROR_CODE[errorCode];
   if (!content) {
     return null;

--- a/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
@@ -67,6 +67,10 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
   }
 
   const content = HOW_TO_FIX_BY_ERROR_CODE[errorCode];
+  if (!content) {
+    return null;
+  }
+
   const docsHref = `${DOCS_BASE_URL}#${errorCode.replaceAll('_', '-')}`;
 
   return (
@@ -97,14 +101,7 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
           boxShadow: t.shadows.$cardContentShadow,
         })}
       >
-        {content ? (
-          <HowToFixContent content={content} />
-        ) : (
-          <Text
-            colorScheme='secondary'
-            localizationKey={localizationKeys('configureSSO.testConfigurationStep.testRunDetails.howToFix.generic')}
-          />
-        )}
+        <HowToFixContent content={content} />
       </Box>
 
       <Link
@@ -174,9 +171,9 @@ const HowToFixContent = ({ content }: { content: HowToFixContent }): JSX.Element
           gap: t.space.$1,
         })}
       >
-        {content.stepKeys.map((stepKey, idx) => (
+        {content.stepKeys.map(stepKey => (
           <Box
-            key={idx}
+            key={stepKey.key}
             as='li'
             sx={t => ({ color: t.colors.$colorMutedForeground })}
           >

--- a/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
@@ -66,6 +66,8 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
     return null;
   }
 
+  errorCode = 'saml_user_attribute_missing';
+
   const content = HOW_TO_FIX_BY_ERROR_CODE[errorCode];
   if (!content) {
     return null;
@@ -102,40 +104,41 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
         })}
       >
         <HowToFixContent content={content} />
-      </Box>
 
-      <Link
-        href={docsHref}
-        target='_blank'
-        rel='noopener noreferrer'
-        sx={t => ({
-          alignSelf: 'flex-start',
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: t.space.$1x5,
-          paddingBlock: t.space.$1,
-          paddingInline: t.space.$3,
-          borderRadius: t.radii.$md,
-          borderWidth: t.borderWidths.$normal,
-          borderStyle: t.borderStyles.$solid,
-          borderColor: t.colors.$borderAlpha150,
-          color: t.colors.$colorForeground,
-          fontSize: t.fontSizes.$sm,
-          fontWeight: t.fontWeights.$medium,
-          textDecoration: 'none',
-          '&:hover': { backgroundColor: t.colors.$neutralAlpha50, textDecoration: 'none' },
-        })}
-      >
-        <Span
-          localizationKey={localizationKeys(
-            'configureSSO.testConfigurationStep.testRunDetails.howToFix.actionLabel__viewDocumentation',
-          )}
-        />
-        <Icon
-          icon={ArrowRightIcon}
-          size='sm'
-        />
-      </Link>
+        <Link
+          href={docsHref}
+          target='_blank'
+          rel='noopener noreferrer'
+          sx={t => ({
+            alignSelf: 'flex-start',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: t.space.$1x5,
+            paddingBlock: t.space.$1,
+            paddingInline: t.space.$3,
+            borderRadius: t.radii.$md,
+            borderWidth: t.borderWidths.$normal,
+            borderStyle: t.borderStyles.$solid,
+            borderColor: t.colors.$borderAlpha150,
+            color: t.colors.$colorForeground,
+            fontSize: t.fontSizes.$sm,
+            fontWeight: t.fontWeights.$medium,
+            textDecoration: 'none',
+            '&:hover': { backgroundColor: t.colors.$neutralAlpha50, textDecoration: 'none' },
+            marginTop: t.space.$2,
+          })}
+        >
+          <Span
+            localizationKey={localizationKeys(
+              'configureSSO.testConfigurationStep.testRunDetails.howToFix.actionLabel__viewDocumentation',
+            )}
+          />
+          <Icon
+            icon={ArrowRightIcon}
+            size='sm'
+          />
+        </Link>
+      </Box>
     </Flex>
   );
 };
@@ -166,6 +169,7 @@ const HowToFixContent = ({ content }: { content: HowToFixContent }): JSX.Element
         sx={t => ({
           margin: 0,
           paddingInlineStart: t.space.$5,
+          listStyleType: 'decimal',
           display: 'flex',
           flexDirection: 'column',
           gap: t.space.$1,
@@ -175,7 +179,14 @@ const HowToFixContent = ({ content }: { content: HowToFixContent }): JSX.Element
           <Box
             key={stepKey.key}
             as='li'
-            sx={t => ({ color: t.colors.$colorMutedForeground })}
+            sx={t => ({
+              color: t.colors.$colorMutedForeground,
+              fontSize: t.fontSizes.$sm,
+              '&::marker': {
+                color: t.colors.$colorMutedForeground,
+                fontSize: t.fontSizes.$sm,
+              },
+            })}
           >
             <Text
               as='span'

--- a/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestRunHowToFixSection.tsx
@@ -122,8 +122,8 @@ export const TestRunHowToFixSection = ({ errorCode }: TestRunHowToFixSectionProp
             fontSize: t.fontSizes.$sm,
             fontWeight: t.fontWeights.$medium,
             textDecoration: 'none',
-            '&:hover': { backgroundColor: t.colors.$neutralAlpha50, textDecoration: 'none' },
             marginTop: t.space.$2,
+            '&:hover': { backgroundColor: t.colors.$neutralAlpha50, textDecoration: 'none' },
           })}
         >
           <Span

--- a/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
+++ b/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
@@ -266,7 +266,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
     <Button
       elementDescriptor={descriptors.paymentAttemptCopyButton}
       variant='unstyled'
-      onClick={onCopy}
+      onClick={() => onCopy()}
       sx={t => ({
         color: 'inherit',
         width: t.sizes.$4,

--- a/packages/ui/src/components/Statements/Statement.tsx
+++ b/packages/ui/src/components/Statements/Statement.tsx
@@ -423,7 +423,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
     <Button
       elementDescriptor={descriptors.statementCopyButton}
       variant='unstyled'
-      onClick={onCopy}
+      onClick={() => onCopy()}
       sx={t => ({
         color: 'inherit',
         width: t.sizes.$4,

--- a/packages/ui/src/components/UserProfile/MfaBackupCodeList.tsx
+++ b/packages/ui/src/components/UserProfile/MfaBackupCodeList.tsx
@@ -131,7 +131,7 @@ export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
           </Button>
           <Button
             variant='ghost'
-            onClick={onCopy}
+            onClick={() => onCopy()}
             sx={t => ({ width: '100%', padding: `${t.space.$2} 0`, borderRadius: 0 })}
           >
             <Icon icon={hasCopied ? Check : Copy} />

--- a/packages/ui/src/elements/ClipboardInput.tsx
+++ b/packages/ui/src/elements/ClipboardInput.tsx
@@ -30,7 +30,7 @@ export const ClipboardInput = (props: ClipboardInputProps) => {
       <Button
         elementDescriptor={descriptors.formFieldInputCopyToClipboardButton}
         variant='ghost'
-        onClick={onCopy}
+        onClick={() => onCopy()}
         sx={{
           position: 'absolute',
           insetInlineEnd: 0,

--- a/packages/ui/src/elements/LineItems.tsx
+++ b/packages/ui/src/elements/LineItems.tsx
@@ -270,7 +270,7 @@ function CopyButton({ text, copyLabel = 'Copy' }: { text: string; copyLabel?: st
   return (
     <Button
       variant='unstyled'
-      onClick={onCopy}
+      onClick={() => onCopy()}
       sx={t => ({
         color: 'inherit',
         width: t.sizes.$4,

--- a/packages/ui/src/elements/LineItems.tsx
+++ b/packages/ui/src/elements/LineItems.tsx
@@ -150,33 +150,49 @@ const Title = React.forwardRef<HTMLTableCellElement, TitleProps>(({ title, descr
  * LineItems.Description
  * -----------------------------------------------------------------------------------------------*/
 
-interface DescriptionProps {
-  text: string | LocalizationKey;
-  /**
-   * When true, the text will be truncated with an ellipsis in the middle and the last 5 characters will be visible.
-   * @default `false`
-   */
-  truncateText?: boolean;
-  /**
-   * When true, there will be a button to copy the providedtext.
-   * @default `false`
-   */
-  copyText?: boolean;
-  /**
-   * The visually hidden label for the copy button.
-   * @default `Copy`
-   */
-  copyLabel?: string;
-  prefix?: string | LocalizationKey;
-  suffix?: string | LocalizationKey;
-}
+type DescriptionProps =
+  | {
+      /**
+       * Custom value content. When provided, `text`, `prefix`, `suffix`, `truncateText`,
+       * `copyText`, and `copyLabel` are ignored.
+       */
+      children: React.ReactNode;
+      text?: never;
+      truncateText?: never;
+      copyText?: never;
+      copyLabel?: never;
+      prefix?: never;
+      suffix?: never;
+    }
+  | {
+      children?: never;
+      text: string | LocalizationKey;
+      /**
+       * When true, the text will be truncated with an ellipsis in the middle and the last 5 characters will be visible.
+       * @default `false`
+       */
+      truncateText?: boolean;
+      /**
+       * When true, there will be a button to copy the providedtext.
+       * @default `false`
+       */
+      copyText?: boolean;
+      /**
+       * The visually hidden label for the copy button.
+       * @default `Copy`
+       */
+      copyLabel?: string;
+      prefix?: string | LocalizationKey;
+      suffix?: string | LocalizationKey;
+    };
 
-function Description({ text, prefix, suffix, truncateText = false, copyText = false, copyLabel }: DescriptionProps) {
+function Description(props: DescriptionProps) {
   const context = React.useContext(GroupContext);
   if (!context) {
     throw new Error('LineItems.Description must be used within LineItems.Group');
   }
   const { variant } = context;
+
   return (
     <Dd
       elementDescriptor={descriptors.lineItemsDescription}
@@ -187,6 +203,25 @@ function Description({ text, prefix, suffix, truncateText = false, copyText = fa
         color: variant === 'tertiary' ? t.colors.$colorMutedForeground : t.colors.$colorForeground,
       })}
     >
+      {'children' in props && props.children !== undefined ? (
+        props.children
+      ) : (
+        <DescriptionContent {...(props as Exclude<DescriptionProps, { children: React.ReactNode }>)} />
+      )}
+    </Dd>
+  );
+}
+
+function DescriptionContent({
+  text,
+  prefix,
+  suffix,
+  truncateText = false,
+  copyText = false,
+  copyLabel,
+}: Exclude<DescriptionProps, { children: React.ReactNode }>) {
+  return (
+    <>
       <Span
         elementDescriptor={descriptors.lineItemsDescriptionInner}
         sx={t => ({
@@ -240,7 +275,7 @@ function Description({ text, prefix, suffix, truncateText = false, copyText = fa
           })}
         />
       ) : null}
-    </Dd>
+    </>
   );
 }
 

--- a/packages/ui/src/elements/LineItems.tsx
+++ b/packages/ui/src/elements/LineItems.tsx
@@ -150,49 +150,33 @@ const Title = React.forwardRef<HTMLTableCellElement, TitleProps>(({ title, descr
  * LineItems.Description
  * -----------------------------------------------------------------------------------------------*/
 
-type DescriptionProps =
-  | {
-      /**
-       * Custom value content. When provided, `text`, `prefix`, `suffix`, `truncateText`,
-       * `copyText`, and `copyLabel` are ignored.
-       */
-      children: React.ReactNode;
-      text?: never;
-      truncateText?: never;
-      copyText?: never;
-      copyLabel?: never;
-      prefix?: never;
-      suffix?: never;
-    }
-  | {
-      children?: never;
-      text: string | LocalizationKey;
-      /**
-       * When true, the text will be truncated with an ellipsis in the middle and the last 5 characters will be visible.
-       * @default `false`
-       */
-      truncateText?: boolean;
-      /**
-       * When true, there will be a button to copy the providedtext.
-       * @default `false`
-       */
-      copyText?: boolean;
-      /**
-       * The visually hidden label for the copy button.
-       * @default `Copy`
-       */
-      copyLabel?: string;
-      prefix?: string | LocalizationKey;
-      suffix?: string | LocalizationKey;
-    };
+interface DescriptionProps {
+  text: string | LocalizationKey;
+  /**
+   * When true, the text will be truncated with an ellipsis in the middle and the last 5 characters will be visible.
+   * @default `false`
+   */
+  truncateText?: boolean;
+  /**
+   * When true, there will be a button to copy the providedtext.
+   * @default `false`
+   */
+  copyText?: boolean;
+  /**
+   * The visually hidden label for the copy button.
+   * @default `Copy`
+   */
+  copyLabel?: string;
+  prefix?: string | LocalizationKey;
+  suffix?: string | LocalizationKey;
+}
 
-function Description(props: DescriptionProps) {
+function Description({ text, prefix, suffix, truncateText = false, copyText = false, copyLabel }: DescriptionProps) {
   const context = React.useContext(GroupContext);
   if (!context) {
     throw new Error('LineItems.Description must be used within LineItems.Group');
   }
   const { variant } = context;
-
   return (
     <Dd
       elementDescriptor={descriptors.lineItemsDescription}
@@ -203,25 +187,6 @@ function Description(props: DescriptionProps) {
         color: variant === 'tertiary' ? t.colors.$colorMutedForeground : t.colors.$colorForeground,
       })}
     >
-      {'children' in props && props.children !== undefined ? (
-        props.children
-      ) : (
-        <DescriptionContent {...(props as Exclude<DescriptionProps, { children: React.ReactNode }>)} />
-      )}
-    </Dd>
-  );
-}
-
-function DescriptionContent({
-  text,
-  prefix,
-  suffix,
-  truncateText = false,
-  copyText = false,
-  copyLabel,
-}: Exclude<DescriptionProps, { children: React.ReactNode }>) {
-  return (
-    <>
       <Span
         elementDescriptor={descriptors.lineItemsDescriptionInner}
         sx={t => ({
@@ -275,7 +240,7 @@ function DescriptionContent({
           })}
         />
       ) : null}
-    </>
+    </Dd>
   );
 }
 

--- a/packages/ui/src/elements/contexts/index.tsx
+++ b/packages/ui/src/elements/contexts/index.tsx
@@ -139,7 +139,7 @@ export type FlowMetadata = {
     | 'verifyDomain'
     | 'configureCreateApp'
     | 'configureMapAttributes'
-    | 'test-sso'
+    | 'testSso'
     | 'ssoConfirmation';
 };
 

--- a/packages/ui/src/hooks/useClipboard.ts
+++ b/packages/ui/src/hooks/useClipboard.ts
@@ -27,10 +27,13 @@ export function useClipboard(text: string, optionsOrTimeout: number | UseClipboa
   const { timeout = 1500, ...copyOptions } =
     typeof optionsOrTimeout === 'number' ? { timeout: optionsOrTimeout } : optionsOrTimeout;
 
-  const onCopy = useCallback(() => {
-    const didCopy = copy(text, copyOptions);
-    setHasCopied(didCopy);
-  }, [text, copyOptions]);
+  const onCopy = useCallback(
+    (overrideText?: string) => {
+      const didCopy = copy(overrideText ?? text, copyOptions);
+      setHasCopied(didCopy);
+    },
+    [text, copyOptions],
+  );
 
   useEffect(() => {
     let timeoutId: number | null = null;


### PR DESCRIPTION
## Description

This PR adds the ability to test the configuration of an enterprise connection. This allows the IT admin to make sure that the configuration is correct and SSO is working before enabling to all users.

https://github.com/user-attachments/assets/afb62d34-872f-460b-9e6f-45ec71abf543


| Scenario | Demo |
| --- | --- |
| Do not allow to continue without a successful test | [View video](https://github.com/user-attachments/assets/87d47919-c6f6-43f8-acd3-623036fcf5cc) |
| Generating first test URL + polling for first test run | [View video](https://github.com/user-attachments/assets/b5a2406c-026f-4184-a7d2-62e14e4f9241) |
| With existing test runs | [Video 1](https://github.com/user-attachments/assets/d076d8b7-8f27-4acb-a8d4-40a5ac38ca23)<br/>[Video 2](https://github.com/user-attachments/assets/51a69f22-fdd9-4d03-b0b6-25d1085bc620) |


## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
