### PR TITLE
fix(clerk-js): Bypass captcha on OAuth backport for Core 2

### DIFF
--- a/.changeset/oauth-captcha-callback-backport.md
+++ b/.changeset/oauth-captcha-callback-backport.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix new OAuth users hanging on the SSO callback. When an OAuth sign-in transfers to a sign-up, the captcha is now correctly bypassed for providers in the captcha OAuth bypass list, instead of unconditionally showing a captcha that could never be completed.

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -182,13 +182,6 @@ export class SignUp extends BaseResource implements SignUpResource {
       finalParams = { ...finalParams, ...captchaParams };
     }
 
-    if (finalParams.transfer && this.shouldBypassCaptchaForAttempt(finalParams)) {
-      const strategy = SignUp.clerk.client?.signIn.firstFactorVerification.strategy;
-      if (strategy) {
-        finalParams = { ...finalParams, strategy: strategy as SignUpCreateParams['strategy'] };
-      }
-    }
-
     return this._basePost({
       path: this.pathRoot,
       body: normalizeUnsafeMetadata(finalParams),
@@ -562,22 +555,24 @@ export class SignUp extends BaseResource implements SignUpResource {
    * We delegate bot detection to the following providers, instead of relying on turnstile exclusively
    */
   protected shouldBypassCaptchaForAttempt(params: SignUpCreateParams) {
-    if (!params.strategy) {
-      return false;
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const captchaOauthBypass = SignUp.clerk.__unstable__environment!.displayConfig.captchaOauthBypass;
 
-    if (captchaOauthBypass.some(strategy => strategy === params.strategy)) {
-      return true;
-    }
-
+    // OAuth transfers: If we delegate captcha detection to the OAuth provider,
+    // do not show another captcha on sign up. The strategy lives on the sign in
+    // verification rather than on `params`, so this must be checked before any
+    // early return based on `params.strategy`.
     if (
       params.transfer &&
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       captchaOauthBypass.some(strategy => strategy === SignUp.clerk.client!.signIn.firstFactorVerification.strategy)
     ) {
+      return true;
+    }
+
+    // OAuth sign ups: If we delegate captcha detection to the OAuth provider,
+    // do not show another captcha on sign up.
+    if (params.strategy && captchaOauthBypass.some(strategy => strategy === params.strategy)) {
       return true;
     }
 

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -25,11 +25,88 @@ vi.mock('../../../utils/captcha/CaptchaChallenge', () => ({
   })),
 }));
 
+// Import the mocked CaptchaChallenge after mocking
+import { CaptchaChallenge } from '../../../utils/captcha/CaptchaChallenge';
+
 describe('SignUp', () => {
   it('can be serialized with JSON.stringify', () => {
     const signUp = new SignUp();
     const snapshot = JSON.stringify(signUp);
     expect(snapshot).toBeDefined();
+  });
+
+  describe('create', () => {
+    beforeEach(() => {
+      SignUp.clerk = {
+        __unstable__environment: {
+          displayConfig: {
+            captchaOauthBypass: [],
+          },
+        },
+      } as any;
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      vi.unstubAllGlobals();
+      SignUp.clerk = {} as any;
+    });
+
+    it('skips captcha challenge for oauth transfer when strategy is in captchaOauthBypass', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signup_123', status: 'missing_requirements' },
+      });
+      BaseResource._fetch = mockFetch;
+      SignUp.clerk = {
+        client: {
+          signIn: {
+            firstFactorVerification: {
+              status: 'transferable',
+              strategy: 'oauth_google',
+            },
+          },
+        },
+        __unstable__environment: {
+          displayConfig: {
+            captchaOauthBypass: ['oauth_google', 'oauth_apple'],
+          },
+        },
+      } as any;
+
+      const signUp = new SignUp();
+      await signUp.create({ transfer: true });
+
+      expect(CaptchaChallenge).not.toHaveBeenCalled();
+    });
+
+    it('does not skip captcha challenge for enterprise_sso transfer', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signup_123', status: 'missing_requirements' },
+      });
+      BaseResource._fetch = mockFetch;
+      SignUp.clerk = {
+        client: {
+          signIn: {
+            firstFactorVerification: {
+              status: 'transferable',
+              strategy: 'enterprise_sso',
+            },
+          },
+        },
+        __unstable__environment: {
+          displayConfig: {
+            captchaOauthBypass: [],
+          },
+        },
+      } as any;
+
+      const signUp = new SignUp();
+      await signUp.create({ transfer: true });
+
+      expect(CaptchaChallenge).toHaveBeenCalledWith(SignUp.clerk);
+    });
   });
 
   describe('SignUpFuture', () => {


### PR DESCRIPTION
## Description

Backport of the OAuth captcha bypass fix from #8030 to Core 2. `shouldBypassCaptchaForAttempt` bailed out early (therefore showing captcha) when `params.strategy` was unset, which is the case on an OAuth transfer to sign up (the strategy lives on the sign in verification). As a result a captcha was unconditionally requested for brand-new OAuth users. Normally this was a no-op, just wasting cycles to Cloudflare and then our backend would ignore captcha results for bypassed providers anyway. However, we got a report that it was producing a bug on Safari where the frontend would hang indefinitely on /sign-in/sso-callback.

The transfer bypass is now checked before any strategy-based early return, and the redundant strategy-injection block in `create` is removed. Enterprise SSO transfers still correctly show a captcha.

Only the captcha bypass fix is backported; the sign_up_if_missing feature from #8030 is intentionally excluded.

For discussion of the regression introduced in 2024, see https://clerkinc.slack.com/archives/C01KTTYKWBU/p1772566383559539.

Written by Claude under Daniel's supervision.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where new OAuth users could hang on the SSO callback during signup transitions. The system now properly bypasses captcha verification for pre-configured OAuth providers instead of showing an inaccessible captcha, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->