### PR TITLE
chore(shared): Bump js-cookie to 3.0.7

### DIFF
--- a/.changeset/js-cookie-security-bump.md
+++ b/.changeset/js-cookie-security-bump.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Bump `js-cookie` to `3.0.7` to address GHSA-qjx8-664m-686j.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -156,7 +156,7 @@
     "csstype": "3.1.3",
     "dequal": "2.0.3",
     "glob-to-regexp": "0.4.1",
-    "js-cookie": "3.0.5",
+    "js-cookie": "3.0.7",
     "std-env": "^3.9.0",
     "swr": "2.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,8 +929,8 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       js-cookie:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -10306,9 +10306,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tiktoken@1.0.18:
     resolution: {integrity: sha512-hFYx4xYf6URgcttcGvGuOBJhTxPYZ2R5eIesqCaNRJmYH8sNmsfTeWg4yu//7u1VD/qIUkgKJTpGom9oHXmB4g==}
@@ -27297,10 +27297,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.4
       glob: 10.4.5
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tiktoken@1.0.18:
     dependencies:


### PR DESCRIPTION
## Summary
- backport the @clerk/shared js-cookie bump from 3.0.5 to 3.0.7 for the Core 2 release line
- update the core-2 pnpm lockfile so the workspace resolves the patched version
- add a patch changeset for @clerk/shared

## Context
Backport for #8626 and GHSA-qjx8-664m-686j. This covers the @clerk/shared 3.x / @clerk/backend 2.x line.

## Verification
- pnpm install --lockfile-only
- pnpm install --ignore-scripts
- pnpm -C packages/shared build
- pnpm why -r js-cookie
- git diff --check
- node runtime check confirmed __proto__ cookie attributes are not emitted with js-cookie@3.0.7

Note: full pnpm install without --ignore-scripts is blocked on this branch by the existing marked-terminal git dependency build-script allowlist.