### PR TITLE
fix(ui): Use new paymentAttempt.totals object in UI

### DIFF
--- a/.changeset/payment-attempt-subtotal.md
+++ b/.changeset/payment-attempt-subtotal.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix the `Subtotal` row in the payment attempt details view to read from `paymentAttempt.totals.subtotal` so it matches the value shown in the Clerk Dashboard. Previously it rendered `subscriptionItem.amount` which caused the displayed subtotal to disagree with the dashboard.

--- a/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
+++ b/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
@@ -273,7 +273,7 @@ function PaymentAttemptBody({ paymentAttempt }: { paymentAttempt: BillingPayment
         >
           <LineItems.Title title={localizationKeys('billing.subtotal')} />
           <LineItems.Description
-            text={`${subscriptionItem.amount?.currencySymbol}${subscriptionItem.amount?.amountFormatted}`}
+            text={`${paymentAttempt.totals?.subtotal.currencySymbol}${paymentAttempt.totals?.subtotal.amountFormatted}`}
           />
         </LineItems.Group>
         {subscriptionItem.credits &&


### PR DESCRIPTION
## Description

Fixes the UI for a payment itemization – subtotal had previously been using `subscriptionItem.amount`, and now uses the correct `totals.subtotal`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
