### PR TITLE
fix(ui): Handle instant password recovery when strict enumeration protection is enabled

### DIFF
--- a/.changeset/tidy-plums-exist.md
+++ b/.changeset/tidy-plums-exist.md
@@ -1,0 +1,6 @@
+---
+"@clerk/shared": patch
+"@clerk/ui": patch
+---
+
+Handle instant password recovery when strict enumeration protection is enabled

--- a/packages/shared/src/internal/clerk-js/constants.ts
+++ b/packages/shared/src/internal/clerk-js/constants.ts
@@ -24,6 +24,7 @@ export const CLERK_SATELLITE_URL = '__clerk_satellite_url';
 export const ERROR_CODES = {
   FORM_IDENTIFIER_NOT_FOUND: 'form_identifier_not_found',
   FORM_PASSWORD_INCORRECT: 'form_password_incorrect',
+  FORM_PASSWORD_OR_IDENTIFIER_INCORRECT: 'form_password_or_identifier_incorrect',
   FORM_PASSWORD_PWNED: 'form_password_pwned',
   INVALID_STRATEGY_FOR_USER: 'strategy_for_user_invalid',
   NOT_ALLOWED_TO_SIGN_UP: 'not_allowed_to_sign_up',

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -432,6 +432,7 @@ function SignInStartInternal(): JSX.Element {
       (e: ClerkAPIError) =>
         e.code === ERROR_CODES.INVALID_STRATEGY_FOR_USER ||
         e.code === ERROR_CODES.FORM_PASSWORD_INCORRECT ||
+        e.code === ERROR_CODES.FORM_PASSWORD_OR_IDENTIFIER_INCORRECT ||
         e.code === ERROR_CODES.FORM_PASSWORD_PWNED,
     );
 

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -480,7 +480,12 @@ describe('SignInStart', () => {
   });
 
   describe('Submitting form via instant password autofill', () => {
-    const ERROR_CODES = ['strategy_for_user_invalid', 'form_password_incorrect', 'form_password_pwned'];
+    const ERROR_CODES = [
+      'strategy_for_user_invalid',
+      'form_password_incorrect',
+      'form_password_pwned',
+      'form_password_or_identifier_incorrect',
+    ];
     ERROR_CODES.forEach(code => {
       it(`calls sign in with identifier again with only the email if the api respondes with the error ${code}`, async () => {
         const { wrapper, fixtures } = await createFixtures(f => {


### PR DESCRIPTION
## Description

When a password manager autofills both email and password on the sign-in start screen and the credentials are wrong, the recovery that silently retries with just the identifier and navigates to factor-one (where "Forgot password?" is visible) never triggered if strict user enumeration protection was enabled.

This is because enumeration protection causes the backend to return `form_password_or_identifier_incorrect` instead of `form_password_incorrect`, and the former was missing from the `instantPasswordError` check.

<img width="436" height="586" alt="Screenshot 2026-05-19 at 2 08 31 PM" src="https://github.com/user-attachments/assets/fd92e007-0491-4c50-b2a8-d29f30a8cdb9" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
