### PR TITLE
fix(backend): strip private_metadata from resource _raw in SSR sanitizer

### DIFF
--- a/.changeset/proud-lions-allow.md
+++ b/.changeset/proud-lions-allow.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Strip `private_metadata` from the backend resource `_raw` payload in `stripPrivateDataFromObject`, preventing it from leaking into `__clerk_ssr_state` when a `User`/`Organization` resource is passed to `buildClerkProps`.

--- a/packages/backend/src/util/__tests__/decorateObjectWithResources.test.ts
+++ b/packages/backend/src/util/__tests__/decorateObjectWithResources.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { Organization } from '../../api/resources/Organization';
+import { User } from '../../api/resources/User';
+import { stripPrivateDataFromObject } from '../decorateObjectWithResources';
+
+describe('stripPrivateDataFromObject', () => {
+  it('removes top-level private metadata from user and organization', () => {
+    const result = stripPrivateDataFromObject({
+      user: { id: 'user_1', privateMetadata: { secret: 'a' } } as any,
+      organization: { id: 'org_1', privateMetadata: { secret: 'b' } } as any,
+    });
+
+    expect(result.user).not.toHaveProperty('privateMetadata');
+    expect(result.organization).not.toHaveProperty('privateMetadata');
+  });
+
+  it('strips private_metadata nested under the backend resource `_raw` payload', () => {
+    const user = User.fromJSON({
+      id: 'user_1',
+      object: 'user',
+      private_metadata: { ssn: '000-00-0000' },
+      public_metadata: { plan: 'pro' },
+      email_addresses: [],
+      phone_numbers: [],
+      web3_wallets: [],
+      external_accounts: [],
+      enterprise_accounts: [],
+    } as any);
+
+    const organization = Organization.fromJSON({
+      id: 'org_1',
+      object: 'organization',
+      name: 'Acme',
+      slug: 'acme',
+      private_metadata: { billingCustomerId: 'cus_secret' },
+      public_metadata: { tier: 'enterprise' },
+    } as any);
+
+    const result = stripPrivateDataFromObject({ user, organization });
+
+    // Serialize the way `buildClerkProps` embeds the state into the HTML response.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('000-00-0000');
+    expect(serialized).not.toContain('cus_secret');
+
+    expect((result.user as any)._raw).not.toHaveProperty('private_metadata');
+    expect((result.organization as any)._raw).not.toHaveProperty('private_metadata');
+
+    // Public metadata under `_raw` is intentionally preserved.
+    expect((result.user as any)._raw.public_metadata).toEqual({ plan: 'pro' });
+    expect((result.organization as any)._raw.public_metadata).toEqual({ tier: 'enterprise' });
+  });
+
+  it('does not mutate the original resource `raw` payload', () => {
+    const user = User.fromJSON({
+      id: 'user_1',
+      object: 'user',
+      private_metadata: { ssn: '000-00-0000' },
+      email_addresses: [],
+      phone_numbers: [],
+      web3_wallets: [],
+      external_accounts: [],
+      enterprise_accounts: [],
+    } as any);
+
+    stripPrivateDataFromObject({ user });
+
+    // The server-side `raw` getter must still expose the full payload.
+    expect(user.raw?.private_metadata).toEqual({ ssn: '000-00-0000' });
+  });
+});

--- a/packages/backend/src/util/__tests__/decorateObjectWithResources.test.ts
+++ b/packages/backend/src/util/__tests__/decorateObjectWithResources.test.ts
@@ -52,6 +52,55 @@ describe('stripPrivateDataFromObject', () => {
     expect((result.organization as any)._raw.public_metadata).toEqual({ tier: 'enterprise' });
   });
 
+  it('recursively strips private_metadata nested under `_raw.organization_memberships`', () => {
+    const user = User.fromJSON({
+      id: 'user_1',
+      object: 'user',
+      private_metadata: { ssn: '000-00-0000' },
+      public_metadata: { plan: 'pro' },
+      email_addresses: [],
+      phone_numbers: [],
+      web3_wallets: [],
+      external_accounts: [],
+      enterprise_accounts: [],
+      organization_memberships: [
+        {
+          id: 'orgmem_1',
+          object: 'organization_membership',
+          role: 'admin',
+          permissions: [],
+          private_metadata: { membershipSecret: 'mem_secret' },
+          public_metadata: { seat: 'a' },
+          created_at: 1,
+          updated_at: 1,
+          organization: {
+            id: 'org_1',
+            object: 'organization',
+            name: 'Acme',
+            slug: 'acme',
+            private_metadata: { billingCustomerId: 'cus_secret' },
+            public_metadata: { tier: 'enterprise' },
+          },
+        },
+      ],
+    } as any);
+
+    const result = stripPrivateDataFromObject({ user });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('000-00-0000');
+    expect(serialized).not.toContain('mem_secret');
+    expect(serialized).not.toContain('cus_secret');
+
+    const membership = (result.user as any)._raw.organization_memberships[0];
+    expect(membership).not.toHaveProperty('private_metadata');
+    expect(membership.organization).not.toHaveProperty('private_metadata');
+
+    // Public metadata throughout the nested payload is intentionally preserved.
+    expect(membership.public_metadata).toEqual({ seat: 'a' });
+    expect(membership.organization.public_metadata).toEqual({ tier: 'enterprise' });
+  });
+
   it('does not mutate the original resource `raw` payload', () => {
     const user = User.fromJSON({
       id: 'user_1',

--- a/packages/backend/src/util/decorateObjectWithResources.ts
+++ b/packages/backend/src/util/decorateObjectWithResources.ts
@@ -52,7 +52,7 @@ export function stripPrivateDataFromObject<T extends WithResources<object>>(auth
   return { ...authObject, user, organization };
 }
 
-function prunePrivateMetadata(resource?: { private_metadata: any } | { privateMetadata: any } | null) {
+function prunePrivateMetadata(resource?: { private_metadata?: any; privateMetadata?: any; _raw?: any } | null) {
   // Delete sensitive private metadata from resource before rendering in SSR
   if (resource) {
     if ('privateMetadata' in resource) {
@@ -60,6 +60,15 @@ function prunePrivateMetadata(resource?: { private_metadata: any } | { privateMe
     }
     if ('private_metadata' in resource) {
       delete resource['private_metadata'];
+    }
+    // Backend resources (`User`, `Organization`) retain the full Backend API
+    // payload on the enumerable `_raw` property, which still contains
+    // `private_metadata`. Strip it from a shallow clone so the original
+    // resource (and its `raw` getter) is left untouched.
+    if ('_raw' in resource && resource['_raw']) {
+      const raw = { ...resource['_raw'] };
+      delete raw['private_metadata'];
+      resource['_raw'] = raw;
     }
   }
 

--- a/packages/backend/src/util/decorateObjectWithResources.ts
+++ b/packages/backend/src/util/decorateObjectWithResources.ts
@@ -63,14 +63,36 @@ function prunePrivateMetadata(resource?: { private_metadata?: any; privateMetada
     }
     // Backend resources (`User`, `Organization`) retain the full Backend API
     // payload on the enumerable `_raw` property, which still contains
-    // `private_metadata`. Strip it from a shallow clone so the original
-    // resource (and its `raw` getter) is left untouched.
+    // `private_metadata`. The payload is also nested (e.g. a `User`'s
+    // `organization_memberships[*]` each carry their own `private_metadata`
+    // and a nested `organization.private_metadata`), so redact recursively on
+    // a deep clone — leaving the original resource (and its `raw` getter)
+    // untouched.
     if ('_raw' in resource && resource['_raw']) {
-      const raw = { ...resource['_raw'] };
-      delete raw['private_metadata'];
-      resource['_raw'] = raw;
+      resource['_raw'] = redactPrivateMetadataDeep(resource['_raw']);
     }
   }
 
   return resource;
+}
+
+/**
+ * Returns a deep clone of `value` with every `private_metadata` / `privateMetadata`
+ * property removed at any depth.
+ */
+function redactPrivateMetadataDeep(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map(redactPrivateMetadataDeep);
+  }
+  if (value && typeof value === 'object') {
+    const clone: Record<string, any> = {};
+    for (const key of Object.keys(value)) {
+      if (key === 'private_metadata' || key === 'privateMetadata') {
+        continue;
+      }
+      clone[key] = redactPrivateMetadataDeep(value[key]);
+    }
+    return clone;
+  }
+  return value;
 }


### PR DESCRIPTION
## Description

`stripPrivateDataFromObject` now removes `private_metadata` from the backend resource `_raw` payload, preventing it from leaking into `__clerk_ssr_state` when a User/Organization resource is passed to `buildClerkProps`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
