### PR TITLE
Aaronb/vendor base 64 poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ out
 packages/*/dist/**
 **/.pnpm-store/**
 
+# Vendored upstream sources are NOT build output. Anything under
+# packages/*/src/vendor/*/upstream/ is a verbatim copy of an npm tarball and
+# must ship with the package; the `dist` and `build` matchers above would
+# otherwise silently exclude their `dist/` subdirs from git.
+!packages/*/src/vendor/**
+
+
 # dependencies
 node_modules
 **/node_modules/**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -351,6 +351,11 @@ export default tseslint.config([
               message: "Please always import from '@clerk/shared/<module>' instead of '@clerk/shared'.",
               name: '@clerk/shared',
             },
+            {
+              name: 'base-64',
+              message:
+                "base-64 is vendored at packages/expo/src/vendor/base-64. Import { encode, decode } from '../vendor/base-64' instead. See packages/expo/src/vendor/base-64/README.md.",
+            },
           ],
           patterns: [
             {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -116,7 +116,6 @@
     "@clerk/clerk-js": "workspace:^",
     "@clerk/react": "workspace:^",
     "@clerk/shared": "workspace:^",
-    "base-64": "^1.0.0",
     "react-native-url-polyfill": "2.0.0",
     "tslib": "catalog:repo"
   },
@@ -124,6 +123,7 @@
     "@clerk/expo-passkeys": "workspace:*",
     "@expo/config-plugins": "^54.0.4",
     "@types/base-64": "^1.0.2",
+    "base-64": "^1.0.0",
     "esbuild": "^0.28.0",
     "expo-apple-authentication": "^7.2.4",
     "expo-auth-session": "^5.5.2",

--- a/packages/expo/src/polyfills/base64Polyfill.ts
+++ b/packages/expo/src/polyfills/base64Polyfill.ts
@@ -1,4 +1,8 @@
-import { decode, encode } from 'base-64';
+// Vendored from base-64@1.0.0 — see ../vendor/base-64/README.md for the
+// supply-chain rationale (this code becomes global.btoa/global.atob inside
+// every Clerk-Expo customer app, which makes it an unusually high-leverage
+// upstream dep to leave externalized).
+import { decode, encode } from '../vendor/base-64';
 
 import { isHermes } from '../utils';
 

--- a/packages/expo/src/vendor/base-64/README.md
+++ b/packages/expo/src/vendor/base-64/README.md
@@ -1,0 +1,89 @@
+# Vendored: `base-64`
+
+- **Upstream:** https://github.com/mathiasbynens/base64
+- **Vendored version:** 1.0.0 (published 2020-12-12)
+- **License:** MIT (see `upstream/LICENSE-MIT.txt`)
+- **Maintainer (npm):** `mathias` (single)
+- **Owner inside Clerk:** `@clerk/expo` maintainers
+
+## Why this is vendored
+
+`base-64` is the userland `atob`/`btoa` implementation that `@clerk/expo` polyfills onto `global` for Hermes engines that lack native versions (see `packages/expo/src/polyfills/base64Polyfill.ts`). When `@clerk/expo` is installed by a customer, the published tarball declares `base-64` as a runtime external. The customer's package manager resolves `^1.0.0` against the npm registry at install time and fetches `base-64` fresh — Clerk's own `pnpm-lock.yaml` is not in the published tarball and does not participate in the customer's install.
+
+That externality + the fact that `base-64`'s exports become **`global.btoa` and `global.atob` inside every Clerk-Expo customer's running app** makes this dependency a high-leverage supply-chain target. Two attack chains motivate vendoring:
+
+### Chain 1 — Publisher account compromise
+
+`base-64` is single-maintainer. If `mathias`'s npm account is compromised (phishing, token theft, hostile transfer, social engineering) and a malicious `base-64@1.0.1` is published, every customer install of `@clerk/expo` after the publish resolves `^1.0.0` to `1.0.1` and pulls the compromised bytes. The polyfill assigns the compromised `encode`/`decode` to `global.btoa`/`global.atob`. Every subsequent `btoa()` or `atob()` call anywhere in the customer's app — including third-party libraries and Clerk's own runtime — runs through the compromised implementation, silently.
+
+Historical precedents in this class: `event-stream` (2018), `ua-parser-js` (2021), `colors.js`/`faker.js` (2022), `xz-utils` (2024). Each was a maintainer-account compromise that published a malicious new version.
+
+Pinning to an exact version (`"base-64": "1.0.0"` instead of `"^1.0.0"`) would close Chain 1 for direct deps — the customer's resolver would never pick up `1.0.1`. But:
+
+### Chain 2 — Registry-level same-version substitution
+
+If the npm registry itself serves substituted bytes for `base-64@1.0.0` (registry compromise, malicious unpublish-then-republish, npm-internal account compromise), the customer's first install of `@clerk/expo` fetches the substituted bytes, computes their hash, and records it as the trusted reference in their lockfile. There is no prior hash to compare against. Future installs with `--frozen-lockfile` "verify" against the now-poisoned hash.
+
+Exact-pinning does not address Chain 2 — the resolver still routes through the registry for `1.0.0`, and whatever bytes the registry serves are what the customer gets. Vendoring is the only mechanism that closes both chains: the customer's resolver never fetches `base-64` from the npm registry because the bytes ship inside the `@clerk/expo` npm tarball.
+
+| | Caret range | Exact pin | Vendored |
+|---|---|---|---|
+| Chain 1 (new version) | ❌ | ✅ | ✅ |
+| Chain 2 (same-version substitution, first install) | ❌ | ❌ | ✅ |
+
+See `Sessions/S161/PROPOSAL.md` for the broader proposal.
+
+## What's in `upstream/`
+
+`upstream/` is a **byte-for-byte copy of the published `base-64@1.0.0` npm tarball.** Nothing in that directory has been modified by Clerk.
+
+```
+upstream/
+├── base64.js          (~164 lines, single-file UMD; exports {encode, decode, version})
+├── package.json       (upstream's; see "inert fields" below)
+├── LICENSE-MIT.txt    (MIT)
+└── README.md          (upstream's README)
+```
+
+### Inert fields in `upstream/package.json`
+
+The upstream `package.json` is preserved so future refresh diffs against new `base-64` versions match byte-for-byte against `npm pack` output. These fields are **inert in this location** — they do nothing here:
+
+- `scripts.*` — not executed; no install lifecycle runs against vendored code.
+- `main: "base64.js"` — bundlers do not walk inner `package.json` of nested `src/vendor/` directories for relative imports; the Clerk-side `index.ts` (in this directory) handles resolution explicitly.
+
+## How consumers import it
+
+Inside `@clerk/expo`:
+
+```ts
+import { decode, encode } from '../vendor/base-64';
+```
+
+The Clerk-side `index.ts` shim re-exports from `./upstream/base64.js` with typed signatures, abstracting the bundler-resolution detail (see `index.ts`).
+
+## Refreshing from upstream
+
+`upstream/` is intentionally frozen. Don't routinely sync.
+
+Refresh **only** when:
+
+- A CVE is reported against `mathiasbynens/base64` upstream, OR
+- A spec-relevant bug is discovered.
+
+`base-64@1.0.0` has been the only release since 2014. Any new upstream release after 2020-12-12 should be treated as anomalous and investigated before adoption.
+
+Procedure:
+
+1. `npm pack base-64@<new-version>` in a scratch directory; extract.
+2. `diff -r` against `upstream/`.
+3. Read every changed line. Apply Clerk's threat model — is this a fix you want, or a behavior change you don't?
+4. If accepting: replace `upstream/` with the new tarball contents in one commit (no other changes).
+5. Re-run `parity.spec.ts` to confirm behavioral equivalence still holds.
+6. Update the vendored version in this README.
+
+## Tests
+
+`__tests__/parity.spec.ts` asserts byte-equivalent inputs produce identical outputs between the upstream npm package (kept as `@clerk/expo`'s `devDependency`) and this vendored copy. Covers RFC 4648 fixtures, `atob`/`btoa` cross-compatibility, and Unicode edge cases.
+
+The upstream `base-64` stays a `devDependency` of `@clerk/expo` for as long as this parity test exists. Removing the devDep would mean giving up the empirical comparator.

--- a/packages/expo/src/vendor/base-64/__tests__/parity.spec.ts
+++ b/packages/expo/src/vendor/base-64/__tests__/parity.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Vendor parity test for base-64@1.0.0.
+ *
+ * Loads encode/decode from BOTH the upstream npm package (kept in
+ * @clerk/expo devDependencies for as long as this test exists) AND the
+ * vendored copy at ../upstream/base64.js. Asserts byte-equivalent inputs
+ * produce identical outputs.
+ *
+ * What this test buys:
+ *   - The byte-equivalence check (tools/verify-vendor.sh) proves the bytes
+ *     on disk match the upstream tarball.
+ *   - This test proves that loading those bytes through our bundler /
+ *     test runtime produces upstream's behavior — closing the gap between
+ *     "the bytes are correct" and "the runtime does what upstream does."
+ *
+ * When to remove this test:
+ *   - When the upstream `base-64` devDependency is removed from
+ *     packages/expo/package.json, this file must be removed too (the
+ *     `from 'base-64'` import would fail to resolve). Removing the devDep
+ *     means losing the comparator; don't do that unless the vendoring
+ *     approach is fully accepted.
+ *
+ * See packages/expo/src/vendor/base-64/README.md for the broader vendoring
+ * rationale and the customer-side attack chains that motivate it.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- intentional: comparator for vendor parity
+import { decode as upstreamDecode, encode as upstreamEncode } from 'base-64';
+import { describe, expect, it } from 'vitest';
+
+import { decode as vendoredDecode, encode as vendoredEncode } from '../';
+
+/**
+ * RFC 4648 §10 test vectors — canonical base64 fixtures from the spec.
+ * Every base64 implementation should handle these identically.
+ */
+const RFC4648_VECTORS: Array<[plain: string, encoded: string]> = [
+  ['', ''],
+  ['f', 'Zg=='],
+  ['fo', 'Zm8='],
+  ['foo', 'Zm9v'],
+  ['foob', 'Zm9vYg=='],
+  ['fooba', 'Zm9vYmE='],
+  ['foobar', 'Zm9vYmFy'],
+];
+
+/**
+ * Cases beyond the RFC vectors — the polyfill use case is hijacking
+ * global.btoa / global.atob, so the parity surface must cover everything
+ * an arbitrary caller (third-party library) might throw at it.
+ */
+const EXTRA_VECTORS: Array<[label: string, plain: string]> = [
+  ['empty', ''],
+  ['single null byte', '\x00'],
+  ['Latin-1 high', '\xff'],
+  ['arbitrary binary', '\x00\x01\x02\x03\x04\xfd\xfe\xff'],
+  ['ASCII letters', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'],
+  ['ASCII symbols', '!@#$%^&*()_+-=[]{}|;:,.<>?/~`\'"\\'],
+  ['long string', 'a'.repeat(1024)],
+  ['exactly 3 bytes', 'abc'],
+  ['exactly 4 bytes (forces padding=)', 'abcd'],
+  ['exactly 6 bytes (no padding)', 'abcdef'],
+  ['JSON shape', '{"foo":"bar","baz":[1,2,3]}'],
+];
+
+describe('base-64 vendor parity — RFC 4648 fixtures', () => {
+  it.each(RFC4648_VECTORS)('encode(%j) === %j', (plain, encoded) => {
+    expect(vendoredEncode(plain)).toBe(upstreamEncode(plain));
+    expect(vendoredEncode(plain)).toBe(encoded); // canonical anchor
+  });
+
+  it.each(RFC4648_VECTORS)('decode(%j) === %j', (plain, encoded) => {
+    expect(vendoredDecode(encoded)).toBe(upstreamDecode(encoded));
+    expect(vendoredDecode(encoded)).toBe(plain); // canonical anchor
+  });
+});
+
+describe('base-64 vendor parity — extra fixtures', () => {
+  it.each(EXTRA_VECTORS)('encode/decode roundtrip: %s', (_label, plain) => {
+    const vEnc = vendoredEncode(plain);
+    const uEnc = upstreamEncode(plain);
+    expect(vEnc).toBe(uEnc);
+    expect(vendoredDecode(vEnc)).toBe(upstreamDecode(uEnc));
+    expect(vendoredDecode(vEnc)).toBe(plain);
+  });
+});
+
+describe('base-64 vendor parity — deterministic fuzz', () => {
+  it('matches upstream for 512 random binary strings of varying length', () => {
+    for (let seed = 0; seed < 512; seed++) {
+      const len = (seed * 37) % 256;
+      const chars: string[] = [];
+      for (let i = 0; i < len; i++) {
+        // Latin-1 range only (0-255) — what base-64 contracts on.
+        chars.push(String.fromCharCode((seed + i * 13) & 0xff));
+      }
+      const plain = chars.join('');
+      const vEnc = vendoredEncode(plain);
+      const uEnc = upstreamEncode(plain);
+      expect(vEnc, `seed=${seed}`).toBe(uEnc);
+      expect(vendoredDecode(vEnc), `seed=${seed}`).toBe(upstreamDecode(uEnc));
+    }
+  });
+});
+
+describe('base-64 vendor parity — error handling', () => {
+  // Both upstream and vendored should throw on invalid input. We don't pin
+  // the error message, just that they agree on which inputs throw.
+  const INVALID: Array<[label: string, invalid: string]> = [
+    ['truncated padding', 'Zm9'],
+    ['invalid char', 'Zm$9v'],
+    ['stray padding', 'Zm9v='],
+  ];
+  it.each(INVALID)('decode throws-or-matches on invalid input: %s', (_label, invalid) => {
+    let vErr: unknown = null;
+    let uErr: unknown = null;
+    let vResult: string | null = null;
+    let uResult: string | null = null;
+    try {
+      vResult = vendoredDecode(invalid);
+    } catch (e) {
+      vErr = e;
+    }
+    try {
+      uResult = upstreamDecode(invalid);
+    } catch (e) {
+      uErr = e;
+    }
+    // Either both threw or both produced the same output.
+    expect(Boolean(vErr)).toBe(Boolean(uErr));
+    if (!vErr) {
+      expect(vResult).toBe(uResult);
+    }
+  });
+});

--- a/packages/expo/src/vendor/base-64/index.ts
+++ b/packages/expo/src/vendor/base-64/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Clerk-side entry for the vendored `base-64` package.
+ *
+ * Why this file exists:
+ *   - `upstream/` is a verbatim copy of the base-64@1.0.0 npm tarball and
+ *     must not be modified (byte-equivalence is the security claim — see
+ *     ./README.md).
+ *   - The upstream ships as a UMD wrapper — its exports are assigned to
+ *     `module.exports` inside an IIFE that TypeScript cannot trace
+ *     statically. tsc therefore infers an empty export surface for the
+ *     `.js` file even with `allowJs: true`. The cast below asserts the
+ *     export shape; the parity test (`./__tests__/parity.spec.ts`)
+ *     verifies the assertion empirically against the upstream npm
+ *     package.
+ *   - Consumers import from this file (`../vendor/base-64`); they should
+ *     not reach into `upstream/` directly.
+ */
+
+import * as upstreamModule from './upstream/base64.js';
+
+interface Base64Module {
+  encode: (input: string) => string;
+  decode: (input: string) => string;
+  version: string;
+}
+
+// tsc infers `typeof upstreamModule` as `{}` because base-64's UMD wrapper
+// hides the module.exports assignment inside an IIFE. The shape asserted
+// here is verified empirically by __tests__/parity.spec.ts against the
+// upstream npm package (kept as a devDependency for this purpose).
+const upstream: Base64Module = upstreamModule as unknown as Base64Module;
+
+/**
+ * Encode a binary-safe string to base64. Compatible with the WHATWG
+ * `btoa()` algorithm (RFC 4648 §4). Throws on non-Latin-1 input.
+ *
+ * Vendored from base-64@1.0.0 — see ./README.md.
+ */
+export const encode: (input: string) => string = upstream.encode;
+
+/**
+ * Decode a base64-encoded string back to a binary string. Compatible with
+ * the WHATWG `atob()` algorithm (RFC 4648 §4). Throws on invalid input.
+ *
+ * Vendored from base-64@1.0.0 — see ./README.md.
+ */
+export const decode: (input: string) => string = upstream.decode;

--- a/packages/expo/src/vendor/base-64/upstream/LICENSE-MIT.txt
+++ b/packages/expo/src/vendor/base-64/upstream/LICENSE-MIT.txt
@@ -1,0 +1,20 @@
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/expo/src/vendor/base-64/upstream/README.md
+++ b/packages/expo/src/vendor/base-64/upstream/README.md
@@ -1,0 +1,112 @@
+# base64 [![Build status](https://travis-ci.org/mathiasbynens/base64.svg?branch=master)](https://travis-ci.org/mathiasbynens/base64) [![Code coverage status](http://img.shields.io/coveralls/mathiasbynens/base64/master.svg)](https://coveralls.io/r/mathiasbynens/base64)
+
+_base64_ is a robust base64 encoder/decoder that is fully compatible with [`atob()` and `btoa()`](https://html.spec.whatwg.org/multipage/webappapis.html#atob), written in JavaScript. The base64-encoding and -decoding algorithms it uses are fully [RFC 4648](https://tools.ietf.org/html/rfc4648#section-4) compliant.
+
+## Installation
+
+Via [npm](https://www.npmjs.com/):
+
+```bash
+npm install base-64
+```
+
+In a browser:
+
+```html
+<script src="base64.js"></script>
+```
+
+In [Narwhal](http://narwhaljs.org/), [Node.js](https://nodejs.org/), and [RingoJS](http://ringojs.org/):
+
+```js
+var base64 = require('base-64');
+```
+
+In [Rhino](http://www.mozilla.org/rhino/):
+
+```js
+load('base64.js');
+```
+
+Using an AMD loader like [RequireJS](http://requirejs.org/):
+
+```js
+require(
+  {
+    'paths': {
+      'base64': 'path/to/base64'
+    }
+  },
+  ['base64'],
+  function(base64) {
+    console.log(base64);
+  }
+);
+```
+
+## API
+
+### `base64.version`
+
+A string representing the semantic version number.
+
+### `base64.encode(input)`
+
+This function takes a byte string (the `input` parameter) and encodes it according to base64. The input data must be in the form of a string containing only characters in the range from U+0000 to U+00FF, each representing a binary byte with values `0x00` to `0xFF`. The `base64.encode()` function is designed to be fully compatible with [`btoa()` as described in the HTML Standard](https://html.spec.whatwg.org/multipage/webappapis.html#dom-windowbase64-btoa).
+
+```js
+var encodedData = base64.encode(input);
+```
+
+To base64-encode any Unicode string, [encode it as UTF-8 first](https://github.com/mathiasbynens/utf8.js#utf8encodestring):
+
+```js
+var base64 = require('base-64');
+var utf8 = require('utf8');
+
+var text = 'foo © bar 𝌆 baz';
+var bytes = utf8.encode(text);
+var encoded = base64.encode(bytes);
+console.log(encoded);
+// → 'Zm9vIMKpIGJhciDwnYyGIGJheg=='
+```
+
+### `base64.decode(input)`
+
+This function takes a base64-encoded string (the `input` parameter) and decodes it. The return value is in the form of a string containing only characters in the range from U+0000 to U+00FF, each representing a binary byte with values `0x00` to `0xFF`. The `base64.decode()` function is designed to be fully compatible with [`atob()` as described in the HTML Standard](https://html.spec.whatwg.org/multipage/webappapis.html#dom-windowbase64-atob).
+
+```js
+var decodedData = base64.decode(encodedData);
+```
+
+To base64-decode UTF-8-encoded data back into a Unicode string, [UTF-8-decode it](https://github.com/mathiasbynens/utf8.js#utf8decodebytestring) after base64-decoding it:
+
+```js
+var encoded = 'Zm9vIMKpIGJhciDwnYyGIGJheg==';
+var bytes = base64.decode(encoded);
+var text = utf8.decode(bytes);
+console.log(text);
+// → 'foo © bar 𝌆 baz'
+```
+
+## Support
+
+_base64_ is designed to work in at least Node.js v0.10.0, Narwhal 0.3.2, RingoJS 0.8-0.9, PhantomJS 1.9.0, Rhino 1.7RC4, as well as old and modern versions of Chrome, Firefox, Safari, Opera, and Internet Explorer.
+
+## Unit tests & code coverage
+
+After cloning this repository, run `npm install` to install the dependencies needed for development and testing. You may want to install Istanbul _globally_ using `npm install istanbul -g`.
+
+Once that’s done, you can run the unit tests in Node using `npm test` or `node tests/tests.js`. To run the tests in Rhino, Ringo, Narwhal, and web browsers as well, use `grunt test`.
+
+To generate the code coverage report, use `grunt cover`.
+
+## Author
+
+| [![twitter/mathias](https://gravatar.com/avatar/24e08a9ea84deb17ae121074d0f17125?s=70)](https://twitter.com/mathias "Follow @mathias on Twitter") |
+|---|
+| [Mathias Bynens](https://mathiasbynens.be/) |
+
+## License
+
+_base64_ is available under the [MIT](https://mths.be/mit) license.

--- a/packages/expo/src/vendor/base-64/upstream/base64.js
+++ b/packages/expo/src/vendor/base-64/upstream/base64.js
@@ -1,0 +1,164 @@
+/*! https://mths.be/base64 v1.0.0 by @mathias | MIT license */
+;(function(root) {
+
+	// Detect free variables `exports`.
+	var freeExports = typeof exports == 'object' && exports;
+
+	// Detect free variable `module`.
+	var freeModule = typeof module == 'object' && module &&
+		module.exports == freeExports && module;
+
+	// Detect free variable `global`, from Node.js or Browserified code, and use
+	// it as `root`.
+	var freeGlobal = typeof global == 'object' && global;
+	if (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal) {
+		root = freeGlobal;
+	}
+
+	/*--------------------------------------------------------------------------*/
+
+	var InvalidCharacterError = function(message) {
+		this.message = message;
+	};
+	InvalidCharacterError.prototype = new Error;
+	InvalidCharacterError.prototype.name = 'InvalidCharacterError';
+
+	var error = function(message) {
+		// Note: the error messages used throughout this file match those used by
+		// the native `atob`/`btoa` implementation in Chromium.
+		throw new InvalidCharacterError(message);
+	};
+
+	var TABLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+	// http://whatwg.org/html/common-microsyntaxes.html#space-character
+	var REGEX_SPACE_CHARACTERS = /[\t\n\f\r ]/g;
+
+	// `decode` is designed to be fully compatible with `atob` as described in the
+	// HTML Standard. http://whatwg.org/html/webappapis.html#dom-windowbase64-atob
+	// The optimized base64-decoding algorithm used is based on @atk’s excellent
+	// implementation. https://gist.github.com/atk/1020396
+	var decode = function(input) {
+		input = String(input)
+			.replace(REGEX_SPACE_CHARACTERS, '');
+		var length = input.length;
+		if (length % 4 == 0) {
+			input = input.replace(/==?$/, '');
+			length = input.length;
+		}
+		if (
+			length % 4 == 1 ||
+			// http://whatwg.org/C#alphanumeric-ascii-characters
+			/[^+a-zA-Z0-9/]/.test(input)
+		) {
+			error(
+				'Invalid character: the string to be decoded is not correctly encoded.'
+			);
+		}
+		var bitCounter = 0;
+		var bitStorage;
+		var buffer;
+		var output = '';
+		var position = -1;
+		while (++position < length) {
+			buffer = TABLE.indexOf(input.charAt(position));
+			bitStorage = bitCounter % 4 ? bitStorage * 64 + buffer : buffer;
+			// Unless this is the first of a group of 4 characters…
+			if (bitCounter++ % 4) {
+				// …convert the first 8 bits to a single ASCII character.
+				output += String.fromCharCode(
+					0xFF & bitStorage >> (-2 * bitCounter & 6)
+				);
+			}
+		}
+		return output;
+	};
+
+	// `encode` is designed to be fully compatible with `btoa` as described in the
+	// HTML Standard: http://whatwg.org/html/webappapis.html#dom-windowbase64-btoa
+	var encode = function(input) {
+		input = String(input);
+		if (/[^\0-\xFF]/.test(input)) {
+			// Note: no need to special-case astral symbols here, as surrogates are
+			// matched, and the input is supposed to only contain ASCII anyway.
+			error(
+				'The string to be encoded contains characters outside of the ' +
+				'Latin1 range.'
+			);
+		}
+		var padding = input.length % 3;
+		var output = '';
+		var position = -1;
+		var a;
+		var b;
+		var c;
+		var buffer;
+		// Make sure any padding is handled outside of the loop.
+		var length = input.length - padding;
+
+		while (++position < length) {
+			// Read three bytes, i.e. 24 bits.
+			a = input.charCodeAt(position) << 16;
+			b = input.charCodeAt(++position) << 8;
+			c = input.charCodeAt(++position);
+			buffer = a + b + c;
+			// Turn the 24 bits into four chunks of 6 bits each, and append the
+			// matching character for each of them to the output.
+			output += (
+				TABLE.charAt(buffer >> 18 & 0x3F) +
+				TABLE.charAt(buffer >> 12 & 0x3F) +
+				TABLE.charAt(buffer >> 6 & 0x3F) +
+				TABLE.charAt(buffer & 0x3F)
+			);
+		}
+
+		if (padding == 2) {
+			a = input.charCodeAt(position) << 8;
+			b = input.charCodeAt(++position);
+			buffer = a + b;
+			output += (
+				TABLE.charAt(buffer >> 10) +
+				TABLE.charAt((buffer >> 4) & 0x3F) +
+				TABLE.charAt((buffer << 2) & 0x3F) +
+				'='
+			);
+		} else if (padding == 1) {
+			buffer = input.charCodeAt(position);
+			output += (
+				TABLE.charAt(buffer >> 2) +
+				TABLE.charAt((buffer << 4) & 0x3F) +
+				'=='
+			);
+		}
+
+		return output;
+	};
+
+	var base64 = {
+		'encode': encode,
+		'decode': decode,
+		'version': '1.0.0'
+	};
+
+	// Some AMD build optimizers, like r.js, check for specific condition patterns
+	// like the following:
+	if (
+		typeof define == 'function' &&
+		typeof define.amd == 'object' &&
+		define.amd
+	) {
+		define(function() {
+			return base64;
+		});
+	}	else if (freeExports && !freeExports.nodeType) {
+		if (freeModule) { // in Node.js or RingoJS v0.8.0+
+			freeModule.exports = base64;
+		} else { // in Narwhal or RingoJS v0.7.0-
+			for (var key in base64) {
+				base64.hasOwnProperty(key) && (freeExports[key] = base64[key]);
+			}
+		}
+	} else { // in Rhino or a web browser
+		root.base64 = base64;
+	}
+
+}(this));

--- a/packages/expo/src/vendor/base-64/upstream/package.json
+++ b/packages/expo/src/vendor/base-64/upstream/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "base-64",
+	"version": "1.0.0",
+	"description": "A robust base64 encoder/decoder that is fully compatible with `atob()` and `btoa()`, written in JavaScript.",
+	"homepage": "https://mths.be/base64",
+	"main": "base64.js",
+	"keywords": [
+		"codec",
+		"decoder",
+		"encoder",
+		"base64",
+		"atob",
+		"btoa"
+	],
+	"license": "MIT",
+	"author": {
+		"name": "Mathias Bynens",
+		"url": "https://mathiasbynens.be/"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/mathiasbynens/base64.git"
+	},
+	"bugs": "https://github.com/mathiasbynens/base64/issues",
+	"files": [
+		"LICENSE-MIT.txt",
+		"base64.js"
+	],
+	"scripts": {
+		"test": "mocha tests/tests.js",
+		"build": "grunt build"
+	},
+	"devDependencies": {
+		"coveralls": "^2.11.4",
+		"grunt": "^0.4.5",
+		"grunt-cli": "^1.3.2",
+		"grunt-shell": "^1.1.2",
+		"grunt-template": "^0.2.3",
+		"istanbul": "^0.4.0",
+		"mocha": "^6.2.0",
+		"regenerate": "^1.2.1"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,9 +541,6 @@ importers:
       '@clerk/shared':
         specifier: workspace:^
         version: link:../shared
-      base-64:
-        specifier: ^1.0.0
-        version: 1.0.0
       expo:
         specifier: '>=53 <56'
         version: 54.0.23(@babel/core@7.29.0)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(bufferutil@4.1.0)(graphql@16.13.2)(react-native@0.85.2(@babel/core@7.29.0)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)
@@ -569,6 +566,9 @@ importers:
       '@types/base-64':
         specifier: ^1.0.2
         version: 1.0.2
+      base-64:
+        specifier: ^1.0.0
+        version: 1.0.0
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0


### PR DESCRIPTION
# Proposal: Address customer-side supply-chain exposure in published Clerk SDKs

## Summary

1. **Two classes of supply-chain attack against Clerk customers.** Both route through a runtime npm dependency that a published `@clerk/*` SDK declares as an external, which the customer's package manager fetches fresh from npm at install time.

    - *Malicious release through the upstream maintainer trust boundary* — a maintainer of a dep we depend on publishes a malicious version. This is the umbrella for several real-world precedents: maintainer account compromise (e.g. `ua-parser-js` 2021), hostile ownership transfer (`event-stream` 2018), maintainer self-sabotage (`colors.js` / `faker.js` 2022), and social engineering into commit authority (`xz-utils` 2024). Customers' resolvers pick up the new version on next install and the malicious code runs in their app.
    - *Registry-level same-version substitution* — the npm registry (or a mirror, CDN, or cache in front of it) serves substituted bytes for an existing version while the version number itself is unchanged. Requires a bypass of npm's immutability invariant (registry-infra compromise, npm-internal account compromise, cache poisoning, etc.) — not simple publisher-side abuse, because npm permanently retires a version number once it's been used. Even so, the customer's first install records the malicious hash as trusted; subsequent installs with `--frozen-lockfile` "verify" against the now-poisoned hash and reproduce the compromise.

2. **Three options Clerk could take per affected dep.**

    - *Vendor*: copy the upstream source byte-for-byte into the Clerk repo, remove the npm dep from `package.json`. The published Clerk tarball ships the source inline.
    - *Build-time bundle (`tsup`/`tsdown --noExternal`)*: keep the dep in `package.json`, but configure the bundler to inline its bytes into the published `dist/` artifact rather than emit a runtime `require()` for it. Cheap to apply per-dep on packages that already bundle (e.g. `@clerk/shared`); more invasive on packages that currently transpile per-file with `bundle: false` (e.g. `@clerk/expo`), where adopting it means changing the build mode.
    - *Replace with a platform primitive*: delete the dep entirely; rewrite the consumer in terms of `crypto.subtle`, `Buffer.from`, native `atob`, etc. (Only viable when the primitive exists and behaves equivalently in every consumer runtime.)

    (A fourth option — status quo — is documented for completeness in the body. None of Clerk's existing supply-chain hardening transits to customer installs, so status quo means accepting both chains against every external runtime dep.)

3. **POC.** Branch `aaronb/vendor-base-64-poc` implements the *vendor* option for `base-64` in `@clerk/expo`, end-to-end. Includes an `npm pack` + clean-fixture install that empirically verifies `base-64` no longer lands in customer `node_modules` after the change. The verification methodology and per-dep reasoning are in the branch's README.

## Why Clerk's lockfile doesn't protect customers

The load-bearing premise of this proposal is that none of Clerk's existing supply-chain hardening transits to customer installs. Quickly:

- `pnpm-lock.yaml` lives at the repo root and is consulted by `pnpm install` *inside the Clerk monorepo*. It pins exact versions and sha512 integrity hashes for every dep in Clerk's dev/CI environment.
- It is **not** included in any published `@clerk/*` npm tarball. Lockfiles aren't part of npm's publish format, and shipping one would actively break customer installs (their package manager has its own lockfile and dep tree).
- When a customer runs `pnpm install @clerk/expo` (or `npm install`, `yarn add`, `expo install`), their package manager reads the published `@clerk/expo`'s `package.json`, walks its `dependencies` (the declared version ranges), and resolves every entry against the npm registry at *their* install time. Clerk's lockfile is not in that path.
- Clerk's `minimumReleaseAge` (configured in `renovate.json5`) gates only Renovate-opened PRs against the Clerk repo. It does not transit to customer Renovate configs.
- Clerk's `pnpm.overrides` and `onlyBuiltDependencies` allowlist apply only to installs that read Clerk's `package.json` — i.e., installs *of* Clerk, not installs that *depend on* Clerk.

The net effect: every defensive control Clerk has built around its own dep tree protects Clerk's CI and Clerk's developers. None of it follows the published `@clerk/*` package into a customer's `node_modules`. The customer's defenses are entirely their own, computed against the registry's state at their install time.

This is why the attack chains below are not defended by any Clerk-side hardening that doesn't change what *ships in the tarball*.

## The two attack chains

Both attacks compromise a Clerk customer's running application via a dependency that Clerk's published SDK declares as a runtime external. The examples below use `base-64` in `@clerk/expo` because that's the worked POC case, but the same shape applies to any external runtime dep in any published Clerk SDK.

### Chain 1 — Malicious release through the upstream maintainer trust boundary

Premise: `@clerk/expo` declares `"base-64": "^1.0.0"` (caret-ranged). Mathias Bynens is the sole `base-64` npm publisher; whoever has publish authority for that package can ship malicious code at any time and customers will pick it up.

1. An adversary obtains the ability to publish a new `base-64` version under Mathias's publish authority. The path varies (see precedents below); the common shape is that the existing publish channel is used to ship a release the original author wouldn't have signed off on.
2. The adversary publishes `base-64@1.0.1` to npm. The tarball contains a malicious `encode` and `decode` that — alongside their normal output — exfiltrate inputs to an attacker-controlled endpoint (or do anything else; pick your payload).
3. A Clerk customer runs `pnpm install @clerk/expo` (or `npm`, `yarn`, `expo install`) on their dev machine, in CI, or as part of a fresh deployment.
4. The customer's resolver evaluates `^1.0.0` against the npm registry's current versions, picks `1.0.1` (the new latest in range), and records its integrity hash in the customer's lockfile.
5. At runtime, `@clerk/expo`'s polyfill imports `encode`/`decode` from the resolved `base-64@1.0.1` and assigns them to `global.btoa`/`global.atob`.
6. From that point on, **every `btoa()` or `atob()` call anywhere in the customer's app** — including third-party libraries the customer uses, payment SDK calls, OAuth flows, Clerk's own runtime — routes through the attacker's `encode`/`decode`.

Historical precedents in this class — malicious releases pushed through the existing upstream maintainer channel — cover several distinct mechanisms, all reaching customers the same way:

- **Maintainer account compromise:** `ua-parser-js` (2021) — credentials phished, three malicious versions published.
- **Hostile ownership transfer:** `event-stream` (2018) — original maintainer handed off to a contributor who later published a malicious version pulling `flatmap-stream`.
- **Maintainer self-sabotage:** `colors.js` / `faker.js` (2022) — original maintainer deliberately published broken/malicious versions.
- **Social engineering into commit/release authority:** `xz-utils` (2024) — years-long cultivation of a co-maintainer position, culminating in malicious commits to a new release.

What ties them together is the trust boundary: customers' resolvers trust whatever the upstream's publish authority shipped, regardless of how that publish came to exist. Chain 2 below adds a residual gap for first-install customers that exact-pinning doesn't close — but Chain 1 alone is sufficient justification on the historical record.

### Chain 2 — Registry-level same-version substitution

Premise: even with an exact pin (`"base-64": "1.0.0"`), the customer's resolver still fetches `1.0.0` from the npm registry on first install.

1. An attacker causes the npm registry — or a mirror, CDN, or caching layer in front of it — to serve substituted bytes for an existing version. Possible mechanisms include compromise of npm's registry infrastructure, compromise of an npm-internal account with publish/admin authority, cache poisoning on a CDN edge, or compromise of an enterprise mirror that downstream resolvers point at. (npm's standard policy prevents the simpler "unpublish-then-republish at the same version" path: once a `name@version` is used, that version number is permanently retired even after unpublish. So Chain 2 requires a bypass of the immutability invariant, not abuse of the published-version-management flow.)
2. **No version number changes.** No Renovate PR. No "new version available" signal anywhere.
3. A Clerk customer runs `pnpm install @clerk/expo` on a fresh machine (new CI runner, new contributor's laptop, fresh deployment image). They have no prior lockfile for this project.
4. The resolver fetches `base-64@1.0.0` from the registry, receives the substituted bytes, computes their sha512, and records that hash in the customer's newly-created lockfile.
5. Subsequent installs by the customer — even with `--frozen-lockfile` — "verify" the bytes against the recorded hash. They match (because the recorded hash is for the malicious bytes). The customer's CI passes integrity checks. The compromise reproduces forever.
6. Detection requires either (a) an independent integrity comparison against archived registry data, or (b) a customer with a pre-substitution lockfile somewhere noticing a hash mismatch and reporting it. Neither is automatic.

Historical precedents in this class are rarer in the public record (the most relevant is npm's 2022 access-token compromise incident, which briefly allowed publishing impersonated versions). The consequence is that for an unknown number of incidents that DID happen this way, nobody knew — there's no version-bump diff to spot. **Chain 2 is the weaker case on its own** — it should be read as the additional residual gap that even exact-pinning leaves open, not as the primary justification for vendoring. Chain 1 is the primary justification.

### What each end-user action looks like in each chain

| End-user action | Chain 1 (account compromise) | Chain 2 (registry substitution) |
|---|---|---|
| First `npm install @clerk/expo` on a fresh machine | Resolver picks `base-64@1.0.1` (malicious). Lockfile records its hash. App runs malicious `btoa`/`atob`. | Resolver picks `base-64@1.0.0`. Registry returns malicious bytes. Lockfile records the malicious hash as trusted. App runs malicious `btoa`/`atob`. |
| Subsequent `npm install --frozen-lockfile` with existing lockfile (pre-compromise) | Lockfile pins `1.0.0`'s original hash. Reinstalling fetches `1.0.0`, hashes match, safe. | Hash mismatch detected: install errors loudly. Customer is alerted (their build breaks). |
| `npm update base-64` | Updates lockfile to point at `1.0.1` (malicious). Subsequent installs use the new hash. | Updates lockfile to point at registry's current `1.0.0` bytes. If registry now serves malicious bytes, the new hash is the malicious hash. |
| Renovate PR that bumps `@clerk/expo`'s version | New `@clerk/expo` tarball, which still declares `"base-64": "^1.0.0"`. Lockfile reconciliation may pick up `1.0.1` if not already pinned. | No effect — `@clerk/expo` tarball's `base-64` declaration is unchanged; the customer still fetches `1.0.0` whose bytes are now malicious. |

## Options for defense

Each option below is a per-dep decision — Clerk can mix and match across the dep tree. The right answer for `base-64` in `@clerk/expo` is not necessarily the right answer for, say, `dequal` in `@clerk/shared`. The dev team should weigh trade-offs case by case.

| | Closes Chain 1? | Closes Chain 2 (first install)? | Closes Chain 2 (existing lockfile)? | Operational cost |
|---|---|---|---|---|
| Status quo (Option 4) | ❌ | ❌ | ✅ hash mismatch caught on second install | None |
| Exact-pin in `package.json` (mentioned for completeness; not a full option) | ✅ | ❌ | ✅ | One line per dep, no maintenance |
| Vendor (Option 1) | ✅ | ✅ | ✅ N/A — no registry fetch | Per-vendor: README, parity test, refresh procedure, ESLint guard, stale-vendor watcher. |
| Build-time bundle (Option 2) | ✅ | ✅ | ✅ N/A — no registry fetch | Two-part: (a) `noExternal:` entry in `tsup`/`tsdown` config, AND (b) move the dep from `dependencies` to `devDependencies` so the published manifest no longer declares it. Renovate continues to manage upgrades as today. |
| REPLACE with platform primitive (Option 3) | ✅ | ✅ | ✅ N/A — no registry fetch | One-time rewrite cost; ongoing maintenance is now Clerk's. |

### Option 1: Vendor the dep

Copy the upstream source byte-for-byte into Clerk's tree under `packages/<consumer>/src/vendor/<name>/upstream/`, remove the npm dep from `package.json` (or move it to `devDependencies` for parity testing). The published Clerk tarball ships the source inline; the customer's resolver never walks to the registry for that dep.

**Pros**
- Severs the upstream maintainer's account from the customer-install trust set, for both chains.
- The committed `vendor/` directory is grep-able, audit-friendly, and clearly labeled — downstream security auditors can inspect what shipped.
- Forces source-diff review on every refresh because the diff IS the source. Reviewers can't LGTM a "version bump" without reading the changed lines.

**Cons**
- Source committed to the Clerk git repo (small bytes per vendor; adds up across many).
- Per-vendor maintenance overhead: README documenting rationale + refresh procedure, parity test against upstream, ESLint guard against direct imports, entry in a `VENDORS.json`.
- Refreshes are manual and deliberate — easy to forget; needs a stale-vendor CI watcher to surface upstream releases / CVEs.
- Pre-existing precedent in Clerk: `clerk_go/api/scimgateway/imported/` (Go-side lift-and-shift) and `packages/nextjs/src/vendor/crypto-es.js` (sync crypto for Next middleware).

**When it's the right answer**
- Security-critical paths where source-level review at every upgrade is genuinely valuable (e.g. polyfills that force-replace runtime primitives, webhook signature verification, crypto).
- Deps that can't be cleanly REPLACEd because the platform primitive isn't available in every consumer runtime.

### Option 2: Build-time bundling (`tsup --noExternal` / `tsdown --noExternal`)

Two changes per dep: (a) configure the bundler to inline the dep's bytes into the published `dist/` artifact rather than emit a runtime `require()` for it, AND (b) move the dep from `dependencies` to `devDependencies` so the published `package.json` no longer declares it as a runtime external. Both are required. Without (a), the bundler still emits a `require()` that the customer's resolver walks. Without (b), the customer's resolver walks the `dependencies` declaration regardless of whether the runtime code actually `require()`s it. With both, the dep ships inlined in the tarball and the customer never fetches it.

**Pros**
- No source committed to Clerk's git tree. No `VENDORS.json`, no per-vendor README, no refresh ritual.
- Renovate continues to handle upgrades as today — the dep stays in `package.json` (under `devDependencies`), version bumps land via the existing PR flow.
- For packages already shipping bundled artifacts (e.g. `@clerk/shared` builds with `tsdown` and unbundle: false), configuration is per-package and minimal: one bundler-config entry + one `package.json` move per dep.
- Clerk's own install still pulls the upstream package normally, so Clerk-side hardening (`minimumReleaseAge`, integrity-pinned lockfile) continues to apply during Clerk's own dev/CI.

**Cons**
- Renovate auto-bumps land via PR review of "version + lockfile delta," not source diff. Reviewers can LGTM a malicious upgrade if they don't drill into the upstream changes.
- Inlined bytes are harder for downstream auditors to inspect — they read a minified `dist/index.js` to find the inlined module, vs. a labeled `vendor/` directory.
- Bundle size grows by the dep's size (same as vendoring on the published-tarball side).
- Forgetting step (b) silently defeats the defense — the customer still fetches the upstream while ALSO getting the inlined bytes, doubling the surface instead of closing it. Worth a CI check that flags any dep listed in `noExternal:` that also appears in `dependencies`.
- **Not a one-line lever on every Clerk package.** Some Clerk packages currently build with `bundle: false` (per-file transpilation rather than bundling) — notably `@clerk/expo` (see `packages/expo/tsup.config.ts`). Switching one dep to `noExternal` there means changing the build mode to bundle the consuming file, which has its own knock-on effects (different output shape, possibly different code-splitting / lazy-load semantics, source-map changes). For those packages, the operational cost of Option 2 starts looking closer to Option 1's, not cheaper.

**When it's the right answer**
- Most deps. If the upgrade-review attention isn't load-bearing for security, `noExternal` achieves the customer-side closure with materially less ceremony than vendoring.

### Option 3: REPLACE the dep with platform primitives

Delete the npm dep entirely. Rewrite the consumer code in terms of platform-available APIs: `crypto.subtle`, `crypto.randomUUID`, `Buffer.from`, `navigator.clipboard`, native `atob`/`btoa`, etc. The replacement is bug-for-bug different from the upstream — that's the point — and is treated as first-party Clerk code with its own tests and code review.

**Pros**
- Eliminates the dep entirely. Customer doesn't need it; Clerk doesn't ship it. Both chains closed for that dep.
- Often a strict win on bundle size (platform primitives don't ship userland source at all).
- No vendor/bundle ceremony.

**Cons**
- One-time engineering cost to rewrite.
- Behavior is now Clerk's responsibility — edge cases may regress and need ongoing fix attention.
- Requires verifying the platform primitive exists *and behaves equivalently* in every consumer target runtime. Often there's no clean answer across Node + browser + Workers + RN/Hermes.

**When it's the right answer**
- The replacement is small, runtime-uniform, and the upstream's edge-case behavior is well-defined enough that Clerk can mirror it.
- Good candidate shape: `fast-sha256` → `crypto.subtle` (uniform across Node 18+, browsers, Workers) — the platform primitive is universally available and the upstream's exposed surface is small enough to mirror cleanly.
- Not a good candidate when the platform primitive isn't available in every consumer runtime, or when the polyfill exists specifically to work around a known bug in the platform primitive. The POC documents one such case (`base-64` in `@clerk/expo`) in detail.

### Option 4: Status quo

Do nothing. Customers' resolvers continue to fetch deps fresh from npm at install time. Both attack chains remain open against every external runtime dep in every published `@clerk/*` package.

This is the option Clerk is on today. It's a defensible choice if the dev team judges that:

- The cost of (1), (2), or (3) — across the dep set worth addressing — outweighs the residual risk.
- The customer threat model doesn't warrant Clerk-side action; customers should harden their own installs.
- The right defense is upstream-of-Clerk: encourage npm provenance adoption, push for upstream-engine fixes that obviate problematic polyfills, etc.

Listing status quo as Option 4 explicitly is meant to ensure the team chooses it knowingly, not by default.

## Highest-priority candidates to harden

Short list of the deps with the strongest customer-side exposure case, in rough priority order. Each row identifies the dep, which `@clerk/*` package pulls it as a customer-facing external, the maintainer-concentration signal, and the suggested option. A longer analysis covering ~30 candidates surfaced by the dependency audit is available on request.

| Dep | Consumer | Maintainers | Customer-side surface | Suggested option |
|---|---|---|---|---|
| [`base-64`](https://github.com/mathiasbynens/base64) | `@clerk/expo` | 1 (`mathias`) | Polyfilled `global.btoa`/`global.atob` — compromised code becomes the base64 implementation for every line of customer app code (third-party libraries, payment SDKs, OAuth flows). | Option 1 — worked example in the POC. |
| [`standardwebhooks`](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/javascript) + transitives [`fast-sha256`](https://github.com/dchest/fast-sha256-js), [`@stablelib/base64`](https://github.com/StableLib/stablelib/tree/master/packages/base64) | `@clerk/backend` | 1 (`tasn`) + 1 (`dchest`) for both transitives | Webhook signature verification primitive. Compromise replaces HMAC-SHA256 / base64 logic; could silently make `verifyWebhook()` always-return-success. | Option 1 or Option 3 — REPLACE via `crypto.subtle` HMAC + native base64 collapses three single-maintainer accounts (tasn + dchest×2) into platform primitives the package already uses elsewhere (e.g. JWT verification). |
| `server-only` (no public source repo; npm `repository` field is null. Owner: `sebmarkbage`) | `@clerk/nextjs` (direct dep, `packages/nextjs/package.json`) | 1 (`sebmarkbage`) | Server-vs-client boundary marker. 611 bytes. Compromise is a privileged-primitive substitution affecting every Next.js server-component path. | Option 1 — trivial source, high-leverage compromise vector. **The lack of a public source repo is itself a supply-chain signal** — auditors can't diff a new version against the previous source. |
| [`std-env`](https://github.com/unjs/std-env) | `@clerk/shared` postinstall | 1 (`pi0`) | `isCI` check during the `postinstall` script that runs in customers' installs. Bounded to install-time, but pi0 controls ~50 reachable packages — high upstream-trust-set exposure for a one-liner check. | Option 3 (REPLACE) — narrowed to the subset Clerk actually needs for telemetry suppression. `std-env`'s `isCI` recognizes ~20 provider-specific env vars; a Clerk-side replacement should either pick the subset that matches Clerk's telemetry threat model (probably `process.env.CI` plus a handful of named CI providers) or accept the narrowing. Either is fine; the choice should be explicit. |
| [`dequal`](https://github.com/lukeed/dequal) | `@clerk/shared`, `@clerk/clerk-js`, `@clerk/ui` | 1 (`lukeed`) | Deep-equality used in React state comparison (`useDeepEqualMemo`) and localization parsing. Runs on every render that goes through these paths. | Option 2 (bundle) — semantic surface is small enough that upgrade-review attention isn't load-bearing; bundling closes the customer-side walk with minimal ceremony. |

The audit surfaced additional candidates with weaker customer-side exposure stories — bounded blast radius, CLI-only consumers, deps where REPLACE is genuinely cheap — that are also worth considering but didn't make this short list. Available on request.

## POC

`base-64` in `@clerk/expo` — branch `aaronb/vendor-base-64-poc`. Implements Option 1 end-to-end, including a `pnpm pack` + clean-fixture install that empirically verifies `base-64` no longer lands in customer `node_modules` after the change. The branch's README documents the verification steps run (byte-equivalence vs. the npm tarball, parity test against upstream, build through `tsup`, the published-tarball smoke test mentioned above, ESLint regression guard) and the case-specific reasoning for choosing Option 1 over the alternatives. The same verification shape is reusable for any future Option 1 decision.

## References

- Existing internal precedent (Go-side lift-and-shift): `clerk_go/api/scimgateway/imported/`
- Existing internal precedent (JS-side vendor for sync crypto): `packages/nextjs/src/vendor/`
- [Hermes #1379](https://github.com/facebook/hermes/issues/1379) — context for the `base-64` polyfill that the POC vendors.