### PR TITLE
chore(ui): Add `ProfileCard.Page` for `UserProfile` and `OrganizationProfile`

### DIFF
--- a/.changeset/chatty-maps-shine.md
+++ b/.changeset/chatty-maps-shine.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Add `ProfileCard.Page` for `UserProfile` and `OrganizationProfile` pages

--- a/packages/ui/src/common/CustomPageContentContainer.tsx
+++ b/packages/ui/src/common/CustomPageContentContainer.tsx
@@ -1,22 +1,25 @@
 import { Col, descriptors } from '../customizables';
+import { ProfileCard } from '../elements/ProfileCard';
 import type { CustomPageContent } from '../utils/createCustomPages';
 import { ExternalElementMounter } from '../utils/ExternalElementMounter';
 
 export const CustomPageContentContainer = ({ mount, unmount }: Omit<CustomPageContent, 'url'>) => {
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      gap={8}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
+        elementDescriptor={descriptors.page}
         gap={8}
       >
-        <ExternalElementMounter
-          mount={mount}
-          unmount={unmount}
-        />
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          gap={8}
+        >
+          <ExternalElementMounter
+            mount={mount}
+            unmount={unmount}
+          />
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 };

--- a/packages/ui/src/components/OrganizationProfile/OrganizationAPIKeysPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationAPIKeysPage.tsx
@@ -4,6 +4,7 @@ import { APIKeysContext, useOrganizationProfileContext } from '@/ui/contexts';
 import { Col, localizationKeys } from '@/ui/customizables';
 import { Header } from '@/ui/elements/Header';
 import { useUnsafeNavbarContext } from '@/ui/elements/Navbar';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 
 import { APIKeysPage } from '../APIKeys/APIKeys';
 
@@ -18,19 +19,21 @@ export const OrganizationAPIKeysPage = () => {
   }
 
   return (
-    <Col gap={4}>
-      <Header.Root>
-        <Header.Title
-          localizationKey={localizationKeys('organizationProfile.apiKeysPage.title')}
-          textVariant='h2'
-        />
-      </Header.Root>
-      <APIKeysContext.Provider value={{ ...apiKeysProps, componentName: 'APIKeys' }}>
-        <APIKeysPage
-          subject={organization.id}
-          revokeModalRoot={contentRef}
-        />
-      </APIKeysContext.Provider>
-    </Col>
+    <ProfileCard.Page>
+      <Col gap={4}>
+        <Header.Root>
+          <Header.Title
+            localizationKey={localizationKeys('organizationProfile.apiKeysPage.title')}
+            textVariant='h2'
+          />
+        </Header.Root>
+        <APIKeysContext.Provider value={{ ...apiKeysProps, componentName: 'APIKeys' }}>
+          <APIKeysPage
+            subject={organization.id}
+            revokeModalRoot={contentRef}
+          />
+        </APIKeysContext.Provider>
+      </Col>
+    </ProfileCard.Page>
   );
 };

--- a/packages/ui/src/components/OrganizationProfile/OrganizationBillingPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationBillingPage.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { Tab, TabPanel, TabPanels, Tabs, TabsList } from '@/ui/elements/Tabs';
 
 import { Protect } from '../../common';
@@ -24,63 +25,67 @@ const OrganizationBillingPageInternal = withCardStateProvider(() => {
   const { selectedTab, handleTabChange } = useTabState(orgTabMap);
 
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('billing')}
-        gap={4}
+        elementDescriptor={descriptors.page}
+        sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
       >
-        <Header.Root>
-          <Header.Title
-            localizationKey={localizationKeys('organizationProfile.billingPage.title')}
-            textVariant='h2'
-          />
-        </Header.Root>
-
-        <Card.Alert>{card.error}</Card.Alert>
-
-        <Tabs
-          value={selectedTab}
-          onChange={handleTabChange}
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('billing')}
+          gap={4}
         >
-          <TabsList sx={t => ({ gap: t.space.$6 })}>
-            <Tab
-              localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__subscriptions')}
+          <Header.Root>
+            <Header.Title
+              localizationKey={localizationKeys('organizationProfile.billingPage.title')}
+              textVariant='h2'
             />
-            <Tab localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__statements')} />
-            <Tab localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__payments')} />
-          </TabsList>
-          <TabPanels>
-            <TabPanel sx={{ width: '100%', flexDirection: 'column' }}>
-              <SubscriptionsList
-                title={localizationKeys('organizationProfile.billingPage.subscriptionsListSection.title')}
-                switchPlansLabel={localizationKeys(
-                  'organizationProfile.billingPage.subscriptionsListSection.actionLabel__switchPlan',
-                )}
-                newSubscriptionLabel={localizationKeys(
-                  'organizationProfile.billingPage.subscriptionsListSection.actionLabel__newSubscription',
-                )}
-                manageSubscriptionLabel={localizationKeys(
-                  'organizationProfile.billingPage.subscriptionsListSection.actionLabel__manageSubscription',
-                )}
+          </Header.Root>
+
+          <Card.Alert>{card.error}</Card.Alert>
+
+          <Tabs
+            value={selectedTab}
+            onChange={handleTabChange}
+          >
+            <TabsList sx={t => ({ gap: t.space.$6 })}>
+              <Tab
+                localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__subscriptions')}
               />
-              <Protect condition={has => has({ permission: 'org:sys_billing:manage' })}>
-                <PaymentMethods />
-              </Protect>
-            </TabPanel>
-            <TabPanel sx={{ width: '100%' }}>
-              <StatementsList />
-            </TabPanel>
-            <TabPanel sx={{ width: '100%' }}>
-              <PaymentAttemptsList />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+              <Tab
+                localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__statements')}
+              />
+              <Tab localizationKey={localizationKeys('organizationProfile.billingPage.start.headerTitle__payments')} />
+            </TabsList>
+            <TabPanels>
+              <TabPanel sx={{ width: '100%', flexDirection: 'column' }}>
+                <SubscriptionsList
+                  title={localizationKeys('organizationProfile.billingPage.subscriptionsListSection.title')}
+                  switchPlansLabel={localizationKeys(
+                    'organizationProfile.billingPage.subscriptionsListSection.actionLabel__switchPlan',
+                  )}
+                  newSubscriptionLabel={localizationKeys(
+                    'organizationProfile.billingPage.subscriptionsListSection.actionLabel__newSubscription',
+                  )}
+                  manageSubscriptionLabel={localizationKeys(
+                    'organizationProfile.billingPage.subscriptionsListSection.actionLabel__manageSubscription',
+                  )}
+                />
+                <Protect condition={has => has({ permission: 'org:sys_billing:manage' })}>
+                  <PaymentMethods />
+                </Protect>
+              </TabPanel>
+              <TabPanel sx={{ width: '100%' }}>
+                <StatementsList />
+              </TabPanel>
+              <TabPanel sx={{ width: '100%' }}>
+                <PaymentAttemptsList />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 });
 

--- a/packages/ui/src/components/OrganizationProfile/OrganizationGeneralPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationGeneralPage.tsx
@@ -2,6 +2,7 @@ import { useOrganization } from '@clerk/shared/react';
 
 import { Header } from '@/ui/elements/Header';
 import { OrganizationPreview } from '@/ui/elements/OrganizationPreview';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { ProfileSection } from '@/ui/elements/Section';
 
 import { Protect, useProtect } from '../../common';
@@ -56,29 +57,31 @@ const DeleteOrganizationScreen = () => {
 
 export const OrganizationGeneralPage = () => {
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      sx={t => ({ gap: t.space.$8 })}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('organizationGeneral')}
+        elementDescriptor={descriptors.page}
+        sx={t => ({ gap: t.space.$8 })}
       >
-        <Header.Root>
-          <Header.Title
-            localizationKey={localizationKeys('organizationProfile.start.headerTitle__general')}
-            sx={t => ({ marginBottom: t.space.$4 })}
-            textVariant='h2'
-          />
-        </Header.Root>
-        <OrganizationProfileSection />
-        <Protect permission='org:sys_domains:read'>
-          <OrganizationDomainsSection />
-        </Protect>
-        <OrganizationLeaveSection />
-        <OrganizationDeleteSection />
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('organizationGeneral')}
+        >
+          <Header.Root>
+            <Header.Title
+              localizationKey={localizationKeys('organizationProfile.start.headerTitle__general')}
+              sx={t => ({ marginBottom: t.space.$4 })}
+              textVariant='h2'
+            />
+          </Header.Root>
+          <OrganizationProfileSection />
+          <Protect permission='org:sys_domains:read'>
+            <OrganizationDomainsSection />
+          </Protect>
+          <OrganizationLeaveSection />
+          <OrganizationDeleteSection />
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 };
 

--- a/packages/ui/src/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationMembers.tsx
@@ -8,6 +8,7 @@ import { Animated } from '@/ui/elements/Animated';
 import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { Tab, TabPanel, TabPanels, Tabs, TabsList } from '@/ui/elements/Tabs';
 
 import { NotificationCountBadge, useProtect } from '../../common';
@@ -50,171 +51,175 @@ export const OrganizationMembers = withCardStateProvider(() => {
   }
 
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      gap={2}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('organizationMembers')}
-        gap={4}
-        sx={theme => ({ paddingBottom: theme.space.$13 })}
+        elementDescriptor={descriptors.page}
+        gap={2}
       >
-        <Action.Root animate={false}>
-          <Animated asChild>
-            <Header.Root
-              contentSx={{
-                [mqu.md]: {
-                  flexDirection: 'row',
-                  width: '100%',
-                  justifyContent: 'space-between',
-                },
-              }}
-            >
-              <Header.Title
-                localizationKey={localizationKeys('organizationProfile.start.headerTitle__members')}
-                textVariant='h2'
-              />
-            </Header.Root>
-          </Animated>
-          <Card.Alert>{card.error}</Card.Alert>
-          <Tabs>
-            <TabsList sx={t => ({ gap: t.space.$2 })}>
-              {canReadMemberships && (
-                <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__members')}>
-                  {!!memberships?.count && (
-                    <NotificationCountBadge
-                      shouldAnimate={!query}
-                      notificationCount={memberships.count}
-                      colorScheme='outline'
-                    />
-                  )}
-                </Tab>
-              )}
-              {canManageMemberships && (
-                <Tab
-                  localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__invitations')}
-                >
-                  {invitations?.data && !invitations.isLoading && (
-                    <NotificationCountBadge
-                      notificationCount={invitations.count}
-                      colorScheme='outline'
-                    />
-                  )}
-                </Tab>
-              )}
-              {canManageMemberships && isDomainsEnabled && (
-                <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')}>
-                  {membershipRequests?.data && !membershipRequests.isLoading && (
-                    <NotificationCountBadge
-                      notificationCount={membershipRequests.count}
-                      colorScheme='outline'
-                    />
-                  )}
-                </Tab>
-              )}
-            </TabsList>
-            <TabPanels>
-              {canReadMemberships && (
-                <TabPanel sx={{ width: '100%' }}>
-                  <Flex
-                    gap={4}
-                    direction='col'
-                    sx={{
-                      width: '100%',
-                    }}
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('organizationMembers')}
+          gap={4}
+          sx={theme => ({ paddingBottom: theme.space.$13 })}
+        >
+          <Action.Root animate={false}>
+            <Animated asChild>
+              <Header.Root
+                contentSx={{
+                  [mqu.md]: {
+                    flexDirection: 'row',
+                    width: '100%',
+                    justifyContent: 'space-between',
+                  },
+                }}
+              >
+                <Header.Title
+                  localizationKey={localizationKeys('organizationProfile.start.headerTitle__members')}
+                  textVariant='h2'
+                />
+              </Header.Root>
+            </Animated>
+            <Card.Alert>{card.error}</Card.Alert>
+            <Tabs>
+              <TabsList sx={t => ({ gap: t.space.$2 })}>
+                {canReadMemberships && (
+                  <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__members')}>
+                    {!!memberships?.count && (
+                      <NotificationCountBadge
+                        shouldAnimate={!query}
+                        notificationCount={memberships.count}
+                        colorScheme='outline'
+                      />
+                    )}
+                  </Tab>
+                )}
+                {canManageMemberships && (
+                  <Tab
+                    localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__invitations')}
                   >
+                    {invitations?.data && !invitations.isLoading && (
+                      <NotificationCountBadge
+                        notificationCount={invitations.count}
+                        colorScheme='outline'
+                      />
+                    )}
+                  </Tab>
+                )}
+                {canManageMemberships && isDomainsEnabled && (
+                  <Tab
+                    localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')}
+                  >
+                    {membershipRequests?.data && !membershipRequests.isLoading && (
+                      <NotificationCountBadge
+                        notificationCount={membershipRequests.count}
+                        colorScheme='outline'
+                      />
+                    )}
+                  </Tab>
+                )}
+              </TabsList>
+              <TabPanels>
+                {canReadMemberships && (
+                  <TabPanel sx={{ width: '100%' }}>
                     <Flex
-                      gap={2}
+                      gap={4}
                       direction='col'
                       sx={{
                         width: '100%',
                       }}
                     >
-                      <MembersActionsRow
-                        actionSlot={
-                          <MembersSearch
-                            query={query}
-                            value={search}
-                            memberships={memberships}
-                            onSearchChange={query => setSearch(query)}
-                            onQueryTrigger={query => setQuery(query)}
-                          />
-                        }
-                      />
-                      {hasRoleSetMigration && (
-                        <Alert
-                          variant='warning'
-                          title={localizationKeys(
-                            'organizationProfile.membersPage.alerts.roleSetMigrationInProgress.title',
-                          )}
-                          subtitle={localizationKeys(
-                            'organizationProfile.membersPage.alerts.roleSetMigrationInProgress.subtitle',
-                          )}
+                      <Flex
+                        gap={2}
+                        direction='col'
+                        sx={{
+                          width: '100%',
+                        }}
+                      >
+                        <MembersActionsRow
+                          actionSlot={
+                            <MembersSearch
+                              query={query}
+                              value={search}
+                              memberships={memberships}
+                              onSearchChange={query => setSearch(query)}
+                              onQueryTrigger={query => setQuery(query)}
+                            />
+                          }
                         />
-                      )}
-                      <ActiveMembersList
-                        pageSize={ACTIVE_MEMBERS_PAGE_SIZE}
-                        memberships={memberships}
-                      />
+                        {hasRoleSetMigration && (
+                          <Alert
+                            variant='warning'
+                            title={localizationKeys(
+                              'organizationProfile.membersPage.alerts.roleSetMigrationInProgress.title',
+                            )}
+                            subtitle={localizationKeys(
+                              'organizationProfile.membersPage.alerts.roleSetMigrationInProgress.subtitle',
+                            )}
+                          />
+                        )}
+                        <ActiveMembersList
+                          pageSize={ACTIVE_MEMBERS_PAGE_SIZE}
+                          memberships={memberships}
+                        />
+                      </Flex>
                     </Flex>
-                  </Flex>
-                </TabPanel>
-              )}
-              {canManageMemberships && (
-                <TabPanel sx={{ width: '100%' }}>
-                  <OrganizationMembersTabInvitations />
-                </TabPanel>
-              )}
-              {canManageMemberships && isDomainsEnabled && (
-                <TabPanel sx={{ width: '100%' }}>
-                  <OrganizationMembersTabRequests />
-                </TabPanel>
-              )}
-            </TabPanels>
-          </Tabs>
-        </Action.Root>
-      </Col>
+                  </TabPanel>
+                )}
+                {canManageMemberships && (
+                  <TabPanel sx={{ width: '100%' }}>
+                    <OrganizationMembersTabInvitations />
+                  </TabPanel>
+                )}
+                {canManageMemberships && isDomainsEnabled && (
+                  <TabPanel sx={{ width: '100%' }}>
+                    <OrganizationMembersTabRequests />
+                  </TabPanel>
+                )}
+              </TabPanels>
+            </Tabs>
+          </Action.Root>
+        </Col>
 
-      {canReadMemberships && !!memberships?.count && organization && organization.maxAllowedMemberships > 0 ? (
-        <Box
-          sx={theme => ({
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            backgroundColor: theme.colors.$colorBackground,
-            borderTop: `1px solid ${theme.colors.$borderAlpha100}`,
-            paddingInline: theme.space.$4,
-            height: theme.space.$13,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          })}
-        >
-          <Text
-            sx={t => ({
-              display: 'inline-flex',
+        {canReadMemberships && !!memberships?.count && organization && organization.maxAllowedMemberships > 0 ? (
+          <Box
+            sx={theme => ({
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              backgroundColor: theme.colors.$colorBackground,
+              borderTop: `1px solid ${theme.colors.$borderAlpha100}`,
+              paddingInline: theme.space.$4,
+              height: theme.space.$13,
+              display: 'flex',
               alignItems: 'center',
-              gap: t.space.$2,
+              justifyContent: 'center',
             })}
           >
-            <Icon
-              icon={Users}
-              size='md'
-              colorScheme='neutral'
-            />
             <Text
-              as='span'
-              colorScheme='inherit'
-              localizationKey={localizationKeys('organizationProfile.start.membershipSeatUsageLabel', {
-                count: organization.membersCount + organization.pendingInvitationsCount,
-                limit: organization.maxAllowedMemberships,
+              sx={t => ({
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: t.space.$2,
               })}
-            />
-          </Text>
-        </Box>
-      ) : null}
-    </Col>
+            >
+              <Icon
+                icon={Users}
+                size='md'
+                colorScheme='neutral'
+              />
+              <Text
+                as='span'
+                colorScheme='inherit'
+                localizationKey={localizationKeys('organizationProfile.start.membershipSeatUsageLabel', {
+                  count: organization.membersCount + organization.pendingInvitationsCount,
+                  limit: organization.maxAllowedMemberships,
+                })}
+              />
+            </Text>
+          </Box>
+        ) : null}
+      </Col>
+    </ProfileCard.Page>
   );
 });

--- a/packages/ui/src/components/OrganizationProfile/OrganizationPlansPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationPlansPage.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@/ui/elements/Alert';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 
 import { Protect } from '../../common';
 import { PricingTableContext, SubscriberTypeContext } from '../../contexts';
@@ -12,7 +13,7 @@ const OrganizationPlansPageInternal = () => {
   const { navigate } = useRouter();
 
   return (
-    <>
+    <ProfileCard.Page>
       <Header.Root
         sx={t => ({
           borderBottomWidth: t.borderWidths.$normal,
@@ -47,7 +48,7 @@ const OrganizationPlansPageInternal = () => {
           <PricingTable />
         </PricingTableContext.Provider>
       </Flex>
-    </>
+    </ProfileCard.Page>
   );
 };
 

--- a/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
+++ b/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
@@ -4,6 +4,7 @@ import type { BillingSubscriptionItemResource } from '@clerk/shared/types';
 import { Alert } from '@/ui/elements/Alert';
 import { Header } from '@/ui/elements/Header';
 import { LineItems } from '@/ui/elements/LineItems';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { formatDate } from '@/ui/utils/formatDate';
 import { truncateWithEndVisible } from '@/ui/utils/truncateTextWithEndVisible';
 
@@ -46,18 +47,20 @@ export const PaymentAttemptPage = () => {
 
   if (isLoading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        <Spinner
-          colorScheme='primary'
-          sx={{ margin: 'auto', display: 'block' }}
-          elementDescriptor={descriptors.spinner}
-        />
-      </Box>
+      <ProfileCard.Page>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+          <Spinner
+            colorScheme='primary'
+            sx={{ margin: 'auto', display: 'block' }}
+            elementDescriptor={descriptors.spinner}
+          />
+        </Box>
+      </ProfileCard.Page>
     );
   }
 
   return (
-    <>
+    <ProfileCard.Page>
       <Header.Root
         sx={t => ({
           borderBlockEndWidth: t.borderWidths.$normal,
@@ -194,7 +197,7 @@ export const PaymentAttemptPage = () => {
           </Box>
         </Box>
       )}
-    </>
+    </ProfileCard.Page>
   );
 };
 

--- a/packages/ui/src/components/Statements/StatementPage.tsx
+++ b/packages/ui/src/components/Statements/StatementPage.tsx
@@ -2,6 +2,7 @@ import { __internal_useStatementQuery } from '@clerk/shared/react/index';
 
 import { Alert } from '@/ui/elements/Alert';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { formatDate } from '@/ui/utils/formatDate';
 
 import { useSubscriberTypeContext, useSubscriberTypeLocalizationRoot } from '../../contexts/components';
@@ -38,18 +39,20 @@ export const StatementPage = () => {
 
   if (isLoading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        <Spinner
-          colorScheme='primary'
-          sx={{ margin: 'auto', display: 'block' }}
-          elementDescriptor={descriptors.spinner}
-        />
-      </Box>
+      <ProfileCard.Page>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+          <Spinner
+            colorScheme='primary'
+            sx={{ margin: 'auto', display: 'block' }}
+            elementDescriptor={descriptors.spinner}
+          />
+        </Box>
+      </ProfileCard.Page>
     );
   }
 
   return (
-    <>
+    <ProfileCard.Page>
       <Header.Root
         sx={t => ({
           borderBlockEndWidth: t.borderWidths.$normal,
@@ -170,6 +173,6 @@ export const StatementPage = () => {
           />
         </Statement.Root>
       )}
-    </>
+    </ProfileCard.Page>
   );
 };

--- a/packages/ui/src/components/UserProfile/APIKeysPage.tsx
+++ b/packages/ui/src/components/UserProfile/APIKeysPage.tsx
@@ -4,6 +4,7 @@ import { APIKeysContext, useUserProfileContext } from '@/ui/contexts';
 import { Col, descriptors, localizationKeys } from '@/ui/customizables';
 import { Header } from '@/ui/elements/Header';
 import { useUnsafeNavbarContext } from '@/ui/elements/Navbar';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 
 import { APIKeysPage as APIKeysPageInternal } from '../APIKeys/APIKeys';
 
@@ -18,22 +19,24 @@ export const APIKeysPage = () => {
   }
 
   return (
-    <Col
-      gap={4}
-      elementDescriptor={descriptors.page}
-    >
-      <Header.Root>
-        <Header.Title
-          localizationKey={localizationKeys('userProfile.apiKeysPage.title')}
-          textVariant='h2'
-        />
-      </Header.Root>
-      <APIKeysContext.Provider value={{ componentName: 'APIKeys', ...apiKeysProps }}>
-        <APIKeysPageInternal
-          subject={user.id}
-          revokeModalRoot={contentRef}
-        />
-      </APIKeysContext.Provider>
-    </Col>
+    <ProfileCard.Page>
+      <Col
+        gap={4}
+        elementDescriptor={descriptors.page}
+      >
+        <Header.Root>
+          <Header.Title
+            localizationKey={localizationKeys('userProfile.apiKeysPage.title')}
+            textVariant='h2'
+          />
+        </Header.Root>
+        <APIKeysContext.Provider value={{ componentName: 'APIKeys', ...apiKeysProps }}>
+          <APIKeysPageInternal
+            subject={user.id}
+            revokeModalRoot={contentRef}
+          />
+        </APIKeysContext.Provider>
+      </Col>
+    </ProfileCard.Page>
   );
 };

--- a/packages/ui/src/components/UserProfile/AccountPage.tsx
+++ b/packages/ui/src/components/UserProfile/AccountPage.tsx
@@ -3,6 +3,7 @@ import { useUser } from '@clerk/shared/react';
 import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 
 import { useEnvironment, useUserProfileContext } from '../../contexts';
 import { Col, descriptors, localizationKeys } from '../../customizables';
@@ -32,44 +33,48 @@ export const AccountPage = withCardStateProvider(() => {
   const isUsernameImmutable = immutableAttributes.has('username');
 
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('account')}
+        elementDescriptor={descriptors.page}
+        sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
       >
-        <Header.Root>
-          <Header.Title
-            localizationKey={localizationKeys('userProfile.start.headerTitle__account')}
-            sx={t => ({ marginBottom: t.space.$4 })}
-            textVariant='h2'
-          />
-        </Header.Root>
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('account')}
+        >
+          <Header.Root>
+            <Header.Title
+              localizationKey={localizationKeys('userProfile.start.headerTitle__account')}
+              sx={t => ({ marginBottom: t.space.$4 })}
+              textVariant='h2'
+            />
+          </Header.Root>
 
-        <Card.Alert>{card.error}</Card.Alert>
+          <Card.Alert>{card.error}</Card.Alert>
 
-        <UserProfileSection />
-        {showUsername && <UsernameSection isImmutable={isUsernameImmutable} />}
-        {showEmail && (
-          <EmailsSection
-            shouldAllowCreation={shouldAllowIdentificationCreation && !isEmailImmutable}
-            shouldAllowDeletion={!isEmailImmutable}
-          />
-        )}
-        {showPhone && (
-          <PhoneSection
-            shouldAllowCreation={shouldAllowIdentificationCreation && !isPhoneImmutable}
-            shouldAllowDeletion={!isPhoneImmutable}
-          />
-        )}
-        {showConnectedAccounts && <ConnectedAccountsSection shouldAllowCreation={shouldAllowIdentificationCreation} />}
+          <UserProfileSection />
+          {showUsername && <UsernameSection isImmutable={isUsernameImmutable} />}
+          {showEmail && (
+            <EmailsSection
+              shouldAllowCreation={shouldAllowIdentificationCreation && !isEmailImmutable}
+              shouldAllowDeletion={!isEmailImmutable}
+            />
+          )}
+          {showPhone && (
+            <PhoneSection
+              shouldAllowCreation={shouldAllowIdentificationCreation && !isPhoneImmutable}
+              shouldAllowDeletion={!isPhoneImmutable}
+            />
+          )}
+          {showConnectedAccounts && (
+            <ConnectedAccountsSection shouldAllowCreation={shouldAllowIdentificationCreation} />
+          )}
 
-        {/*TODO-STEP-UP: Verify that these work as expected*/}
-        {showEnterpriseAccounts && <EnterpriseAccountsSection />}
-        {showWeb3 && <Web3Section shouldAllowCreation={shouldAllowIdentificationCreation} />}
+          {/*TODO-STEP-UP: Verify that these work as expected*/}
+          {showEnterpriseAccounts && <EnterpriseAccountsSection />}
+          {showWeb3 && <Web3Section shouldAllowCreation={shouldAllowIdentificationCreation} />}
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 });

--- a/packages/ui/src/components/UserProfile/BillingPage.tsx
+++ b/packages/ui/src/components/UserProfile/BillingPage.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { Tab, TabPanel, TabPanels, Tabs, TabsList } from '@/ui/elements/Tabs';
 
 import { SubscriberTypeContext } from '../../contexts';
@@ -22,59 +23,61 @@ const BillingPageInternal = withCardStateProvider(() => {
   const { selectedTab, handleTabChange } = useTabState(tabMap);
 
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('billing')}
-        gap={4}
+        elementDescriptor={descriptors.page}
+        sx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground })}
       >
-        <Header.Root>
-          <Header.Title
-            localizationKey={localizationKeys('userProfile.billingPage.title')}
-            textVariant='h2'
-          />
-        </Header.Root>
-
-        <Card.Alert>{card.error}</Card.Alert>
-
-        <Tabs
-          value={selectedTab}
-          onChange={handleTabChange}
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('billing')}
+          gap={4}
         >
-          <TabsList sx={t => ({ gap: t.space.$6 })}>
-            <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__subscriptions')} />
-            <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__statements')} />
-            <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__payments')} />
-          </TabsList>
-          <TabPanels>
-            <TabPanel sx={_ => ({ width: '100%', flexDirection: 'column' })}>
-              <SubscriptionsList
-                title={localizationKeys('userProfile.billingPage.subscriptionsListSection.title')}
-                switchPlansLabel={localizationKeys(
-                  'userProfile.billingPage.subscriptionsListSection.actionLabel__switchPlan',
-                )}
-                newSubscriptionLabel={localizationKeys(
-                  'userProfile.billingPage.subscriptionsListSection.actionLabel__newSubscription',
-                )}
-                manageSubscriptionLabel={localizationKeys(
-                  'userProfile.billingPage.subscriptionsListSection.actionLabel__manageSubscription',
-                )}
-              />
-              <PaymentMethods />
-            </TabPanel>
-            <TabPanel sx={{ width: '100%' }}>
-              <StatementsList />
-            </TabPanel>
-            <TabPanel sx={{ width: '100%' }}>
-              <PaymentAttemptsList />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+          <Header.Root>
+            <Header.Title
+              localizationKey={localizationKeys('userProfile.billingPage.title')}
+              textVariant='h2'
+            />
+          </Header.Root>
+
+          <Card.Alert>{card.error}</Card.Alert>
+
+          <Tabs
+            value={selectedTab}
+            onChange={handleTabChange}
+          >
+            <TabsList sx={t => ({ gap: t.space.$6 })}>
+              <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__subscriptions')} />
+              <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__statements')} />
+              <Tab localizationKey={localizationKeys('userProfile.billingPage.start.headerTitle__payments')} />
+            </TabsList>
+            <TabPanels>
+              <TabPanel sx={_ => ({ width: '100%', flexDirection: 'column' })}>
+                <SubscriptionsList
+                  title={localizationKeys('userProfile.billingPage.subscriptionsListSection.title')}
+                  switchPlansLabel={localizationKeys(
+                    'userProfile.billingPage.subscriptionsListSection.actionLabel__switchPlan',
+                  )}
+                  newSubscriptionLabel={localizationKeys(
+                    'userProfile.billingPage.subscriptionsListSection.actionLabel__newSubscription',
+                  )}
+                  manageSubscriptionLabel={localizationKeys(
+                    'userProfile.billingPage.subscriptionsListSection.actionLabel__manageSubscription',
+                  )}
+                />
+                <PaymentMethods />
+              </TabPanel>
+              <TabPanel sx={{ width: '100%' }}>
+                <StatementsList />
+              </TabPanel>
+              <TabPanel sx={{ width: '100%' }}>
+                <PaymentAttemptsList />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 });
 

--- a/packages/ui/src/components/UserProfile/PlansPage.tsx
+++ b/packages/ui/src/components/UserProfile/PlansPage.tsx
@@ -1,4 +1,5 @@
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 
 import { PricingTableContext, SubscriberTypeContext } from '../../contexts';
 import { localizationKeys } from '../../localization';
@@ -9,7 +10,7 @@ const PlansPageInternal = () => {
   const { navigate } = useRouter();
 
   return (
-    <>
+    <ProfileCard.Page>
       <Header.Root
         sx={t => ({
           borderBottomWidth: t.borderWidths.$normal,
@@ -32,7 +33,7 @@ const PlansPageInternal = () => {
       <PricingTableContext.Provider value={{ componentName: 'PricingTable', mode: 'modal' }}>
         <PricingTable />
       </PricingTableContext.Provider>
-    </>
+    </ProfileCard.Page>
   );
 };
 

--- a/packages/ui/src/components/UserProfile/SecurityPage.tsx
+++ b/packages/ui/src/components/UserProfile/SecurityPage.tsx
@@ -3,6 +3,7 @@ import { useUser } from '@clerk/shared/react';
 import { Card } from '@/ui/elements/Card';
 import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
 import { getSecondFactors } from '@/ui/utils/mfa';
 
 import { useEnvironment, useUserProfileContext } from '../../contexts';
@@ -24,28 +25,30 @@ export const SecurityPage = withCardStateProvider(() => {
   const showDelete = user?.deleteSelfEnabled;
 
   return (
-    <Col
-      elementDescriptor={descriptors.page}
-      sx={t => ({ gap: t.space.$8 })}
-    >
+    <ProfileCard.Page>
       <Col
-        elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('security')}
+        elementDescriptor={descriptors.page}
+        sx={t => ({ gap: t.space.$8 })}
       >
-        <Header.Root>
-          <Header.Title
-            localizationKey={localizationKeys('userProfile.start.headerTitle__security')}
-            sx={t => ({ marginBottom: t.space.$4 })}
-            textVariant='h2'
-          />
-        </Header.Root>
-        <Card.Alert>{card.error}</Card.Alert>
-        {showPassword && <PasswordSection />}
-        {showPasskey && <PasskeySection />}
-        {showMfa && <MfaSection />}
-        <ActiveDevicesSection />
-        {showDelete && <DeleteSection />}
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          elementId={descriptors.profilePage.setId('security')}
+        >
+          <Header.Root>
+            <Header.Title
+              localizationKey={localizationKeys('userProfile.start.headerTitle__security')}
+              sx={t => ({ marginBottom: t.space.$4 })}
+              textVariant='h2'
+            />
+          </Header.Root>
+          <Card.Alert>{card.error}</Card.Alert>
+          {showPassword && <PasswordSection />}
+          {showPasskey && <PasskeySection />}
+          {showMfa && <MfaSection />}
+          <ActiveDevicesSection />
+          {showDelete && <DeleteSection />}
+        </Col>
       </Col>
-    </Col>
+    </ProfileCard.Page>
   );
 });

--- a/packages/ui/src/elements/ProfileCard/ProfileCardContent.tsx
+++ b/packages/ui/src/elements/ProfileCard/ProfileCardContent.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 
 import { Col, descriptors } from '../../customizables';
 import { useRouter } from '../../router';
-import { common, mqu } from '../../styledSystem';
+import { common } from '../../styledSystem';
 
 type ProfileCardContentProps = React.PropsWithChildren<{
   contentRef?: React.RefObject<HTMLDivElement>;
   scrollBoxId?: string;
 }>;
+
 export const ProfileCardContent = (props: ProfileCardContentProps) => {
   const { contentRef, children, scrollBoxId } = props;
   const router = useRouter();
@@ -53,13 +54,6 @@ export const ProfileCardContent = (props: ProfileCardContentProps) => {
         sx={theme => ({
           flex: `1`,
           scrollbarGutter: 'stable',
-          paddingTop: theme.space.$7,
-          paddingBottom: theme.space.$7,
-          paddingInlineStart: theme.space.$8,
-          paddingInlineEnd: theme.space.$6, //smaller because of stable scrollbar gutter
-          [mqu.sm]: {
-            padding: `${theme.space.$8} ${theme.space.$5}`,
-          },
           ...common.maxHeightScroller(theme),
         })}
         ref={contentRef}

--- a/packages/ui/src/elements/ProfileCard/ProfileCardPage.tsx
+++ b/packages/ui/src/elements/ProfileCard/ProfileCardPage.tsx
@@ -5,9 +5,16 @@ import { mqu } from '../../styledSystem';
 
 type ProfileCardPageProps = PropsWithChildren<{
   /**
-   * Use this for pages that manage their own layout/padding
+   * Whether to apply the standard per-page padding.
+   * @default true
    */
-  noPadding?: boolean;
+  padding?: boolean;
+  /**
+   * Whether the page should bleed past the standard padding by applying matching
+   * negative inline margins, so children render flush with the scroll-gutter / card border.
+   * @default false
+   */
+  bleeding?: boolean;
 }>;
 
 /**
@@ -16,21 +23,30 @@ type ProfileCardPageProps = PropsWithChildren<{
  * Each routed page inside `UserProfile` / `OrganizationProfile` should wrap its content
  * in this component
  */
-export const ProfileCardPage = ({ children, noPadding }: ProfileCardPageProps) => {
-  if (noPadding) {
+export const ProfileCardPage = ({ children, padding = true, bleeding = false }: ProfileCardPageProps) => {
+  if (!padding && !bleeding) {
     return <>{children}</>;
   }
 
   return (
     <Col
       sx={theme => ({
-        paddingTop: theme.space.$7,
-        paddingBottom: theme.space.$7,
-        paddingInlineStart: theme.space.$8,
-        paddingInlineEnd: theme.space.$6, //smaller because of stable scrollbar gutter on the parent
-        [mqu.sm]: {
-          padding: `${theme.space.$8} ${theme.space.$5}`,
-        },
+        ...(padding && {
+          paddingTop: theme.space.$7,
+          paddingBottom: theme.space.$7,
+          paddingInlineStart: theme.space.$8,
+          paddingInlineEnd: theme.space.$6, //smaller because of stable scrollbar gutter on the parent
+          [mqu.sm]: {
+            padding: `${theme.space.$8} ${theme.space.$5}`,
+          },
+        }),
+        ...(bleeding && {
+          marginInlineStart: `calc(${theme.space.$8} * -1)`,
+          marginInlineEnd: `calc(${theme.space.$6} * -1)`,
+          [mqu.sm]: {
+            marginInline: `calc(${theme.space.$5} * -1)`,
+          },
+        }),
       })}
     >
       {children}

--- a/packages/ui/src/elements/ProfileCard/ProfileCardPage.tsx
+++ b/packages/ui/src/elements/ProfileCard/ProfileCardPage.tsx
@@ -1,0 +1,39 @@
+import type { PropsWithChildren } from 'react';
+
+import { Col } from '../../customizables';
+import { mqu } from '../../styledSystem';
+
+type ProfileCardPageProps = PropsWithChildren<{
+  /**
+   * Use this for pages that manage their own layout/padding
+   */
+  noPadding?: boolean;
+}>;
+
+/**
+ * Per-page padding wrapper rendered inside `ProfileCardContent`
+ *
+ * Each routed page inside `UserProfile` / `OrganizationProfile` should wrap its content
+ * in this component
+ */
+export const ProfileCardPage = ({ children, noPadding }: ProfileCardPageProps) => {
+  if (noPadding) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Col
+      sx={theme => ({
+        paddingTop: theme.space.$7,
+        paddingBottom: theme.space.$7,
+        paddingInlineStart: theme.space.$8,
+        paddingInlineEnd: theme.space.$6, //smaller because of stable scrollbar gutter on the parent
+        [mqu.sm]: {
+          padding: `${theme.space.$8} ${theme.space.$5}`,
+        },
+      })}
+    >
+      {children}
+    </Col>
+  );
+};

--- a/packages/ui/src/elements/ProfileCard/index.ts
+++ b/packages/ui/src/elements/ProfileCard/index.ts
@@ -1,7 +1,9 @@
 import { ProfileCardContent } from './ProfileCardContent';
+import { ProfileCardPage } from './ProfileCardPage';
 import { ProfileCardRoot } from './ProfileCardRoot';
 
 export const ProfileCard = {
   Root: ProfileCardRoot,
   Content: ProfileCardContent,
+  Page: ProfileCardPage,
 };


### PR DESCRIPTION
## Description


Introduce separate `ProfileContentPage` to allow for opt-out padding, an example being the new self-serve SSO page:

<img width="974" height="793" alt="CleanShot 2026-05-20 at 10 36 43" src="https://github.com/user-attachments/assets/d17db79a-56b6-430d-96bf-afc659bf60e3" />

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
