### PR TITLE
fix(react): accept single array child in unstyled buttons

### DIFF
--- a/.changeset/smooth-buttons-accept-one.md
+++ b/.changeset/smooth-buttons-accept-one.md
@@ -1,0 +1,5 @@
+---
+'@clerk/react': patch
+---
+
+Allow unstyled button components to accept a single React element passed as an array.

--- a/packages/react/src/components/__tests__/SignInButton.test.tsx
+++ b/packages/react/src/components/__tests__/SignInButton.test.tsx
@@ -89,6 +89,30 @@ describe('<SignInButton/>', () => {
     expect(mockRedirectToSignIn).toHaveBeenCalled();
   });
 
+  it('accepts a single child passed as an array', async () => {
+    const handler = vi.fn();
+
+    render(
+      <SignInButton>
+        {[
+          <button
+            key='custom'
+            onClick={handler}
+            type='button'
+          >
+            custom button
+          </button>,
+        ]}
+      </SignInButton>,
+    );
+
+    const btn = screen.getByText('custom button');
+    await userEvent.click(btn);
+
+    expect(handler).toHaveBeenCalled();
+    expect(mockRedirectToSignIn).toHaveBeenCalled();
+  });
+
   it('uses text passed as children', async () => {
     render(<SignInButton>text</SignInButton>);
 

--- a/packages/react/src/utils/childrenUtils.tsx
+++ b/packages/react/src/utils/childrenUtils.tsx
@@ -18,6 +18,12 @@ export const assertSingleChild =
     try {
       return React.Children.only(children);
     } catch {
+      const childArray = React.Children.toArray(children);
+
+      if (childArray.length === 1 && React.isValidElement(childArray[0])) {
+        return childArray[0];
+      }
+
       return errorThrower.throw(multipleChildrenInButtonComponent(name));
     }
   };


### PR DESCRIPTION
## Summary

- Allow Clerk's unstyled button components to accept a single valid React element when React passes it as a one-item children array.
- Keep the existing multiple-children error for real multi-child input.
- Add a `SignInButton` regression test for the one-item array child shape.
- Add a patch changeset for `@clerk/react`.

## Context

`SignInButton` currently validates custom children with `React.Children.only()`. That is correct for normal JSX, but it also rejects one-item arrays. In a Next.js App Router server/client boundary, a custom child rendered through `Show` can reach the client button wrapper in that array shape even though the source JSX contains a single `<button>`.

The resulting runtime error says multiple children were passed to `<SignInButton />`, which is misleading for users who supplied one custom child.
