### PR TITLE
chore(shared): Remove internal tag from publicly re-exported error helpers

### DIFF
--- a/.changeset/orange-pandas-burn.md
+++ b/.changeset/orange-pandas-burn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Remove internal tag from publicly re-exported error helpers

--- a/packages/shared/src/errors/helpers.ts
+++ b/packages/shared/src/errors/helpers.ts
@@ -80,8 +80,6 @@ export function isNetworkError(e: any): boolean {
 
 /**
  * Checks if the provided error is either a ClerkAPIResponseError, a ClerkRuntimeError, or a MetamaskError.
- *
- * @internal
  */
 export function isKnownError(error: any): error is ClerkAPIResponseError | ClerkRuntimeError | MetamaskError {
   return isClerkAPIResponseError(error) || isMetamaskError(error) || isClerkRuntimeError(error);
@@ -89,8 +87,6 @@ export function isKnownError(error: any): error is ClerkAPIResponseError | Clerk
 
 /**
  * Checks if the provided error is a Clerk runtime error indicating a reverification was cancelled.
- *
- * @internal
  */
 export function isReverificationCancelledError(err: any) {
   return isClerkRuntimeError(err) && err.code === 'reverification_cancelled';
@@ -98,8 +94,6 @@ export function isReverificationCancelledError(err: any) {
 
 /**
  * Checks if the provided error is a Metamask error.
- *
- * @internal
  */
 export function isMetamaskError(err: any): err is MetamaskError {
   return 'code' in err && [4001, 32602, 32603].includes(err.code) && 'message' in err;
@@ -107,8 +101,6 @@ export function isMetamaskError(err: any): err is MetamaskError {
 
 /**
  * Checks if the provided error is clerk api response error indicating a user is locked.
- *
- * @internal
  */
 export function isUserLockedError(err: any) {
   return isClerkAPIResponseError(err) && err.errors?.[0]?.code === 'user_locked';
@@ -134,8 +126,6 @@ export function isPasswordCompromisedError(err: any) {
 
 /**
  * Checks if the provided error is an EmailLinkError.
- *
- * @internal
  */
 export function isEmailLinkError(err: Error): err is EmailLinkError {
   return err.name === 'EmailLinkError';


### PR DESCRIPTION
## Description

- Removes the `@internal` JSDoc tag from error helpers in `@clerk/shared` that are explicitly re-exported for public use by SDK packages (`isKnownError`, `isReverificationCancelledError`, `isMetamaskError`, `isUserLockedError`, `isEmailLinkError`)
- Helpers that are genuinely internal and not re-exported retain the `@internal` tag

The `@internal` tag was originally applied because these helpers live in `@clerk/shared`, which users shouldn't import from directly. However, since they are explicitly re-exported from the SDK packages, the tag was misleading.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
