### PR TITLE
chore(repo): Block snapshots from forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,31 @@ jobs:
               core.setFailed(`@${context.actor} is not a member of the Clerk organization`);
             }
 
+      - name: Validate PR source and freshness
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'clerk',
+              repo: 'javascript',
+              pull_number: context.issue.number,
+            });
+
+            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
+              core.setFailed('Snapshots are restricted to branches within clerk/javascript.');
+              return;
+            }
+
+            const commentCreated = new Date(context.payload.comment.created_at);
+            const prLastUpdated = new Date(pr.updated_at);
+
+            if (prLastUpdated > commentCreated) {
+              core.setFailed("The PR has been updated since !snapshot was initiated. Please review the changes and re-run the !snapshot command.");
+            }
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -379,26 +404,6 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
           filter: 'blob:none'
-
-      - name: Ensure the PR hasn't changed since initiating the !snapshot command.
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          retries: 3
-          retry-exempt-status-codes: 400,401
-          script: |
-            const commentCreated = new Date(context.payload.comment.created_at);
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner: 'clerk',
-              repo: 'javascript',
-              pull_number: context.issue.number,
-            });
-            const prLastUpdated = new Date(pr.updated_at);
-
-            if (prLastUpdated > commentCreated) {
-              core.setFailed("The PR has been updated since !snapshot was initiated. Please review the changes and re-run the !snapshot command.");
-            }
 
       - name: Setup
         id: config


### PR DESCRIPTION
## Description

Fixes SEC-266

It was a recommendation that came out of https://github.com/clerk/javascript/pull/7915

Given that we already restricted the job to Clerk org members the attack surface was slim but it doesn't hurt to add an extra layer of checks here.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI
