### PR TITLE
chore(repo): Remove unused workflow permission

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -8,7 +8,6 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
-  contents: write # only for delete-branch option
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Description

The `contents: write` permission is only used for the `delete-branch` option in the `actions/stale` workflow, however we never use that option. It is safe to remove the permission.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:
