### PR TITLE
feat(ui): add Configure manually path to ConfigureSSO submit-config sub-step

### DIFF
--- a/.changeset/configure-sso-segmented-control-shell.md
+++ b/.changeset/configure-sso-segmented-control-shell.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Add a two-mode segmented control to the SAML config submission sub-step in `<__experimental_ConfigureSSO />`. Users pick between **Add via metadata URL** (default) and **Configure manually**. The metadata URL form is unchanged; the manual entry form ships in a follow-up commit. Locale keys added under `configureSSO.configureStep.samlOkta.modes` in `en-US`.

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -347,6 +347,21 @@ export const enUS: LocalizationResource = {
         submitSamlConfig: {
           title: 'Fill in your Okta SAML application details',
         },
+        manual: {
+          description: 'In your Okta SAML app, go to the Sign On tab and retrieve these values.',
+          signOnUrl: {
+            label: 'Sign on URL',
+            placeholder: 'Paste URL here...',
+          },
+          issuer: {
+            label: 'Issuer',
+            placeholder: 'Paste URL here...',
+          },
+          signingCertificate: {
+            label: 'Signing certificate',
+            uploadFile: 'Upload file',
+          },
+        },
       },
     },
   },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -339,6 +339,11 @@ export const enUS: LocalizationResource = {
           placeholder: 'Paste URL here...',
           description: 'In your Okta SAML app, go to the Sign On tab and retrieve the metadata URL. Paste it below.',
         },
+        modes: {
+          ariaLabel: 'Configuration mode',
+          metadataUrl: 'Add via metadata URL',
+          manual: 'Configure manually',
+        },
       },
     },
   },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -360,6 +360,7 @@ export const enUS: LocalizationResource = {
           signingCertificate: {
             label: 'Signing certificate',
             uploadFile: 'Upload file',
+            removeFile: 'Remove file',
           },
         },
       },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -360,6 +360,7 @@ export const enUS: LocalizationResource = {
           signingCertificate: {
             label: 'Signing certificate',
             uploadFile: 'Upload file',
+            replaceFile: 'Replace file',
             removeFile: 'Remove file',
           },
         },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -341,8 +341,11 @@ export const enUS: LocalizationResource = {
         },
         modes: {
           ariaLabel: 'Configuration mode',
-          metadataUrl: 'Add via metadata URL',
+          metadataUrl: 'Add via metadata',
           manual: 'Configure manually',
+        },
+        submitSamlConfig: {
+          title: 'Fill in your Okta SAML application details',
         },
       },
     },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -364,6 +364,7 @@ export const enUS: LocalizationResource = {
             uploadFile: 'Upload file',
             replaceFile: 'Replace file',
             removeFile: 'Remove file',
+            fileUploaded: 'File uploaded',
           },
         },
       },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -288,11 +288,11 @@ export const enUS: LocalizationResource = {
         subtitle: 'Create a new enterprise application in your Okta Dashboard',
         createApp: {
           title: 'Create a new enterprise application in Okta',
-          step1: 'Sign in to Okta and go to Admin → Applications.',
-          step2: 'Click Create App Integration.',
-          step3: 'Select SAML 2.0.',
+          step1: 'Sign in to Okta and go to <bold>Admin → Applications.</bold>',
+          step2: 'Click <bold>Create App Integration.</bold>',
+          step3: 'Select <bold>SAML 2.0.</bold>',
           step4: 'Fill in the General Settings (App name is required).',
-          step5: 'Click Next to complete creating the application.',
+          step5: 'Click <bold>Next</bold> to complete creating the application.',
         },
         serviceProvider: {
           title: 'Configure service provider',
@@ -303,12 +303,13 @@ export const enUS: LocalizationResource = {
         },
         completeSamlIntegration: {
           title: 'Complete SAML integration',
-          step1: 'Select This is an internal app that we have created from the options menu.',
-          step2: 'Complete the form with any comments and select "Finish".',
+          step1: 'Select <bold>This is an internal app</bold> that we have created from the options menu.',
+          step2: 'Complete the form with any comments and select <bold>Finish</bold>.',
         },
         configureAttributes: {
-          step1: 'In the Okta dashboard, find the Attribute Statements section.',
-          step2: 'Select Add Expression for each attribute, and enter the following name and expression pairs:',
+          step1: 'In the Okta dashboard, find the <bold>Attribute Statements</bold> section.',
+          step2:
+            'Select <bold>Add Expression</bold> for each attribute, and enter the following name and expression pairs:',
           pairs: {
             conjunction: ' and ',
             email: {
@@ -328,11 +329,12 @@ export const enUS: LocalizationResource = {
         assignUsers: {
           title: 'Assign selected user or group in Okta',
           paragraph: 'You need to assign users or groups to your enterprise app before they can use it to sign in.',
-          step1: 'In the Okta dashboard, select the Assignments tab.',
-          step2: 'Select the Assign dropdown. You can either select Assign to people or Assign to groups.',
+          step1: 'In the Okta dashboard, select the <bold>Assignments</bold> tab.',
+          step2:
+            'Select the <bold>Assign</bold> dropdown. You can either select <bold>Assign to people</bold> or <bold>Assign to groups</bold>.',
           step3: 'In the search field, enter the user or group of users that you want to assign to the application.',
-          step4: 'Select the Assign button next to the user or group that you want to assign.',
-          step5: 'Select the Done button to complete the assignment.',
+          step4: 'Select the <bold>Assign</bold> button next to the user or group that you want to assign.',
+          step5: 'Select the <bold>Done</bold> button to complete the assignment.',
         },
         metadataUrl: {
           label: 'Metadata URL',

--- a/packages/shared/src/types/elementIds.ts
+++ b/packages/shared/src/types/elementIds.ts
@@ -26,7 +26,9 @@ export type FieldId =
   | 'apiKeyExpirationDate'
   | 'apiKeyRevokeConfirmation'
   | 'apiKeySecret'
+  | 'idpEntityId'
   | 'idpMetadataUrl'
+  | 'idpSsoUrl'
   | 'acsUrl'
   | 'spEntityId'
   | 'web3WalletName';

--- a/packages/shared/src/types/elementIds.ts
+++ b/packages/shared/src/types/elementIds.ts
@@ -26,6 +26,7 @@ export type FieldId =
   | 'apiKeyExpirationDate'
   | 'apiKeyRevokeConfirmation'
   | 'apiKeySecret'
+  | 'idpCertificate'
   | 'idpEntityId'
   | 'idpMetadataUrl'
   | 'idpSsoUrl'

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1448,6 +1448,7 @@ export type __internal_LocalizationResource = {
           signingCertificate: {
             label: LocalizationValue;
             uploadFile: LocalizationValue;
+            replaceFile: LocalizationValue;
             removeFile: LocalizationValue;
           };
         };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1450,6 +1450,7 @@ export type __internal_LocalizationResource = {
             uploadFile: LocalizationValue;
             replaceFile: LocalizationValue;
             removeFile: LocalizationValue;
+            fileUploaded: LocalizationValue;
           };
         };
       };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1427,6 +1427,11 @@ export type __internal_LocalizationResource = {
           placeholder: LocalizationValue;
           description: LocalizationValue;
         };
+        modes: {
+          ariaLabel: LocalizationValue;
+          metadataUrl: LocalizationValue;
+          manual: LocalizationValue;
+        };
       };
     };
   };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1432,6 +1432,9 @@ export type __internal_LocalizationResource = {
           metadataUrl: LocalizationValue;
           manual: LocalizationValue;
         };
+        submitSamlConfig: {
+          title: LocalizationValue;
+        };
       };
     };
   };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1435,6 +1435,21 @@ export type __internal_LocalizationResource = {
         submitSamlConfig: {
           title: LocalizationValue;
         };
+        manual: {
+          description: LocalizationValue;
+          signOnUrl: {
+            label: LocalizationValue;
+            placeholder: LocalizationValue;
+          };
+          issuer: {
+            label: LocalizationValue;
+            placeholder: LocalizationValue;
+          };
+          signingCertificate: {
+            label: LocalizationValue;
+            uploadFile: LocalizationValue;
+          };
+        };
       };
     };
   };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1448,6 +1448,7 @@ export type __internal_LocalizationResource = {
           signingCertificate: {
             label: LocalizationValue;
             uploadFile: LocalizationValue;
+            removeFile: LocalizationValue;
           };
         };
       };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -735,28 +735,40 @@ const ManualEntryPanel = ({
             />
 
             {certFile === null ? (
-              <Button
-                size='sm'
-                variant='outline'
-                sx={{ alignSelf: 'flex-start' }}
-                onClick={() => certInputRef.current?.click()}
+              <Flex
+                align='center'
+                gap={2}
+                sx={{ alignSelf: 'flex-start', flexWrap: 'wrap' }}
               >
-                <Icon
-                  icon={Upload}
+                {existingCertPresent && (
+                  <Badge
+                    localizationKey={localizationKeys(
+                      'configureSSO.configureStep.samlOkta.manual.signingCertificate.fileUploaded',
+                    )}
+                  />
+                )}
+                <Button
                   size='sm'
-                  colorScheme='neutral'
-                  sx={t => ({ marginInlineEnd: t.space.$1 })}
-                />
+                  variant='outline'
+                  onClick={() => certInputRef.current?.click()}
+                >
+                  <Icon
+                    icon={Upload}
+                    size='sm'
+                    colorScheme='neutral'
+                    sx={t => ({ marginInlineEnd: t.space.$1 })}
+                  />
 
-                <Text
-                  as='span'
-                  localizationKey={localizationKeys(
-                    existingCertPresent
-                      ? 'configureSSO.configureStep.samlOkta.manual.signingCertificate.replaceFile'
-                      : 'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
-                  )}
-                />
-              </Button>
+                  <Text
+                    as='span'
+                    localizationKey={localizationKeys(
+                      existingCertPresent
+                        ? 'configureSSO.configureStep.samlOkta.manual.signingCertificate.replaceFile'
+                        : 'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+                    )}
+                  />
+                </Button>
+              </Flex>
             ) : (
               <Flex
                 align='center'

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -1,5 +1,5 @@
 import { __internal_useUserEnterpriseConnections, useReverification } from '@clerk/shared/react';
-import type { UpdateMeEnterpriseConnectionParams } from '@clerk/shared/types';
+import type { FieldId, UpdateMeEnterpriseConnectionParams } from '@clerk/shared/types';
 import React from 'react';
 
 import {
@@ -27,6 +27,7 @@ import { useCardState } from '@/elements/contexts';
 import { Form } from '@/elements/Form';
 import { SegmentedControl } from '@/elements/SegmentedControl';
 import { Check, ClipboardOutline, Close, Upload } from '@/icons';
+import type { FormControlState } from '@/ui/utils/useFormControl';
 import { useFormControl } from '@/ui/utils/useFormControl';
 import { handleError } from '@/utils/errorHandler';
 
@@ -494,6 +495,137 @@ export const AssignUsersSubStep = (): JSX.Element => {
   );
 };
 
+type FormControl = FormControlState<FieldId>;
+
+type MetadataUrlPanelProps = {
+  field: FormControl;
+};
+
+type ManualEntryPanelProps = {
+  signOnUrlField: FormControl;
+  issuerField: FormControl;
+  certFile: File | null;
+  setCertFile: React.Dispatch<React.SetStateAction<File | null>>;
+};
+
+const MetadataUrlPanel = ({ field }: MetadataUrlPanelProps): JSX.Element => {
+  return (
+    <>
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.description')}
+      />
+      <Form.ControlRow elementId={field.id}>
+        <Form.PlainInput {...field.props} />
+      </Form.ControlRow>
+    </>
+  );
+};
+
+const ManualEntryPanel = ({
+  signOnUrlField,
+  issuerField,
+  certFile,
+  setCertFile,
+}: ManualEntryPanelProps): JSX.Element => {
+  const { t } = useLocalizations();
+  const certInputRef = React.useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.description')}
+      />
+
+      <Form.ControlRow elementId={signOnUrlField.id}>
+        <Form.PlainInput {...signOnUrlField.props} />
+      </Form.ControlRow>
+
+      <Form.ControlRow elementId={issuerField.id}>
+        <Form.PlainInput {...issuerField.props} />
+      </Form.ControlRow>
+
+      <Col gap={2}>
+        <FormLabel>
+          <Text
+            as='span'
+            variant='subtitle'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.label')}
+          />
+        </FormLabel>
+
+        <input
+          ref={certInputRef}
+          type='file'
+          accept='.pem,.key,.crt,.cer,.cert'
+          multiple={false}
+          style={{ display: 'none' }}
+          onChange={e => setCertFile(e.target.files?.[0] ?? null)}
+        />
+
+        {certFile === null ? (
+          <Button
+            size='sm'
+            variant='outline'
+            sx={{ alignSelf: 'flex-start' }}
+            onClick={() => certInputRef.current?.click()}
+          >
+            <Icon
+              icon={Upload}
+              size='sm'
+              colorScheme='neutral'
+              sx={t => ({ marginInlineEnd: t.space.$1 })}
+            />
+
+            <Text
+              as='span'
+              localizationKey={localizationKeys(
+                'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+              )}
+            />
+          </Button>
+        ) : (
+          <Flex
+            align='center'
+            gap={2}
+          >
+            <Text
+              as='span'
+              colorScheme='secondary'
+              sx={t => ({ fontSize: t.fontSizes.$sm })}
+            >
+              {certFile.name}
+            </Text>
+
+            <Button
+              variant='ghost'
+              colorScheme='neutral'
+              aria-label={t(
+                localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.removeFile'),
+              )}
+              onClick={() => {
+                setCertFile(null);
+                if (certInputRef.current) {
+                  certInputRef.current.value = '';
+                }
+              }}
+              sx={t => ({ padding: t.space.$1 })}
+            >
+              <Icon
+                icon={Close}
+                size='xs'
+              />
+            </Button>
+          </Flex>
+        )}
+      </Col>
+    </>
+  );
+};
+
 export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const card = useCardState();
   const { t } = useLocalizations();
@@ -503,7 +635,6 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
 
   const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
   const [certFile, setCertFile] = React.useState<File | null>(null);
-  const certInputRef = React.useRef<HTMLInputElement>(null);
 
   const updateConnection = useReverification(
     React.useCallback(
@@ -609,112 +740,15 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
             />
           </SegmentedControl.Root>
 
-          {mode === 'metadataUrl' && (
-            <>
-              <Text
-                as='p'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.description')}
-              />
-              <Form.ControlRow elementId={metadataUrlField.id}>
-                <Form.PlainInput {...metadataUrlField.props} />
-              </Form.ControlRow>
-            </>
-          )}
-
-          {mode === 'manual' && (
-            <>
-              <Text
-                as='p'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.description')}
-              />
-
-              <Form.ControlRow elementId={signOnUrlField.id}>
-                <Form.PlainInput {...signOnUrlField.props} />
-              </Form.ControlRow>
-
-              <Form.ControlRow elementId={issuerField.id}>
-                <Form.PlainInput {...issuerField.props} />
-              </Form.ControlRow>
-
-              <Col gap={2}>
-                <FormLabel>
-                  <Text
-                    as='span'
-                    variant='subtitle'
-                    localizationKey={localizationKeys(
-                      'configureSSO.configureStep.samlOkta.manual.signingCertificate.label',
-                    )}
-                  />
-                </FormLabel>
-
-                <input
-                  ref={certInputRef}
-                  type='file'
-                  accept='.pem,.crt,.cer,.txt'
-                  multiple={false}
-                  style={{ display: 'none' }}
-                  onChange={e => setCertFile(e.target.files?.[0] ?? null)}
-                />
-
-                {certFile === null ? (
-                  <Button
-                    size='sm'
-                    variant='outline'
-                    sx={{ alignSelf: 'flex-start' }}
-                    onClick={() => certInputRef.current?.click()}
-                  >
-                    <Icon
-                      icon={Upload}
-                      size='sm'
-                      colorScheme='neutral'
-                      sx={t => ({ marginInlineEnd: t.space.$1 })}
-                    />
-
-                    <Text
-                      as='span'
-                      localizationKey={localizationKeys(
-                        'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
-                      )}
-                    />
-                  </Button>
-                ) : (
-                  <Flex
-                    align='center'
-                    gap={2}
-                  >
-                    <Text
-                      as='span'
-                      colorScheme='secondary'
-                      sx={t => ({ fontSize: t.fontSizes.$sm })}
-                    >
-                      {certFile.name}
-                    </Text>
-
-                    <Button
-                      variant='ghost'
-                      colorScheme='neutral'
-                      aria-label={t(
-                        localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.removeFile'),
-                      )}
-                      onClick={() => {
-                        setCertFile(null);
-                        if (certInputRef.current) {
-                          certInputRef.current.value = '';
-                        }
-                      }}
-                      sx={t => ({ padding: t.space.$1 })}
-                    >
-                      <Icon
-                        icon={Close}
-                        size='xs'
-                      />
-                    </Button>
-                  </Flex>
-                )}
-              </Col>
-            </>
+          {mode === 'metadataUrl' ? (
+            <MetadataUrlPanel field={metadataUrlField} />
+          ) : (
+            <ManualEntryPanel
+              signOnUrlField={signOnUrlField}
+              issuerField={issuerField}
+              certFile={certFile}
+              setCertFile={setCertFile}
+            />
           )}
         </Step.Section>
       </Step.Body>

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -548,6 +548,11 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
           fill
           sx={theme => ({ gap: theme.space.$5 })}
         >
+          <Heading
+            as='h3'
+            textVariant='subtitle'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.submitSamlConfig.title')}
+          />
           <SegmentedControl.Root
             aria-label={t(localizationKeys('configureSSO.configureStep.samlOkta.modes.ariaLabel'))}
             value={mode}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -9,7 +9,6 @@ import {
   descriptors,
   Flex,
   Flow,
-  FormLabel,
   Heading,
   Icon,
   localizationKeys,
@@ -24,6 +23,7 @@ import {
 } from '@/customizables';
 import { ClipboardInput } from '@/elements/ClipboardInput';
 import { useCardState } from '@/elements/contexts';
+import { Field } from '@/elements/FieldControl';
 import { Form } from '@/elements/Form';
 import { SegmentedControl } from '@/elements/SegmentedControl';
 import { Check, ClipboardOutline, Close, Upload } from '@/icons';
@@ -502,7 +502,16 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const { enterpriseConnection } = useConfigureSSO();
   const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
 
-  const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
+  const samlConnection = enterpriseConnection?.samlConnection;
+  const hasExistingConfig = Boolean(
+    samlConnection?.idpSsoUrl ||
+    samlConnection?.idpEntityId ||
+    samlConnection?.idpCertificate ||
+    samlConnection?.idpMetadataUrl,
+  );
+  const existingCertPresent = Boolean(samlConnection?.idpCertificate);
+
+  const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>(hasExistingConfig ? 'manual' : 'metadataUrl');
   const [certFile, setCertFile] = React.useState<File | null>(null);
 
   const updateConnection = useReverification(
@@ -518,24 +527,30 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
     ),
   );
 
-  const metadataUrlField = useFormControl('idpMetadataUrl', '', {
+  const metadataUrlField = useFormControl('idpMetadataUrl', samlConnection?.idpMetadataUrl ?? '', {
     type: 'text',
     label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
     placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),
     isRequired: true,
   });
 
-  const signOnUrlField = useFormControl('idpSsoUrl', '', {
+  const signOnUrlField = useFormControl('idpSsoUrl', samlConnection?.idpSsoUrl ?? '', {
     type: 'text',
     label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.label'),
     placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.placeholder'),
     isRequired: true,
   });
 
-  const issuerField = useFormControl('idpEntityId', '', {
+  const issuerField = useFormControl('idpEntityId', samlConnection?.idpEntityId ?? '', {
     type: 'text',
     label: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.label'),
     placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.placeholder'),
+    isRequired: true,
+  });
+
+  const certFileField = useFormControl('idpCertificate', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.label'),
     isRequired: true,
   });
 
@@ -543,13 +558,14 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const trimmedSignOnUrl = signOnUrlField.value.trim();
   const trimmedIssuer = issuerField.value.trim();
 
+  const hasCert = certFile !== null || existingCertPresent;
   const canSubmit =
     !card.isLoading &&
     ((mode === 'metadataUrl' && trimmedMetadataUrl.length > 0) ||
-      (mode === 'manual' && trimmedSignOnUrl.length > 0 && trimmedIssuer.length > 0 && certFile !== null));
+      (mode === 'manual' && trimmedSignOnUrl.length > 0 && trimmedIssuer.length > 0 && hasCert));
 
   const handleContinue = async () => {
-    if (!certFile || !enterpriseConnection || !canSubmit) {
+    if (!enterpriseConnection || !canSubmit) {
       return;
     }
 
@@ -560,21 +576,23 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
       if (mode === 'metadataUrl') {
         await updateConnection({ saml: { idpMetadataUrl: trimmedMetadataUrl } });
       } else {
-        const idpCertificate = await certFile.text();
-        await updateConnection({
-          saml: {
-            idpSsoUrl: trimmedSignOnUrl,
-            idpEntityId: trimmedIssuer,
-            idpCertificate,
-          },
-        });
+        const samlPayload: NonNullable<UpdateMeEnterpriseConnectionParams['saml']> = {
+          idpSsoUrl: trimmedSignOnUrl,
+          idpEntityId: trimmedIssuer,
+        };
+
+        if (certFile !== null) {
+          samlPayload.idpCertificate = await certFile.text();
+        }
+
+        await updateConnection({ saml: samlPayload });
       }
       void goNext();
     } catch (err) {
       if (mode === 'metadataUrl') {
         handleError(err as Error, [metadataUrlField], card.setError);
       } else {
-        handleError(err as Error, [signOnUrlField, issuerField], card.setError);
+        handleError(err as Error, [signOnUrlField, issuerField, certFileField], card.setError);
       }
     } finally {
       card.setIdle();
@@ -615,8 +633,10 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
             <ManualEntryPanel
               signOnUrlField={signOnUrlField}
               issuerField={issuerField}
+              certFileField={certFileField}
               certFile={certFile}
               setCertFile={setCertFile}
+              existingCertPresent={existingCertPresent}
             />
           )}
         </Step.Section>
@@ -646,8 +666,10 @@ type MetadataUrlPanelProps = {
 type ManualEntryPanelProps = {
   signOnUrlField: FormControl;
   issuerField: FormControl;
+  certFileField: FormControl;
   certFile: File | null;
   setCertFile: React.Dispatch<React.SetStateAction<File | null>>;
+  existingCertPresent: boolean;
 };
 
 const MetadataUrlPanel = ({ field }: MetadataUrlPanelProps): JSX.Element => {
@@ -668,8 +690,10 @@ const MetadataUrlPanel = ({ field }: MetadataUrlPanelProps): JSX.Element => {
 const ManualEntryPanel = ({
   signOnUrlField,
   issuerField,
+  certFileField,
   certFile,
   setCertFile,
+  existingCertPresent,
 }: ManualEntryPanelProps): JSX.Element => {
   const { t } = useLocalizations();
   const certInputRef = React.useRef<HTMLInputElement>(null);
@@ -690,14 +714,10 @@ const ManualEntryPanel = ({
         <Form.PlainInput {...issuerField.props} />
       </Form.ControlRow>
 
-      <Col gap={2}>
-        <FormLabel>
-          <Text
-            as='span'
-            variant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.label')}
-          />
-        </FormLabel>
+      <Field.Root {...certFileField.props}>
+        <Field.LabelRow>
+          <Field.Label />
+        </Field.LabelRow>
 
         <input
           ref={certInputRef}
@@ -705,7 +725,10 @@ const ManualEntryPanel = ({
           accept='.pem,.key,.crt,.cer,.cert'
           multiple={false}
           style={{ display: 'none' }}
-          onChange={e => setCertFile(e.target.files?.[0] ?? null)}
+          onChange={e => {
+            setCertFile(e.target.files?.[0] ?? null);
+            certFileField.clearFeedback();
+          }}
         />
 
         {certFile === null ? (
@@ -725,7 +748,9 @@ const ManualEntryPanel = ({
             <Text
               as='span'
               localizationKey={localizationKeys(
-                'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+                existingCertPresent
+                  ? 'configureSSO.configureStep.samlOkta.manual.signingCertificate.replaceFile'
+                  : 'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
               )}
             />
           </Button>
@@ -751,6 +776,7 @@ const ManualEntryPanel = ({
               )}
               onClick={() => {
                 setCertFile(null);
+                certFileField.clearFeedback();
                 if (certInputRef.current) {
                   certInputRef.current.value = '';
                 }
@@ -764,7 +790,9 @@ const ManualEntryPanel = ({
             </Button>
           </Flex>
         )}
-      </Col>
+
+        <Field.Feedback />
+      </Field.Root>
     </>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {
   Badge,
+  Box,
   Button,
   Col,
   descriptors,
@@ -714,85 +715,88 @@ const ManualEntryPanel = ({
         <Form.PlainInput {...issuerField.props} />
       </Form.ControlRow>
 
-      <Field.Root {...certFileField.props}>
-        <Field.LabelRow>
-          <Field.Label />
-        </Field.LabelRow>
+      <Box>
+        <Field.Root {...certFileField.props}>
+          <Col gap={2}>
+            <Field.LabelRow>
+              <Field.Label />
+            </Field.LabelRow>
 
-        <input
-          ref={certInputRef}
-          type='file'
-          accept='.pem,.key,.crt,.cer,.cert'
-          multiple={false}
-          style={{ display: 'none' }}
-          onChange={e => {
-            setCertFile(e.target.files?.[0] ?? null);
-            certFileField.clearFeedback();
-          }}
-        />
-
-        {certFile === null ? (
-          <Button
-            size='sm'
-            variant='outline'
-            sx={{ alignSelf: 'flex-start' }}
-            onClick={() => certInputRef.current?.click()}
-          >
-            <Icon
-              icon={Upload}
-              size='sm'
-              colorScheme='neutral'
-              sx={t => ({ marginInlineEnd: t.space.$1 })}
-            />
-
-            <Text
-              as='span'
-              localizationKey={localizationKeys(
-                existingCertPresent
-                  ? 'configureSSO.configureStep.samlOkta.manual.signingCertificate.replaceFile'
-                  : 'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
-              )}
-            />
-          </Button>
-        ) : (
-          <Flex
-            align='center'
-            gap={2}
-            sx={theme => ({ paddingTop: theme.space.$1, paddingBottom: theme.space.$1 })}
-          >
-            <Text
-              as='span'
-              colorScheme='secondary'
-              variant='buttonSmall'
-            >
-              {certFile.name}
-            </Text>
-
-            <Button
-              variant='ghost'
-              colorScheme='neutral'
-              aria-label={t(
-                localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.removeFile'),
-              )}
-              onClick={() => {
-                setCertFile(null);
+            <input
+              ref={certInputRef}
+              type='file'
+              accept='.pem,.key,.crt,.cer,.cert'
+              multiple={false}
+              style={{ display: 'none' }}
+              onChange={e => {
+                setCertFile(e.target.files?.[0] ?? null);
                 certFileField.clearFeedback();
-                if (certInputRef.current) {
-                  certInputRef.current.value = '';
-                }
               }}
-              sx={t => ({ padding: t.space.$1 })}
-            >
-              <Icon
-                icon={Close}
-                size='xs'
-              />
-            </Button>
-          </Flex>
-        )}
+            />
 
-        <Field.Feedback />
-      </Field.Root>
+            {certFile === null ? (
+              <Button
+                size='sm'
+                variant='outline'
+                sx={{ alignSelf: 'flex-start' }}
+                onClick={() => certInputRef.current?.click()}
+              >
+                <Icon
+                  icon={Upload}
+                  size='sm'
+                  colorScheme='neutral'
+                  sx={t => ({ marginInlineEnd: t.space.$1 })}
+                />
+
+                <Text
+                  as='span'
+                  localizationKey={localizationKeys(
+                    existingCertPresent
+                      ? 'configureSSO.configureStep.samlOkta.manual.signingCertificate.replaceFile'
+                      : 'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+                  )}
+                />
+              </Button>
+            ) : (
+              <Flex
+                align='center'
+                gap={2}
+                sx={theme => ({ paddingTop: theme.space.$1, paddingBottom: theme.space.$1 })}
+              >
+                <Text
+                  as='span'
+                  colorScheme='secondary'
+                  variant='buttonSmall'
+                >
+                  {certFile.name}
+                </Text>
+
+                <Button
+                  variant='ghost'
+                  colorScheme='neutral'
+                  aria-label={t(
+                    localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.removeFile'),
+                  )}
+                  onClick={() => {
+                    setCertFile(null);
+                    certFileField.clearFeedback();
+                    if (certInputRef.current) {
+                      certInputRef.current.value = '';
+                    }
+                  }}
+                  sx={t => ({ padding: t.space.$1 })}
+                >
+                  <Icon
+                    icon={Close}
+                    size='xs'
+                  />
+                </Button>
+              </Flex>
+            )}
+          </Col>
+          <Field.Feedback />
+        </Field.Root>
+      </Box>
     </>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -528,7 +528,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
     ),
   );
 
-  const metadataUrlField = useFormControl('idpMetadataUrl', samlConnection?.idpMetadataUrl ?? '', {
+  const metadataUrlField = useFormControl('idpMetadataUrl', '', {
     type: 'text',
     label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
     placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -26,7 +26,7 @@ import { ClipboardInput } from '@/elements/ClipboardInput';
 import { useCardState } from '@/elements/contexts';
 import { Form } from '@/elements/Form';
 import { SegmentedControl } from '@/elements/SegmentedControl';
-import { Check, ClipboardOutline, Upload } from '@/icons';
+import { Check, ClipboardOutline, Close, Upload } from '@/icons';
 import { useFormControl } from '@/ui/utils/useFormControl';
 import { handleError } from '@/utils/errorHandler';
 
@@ -502,6 +502,8 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
 
   const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
+  const [certFile, setCertFile] = React.useState<File | null>(null);
+  const certInputRef = React.useRef<HTMLInputElement>(null);
 
   const updateConnection = useReverification(
     React.useCallback(
@@ -626,25 +628,70 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
                   />
                 </FormLabel>
 
-                <Button
-                  size='sm'
-                  variant='outline'
-                  sx={{ alignSelf: 'flex-start' }}
-                >
-                  <Icon
-                    icon={Upload}
-                    size='sm'
-                    colorScheme='neutral'
-                    sx={t => ({ marginInlineEnd: t.space.$1 })}
-                  />
+                <input
+                  ref={certInputRef}
+                  type='file'
+                  accept='.pem,.crt,.cer,.txt'
+                  multiple={false}
+                  style={{ display: 'none' }}
+                  onChange={e => setCertFile(e.target.files?.[0] ?? null)}
+                />
 
-                  <Text
-                    as='span'
-                    localizationKey={localizationKeys(
-                      'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
-                    )}
-                  />
-                </Button>
+                {certFile === null ? (
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    sx={{ alignSelf: 'flex-start' }}
+                    onClick={() => certInputRef.current?.click()}
+                  >
+                    <Icon
+                      icon={Upload}
+                      size='sm'
+                      colorScheme='neutral'
+                      sx={t => ({ marginInlineEnd: t.space.$1 })}
+                    />
+
+                    <Text
+                      as='span'
+                      localizationKey={localizationKeys(
+                        'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+                      )}
+                    />
+                  </Button>
+                ) : (
+                  <Flex
+                    align='center'
+                    gap={2}
+                  >
+                    <Text
+                      as='span'
+                      colorScheme='secondary'
+                      sx={t => ({ fontSize: t.fontSizes.$sm })}
+                    >
+                      {certFile.name}
+                    </Text>
+
+                    <Button
+                      variant='ghost'
+                      colorScheme='neutral'
+                      aria-label={t(
+                        localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.removeFile'),
+                      )}
+                      onClick={() => {
+                        setCertFile(null);
+                        if (certInputRef.current) {
+                          certInputRef.current.value = '';
+                        }
+                      }}
+                      sx={t => ({ padding: t.space.$1 })}
+                    >
+                      <Icon
+                        icon={Close}
+                        size='xs'
+                      />
+                    </Button>
+                  </Flex>
+                )}
               </Col>
             </>
           )}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -4,11 +4,14 @@ import React from 'react';
 
 import {
   Badge,
+  Button,
   Col,
   descriptors,
   Flex,
   Flow,
+  FormLabel,
   Heading,
+  Icon,
   localizationKeys,
   Table,
   Tbody,
@@ -23,7 +26,7 @@ import { ClipboardInput } from '@/elements/ClipboardInput';
 import { useCardState } from '@/elements/contexts';
 import { Form } from '@/elements/Form';
 import { SegmentedControl } from '@/elements/SegmentedControl';
-import { Check, ClipboardOutline } from '@/icons';
+import { Check, ClipboardOutline, Upload } from '@/icons';
 import { useFormControl } from '@/ui/utils/useFormControl';
 import { handleError } from '@/utils/errorHandler';
 
@@ -520,6 +523,20 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
     isRequired: true,
   });
 
+  const signOnUrlField = useFormControl('idpSsoUrl', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.label'),
+    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.placeholder'),
+    isRequired: true,
+  });
+
+  const issuerField = useFormControl('idpEntityId', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.label'),
+    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.placeholder'),
+    isRequired: true,
+  });
+
   const trimmedMetadataUrl = metadataUrlField.value.trim();
   const canSubmit = mode === 'metadataUrl' && trimmedMetadataUrl.length > 0 && !card.isLoading;
 
@@ -579,6 +596,56 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
               <Form.ControlRow elementId={metadataUrlField.id}>
                 <Form.PlainInput {...metadataUrlField.props} />
               </Form.ControlRow>
+            </>
+          )}
+
+          {mode === 'manual' && (
+            <>
+              <Text
+                as='p'
+                colorScheme='secondary'
+                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.description')}
+              />
+
+              <Form.ControlRow elementId={signOnUrlField.id}>
+                <Form.PlainInput {...signOnUrlField.props} />
+              </Form.ControlRow>
+
+              <Form.ControlRow elementId={issuerField.id}>
+                <Form.PlainInput {...issuerField.props} />
+              </Form.ControlRow>
+
+              <Col gap={2}>
+                <FormLabel>
+                  <Text
+                    as='span'
+                    variant='subtitle'
+                    localizationKey={localizationKeys(
+                      'configureSSO.configureStep.samlOkta.manual.signingCertificate.label',
+                    )}
+                  />
+                </FormLabel>
+
+                <Button
+                  size='sm'
+                  variant='outline'
+                  sx={{ alignSelf: 'flex-start' }}
+                >
+                  <Icon
+                    icon={Upload}
+                    size='sm'
+                    colorScheme='neutral'
+                    sx={t => ({ marginInlineEnd: t.space.$1 })}
+                  />
+
+                  <Text
+                    as='span'
+                    localizationKey={localizationKeys(
+                      'configureSSO.configureStep.samlOkta.manual.signingCertificate.uploadFile',
+                    )}
+                  />
+                </Button>
+              </Col>
             </>
           )}
         </Step.Section>

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -17,13 +17,15 @@ import {
   Th,
   Thead,
   Tr,
+  useLocalizations,
 } from '@/customizables';
 import { ClipboardInput } from '@/elements/ClipboardInput';
 import { useCardState } from '@/elements/contexts';
 import { Form } from '@/elements/Form';
+import { SegmentedControl } from '@/elements/SegmentedControl';
 import { Check, ClipboardOutline } from '@/icons';
-import { handleError } from '@/utils/errorHandler';
 import { useFormControl } from '@/ui/utils/useFormControl';
+import { handleError } from '@/utils/errorHandler';
 
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
@@ -270,139 +272,137 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
     <>
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
-          <Col sx={theme => ({ gap: theme.space.$3 })}>
-            <Heading
-              as='h3'
-              textVariant='subtitle'
-              localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.title')}
-            />
+          <Heading
+            as='h3'
+            textVariant='subtitle'
+            localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.title')}
+          />
 
-            <Table
-              sx={theme => ({
-                'tr > th:first-of-type': {
-                  paddingInlineStart: theme.space.$4,
-                },
-              })}
-            >
-              <Thead>
-                <Tr>
-                  <Th>
-                    <Text
-                      sx={theme => ({ fontSize: theme.fontSizes.$xs })}
-                      localizationKey={localizationKeys(
-                        'configureSSO.configureStep.attributeMapping.columns.attribute',
-                      )}
-                    />
-                  </Th>
+          <Table
+            sx={theme => ({
+              'tr > th:first-of-type': {
+                paddingInlineStart: theme.space.$4,
+              },
+            })}
+          >
+            <Thead>
+              <Tr>
+                <Th>
+                  <Text
+                    sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+                    localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.columns.attribute')}
+                  />
+                </Th>
 
-                  <Th>
-                    <Text
-                      sx={theme => ({ fontSize: theme.fontSizes.$xs })}
-                      localizationKey={localizationKeys(
-                        'configureSSO.configureStep.attributeMapping.columns.claimName',
-                      )}
-                    />
-                  </Th>
-                </Tr>
-              </Thead>
+                <Th>
+                  <Text
+                    sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+                    localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.columns.claimName')}
+                  />
+                </Th>
+              </Tr>
+            </Thead>
 
-              <Tbody>
-                {ATTRIBUTE_ROWS.map(row => (
-                  <Tr key={row.id}>
-                    <Td>
-                      <Flex
-                        as='span'
-                        align='center'
-                        sx={theme => ({ gap: theme.space.$2 })}
-                      >
-                        <Text
-                          colorScheme='secondary'
-                          localizationKey={row.attribute}
-                        />
-
-                        <Badge
-                          colorScheme={row.isRequired ? 'warning' : 'primary'}
-                          localizationKey={localizationKeys(
-                            row.isRequired
-                              ? 'configureSSO.configureStep.attributeMapping.badges.required'
-                              : 'configureSSO.configureStep.attributeMapping.badges.optional',
-                          )}
-                        />
-                      </Flex>
-                    </Td>
-
-                    <Td>
-                      <Text
-                        as='span'
-                        sx={{ fontFamily: 'monospace' }}
-                        localizationKey={row.claim}
-                      />
-                    </Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </Col>
-
-          <Col sx={theme => ({ gap: theme.space.$3 })}>
-            <Text
-              as='p'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.paragraph')}
-            />
-
-            <Col
-              as='ol'
-              sx={theme => ({
-                gap: theme.space.$1x5,
-                margin: 0,
-                paddingInlineStart: theme.space.$5,
-                listStyleType: 'decimal',
-              })}
-            >
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step1')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-              >
-                <Text
-                  as='span'
-                  localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step2')}
-                />
-                <Col
-                  as='ul'
-                  sx={theme => ({
-                    gap: theme.space.$1x5,
-                    margin: 0,
-                    marginTop: theme.space.$1x5,
-                    paddingInlineStart: theme.space.$5,
-                    listStyleType: '"- "',
-                  })}
-                >
-                  {ATTRIBUTE_PAIRS.map(pair => (
-                    <Text
-                      key={pair.id}
-                      as='li'
+            <Tbody>
+              {ATTRIBUTE_ROWS.map(row => (
+                <Tr key={row.id}>
+                  <Td>
+                    <Flex
+                      as='span'
+                      align='center'
+                      sx={theme => ({ gap: theme.space.$2 })}
                     >
-                      <Badge localizationKey={pair.name} />
-
                       <Text
-                        as='span'
+                        colorScheme='secondary'
+                        localizationKey={row.attribute}
+                      />
+
+                      <Badge
+                        colorScheme={row.isRequired ? 'warning' : 'primary'}
                         localizationKey={localizationKeys(
-                          'configureSSO.configureStep.samlOkta.configureAttributes.pairs.conjunction',
+                          row.isRequired
+                            ? 'configureSSO.configureStep.attributeMapping.badges.required'
+                            : 'configureSSO.configureStep.attributeMapping.badges.optional',
                         )}
                       />
+                    </Flex>
+                  </Td>
 
-                      <Badge localizationKey={pair.expression} />
-                    </Text>
-                  ))}
-                </Col>
-              </Text>
-            </Col>
+                  <Td>
+                    <Text
+                      as='span'
+                      sx={{ fontFamily: 'monospace' }}
+                      localizationKey={row.claim}
+                    />
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+
+          <Text
+            as='p'
+            colorScheme='secondary'
+            localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.paragraph')}
+          />
+
+          <Col
+            as='ol'
+            sx={theme => ({
+              gap: theme.space.$1x5,
+              margin: 0,
+              paddingInlineStart: theme.space.$5,
+              listStyleType: 'decimal',
+            })}
+          >
+            <Text
+              as='li'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step1')}
+            />
+            <Text
+              as='li'
+              colorScheme='secondary'
+            >
+              <Text
+                as='span'
+                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step2')}
+              />
+              <Col
+                as='ul'
+                sx={theme => ({
+                  gap: theme.space.$1x5,
+                  margin: 0,
+                  marginTop: theme.space.$1x5,
+                  paddingInlineStart: theme.space.$5,
+                  listStyleType: '"- "',
+                })}
+              >
+                {ATTRIBUTE_PAIRS.map(pair => (
+                  <Text
+                    key={pair.id}
+                    as='li'
+                  >
+                    <Badge
+                      localizationKey={pair.name}
+                      sx={{ fontFamily: 'monospace' }}
+                    />
+
+                    <Text
+                      as='span'
+                      localizationKey={localizationKeys(
+                        'configureSSO.configureStep.samlOkta.configureAttributes.pairs.conjunction',
+                      )}
+                    />
+
+                    <Badge
+                      localizationKey={pair.expression}
+                      sx={{ fontFamily: 'monospace' }}
+                    />
+                  </Text>
+                ))}
+              </Col>
+            </Text>
           </Col>
         </Step.Section>
       </Step.Body>
@@ -427,54 +427,52 @@ export const AssignUsersSubStep = (): JSX.Element => {
   return (
     <>
       <Step.Body>
-        <Step.Section sx={theme => ({ gap: theme.space.$5 })}>
-          <Col sx={theme => ({ gap: theme.space.$3 })}>
-            <Heading
-              as='h3'
-              textVariant='subtitle'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.title')}
+        <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
+          <Heading
+            as='h3'
+            textVariant='subtitle'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.title')}
+          />
+          <Text
+            as='p'
+            colorScheme='secondary'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.paragraph')}
+          />
+
+          <Col
+            as='ol'
+            sx={theme => ({
+              gap: theme.space.$1x5,
+              margin: 0,
+              paddingInlineStart: theme.space.$5,
+              listStyleType: 'decimal',
+            })}
+          >
+            <Text
+              as='li'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step1')}
             />
             <Text
-              as='p'
+              as='li'
               colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.paragraph')}
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step2')}
             />
-
-            <Col
-              as='ol'
-              sx={theme => ({
-                gap: theme.space.$1x5,
-                margin: 0,
-                paddingInlineStart: theme.space.$5,
-                listStyleType: 'decimal',
-              })}
-            >
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step1')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step2')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step3')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step4')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step5')}
-              />
-            </Col>
+            <Text
+              as='li'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step3')}
+            />
+            <Text
+              as='li'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step4')}
+            />
+            <Text
+              as='li'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.step5')}
+            />
           </Col>
         </Step.Section>
       </Step.Body>
@@ -495,9 +493,12 @@ export const AssignUsersSubStep = (): JSX.Element => {
 
 export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const card = useCardState();
+  const { t } = useLocalizations();
   const { goNext, goPrev, isFirstStep } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
   const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
+
+  const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
 
   const updateConnection = useReverification(
     React.useCallback(
@@ -520,7 +521,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   });
 
   const trimmedMetadataUrl = metadataUrlField.value.trim();
-  const canSubmit = trimmedMetadataUrl.length > 0 && !card.isLoading;
+  const canSubmit = mode === 'metadataUrl' && trimmedMetadataUrl.length > 0 && !card.isLoading;
 
   const handleContinue = async () => {
     if (!enterpriseConnection || !canSubmit) {
@@ -547,14 +548,34 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
           fill
           sx={theme => ({ gap: theme.space.$5 })}
         >
-          <Text
-            as='p'
-            colorScheme='secondary'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.description')}
-          />
-          <Form.ControlRow elementId={metadataUrlField.id}>
-            <Form.PlainInput {...metadataUrlField.props} />
-          </Form.ControlRow>
+          <SegmentedControl.Root
+            aria-label={t(localizationKeys('configureSSO.configureStep.samlOkta.modes.ariaLabel'))}
+            value={mode}
+            onChange={value => setMode(value as 'metadataUrl' | 'manual')}
+            fullWidth
+          >
+            <SegmentedControl.Button
+              value='metadataUrl'
+              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.metadataUrl')}
+            />
+            <SegmentedControl.Button
+              value='manual'
+              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.manual')}
+            />
+          </SegmentedControl.Root>
+
+          {mode === 'metadataUrl' && (
+            <>
+              <Text
+                as='p'
+                colorScheme='secondary'
+                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.description')}
+              />
+              <Form.ControlRow elementId={metadataUrlField.id}>
+                <Form.PlainInput {...metadataUrlField.props} />
+              </Form.ControlRow>
+            </>
+          )}
         </Step.Section>
       </Step.Body>
 

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -528,7 +528,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
     ),
   );
 
-  const metadataUrlField = useFormControl('idpMetadataUrl', '', {
+  const metadataUrlField = useFormControl('idpMetadataUrl', samlConnection?.idpMetadataUrl ?? '', {
     type: 'text',
     label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
     placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -495,6 +495,148 @@ export const AssignUsersSubStep = (): JSX.Element => {
   );
 };
 
+export const SubmitSamlConfigSubStep = (): JSX.Element => {
+  const card = useCardState();
+  const { t } = useLocalizations();
+  const { goNext, goPrev, isFirstStep } = useWizard();
+  const { enterpriseConnection } = useConfigureSSO();
+  const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
+
+  const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
+  const [certFile, setCertFile] = React.useState<File | null>(null);
+
+  const updateConnection = useReverification(
+    React.useCallback(
+      async (params: UpdateMeEnterpriseConnectionParams) => {
+        if (!enterpriseConnection) {
+          throw new Error('Enterprise connection required');
+        }
+
+        return updateEnterpriseConnection(enterpriseConnection.id, params);
+      },
+      [enterpriseConnection, updateEnterpriseConnection],
+    ),
+  );
+
+  const metadataUrlField = useFormControl('idpMetadataUrl', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
+    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),
+    isRequired: true,
+  });
+
+  const signOnUrlField = useFormControl('idpSsoUrl', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.label'),
+    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.placeholder'),
+    isRequired: true,
+  });
+
+  const issuerField = useFormControl('idpEntityId', '', {
+    type: 'text',
+    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.label'),
+    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.placeholder'),
+    isRequired: true,
+  });
+
+  const trimmedMetadataUrl = metadataUrlField.value.trim();
+  const trimmedSignOnUrl = signOnUrlField.value.trim();
+  const trimmedIssuer = issuerField.value.trim();
+
+  const canSubmit =
+    !card.isLoading &&
+    ((mode === 'metadataUrl' && trimmedMetadataUrl.length > 0) ||
+      (mode === 'manual' && trimmedSignOnUrl.length > 0 && trimmedIssuer.length > 0 && certFile !== null));
+
+  const handleContinue = async () => {
+    if (!certFile || !enterpriseConnection || !canSubmit) {
+      return;
+    }
+
+    card.setError(undefined);
+    card.setLoading();
+
+    try {
+      if (mode === 'metadataUrl') {
+        await updateConnection({ saml: { idpMetadataUrl: trimmedMetadataUrl } });
+      } else {
+        const idpCertificate = await certFile.text();
+        await updateConnection({
+          saml: {
+            idpSsoUrl: trimmedSignOnUrl,
+            idpEntityId: trimmedIssuer,
+            idpCertificate,
+          },
+        });
+      }
+      void goNext();
+    } catch (err) {
+      if (mode === 'metadataUrl') {
+        handleError(err as Error, [metadataUrlField], card.setError);
+      } else {
+        handleError(err as Error, [signOnUrlField, issuerField], card.setError);
+      }
+    } finally {
+      card.setIdle();
+    }
+  };
+
+  return (
+    <>
+      <Step.Body>
+        <Step.Section
+          fill
+          gap={5}
+        >
+          <Heading
+            as='h3'
+            textVariant='subtitle'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.submitSamlConfig.title')}
+          />
+          <SegmentedControl.Root
+            aria-label={t(localizationKeys('configureSSO.configureStep.samlOkta.modes.ariaLabel'))}
+            value={mode}
+            onChange={value => setMode(value as 'metadataUrl' | 'manual')}
+            fullWidth
+          >
+            <SegmentedControl.Button
+              value='metadataUrl'
+              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.metadataUrl')}
+            />
+            <SegmentedControl.Button
+              value='manual'
+              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.manual')}
+            />
+          </SegmentedControl.Root>
+
+          {mode === 'metadataUrl' ? (
+            <MetadataUrlPanel field={metadataUrlField} />
+          ) : (
+            <ManualEntryPanel
+              signOnUrlField={signOnUrlField}
+              issuerField={issuerField}
+              certFile={certFile}
+              setCertFile={setCertFile}
+            />
+          )}
+        </Step.Section>
+      </Step.Body>
+
+      <Step.Footer>
+        <Step.Footer.Previous
+          onClick={() => goPrev()}
+          isDisabled={isFirstStep || card.isLoading}
+        />
+        <Step.Footer.Continue
+          onClick={handleContinue}
+          isLoading={card.isLoading}
+          isDisabled={!canSubmit}
+        />
+      </Step.Footer>
+    </>
+  );
+};
+
 type FormControl = FormControlState<FieldId>;
 
 type MetadataUrlPanelProps = {
@@ -591,11 +733,12 @@ const ManualEntryPanel = ({
           <Flex
             align='center'
             gap={2}
+            sx={theme => ({ paddingTop: theme.space.$1, paddingBottom: theme.space.$1 })}
           >
             <Text
               as='span'
               colorScheme='secondary'
-              sx={t => ({ fontSize: t.fontSizes.$sm })}
+              variant='buttonSmall'
             >
               {certFile.name}
             </Text>
@@ -622,148 +765,6 @@ const ManualEntryPanel = ({
           </Flex>
         )}
       </Col>
-    </>
-  );
-};
-
-export const SubmitSamlConfigSubStep = (): JSX.Element => {
-  const card = useCardState();
-  const { t } = useLocalizations();
-  const { goNext, goPrev, isFirstStep } = useWizard();
-  const { enterpriseConnection } = useConfigureSSO();
-  const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
-
-  const [mode, setMode] = React.useState<'metadataUrl' | 'manual'>('metadataUrl');
-  const [certFile, setCertFile] = React.useState<File | null>(null);
-
-  const updateConnection = useReverification(
-    React.useCallback(
-      async (params: UpdateMeEnterpriseConnectionParams) => {
-        if (!enterpriseConnection) {
-          throw new Error('Enterprise connection required');
-        }
-
-        return updateEnterpriseConnection(enterpriseConnection.id, params);
-      },
-      [enterpriseConnection, updateEnterpriseConnection],
-    ),
-  );
-
-  const metadataUrlField = useFormControl('idpMetadataUrl', '', {
-    type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),
-    isRequired: true,
-  });
-
-  const signOnUrlField = useFormControl('idpSsoUrl', '', {
-    type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.placeholder'),
-    isRequired: true,
-  });
-
-  const issuerField = useFormControl('idpEntityId', '', {
-    type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.placeholder'),
-    isRequired: true,
-  });
-
-  const trimmedMetadataUrl = metadataUrlField.value.trim();
-  const trimmedSignOnUrl = signOnUrlField.value.trim();
-  const trimmedIssuer = issuerField.value.trim();
-
-  const canSubmit =
-    !card.isLoading &&
-    ((mode === 'metadataUrl' && trimmedMetadataUrl.length > 0) ||
-      (mode === 'manual' && trimmedSignOnUrl.length > 0 && trimmedIssuer.length > 0 && certFile !== null));
-
-  const handleContinue = async () => {
-    if (!enterpriseConnection || !canSubmit) {
-      return;
-    }
-
-    card.setError(undefined);
-    card.setLoading();
-
-    try {
-      if (mode === 'metadataUrl') {
-        await updateConnection({ saml: { idpMetadataUrl: trimmedMetadataUrl } });
-      } else {
-        const idpCertificate = await certFile!.text();
-        await updateConnection({
-          saml: {
-            idpSsoUrl: trimmedSignOnUrl,
-            idpEntityId: trimmedIssuer,
-            idpCertificate,
-          },
-        });
-      }
-      void goNext();
-    } catch (err) {
-      if (mode === 'metadataUrl') {
-        handleError(err as Error, [metadataUrlField], card.setError);
-      } else {
-        handleError(err as Error, [signOnUrlField, issuerField], card.setError);
-      }
-    } finally {
-      card.setIdle();
-    }
-  };
-
-  return (
-    <>
-      <Step.Body>
-        <Step.Section
-          fill
-          sx={theme => ({ gap: theme.space.$5 })}
-        >
-          <Heading
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.submitSamlConfig.title')}
-          />
-          <SegmentedControl.Root
-            aria-label={t(localizationKeys('configureSSO.configureStep.samlOkta.modes.ariaLabel'))}
-            value={mode}
-            onChange={value => setMode(value as 'metadataUrl' | 'manual')}
-            fullWidth
-          >
-            <SegmentedControl.Button
-              value='metadataUrl'
-              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.metadataUrl')}
-            />
-            <SegmentedControl.Button
-              value='manual'
-              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.manual')}
-            />
-          </SegmentedControl.Root>
-
-          {mode === 'metadataUrl' ? (
-            <MetadataUrlPanel field={metadataUrlField} />
-          ) : (
-            <ManualEntryPanel
-              signOnUrlField={signOnUrlField}
-              issuerField={issuerField}
-              certFile={certFile}
-              setCertFile={setCertFile}
-            />
-          )}
-        </Step.Section>
-      </Step.Body>
-
-      <Step.Footer>
-        <Step.Footer.Previous
-          onClick={() => goPrev()}
-          isDisabled={isFirstStep || card.isLoading}
-        />
-        <Step.Footer.Continue
-          onClick={handleContinue}
-          isLoading={card.isLoading}
-          isDisabled={!canSubmit}
-        />
-      </Step.Footer>
     </>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -540,7 +540,13 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   });
 
   const trimmedMetadataUrl = metadataUrlField.value.trim();
-  const canSubmit = mode === 'metadataUrl' && trimmedMetadataUrl.length > 0 && !card.isLoading;
+  const trimmedSignOnUrl = signOnUrlField.value.trim();
+  const trimmedIssuer = issuerField.value.trim();
+
+  const canSubmit =
+    !card.isLoading &&
+    ((mode === 'metadataUrl' && trimmedMetadataUrl.length > 0) ||
+      (mode === 'manual' && trimmedSignOnUrl.length > 0 && trimmedIssuer.length > 0 && certFile !== null));
 
   const handleContinue = async () => {
     if (!enterpriseConnection || !canSubmit) {
@@ -551,10 +557,25 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
     card.setLoading();
 
     try {
-      await updateConnection({ saml: { idpMetadataUrl: trimmedMetadataUrl } });
+      if (mode === 'metadataUrl') {
+        await updateConnection({ saml: { idpMetadataUrl: trimmedMetadataUrl } });
+      } else {
+        const idpCertificate = await certFile!.text();
+        await updateConnection({
+          saml: {
+            idpSsoUrl: trimmedSignOnUrl,
+            idpEntityId: trimmedIssuer,
+            idpCertificate,
+          },
+        });
+      }
       void goNext();
     } catch (err) {
-      handleError(err as Error, [metadataUrlField], card.setError);
+      if (mode === 'metadataUrl') {
+        handleError(err as Error, [metadataUrlField], card.setError);
+      } else {
+        handleError(err as Error, [signOnUrlField, issuerField], card.setError);
+      }
     } finally {
       card.setIdle();
     }


### PR DESCRIPTION
## Description

Adds the **Configure manually** path to the SAML config submission sub-step of `<__experimental_ConfigureSSO />`'s Configure step, and reshapes the sub-step so the per-mode bodies are isolated, the cert field routes errors inline, and Configure-again from the Confirmation step lands users on an editable, pre-populated form.

### Segmented control + per-mode panels

The sub-step body now sits behind a two-mode `SegmentedControl` and the per-mode JSX is split into `MetadataUrlPanel` and `ManualEntryPanel` render components (internal to `ConfigureStep.tsx`). State stays lifted in `SubmitSamlConfigSubStep` — `useFormControl` hooks, cert file, mode, card state, mutation, Continue handler, and `Step.Footer` all live in the orchestrator. Panels receive their fields and cert state as props.

1. **Add via metadata** (default for fresh setups) — single Metadata URL input. Continue posts `{ saml: { idpMetadataUrl } }`.
2. **Configure manually** — three fields:
   - **Sign on URL** — text input wired through a new `idpSsoUrl` `FieldId`.
   - **Issuer** — text input wired through a new `idpEntityId` `FieldId`.
   - **Signing certificate** — file picker behind a new `idpCertificate` `FieldId`. A hidden `<input type="file" accept=".pem,.key,.crt,.cer,.cert">` is triggered by the visible Upload/Replace button. When a file is selected, the cert row swaps to a filename label plus a small remove button that clears the selection and resets the input value (so re-picking the same file refires the change). The accept list mirrors the Clerk Dashboard's existing SAML connection form.

Continue is gated to the selected mode's required fields. In manual mode, the handler reads the cert via `File.text()` and posts `{ saml: { idpSsoUrl, idpEntityId, idpCertificate } }` through the same `user.updateEnterpriseConnection` call wrapped in `useReverification`.

### Cert errors route inline

The cert field is a real `useFormControl`-backed field with its own `FieldId`. The cert section renders inside `Field.Root` / `Field.LabelRow` / `Field.Label` / `Field.Feedback`, matching the surrounding inputs. Backend errors keyed `idp_certificate` route inline below the cert UI via `handleError([signOnUrlField, issuerField, certFileField], card.setError)`. Fresh interaction (file pick or remove) clears stale field-level feedback via `clearFeedback()`. The field's `value` stays empty — we only use the field for label rendering and error state, not value tracking.

### Configure-again pre-fill

When the user lands on the Configure step with an existing `enterpriseConnection.samlConnection` (typically via `goToStep('configure')` from the Confirmation step's Configure again button), the form populates:

- `signOnUrlField` and `issuerField` initialize from `samlConnection.idpSsoUrl` / `idpEntityId`.
- The segmented control defaults to **Configure manually** when prior config exists, otherwise **Add via metadata**.
- The cert row defaults to a **Replace file** button when `samlConnection.idpCertificate` is present. Continue stays enabled without requiring a fresh upload; the manual PATCH conditionally includes `idpCertificate` only when a new file was selected so the backend retains the existing cert on submit.
- The Metadata URL field is intentionally **not** pre-filled — metadata submission is a one-shot flow and matches the Dashboard's posture of always starting fresh.

### Locale keys

Live under `configureSSO.configureStep.samlOkta`:

- `modes.*` for the segmented control labels and aria-label.
- `submitSamlConfig.title` for the "Fill in your Okta SAML application details" section heading.
- `manual.*` for the per-mode description, field labels, placeholders, and the Upload file / Replace file / Remove file copy.

Also tightens the metadata-mode tab label from "Add via metadata URL" to "Add via metadata" to match Figma.

Linear: ORGS-1535

### Follow-ups (separate PR)

- **Custom SAML provider variant** (ORGS-1536) — generic SAML instructional copy across all 4 Configure sub-steps, switching by `connection.provider`. The Custom SAML manual path will reuse the segmented control, panel split, cert field, and Continue handler shipped here.
- **Field validations** — client-side URL format checks. Today the PR matches the Dashboard's "trust user, backend rejects" posture; only required-empty is enforced (via the `canSubmit` gate, no inline message).
- **Tests** — unit coverage for the Configure step (mode switching, cert state lifecycle, Continue payloads per mode, error routing, Configure-again pre-fill, initial-step deriving) ships alongside the broader ConfigureSSO test pass after the Custom SAML PR lands.

### How to test

**Fresh setup**

In a sandbox with the ConfigureSSO wizard, walk through Select Provider → Verify Domain → land on Configure. Advance through sub-steps 1–3, then on the SAML config sub-step:

- **Add via metadata** tab (default): paste a valid Okta SAML metadata URL → Continue → wizard advances to Test.
- **Configure manually** tab: fill Sign on URL + Issuer, pick a `.pem`/`.key`/`.crt`/`.cer`/`.cert` cert file → Continue stays disabled until all three are present → click Continue → connection is patched with `{ saml: { idpSsoUrl, idpEntityId, idpCertificate } }` → wizard advances to Test.

Click the × on the filename chip → cert state clears and the Upload file button returns. Picking the same file again refires the change.

**Configure-again (editing)**

From the Confirmation step's Configure again button (`goToStep('configure')`), land back on the SAML config sub-step:

- Segmented control defaults to **Configure manually**.
- Sign on URL + Issuer pre-populate from the existing connection.
- Cert row shows **Replace file**; Continue is enabled without re-uploading. Submitting omits `idpCertificate` from the payload so the backend keeps the existing cert.
- Pick a new cert file → row swaps to filename chip → Submit replaces the cert with the new one.

**Errors**

Backend errors keyed `idp_sso_url`, `idp_entity_id`, or `idp_certificate` render inline below the corresponding field; everything else surfaces at the card level.

### Base

Branches from `main` — stacks on top of #8535 (merged).

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation