### PR TITLE
fix(ui): Align legal consent checkbox in simple theme

### DIFF
--- a/.changeset/fair-singers-consent.md
+++ b/.changeset/fair-singers-consent.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix the legal consent checkbox growing in size when its label wraps to a second line while using the `simple` theme. The checkbox is now aligned to the start of the row so it no longer stretches to match the label height.

--- a/packages/clerk-js/sandbox/app.ts
+++ b/packages/clerk-js/sandbox/app.ts
@@ -281,6 +281,8 @@ async function initControls() {
     .addBinding(PARAMS, 'baseTheme', {
       options: {
         default: '',
+        clerk: 'clerk',
+        simple: 'simple',
         dark: 'dark',
         shadesOfPurple: 'shadesOfPurple',
         neobrutalism: 'neobrutalism',
@@ -357,6 +359,8 @@ async function initControls() {
 }
 
 const themes: Record<string, unknown> = {
+  clerk: 'clerk',
+  simple: 'simple',
   dark,
   shadesOfPurple,
   neobrutalism,

--- a/packages/ui/src/elements/LegalConsentCheckbox.tsx
+++ b/packages/ui/src/elements/LegalConsentCheckbox.tsx
@@ -79,7 +79,10 @@ export const LegalCheckbox = (
 
   return (
     <Field.Root {...props}>
-      <Flex justify='center'>
+      <Flex
+        justify='center'
+        align='start'
+      >
         <Field.CheckboxIndicator
           elementDescriptor={descriptors.formFieldCheckboxInput}
           elementId={descriptors.formFieldInput.setId('legalAccepted')}


### PR DESCRIPTION
## Description

In the simple theme, the legal consent checkbox would display a large square when wrapped to a second line. This is because it's inside a flex container which defaults align to `stretch`. Explicitly set it to `align='start'` to match the behavior of `CheckboxField`.

Some other themes don't have this problem because they set an explicit height and width. But that approach doesn't seem appropriate for `simple`. This fix also fixes `neobrutalism` which had the same issue.

This doesn't break existing themes because if you already have a height, the default align of `stretch` falls back to `start`. I also verified this visually by checking each theme before and after the change.

Also add `simple` to the Sandbox for easy verification of the fix.

<img width="812" height="862" alt="CleanShot 2026-05-29 at 09 23 49@2x" src="https://github.com/user-attachments/assets/1ea9468e-bd1b-40f0-9539-76f19b8494ea" />

Fixes USER-5441.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
