### PR TITLE
feat(ui): Add highlightedPlan badge option to PricingTable component

### DIFF
--- a/.changeset/add-highlighted-plan-to-pricing-table.md
+++ b/.changeset/add-highlighted-plan-to-pricing-table.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': minor
+'@clerk/ui': minor
+---
+
+Add `highlightedPlan` prop to PricingTable default layout to render a "Popular" badge on the matching plan

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -141,7 +141,7 @@ export const arSA: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -141,7 +141,7 @@ export const beBY: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -142,7 +142,7 @@ export const bgBG: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -141,7 +141,7 @@ export const bnIN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -148,7 +148,7 @@ export const caES: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Mètodes de pagament',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Cicle de facturació',
       included: 'Inclòs',

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -145,7 +145,7 @@ export const csCZ: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Platební metody',
-    popular: 'Populární',
+    highlightedPlanBadge: 'Populární',
     pricingTable: {
       billingCycle: 'Fakturační cyklus',
       included: 'Zahrnuto',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -141,7 +141,7 @@ export const daDK: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -147,7 +147,7 @@ export const deDE: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Zahlungsmethoden',
-    popular: 'Beliebt',
+    highlightedPlanBadge: 'Beliebt',
     pricingTable: {
       billingCycle: 'Abrechnungszyklus',
       included: 'Enthalten',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -141,7 +141,7 @@ export const elGR: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Μέθοδοι πληρωμής',
-    popular: 'Δημοφιλές',
+    highlightedPlanBadge: 'Δημοφιλές',
     pricingTable: {
       billingCycle: 'Κύκλος χρέωσης',
       included: 'Περιλαμβάνεται',

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -141,7 +141,7 @@ export const enGB: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -147,7 +147,7 @@ export const enUS: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Payment Methods',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Billing cycle',
       included: 'Included',

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -141,7 +141,7 @@ export const esCR: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -147,7 +147,7 @@ export const esES: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Métodos de pago',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Ciclo de facturación',
       included: 'Incluido',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -142,7 +142,7 @@ export const esMX: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -141,7 +141,7 @@ export const esUY: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -146,7 +146,7 @@ export const faIR: LocalizationResource = {
       },
     },
     paymentMethods__label: 'روش های پرداخت',
-    popular: 'محبوب',
+    highlightedPlanBadge: 'محبوب',
     pricingTable: {
       billingCycle: 'چرخه صورتحساب',
       included: 'شامل',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -153,7 +153,7 @@ export const fiFI: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Maksutavat',
-    popular: 'Suosittu',
+    highlightedPlanBadge: 'Suosittu',
     pricingTable: {
       billingCycle: 'Laskutusjakso',
       included: 'Sisältyy',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -149,7 +149,7 @@ export const frFR: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Méthodes de paiement',
-    popular: 'Populaire',
+    highlightedPlanBadge: 'Populaire',
     pricingTable: {
       billingCycle: 'Cycle de facturation',
       included: 'Inclus',

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -141,7 +141,7 @@ export const heIL: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -141,7 +141,7 @@ export const hiIN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -154,7 +154,7 @@ export const hrHR: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Načini plaćanja',
-    popular: 'Popularno',
+    highlightedPlanBadge: 'Popularno',
     pricingTable: {
       billingCycle: 'Obračunsko razdoblje',
       included: 'Uključeno',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -154,7 +154,7 @@ export const huHU: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Fizetési módok',
-    popular: 'Népszerű',
+    highlightedPlanBadge: 'Népszerű',
     pricingTable: {
       billingCycle: 'Számlázási ciklus',
       included: 'Tartalmazza',

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -141,7 +141,7 @@ export const idID: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -150,7 +150,7 @@ export const isIS: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Greiðslumátar',
-    popular: 'Vinsælt',
+    highlightedPlanBadge: 'Vinsælt',
     pricingTable: {
       billingCycle: 'Greiðslutímabil',
       included: 'Innifalið',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -147,7 +147,7 @@ export const itIT: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Metodi di pagamento',
-    popular: 'Popolare',
+    highlightedPlanBadge: 'Popolare',
     pricingTable: {
       billingCycle: 'Ciclo di fatturazione',
       included: 'Incluso',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -152,7 +152,7 @@ export const jaJP: LocalizationResource = {
       },
     },
     paymentMethods__label: '支払い方法',
-    popular: '人気',
+    highlightedPlanBadge: '人気',
     pricingTable: {
       billingCycle: '請求サイクル',
       included: '含まれる内容',

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -141,7 +141,7 @@ export const kkKZ: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -148,7 +148,7 @@ export const koKR: LocalizationResource = {
       },
     },
     paymentMethods__label: '결제 수단',
-    popular: '인기',
+    highlightedPlanBadge: '인기',
     pricingTable: {
       billingCycle: '결제 주기',
       included: '포함',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -141,7 +141,7 @@ export const mnMN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -141,7 +141,7 @@ export const msMY: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -154,7 +154,7 @@ export const nbNO: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Betalingsmetoder',
-    popular: 'Populær',
+    highlightedPlanBadge: 'Populær',
     pricingTable: {
       billingCycle: 'Faktureringsperiode',
       included: 'Inkludert',

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -141,7 +141,7 @@ export const nlBE: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -141,7 +141,7 @@ export const nlNL: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -141,7 +141,7 @@ export const plPL: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -147,7 +147,7 @@ export const ptBR: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Métodos de pagamento',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Ciclo de faturamento',
       included: 'Incluso',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -149,7 +149,7 @@ export const ptPT: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Métodos de pagamento',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Ciclo de faturação',
       included: 'Incluído',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -147,7 +147,7 @@ export const roRO: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Metode de plată',
-    popular: 'Popular',
+    highlightedPlanBadge: 'Popular',
     pricingTable: {
       billingCycle: 'Ciclu de facturare',
       included: 'Inclus',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -141,7 +141,7 @@ export const ruRU: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -141,7 +141,7 @@ export const skSK: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -141,7 +141,7 @@ export const srRS: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -141,7 +141,7 @@ export const svSE: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -141,7 +141,7 @@ export const taIN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -141,7 +141,7 @@ export const teIN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -145,7 +145,7 @@ export const thTH: LocalizationResource = {
       },
     },
     paymentMethods__label: 'วิธีการชำระเงิน',
-    popular: 'ยอดนิยม',
+    highlightedPlanBadge: 'ยอดนิยม',
     pricingTable: {
       billingCycle: 'รอบการเรียกเก็บเงิน',
       included: 'รวมอยู่',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -141,7 +141,7 @@ export const trTR: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -141,7 +141,7 @@ export const ukUA: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -145,7 +145,7 @@ export const viVN: LocalizationResource = {
       },
     },
     paymentMethods__label: 'Phương thức thanh toán',
-    popular: 'Phổ biến',
+    highlightedPlanBadge: 'Phổ biến',
     pricingTable: {
       billingCycle: 'Chu kỳ thanh toán',
       included: 'Bao gồm',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -141,7 +141,7 @@ export const zhCN: LocalizationResource = {
       },
     },
     paymentMethods__label: undefined,
-    popular: undefined,
+    highlightedPlanBadge: undefined,
     pricingTable: {
       billingCycle: undefined,
       included: undefined,

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -147,7 +147,7 @@ export const zhTW: LocalizationResource = {
       },
     },
     paymentMethods__label: '付款方式',
-    popular: '熱門',
+    highlightedPlanBadge: '熱門',
     pricingTable: {
       billingCycle: '計費週期',
       included: '包含',

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -2125,6 +2125,10 @@ type PricingTableDefaultProps = {
 
 type PricingTableBaseProps = {
   /**
+   * The plan slug to highlight with a "Popular" badge.
+   */
+  highlightedPlan?: string;
+  /**
    * The subscriber type to display plans for.
    * If `organization`, show Plans for the Active Organization; otherwise for the user.
    *

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -227,7 +227,7 @@ export type __internal_LocalizationResource = {
     cancelSubscriptionNoCharge: LocalizationValue;
     cancelSubscriptionAccessUntil: LocalizationValue<'plan' | 'date'>;
     cancelSubscriptionPastDue: LocalizationValue;
-    popular: LocalizationValue;
+    highlightedPlanBadge: LocalizationValue;
     paymentMethods__label: LocalizationValue;
     addPaymentMethod__label: LocalizationValue;
     paymentMethod: {

--- a/packages/ui/src/components/PricingTable/PricingTable.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTable.tsx
@@ -11,7 +11,7 @@ import { PricingTableMatrix } from './PricingTableMatrix';
 const PricingTableRoot = (props: PricingTableProps) => {
   const clerk = useClerk();
   const getContainer = usePortalRoot();
-  const { mode = 'mounted', signInMode = 'redirect' } = usePricingTableContext();
+  const { mode = 'mounted', signInMode = 'redirect', highlightedPlan } = usePricingTableContext();
   const isCompact = mode === 'modal';
   const { data: subscription, subscriptionItems } = useSubscription();
   const { data: plans } = usePlans();
@@ -86,12 +86,12 @@ const PricingTableRoot = (props: PricingTableProps) => {
           planPeriod={planPeriod}
           setPlanPeriod={setPlanPeriod}
           onSelect={selectPlan}
-          highlightedPlan={props.highlightedPlan}
+          highlightedPlan={highlightedPlan}
         />
       ) : (
         <PricingTableDefault
           plans={plansToRender}
-          highlightedPlan={props.highlightedPlan}
+          highlightedPlan={highlightedPlan}
           planPeriod={planPeriod}
           setPlanPeriod={setPlanPeriod}
           onSelect={selectPlan}

--- a/packages/ui/src/components/PricingTable/PricingTable.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTable.tsx
@@ -86,11 +86,12 @@ const PricingTableRoot = (props: PricingTableProps) => {
           planPeriod={planPeriod}
           setPlanPeriod={setPlanPeriod}
           onSelect={selectPlan}
-          highlightedPlan={(props as any).highlightPlan}
+          highlightedPlan={props.highlightedPlan}
         />
       ) : (
         <PricingTableDefault
           plans={plansToRender}
+          highlightedPlan={props.highlightedPlan}
           planPeriod={planPeriod}
           setPlanPeriod={setPlanPeriod}
           onSelect={selectPlan}

--- a/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
@@ -15,6 +15,7 @@ import { getClosestProfileScrollBox } from '@/ui/utils/getClosestProfileScrollBo
 import { useProtect } from '../../common';
 import { normalizeFormatted, usePlansContext, usePricingTableContext, useSubscriberTypeContext } from '../../contexts';
 import {
+  Badge,
   Box,
   Button,
   Col,
@@ -45,6 +46,7 @@ interface PricingTableDefaultProps {
 
 export function PricingTableDefault({
   plans,
+  highlightedPlan,
   planPeriod,
   setPlanPeriod,
   onSelect,
@@ -80,6 +82,7 @@ export function PricingTableDefault({
           <Card
             key={plan.id}
             plan={plan}
+            highlighted={plan.slug === highlightedPlan}
             planPeriod={planPeriod}
             setPlanPeriod={setPlanPeriod}
             onSelect={onSelect}
@@ -98,6 +101,7 @@ export function PricingTableDefault({
 
 interface CardProps {
   plan: BillingPlanResource;
+  highlighted?: boolean;
   planPeriod: BillingSubscriptionPlanPeriod;
   setPlanPeriod: (p: BillingSubscriptionPlanPeriod) => void;
   onSelect: (plan: BillingPlanResource, event?: React.MouseEvent<HTMLElement>) => void;
@@ -106,7 +110,7 @@ interface CardProps {
 }
 
 function Card(props: CardProps) {
-  const { plan, planPeriod, setPlanPeriod, onSelect, props: pricingTableProps, isCompact = false } = props;
+  const { plan, highlighted, planPeriod, setPlanPeriod, onSelect, props: pricingTableProps, isCompact = false } = props;
   const clerk = useClerk();
   const { isSignedIn } = useSession();
   const { mode = 'mounted', ctaPosition: ctxCtaPosition } = usePricingTableContext();
@@ -193,6 +197,13 @@ function Card(props: CardProps) {
         badge={
           subscription ? (
             <SubscriptionBadge subscription={subscription.isFreeTrial ? { status: 'free_trial' } : subscription} />
+          ) : highlighted ? (
+            <Badge
+              elementDescriptor={descriptors.pricingTableCardBadge}
+              colorScheme='secondary'
+              localizationKey={localizationKeys('billing.popular')}
+              data-highlighted-plan
+            />
           ) : undefined
         }
       />

--- a/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTableDefault.tsx
@@ -201,7 +201,7 @@ function Card(props: CardProps) {
             <Badge
               elementDescriptor={descriptors.pricingTableCardBadge}
               colorScheme='secondary'
-              localizationKey={localizationKeys('billing.popular')}
+              localizationKey={localizationKeys('billing.highlightedPlanBadge')}
               data-highlighted-plan
             />
           ) : undefined

--- a/packages/ui/src/components/PricingTable/PricingTableMatrix.tsx
+++ b/packages/ui/src/components/PricingTable/PricingTableMatrix.tsx
@@ -212,7 +212,7 @@ export function PricingTableMatrix({
                             <Badge
                               elementDescriptor={descriptors.pricingTableMatrixBadge}
                               colorScheme='secondary'
-                              localizationKey={localizationKeys('billing.popular')}
+                              localizationKey={localizationKeys('billing.highlightedPlanBadge')}
                             />
                           ) : null}
                         </Span>

--- a/packages/ui/src/components/PricingTable/__tests__/PricingTable.test.tsx
+++ b/packages/ui/src/components/PricingTable/__tests__/PricingTable.test.tsx
@@ -799,4 +799,72 @@ describe('PricingTable - plans visibility', () => {
       );
     });
   });
+
+  it('renders Popular badge on the highlighted plan', async () => {
+    const { wrapper, fixtures, props } = await createFixtures(f => {
+      f.withBilling();
+    });
+
+    props.setProps({ highlightedPlan: 'test' });
+
+    fixtures.clerk.billing.getStatements.mockRejectedValue();
+    fixtures.clerk.billing.getPlans.mockResolvedValue({ data: [testPlan as any], total_count: 1 });
+    fixtures.clerk.billing.getSubscription.mockRejectedValue(new Error('Unauthenticated'));
+
+    const { getByText, queryAllByText } = render(<PricingTable />, { wrapper });
+
+    await waitFor(() => {
+      expect(getByText('Popular')).toBeVisible();
+      expect(queryAllByText('Popular')).toHaveLength(1);
+    });
+  });
+
+  it('shows subscription badge instead of Popular badge when plan has active subscription', async () => {
+    const { wrapper, fixtures, props } = await createFixtures(f => {
+      f.withUser({ email_addresses: ['test@clerk.com'] });
+      f.withBilling();
+    });
+
+    props.setProps({ highlightedPlan: 'test' });
+
+    fixtures.clerk.billing.getStatements.mockRejectedValue();
+    fixtures.clerk.user.getPaymentMethods.mockRejectedValue();
+    fixtures.clerk.billing.getPlans.mockResolvedValue({ data: [testPlan as any], total_count: 1 });
+    fixtures.clerk.billing.getSubscription.mockResolvedValue({
+      id: 'sub_active',
+      status: 'active',
+      activeAt: new Date('2021-01-01'),
+      createdAt: new Date('2021-01-01'),
+      nextPayment: null,
+      pastDueAt: null,
+      updatedAt: null,
+      subscriptionItems: [
+        {
+          id: 'si_active',
+          plan: testPlan,
+          createdAt: new Date('2021-01-01'),
+          pastDueAt: null,
+          canceledAt: null,
+          periodStart: new Date('2021-01-01'),
+          periodEnd: new Date('2021-01-31'),
+          planPeriod: 'month' as const,
+          status: 'active' as const,
+          isFreeTrial: false,
+          cancel: vi.fn(),
+          pathRoot: '',
+          reload: vi.fn(),
+        },
+      ],
+      pathRoot: '',
+      reload: vi.fn(),
+    });
+
+    const { queryByText, findByRole } = render(<PricingTable />, { wrapper });
+
+    await findByRole('heading', { name: 'Test Plan' });
+
+    await waitFor(() => {
+      expect(queryByText('Popular')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ui/src/customizables/elementDescriptors.ts
+++ b/packages/ui/src/customizables/elementDescriptors.ts
@@ -281,6 +281,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'pricingTableCardHeader',
   'pricingTableCardTitleContainer',
   'pricingTableCardTitle',
+  'pricingTableCardBadge',
   'pricingTableCardDescription',
   'pricingTableCardBody',
   'pricingTableCardStatusRow',

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -423,6 +423,7 @@ export type ElementsConfig = {
   pricingTableCardHeader: WithOptions;
   pricingTableCardTitleContainer: WithOptions;
   pricingTableCardTitle: WithOptions;
+  pricingTableCardBadge: WithOptions;
   pricingTableCardDescription: WithOptions;
   pricingTableCardFeeContainer: WithOptions;
   pricingTableCardFee: WithOptions;


### PR DESCRIPTION
## Description

Add `highlightedPlan` prop to PricingTable default layout to render a "Popular" badge on the matching plan

docs: https://github.com/clerk/clerk-docs/pull/3371

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
