### PR TITLE
fix(ui): Update `ClipboardInput` positioning and change from disabled to readonly

### DIFF
--- a/.changeset/qcwt-pcxyt-vbpuw.md
+++ b/.changeset/qcwt-pcxyt-vbpuw.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Improve ClipboardInput positioning and accessibility by using `readOnly` instead of `isDisabled`

--- a/packages/ui/src/elements/ClipboardInput.tsx
+++ b/packages/ui/src/elements/ClipboardInput.tsx
@@ -24,7 +24,7 @@ export const ClipboardInput = (props: ClipboardInputProps) => {
         {...rest}
         value={value}
         readOnly
-        sx={theme => ({ paddingInlineEnd: theme.space.$10, textOverflow: 'ellipsis' })}
+        sx={theme => ({ paddingInlineEnd: theme.space.$7x5, textOverflow: 'ellipsis' })}
       />
 
       <Button
@@ -34,7 +34,10 @@ export const ClipboardInput = (props: ClipboardInputProps) => {
         sx={t => {
           return {
             position: 'absolute',
+            padding: 0,
             insetInlineEnd: t.space.$0x5,
+            insetBlock: t.space.$0x5,
+            aspectRatio: 1,
           };
         }}
       >

--- a/packages/ui/src/elements/ClipboardInput.tsx
+++ b/packages/ui/src/elements/ClipboardInput.tsx
@@ -23,17 +23,19 @@ export const ClipboardInput = (props: ClipboardInputProps) => {
       <Input
         {...rest}
         value={value}
-        isDisabled
-        sx={theme => ({ paddingInlineEnd: theme.space.$8 })}
+        readOnly
+        sx={theme => ({ paddingInlineEnd: theme.space.$10, textOverflow: 'ellipsis' })}
       />
 
       <Button
         elementDescriptor={descriptors.formFieldInputCopyToClipboardButton}
         variant='ghost'
         onClick={() => onCopy()}
-        sx={{
-          position: 'absolute',
-          insetInlineEnd: 0,
+        sx={t => {
+          return {
+            position: 'absolute',
+            insetInlineEnd: t.space.$0x5,
+          };
         }}
       >
         <Icon


### PR DESCRIPTION
## Description

 - Use readOnly instead of isDisabled on ClipboardInput for better accessibility (allows focus and screen reader access)
- Fix copy button positioning with proper inline-end spacing
- Add textOverflow: 'ellipsis' for long values

| BEFORE | AFTER |
|--------|--------|
| <img width="328" height="177" alt="Screenshot 2026-05-18 at 4 56 52 PM" src="https://github.com/user-attachments/assets/cb195ae1-7e5d-4ecb-ad2a-6f34416be552" /> | <img width="260" height="181" alt="Screenshot 2026-05-18 at 4 56 25 PM" src="https://github.com/user-attachments/assets/1c294a24-2d28-4b26-9e69-9a8f18d2f550" /> | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
