### PR TITLE
fix(astro): accept single array child in unstyled buttons

### DIFF
--- a/.changeset/astro-buttons-accept-one.md
+++ b/.changeset/astro-buttons-accept-one.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': patch
+---
+
+Allow unstyled button components to accept a single React element passed as an array. Fixes a misleading "multiple children" error that could appear when a custom button child crossed a server/client boundary and arrived as a one-item array.

--- a/packages/astro/src/react/__tests__/SignInButton.test.tsx
+++ b/packages/astro/src/react/__tests__/SignInButton.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as UtilsModule from '../utils';
+
+const mockRedirectToSignIn = vi.fn();
+const originalError = console.error;
+
+const mockClerk = {
+  redirectToSignIn: mockRedirectToSignIn,
+} as any;
+
+vi.mock('../utils', async importActual => {
+  const actual = await importActual<typeof UtilsModule>();
+  return {
+    ...actual,
+    withClerk: (Component: any) => (props: any) => {
+      return (
+        <Component
+          {...props}
+          clerk={mockClerk}
+        />
+      );
+    },
+  };
+});
+
+const { SignInButton } = await import('../SignInButton');
+
+describe('<SignInButton/>', () => {
+  beforeAll(() => {
+    console.error = vi.fn();
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  beforeEach(() => {
+    mockRedirectToSignIn.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the default button and calls clerk.redirectToSignIn when clicked', async () => {
+    render(<SignInButton />);
+    const btn = screen.getByText('Sign in');
+    await userEvent.click(btn);
+    expect(mockRedirectToSignIn).toHaveBeenCalled();
+  });
+
+  it('renders passed button and calls both click handlers', async () => {
+    const handler = vi.fn();
+
+    render(
+      <SignInButton>
+        <button
+          onClick={handler}
+          type='button'
+        >
+          custom button
+        </button>
+      </SignInButton>,
+    );
+
+    const btn = screen.getByText('custom button');
+    await userEvent.click(btn);
+
+    expect(handler).toHaveBeenCalled();
+    expect(mockRedirectToSignIn).toHaveBeenCalled();
+  });
+
+  it('accepts a single child passed as an array', async () => {
+    const handler = vi.fn();
+
+    render(
+      <SignInButton>
+        {[
+          <button
+            key='custom'
+            onClick={handler}
+            type='button'
+          >
+            custom button
+          </button>,
+        ]}
+      </SignInButton>,
+    );
+
+    const btn = screen.getByText('custom button');
+    await userEvent.click(btn);
+
+    expect(handler).toHaveBeenCalled();
+    expect(mockRedirectToSignIn).toHaveBeenCalled();
+  });
+});

--- a/packages/astro/src/react/utils.tsx
+++ b/packages/astro/src/react/utils.tsx
@@ -62,6 +62,12 @@ export const assertSingleChild =
     try {
       return React.Children.only(children);
     } catch {
+      const childArray = React.Children.toArray(children);
+
+      if (childArray.length === 1 && React.isValidElement(childArray[0])) {
+        return childArray[0];
+      }
+
       return `You've passed multiple children components to <${name}/>. You can only pass a single child component or text.`;
     }
   };


### PR DESCRIPTION
## Description

Ports the `@clerk/react` fix from #8556 to `@clerk/astro`. Astro carries its own duplicate copy of `assertSingleChild` (marked `// TODO-SHARED`) that was not updated when the React-side fix landed.

Same root cause as #8556: when a custom button child crosses a Next-style server/client boundary, React can deliver it as a one-item array. `React.Children.only()` rejects that shape, which the SDK catches and surfaces as a misleading "multiple children" error to the user. The fix falls back to `React.Children.toArray()` and accepts a length-1 array of a valid element, preserving the genuine multi-child error path.

This benefits all seven astro unstyled buttons via the shared util: `SignInButton`, `SignUpButton`, `SignOutButton`, `SignInWithMetamaskButton`, `CheckoutButton`, `SubscriptionDetailsButton`, `PlanDetailsButton`.

Also adds the first React component tests to the astro package, mirroring the regression test from #8556 plus baseline coverage (default child, custom child, array-wrapped single child).

## Checklist

- [x] `pnpm test` runs as expected. (21/21 in `@clerk/astro`, including 3 new tests.)
- [ ] `pnpm build` runs as expected. (Full repo build not verified end-to-end — pre-existing failures in unrelated workspace packages, unrelated to this change.)
- [ ] (If applicable) JSDoc comments have been added or updated for any package exports — N/A, no public API surface change.
- [ ] (If applicable) Documentation has been updated — N/A, `clerk-docs` PR clerk/clerk-docs#3358 already covers the multi-child guidance.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## References

- #8556 — original `@clerk/react` fix this ports
- https://www.reddit.com/r/nextjs/comments/1tcilsv/can_you_please_help_me_to_fix_an_error_from_clerk/ — user report and Jeff's explanation of the RSC boundary mechanism
- clerk/clerk-docs#3358 — related docs update on passing multiple children
