### PR TITLE
chore(clerk-js): remove redundant dequal dependency

### DIFF
--- a/.changeset/remove-clerk-js-dequal.md
+++ b/.changeset/remove-clerk-js-dequal.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove a redundant direct `dequal` dependency.

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -98,8 +98,7 @@
     "alien-signals": "2.0.6",
     "browser-tabs-lock": "1.3.0",
     "core-js": "catalog:repo",
-    "crypto-js": "^4.2.0",
-    "dequal": "2.0.3"
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
     "@clerk/msw": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,9 +468,6 @@ importers:
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
-      dequal:
-        specifier: 2.0.3
-        version: 2.0.3
     devDependencies:
       '@clerk/msw':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,9 +489,6 @@ importers:
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
-      dequal:
-        specifier: 2.0.3
-        version: 2.0.3
     devDependencies:
       '@clerk/msw':
         specifier: workspace:^


### PR DESCRIPTION
Nothing in `@clerk/clerk-js` imports `dequal` directly. It was listed as a direct runtime dependency but is only reached transitively through `@clerk/shared` (`useDeepEqualMemo`). Drop it from `packages/clerk-js/package.json` and the lockfile, with a patch changeset.

Resolves AISEC-32. Thanks to @7188ce06 for reporting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined package maintenance by removing an unnecessary internal dependency.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->