### PR TITLE
fix(ui): Add claim name for Custom SAML provider in `<ConfigureSSO />`

### DIFF
--- a/.changeset/fancy-zoos-mate.md
+++ b/.changeset/fancy-zoos-mate.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Fix attribute statement section in `<ConfigureSSO />` with claim name for Custom SAML provider

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -358,6 +358,7 @@ export const enUS: LocalizationResource = {
         columns: {
           attribute: 'Attribute',
           claimName: 'Claim Name',
+          claimValue: 'Claim Value',
         },
         badges: {
           required: 'Required',
@@ -366,15 +367,15 @@ export const enUS: LocalizationResource = {
         rows: {
           email: {
             attribute: 'Email address',
-            claim: 'user.email',
+            claim: 'mail',
           },
           firstName: {
             attribute: 'First Name',
-            claim: 'user.firstName',
+            claim: 'firstName',
           },
           lastName: {
             attribute: 'Last Name',
-            claim: 'user.lastName',
+            claim: 'lastName',
           },
         },
       },

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1415,6 +1415,7 @@ export type __internal_LocalizationResource = {
         columns: {
           attribute: LocalizationValue;
           claimName: LocalizationValue;
+          claimValue: LocalizationValue;
         };
         badges: {
           required: LocalizationValue;

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep.tsx
@@ -113,18 +113,25 @@ const ATTRIBUTE_ROWS = [
     isRequired: true,
     attribute: localizationKeys('configureSSO.configureStep.attributeMapping.rows.email.attribute'),
     claim: localizationKeys('configureSSO.configureStep.attributeMapping.rows.email.claim'),
+    oktaClaimValue: localizationKeys('configureSSO.configureStep.samlOkta.configureAttributes.pairs.email.expression'),
   },
   {
     id: 'firstName',
     isRequired: false,
     attribute: localizationKeys('configureSSO.configureStep.attributeMapping.rows.firstName.attribute'),
     claim: localizationKeys('configureSSO.configureStep.attributeMapping.rows.firstName.claim'),
+    oktaClaimValue: localizationKeys(
+      'configureSSO.configureStep.samlOkta.configureAttributes.pairs.firstName.expression',
+    ),
   },
   {
     id: 'lastName',
     isRequired: false,
     attribute: localizationKeys('configureSSO.configureStep.attributeMapping.rows.lastName.attribute'),
     claim: localizationKeys('configureSSO.configureStep.attributeMapping.rows.lastName.claim'),
+    oktaClaimValue: localizationKeys(
+      'configureSSO.configureStep.samlOkta.configureAttributes.pairs.lastName.expression',
+    ),
   },
 ] as const;
 
@@ -328,6 +335,7 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
 
   const { provider } = useConfigureSSO();
+  const isOkta = provider === 'saml_okta';
 
   return (
     <>
@@ -363,6 +371,17 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
                     localizationKey={localizationKeys('configureSSO.configureStep.attributeMapping.columns.claimName')}
                   />
                 </Th>
+
+                {isOkta && (
+                  <Th>
+                    <Text
+                      sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+                      localizationKey={localizationKeys(
+                        'configureSSO.configureStep.attributeMapping.columns.claimValue',
+                      )}
+                    />
+                  </Th>
+                )}
               </Tr>
             </Thead>
 
@@ -398,12 +417,22 @@ export const ConfigureAttributesSubStep = (): JSX.Element => {
                       localizationKey={row.claim}
                     />
                   </Td>
+
+                  {isOkta && (
+                    <Td>
+                      <Text
+                        as='span'
+                        sx={{ fontFamily: 'monospace' }}
+                        localizationKey={row.oktaClaimValue}
+                      />
+                    </Td>
+                  )}
                 </Tr>
               ))}
             </Tbody>
           </Table>
 
-          {provider === 'saml_okta' && <OktaConfigureAttributesStepContent />}
+          {isOkta && <OktaConfigureAttributesStepContent />}
         </Step.Section>
       </Step.Body>
 

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -252,7 +252,6 @@ const ContinueTestSsoStepButton = ({
     <Step.Footer.Continue
       onClick={() => void handleContinue()}
       isLoading={isValidating}
-      isDisabled={!enterpriseConnectionId || isConnectionActive}
     />
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -196,7 +196,6 @@ export const TestConfigurationStep = (): JSX.Element => {
           <Step.Footer.Previous onClick={() => goPrev()} />
           <ContinueTestSsoStepButton
             enterpriseConnectionId={enterpriseConnection?.id}
-            isConnectionActive={enterpriseConnection?.active}
             onContinue={() => void goNext()}
           />
         </Step.Footer>
@@ -207,13 +206,11 @@ export const TestConfigurationStep = (): JSX.Element => {
 
 type ContinueTestSsoStepButtonProps = {
   enterpriseConnectionId: string | undefined;
-  isConnectionActive: boolean | undefined;
   onContinue: () => void;
 };
 
 const ContinueTestSsoStepButton = ({
   enterpriseConnectionId,
-  isConnectionActive,
   onContinue,
 }: ContinueTestSsoStepButtonProps): JSX.Element => {
   const { user } = useUser();


### PR DESCRIPTION
## Description

This PR fixes the attribute statements step for Custom SAML provider, where previously was displaying the claim value with an expression that is specific to Okta 

It also fixes an issue on the test step, where it was always disabling the button, but the validation actually happens on click.

#### Custom SAML 

<img width="940" height="765" alt="Screenshot 2026-05-18 at 15 56 35" src="https://github.com/user-attachments/assets/c078eb12-9341-41be-a490-bd4e06fa2dbb" />

#### Okta


<img width="994" height="788" alt="Screenshot 2026-05-18 at 15 39 49" src="https://github.com/user-attachments/assets/48f8e6a9-50b0-4fb5-95e6-a3b0f1445694" />

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
