### PR TITLE
fix(ui): Pricing table layout shift on switch changes

### DIFF
--- a/.changeset/fix-switch-scroll-jump.md
+++ b/.changeset/fix-switch-scroll-jump.md
@@ -1,0 +1,6 @@
+---
+'@clerk/ui': patch
+'@clerk/clerk-js': patch
+---
+
+Fix Chrome-specific scroll jump when toggling the billing period switch on the pricing table.

--- a/.changeset/fix-switch-scroll-jump.md
+++ b/.changeset/fix-switch-scroll-jump.md
@@ -1,6 +1,5 @@
 ---
 '@clerk/ui': patch
-'@clerk/clerk-js': patch
 ---
 
 Fix Chrome-specific scroll jump when toggling the billing period switch on the pricing table.

--- a/packages/ui/src/elements/Switch.tsx
+++ b/packages/ui/src/elements/Switch.tsx
@@ -53,6 +53,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
         align='center'
         as='label'
         sx={t => ({
+          position: 'relative',
           isolation: 'isolate',
           width: 'fit-content',
           '&:has(input:focus-visible) > input + span': {
@@ -73,6 +74,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(
           aria-labelledby={ariaLabelledBy}
           style={{
             ...common.visuallyHidden(),
+            inset: 0,
           }}
         />
         <Flex


### PR DESCRIPTION
## Description

Fix Chrome-specific scroll jump when toggling the billing period switch on the pricing table.

BEFORE

https://github.com/user-attachments/assets/ff4460b5-69e1-49e4-b512-b23e75c8f402

AFTER

https://github.com/user-attachments/assets/cda0c75d-8f31-4f00-a899-81f1bce90a68


Fixes BILL-1705

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
