### PR TITLE
chore(expo,expo-passkeys): Support Expo SDK 56

### DIFF
--- a/.changeset/petite-ends-invent.md
+++ b/.changeset/petite-ends-invent.md
@@ -1,0 +1,6 @@
+---
+"@clerk/expo-passkeys": minor
+"@clerk/expo": minor
+---
+
+Add support for Expo SDK 56

--- a/packages/expo-passkeys/package.json
+++ b/packages/expo-passkeys/package.json
@@ -38,7 +38,7 @@
     "expo": "~52.0.49"
   },
   "peerDependencies": {
-    "expo": ">=53 <55",
+    "expo": ">=53 <57",
     "react": "catalog:peer-react",
     "react-native": "*"
   }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -136,7 +136,7 @@
   },
   "peerDependencies": {
     "@clerk/expo-passkeys": ">=0.0.6",
-    "expo": ">=53 <56",
+    "expo": ">=53 <57",
     "expo-apple-authentication": ">=7.0.0",
     "expo-auth-session": ">=5",
     "expo-constants": ">=12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,7 +544,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       expo:
-        specifier: '>=53 <56'
+        specifier: '>=53 <57'
         version: 54.0.23(@babel/core@7.29.0)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(bufferutil@4.1.0)(graphql@16.13.2)(react-native@0.85.2(@babel/core@7.29.0)(@react-native-community/cli@12.3.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)
       react:
         specifier: 18.3.1


### PR DESCRIPTION
## Description

https://expo.dev/changelog/sdk-56

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
