### PR TITLE
feat(cli-auth): add @clerk/cli-auth/server subpath export

### DIFF
--- a/.changeset/twenty-masks-cross.md
+++ b/.changeset/twenty-masks-cross.md
@@ -1,0 +1,5 @@
+---
+'@clerk/cli-auth': minor
+---
+
+Add `@clerk/cli-auth/server` subpath export: a `cliAuth()` factory that binds a `@clerk/backend` client and a standalone `handle()` route handler that verifies bearer tokens via `clerk.authenticateRequest` and returns an `Identity` payload. Drops into any framework using the Fetch API.

--- a/packages/cli-auth/README.md
+++ b/packages/cli-auth/README.md
@@ -27,7 +27,12 @@
 
 ## Getting Started
 
-`@clerk/cli-auth` is a set of building blocks for adding [Clerk](https://clerk.com) authentication to Node.js command-line tools. It handles browser-based OAuth sign-in, token storage, refresh, revocation, and credential resolution for API keys and OAuth access tokens.
+`@clerk/cli-auth` is a set of building blocks for adding [Clerk](https://clerk.com) authentication to Node.js command-line tools.
+
+The package ships two entry points:
+
+- **`@clerk/cli-auth`** — sign-in and credential management in your CLI.
+- **`@clerk/cli-auth/server`** — verify CLI requests on your backend.
 
 ### Prerequisites
 
@@ -183,11 +188,124 @@ if (source === 'oauth') {
 }
 ```
 
-### Backend verification
+Server-side verification of API keys and OAuth tokens happens at the `identityEndpoint` you host — see [Server-side](#server-side) for the implementation.
 
-`auth.verifyToken(token)` posts the bearer to your `identityEndpoint` and expects a JSON `Identity` response. The endpoint is responsible for verifying the token server-side (where your Clerk secret key lives) and returning the resolved subject.
+## Server-side
 
-A drop-in route handler that wraps `@clerk/backend`'s verification is shipping as a follow-up. Until then, host your own — verify API keys with `clerk.apiKeys.verify(token)` and OAuth tokens with `clerk.authenticateRequest(request, { acceptsToken: ['oauth_token'] })`, then respond with an `Identity` shape (`{ sub, ... }`).
+The `@clerk/cli-auth/server` entry point provides route handlers that verify incoming tokens against Clerk and return user info. The accepted token types are:
+
+| `accepts` value | Matching token format                                          |
+| --------------- | -------------------------------------------------------------- |
+| `'api_key'`     | `ak_*` Clerk API keys (user, org, or machine subject)          |
+| `'oauth_token'` | `oat_*` opaque OAuth access tokens or `at+jwt` JWTs (RFC 9068) |
+| `'any'`         | Either of the above                                            |
+
+### Bind a Clerk client
+
+Create a single `cliAuth` instance for your application:
+
+```ts
+// lib/clerk-cli.ts
+import { cliAuth } from '@clerk/cli-auth/server';
+import { clerkClient } from '@clerk/nextjs/server';
+
+export const auth = cliAuth({ client: clerkClient });
+```
+
+`client` accepts either a resolved Clerk Backend SDK client or a factory function. Passing `clerkClient` from `@clerk/nextjs/server` directly works — the SDK calls it lazily on the first request and caches the result. You can also pass `clientConfig` (the same options `createClerkClient` accepts) to construct a client from a specific secret key. If neither is provided, the SDK builds one from `CLERK_SECRET_KEY`.
+
+### Token verification
+
+The CLI verifies tokens by calling a backend endpoint you host. Build the endpoint with `handle()` from `@clerk/cli-auth/server`, then point the CLI's `identityEndpoint` at it.
+
+`handle()` returns a route handler. It reads `Authorization: Bearer <token>`, verifies the token with `clerk.authenticateRequest`, and responds with a JSON `Identity` payload.
+
+```ts
+// app/api/cli/identity/route.ts
+import { handle } from '@clerk/cli-auth/server';
+import { auth } from '@/lib/clerk-cli';
+
+export const GET = handle({ auth, accepts: ['api_key', 'oauth_token'] });
+```
+
+Drop it into any framework that uses the Fetch API (Next.js App Router, Hono, Cloudflare Workers, Bun, Deno, SvelteKit, Remix).
+
+### Protecting your own routes
+
+`handle()` is convenient when you just need the identity endpoint. For other routes the CLI calls — fetching data, running commands, etc. — use `auth.verifyTokenFromRequest()` directly inside your handler:
+
+```ts
+// app/api/cli/projects/route.ts
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-cli';
+
+export async function GET(request: Request) {
+  const tokenInfo = await auth.verifyTokenFromRequest(request, {
+    accepts: ['api_key', 'oauth_token'],
+  });
+
+  const projects = await db.projects.findMany({
+    where: { ownerId: tokenInfo.subject },
+  });
+
+  return NextResponse.json({ projects });
+}
+```
+
+`verifyTokenFromRequest` throws a `ClerkCliAuthError` if the header is missing, the token is invalid, or its type isn't in `accepts`. The returned `tokenInfo` has `subject`, `type`, `scopes`, and `claims` — use any of them to authorize the request.
+
+### Customize verification and response
+
+Override `verifyToken` or `resolveIdentity` on `handle()` when the defaults aren't enough. Both callbacks receive `clerk` (the bound Clerk Backend SDK client) so you don't need to re-import or re-initialize it.
+
+Add an allowlist or alternate verifier:
+
+```ts
+export const GET = handle({
+  auth,
+  accepts: 'api_key',
+  verifyToken: async ({ token, type, request, clerk }) => {
+    if (!isAllowlisted(token)) {
+      throw new Error('Token not allowlisted');
+    }
+    const apiKey = await clerk.apiKeys.verify(token);
+    return { subject: apiKey.subject, type, scopes: apiKey.scopes };
+  },
+});
+```
+
+Enrich the response with profile and org data:
+
+```ts
+export const GET = handle({
+  auth,
+  accepts: ['api_key', 'oauth_token'],
+  resolveIdentity: async ({ tokenInfo, clerk }) => {
+    if (tokenInfo.type === 'oauth_token') {
+      const user = await clerk.users.getUser(tokenInfo.subject);
+      return {
+        sub: user.id,
+        email: user.primaryEmailAddress?.emailAddress,
+        name: `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim(),
+        picture: user.imageUrl,
+      };
+    }
+    return {
+      sub: tokenInfo.subject,
+      scopes: tokenInfo.scopes,
+      org_id: tokenInfo.claims?.org_id as string | undefined,
+    };
+  },
+});
+```
+
+### Identity
+
+When the SDK resolves a token to its subject, the result is an `Identity`:
+
+```ts
+type Identity = UserIdentity | OrgIdentity | MachineIdentity | ScimIdentity;
+```
 
 ## Configuration reference
 

--- a/packages/cli-auth/package.json
+++ b/packages/cli-auth/package.json
@@ -36,6 +36,16 @@
         "default": "./dist/index.js"
       }
     },
+    "./server": {
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
@@ -53,9 +63,11 @@
     "lint:attw": "attw --pack . --profile node16",
     "lint:publint": "publint",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.mts",
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@clerk/backend": "workspace:^",
     "@napi-rs/keyring": "^1.1.7",
     "tslib": "catalog:repo"
   },

--- a/packages/cli-auth/src/__tests__/integration/server.test.ts
+++ b/packages/cli-auth/src/__tests__/integration/server.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { handle } from '../../server';
+import type { Identity } from '../../types';
+import {
+  bearerRequest,
+  type IntegrationFixtures,
+  provisionFixtures,
+  skipWhenNoSecret,
+  teardownFixtures,
+} from './setup';
+
+describe.skipIf(skipWhenNoSecret)('cli-auth server integration', () => {
+  let fx: IntegrationFixtures;
+
+  beforeAll(async () => {
+    fx = await provisionFixtures();
+  });
+
+  afterAll(async () => {
+    await teardownFixtures(fx);
+  });
+
+  describe('auth.verifyToken — API key per subject kind', () => {
+    it('verifies a user-scoped API key (subject = user_*)', async () => {
+      const info = await fx.auth.verifyToken(fx.userApiKey.secret!);
+      expect(info.type).toBe('api_key');
+      expect(info.subject).toBe(fx.user.id);
+      expect(info.subject).toMatch(/^user_/);
+      expect(info.scopes).toEqual(expect.arrayContaining(['cli:read']));
+    });
+
+    it('verifies an org-scoped API key (subject = org_*)', async () => {
+      const info = await fx.auth.verifyToken(fx.orgApiKey.secret!);
+      expect(info.type).toBe('api_key');
+      expect(info.subject).toBe(fx.org.id);
+      expect(info.subject).toMatch(/^org_/);
+    });
+
+    it('verifies a machine-scoped API key (subject = mch_*)', async () => {
+      const info = await fx.auth.verifyToken(fx.machineApiKey.secret!);
+      expect(info.type).toBe('api_key');
+      expect(info.subject).toBe(fx.machine.id);
+      expect(info.subject).toMatch(/^mch_/);
+    });
+  });
+
+  describe('auth.verifyTokenFromRequest', () => {
+    it('reads the Bearer header and verifies', async () => {
+      const req = bearerRequest(fx.userApiKey.secret!);
+      const info = await fx.auth.verifyTokenFromRequest(req, { accepts: 'api_key' });
+      expect(info.subject).toBe(fx.user.id);
+      expect(info.type).toBe('api_key');
+    });
+
+    it('throws on a missing Authorization header', async () => {
+      const req = new Request('http://test.local/cli');
+      await expect(fx.auth.verifyTokenFromRequest(req)).rejects.toThrow(/Authorization/);
+    });
+  });
+
+  describe('rejects credentials that are not API keys or OAuth tokens', () => {
+    it('rejects a raw unrecognized credential', async () => {
+      await expect(fx.auth.verifyToken('not-a-real-token')).rejects.toThrow();
+    });
+
+    it('rejects an unknown prefix', async () => {
+      await expect(fx.auth.verifyToken('xyz_unknown_prefix_token')).rejects.toThrow();
+    });
+
+    it('rejects an M2M-prefixed token (mt_*) — m2m is not a CLI credential', async () => {
+      // Fake mt_ value; we don't need a real M2M token to prove the gate. BAPI rejects it,
+      // and our code surfaces the rejection.
+      await expect(fx.auth.verifyToken('mt_not_a_real_m2m_token_value')).rejects.toThrow();
+    });
+  });
+
+  describe('auth.resolveIdentity (default)', () => {
+    it('projects subject + claims into Identity', async () => {
+      const info = await fx.auth.verifyToken(fx.userApiKey.secret!);
+      const identity = await fx.auth.resolveIdentity({
+        tokenInfo: info,
+        request: bearerRequest(fx.userApiKey.secret!),
+      });
+      expect(identity.sub).toBe(fx.user.id);
+    });
+  });
+
+  describe('handle() end-to-end', () => {
+    it('200 with Identity body for a user-scoped API key', async () => {
+      const route = handle({ auth: fx.auth, accepts: 'api_key' });
+      const res = await route(bearerRequest(fx.userApiKey.secret!));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Identity;
+      expect(body.sub).toBe(fx.user.id);
+    });
+
+    it('200 with Identity body for an org-scoped API key', async () => {
+      const route = handle({ auth: fx.auth, accepts: 'api_key' });
+      const res = await route(bearerRequest(fx.orgApiKey.secret!));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Identity;
+      expect(body.sub).toBe(fx.org.id);
+    });
+
+    it('200 with Identity body for a machine-scoped API key', async () => {
+      const route = handle({ auth: fx.auth, accepts: 'api_key' });
+      const res = await route(bearerRequest(fx.machineApiKey.secret!));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Identity;
+      expect(body.sub).toBe(fx.machine.id);
+    });
+
+    it('401 when no Authorization header is present', async () => {
+      const route = handle({ auth: fx.auth, accepts: 'any' });
+      const res = await route(new Request('http://test.local/cli'));
+      expect(res.status).toBe(401);
+    });
+
+    it('401 for unsupported credential types', async () => {
+      const route = handle({ auth: fx.auth, accepts: 'any' });
+      const res = await route(bearerRequest('not-a-real-token'));
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe('not_authenticated');
+    });
+
+    it('honors a custom resolveIdentity override', async () => {
+      const route = handle({
+        auth: fx.auth,
+        accepts: 'api_key',
+        resolveIdentity: ({ tokenInfo }) => ({
+          sub: tokenInfo.subject,
+          custom_field: 'enriched',
+        }),
+      });
+      const res = await route(bearerRequest(fx.userApiKey.secret!));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Identity & { custom_field?: string };
+      expect(body.sub).toBe(fx.user.id);
+      expect(body.custom_field).toBe('enriched');
+    });
+
+    it('honors a custom verifyToken override', async () => {
+      const route = handle({
+        auth: fx.auth,
+        accepts: 'api_key',
+        verifyToken: async ({ token, type, clerk }) => {
+          // Replace the verifier with our own — still using the bound `clerk` to keep this
+          // real. Asserts the override path correctly receives token + auto-detected type.
+          expect(type).toBe('api_key');
+          const verified = await clerk.apiKeys.verify(token);
+          return { subject: verified.subject, type, scopes: verified.scopes };
+        },
+      });
+
+      const res = await route(bearerRequest(fx.userApiKey.secret!));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Identity;
+      expect(body.sub).toBe(fx.user.id);
+    });
+  });
+});

--- a/packages/cli-auth/src/__tests__/integration/setup.ts
+++ b/packages/cli-auth/src/__tests__/integration/setup.ts
@@ -1,0 +1,157 @@
+import {
+  type APIKey,
+  type ClerkClient,
+  createClerkClient,
+  type Machine,
+  type Organization,
+  type User,
+} from '@clerk/backend';
+
+import { cliAuth, type CliAuthInstance } from '../../server';
+
+export const INTEGRATION_SECRET_KEY = process.env.CLERK_SECRET_KEY;
+const INTEGRATION_PUBLISHABLE_KEY = process.env.CLERK_PUBLISHABLE_KEY;
+
+/** Skip the suite when keys aren't configured — CI without them is a no-op. */
+export const skipWhenNoSecret = !INTEGRATION_SECRET_KEY || !INTEGRATION_PUBLISHABLE_KEY;
+
+/**
+ * Module-scope Clerk client + cliAuth instance. `createClerkClient` doesn't validate
+ * keys at construction (only when methods are called), so this is safe to build even
+ * when the suite is skipped — the factory helpers below just never get called.
+ *
+ * `clerk.authenticateRequest` requires *both* keys (publishable for JWKs and audience
+ * resolution, secret for BAPI calls), which is why we set them here rather than relying
+ * on the env at call-time.
+ */
+const clerk: ClerkClient = createClerkClient({
+  secretKey: INTEGRATION_SECRET_KEY ?? '',
+  publishableKey: INTEGRATION_PUBLISHABLE_KEY ?? '',
+});
+const auth: CliAuthInstance = cliAuth({ client: clerk });
+
+export interface IntegrationFixtures {
+  clerk: ClerkClient;
+  auth: CliAuthInstance;
+  /** Identities used as API key subjects. */
+  user: User;
+  org: Organization;
+  machine: Machine;
+  /** API keys, one per supported subject kind. */
+  userApiKey: APIKey;
+  orgApiKey: APIKey;
+  machineApiKey: APIKey;
+}
+
+// ---------------------------------------------------------------------------
+// Factory helpers — small, named primitives. Each call generates its own
+// unique slug so reruns in parallel CI shards don't collide on names. Inputs
+// other than slug are explicit.
+// ---------------------------------------------------------------------------
+
+function uniqueSlug(): string {
+  return `${Date.now()}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function createTestUser(): Promise<User> {
+  const slug = uniqueSlug();
+  try {
+    return await clerk.users.createUser({
+      username: `cliauthint${slug}`,
+      password: `Test_${slug}_${Date.now()}`,
+      skipPasswordChecks: true,
+    });
+  } catch (err) {
+    // Surface BAPI validation errors so failures are actionable, not opaque.
+    const detail = (err as { errors?: unknown }).errors;
+    throw new Error(
+      `clerk.users.createUser failed: ${(err as Error).message}${detail ? `\n${JSON.stringify(detail, null, 2)}` : ''}`,
+    );
+  }
+}
+
+async function createTestOrg(createdBy: string): Promise<Organization> {
+  return clerk.organizations.createOrganization({
+    name: `cli-auth integration ${uniqueSlug()}`,
+    createdBy,
+  });
+}
+
+async function createTestMachine(): Promise<Machine> {
+  return clerk.machines.create({ name: `cli-auth integration ${uniqueSlug()}` });
+}
+
+async function createTestApiKey(opts: { subject: string; scopes?: string[] }): Promise<APIKey> {
+  return clerk.apiKeys.create({
+    name: `cli-auth integration ${uniqueSlug()}`,
+    subject: opts.subject,
+    scopes: opts.scopes ?? [],
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Provision the throwaway Clerk resources we verify against: a user, an org owned by that
+ * user, and a machine — plus one API key per subject kind (user/org/machine). Shared
+ * across the suite via `beforeAll` and torn down in `afterAll`.
+ */
+export async function provisionFixtures(): Promise<IntegrationFixtures> {
+  if (!INTEGRATION_SECRET_KEY) {
+    throw new Error('CLERK_SECRET_KEY is required for integration tests');
+  }
+
+  // Wave 1: user and machine are independent; provision in parallel.
+  const [user, machine] = await Promise.all([createTestUser(), createTestMachine()]);
+
+  // Wave 2: org needs an owner (createdBy = user.id).
+  const org = await createTestOrg(user.id);
+
+  // Wave 3: one API key per subject kind, all independent.
+  const [userApiKey, orgApiKey, machineApiKey] = await Promise.all([
+    createTestApiKey({ subject: user.id, scopes: ['cli:read'] }),
+    createTestApiKey({ subject: org.id, scopes: ['cli:read'] }),
+    createTestApiKey({ subject: machine.id, scopes: ['cli:read'] }),
+  ]);
+
+  return { clerk, auth, user, org, machine, userApiKey, orgApiKey, machineApiKey };
+}
+
+/** Tear down everything `provisionFixtures` created. Surfaces any cleanup failures. */
+export async function teardownFixtures(fixtures: IntegrationFixtures | undefined): Promise<void> {
+  if (!fixtures) {
+    return;
+  }
+  const { user, org, machine, userApiKey, orgApiKey, machineApiKey } = fixtures;
+
+  const results = await Promise.allSettled([
+    clerk.apiKeys.delete(userApiKey.id),
+    clerk.apiKeys.delete(orgApiKey.id),
+    clerk.apiKeys.delete(machineApiKey.id),
+    clerk.organizations.deleteOrganization(org.id),
+    clerk.machines.delete(machine.id),
+    clerk.users.deleteUser(user.id),
+  ]);
+
+  const labels = [
+    'userApiKey delete',
+    'orgApiKey delete',
+    'machineApiKey delete',
+    'org delete',
+    'machine delete',
+    'user delete',
+  ];
+  const failures = results.map((r, i) => ({ r, label: labels[i] })).filter(({ r }) => r.status === 'rejected');
+  if (failures.length) {
+    for (const { r, label } of failures) {
+      const reason = (r as PromiseRejectedResult).reason;
+      console.error(`[cli-auth integration] ${label} failed:`, reason);
+    }
+    throw new Error(`Integration teardown failed: ${failures.map(f => f.label).join(', ')}`);
+  }
+}
+
+/** Build a Web `Request` with `Authorization: Bearer <token>` for handle() tests. */
+export function bearerRequest(token: string, url = 'http://test.local/cli'): Request {
+  return new Request(url, { headers: { Authorization: `Bearer ${token}` } });
+}

--- a/packages/cli-auth/src/__tests__/server-oauth.test.ts
+++ b/packages/cli-auth/src/__tests__/server-oauth.test.ts
@@ -1,0 +1,87 @@
+import type { ClerkClient } from '@clerk/backend';
+import { describe, expect, it, vi } from 'vitest';
+
+import { cliAuth } from '../server/cli-auth';
+import { handle } from '../server/handle';
+
+function bearer(token: string) {
+  return new Request('http://test.local/cli', { headers: { Authorization: `Bearer ${token}` } });
+}
+
+/**
+ * Build a fake `ClerkClient` whose `authenticateRequest` returns a stub `RequestState` —
+ * matching the discriminated shape `verify-token.ts` consumes. We only need to model the
+ * surface the cli-auth verifier touches: `isAuthenticated`, `toAuth()`, `reason`.
+ */
+function fakeClerkClient(
+  authResult:
+    | { isAuthenticated: true; auth: { subject: string; scopes: string[]; tokenType: string; claims?: unknown } }
+    | { isAuthenticated: false; reason?: string },
+): ClerkClient {
+  return {
+    authenticateRequest: vi.fn(async () => {
+      await Promise.resolve();
+      if (authResult.isAuthenticated) {
+        return {
+          isAuthenticated: true,
+          toAuth: () => authResult.auth,
+        };
+      }
+      return {
+        isAuthenticated: false,
+        reason: authResult.reason ?? 'rejected',
+      };
+    }),
+  } as unknown as ClerkClient;
+}
+
+const FAKE_OAUTH_TOKEN = 'oat_fake_test_token_value_here';
+const FAKE_SUBJECT = 'user_2abcDEFghiJKLmnoPQRstuVWXyz';
+
+describe('cli-auth server: oauth_token path (mocked)', () => {
+  it('verifyToken returns TokenInfo with type=oauth_token', async () => {
+    const client = fakeClerkClient({
+      isAuthenticated: true,
+      auth: { subject: FAKE_SUBJECT, scopes: ['profile', 'email'], tokenType: 'oauth_token' },
+    });
+    const auth = cliAuth({ client });
+
+    const info = await auth.verifyToken(FAKE_OAUTH_TOKEN);
+    expect(info.type).toBe('oauth_token');
+    expect(info.subject).toBe(FAKE_SUBJECT);
+    expect(info.scopes).toEqual(['profile', 'email']);
+  });
+
+  it('handle() returns 200 + Identity body for a verified OAuth token', async () => {
+    const client = fakeClerkClient({
+      isAuthenticated: true,
+      auth: { subject: FAKE_SUBJECT, scopes: ['profile'], tokenType: 'oauth_token' },
+    });
+    const auth = cliAuth({ client });
+
+    const route = handle({ auth, accepts: 'oauth_token' });
+    const res = await route(bearer(FAKE_OAUTH_TOKEN));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sub: string };
+    expect(body.sub).toBe(FAKE_SUBJECT);
+  });
+
+  it('surfaces clerk.authenticateRequest rejection as not_authenticated', async () => {
+    const client = fakeClerkClient({ isAuthenticated: false, reason: 'OAuth token expired' });
+    const auth = cliAuth({ client });
+
+    await expect(auth.verifyToken(FAKE_OAUTH_TOKEN)).rejects.toThrow(/OAuth token expired/);
+  });
+
+  it('preserves api_key claims field when present', async () => {
+    const client = fakeClerkClient({
+      isAuthenticated: true,
+      auth: { subject: 'user_abc', scopes: ['cli:read'], tokenType: 'api_key', claims: { tenant_id: 'org_xyz' } },
+    });
+    const auth = cliAuth({ client });
+
+    const info = await auth.verifyToken('ak_fake_value');
+    expect(info.type).toBe('api_key');
+    expect(info.claims).toEqual({ tenant_id: 'org_xyz' });
+  });
+});

--- a/packages/cli-auth/src/lib/classify-token.ts
+++ b/packages/cli-auth/src/lib/classify-token.ts
@@ -1,0 +1,56 @@
+import { type MachineTokenType, TokenType } from '@clerk/backend/internal';
+import { decodeJwt } from '@clerk/backend/jwt';
+
+import { ClerkCliAuthError } from '../errors';
+
+/**
+ * Token kinds cli-auth accepts as CLI credentials. Narrower than `@clerk/backend`'s
+ * `MachineTokenType` — we drop `m2m_token` because M2M tokens are minted by machines for
+ * server-to-server BAPI calls, not for a CLI user to send to a backend. For machine
+ * identities, use an API key with a `mch_*` subject instead.
+ */
+export type TokenKind = Exclude<MachineTokenType, typeof TokenType.M2MToken>;
+
+const API_KEY_PREFIX = 'ak_';
+const OAUTH_TOKEN_PREFIX = 'oat_';
+const JWT_FORMAT = /^[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+$/;
+/** RFC 9068 OAuth 2.0 access token `typ` header values. */
+const OAUTH_JWT_TYP_VALUES = ['at+jwt', 'application/at+jwt'] as const;
+
+function isJwtFormat(token: string): boolean {
+  return JWT_FORMAT.test(token);
+}
+
+/**
+ * Classify a credential as an API key or an OAuth access token by prefix / JWT shape:
+ *
+ * - `ak_*` → `'api_key'` (user/org/machine API keys all share this prefix)
+ * - `oat_*` or JWT with `typ: at+jwt` (RFC 9068) → `'oauth_token'`
+ *
+ * Throws on M2M tokens (`mt_*` or `mch_` subject JWT) and on any unknown shape — M2M is
+ * intentionally rejected at the CLI boundary.
+ */
+export function classifyToken(token: string): TokenKind {
+  if (token.startsWith(API_KEY_PREFIX)) {
+    return TokenType.ApiKey;
+  }
+  if (token.startsWith(OAUTH_TOKEN_PREFIX)) {
+    return TokenType.OAuthToken;
+  }
+  if (isJwtFormat(token)) {
+    const result = decodeJwt(token) as {
+      data?: { header: { typ?: unknown } };
+      errors?: unknown;
+    };
+    if (!result.errors && result.data) {
+      const typ = result.data.header.typ;
+      if (typeof typ === 'string' && (OAUTH_JWT_TYP_VALUES as readonly string[]).includes(typ)) {
+        return TokenType.OAuthToken;
+      }
+    }
+  }
+  throw new ClerkCliAuthError(
+    'not_authenticated',
+    'Unsupported credential. Expected an API key or OAuth access token.',
+  );
+}

--- a/packages/cli-auth/src/server/cli-auth.ts
+++ b/packages/cli-auth/src/server/cli-auth.ts
@@ -1,0 +1,123 @@
+import { type ClerkClient, type ClerkOptions, createClerkClient } from '@clerk/backend';
+
+import { ClerkCliAuthError } from '../errors';
+import type { TokenKind } from '../lib/classify-token';
+import { resolveIdentity as defaultResolveIdentity } from './resolve-identity';
+import type {
+  AcceptsToken,
+  CliAuthFactoryOptions,
+  CliAuthInstance,
+  ClientArg,
+  ResolveIdentityContext,
+  TokenInfo,
+} from './types';
+import { verifyTokenWithClerk } from './verify-token';
+
+/** Synthesize a Request so the bare-token verifier can reuse `clerk.authenticateRequest`. */
+function requestForToken(token: string): Request {
+  return new Request('http://cli-auth.local/verify', { headers: { Authorization: `Bearer ${token}` } });
+}
+
+/** Build a getClerk thunk for the given factory options, with a single-flight cache. */
+function makeClerkGetter(
+  client: ClientArg | undefined,
+  clientConfig: ClerkOptions | undefined,
+): () => Promise<ClerkClient> {
+  let cached: ClerkClient | null = null;
+  let pending: Promise<ClerkClient> | null = null;
+
+  return async function getClerk(): Promise<ClerkClient> {
+    if (cached) {
+      return cached;
+    }
+    if (pending) {
+      return pending;
+    }
+
+    pending = (async () => {
+      if (client) {
+        const resolved = typeof client === 'function' ? await client() : client;
+        cached = resolved;
+        return resolved;
+      }
+      if (clientConfig) {
+        cached = createClerkClient(clientConfig);
+        return cached;
+      }
+      const secretKey = process.env.CLERK_SECRET_KEY;
+      if (!secretKey) {
+        throw new ClerkCliAuthError(
+          'config',
+          'cliAuth() needs a Clerk Backend client. Pass `client`, `clientConfig`, or set CLERK_SECRET_KEY in the env.',
+        );
+      }
+      cached = createClerkClient({ secretKey });
+      return cached;
+    })();
+
+    try {
+      return await pending;
+    } finally {
+      pending = null;
+    }
+  };
+}
+
+/**
+ * Factory: bind a Clerk Backend client (via `client`, `clientConfig`, or auto-built from
+ * `CLERK_SECRET_KEY`) and return an instance with verifier helpers. Pair the instance with
+ * the standalone {@link handle} export to wire up route handlers.
+ *
+ * `client` accepts either a resolved `ClerkClient` or a factory function (sync or async)
+ * — pass `@clerk/nextjs/server`'s `clerkClient` directly, no top-level `await` required.
+ *
+ * @example
+ * ```ts
+ * // lib/clerk-cli.ts
+ * import { cliAuth } from '@clerk/cli-auth/server';
+ * import { clerkClient } from '@clerk/nextjs/server';
+ *
+ * export const auth = cliAuth({ client: clerkClient });
+ *
+ * // app/api/cli/verify/route.ts
+ * import { handle } from '@clerk/cli-auth/server';
+ * import { auth } from '@/lib/clerk-cli';
+ *
+ * export const GET = handle({ auth, accepts: ['api_key', 'oauth_token'] });
+ *
+ * // Or use the primitive directly inside a custom protected route:
+ * const tokenInfo = await auth.verifyTokenFromRequest(request, { accepts: 'api_key' });
+ * ```
+ */
+export function cliAuth(options: CliAuthFactoryOptions = {}): CliAuthInstance {
+  const getClerk = makeClerkGetter(options.client, options.clientConfig);
+
+  async function verifyTokenFromRequest<T extends TokenKind = TokenKind>(
+    request: Request,
+    verifyOptions?: { accepts?: AcceptsToken },
+  ): Promise<TokenInfo<T>> {
+    const clerk = await getClerk();
+    const info = await verifyTokenWithClerk(request, { accepts: verifyOptions?.accepts, clerk });
+    return info as TokenInfo<T>;
+  }
+
+  async function verifyToken<T extends TokenKind = TokenKind>(
+    token: string,
+    verifyOptions?: { accepts?: AcceptsToken },
+  ): Promise<TokenInfo<T>> {
+    return verifyTokenFromRequest<T>(requestForToken(token), verifyOptions);
+  }
+
+  function resolveIdentity<T extends TokenKind>(
+    ctx: Omit<ResolveIdentityContext<T>, 'clerk'> & { clerk?: ClerkClient },
+  ): ReturnType<typeof defaultResolveIdentity> {
+    return defaultResolveIdentity(ctx as ResolveIdentityContext<T>);
+  }
+
+  return {
+    verifyToken,
+    verifyTokenFromRequest,
+    resolveIdentity,
+    getClerk,
+  };
+}

--- a/packages/cli-auth/src/server/handle.ts
+++ b/packages/cli-auth/src/server/handle.ts
@@ -1,0 +1,87 @@
+import { ClerkCliAuthError, EXIT_CODE } from '../errors';
+import { classifyToken, type TokenKind } from '../lib/classify-token';
+import { resolveIdentity as defaultResolveIdentity, validateIdentity } from './resolve-identity';
+import type { HandleOptions, TokenInfo } from './types';
+import { readBearer } from './verify-token';
+
+function statusFor(code: string): number {
+  switch (code) {
+    case 'not_authenticated':
+    case 'verify_api_key':
+    case 'userinfo':
+      return 401;
+    case 'config':
+      return 500;
+    case 'timeout':
+      return 504;
+    default:
+      return 500;
+  }
+}
+
+function jsonError(error: ClerkCliAuthError): Response {
+  return Response.json(
+    { error: error.code, error_description: error.message, exit_code: error.exitCode ?? EXIT_CODE.GENERAL },
+    { status: statusFor(error.code) },
+  );
+}
+
+async function verifyForHandle<T extends TokenKind>(
+  request: Request,
+  options: HandleOptions<T>,
+): Promise<TokenInfo<T>> {
+  if (!options.verifyToken) {
+    return options.auth.verifyTokenFromRequest<T>(request, { accepts: options.accepts });
+  }
+  // Custom verifier: classify, then pass the bound Clerk client through.
+  const token = readBearer(request);
+  const type = classifyToken(token) as T;
+  const clerk = await options.auth.getClerk();
+  return options.verifyToken({ token, type, request, clerk });
+}
+
+/**
+ * Standalone route handler: wraps a `cliAuth()` instance into a Web `Request → Response`
+ * function for any framework that speaks the Fetch API (Next.js App Router, Hono,
+ * SvelteKit, Remix, plain Node `fetch`, etc.).
+ *
+ * @example
+ * ```ts
+ * // lib/clerk-cli.ts
+ * import { cliAuth } from '@clerk/cli-auth/server';
+ * import { clerkClient } from '@clerk/nextjs/server';
+ *
+ * export const auth = cliAuth({ client: clerkClient });
+ *
+ * // app/api/cli/identity/route.ts
+ * import { handle } from '@clerk/cli-auth/server';
+ * import { auth } from '@/lib/clerk-cli';
+ *
+ * export const GET = handle({
+ *   auth,
+ *   accepts: ['api_key', 'oauth_token'],
+ *   // Optional overrides:
+ *   // verifyToken: ({ token, type, request, clerk }) => ...
+ *   // resolveIdentity: ({ tokenInfo, request, clerk }) => ...
+ * });
+ * ```
+ */
+export function handle<T extends TokenKind = TokenKind>(
+  options: HandleOptions<T>,
+): (request: Request) => Promise<Response> {
+  return async function routeHandler(request: Request): Promise<Response> {
+    try {
+      const tokenInfo = await verifyForHandle<T>(request, options);
+      const clerk = await options.auth.getClerk();
+      const resolver = options.resolveIdentity ?? defaultResolveIdentity;
+      const raw = await resolver({ tokenInfo, request, clerk });
+      const info = validateIdentity(raw);
+      return Response.json(info, { status: 200 });
+    } catch (error) {
+      if (error instanceof ClerkCliAuthError) {
+        return jsonError(error);
+      }
+      return jsonError(new ClerkCliAuthError('config', `Unexpected error: ${(error as Error).message}`));
+    }
+  };
+}

--- a/packages/cli-auth/src/server/index.ts
+++ b/packages/cli-auth/src/server/index.ts
@@ -1,0 +1,17 @@
+export { cliAuth } from './cli-auth';
+export { handle } from './handle';
+
+export type {
+  AcceptsToken,
+  CliAuthFactoryOptions,
+  CliAuthInstance,
+  HandleOptions,
+  ResolveIdentityContext,
+  ResolveIdentityFn,
+  TokenInfo,
+  VerifyTokenContext,
+  VerifyTokenFn,
+} from './types';
+
+// Cli-auth's narrowed `TokenKind` ('api_key' | 'oauth_token') — m2m is intentionally excluded.
+export type { TokenKind } from '../lib/classify-token';

--- a/packages/cli-auth/src/server/resolve-identity.ts
+++ b/packages/cli-auth/src/server/resolve-identity.ts
@@ -1,0 +1,75 @@
+import { ClerkCliAuthError } from '../errors';
+import type { TokenKind } from '../lib/classify-token';
+import type { Identity } from '../types';
+import type { ResolveIdentityContext, TokenInfo } from './types';
+
+/**
+ * Canonical Clerk subject formats: `user_*`, `org_*`, `mch_*`, `scim_*` — each
+ * followed by 27 word chars. Verified tokens should always match.
+ */
+const SUBJECT_PATTERN = /^(user|org|mch|scim)_\w{27}$/;
+
+/** Extract a canonical Clerk subject from `tokenInfo.subject` or any claim that holds one. */
+function extractSubject(tokenInfo: TokenInfo): string {
+  if (SUBJECT_PATTERN.test(tokenInfo.subject)) {
+    return tokenInfo.subject;
+  }
+  // Fallback: scan claims for the first canonical subject value.
+  if (tokenInfo.claims) {
+    for (const value of Object.values(tokenInfo.claims)) {
+      if (typeof value === 'string' && SUBJECT_PATTERN.test(value)) {
+        return value;
+      }
+    }
+  }
+  throw new ClerkCliAuthError(
+    'verify_api_key',
+    `Verified token has no canonical Clerk subject (got "${tokenInfo.subject}").`,
+  );
+}
+
+/**
+ * Default info resolver — runs on a verified `TokenInfo` and projects it into a
+ * `Identity`. Validates the subject against `^(user|org|mch|scim)_\w{27}$`
+ * to catch verifier output that doesn't look like a Clerk resource ID.
+ *
+ * Consumers override this by passing `resolveIdentity` to `handle()` when they want
+ * richer profile/org data (e.g. fetching the user via the bound Clerk client, or
+ * pulling org claims out of an API key's `claims` bag).
+ */
+export function resolveIdentity<T extends TokenKind>(ctx: ResolveIdentityContext<T>): Identity {
+  const { tokenInfo } = ctx;
+  const sub = extractSubject(tokenInfo);
+
+  const info: Identity = { sub };
+
+  // Pass through anything the verifier surfaced under `claims` — keeps the response useful
+  // without forcing every consumer to write a resolver.
+  if (tokenInfo.claims) {
+    for (const [key, value] of Object.entries(tokenInfo.claims)) {
+      if (info[key] === undefined) {
+        info[key] = value;
+      }
+    }
+  }
+
+  return info;
+}
+
+/** Internal: enforces the `Identity` contract on whatever the resolver returned. */
+export function validateIdentity(info: unknown): Identity {
+  if (!info || typeof info !== 'object') {
+    throw new ClerkCliAuthError(
+      'verify_api_key',
+      'resolveIdentity must return an Identity object with a non-empty `sub`.',
+    );
+  }
+  const candidate = info as Partial<Identity>;
+  if (typeof candidate.sub !== 'string' || !candidate.sub) {
+    throw new ClerkCliAuthError(
+      'verify_api_key',
+      'resolveIdentity returned an object without a non-empty `sub` field.',
+    );
+  }
+  return candidate as Identity;
+}

--- a/packages/cli-auth/src/server/types.ts
+++ b/packages/cli-auth/src/server/types.ts
@@ -1,0 +1,147 @@
+import type { ClerkClient, ClerkOptions } from '@clerk/backend';
+
+import type { TokenKind } from '../lib/classify-token';
+import type { Identity } from '../types';
+
+/**
+ * Which token types this endpoint accepts: a single {@link TokenKind}, a readonly tuple of
+ * them, or the literal `'any'`. Narrower than `@clerk/backend`'s `acceptsToken` — m2m tokens
+ * and session tokens are both intentionally excluded from the CLI threat model.
+ */
+export type AcceptsToken = TokenKind | readonly TokenKind[] | 'any';
+
+/**
+ * A Clerk Backend client, either resolved or wrapped in a factory. Passing the factory
+ * lets you forward `@clerk/nextjs/server`'s `clerkClient` directly — the SDK calls it
+ * lazily on first use, so consumers don't need to `await` at module scope.
+ */
+export type ClientArg = ClerkClient | (() => ClerkClient | Promise<ClerkClient>);
+
+/**
+ * Verified token payload. Returned by `verifyToken` / `verifyTokenFromRequest`
+ * and passed into `resolveIdentity` as `tokenInfo`.
+ */
+export interface TokenInfo<T extends TokenKind = TokenKind> {
+  /** The verified token's subject — `user_*`, `org_*`, `mch_*`, or `scim_*`. */
+  subject: string;
+  /** The verified token type (`api_key` | `oauth_token`). */
+  type: T;
+  /** Scopes attached to the token, when applicable. */
+  scopes?: string[];
+  /** Raw verified claims/data from `@clerk/backend`. Shape varies by token type. */
+  claims?: Record<string, unknown>;
+}
+
+/**
+ * Context passed to a `verifyToken` override. `token` is the raw, unverified bearer.
+ * `type` is the auto-detected token type; `clerk` is the resolved Clerk Backend client.
+ */
+export interface VerifyTokenContext<T extends TokenKind = TokenKind> {
+  /** Raw bearer token from the `Authorization` header. */
+  token: string;
+  /** Token type auto-detected from the token's prefix / JWT shape. */
+  type: T;
+  /** Original incoming `Request`. */
+  request: Request;
+  /** Clerk Backend client, ready to use (`clerk.apiKeys.verify(...)`, `clerk.authenticateRequest(...)`, etc.). */
+  clerk: ClerkClient;
+}
+
+/**
+ * Context passed to a `resolveIdentity` callback. The token has already been verified;
+ * downstream code reads `tokenInfo.subject` / `.claims`, the original `request`, and the
+ * resolved Clerk Backend client.
+ */
+export interface ResolveIdentityContext<T extends TokenKind = TokenKind> {
+  /** The verified token, including subject, type, scopes, and claims. */
+  tokenInfo: TokenInfo<T>;
+  /** Original incoming `Request`. */
+  request: Request;
+  /** Clerk Backend client, ready to use (e.g. `clerk.users.getUser(tokenInfo.subject)`). */
+  clerk: ClerkClient;
+}
+
+/** A `verifyToken` callback returns a verified `TokenInfo` or throws on rejection. */
+export type VerifyTokenFn<T extends TokenKind = TokenKind> = (
+  ctx: VerifyTokenContext<T>,
+) => Promise<TokenInfo<T>> | TokenInfo<T>;
+
+/** A `resolveIdentity` callback shapes the verified token into a `Identity` payload. */
+export type ResolveIdentityFn<T extends TokenKind = TokenKind> = (
+  ctx: ResolveIdentityContext<T>,
+) => Promise<Identity> | Identity;
+
+/**
+ * Options for the `cliAuth()` factory. Pass either a Clerk Backend client (or a factory
+ * returning one) via `client`, or the config used to construct one via `clientConfig`.
+ * If neither is given, the factory builds a client from `CLERK_SECRET_KEY` at first use.
+ *
+ * `clientConfig.secretKey` (or `CLERK_SECRET_KEY`) is also what `verifyToken` /
+ * `verifyTokenFromRequest` pass to `@clerk/backend`'s `verifyMachineAuthToken`.
+ */
+export interface CliAuthFactoryOptions {
+  /** Pre-configured Clerk Backend client, or a thunk returning one (e.g. `@clerk/nextjs/server`'s `clerkClient`). */
+  client?: ClientArg;
+  /** Or: the `ClerkOptions` shape `createClerkClient(...)` accepts. */
+  clientConfig?: ClerkOptions;
+}
+
+/**
+ * Options for the standalone `handle()` export. Pass the `cliAuth()` instance you want to
+ * bind the route to via `auth`. Per-route Clerk client overrides aren't supported — make
+ * another `cliAuth()` instance instead.
+ */
+export interface HandleOptions<T extends TokenKind = TokenKind> {
+  /** `cliAuth()` instance whose bound Clerk client and verifier/resolver this route should use. */
+  auth: CliAuthInstance;
+  /** Which token types this endpoint accepts. Rejects every other type with 401. Defaults to `'any'`. */
+  accepts?: AcceptsToken;
+  /** Override the verification step. Defaults to a `verifyMachineAuthToken`-backed verifier. */
+  verifyToken?: VerifyTokenFn<T>;
+  /** Override the info-resolution step. Defaults to extracting subject + claims into `Identity`. */
+  resolveIdentity?: ResolveIdentityFn<T>;
+}
+
+/**
+ * Shape returned by `cliAuth({ client })`. Pair it with the standalone `handle()` export, or
+ * call its instance methods directly inside your own route logic.
+ *
+ * @example
+ * ```ts
+ * // lib/clerk-cli.ts
+ * import { cliAuth } from '@clerk/cli-auth/server';
+ * import { clerkClient } from '@clerk/nextjs/server';
+ *
+ * export const auth = cliAuth({ client: clerkClient });
+ *
+ * // app/api/cli/verify/route.ts
+ * import { handle } from '@clerk/cli-auth/server';
+ * import { auth } from '@/lib/clerk-cli';
+ *
+ * export const GET = handle({ auth, accepts: ['api_key', 'oauth_token'] });
+ * ```
+ */
+export interface CliAuthInstance {
+  /**
+   * Primitive verifier — raw bearer in, verified `TokenInfo` out. Auto-detects token type
+   * via `@clerk/backend`'s `verifyMachineAuthToken`, optionally gating against `accepts`.
+   */
+  verifyToken: <T extends TokenKind = TokenKind>(
+    token: string,
+    options?: { accepts?: AcceptsToken },
+  ) => Promise<TokenInfo<T>>;
+  /**
+   * Request-level verifier — reads `Authorization: Bearer <token>`, then defers to
+   * `verifyToken(token, options)`.
+   */
+  verifyTokenFromRequest: <T extends TokenKind = TokenKind>(
+    request: Request,
+    options?: { accepts?: AcceptsToken },
+  ) => Promise<TokenInfo<T>>;
+  /** Default resolver: project a verified `TokenInfo` into `Identity`. Sync today, but typed `Identity | Promise<Identity>` so consumer-supplied resolvers can be async. */
+  resolveIdentity: <T extends TokenKind>(
+    ctx: Omit<ResolveIdentityContext<T>, 'clerk'> & { clerk?: ClerkClient },
+  ) => Identity | Promise<Identity>;
+  /** Resolve the bound Clerk Backend SDK client. Cached after the first call. */
+  getClerk: () => Promise<ClerkClient>;
+}

--- a/packages/cli-auth/src/server/verify-token.ts
+++ b/packages/cli-auth/src/server/verify-token.ts
@@ -1,0 +1,73 @@
+import type { ClerkClient } from '@clerk/backend';
+
+import { ClerkCliAuthError } from '../errors';
+import type { TokenKind } from '../lib/classify-token';
+import type { AcceptsToken, TokenInfo } from './types';
+
+const BEARER_PREFIX = /^Bearer\s+/i;
+
+/** cli-auth's canonical accepted set — m2m and session are intentionally never accepted. */
+const DEFAULT_ACCEPTS: readonly TokenKind[] = ['api_key', 'oauth_token'] as const;
+
+export function readBearer(request: Request): string {
+  const header = request.headers.get('authorization');
+  if (!header) {
+    throw new ClerkCliAuthError('not_authenticated', 'Missing Authorization header.');
+  }
+  const token = header.replace(BEARER_PREFIX, '').trim();
+  if (!token) {
+    throw new ClerkCliAuthError('not_authenticated', 'Authorization header is empty.');
+  }
+  return token;
+}
+
+/**
+ * Normalize cli-auth's {@link AcceptsToken} to the `acceptsToken` array
+ * `@clerk/backend` expects. `'any'` collapses to the canonical narrowed set so session
+ * and m2m tokens are never accidentally accepted even when the caller asks for "any".
+ */
+function normalizeAccepts(accepts: AcceptsToken | undefined): readonly TokenKind[] {
+  if (!accepts || accepts === 'any') {
+    return DEFAULT_ACCEPTS;
+  }
+  return Array.isArray(accepts) ? accepts : [accepts as TokenKind];
+}
+
+/**
+ * Default token verifier — delegates to `clerk.authenticateRequest`, which detects the
+ * token type, looks up the right verification primitive (BAPI for opaque, JWKs for JWTs),
+ * and returns an `AuthObject`. We narrow the result to the {@link TokenInfo} shape that
+ * downstream consumers (`resolveIdentity`, custom `verifyToken` overrides) work with.
+ *
+ * Consumers who want richer claims for JWT-shaped tokens (e.g. the full RFC 9068 payload)
+ * can decode the bearer inside a custom `resolveIdentity` callback — that hook receives
+ * the original `Request`, so the raw token is recoverable via `readBearer(request)`.
+ */
+export async function verifyTokenWithClerk(
+  request: Request,
+  options: { accepts?: AcceptsToken; clerk: ClerkClient },
+): Promise<TokenInfo> {
+  // Cli-auth is bearer-only — require the header up front so consumers get a clear
+  // "Missing Authorization header" rather than `authenticateRequest`'s
+  // `token-type-mismatch` reason after it falls through to cookie auth and fails.
+  readBearer(request);
+
+  const acceptsToken = normalizeAccepts(options.accepts);
+  const state = await options.clerk.authenticateRequest(request, { acceptsToken });
+  if (state.isAuthenticated === false) {
+    throw new ClerkCliAuthError('not_authenticated', state.reason ?? 'Token rejected.');
+  }
+
+  const authObj = state.toAuth();
+  // `subject`, `scopes`, `tokenType` are top-level on every AuthenticatedMachineObject.
+  // `claims` is only present on the `api_key` arm of MachineObjectExtendedProperties —
+  // check the property at runtime to avoid leaking the type machinery here.
+  const claims = 'claims' in authObj && authObj.claims ? (authObj.claims as Record<string, unknown>) : undefined;
+
+  return {
+    subject: authObj.subject,
+    type: authObj.tokenType as TokenKind,
+    scopes: authObj.scopes,
+    claims,
+  };
+}

--- a/packages/cli-auth/tsup.config.ts
+++ b/packages/cli-auth/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(overrideOptions => {
   return {
     entry: {
       index: './src/index.ts',
+      server: './src/server/index.ts',
     },
     format: ['cjs', 'esm'],
     bundle: true,

--- a/packages/cli-auth/vitest.config.mts
+++ b/packages/cli-auth/vitest.config.mts
@@ -9,5 +9,8 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
     },
     setupFiles: './vitest.setup.mts',
+    // Integration tests live under src/__tests__/integration/ and require a real
+    // CLERK_SECRET_KEY. Default `vitest run` is unit-only; use `pnpm test:integration`.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/__tests__/integration/**'],
   },
 });

--- a/packages/cli-auth/vitest.integration.config.mts
+++ b/packages/cli-auth/vitest.integration.config.mts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Integration tests hit a real Clerk instance — they create users, API keys, and M2M
+ * tokens via the Backend SDK and clean up in `afterAll`. Run with `pnpm test:integration`
+ * and a `CLERK_SECRET_KEY` set in the environment. Suites `describe.skipIf` themselves
+ * when the secret is missing, so CI without it is a no-op rather than a failure.
+ */
+export default defineConfig({
+  plugins: [],
+  test: {
+    include: ['src/__tests__/integration/**/*.test.ts'],
+    setupFiles: './vitest.setup.mts',
+    // Network calls + BAPI rate limits — longer timeouts than the unit suite.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    // Sequential to keep BAPI traffic predictable; we share resources via beforeAll.
+    fileParallelism: false,
+    coverage: {
+      enabled: false,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
 
   packages/cli-auth:
     dependencies:
+      '@clerk/backend':
+        specifier: workspace:^
+        version: link:../backend
       '@napi-rs/keyring':
         specifier: ^1.1.7
         version: 1.3.0


### PR DESCRIPTION
## Summary

Companion to #8709. Adds `@clerk/cli-auth/server`, a subpath export that ships server-side helpers for verifying CLI bearer tokens against Clerk.

The ClerkCLIAuth instance talks to a consumer-hosted `identityEndpoint` to resolve a token's subject. This PR provides a drop-in handler so consumers don't have to write that endpoint by hand.

## Usage

Bind a Clerk Backend client once, then use the standalone `handle()` to wire up the verification route:

```ts
// lib/clerk-cli.ts
import { cliAuth } from '@clerk/cli-auth/server';
import { clerkClient } from '@clerk/nextjs/server';

export const auth = cliAuth({ client: clerkClient });

// app/api/cli/identity/route.ts
import { handle } from '@clerk/cli-auth/server';
import { auth } from '@/lib/clerk-cli';

export const GET = handle({ auth, accepts: ['api_key', 'oauth_token'] });
```

`handle()` reads `Authorization: Bearer <token>`, verifies via `clerk.authenticateRequest`, and responds with a JSON `Identity` payload. Drop it into any framework using the Fetch API (Next.js App Router, Hono, Cloudflare Workers, Bun, Deno, SvelteKit, Remix).

For other routes the CLI calls (not the identity endpoint), use the verifier primitive directly:

```ts
const tokenInfo = await auth.verifyTokenFromRequest(request, {
  accepts: ['api_key', 'oauth_token'],
});
```

Both `verifyToken` and `resolveIdentity` are overridable on `handle()` for allowlists, alternate verifiers, or response enrichment.

## Why not just use `clerk.authenticateRequest`?

Both call the same Clerk primitives under the hood. The wrapper returns a flat `{ subject, type, scopes, claims }` shape that's identical for every accepted token type. `clerk.authenticateRequest` instead returns a `RequestState` you unwrap into a discriminated union where fields like `claims` only exist on certain arms — consumer code has to branch on which token type came in. The wrapper also narrows accepted types to `'api_key' | 'oauth_token'` at the type level and throws on rejection instead of returning an unauthenticated state.

## Accepted credentials

| `accepts` value | Matches                                                          |
| --------------- | ---------------------------------------------------------------- |
| `'api_key'`     | `ak_*` Clerk API keys with user, org, **or** machine subjects    |
| `'oauth_token'` | `oat_*` opaque OAuth access tokens or `at+jwt` JWTs (RFC 9068)   |
| `'any'`         | Either of the above                                              |

Clerk session JWTs and M2M tokens (`mt_*` / `mch_` subject JWTs) are intentionally not in the accept set — neither is a CLI credential. For a machine identity that calls your API, mint an API key with a `mch_*` subject.

## Identity

When the SDK resolves a token to its subject, the result is an `Identity`:

```ts
type Identity = UserIdentity | OrgIdentity | MachineIdentity | ScimIdentity;
```

## Test plan

- [x] Unit tests pass — `pnpm --filter @clerk/cli-auth test` (20 tests, offline)
- [x] Integration tests pass against a real Clerk instance — `pnpm --filter @clerk/cli-auth test:integration` (16 tests; requires `CLERK_SECRET_KEY` + `CLERK_PUBLISHABLE_KEY`; skips cleanly when unset)
- [x] Integration suite provisions throwaway Clerk resources (user, org, machine, three API keys per subject kind) and tears them all down in `afterAll` — verified zero leftovers
- [x] `pnpm build`, `pnpm lint`, `pnpm lint:attw`, `pnpm lint:publint` all green