### PR TITLE
fix(react): key custom page portals by stable id

### DIFF
--- a/.changeset/custom-page-portal-stable-keys.md
+++ b/.changeset/custom-page-portal-stable-keys.md
@@ -1,0 +1,5 @@
+---
+'@clerk/react': patch
+---
+
+Keep custom pages and menu items mounted when sibling pages are added, removed, or reordered. Portals are now keyed by a stable id rather than their array index, so a surviving page is reconciled as an update instead of being remounted.

--- a/integration/templates/react-vite/src/custom-user-profile/index.tsx
+++ b/integration/templates/react-vite/src/custom-user-profile/index.tsx
@@ -1,9 +1,12 @@
 import { UserProfile } from '@clerk/react';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { PageContext, PageContextProvider } from '../PageContext.tsx';
 
 function Page1() {
   const { counter, setCounter } = useContext(PageContext);
+  // Local state lives INSIDE the portaled custom page. It only resets if the
+  // page is remounted, so it is our instrument for detecting remounts.
+  const [localCounter, setLocalCounter] = useState(0);
 
   return (
     <>
@@ -15,13 +18,31 @@ function Page1() {
       >
         Update
       </button>
+      <p data-local-counter={1}>Local counter: {localCounter}</p>
+      <button
+        data-local-counter={1}
+        onClick={() => setLocalCounter(a => a + 1)}
+      >
+        Increment local
+      </button>
     </>
   );
 }
 
 export default function Page() {
+  // Bumping parent state recreates the <UserProfile> element, forcing the
+  // profile component (and useCustomPages) to rerender. The custom page content
+  // must survive this without remounting.
+  const [parentTick, setParentTick] = useState(0);
+
   return (
     <PageContextProvider>
+      <button
+        data-testid='rerender-parent'
+        onClick={() => setParentTick(t => t + 1)}
+      >
+        Rerender parent: {parentTick}
+      </button>
       <UserProfile
         fallback={<>Loading user profile</>}
         path={'/custom-user-profile'}

--- a/integration/tests/custom-pages.test.ts
+++ b/integration/tests/custom-pages.test.ts
@@ -171,6 +171,37 @@ testAgainstRunningApps({ withPattern: ['react.vite.withEmailCodes'] })(
       });
     });
 
+    test('custom profile page survives a parent rerender without remounting', async ({ page, context }) => {
+      const u = createTestUtils({ app, page, context });
+      await u.po.signIn.goTo();
+      await u.po.signIn.waitForMounted();
+      await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });
+      await u.po.expect.toBeSignedIn();
+
+      await u.page.goToRelative(CUSTOM_PROFILE_PAGE);
+      await u.po.userProfile.waitForMounted();
+
+      // Open the custom page (Page 1)
+      const [profilePage] = await u.page.locator('button.cl-navbarButton__custom-page-0').all();
+      await profilePage.click();
+
+      // Local state lives inside the portaled custom page and starts at 0.
+      await u.page.waitForSelector('p[data-local-counter="1"]', { state: 'attached' });
+      await expect(u.page.locator('p[data-local-counter="1"]')).toHaveText('Local counter: 0');
+
+      // Mutate the local state to 2.
+      await u.page.locator('button[data-local-counter="1"]').click();
+      await u.page.locator('button[data-local-counter="1"]').click();
+      await expect(u.page.locator('p[data-local-counter="1"]')).toHaveText('Local counter: 2');
+
+      // Force a parent rerender: this re-creates the <UserProfile> element and reruns useCustomPages.
+      await u.page.locator('button[data-testid="rerender-parent"]').click();
+      await expect(u.page.locator('button[data-testid="rerender-parent"]')).toHaveText('Rerender parent: 1');
+
+      // The custom page must NOT remount, so its local state is preserved.
+      await expect(u.page.locator('p[data-local-counter="1"]')).toHaveText('Local counter: 2');
+    });
+
     test.describe('User Button with experimental asStandalone and asProvider', () => {
       test('items at the specified order', async ({ page, context }) => {
         const u = createTestUtils({ app, page, context });

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -127,8 +127,8 @@ type OrganizationSwitcherPropsWithoutCustomPages = Without<
 const CustomPortalsRenderer = (props: CustomPortalsRendererProps) => {
   return (
     <>
-      {props?.customPagesPortals?.map((portal, index) => createElement(portal, { key: index }))}
-      {props?.customMenuItemsPortals?.map((portal, index) => createElement(portal, { key: index }))}
+      {props?.customPagesPortals?.map(({ key, portal }) => createElement(portal, { key }))}
+      {props?.customMenuItemsPortals?.map(({ key, portal }) => createElement(portal, { key }))}
     </>
   );
 };

--- a/packages/react/src/utils/__tests__/customPages.remount.integration.test.tsx
+++ b/packages/react/src/utils/__tests__/customPages.remount.integration.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import React, { createElement, useEffect, useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { OrganizationProfilePage } from '../../components/uiComponents';
+import { useOrganizationProfileCustomPages } from '../useCustomPages';
+
+vi.mock('@clerk/shared/utils', () => ({
+  logErrorInDevMode: vi.fn(),
+}));
+
+// Per-page mount/unmount counters. A remount re-runs the mount effect.
+const mounts: Record<string, number> = {};
+const unmounts: Record<string, number> = {};
+
+// Stable component type, defined once. If it remounts across a rerender it is
+// because the portal wrapping it changed identity or render key.
+const TrackedContent = ({ id, text }: { id: string; text: string }) => {
+  useEffect(() => {
+    mounts[id] = (mounts[id] ?? 0) + 1;
+    return () => {
+      unmounts[id] = (unmounts[id] ?? 0) + 1;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once instrument; id is stable per instance
+  }, []);
+  return <div data-testid={`content-${id}`}>{text}</div>;
+};
+
+/**
+ * Faithfully reproduces the production render path for custom pages:
+ *  - useOrganizationProfileCustomPages parses children into { customPages, customPagesPortals }
+ *  - clerk-js calls customPages[i].mount(node) once per logical page (by identity; here keyed by url)
+ *  - CustomPortalsRenderer renders each portal via createElement(portal, { key }) using the STABLE key
+ */
+const Harness = ({ children, tick }: { children: React.ReactNode; tick: number }) => {
+  const { customPages, customPagesPortals } = useOrganizationProfileCustomPages(children);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const mountedUrls = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    customPages.forEach(page => {
+      if (page.mount && page.url && !mountedUrls.current.has(page.url)) {
+        mountedUrls.current.add(page.url);
+        const node = document.createElement('div');
+        hostRef.current?.appendChild(node);
+        page.mount(node);
+      }
+    });
+  });
+
+  return (
+    <>
+      <div
+        data-tick={tick}
+        ref={hostRef}
+      />
+      {customPagesPortals.map(({ key, portal }) => createElement(portal, { key }))}
+    </>
+  );
+};
+
+const makePage = (id: string, label: string, url: string, text: string) => (
+  <OrganizationProfilePage
+    key={id}
+    label={label}
+    labelIcon={<span>i</span>}
+    url={url}
+  >
+    <TrackedContent
+      id={id}
+      text={text}
+    />
+  </OrganizationProfilePage>
+);
+
+afterEach(() => {
+  for (const k of Object.keys(mounts)) {
+    delete mounts[k];
+  }
+  for (const k of Object.keys(unmounts)) {
+    delete unmounts[k];
+  }
+});
+
+describe('custom pages remount behavior (integration through CustomPortalsRenderer path)', () => {
+  it('does not remount custom page content when the parent rerenders', async () => {
+    const { rerender } = render(<Harness tick={0}>{[makePage('p1', 'Page 1', 'page-1', 'first')]}</Harness>);
+
+    await screen.findByText('first');
+    expect(mounts['p1']).toBe(1);
+
+    // Parent rerenders for an unrelated reason; the page content prop changes but the
+    // logical page (key/label/url) is identical.
+    rerender(<Harness tick={1}>{[makePage('p1', 'Page 1', 'page-1', 'second')]}</Harness>);
+
+    await screen.findByText('second');
+    expect(mounts['p1']).toBe(1);
+    expect(unmounts['p1'] ?? 0).toBe(0);
+  });
+
+  it('does not remount a surviving custom page when another page is inserted before it', async () => {
+    const second = makePage('second', 'Second', 'second', 'second-content');
+    const first = makePage('first', 'First', 'first', 'first-content');
+
+    const { rerender } = render(<Harness tick={0}>{[second]}</Harness>);
+    await screen.findByText('second-content');
+    expect(mounts['second']).toBe(1);
+
+    // Insert a new page BEFORE the existing one.
+    rerender(<Harness tick={1}>{[first, second]}</Harness>);
+    await screen.findByText('first-content');
+
+    // The surviving page keeps its stable key + portal identity, so React reconciles it as an
+    // update rather than a remount.
+    expect(mounts['second']).toBe(1);
+    expect(unmounts['second'] ?? 0).toBe(0);
+    // The newly inserted page mounts exactly once.
+    expect(mounts['first']).toBe(1);
+  });
+});

--- a/packages/react/src/utils/__tests__/useCustomMenuItems.test.tsx
+++ b/packages/react/src/utils/__tests__/useCustomMenuItems.test.tsx
@@ -156,7 +156,8 @@ describe('useUserButtonCustomMenuItems', () => {
 
     expect(result.current.customMenuItems).toHaveLength(2);
     expect(result.current.customMenuItemsPortals).toHaveLength(2);
-    expect(result.current.customMenuItemsPortals[0]).not.toBe(result.current.customMenuItemsPortals[1]);
+    expect(result.current.customMenuItemsPortals[0].portal).not.toBe(result.current.customMenuItemsPortals[1].portal);
+    expect(result.current.customMenuItemsPortals[0].key).not.toBe(result.current.customMenuItemsPortals[1].key);
   });
 
   it('keeps portal identity with the logical menu item when inserting before it', () => {
@@ -187,12 +188,14 @@ describe('useUserButtonCustomMenuItems', () => {
       },
     );
 
-    const secondItemIconPortal = result.current.customMenuItemsPortals[0];
+    const secondItemIconPortal = result.current.customMenuItemsPortals[0].portal;
+    const secondItemIconKey = result.current.customMenuItemsPortals[0].key;
 
     rerender({ includeFirstItem: true });
 
     expect(result.current.customMenuItems).toHaveLength(2);
-    expect(result.current.customMenuItemsPortals[0]).not.toBe(secondItemIconPortal);
-    expect(result.current.customMenuItemsPortals[1]).toBe(secondItemIconPortal);
+    expect(result.current.customMenuItemsPortals[0].portal).not.toBe(secondItemIconPortal);
+    expect(result.current.customMenuItemsPortals[1].portal).toBe(secondItemIconPortal);
+    expect(result.current.customMenuItemsPortals[1].key).toBe(secondItemIconKey);
   });
 });

--- a/packages/react/src/utils/__tests__/useCustomPages.test.tsx
+++ b/packages/react/src/utils/__tests__/useCustomPages.test.tsx
@@ -36,8 +36,12 @@ describe('useOrganizationProfileCustomPages', () => {
 
     expect(result.current.customPages).toHaveLength(2);
     expect(result.current.customPagesPortals).toHaveLength(4);
-    expect(result.current.customPagesPortals[0]).not.toBe(result.current.customPagesPortals[2]);
-    expect(result.current.customPagesPortals[1]).not.toBe(result.current.customPagesPortals[3]);
+    // Duplicate (same label+url, no key) pages get distinct portal identities...
+    expect(result.current.customPagesPortals[0].portal).not.toBe(result.current.customPagesPortals[2].portal);
+    expect(result.current.customPagesPortals[1].portal).not.toBe(result.current.customPagesPortals[3].portal);
+    // ...and distinct stable render keys.
+    const keys = result.current.customPagesPortals.map(p => p.key);
+    expect(new Set(keys).size).toBe(keys.length);
   });
 
   it('keeps portal identity with the logical custom page when inserting before it', () => {
@@ -70,15 +74,21 @@ describe('useOrganizationProfileCustomPages', () => {
       },
     );
 
-    const secondPageContentPortal = result.current.customPagesPortals[0];
-    const secondPageIconPortal = result.current.customPagesPortals[1];
+    const secondPageContentPortal = result.current.customPagesPortals[0].portal;
+    const secondPageContentKey = result.current.customPagesPortals[0].key;
+    const secondPageIconPortal = result.current.customPagesPortals[1].portal;
+    const secondPageIconKey = result.current.customPagesPortals[1].key;
 
     rerender({ includeFirstPage: true });
 
     expect(result.current.customPages).toHaveLength(2);
-    expect(result.current.customPagesPortals[0]).not.toBe(secondPageContentPortal);
-    expect(result.current.customPagesPortals[1]).not.toBe(secondPageIconPortal);
-    expect(result.current.customPagesPortals[2]).toBe(secondPageContentPortal);
-    expect(result.current.customPagesPortals[3]).toBe(secondPageIconPortal);
+    expect(result.current.customPagesPortals[0].portal).not.toBe(secondPageContentPortal);
+    expect(result.current.customPagesPortals[1].portal).not.toBe(secondPageIconPortal);
+    // The second page keeps BOTH its portal identity and its stable render key when it moves
+    // position, so CustomPortalsRenderer reconciles it as an update instead of a remount.
+    expect(result.current.customPagesPortals[2].portal).toBe(secondPageContentPortal);
+    expect(result.current.customPagesPortals[2].key).toBe(secondPageContentKey);
+    expect(result.current.customPagesPortals[3].portal).toBe(secondPageIconPortal);
+    expect(result.current.customPagesPortals[3].key).toBe(secondPageIconKey);
   });
 });

--- a/packages/react/src/utils/useCustomMenuItems.tsx
+++ b/packages/react/src/utils/useCustomMenuItems.tsx
@@ -57,7 +57,7 @@ const useCustomMenuItems = ({
 }: UseCustomMenuItemsParams) => {
   const validChildren: CustomMenuItemType[] = [];
   const customMenuItems: CustomMenuItem[] = [];
-  const customMenuItemsPortals: React.ComponentType[] = [];
+  const customMenuItemsPortals: Array<{ key: string; portal: React.ComponentType }> = [];
   const portalIdCounts = new Map<string, number>();
 
   React.Children.forEach(children, child => {
@@ -181,7 +181,7 @@ const useCustomMenuItems = ({
         menuItem.open = mi.open;
       }
       customMenuItems.push(menuItem);
-      customMenuItemsPortals.push(iconPortal);
+      customMenuItemsPortals.push({ key: `icon:${mi.portalId || index}`, portal: iconPortal });
     }
     if (isExternalLink(mi)) {
       const {
@@ -195,7 +195,7 @@ const useCustomMenuItems = ({
         mountIcon,
         unmountIcon,
       });
-      customMenuItemsPortals.push(iconPortal);
+      customMenuItemsPortals.push({ key: `icon:${mi.portalId || index}`, portal: iconPortal });
     }
   });
 

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -179,7 +179,7 @@ const useCustomPages = (params: UseCustomPagesParams, options?: UseCustomPagesOp
   const customLinkLabelIconsPortals = useCustomElementPortal(customLinkLabelIcons);
 
   const customPages: CustomPage[] = [];
-  const customPagesPortals: React.ComponentType[] = [];
+  const customPagesPortals: Array<{ key: string; portal: React.ComponentType }> = [];
 
   validChildren.forEach((cp, index) => {
     if (isReorderItem(cp, reorderItemsLabels)) {
@@ -198,8 +198,8 @@ const useCustomPages = (params: UseCustomPagesParams, options?: UseCustomPagesOp
         unmount: unmountIcon,
       } = customPageLabelIconsPortals.find(p => p.id === (cp.portalId || index)) as UseCustomElementPortalReturn;
       customPages.push({ label: cp.label, url: cp.url, mount, unmount, mountIcon, unmountIcon });
-      customPagesPortals.push(contentPortal);
-      customPagesPortals.push(labelPortal);
+      customPagesPortals.push({ key: `content:${cp.portalId || index}`, portal: contentPortal });
+      customPagesPortals.push({ key: `label:${cp.portalId || index}`, portal: labelPortal });
       return;
     }
     if (isExternalLink(cp)) {
@@ -209,7 +209,7 @@ const useCustomPages = (params: UseCustomPagesParams, options?: UseCustomPagesOp
         unmount: unmountIcon,
       } = customLinkLabelIconsPortals.find(p => p.id === (cp.portalId || index)) as UseCustomElementPortalReturn;
       customPages.push({ label: cp.label, url: cp.url, mountIcon, unmountIcon });
-      customPagesPortals.push(labelPortal);
+      customPagesPortals.push({ key: `label:${cp.portalId || index}`, portal: labelPortal });
       return;
     }
   });


### PR DESCRIPTION
Follow-up to the custom-page remount fix. That change stabilized each portal's identity so a custom page survives a parent rerender; this goes one step further. `CustomPortalsRenderer` was still keying portals by array index, so adding, removing, or reordering pages remounted the survivors anyway. Each portal now carries a stable key from its `portalId`, so a page that moves position reconciles as an update.

```tsx
- customPagesPortals.map((portal, index) => createElement(portal, { key: index }))
+ customPagesPortals.map(({ key, portal }) => createElement(portal, { key }))
```

The hooks now emit `{ key, portal }` (with `content:`/`label:`/`icon:` prefixes so a page's two portals stay distinct). Coverage added: a jsdom integration test that renders through the real portal path (no remount on a parent rerender or an insert), and an e2e test that a custom page keeps its local state across a parent rerender.
