### PR TITLE
feat(backend): Support recent BAPI users and email/phone features

### DIFF
--- a/.changeset/auto-resend-expired-email-verification.md
+++ b/.changeset/auto-resend-expired-email-verification.md
@@ -1,0 +1,7 @@
+---
+'@clerk/ui': patch
+'@clerk/localizations': patch
+'@clerk/shared': patch
+---
+
+When an email verification code expires, components now automatically request a new code instead of leaving the user staring at a raw "This verification has expired. You must create a new one." message and waiting for them to click the Resend button. The OTP input is reset and a softer "Your code expired. We sent a new one." message is shown via the new `formFieldError__verificationExpiredCodeResent` localization key. Phone-code expiration is unchanged (manual Resend remains).

--- a/.changeset/auto-resend-expired-email-verification.md
+++ b/.changeset/auto-resend-expired-email-verification.md
@@ -1,7 +1,0 @@
----
-'@clerk/ui': patch
-'@clerk/localizations': patch
-'@clerk/shared': patch
----
-
-When an email verification code expires, components now automatically request a new code instead of leaving the user staring at a raw "This verification has expired. You must create a new one." message and waiting for them to click the Resend button. The OTP input is reset and a softer "Your code expired. We sent a new one." message is shown via the new `formFieldError__verificationExpiredCodeResent` localization key. Phone-code expiration is unchanged (manual Resend remains).

--- a/.changeset/backend-user-replace-email-phone-and-banned-locked.md
+++ b/.changeset/backend-user-replace-email-phone-and-banned-locked.md
@@ -1,0 +1,9 @@
+---
+'@clerk/backend': minor
+---
+
+Add support for new Backend API user endpoints:
+
+- `users.replaceUserEmailAddress(userId, { emailAddress })` replaces all of a user's email addresses with a single verified, primary email address (`PUT /users/{user_id}/email_address`).
+- `users.replaceUserPhoneNumber(userId, { phoneNumber })` replaces all of a user's phone numbers with a single verified, primary phone number (`PUT /users/{user_id}/phone_number`).
+- `users.createUser` now accepts `banned` and `locked` parameters to create a user that is already banned or locked.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -5,9 +5,11 @@ import { joinPaths } from '../../util/path';
 import { deprecated } from '../../util/shared';
 import type {
   DeletedObject,
+  EmailAddress,
   OauthAccessToken,
   OrganizationInvitation,
   OrganizationMembership,
+  PhoneNumber,
   User,
 } from '../resources';
 import type { PaginatedResourceResponse } from '../resources/Deserializer';
@@ -99,6 +101,10 @@ type CreateUserParams = {
   totpSecret?: string;
   backupCodes?: string[];
   createdAt?: Date;
+  /** When set to `true`, the user is created already banned and cannot sign in. Requires the same plan support as the ban user endpoint. */
+  banned?: boolean;
+  /** When set to `true`, the user is created already locked. Requires the user lockout feature to be enabled on the instance. */
+  locked?: boolean;
 } & UserMetadataParams &
   (UserPasswordHashingParams | object);
 
@@ -212,6 +218,16 @@ type SetPasswordCompromisedParams = {
   revokeAllSessions?: boolean;
 };
 
+type ReplaceUserEmailAddressParams = {
+  /** The new email address. Must adhere to the RFC 5322 specification for email address format. */
+  emailAddress: string;
+};
+
+type ReplaceUserPhoneNumberParams = {
+  /** The new phone number. Must adhere to the E.164 standard for phone number format. */
+  phoneNumber: string;
+};
+
 type UserID = {
   userId: string;
 };
@@ -255,6 +271,26 @@ export class UserAPI extends AbstractAPI {
     return this.request<User>({
       method: 'PATCH',
       path: joinPaths(basePath, userId),
+      bodyParams: params,
+    });
+  }
+
+  public async replaceUserEmailAddress(userId: string, params: ReplaceUserEmailAddressParams) {
+    this.requireId(userId);
+
+    return this.request<EmailAddress>({
+      method: 'PUT',
+      path: joinPaths(basePath, userId, 'email_address'),
+      bodyParams: params,
+    });
+  }
+
+  public async replaceUserPhoneNumber(userId: string, params: ReplaceUserPhoneNumberParams) {
+    this.requireId(userId);
+
+    return this.request<PhoneNumber>({
+      method: 'PUT',
+      path: joinPaths(basePath, userId, 'phone_number'),
       bodyParams: params,
     });
   }


### PR DESCRIPTION
## Description

Add support for `PUT` endpoints to replace emails or phones with a new email or phone.

Add support for `banned` and `locked` param when creating a user. Since this is a tiny change I just grouped it into this PR.

Following existing patterns for these simple backend changes we don't really include tests.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
