### PR TITLE
feat(ui): Add `fontFamilyMono` variable

### DIFF
--- a/.changeset/font-family-mono-variable.md
+++ b/.changeset/font-family-mono-variable.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': minor
+---
+
+Add `fontFamilyMono` appearance variable for customizing the monospace font used in Clerk components. Defaults to `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace` and is exposed as the `--clerk-font-family-mono` CSS variable.

--- a/packages/ui/src/customizables/parseVariables.ts
+++ b/packages/ui/src/customizables/parseVariables.ts
@@ -177,8 +177,8 @@ export const createFontWeightScale = (theme: Theme): Partial<Record<keyof typeof
 };
 
 export const createFonts = (theme: Theme) => {
-  const { fontFamily, fontFamilyButtons } = theme.variables || {};
-  return removeUndefinedProps({ main: fontFamily, buttons: fontFamilyButtons });
+  const { fontFamily, fontFamilyButtons, fontFamilyMono } = theme.variables || {};
+  return removeUndefinedProps({ main: fontFamily, buttons: fontFamilyButtons, mono: fontFamilyMono });
 };
 
 export const createShadowsUnits = (theme: Theme) => {

--- a/packages/ui/src/foundations/typography.ts
+++ b/packages/ui/src/foundations/typography.ts
@@ -45,6 +45,7 @@ const fontStyles = Object.freeze({
 const fonts = Object.freeze({
   main: clerkCssVar('font-family', 'inherit'),
   buttons: clerkCssVar('font-family-buttons', clerkCssVar('font-family', 'inherit')),
+  mono: clerkCssVar('font-family-mono', 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'),
 } as const);
 
 export { fontSizes, fontWeights, letterSpacings, lineHeights, fonts, fontStyles };

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -825,6 +825,13 @@ export type Variables = {
    */
   fontFamilyButtons?: FontFamily;
   /**
+   * The default monospace font that will be used for monospaced text (e.g. code, OTP inputs).
+   * See {@link Variables.fontFamily} for details on accepted values.
+   *
+   * @default 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+   */
+  fontFamilyMono?: FontFamily;
+  /**
    * The value will be used as the base `md` to calculate all the other scale values (`xs`, `sm`, `lg` and `xl`).
    * By default, this value is relative to the root fontSize of the html element.
    *


### PR DESCRIPTION
## Description

Adds new `fontFamilyMono` variable option to be used in ConfigureSSO work.

docs: https://github.com/clerk/clerk-docs/pull/3369

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
