### PR TITLE
fix(expo): preserve token cache method context

### DIFF
--- a/.changeset/clean-token-cache.md
+++ b/.changeset/clean-token-cache.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Preserve custom token cache method context when initializing the native Clerk singleton.

--- a/packages/expo/src/provider/singleton/__tests__/createClerkInstance.test.ts
+++ b/packages/expo/src/provider/singleton/__tests__/createClerkInstance.test.ts
@@ -1,6 +1,9 @@
 import type { Clerk } from '@clerk/clerk-js';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { TokenCache } from '../../../cache/types';
+import { CLERK_CLIENT_JWT_KEY } from '../../../constants';
+
 const mocks = vi.hoisted(() => {
   return {
     constructorSpy: vi.fn(),
@@ -238,5 +241,47 @@ describe('createClerkInstance', () => {
         proxyUrl: () => '/api/__clerk',
       }),
     ).toThrow(/`proxyUrl` must be a string/);
+  });
+
+  test('preserves tokenCache method context for class instances', async () => {
+    class InstanceTokenCache implements TokenCache {
+      private readonly tokens = new Map<string, string>();
+
+      getToken(key: string) {
+        return Promise.resolve(this.tokens.get(key) ?? null);
+      }
+
+      saveToken(key: string, token: string) {
+        this.tokens.set(key, token);
+        return Promise.resolve();
+      }
+    }
+
+    const tokenCache = new InstanceTokenCache();
+    await tokenCache.saveToken(CLERK_CLIENT_JWT_KEY, 'cached-token');
+
+    const createClerkInstance = await loadCreateClerkInstance();
+    const getClerkInstance = createClerkInstance(MockClerk as unknown as typeof Clerk);
+    const clerk = getClerkInstance({
+      publishableKey: 'pk_test_123',
+      tokenCache,
+    }) as unknown as MockClerk;
+
+    const beforeRequest = clerk.__internal_onBeforeRequest.mock.calls[0][0];
+    const requestInit = {
+      headers: new Headers(),
+      url: new URL('https://clerk.example.com/v1/client'),
+    };
+    await beforeRequest(requestInit);
+
+    expect(requestInit.headers.get('authorization')).toBe('cached-token');
+
+    const afterResponse = clerk.__internal_onAfterResponse.mock.calls[0][0];
+    await afterResponse(requestInit, {
+      headers: new Headers({ authorization: 'fresh-token' }),
+      payload: null,
+    });
+
+    await expect(tokenCache.getToken(CLERK_CLIENT_JWT_KEY)).resolves.toBe('fresh-token');
   });
 });

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -106,8 +106,8 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
         tokenCache.clearToken?.(CLERK_CLIENT_JWT_KEY);
       }
 
-      const getToken = tokenCache.getToken;
-      const saveToken = tokenCache.saveToken;
+      const getToken = (key: string) => tokenCache.getToken(key);
+      const saveToken = (key: string, token: string) => tokenCache.saveToken(key, token);
 
       __internal_clerkOptions = { publishableKey, proxyUrl, domain };
       __internal_clerk = new ClerkClass(publishableKey, { proxyUrl, domain }) as unknown as BrowserClerk;


### PR DESCRIPTION
## Summary

- Preserve `tokenCache` method context when `@clerk/expo` wires the native Clerk singleton into `clerk-js` request hooks.
- Add regression coverage for a class-instance token cache whose methods rely on `this`.
- Add a patch changeset for `@clerk/expo`.
- [Plain Ticket](https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01KSR6YGTF30669WAT36Z6DT70/)

> This was an issue with some updates internally in the clerk sdk, with how it uses the `tokenCache`. The previous recommended code for the tokenCache no longer worked as clerk destructured the `getValue` and `setValue` functions from the tokenCache internally. This broke the cache when implemented as a class instance and not a pure object as the functions are not bound to the class instance when they rely on instance properties from the tokenCache class. 

>It's worth noting that anyone using a standard setup with the recomended code from (older) clerk documentation prior to clerk exporting a tokenCache from ckerk itself will have a high chance to hit this issue, so I suggest changing the clerk react-native sdk to be backwards compatible with the older tokenCache class instance.

## Customer Context

A customer upgrading to Expo 56 and the latest `@clerk/expo` reported that the app stayed stuck loading forever on `<ClerkLoaded>`, and calls such as `useAuth().getToken()` did not resolve on iOS Simulator 26.3.

They later narrowed it down to their older documented `tokenCache` implementation. Their cache was implemented as a class instance, and the cache methods depended on instance properties. Because `@clerk/expo` detached `getToken` and `saveToken` from the provided `tokenCache`, those methods lost their receiver and no longer had access to `this`.

This keeps both cache styles working.

## Supported Token Cache Styles

Plain object cache:

```ts
const tokenCache = {
  async getToken(key: string) {
    return await SecureStore.getItemAsync(key);
  },

  async saveToken(key: string, token: string) {
    await SecureStore.setItemAsync(key, token);
  },
};

<ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
  {children}
</ClerkProvider>;
```

Class instance cache:

```ts
class TokenCache {
  private prefix = 'clerk:';

  async getToken(key: string) {
    return await SecureStore.getItemAsync(this.prefix + key);
  }

  async saveToken(key: string, token: string) {
    await SecureStore.setItemAsync(this.prefix + key, token);
  }
}

const tokenCache = new TokenCache();

<ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
  {children}
</ClerkProvider>;
```

## Testing

- `pnpm --dir packages/expo exec vitest run src/provider/singleton/__tests__/createClerkInstance.test.ts`
- `pnpm --dir packages/expo exec prettier --check src/provider/singleton/createClerkInstance.ts src/provider/singleton/__tests__/createClerkInstance.test.ts ../../.changeset/clean-token-cache.md`
- `git diff --check`

Note: `pnpm --filter @clerk/expo test -- createClerkInstance` ran the new singleton test successfully, but the package-level pattern also collected unrelated hook tests that require built `@clerk/react` exports in this fresh worktree.
