### PR TITLE
chore(shared): bump js-cookie to 3.0.7

### DIFF
--- a/.changeset/js-cookie-security-bump.md
+++ b/.changeset/js-cookie-security-bump.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Bump `js-cookie` to `3.0.7` to address GHSA-qjx8-664m-686j.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -143,7 +143,7 @@
     "@tanstack/query-core": "catalog:repo",
     "dequal": "2.0.3",
     "glob-to-regexp": "0.4.1",
-    "js-cookie": "3.0.5",
+    "js-cookie": "3.0.7",
     "std-env": "^3.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -823,8 +823,8 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       js-cookie:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -9866,9 +9866,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -25519,10 +25519,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.4
       glob: 10.4.5
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- bump @clerk/shared's js-cookie dependency from 3.0.5 to 3.0.7
- update the pnpm lockfile so the workspace resolves the patched version
- add a patch changeset for @clerk/shared

## Context
Fixes #8626 and addresses GHSA-qjx8-664m-686j / Dependabot alerts #870 and #871.

## Verification
- pnpm install --lockfile-only
- pnpm install
- pnpm --dir packages/shared build:declarations
- pnpm --dir packages/shared build
- pnpm why -r js-cookie
- git diff --check
- node runtime check confirmed __proto__ cookie attributes are not emitted with js-cookie@3.0.7