### PR TITLE
feat(ui): Add support for custom SAML provider in `<ConfigureSSO />`

### DIFF
--- a/.changeset/public-parts-chew.md
+++ b/.changeset/public-parts-chew.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Add support for custom SAML provider in `<ConfigureSSO />`

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -379,9 +379,9 @@ export const enUS: LocalizationResource = {
         },
       },
       samlOkta: {
-        title: 'Configure Okta Workforce',
-        subtitle: 'Create a new enterprise application in your Okta Dashboard',
+        headerTitle: 'Configure Okta Workforce',
         createApp: {
+          headerSubtitle: 'Create a new enterprise application in your Okta Dashboard',
           title: 'Create a new enterprise application in Okta',
           step1: 'Sign in to Okta and go to <bold>Admin → Applications.</bold>',
           step2: 'Click <bold>Create App Integration.</bold>',
@@ -402,6 +402,7 @@ export const enUS: LocalizationResource = {
           step2: 'Complete the form with any comments and select <bold>Finish</bold>.',
         },
         configureAttributes: {
+          headerSubtitle: 'Map users attributes from Okta to Clerk',
           step1: 'In the Okta dashboard, find the <bold>Attribute Statements</bold> section.',
           step2:
             'Select <bold>Add Expression</bold> for each attribute, and enter the following name and expression pairs:',
@@ -422,6 +423,7 @@ export const enUS: LocalizationResource = {
           },
         },
         assignUsers: {
+          headerSubtitle: 'Assign users to the enterprise app',
           title: 'Assign selected user or group in Okta',
           paragraph: 'You need to assign users or groups to your enterprise app before they can use it to sign in.',
           step1: 'In the Okta dashboard, select the <bold>Assignments</bold> tab.',
@@ -432,6 +434,7 @@ export const enUS: LocalizationResource = {
           step5: 'Select the <bold>Done</bold> button to complete the assignment.',
         },
         metadataUrl: {
+          headerSubtitle: 'Configure identity provider metadata',
           label: 'Metadata URL',
           placeholder: 'Paste URL here...',
           description: 'In your Okta SAML app, go to the Sign On tab and retrieve the metadata URL. Paste it below.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -472,6 +472,8 @@ export const enUS: LocalizationResource = {
           headerSubtitle:
             'Register Clerk as a service provider in your IdP, then add your identity provider configuration.',
           title: 'Create a SAML application on your identity provider',
+          subtitle:
+            'In your identity provider’s admin dashboard, create a new SAML 2.0 application and use the following service provider details:',
         },
         configureAttributes: {
           headerSubtitle: 'Map user attributes from your identity provider to Clerk.',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -466,6 +466,55 @@ export const enUS: LocalizationResource = {
           },
         },
       },
+      samlCustom: {
+        headerTitle: 'Configure your identity provider (IdP)',
+        createApp: {
+          headerSubtitle:
+            'Register Clerk as a service provider in your IdP, then add your identity provider configuration.',
+          title: 'Create a SAML application on your identity provider',
+        },
+        configureAttributes: {
+          headerSubtitle: 'Map user attributes from your identity provider to Clerk.',
+          title: 'We expect your SAML responses to have the following specific attributes:',
+        },
+        assignUsers: {
+          headerSubtitle: 'Assign users to the enterprise app',
+          title: 'Assign selected user or group',
+          paragraph: 'You need to assign users or groups to your enterprise app before they can use it to sign in.',
+        },
+        metadataUrl: {
+          headerSubtitle: 'Configure identity provider metadata',
+          label: 'Metadata URL',
+          placeholder: 'Paste URL here...',
+          description: 'In your enterprise app, retrieve the metadata URL. Paste it below.',
+        },
+        modes: {
+          ariaLabel: 'Configuration mode',
+          metadataUrl: 'Add via metadata',
+          manual: 'Configure manually',
+        },
+        submitSamlConfig: {
+          title: 'Fill in your SAML application details',
+        },
+        manual: {
+          description: 'In your SAML app, retrieve these values.',
+          signOnUrl: {
+            label: 'Sign on URL',
+            placeholder: 'Paste URL here...',
+          },
+          issuer: {
+            label: 'Issuer',
+            placeholder: 'Paste URL here...',
+          },
+          signingCertificate: {
+            label: 'Signing certificate',
+            uploadFile: 'Upload file',
+            replaceFile: 'Replace file',
+            removeFile: 'Remove file',
+            fileUploaded: 'File uploaded',
+          },
+        },
+      },
     },
   },
   createOrganization: {

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1519,6 +1519,54 @@ export type __internal_LocalizationResource = {
           };
         };
       };
+      samlCustom: {
+        headerTitle: LocalizationValue;
+        createApp: {
+          headerSubtitle: LocalizationValue;
+          title: LocalizationValue;
+        };
+        configureAttributes: {
+          headerSubtitle: LocalizationValue;
+          title: LocalizationValue;
+        };
+        assignUsers: {
+          headerSubtitle: LocalizationValue;
+          title: LocalizationValue;
+          paragraph: LocalizationValue;
+        };
+        metadataUrl: {
+          headerSubtitle: LocalizationValue;
+          label: LocalizationValue;
+          placeholder: LocalizationValue;
+          description: LocalizationValue;
+        };
+        modes: {
+          ariaLabel: LocalizationValue;
+          metadataUrl: LocalizationValue;
+          manual: LocalizationValue;
+        };
+        submitSamlConfig: {
+          title: LocalizationValue;
+        };
+        manual: {
+          description: LocalizationValue;
+          signOnUrl: {
+            label: LocalizationValue;
+            placeholder: LocalizationValue;
+          };
+          issuer: {
+            label: LocalizationValue;
+            placeholder: LocalizationValue;
+          };
+          signingCertificate: {
+            label: LocalizationValue;
+            uploadFile: LocalizationValue;
+            replaceFile: LocalizationValue;
+            removeFile: LocalizationValue;
+            fileUploaded: LocalizationValue;
+          };
+        };
+      };
     };
     confirmation: {
       statusSection: {

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1436,9 +1436,9 @@ export type __internal_LocalizationResource = {
         };
       };
       samlOkta: {
-        title: LocalizationValue;
-        subtitle: LocalizationValue;
+        headerTitle: LocalizationValue;
         createApp: {
+          headerSubtitle: LocalizationValue;
           title: LocalizationValue;
           step1: LocalizationValue;
           step2: LocalizationValue;
@@ -1457,6 +1457,7 @@ export type __internal_LocalizationResource = {
           step2: LocalizationValue;
         };
         configureAttributes: {
+          headerSubtitle: LocalizationValue;
           step1: LocalizationValue;
           step2: LocalizationValue;
           pairs: {
@@ -1476,6 +1477,7 @@ export type __internal_LocalizationResource = {
           };
         };
         assignUsers: {
+          headerSubtitle: LocalizationValue;
           title: LocalizationValue;
           paragraph: LocalizationValue;
           step1: LocalizationValue;
@@ -1485,6 +1487,7 @@ export type __internal_LocalizationResource = {
           step5: LocalizationValue;
         };
         metadataUrl: {
+          headerSubtitle: LocalizationValue;
           label: LocalizationValue;
           placeholder: LocalizationValue;
           description: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1524,6 +1524,7 @@ export type __internal_LocalizationResource = {
         createApp: {
           headerSubtitle: LocalizationValue;
           title: LocalizationValue;
+          subtitle: LocalizationValue;
         };
         configureAttributes: {
           headerSubtitle: LocalizationValue;

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -1,5 +1,9 @@
-import { __internal_useUserEnterpriseConnections, useSession } from '@clerk/shared/react';
-import type { __experimental_ConfigureSSOProps } from '@clerk/shared/types';
+import {
+  __internal_useEnterpriseConnectionTestRuns,
+  __internal_useUserEnterpriseConnections,
+  useSession,
+} from '@clerk/shared/react';
+import type { __experimental_ConfigureSSOProps, EnterpriseConnectionResource } from '@clerk/shared/types';
 import React from 'react';
 
 import { useProtect } from '@/common';
@@ -64,19 +68,31 @@ const AuthenticatedContent = withCoreUserGuard(() => {
 });
 
 const ConfigureSSOCardContent = ({ contentRef }: { contentRef: React.RefObject<HTMLDivElement> }) => {
-  const { data: enterpriseConnections, isLoading } = __internal_useUserEnterpriseConnections({ enabled: true });
-
+  const {
+    data: enterpriseConnections,
+    isLoading: isLoadingEnterpriseConnections,
+    createEnterpriseConnection,
+    updateEnterpriseConnection,
+    deleteEnterpriseConnection,
+  } = __internal_useUserEnterpriseConnections({ enabled: true });
   // Currently FAPI only supports one enterprise connection per user
   const enterpriseConnection = enterpriseConnections?.[0];
 
+  const { hasSuccessfulTestRun, isLoading: isLoadingTestRuns } = useHasSuccessfulTestRun(enterpriseConnection);
+
+  const isLoading = isLoadingEnterpriseConnections || isLoadingTestRuns;
   if (isLoading && !enterpriseConnection) {
     return <ConfigureSSOSkeleton />;
   }
 
   return (
     <ConfigureSSOProvider
+      hasSuccessfulTestRun={hasSuccessfulTestRun}
       enterpriseConnection={enterpriseConnection}
       contentRef={contentRef}
+      createEnterpriseConnection={createEnterpriseConnection}
+      updateEnterpriseConnection={updateEnterpriseConnection}
+      deleteEnterpriseConnection={deleteEnterpriseConnection}
     >
       <ConfigureSSOSteps />
     </ConfigureSSOProvider>
@@ -182,6 +198,23 @@ const MissingManageEnterpriseConnectionsPermission = () => (
     <ProfileCardFooter />
   </>
 );
+
+/**
+ * Fetches a single successful test run for the given connection on mount
+ */
+const useHasSuccessfulTestRun = (
+  enterpriseConnection: EnterpriseConnectionResource | undefined,
+): { hasSuccessfulTestRun: boolean; isLoading: boolean } => {
+  const { data: successfulTestRuns, isLoading } = __internal_useEnterpriseConnectionTestRuns({
+    enterpriseConnectionId: enterpriseConnection?.id ?? null,
+    params: { initialPage: 1, pageSize: 1, status: ['success'] },
+  });
+
+  return {
+    hasSuccessfulTestRun: (successfulTestRuns?.length ?? 0) > 0,
+    isLoading,
+  };
+};
 
 export const ConfigureSSO: React.ComponentType<__experimental_ConfigureSSOProps> =
   withCardStateProvider(ConfigureSSOInternal);

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { useProtect } from '@/common';
 import { withCoreUserGuard } from '@/contexts';
 import { Col, descriptors, Flex, Flow, Heading, Icon, localizationKeys, Text } from '@/customizables';
-import { withCardStateProvider } from '@/elements/contexts';
+import { useCardState, withCardStateProvider } from '@/elements/contexts';
 import { ProfileCard } from '@/elements/ProfileCard';
 import { ExclamationTriangle } from '@/icons';
 import { Route, Switch } from '@/router';
@@ -20,7 +20,7 @@ import { ConfigureSSONavbar } from './ConfigureSSONavbar';
 import { ConfigureSSOSkeleton } from './ConfigureSSOSkeleton';
 import { ProfileCardFooter, ProfileCardHeader } from './elements/ProfileCard';
 import { Step } from './elements/Step';
-import { Wizard } from './elements/Wizard';
+import { useWizard, Wizard } from './elements/Wizard';
 import { ConfigureStep, ConfirmationStep, SelectProviderStep, TestConfigurationStep, VerifyDomainStep } from './steps';
 
 const ConfigureSSOInternal = () => {
@@ -104,6 +104,7 @@ const ConfigureSSOSteps = () => {
 
   return (
     <Wizard initialStepId={initialStepId}>
+      <ResetCardErrorOnStepChange />
       <ConfigureSSOHeader />
 
       <Wizard.Step id='select-provider'>
@@ -198,6 +199,29 @@ const MissingManageEnterpriseConnectionsPermission = () => (
     <ProfileCardFooter />
   </>
 );
+
+/**
+ * Sentinel component rendered inside `<Wizard>`
+ *
+ * Clears any card-level error whenever the active step transitions, so a stale failure from one step
+ * doesn't leak into the next
+ */
+const ResetCardErrorOnStepChange = (): null => {
+  const { currentStep } = useWizard();
+  const card = useCardState();
+  const previousStepIdRef = React.useRef(currentStep?.id);
+
+  React.useEffect(() => {
+    if (previousStepIdRef.current === currentStep?.id) {
+      return;
+    }
+
+    previousStepIdRef.current = currentStep?.id;
+    card.setError(undefined);
+  }, [currentStep?.id, card]);
+
+  return null;
+};
 
 /**
  * Fetches a single successful test run for the given connection on mount

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSO.tsx
@@ -81,7 +81,7 @@ const ConfigureSSOCardContent = ({ contentRef }: { contentRef: React.RefObject<H
   const { hasSuccessfulTestRun, isLoading: isLoadingTestRuns } = useHasSuccessfulTestRun(enterpriseConnection);
 
   const isLoading = isLoadingEnterpriseConnections || isLoadingTestRuns;
-  if (isLoading && !enterpriseConnection) {
+  if (isLoading) {
     return <ConfigureSSOSkeleton />;
   }
 

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -1,6 +1,11 @@
 import type { UseUserEnterpriseConnectionsReturn } from '@clerk/shared/react/index';
 import { useSession, useUser } from '@clerk/shared/react/index';
-import type { EnterpriseConnectionResource, SignedInSessionResource, UserResource } from '@clerk/shared/types';
+import type {
+  EmailAddressResource,
+  EnterpriseConnectionResource,
+  SignedInSessionResource,
+  UserResource,
+} from '@clerk/shared/types';
 import React, { type PropsWithChildren, useCallback } from 'react';
 
 import { useCardState } from '@/elements/contexts';
@@ -35,7 +40,7 @@ export interface ConfigureSSOData {
   /**
    * Creates a new enterprise connection
    */
-  createEnterpriseConnection: (provider: ProviderType) => Promise<void>;
+  createEnterpriseConnection: (provider: ProviderType, primaryEmailAddress?: EmailAddressResource) => Promise<void>;
   /**
    * Updates an existing enterprise connection
    */
@@ -75,16 +80,16 @@ export const ConfigureSSOProvider = ({
   const [provider, setProvider] = React.useState<ProviderType | undefined>(
     enterpriseConnection?.provider as ProviderType,
   );
-  const { user } = useUser();
   const { session } = useSession();
+  const { user } = useUser();
   const card = useCardState();
 
   const isDomainTakenByOtherOrg = checkDomainTakenByOtherOrg(user, session, enterpriseConnection);
   const initialStepId = deriveInitialStep(enterpriseConnection, { isDomainTakenByOtherOrg, hasSuccessfulTestRun });
 
   const createEnterpriseConnection = useCallback(
-    async (provider: ProviderType): Promise<void> => {
-      const emailDomain = user?.primaryEmailAddress?.emailAddress.split('@')[1];
+    async (provider: ProviderType, primaryEmailAddress?: EmailAddressResource): Promise<void> => {
+      const emailDomain = primaryEmailAddress?.emailAddress.split('@')[1];
       const organizationId = session?.lastActiveOrganizationId ?? null;
 
       if (!emailDomain) {
@@ -103,7 +108,7 @@ export const ConfigureSSOProvider = ({
         card.setIdle();
       }
     },
-    [user, card, session, createEnterpriseConnectionApi],
+    [card, session, createEnterpriseConnectionApi],
   );
 
   const value = React.useMemo<ConfigureSSOData>(

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -1,5 +1,6 @@
-import { __internal_useUserEnterpriseConnections, useSession, useUser } from '@clerk/shared/react/index';
-import type { EnterpriseConnectionResource } from '@clerk/shared/types';
+import type { UseUserEnterpriseConnectionsReturn } from '@clerk/shared/react/index';
+import { useSession, useUser } from '@clerk/shared/react/index';
+import type { EnterpriseConnectionResource, SignedInSessionResource, UserResource } from '@clerk/shared/types';
 import React, { type PropsWithChildren, useCallback } from 'react';
 
 import { useCardState } from '@/elements/contexts';
@@ -32,14 +33,31 @@ export interface ConfigureSSOData {
    */
   contentRef: React.RefObject<HTMLDivElement>;
   /**
-   * Creates a new enterprise connection.
+   * Creates a new enterprise connection
    */
   createEnterpriseConnection: (provider: ProviderType) => Promise<void>;
+  /**
+   * Updates an existing enterprise connection
+   */
+  updateEnterpriseConnection: UseUserEnterpriseConnectionsReturn['updateEnterpriseConnection'];
+  /**
+   * Deletes an enterprise connection
+   */
+  deleteEnterpriseConnection: UseUserEnterpriseConnectionsReturn['deleteEnterpriseConnection'];
+  /**
+   * Determines if the user's domain is already wired to an enterprise connection that
+   * doesn't belong to the org they're currently configuring
+   */
+  isDomainTakenByOtherOrg: boolean;
 }
 
 interface ConfigureSSOProviderProps {
   enterpriseConnection: EnterpriseConnectionResource | undefined;
+  hasSuccessfulTestRun: boolean;
   contentRef: React.RefObject<HTMLDivElement>;
+  createEnterpriseConnection: UseUserEnterpriseConnectionsReturn['createEnterpriseConnection'];
+  updateEnterpriseConnection: UseUserEnterpriseConnectionsReturn['updateEnterpriseConnection'];
+  deleteEnterpriseConnection: UseUserEnterpriseConnectionsReturn['deleteEnterpriseConnection'];
 }
 
 const ConfigureSSOContext = React.createContext<ConfigureSSOData | null>(null);
@@ -47,17 +65,22 @@ ConfigureSSOContext.displayName = 'ConfigureSSOContext';
 
 export const ConfigureSSOProvider = ({
   enterpriseConnection,
+  hasSuccessfulTestRun,
   contentRef,
+  createEnterpriseConnection: createEnterpriseConnectionApi,
+  updateEnterpriseConnection,
+  deleteEnterpriseConnection,
   children,
 }: PropsWithChildren<ConfigureSSOProviderProps>): JSX.Element => {
   const [provider, setProvider] = React.useState<ProviderType | undefined>(
     enterpriseConnection?.provider as ProviderType,
   );
-  const enterpriseConnectionApi = __internal_useUserEnterpriseConnections();
   const { user } = useUser();
   const { session } = useSession();
   const card = useCardState();
-  const initialStepId = deriveInitialStep(enterpriseConnection);
+
+  const isDomainTakenByOtherOrg = checkDomainTakenByOtherOrg(user, session, enterpriseConnection);
+  const initialStepId = deriveInitialStep(enterpriseConnection, { isDomainTakenByOtherOrg, hasSuccessfulTestRun });
 
   const createEnterpriseConnection = useCallback(
     async (provider: ProviderType): Promise<void> => {
@@ -71,7 +94,7 @@ export const ConfigureSSOProvider = ({
       card.setLoading();
 
       try {
-        await enterpriseConnectionApi.createEnterpriseConnection({
+        await createEnterpriseConnectionApi({
           provider,
           name: emailDomain,
           organizationId,
@@ -80,19 +103,31 @@ export const ConfigureSSOProvider = ({
         card.setIdle();
       }
     },
-    [user, card, session, enterpriseConnectionApi],
+    [user, card, session, createEnterpriseConnectionApi],
   );
 
   const value = React.useMemo<ConfigureSSOData>(
     () => ({
+      provider,
+      contentRef,
+      setProvider,
       initialStepId,
       enterpriseConnection,
-      provider,
+      isDomainTakenByOtherOrg,
       createEnterpriseConnection,
-      setProvider,
-      contentRef,
+      updateEnterpriseConnection,
+      deleteEnterpriseConnection,
     }),
-    [initialStepId, enterpriseConnection, createEnterpriseConnection, provider, contentRef],
+    [
+      provider,
+      contentRef,
+      initialStepId,
+      enterpriseConnection,
+      createEnterpriseConnection,
+      updateEnterpriseConnection,
+      deleteEnterpriseConnection,
+      isDomainTakenByOtherOrg,
+    ],
   );
 
   return <ConfigureSSOContext.Provider value={value}>{children}</ConfigureSSOContext.Provider>;
@@ -104,4 +139,21 @@ export const useConfigureSSO = (): ConfigureSSOData => {
     throw new Error('useConfigureSSO called outside <ConfigureSSOProvider>.');
   }
   return ctx;
+};
+
+/**
+ * Determines if the user's domain is already wired to an enterprise connection that
+ * doesn't belong to the org they're currently configuring
+ */
+const checkDomainTakenByOtherOrg = (
+  user: UserResource | null | undefined,
+  session: SignedInSessionResource | null | undefined,
+  enterpriseConnection: EnterpriseConnectionResource | undefined,
+): boolean => {
+  const emailToVerify =
+    user?.primaryEmailAddress ?? user?.emailAddresses?.find(e => e.verification.status !== 'verified');
+  const isVerified = emailToVerify?.verification.status === 'verified';
+  const activeOrganizationId = session?.lastActiveOrganizationId ?? null;
+
+  return Boolean(isVerified && enterpriseConnection && enterpriseConnection.organizationId !== activeOrganizationId);
 };

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -3,7 +3,6 @@ import type { EnterpriseConnectionResource } from '@clerk/shared/types';
 import React, { type PropsWithChildren, useCallback } from 'react';
 
 import { useCardState } from '@/elements/contexts';
-import { handleError } from '@/utils/errorHandler';
 
 import { deriveInitialStep } from './deriveInitialStep';
 import type { ProviderType, WizardStepId } from './types';
@@ -71,18 +70,15 @@ export const ConfigureSSOProvider = ({
 
       card.setLoading();
 
-      await enterpriseConnectionApi
-        .createEnterpriseConnection({
+      try {
+        await enterpriseConnectionApi.createEnterpriseConnection({
           provider,
           name: emailDomain,
           organizationId,
-        })
-        .catch(err => {
-          handleError(err, [], card.setError);
-        })
-        .finally(() => {
-          card.setIdle();
         });
+      } finally {
+        card.setIdle();
+      }
     },
     [user, card, session, enterpriseConnectionApi],
   );

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -1,5 +1,9 @@
+import { __internal_useUserEnterpriseConnections, useSession, useUser } from '@clerk/shared/react/index';
 import type { EnterpriseConnectionResource } from '@clerk/shared/types';
-import React, { type PropsWithChildren } from 'react';
+import React, { type PropsWithChildren, useCallback } from 'react';
+
+import { useCardState } from '@/elements/contexts';
+import { handleError } from '@/utils/errorHandler';
 
 import { deriveInitialStep } from './deriveInitialStep';
 import type { ProviderType, WizardStepId } from './types';
@@ -28,6 +32,10 @@ export interface ConfigureSSOData {
    * Ref to the scrollable content container of the wizard.
    */
   contentRef: React.RefObject<HTMLDivElement>;
+  /**
+   * Creates a new enterprise connection.
+   */
+  createEnterpriseConnection: (provider: ProviderType) => Promise<void>;
 }
 
 interface ConfigureSSOProviderProps {
@@ -46,18 +54,49 @@ export const ConfigureSSOProvider = ({
   const [provider, setProvider] = React.useState<ProviderType | undefined>(
     enterpriseConnection?.provider as ProviderType,
   );
-
+  const enterpriseConnectionApi = __internal_useUserEnterpriseConnections();
+  const { user } = useUser();
+  const { session } = useSession();
+  const card = useCardState();
   const initialStepId = deriveInitialStep(enterpriseConnection);
+
+  const createEnterpriseConnection = useCallback(
+    async (provider: ProviderType): Promise<void> => {
+      const emailDomain = user?.primaryEmailAddress?.emailAddress.split('@')[1];
+      const organizationId = session?.lastActiveOrganizationId ?? null;
+
+      if (!emailDomain) {
+        return;
+      }
+
+      card.setLoading();
+
+      await enterpriseConnectionApi
+        .createEnterpriseConnection({
+          provider,
+          name: emailDomain,
+          organizationId,
+        })
+        .catch(err => {
+          handleError(err, [], card.setError);
+        })
+        .finally(() => {
+          card.setIdle();
+        });
+    },
+    [user, card, session, enterpriseConnectionApi],
+  );
 
   const value = React.useMemo<ConfigureSSOData>(
     () => ({
       initialStepId,
       enterpriseConnection,
       provider,
+      createEnterpriseConnection,
       setProvider,
       contentRef,
     }),
-    [initialStepId, enterpriseConnection, provider, contentRef],
+    [initialStepId, enterpriseConnection, createEnterpriseConnection, provider, contentRef],
   );
 
   return <ConfigureSSOContext.Provider value={value}>{children}</ConfigureSSOContext.Provider>;

--- a/packages/ui/src/components/ConfigureSSO/__tests__/deriveInitialStep.test.ts
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/deriveInitialStep.test.ts
@@ -1,4 +1,4 @@
-import type { EnterpriseConnectionResource } from '@clerk/shared/types';
+import type { EnterpriseConnectionResource, SamlAccountConnectionResource } from '@clerk/shared/types';
 import { describe, expect, it } from 'vitest';
 
 import { deriveInitialStep } from '../deriveInitialStep';
@@ -25,65 +25,83 @@ const makeConnection = (overrides: Partial<EnterpriseConnectionResource> = {}): 
     ...overrides,
   }) as EnterpriseConnectionResource;
 
+const makeSamlConnection = (overrides: Partial<SamlAccountConnectionResource> = {}): SamlAccountConnectionResource =>
+  ({
+    id: 'saml_1',
+    name: 'acme.com',
+    active: false,
+    idpEntityId: '',
+    idpSsoUrl: '',
+    idpCertificate: '',
+    idpMetadataUrl: '',
+    idpMetadata: '',
+    acsUrl: 'https://clerk.example.com/acs',
+    spEntityId: 'https://clerk.example.com',
+    spMetadataUrl: 'https://clerk.example.com/sp-metadata',
+    allowSubdomains: false,
+    allowIdpInitiated: false,
+    forceAuthn: false,
+    ...overrides,
+  }) as SamlAccountConnectionResource;
+
+const defaultOptions = { isDomainTakenByOtherOrg: false, hasSuccessfulTestRun: false };
+
 describe('deriveInitialStep', () => {
-  const cases: Array<{ name: string; input: EnterpriseConnectionResource | undefined; expected: WizardStepId }> = [
+  const cases: Array<{
+    name: string;
+    input: EnterpriseConnectionResource | undefined;
+    options?: Partial<typeof defaultOptions>;
+    expected: WizardStepId;
+  }> = [
+    {
+      name: 'domain taken by other org → verify-domain',
+      input: makeConnection(),
+      options: { isDomainTakenByOtherOrg: true },
+      expected: 'verify-domain',
+    },
     {
       name: 'no connection → select-provider',
       input: undefined,
       expected: 'select-provider',
     },
     {
-      name: 'connection without samlConnection → configure',
-      input: makeConnection({ samlConnection: null }),
+      name: 'active connection → confirmation',
+      input: makeConnection({ active: true, samlConnection: makeSamlConnection() }),
+      expected: 'confirmation',
+    },
+    {
+      name: 'connection with empty SAML IdP config → configure',
+      input: makeConnection({ samlConnection: makeSamlConnection() }),
       expected: 'configure',
     },
     {
-      name: 'connection with empty samlConnection.idpSsoUrl → configure',
+      name: 'configured connection without successful test run → test',
       input: makeConnection({
-        samlConnection: {
-          id: 'saml_1',
-          name: 'acme.com',
-          active: false,
-          idpEntityId: '',
-          idpSsoUrl: '',
-          idpCertificate: '',
-          idpMetadataUrl: '',
-          idpMetadata: '',
-          acsUrl: 'https://clerk.example.com/acs',
-          spEntityId: 'https://clerk.example.com',
-          spMetadataUrl: 'https://clerk.example.com/sp-metadata',
-          allowSubdomains: false,
-          allowIdpInitiated: false,
-          forceAuthn: false,
-        },
-      }),
-      expected: 'configure',
-    },
-    {
-      name: 'connection with samlConnection.idpSsoUrl populated → confirmation',
-      input: makeConnection({
-        samlConnection: {
-          id: 'saml_1',
-          name: 'acme.com',
-          active: true,
+        samlConnection: makeSamlConnection({
           idpEntityId: 'https://idp.example.com/entity',
           idpSsoUrl: 'https://idp.example.com/sso',
           idpCertificate: 'CERT',
           idpMetadataUrl: 'https://idp.example.com/metadata',
-          idpMetadata: '',
-          acsUrl: 'https://clerk.example.com/acs',
-          spEntityId: 'https://clerk.example.com',
-          spMetadataUrl: 'https://clerk.example.com/sp-metadata',
-          allowSubdomains: false,
-          allowIdpInitiated: false,
-          forceAuthn: false,
-        },
+        }),
       }),
+      expected: 'test',
+    },
+    {
+      name: 'configured connection with successful test run → confirmation',
+      input: makeConnection({
+        samlConnection: makeSamlConnection({
+          idpEntityId: 'https://idp.example.com/entity',
+          idpSsoUrl: 'https://idp.example.com/sso',
+          idpCertificate: 'CERT',
+          idpMetadataUrl: 'https://idp.example.com/metadata',
+        }),
+      }),
+      options: { hasSuccessfulTestRun: true },
       expected: 'confirmation',
     },
   ];
 
-  it.each(cases)('$name', ({ input, expected }) => {
-    expect(deriveInitialStep(input)).toBe(expected);
+  it.each(cases)('$name', ({ input, options, expected }) => {
+    expect(deriveInitialStep(input, { ...defaultOptions, ...options })).toBe(expected);
   });
 });

--- a/packages/ui/src/components/ConfigureSSO/deriveInitialStep.ts
+++ b/packages/ui/src/components/ConfigureSSO/deriveInitialStep.ts
@@ -5,21 +5,47 @@ import type { WizardStepId } from './types';
 /**
  * Decides where the ConfigureSSO wizard should mount on (re)load based on
  * the current state of the user's enterprise connection.
- *
- * No connection → `select-provider`
- * Connection without SAML IdP metadata → `configure`
- * Connection with SAML IdP metadata → `confirmation`
- *
- * The `test` step is intentionally absent — we can't derive a "last test
- * passed" signal synchronously from the resource. Users can re-test from
- * Confirmation.
  */
-export const deriveInitialStep = (connection: EnterpriseConnectionResource | undefined): WizardStepId => {
-  if (!connection) {
+export const deriveInitialStep = (
+  enterpriseConnection: EnterpriseConnectionResource | undefined,
+  options: { isDomainTakenByOtherOrg: boolean; hasSuccessfulTestRun: boolean },
+): WizardStepId => {
+  const { isDomainTakenByOtherOrg, hasSuccessfulTestRun } = options;
+
+  // Go to the verify domain step in order to display warning
+  if (isDomainTakenByOtherOrg) {
+    return 'verify-domain';
+  }
+
+  // If no initial connection, go to the select provider step
+  if (!enterpriseConnection) {
     return 'select-provider';
   }
-  if (!connection.samlConnection?.idpSsoUrl) {
+
+  // Connection is enabled, go to the confirmation step
+  const isEnabled = enterpriseConnection?.active;
+  if (isEnabled) {
+    return 'confirmation';
+  }
+
+  const hasMinimumIdPConfiguration = checkHasMinimumIdPConfiguration(enterpriseConnection);
+
+  // If the connection hasn't finished configuring it, go to the configure step
+  // Connection exists, but is not enabled and hasn't finished configuring it
+  if (!hasMinimumIdPConfiguration) {
     return 'configure';
   }
+
+  // If the connection hasn't been tested, go to the test step
+  if (!hasSuccessfulTestRun) {
+    return 'test';
+  }
+
+  // Connection is disabled but has been tested and configured
   return 'confirmation';
+};
+
+// TODO - Update to support OpenID Connect
+const checkHasMinimumIdPConfiguration = (connection: EnterpriseConnectionResource): boolean => {
+  return Boolean(connection.samlConnection?.idpSsoUrl && connection.samlConnection?.idpEntityId);
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -44,26 +44,47 @@ export const ConfigureStep = (): JSX.Element => {
         elementId={descriptors.configureSSOStep.setId('configure')}
       >
         <Wizard>
-          <Step.Header
-            title={localizationKeys('configureSSO.configureStep.samlOkta.title')}
-            description={localizationKeys('configureSSO.configureStep.samlOkta.subtitle')}
-          >
-            <InnerStepCounter />
-          </Step.Header>
-
           <Wizard.Step id='create-app'>
+            <Step.Header
+              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
+              description={localizationKeys('configureSSO.configureStep.samlOkta.createApp.headerSubtitle')}
+            >
+              <InnerStepCounter />
+            </Step.Header>
+
             <CreateAppSubStep />
           </Wizard.Step>
 
           <Wizard.Step id='configure-attributes'>
+            <Step.Header
+              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
+              description={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.headerSubtitle')}
+            >
+              <InnerStepCounter />
+            </Step.Header>
+
             <ConfigureAttributesSubStep />
           </Wizard.Step>
 
           <Wizard.Step id='assign-users'>
+            <Step.Header
+              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
+              description={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.headerSubtitle')}
+            >
+              <InnerStepCounter />
+            </Step.Header>
+
             <AssignUsersSubStep />
           </Wizard.Step>
 
           <Wizard.Step id='submit-saml-config'>
+            <Step.Header
+              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
+              description={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.headerSubtitle')}
+            >
+              <InnerStepCounter />
+            </Step.Header>
+
             <SubmitSamlConfigSubStep />
           </Wizard.Step>
         </Wizard>

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -1,8 +1,9 @@
 import { __internal_useUserEnterpriseConnections, useReverification } from '@clerk/shared/react';
 import type { FieldId, UpdateMeEnterpriseConnectionParams } from '@clerk/shared/types';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
+  Alert,
   Badge,
   Box,
   Button,
@@ -147,7 +148,7 @@ const ATTRIBUTE_PAIRS = [
 
 export const CreateAppSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
-  const { enterpriseConnection } = useConfigureSSO();
+  const { enterpriseConnection, provider } = useConfigureSSO();
   const { key } = useConfigureStepTranslations();
 
   const acsUrl = enterpriseConnection?.samlConnection?.acsUrl ?? '';
@@ -174,60 +175,19 @@ export const CreateAppSubStep = (): JSX.Element => {
               textVariant='subtitle'
               localizationKey={localizationKeys(key('createApp.title'))}
             />
-            <Col
-              as='ul'
-              sx={theme => ({
-                gap: theme.space.$1x5,
-                margin: 0,
-                paddingInlineStart: theme.space.$5,
-                listStyleType: 'disc',
-              })}
-            >
+
+            {provider === 'saml_okta' && <OktaCreateAppStepContent />}
+
+            {provider === 'saml_custom' && (
               <Text
-                as='li'
+                as='p'
                 colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step1')}
+                localizationKey={localizationKeys('configureSSO.configureStep.samlCustom.createApp.subtitle')}
               />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step2')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step3')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step4')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step5')}
-              />
-            </Col>
+            )}
           </Col>
 
-          <Col sx={theme => ({ gap: theme.space.$1x5 })}>
-            <Heading
-              as='h3'
-              textVariant='subtitle'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.title')}
-            />
-            <Text
-              as='p'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.paragraph1')}
-            />
-            <Text
-              as='p'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.paragraph2')}
-            />
-          </Col>
+          {provider === 'saml_okta' && <OktaServiceProviderStepContent />}
 
           <Form.ControlRow elementId={acsUrlField.id}>
             <Form.CommonInputWrapper {...acsUrlField.props}>
@@ -251,33 +211,7 @@ export const CreateAppSubStep = (): JSX.Element => {
             </Form.CommonInputWrapper>
           </Form.ControlRow>
 
-          <Col sx={theme => ({ gap: theme.space.$1x5 })}>
-            <Heading
-              as='h3'
-              textVariant='subtitle'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.title')}
-            />
-            <Col
-              as='ul'
-              sx={theme => ({
-                gap: theme.space.$1x5,
-                margin: 0,
-                paddingInlineStart: theme.space.$5,
-                listStyleType: 'disc',
-              })}
-            >
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.step1')}
-              />
-              <Text
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.step2')}
-              />
-            </Col>
-          </Col>
+          {provider === 'saml_okta' && <OktaCompleteSamlIntegrationStepContent />}
         </Step.Section>
       </Step.Body>
 
@@ -295,8 +229,106 @@ export const CreateAppSubStep = (): JSX.Element => {
   );
 };
 
+// TODO - Move IdP specific content to separate modules
+const OktaServiceProviderStepContent = (): JSX.Element => {
+  return (
+    <Col sx={theme => ({ gap: theme.space.$1x5 })}>
+      <Heading
+        as='h3'
+        textVariant='subtitle'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.title')}
+      />
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.paragraph1')}
+      />
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.serviceProvider.paragraph2')}
+      />
+    </Col>
+  );
+};
+
+const OktaCreateAppStepContent = (): JSX.Element => {
+  return (
+    <Col
+      as='ul'
+      sx={theme => ({
+        gap: theme.space.$1x5,
+        margin: 0,
+        paddingInlineStart: theme.space.$5,
+        listStyleType: 'disc',
+      })}
+    >
+      <Text
+        as='li'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step1')}
+      />
+      <Text
+        as='li'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step2')}
+      />
+      <Text
+        as='li'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step3')}
+      />
+      <Text
+        as='li'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step4')}
+      />
+      <Text
+        as='li'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.step5')}
+      />
+    </Col>
+  );
+};
+
+const OktaCompleteSamlIntegrationStepContent = (): JSX.Element => {
+  return (
+    <Col sx={theme => ({ gap: theme.space.$1x5 })}>
+      <Heading
+        as='h3'
+        textVariant='subtitle'
+        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.title')}
+      />
+      <Col
+        as='ul'
+        sx={theme => ({
+          gap: theme.space.$1x5,
+          margin: 0,
+          paddingInlineStart: theme.space.$5,
+          listStyleType: 'disc',
+        })}
+      >
+        <Text
+          as='li'
+          colorScheme='secondary'
+          localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.step1')}
+        />
+        <Text
+          as='li'
+          colorScheme='secondary'
+          localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.completeSamlIntegration.step2')}
+        />
+      </Col>
+    </Col>
+  );
+};
+
 export const ConfigureAttributesSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
+
+  const { provider } = useConfigureSSO();
+  const { key } = useConfigureStepTranslations();
 
   return (
     <>
@@ -305,7 +337,7 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
           <Heading
             as='h3'
             textVariant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.title')}
+            localizationKey={localizationKeys(key('configureAttributes.title'))}
           />
 
           <Table
@@ -370,70 +402,7 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
             </Tbody>
           </Table>
 
-          <Text
-            as='p'
-            colorScheme='secondary'
-            localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.paragraph')}
-          />
-
-          <Col
-            as='ol'
-            sx={theme => ({
-              gap: theme.space.$1x5,
-              margin: 0,
-              paddingInlineStart: theme.space.$5,
-              listStyleType: 'decimal',
-            })}
-          >
-            <Text
-              as='li'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step1')}
-            />
-            <Text
-              as='li'
-              colorScheme='secondary'
-            >
-              <Text
-                as='span'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step2')}
-              />
-              <Col
-                as='ul'
-                sx={theme => ({
-                  gap: theme.space.$1x5,
-                  margin: 0,
-                  marginTop: theme.space.$1x5,
-                  paddingInlineStart: theme.space.$5,
-                  listStyleType: '"- "',
-                })}
-              >
-                {ATTRIBUTE_PAIRS.map(pair => (
-                  <Text
-                    key={pair.id}
-                    as='li'
-                  >
-                    <Badge
-                      localizationKey={pair.name}
-                      sx={{ fontFamily: 'monospace' }}
-                    />
-
-                    <Text
-                      as='span'
-                      localizationKey={localizationKeys(
-                        'configureSSO.configureStep.samlOkta.configureAttributes.pairs.conjunction',
-                      )}
-                    />
-
-                    <Badge
-                      localizationKey={pair.expression}
-                      sx={{ fontFamily: 'monospace' }}
-                    />
-                  </Text>
-                ))}
-              </Col>
-            </Text>
-          </Col>
+          {provider === 'saml_okta' && <OktaConfigureAttributesStepContent />}
         </Step.Section>
       </Step.Body>
 
@@ -451,8 +420,112 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
   );
 };
 
+const OktaConfigureAttributesStepContent = (): JSX.Element => {
+  return (
+    <>
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.paragraph')}
+      />
+
+      <Col
+        as='ol'
+        sx={theme => ({
+          gap: theme.space.$1x5,
+          margin: 0,
+          paddingInlineStart: theme.space.$5,
+          listStyleType: 'decimal',
+        })}
+      >
+        <Text
+          as='li'
+          colorScheme='secondary'
+          localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step1')}
+        />
+        <Text
+          as='li'
+          colorScheme='secondary'
+        >
+          <Text
+            as='span'
+            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.step2')}
+          />
+          <Col
+            as='ul'
+            sx={theme => ({
+              gap: theme.space.$1x5,
+              margin: 0,
+              marginTop: theme.space.$1x5,
+              paddingInlineStart: theme.space.$5,
+              listStyleType: '"- "',
+            })}
+          >
+            {ATTRIBUTE_PAIRS.map(pair => (
+              <Text
+                key={pair.id}
+                as='li'
+              >
+                <Badge
+                  localizationKey={pair.name}
+                  sx={{ fontFamily: 'monospace' }}
+                />
+
+                <Text
+                  as='span'
+                  localizationKey={localizationKeys(
+                    'configureSSO.configureStep.samlOkta.configureAttributes.pairs.conjunction',
+                  )}
+                />
+
+                <Badge
+                  localizationKey={pair.expression}
+                  sx={{ fontFamily: 'monospace' }}
+                />
+              </Text>
+            ))}
+          </Col>
+        </Text>
+      </Col>
+    </>
+  );
+};
+
 export const AssignUsersSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
+  const { provider } = useConfigureSSO();
+
+  if (provider === 'saml_custom') {
+    return (
+      <>
+        <Step.Body>
+          <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
+            <Heading
+              as='h3'
+              textVariant='subtitle'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlCustom.assignUsers.title')}
+            />
+            <Text
+              as='p'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlCustom.assignUsers.paragraph')}
+            />
+          </Step.Section>
+        </Step.Body>
+
+        <Step.Footer>
+          <Step.Footer.Previous
+            onClick={() => goPrev()}
+            isDisabled={isFirstStep}
+          />
+          <Step.Footer.Continue
+            onClick={() => goNext()}
+            isDisabled={isLastStep}
+          />
+        </Step.Footer>
+      </>
+    );
+  }
 
   return (
     <>
@@ -527,6 +600,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
   const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
+  const { key } = useConfigureStepTranslations();
 
   const samlConnection = enterpriseConnection?.samlConnection;
   const hasExistingConfig = Boolean(
@@ -555,28 +629,28 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
 
   const metadataUrlField = useFormControl('idpMetadataUrl', samlConnection?.idpMetadataUrl ?? '', {
     type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.placeholder'),
+    label: localizationKeys(key('metadataUrl.label')),
+    placeholder: localizationKeys(key('metadataUrl.placeholder')),
     isRequired: true,
   });
 
   const signOnUrlField = useFormControl('idpSsoUrl', samlConnection?.idpSsoUrl ?? '', {
     type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.signOnUrl.placeholder'),
+    label: localizationKeys(key('manual.signOnUrl.label')),
+    placeholder: localizationKeys(key('manual.signOnUrl.placeholder')),
     isRequired: true,
   });
 
   const issuerField = useFormControl('idpEntityId', samlConnection?.idpEntityId ?? '', {
     type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.label'),
-    placeholder: localizationKeys('configureSSO.configureStep.samlOkta.manual.issuer.placeholder'),
+    label: localizationKeys(key('manual.issuer.label')),
+    placeholder: localizationKeys(key('manual.issuer.placeholder')),
     isRequired: true,
   });
 
   const certFileField = useFormControl('idpCertificate', '', {
     type: 'text',
-    label: localizationKeys('configureSSO.configureStep.samlOkta.manual.signingCertificate.label'),
+    label: localizationKeys(key('manual.signingCertificate.label')),
     isRequired: true,
   });
 
@@ -635,21 +709,21 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
           <Heading
             as='h3'
             textVariant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.submitSamlConfig.title')}
+            localizationKey={localizationKeys(key('submitSamlConfig.title'))}
           />
           <SegmentedControl.Root
-            aria-label={t(localizationKeys('configureSSO.configureStep.samlOkta.modes.ariaLabel'))}
+            aria-label={t(localizationKeys(key('modes.ariaLabel')))}
             value={mode}
             onChange={value => setMode(value as 'metadataUrl' | 'manual')}
             fullWidth
           >
             <SegmentedControl.Button
               value='metadataUrl'
-              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.metadataUrl')}
+              text={localizationKeys(key('modes.metadataUrl'))}
             />
             <SegmentedControl.Button
               value='manual'
-              text={localizationKeys('configureSSO.configureStep.samlOkta.modes.manual')}
+              text={localizationKeys(key('modes.manual'))}
             />
           </SegmentedControl.Root>
 
@@ -666,6 +740,14 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
             />
           )}
         </Step.Section>
+
+        {card.error && (
+          <Alert
+            colorScheme='danger'
+            title={card.error}
+            sx={t => ({ margin: t.space.$3 })}
+          />
+        )}
       </Step.Body>
 
       <Step.Footer>
@@ -676,7 +758,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
         <Step.Footer.Continue
           onClick={handleContinue}
           isLoading={card.isLoading}
-          isDisabled={!canSubmit}
+          isDisabled={!canSubmit || !!card.error}
         />
       </Step.Footer>
     </>
@@ -699,12 +781,14 @@ type ManualEntryPanelProps = {
 };
 
 const MetadataUrlPanel = ({ field }: MetadataUrlPanelProps): JSX.Element => {
+  const { key } = useConfigureStepTranslations();
+
   return (
     <>
       <Text
         as='p'
         colorScheme='secondary'
-        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.description')}
+        localizationKey={localizationKeys(key('metadataUrl.description'))}
       />
       <Form.ControlRow elementId={field.id}>
         <Form.PlainInput {...field.props} />
@@ -723,13 +807,14 @@ const ManualEntryPanel = ({
 }: ManualEntryPanelProps): JSX.Element => {
   const { t } = useLocalizations();
   const certInputRef = React.useRef<HTMLInputElement>(null);
+  const { key } = useConfigureStepTranslations();
 
   return (
     <>
       <Text
         as='p'
         colorScheme='secondary'
-        localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.manual.description')}
+        localizationKey={localizationKeys(key('manual.description'))}
       />
 
       <Form.ControlRow elementId={signOnUrlField.id}>

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -35,8 +35,11 @@ import { handleError } from '@/utils/errorHandler';
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard, Wizard } from '../elements/Wizard';
+import { useConfigureStepTranslations } from './configureStepTranslations';
 
 export const ConfigureStep = (): JSX.Element => {
+  const { key } = useConfigureStepTranslations();
+
   return (
     <Flow.Part part='configureCreateApp'>
       <Step
@@ -46,8 +49,8 @@ export const ConfigureStep = (): JSX.Element => {
         <Wizard>
           <Wizard.Step id='create-app'>
             <Step.Header
-              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
-              description={localizationKeys('configureSSO.configureStep.samlOkta.createApp.headerSubtitle')}
+              title={localizationKeys(key('headerTitle'))}
+              description={localizationKeys(key('createApp.headerSubtitle'))}
             >
               <InnerStepCounter />
             </Step.Header>
@@ -57,8 +60,8 @@ export const ConfigureStep = (): JSX.Element => {
 
           <Wizard.Step id='configure-attributes'>
             <Step.Header
-              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
-              description={localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.headerSubtitle')}
+              title={localizationKeys(key('headerTitle'))}
+              description={localizationKeys(key('configureAttributes.headerSubtitle'))}
             >
               <InnerStepCounter />
             </Step.Header>
@@ -68,8 +71,8 @@ export const ConfigureStep = (): JSX.Element => {
 
           <Wizard.Step id='assign-users'>
             <Step.Header
-              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
-              description={localizationKeys('configureSSO.configureStep.samlOkta.assignUsers.headerSubtitle')}
+              title={localizationKeys(key('headerTitle'))}
+              description={localizationKeys(key('assignUsers.headerSubtitle'))}
             >
               <InnerStepCounter />
             </Step.Header>
@@ -79,8 +82,8 @@ export const ConfigureStep = (): JSX.Element => {
 
           <Wizard.Step id='submit-saml-config'>
             <Step.Header
-              title={localizationKeys('configureSSO.configureStep.samlOkta.headerTitle')}
-              description={localizationKeys('configureSSO.configureStep.samlOkta.metadataUrl.headerSubtitle')}
+              title={localizationKeys(key('headerTitle'))}
+              description={localizationKeys(key('metadataUrl.headerSubtitle'))}
             >
               <InnerStepCounter />
             </Step.Header>
@@ -145,6 +148,7 @@ const ATTRIBUTE_PAIRS = [
 export const CreateAppSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
   const { enterpriseConnection } = useConfigureSSO();
+  const { key } = useConfigureStepTranslations();
 
   const acsUrl = enterpriseConnection?.samlConnection?.acsUrl ?? '';
   const spEntityId = enterpriseConnection?.samlConnection?.spEntityId ?? '';
@@ -168,7 +172,7 @@ export const CreateAppSubStep = (): JSX.Element => {
             <Heading
               as='h3'
               textVariant='subtitle'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlOkta.createApp.title')}
+              localizationKey={localizationKeys(key('createApp.title'))}
             />
             <Col
               as='ul'

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -328,17 +328,18 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
 
   const { provider } = useConfigureSSO();
-  const { key } = useConfigureStepTranslations();
 
   return (
     <>
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
-          <Heading
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(key('configureAttributes.title'))}
-          />
+          {provider === 'saml_custom' && (
+            <Heading
+              as='h3'
+              textVariant='subtitle'
+              localizationKey={localizationKeys('configureSSO.configureStep.samlCustom.configureAttributes.title')}
+            />
+          )}
 
           <Table
             sx={theme => ({
@@ -758,7 +759,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
         <Step.Footer.Continue
           onClick={handleContinue}
           isLoading={card.isLoading}
-          isDisabled={!canSubmit || !!card.error}
+          isDisabled={!canSubmit}
         />
       </Step.Footer>
     </>

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -1,9 +1,9 @@
+import { isClerkAPIResponseError } from '@clerk/shared/error';
 import { useReverification } from '@clerk/shared/react';
 import type { FieldId, UpdateMeEnterpriseConnectionParams } from '@clerk/shared/types';
 import React, { type JSX } from 'react';
 
 import {
-  Alert,
   Badge,
   Box,
   Button,
@@ -687,12 +687,21 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
 
         await updateConnection({ saml: samlPayload });
       }
+
       void goNext();
     } catch (err) {
-      if (mode === 'metadataUrl') {
-        handleError(err as Error, [metadataUrlField], card.setError);
-      } else {
-        handleError(err as Error, [signOnUrlField, issuerField, certFileField], card.setError);
+      const fields = mode === 'metadataUrl' ? [metadataUrlField] : [signOnUrlField, issuerField, certFileField];
+
+      handleError(err as Error, fields, card.setError);
+
+      if (isClerkAPIResponseError(err)) {
+        const unscopedSamlError = err.errors.find(e => e.code?.startsWith('saml_') && !e.meta?.paramName);
+
+        if (unscopedSamlError) {
+          const primaryField = mode === 'metadataUrl' ? metadataUrlField : signOnUrlField;
+          primaryField.setError(unscopedSamlError);
+          card.setError(undefined);
+        }
       }
     } finally {
       card.setIdle();
@@ -714,7 +723,10 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
           <SegmentedControl.Root
             aria-label={t(localizationKeys(key('modes.ariaLabel')))}
             value={mode}
-            onChange={value => setMode(value as 'metadataUrl' | 'manual')}
+            onChange={value => {
+              card.setError(undefined);
+              setMode(value as 'metadataUrl' | 'manual');
+            }}
             fullWidth
           >
             <SegmentedControl.Button
@@ -740,14 +752,6 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
             />
           )}
         </Step.Section>
-
-        {card.error && (
-          <Alert
-            colorScheme='danger'
-            title={card.error}
-            sx={t => ({ margin: t.space.$3 })}
-          />
-        )}
       </Step.Body>
 
       <Step.Footer>
@@ -858,7 +862,7 @@ const ManualEntryPanel = ({
                   />
                 )}
                 <Button
-                  size='sm'
+                  size='xs'
                   variant='outline'
                   onClick={() => certInputRef.current?.click()}
                 >

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -1,4 +1,4 @@
-import { __internal_useUserEnterpriseConnections, useReverification } from '@clerk/shared/react';
+import { useReverification } from '@clerk/shared/react';
 import type { FieldId, UpdateMeEnterpriseConnectionParams } from '@clerk/shared/types';
 import React, { type JSX } from 'react';
 
@@ -599,8 +599,7 @@ export const SubmitSamlConfigSubStep = (): JSX.Element => {
   const card = useCardState();
   const { t } = useLocalizations();
   const { goNext, goPrev, isFirstStep } = useWizard();
-  const { enterpriseConnection } = useConfigureSSO();
-  const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections();
+  const { enterpriseConnection, updateEnterpriseConnection } = useConfigureSSO();
   const { key } = useConfigureStepTranslations();
 
   const samlConnection = enterpriseConnection?.samlConnection;

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfirmationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfirmationStep.tsx
@@ -1,4 +1,4 @@
-import { __internal_useUserEnterpriseConnections, useReverification } from '@clerk/shared/react';
+import { useReverification } from '@clerk/shared/react';
 import { useState } from 'react';
 
 import { Badge, Col, descriptors, Flex, Flow, Grid, Link, localizationKeys, Text } from '@/customizables';
@@ -65,8 +65,7 @@ const SsoStatusSection = (): JSX.Element => {
 };
 
 const EnableSsoSection = (): JSX.Element => {
-  const { enterpriseConnection } = useConfigureSSO();
-  const { updateEnterpriseConnection } = __internal_useUserEnterpriseConnections({ enabled: false });
+  const { enterpriseConnection, updateEnterpriseConnection } = useConfigureSSO();
   const card = useCardState();
 
   const [isChecked, setIsChecked] = useState(!!enterpriseConnection?.active);
@@ -220,8 +219,7 @@ const ConfigurationDetailsSection = (): JSX.Element => {
 const ResetConnectionForm = withCardStateProvider((props: FormProps) => {
   const { onReset, onSuccess } = props;
   const card = useCardState();
-  const { enterpriseConnection } = useConfigureSSO();
-  const { deleteEnterpriseConnection } = __internal_useUserEnterpriseConnections({ enabled: false });
+  const { enterpriseConnection, deleteEnterpriseConnection } = useConfigureSSO();
   const { goToStep } = useWizard();
 
   const deleteConnection = useReverification((id: string) => deleteEnterpriseConnection(id));

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfirmationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfirmationStep.tsx
@@ -205,7 +205,7 @@ const ConfigurationDetailsSection = (): JSX.Element => {
         >
           <ProfileSection.Button
             id='configureAgain'
-            onClick={() => goToStep('select-provider')}
+            onClick={() => goToStep('configure')}
             variant='ghost'
             colorScheme='primary'
             localizationKey={localizationKeys('configureSSO.confirmation.configurationSection.configureAgainLink')}

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -7,6 +7,7 @@ import { Box, Col, descriptors, Flow, Grid, localizationKeys, Span, Text, useLoc
 import { useCardState } from '@/elements/contexts';
 import { common, mqu } from '@/styledSystem';
 import { Alert } from '@/ui/elements/Alert';
+import { handleError } from '@/utils/errorHandler';
 
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
@@ -51,6 +52,8 @@ export const SelectProviderStep = (): JSX.Element => {
       return;
     }
 
+    setProvider(selected);
+
     const primaryEmailAddress = user?.primaryEmailAddress;
     const hasVerifiedPrimaryEmailAddress = primaryEmailAddress?.verification.status === 'verified';
 
@@ -67,8 +70,13 @@ export const SelectProviderStep = (): JSX.Element => {
     }
 
     // Otherwise, set the provider and create the enterprise connection
-    setProvider(selected);
-    await createEnterpriseConnection(selected);
+    try {
+      await createEnterpriseConnection(selected);
+    } catch (err) {
+      handleError(err as Error, [], card.setError);
+      return;
+    }
+
     void goToStep('configure');
   };
 
@@ -155,7 +163,7 @@ export const SelectProviderStep = (): JSX.Element => {
           <Step.Footer.Continue
             onClick={handleContinue}
             isLoading={card.isLoading}
-            isDisabled={!selected || !!card.error}
+            isDisabled={!selected}
           />
         </Step.Footer>
       </Step>

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -1,8 +1,10 @@
 import { iconImageUrl } from '@clerk/shared/constants';
+import { useUser } from '@clerk/shared/react/index';
 import React from 'react';
 
 import type { LocalizationKey } from '@/customizables';
 import { Box, Col, descriptors, Flow, Grid, localizationKeys, Span, Text, useLocalizations } from '@/customizables';
+import { useCardState } from '@/elements/contexts';
 import { common, mqu } from '@/styledSystem';
 import { Alert } from '@/ui/elements/Alert';
 
@@ -38,16 +40,36 @@ const PROVIDER_GROUPS: ReadonlyArray<{
 ];
 
 export const SelectProviderStep = (): JSX.Element => {
-  const { goNext } = useWizard();
-  const { setProvider } = useConfigureSSO();
+  const { goToStep } = useWizard();
+  const { setProvider, createEnterpriseConnection } = useConfigureSSO();
   const [selected, setSelected] = React.useState<ProviderType | null>(null);
+  const { user } = useUser();
+  const card = useCardState();
 
-  const handleContinue = () => {
-    if (!selected) {
+  const handleContinue = async () => {
+    if (!selected || !user) {
       return;
     }
+
+    const primaryEmailAddress = user?.primaryEmailAddress;
+    const hasVerifiedPrimaryEmailAddress = primaryEmailAddress?.verification.status === 'verified';
+
+    // If the user doesn't have a primary email address, go direct to the provide email step
+    if (!primaryEmailAddress) {
+      void goToStep('provide-email');
+      return;
+    }
+
+    // If the user's primary email address is not verified, go to the verify email address step
+    if (!hasVerifiedPrimaryEmailAddress) {
+      void goToStep('verify-email-address');
+      return;
+    }
+
+    // Otherwise, set the provider and create the enterprise connection
     setProvider(selected);
-    void goNext();
+    await createEnterpriseConnection(selected);
+    void goToStep('configure');
   };
 
   return (
@@ -116,6 +138,13 @@ export const SelectProviderStep = (): JSX.Element => {
               variant='warning'
               title={localizationKeys('configureSSO.selectProviderStep.warning')}
             />
+
+            {card.error && (
+              <Alert
+                variant='danger'
+                title={card.error}
+              />
+            )}
           </Step.Section>
         </Step.Body>
 
@@ -124,7 +153,8 @@ export const SelectProviderStep = (): JSX.Element => {
 
           <Step.Footer.Continue
             onClick={handleContinue}
-            isDisabled={!selected}
+            isLoading={card.isLoading}
+            isDisabled={!selected || !!card.error}
           />
         </Step.Footer>
       </Step>

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -57,21 +57,14 @@ export const SelectProviderStep = (): JSX.Element => {
     const primaryEmailAddress = user?.primaryEmailAddress;
     const hasVerifiedPrimaryEmailAddress = primaryEmailAddress?.verification.status === 'verified';
 
-    // If the user doesn't have a primary email address, go direct to the provide email step
-    if (!primaryEmailAddress) {
-      void goToStep('provide-email');
-      return;
-    }
-
-    // If the user's primary email address is not verified, go to the verify email address step
-    if (!hasVerifiedPrimaryEmailAddress) {
-      void goToStep('verify-email-address');
+    if (!primaryEmailAddress || !hasVerifiedPrimaryEmailAddress) {
+      void goToStep('verify-domain');
       return;
     }
 
     // Otherwise, set the provider and create the enterprise connection
     try {
-      await createEnterpriseConnection(selected);
+      await createEnterpriseConnection(selected, primaryEmailAddress);
     } catch (err) {
       handleError(err as Error, [], card.setError);
       return;

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -143,6 +143,7 @@ export const SelectProviderStep = (): JSX.Element => {
               <Alert
                 variant='danger'
                 title={card.error}
+                sx={t => ({ margin: t.space.$3 })}
               />
             )}
           </Step.Section>

--- a/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
@@ -353,7 +353,7 @@ export const EnterVerificationCodeStep = ({
         <Step.Footer.Continue
           onClick={() => goNext()}
           isLoading={otp.isLoading || card.isLoading}
-          isDisabled={!isVerified || !!card.error}
+          isDisabled={!isVerified}
         />
       </Step.Footer>
     </>

--- a/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
@@ -1,6 +1,6 @@
 import { useReverification, useSession, useUser } from '@clerk/shared/react';
 import type { EmailAddressResource } from '@clerk/shared/types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   Col,
@@ -42,6 +42,11 @@ export const VerifyDomainStep = (): JSX.Element => {
   );
 
   const wasVerifiedOnMountRef = useRef(isVerified);
+  const emailAddressRef = useRef<EmailAddressResource | undefined>(emailToVerify);
+  const preExistingEmailIdRef = useRef<string | undefined>(emailToVerify?.id);
+  const initialInnerStepIdRef = useRef<'provide-email' | 'verify-email-address'>(
+    emailToVerify ? 'verify-email-address' : 'provide-email',
+  );
 
   if (isDomainTakenByOtherOrg) {
     const conflictingDomain = enterpriseConnection?.domains[0] as string;
@@ -122,7 +127,7 @@ export const VerifyDomainStep = (): JSX.Element => {
         elementDescriptor={descriptors.configureSSOStep}
         elementId={descriptors.configureSSOStep.setId('verify-domain')}
       >
-        <Wizard>
+        <Wizard initialStepId={initialInnerStepIdRef.current}>
           <Step.Header
             title={t(localizationKeys('configureSSO.verifyEmailDomainStep.title'))}
             description={t(localizationKeys('configureSSO.verifyEmailDomainStep.subtitle'))}
@@ -132,11 +137,14 @@ export const VerifyDomainStep = (): JSX.Element => {
 
           <Step.Body>
             <Wizard.Step id='provide-email'>
-              <ProvideEmailStep />
+              <ProvideEmailStep
+                emailAddressRef={emailAddressRef}
+                preExistingEmailIdRef={preExistingEmailIdRef}
+              />
             </Wizard.Step>
 
             <Wizard.Step id='verify-email-address'>
-              <EnterVerificationCodeStep emailToVerify={emailToVerify} />
+              <EnterVerificationCodeStep emailAddressRef={emailAddressRef} />
             </Wizard.Step>
           </Step.Body>
         </Wizard>
@@ -157,12 +165,21 @@ const InnerStepCounter = (): JSX.Element => {
 
 const isEmail = (str: string) => /^\S+@\S+\.\S+$/.test(str);
 
-export const ProvideEmailStep = (): JSX.Element => {
-  const { goNext, goPrev, isFirstStep } = useWizard();
+type ProvideEmailStepProps = {
+  emailAddressRef: React.MutableRefObject<EmailAddressResource | undefined>;
+  preExistingEmailIdRef: React.MutableRefObject<string | undefined>;
+};
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase();
+
+export const ProvideEmailStep = ({ emailAddressRef, preExistingEmailIdRef }: ProvideEmailStepProps): JSX.Element => {
+  const { goNext, goPrev } = useWizard();
   const { user } = useUser();
   const card = useCardState();
   const { t } = useLocalizations();
-  const [email, setEmail] = useState('');
+  // Pre-fill with whatever email the parent is currently tracking so navigating back from the
+  // verify step shows the user what they previously submitted instead of an empty field.
+  const [email, setEmail] = useState(() => emailAddressRef.current?.emailAddress ?? '');
   const createEmailAddress = useReverification((value: string) => user?.createEmailAddress({ email: value }));
 
   const canSubmit = isEmail(email) && !card.isLoading;
@@ -171,18 +188,41 @@ export const ProvideEmailStep = (): JSX.Element => {
       return;
     }
 
+    const current = emailAddressRef.current;
+    const submittedEmail = email.trim();
+
+    // Same email address as previously submitted, skip the flow
+    if (current && normalizeEmail(current.emailAddress) === normalizeEmail(submittedEmail)) {
+      await goNext();
+      return;
+    }
+
     card.setError(undefined);
     card.setLoading();
 
     try {
-      await createEmailAddress(email);
+      const created = await createEmailAddress(submittedEmail);
+      const previous = current;
+      emailAddressRef.current = created ?? undefined;
+
+      // Clean up the previous in-flight address so the user doesn't accumulate orphans on
+      // their account
+      if (previous && previous.id !== preExistingEmailIdRef.current && previous.id !== created?.id) {
+        try {
+          await previous.destroy();
+        } catch {
+          // A leftover unverified address is preferable to surfacing a cleanup
+          // error after a successful create.
+        }
+      }
+
       await goNext();
     } catch (err) {
       handleError(err as Error, [], card.setError);
     } finally {
       card.setIdle();
     }
-  }, [canSubmit, email, createEmailAddress, card, goNext]);
+  }, [canSubmit, email, createEmailAddress, card, goNext, emailAddressRef, preExistingEmailIdRef]);
 
   return (
     <>
@@ -255,7 +295,7 @@ export const ProvideEmailStep = (): JSX.Element => {
       <Step.Footer>
         <Step.Footer.Previous
           onClick={() => goPrev()}
-          isDisabled={isFirstStep}
+          isDisabled
         />
         <Step.Footer.Continue
           onClick={handleSubmit}
@@ -268,22 +308,26 @@ export const ProvideEmailStep = (): JSX.Element => {
 };
 
 export const EnterVerificationCodeStep = ({
-  emailToVerify,
+  emailAddressRef,
 }: {
-  emailToVerify?: EmailAddressResource;
+  emailAddressRef: React.MutableRefObject<EmailAddressResource | undefined>;
 }): JSX.Element | null => {
   const { user } = useUser();
   const { provider, createEnterpriseConnection } = useConfigureSSO();
   const card = useCardState();
-  const { goNext, goPrev, isFirstStep } = useWizard();
+  const { goNext, goPrev } = useWizard();
+  const primaryEmailAddress = user?.primaryEmailAddress;
 
+  const emailToVerify = emailAddressRef.current;
   const isVerified = emailToVerify?.verification.status === 'verified';
   const isPrimary = emailToVerify?.id === user?.primaryEmailAddressId;
 
   const prepareEmailVerification = useReverification(() =>
-    emailToVerify?.prepareVerification({ strategy: 'email_code' }),
+    emailAddressRef.current?.prepareVerification({ strategy: 'email_code' }),
   );
-  const attemptEmailVerification = useReverification((code: string) => emailToVerify?.attemptVerification({ code }));
+  const attemptEmailVerification = useReverification((code: string) =>
+    emailAddressRef.current?.attemptVerification({ code }),
+  );
   const setPrimaryEmailAddress = useReverification((emailAddressId: string) =>
     user?.update({ primaryEmailAddressId: emailAddressId }),
   );
@@ -303,9 +347,10 @@ export const EnterVerificationCodeStep = ({
       void prepare();
     },
     onResolve: async () => {
-      if (emailToVerify && !isPrimary) {
+      const target = emailAddressRef.current;
+      if (target && !isPrimary) {
         try {
-          await setPrimaryEmailAddress(emailToVerify.id);
+          await setPrimaryEmailAddress(target.id);
         } catch (err) {
           handleError(err as Error, [], card.setError);
           return;
@@ -318,7 +363,7 @@ export const EnterVerificationCodeStep = ({
       }
 
       try {
-        await createEnterpriseConnection(provider);
+        await createEnterpriseConnection(provider, emailToVerify);
       } catch (err) {
         handleError(err as Error, [], card.setError);
         return;
@@ -328,10 +373,12 @@ export const EnterVerificationCodeStep = ({
     },
   });
 
+  // Send a code on mount, but only when the target address is not already verified
   useEffect(() => {
     if (emailToVerify && !isVerified) {
       void prepare();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!emailToVerify) {
@@ -374,7 +421,7 @@ export const EnterVerificationCodeStep = ({
       <Step.Footer>
         <Step.Footer.Previous
           onClick={() => goPrev()}
-          isDisabled={isFirstStep}
+          isDisabled={!!primaryEmailAddress}
         />
         <Step.Footer.Continue
           onClick={() => goNext()}

--- a/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
@@ -28,6 +28,7 @@ export const VerifyDomainStep = (): JSX.Element => {
   const { session } = useSession();
   const { enterpriseConnection } = useConfigureSSO();
   const { t } = useLocalizations();
+  const { goNext: outerGoNext } = useWizard();
 
   const emailToVerify =
     user?.primaryEmailAddress ?? user?.emailAddresses?.find(e => e.verification.status !== 'verified');
@@ -39,6 +40,8 @@ export const VerifyDomainStep = (): JSX.Element => {
   const isDomainTakenByOtherOrg = Boolean(
     isVerified && enterpriseConnection && enterpriseConnection.organizationId !== activeOrganizationId,
   );
+
+  const wasVerifiedOnMountRef = useRef(isVerified);
 
   if (isDomainTakenByOtherOrg) {
     const conflictingDomain = enterpriseConnection?.domains[0] as string;
@@ -78,6 +81,36 @@ export const VerifyDomainStep = (): JSX.Element => {
               />
             </Col>
           </Col>
+        </Step>
+      </Flow.Part>
+    );
+  }
+
+  if (wasVerifiedOnMountRef.current && emailToVerify?.emailAddress) {
+    return (
+      <Flow.Part part='verifyDomain'>
+        <Step
+          elementDescriptor={descriptors.configureSSOStep}
+          elementId={descriptors.configureSSOStep.setId('verify-domain')}
+        >
+          <Step.Header
+            title={t(localizationKeys('configureSSO.verifyEmailDomainStep.title'))}
+            description={t(localizationKeys('configureSSO.verifyEmailDomainStep.subtitle'))}
+          />
+
+          <Step.Body>
+            <Step.Section
+              sx={{ flex: 1 }}
+              align='center'
+              justify='center'
+            >
+              <EmailAlreadyVerified emailAddress={emailToVerify.emailAddress} />
+            </Step.Section>
+          </Step.Body>
+
+          <Step.Footer>
+            <Step.Footer.Continue onClick={() => outerGoNext()} />
+          </Step.Footer>
         </Step>
       </Flow.Part>
     );
@@ -242,12 +275,10 @@ export const EnterVerificationCodeStep = ({
   const { user } = useUser();
   const { provider, createEnterpriseConnection } = useConfigureSSO();
   const card = useCardState();
-  const codeSubmittedRef = useRef(false);
   const { goNext, goPrev, isFirstStep } = useWizard();
 
   const isVerified = emailToVerify?.verification.status === 'verified';
   const isPrimary = emailToVerify?.id === user?.primaryEmailAddressId;
-  const hasVerifiedEmail = emailToVerify?.emailAddress && isVerified && !codeSubmittedRef.current;
 
   const prepareEmailVerification = useReverification(() =>
     emailToVerify?.prepareVerification({ strategy: 'email_code' }),
@@ -264,7 +295,6 @@ export const EnterVerificationCodeStep = ({
 
   const otp = useFieldOTP({
     onCodeEntryFinished: (code, resolve, reject) => {
-      codeSubmittedRef.current = true;
       attemptEmailVerification(code)
         .then(() => resolve())
         .catch(reject);
@@ -315,34 +345,30 @@ export const EnterVerificationCodeStep = ({
         align='center'
         justify='center'
       >
-        {hasVerifiedEmail ? (
-          <EmailAlreadyVerified emailAddress={emailToVerify.emailAddress} />
-        ) : (
-          <Col
-            gap={4}
-            sx={{ textAlign: 'center' }}
-          >
-            <Col gap={1}>
-              <Heading
-                textVariant='h1'
-                sx={t => ({ fontSize: t.fontSizes.$sm })}
-                localizationKey={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.formTitle')}
-              />
-              <Text
-                as='p'
-                variant='body'
-                colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.formSubtitle', {
-                  identifier: emailToVerify.emailAddress,
-                })}
-              />
-            </Col>
-            <Form.OTPInput
-              {...otp}
-              resendButton={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.resendButton')}
+        <Col
+          gap={4}
+          sx={{ textAlign: 'center' }}
+        >
+          <Col gap={1}>
+            <Heading
+              textVariant='h1'
+              sx={t => ({ fontSize: t.fontSizes.$sm })}
+              localizationKey={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.formTitle')}
+            />
+            <Text
+              as='p'
+              variant='body'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.formSubtitle', {
+                identifier: emailToVerify.emailAddress,
+              })}
             />
           </Col>
-        )}
+          <Form.OTPInput
+            {...otp}
+            resendButton={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.resendButton')}
+          />
+        </Col>
       </Step.Section>
 
       <Step.Footer>
@@ -377,8 +403,8 @@ const EmailAlreadyVerified = ({ emailAddress }: { emailAddress: string }): JSX.E
         })}
       />
       <Col
-        gap={1}
-        sx={t => ({ textAlign: 'center', maxWidth: t.sizes.$94 })}
+        gap={2}
+        sx={t => ({ textAlign: 'center', maxWidth: t.sizes.$66 })}
       >
         <Heading
           textVariant='h1'
@@ -386,7 +412,7 @@ const EmailAlreadyVerified = ({ emailAddress }: { emailAddress: string }): JSX.E
           localizationKey={localizationKeys('configureSSO.verifyEmailDomainStep.emailCode.verified.title')}
         />
         <Col
-          gap={1}
+          gap={3}
           sx={{ flex: 1 }}
         >
           <Text

--- a/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/VerifyDomainStep.tsx
@@ -1,4 +1,4 @@
-import { __internal_useUserEnterpriseConnections, useReverification, useSession, useUser } from '@clerk/shared/react';
+import { useReverification, useSession, useUser } from '@clerk/shared/react';
 import type { EmailAddressResource } from '@clerk/shared/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -22,7 +22,6 @@ import { handleError } from '@/utils/errorHandler';
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard, Wizard } from '../elements/Wizard';
-import type { ProviderType } from '../types';
 
 export const VerifyDomainStep = (): JSX.Element => {
   const { user } = useUser();
@@ -241,9 +240,7 @@ export const EnterVerificationCodeStep = ({
   emailToVerify?: EmailAddressResource;
 }): JSX.Element | null => {
   const { user } = useUser();
-  const { session } = useSession();
-  const { provider, enterpriseConnection } = useConfigureSSO();
-  const { createEnterpriseConnection } = __internal_useUserEnterpriseConnections();
+  const { provider, createEnterpriseConnection } = useConfigureSSO();
   const card = useCardState();
   const codeSubmittedRef = useRef(false);
   const { goNext, goPrev, isFirstStep } = useWizard();
@@ -259,28 +256,7 @@ export const EnterVerificationCodeStep = ({
   const setPrimaryEmailAddress = useReverification((emailAddressId: string) =>
     user?.update({ primaryEmailAddressId: emailAddressId }),
   );
-  const createConnection = useReverification(
-    useCallback(
-      async (selectedProvider: ProviderType) => {
-        if (enterpriseConnection) {
-          return;
-        }
-        if (!user?.primaryEmailAddress) {
-          throw new Error('Primary email required');
-        }
 
-        const emailDomain = user.primaryEmailAddress.emailAddress.split('@')[1];
-        const organizationId = session?.lastActiveOrganizationId ?? null;
-
-        await createEnterpriseConnection({
-          provider: selectedProvider,
-          name: emailDomain,
-          organizationId,
-        });
-      },
-      [enterpriseConnection, user, session, createEnterpriseConnection],
-    ),
-  );
   const prepare = useCallback(
     () => prepareEmailVerification()?.catch(err => handleError(err, [], card.setError)),
     [prepareEmailVerification, card],
@@ -312,7 +288,7 @@ export const EnterVerificationCodeStep = ({
       }
 
       try {
-        await createConnection(provider);
+        await createEnterpriseConnection(provider);
       } catch (err) {
         handleError(err as Error, [], card.setError);
         return;
@@ -376,8 +352,8 @@ export const EnterVerificationCodeStep = ({
         />
         <Step.Footer.Continue
           onClick={() => goNext()}
-          isLoading={otp.isLoading}
-          isDisabled={!isVerified}
+          isLoading={otp.isLoading || card.isLoading}
+          isDisabled={!isVerified || !!card.error}
         />
       </Step.Footer>
     </>

--- a/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
@@ -40,17 +40,26 @@ vi.mock('../../ConfigureSSOContext', () => ({
   }),
 }));
 
+const userMockState = vi.hoisted(() => ({
+  current: {
+    primaryEmailAddress: {
+      emailAddress: 'test@clerk.com',
+      verification: { status: 'verified' as 'verified' | 'unverified' },
+    },
+  } as {
+    primaryEmailAddress?: {
+      emailAddress: string;
+      verification: { status: 'verified' | 'unverified' };
+    };
+  } | null,
+}));
+
 vi.mock('@clerk/shared/react/index', async importOriginal => {
   const actual = await importOriginal<typeof import('@clerk/shared/react/index')>();
   return {
     ...actual,
     useUser: () => ({
-      user: {
-        primaryEmailAddress: {
-          emailAddress: 'test@clerk.com',
-          verification: { status: 'verified' },
-        },
-      },
+      user: userMockState.current,
       isLoaded: true,
       isSignedIn: true,
     }),
@@ -75,6 +84,12 @@ const resetMocks = () => {
   setProvider.mockReset();
   createEnterpriseConnection.mockReset();
   createEnterpriseConnection.mockResolvedValue(undefined);
+  userMockState.current = {
+    primaryEmailAddress: {
+      emailAddress: 'test@clerk.com',
+      verification: { status: 'verified' },
+    },
+  };
 };
 
 describe('SelectProviderStep', () => {
@@ -179,7 +194,7 @@ describe('SelectProviderStep', () => {
     });
 
     expect(setProvider).toHaveBeenCalledWith('saml_okta');
-    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta');
+    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta', userMockState.current?.primaryEmailAddress);
     expect(callOrder).toEqual(['setProvider', 'createEnterpriseConnection', 'goToStep']);
   });
 
@@ -196,7 +211,7 @@ describe('SelectProviderStep', () => {
     });
 
     expect(setProvider).toHaveBeenCalledWith('saml_custom');
-    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_custom');
+    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_custom', userMockState.current?.primaryEmailAddress);
   });
 
   it('does not advance when failing to create enterprise connection', async () => {
@@ -214,7 +229,7 @@ describe('SelectProviderStep', () => {
     await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta');
+      expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta', userMockState.current?.primaryEmailAddress);
     });
 
     expect(goToStep).not.toHaveBeenCalled();
@@ -226,5 +241,46 @@ describe('SelectProviderStep', () => {
     renderStep(wrapper);
 
     expect(screen.getByRole('button', { name: /Previous/i })).toBeDisabled();
+  });
+
+  it('routes to verify-domain when the user has no primary email address', async () => {
+    resetMocks();
+    userMockState.current = {};
+
+    const { wrapper } = await createFixtures();
+    const { userEvent } = renderStep(wrapper);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Okta Workforce' }));
+    await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+    await waitFor(() => {
+      expect(goToStep).toHaveBeenCalledWith('verify-domain');
+    });
+
+    expect(setProvider).toHaveBeenCalledWith('saml_okta');
+    expect(createEnterpriseConnection).not.toHaveBeenCalled();
+  });
+
+  it('routes to verify-domain when the user has an unverified primary email address', async () => {
+    resetMocks();
+    userMockState.current = {
+      primaryEmailAddress: {
+        emailAddress: 'test@clerk.com',
+        verification: { status: 'unverified' },
+      },
+    };
+
+    const { wrapper } = await createFixtures();
+    const { userEvent } = renderStep(wrapper);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Okta Workforce' }));
+    await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+    await waitFor(() => {
+      expect(goToStep).toHaveBeenCalledWith('verify-domain');
+    });
+
+    expect(setProvider).toHaveBeenCalledWith('saml_okta');
+    expect(createEnterpriseConnection).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
@@ -1,3 +1,4 @@
+import { ClerkRuntimeError } from '@clerk/shared/error';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -7,6 +8,7 @@ import { CardStateProvider } from '@/ui/elements/contexts';
 
 const goNext = vi.fn();
 const goPrev = vi.fn();
+const goToStep = vi.fn();
 
 vi.mock('../../elements/Wizard', () => ({
   useWizard: () => ({
@@ -19,22 +21,41 @@ vi.mock('../../elements/Wizard', () => ({
     isNested: false,
     goNext,
     goPrev,
-    goToStep: vi.fn(),
+    goToStep,
     registerStep: vi.fn(),
     unregisterStep: vi.fn(),
   }),
 }));
 
 const setProvider = vi.fn();
+const createEnterpriseConnection = vi.fn();
 
 vi.mock('../../ConfigureSSOContext', () => ({
   useConfigureSSO: () => ({
     enterpriseConnection: undefined,
     provider: undefined,
     setProvider,
+    createEnterpriseConnection,
     initialStepId: 'select-provider',
   }),
 }));
+
+vi.mock('@clerk/shared/react/index', async importOriginal => {
+  const actual = await importOriginal<typeof import('@clerk/shared/react/index')>();
+  return {
+    ...actual,
+    useUser: () => ({
+      user: {
+        primaryEmailAddress: {
+          emailAddress: 'test@clerk.com',
+          verification: { status: 'verified' },
+        },
+      },
+      isLoaded: true,
+      isSignedIn: true,
+    }),
+  };
+});
 
 import { SelectProviderStep } from '../SelectProviderStep';
 
@@ -50,7 +71,10 @@ const renderStep = (
 const resetMocks = () => {
   goNext.mockReset();
   goPrev.mockReset();
+  goToStep.mockReset();
   setProvider.mockReset();
+  createEnterpriseConnection.mockReset();
+  createEnterpriseConnection.mockResolvedValue(undefined);
 };
 
 describe('SelectProviderStep', () => {
@@ -137,8 +161,11 @@ describe('SelectProviderStep', () => {
     setProvider.mockImplementation(() => {
       callOrder.push('setProvider');
     });
-    goNext.mockImplementation(() => {
-      callOrder.push('goNext');
+    createEnterpriseConnection.mockImplementation(async () => {
+      callOrder.push('createEnterpriseConnection');
+    });
+    goToStep.mockImplementation(() => {
+      callOrder.push('goToStep');
     });
 
     const { wrapper } = await createFixtures();
@@ -148,11 +175,12 @@ describe('SelectProviderStep', () => {
     await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(goNext).toHaveBeenCalledTimes(1);
+      expect(goToStep).toHaveBeenCalledWith('configure');
     });
 
     expect(setProvider).toHaveBeenCalledWith('saml_okta');
-    expect(callOrder).toEqual(['setProvider', 'goNext']);
+    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta');
+    expect(callOrder).toEqual(['setProvider', 'createEnterpriseConnection', 'goToStep']);
   });
 
   it('forwards the Custom SAML backend provider id when selected', async () => {
@@ -164,10 +192,32 @@ describe('SelectProviderStep', () => {
     await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(goNext).toHaveBeenCalledTimes(1);
+      expect(goToStep).toHaveBeenCalledWith('configure');
     });
 
     expect(setProvider).toHaveBeenCalledWith('saml_custom');
+    expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_custom');
+  });
+
+  it('does not advance when failing to create enterprise connection', async () => {
+    resetMocks();
+    createEnterpriseConnection.mockRejectedValue(
+      new ClerkRuntimeError('failed to create enterprise connection', {
+        code: 'enterprise_connection_creation_failed',
+      }),
+    );
+
+    const { wrapper } = await createFixtures();
+    const { userEvent } = renderStep(wrapper);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Okta Workforce' }));
+    await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+    await waitFor(() => {
+      expect(createEnterpriseConnection).toHaveBeenCalledWith('saml_okta');
+    });
+
+    expect(goToStep).not.toHaveBeenCalled();
   });
 
   it('disables Previous on the first step', async () => {

--- a/packages/ui/src/components/ConfigureSSO/steps/configureStepTranslations.ts
+++ b/packages/ui/src/components/ConfigureSSO/steps/configureStepTranslations.ts
@@ -3,11 +3,6 @@ import type { __internal_LocalizationResource } from '@clerk/shared/types';
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import type { ProviderType } from '../types';
 
-/**
- * Camel-cased keys under `configureSSO.configureStep` that hold provider-specific
- * translations (e.g. `samlOkta`, `samlCustom`). Derived from the localization
- * resource so adding a new provider namespace updates this automatically.
- */
 type ConfigureStepProviderKey = Extract<
   keyof __internal_LocalizationResource['configureSSO']['configureStep'],
   `saml${string}`
@@ -15,46 +10,24 @@ type ConfigureStepProviderKey = Extract<
 
 export type TranslationKeyPrefix = `configureSSO.configureStep.${ConfigureStepProviderKey}`;
 
-/**
- * Maps each {@link ProviderType} to the matching localization namespace under
- * `configureSSO.configureStep`. Typed via `satisfies` so the values are validated
- * against the localization resource shape while keeping literal types — that way
- * `` `${PROVIDER_TRANSLATION_KEY_PREFIX[provider]}.headerTitle` `` is still a
- * valid `DefaultLocalizationKey` at the call site.
- */
 export const PROVIDER_TRANSLATION_KEY_PREFIX = {
   saml_okta: 'configureSSO.configureStep.samlOkta',
   saml_custom: 'configureSSO.configureStep.samlCustom',
 } as const satisfies Record<ProviderType, TranslationKeyPrefix>;
 
-/**
- * Builds a fully-qualified localization key under the active provider's
- * `configureSSO.configureStep` namespace. The return type is a literal template
- * string (e.g. `configureSSO.configureStep.samlOkta.createApp.headerTitle`) so
- * it remains a valid `DefaultLocalizationKey` accepted by `localizationKeys()`.
- */
 export function getConfigureStepKey<P extends ProviderType, S extends string>(
   provider: P,
   suffix: S,
 ): `${(typeof PROVIDER_TRANSLATION_KEY_PREFIX)[P]}.${S}` {
-  return `${PROVIDER_TRANSLATION_KEY_PREFIX[provider]}.${suffix}` as `${(typeof PROVIDER_TRANSLATION_KEY_PREFIX)[P]}.${S}`;
+  return `${PROVIDER_TRANSLATION_KEY_PREFIX[provider]}.${suffix}`;
 }
 
-/**
- * Hook for the `ConfigureStep` wizard. Reads the active provider from
- * `ConfigureSSOContext` and returns:
- *
- * - `provider`: the currently selected provider (use it for conditional rendering).
- * - `key(suffix)`: builds a provider-scoped localization key for the configure step.
- *
- * Throws when called without a selected provider — `ConfigureStep` should only
- * be rendered after a provider has been chosen.
- */
 export function useConfigureStepTranslations() {
   const { provider } = useConfigureSSO();
   if (!provider) {
     throw new Error('useConfigureStepTranslations called without a selected provider.');
   }
+
   return {
     provider,
     key: <S extends string>(suffix: S) => getConfigureStepKey(provider, suffix),

--- a/packages/ui/src/components/ConfigureSSO/steps/configureStepTranslations.ts
+++ b/packages/ui/src/components/ConfigureSSO/steps/configureStepTranslations.ts
@@ -1,0 +1,62 @@
+import type { __internal_LocalizationResource } from '@clerk/shared/types';
+
+import { useConfigureSSO } from '../ConfigureSSOContext';
+import type { ProviderType } from '../types';
+
+/**
+ * Camel-cased keys under `configureSSO.configureStep` that hold provider-specific
+ * translations (e.g. `samlOkta`, `samlCustom`). Derived from the localization
+ * resource so adding a new provider namespace updates this automatically.
+ */
+type ConfigureStepProviderKey = Extract<
+  keyof __internal_LocalizationResource['configureSSO']['configureStep'],
+  `saml${string}`
+>;
+
+export type TranslationKeyPrefix = `configureSSO.configureStep.${ConfigureStepProviderKey}`;
+
+/**
+ * Maps each {@link ProviderType} to the matching localization namespace under
+ * `configureSSO.configureStep`. Typed via `satisfies` so the values are validated
+ * against the localization resource shape while keeping literal types — that way
+ * `` `${PROVIDER_TRANSLATION_KEY_PREFIX[provider]}.headerTitle` `` is still a
+ * valid `DefaultLocalizationKey` at the call site.
+ */
+export const PROVIDER_TRANSLATION_KEY_PREFIX = {
+  saml_okta: 'configureSSO.configureStep.samlOkta',
+  saml_custom: 'configureSSO.configureStep.samlCustom',
+} as const satisfies Record<ProviderType, TranslationKeyPrefix>;
+
+/**
+ * Builds a fully-qualified localization key under the active provider's
+ * `configureSSO.configureStep` namespace. The return type is a literal template
+ * string (e.g. `configureSSO.configureStep.samlOkta.createApp.headerTitle`) so
+ * it remains a valid `DefaultLocalizationKey` accepted by `localizationKeys()`.
+ */
+export function getConfigureStepKey<P extends ProviderType, S extends string>(
+  provider: P,
+  suffix: S,
+): `${(typeof PROVIDER_TRANSLATION_KEY_PREFIX)[P]}.${S}` {
+  return `${PROVIDER_TRANSLATION_KEY_PREFIX[provider]}.${suffix}` as `${(typeof PROVIDER_TRANSLATION_KEY_PREFIX)[P]}.${S}`;
+}
+
+/**
+ * Hook for the `ConfigureStep` wizard. Reads the active provider from
+ * `ConfigureSSOContext` and returns:
+ *
+ * - `provider`: the currently selected provider (use it for conditional rendering).
+ * - `key(suffix)`: builds a provider-scoped localization key for the configure step.
+ *
+ * Throws when called without a selected provider — `ConfigureStep` should only
+ * be rendered after a provider has been chosen.
+ */
+export function useConfigureStepTranslations() {
+  const { provider } = useConfigureSSO();
+  if (!provider) {
+    throw new Error('useConfigureStepTranslations called without a selected provider.');
+  }
+  return {
+    provider,
+    key: <S extends string>(suffix: S) => getConfigureStepKey(provider, suffix),
+  } as const;
+}


### PR DESCRIPTION
## Description

- Introduces different header subtitles per provider
- Introduces localization support for custom SAML provider within configure steps
- Update select provider step logic to go to add/verify email verification according to the user data 

Also: 

- Fixes initial step resolution based on existing testing runs, enterprise connection status, etc 
- Fixes navigation and validation between steps
- Fixes initial state of verified domain step 

#### With Custom SAML 


https://github.com/user-attachments/assets/de39f0ea-1797-411d-ae31-c7f5424e47a1



#### With Okta 




https://github.com/user-attachments/assets/44d67dde-9c2f-4d30-ace6-591a94ceee6a





<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
