### PR TITLE
chore(repo): Pin renovate config validator version

### DIFF
--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -16,14 +16,5 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup
-        id: config
-        uses: ./.github/actions/init
-        with:
-          cache-enabled: true
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-          turbo-team: ${{ vars.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-
       - name: Validate Renovate Config
-        run: npx --yes --package renovate@latest renovate-config-validator
+        run: npx --yes --package renovate@43.150.0 renovate-config-validator


### PR DESCRIPTION
## Description

This pins the validator version and removes the unnecessary init step to harden against supply chain compromises. In the previous workflow we would fetch the latest version and bypass other security mechanisms we have around dependency management.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: CI
