### PR TITLE
fix(ui): Pass current subscription item price ID when checking out

### DIFF
--- a/packages/ui/src/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/ui/src/components/OrganizationProfile/InviteMembersForm.tsx
@@ -187,6 +187,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
                   plan: currentPlan,
                   planPeriod: activeSubscriptionItem.planPeriod,
                   seatsQuantity: err.errors[0].meta?.seatsQuantity,
+                  priceId: activeSubscriptionItem.priceId,
                   portalRoot,
                 });
                 break;


### PR DESCRIPTION
## Description

This PR fixes an issue where the current active subscription item's price ID was not passed to checkouts initiated from the invite members flow.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
