### PR TITLE
fix(backend): correct createOrganizationInvitationBulk return type to PaginatedResourceResponse

### DIFF
--- a/.changeset/fix-bulk-invitation-return-type.md
+++ b/.changeset/fix-bulk-invitation-return-type.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix the return type of `clerkClient.organizations.createOrganizationInvitationBulk()` to `PaginatedResourceResponse<OrganizationInvitation[]>`. The Backend API returns the bulk-created invitations in a `{ data, totalCount }` envelope (the same shape as `getOrganizationInvitationList()`), but the method was typed as `OrganizationInvitation[]`, which did not match the value returned at runtime.

--- a/packages/backend/src/api/__tests__/OrganizationApi.test.ts
+++ b/packages/backend/src/api/__tests__/OrganizationApi.test.ts
@@ -1,0 +1,73 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { server, validateHeaders } from '../../mock-server';
+import { createBackendApiClient } from '../factory';
+import type { PaginatedResourceResponse } from '../resources/Deserializer';
+import type { OrganizationInvitation } from '../resources/OrganizationInvitation';
+
+describe('OrganizationAPI', () => {
+  const apiClient = createBackendApiClient({
+    apiUrl: 'https://api.clerk.test',
+    secretKey: 'deadbeef',
+  });
+
+  const organizationId = 'org_123';
+
+  const mockInvitation = {
+    object: 'organization_invitation',
+    id: 'orginv_1',
+    email_address: 'one@example.com',
+    role: 'org:member',
+    role_name: 'Member',
+    organization_id: organizationId,
+    status: 'pending',
+    public_metadata: {},
+    private_metadata: {},
+    url: null,
+    created_at: 1640995200,
+    updated_at: 1640995200,
+    expires_at: 1643673600,
+  };
+
+  describe('createOrganizationInvitationBulk', () => {
+    it('returns a paginated { data, totalCount } response matching the Backend API shape', async () => {
+      server.use(
+        http.post(
+          `https://api.clerk.test/v1/organizations/${organizationId}/invitations/bulk`,
+          validateHeaders(async ({ request }) => {
+            // The SDK should forward the invitations as a snake_cased array body.
+            const body = (await request.json()) as Array<Record<string, unknown>>;
+            expect(body).toHaveLength(2);
+            expect(body[0]).toMatchObject({
+              email_address: 'one@example.com',
+              role: 'org:member',
+              inviter_user_id: 'user_1',
+            });
+
+            return HttpResponse.json({
+              data: [mockInvitation, { ...mockInvitation, id: 'orginv_2', email_address: 'two@example.com' }],
+              total_count: 2,
+            });
+          }),
+        ),
+      );
+
+      const response = await apiClient.organizations.createOrganizationInvitationBulk(organizationId, [
+        { emailAddress: 'one@example.com', role: 'org:member', inviterUserId: 'user_1' },
+        { emailAddress: 'two@example.com', role: 'org:member', inviterUserId: 'user_1' },
+      ]);
+
+      // The Backend API wraps bulk results in a paginated envelope, and the
+      // deserializer surfaces it as `{ data, totalCount }`.
+      expect(response.data).toHaveLength(2);
+      expect(response.data[0].emailAddress).toBe('one@example.com');
+      expect(response.data[0].organizationId).toBe(organizationId);
+      expect(response.totalCount).toBe(2);
+
+      // The declared return type must reflect that paginated shape, the same
+      // way the sibling `getOrganizationInvitationList` does.
+      expectTypeOf(response).toEqualTypeOf<PaginatedResourceResponse<OrganizationInvitation[]>>();
+    });
+  });
+});

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -394,7 +394,7 @@ export class OrganizationAPI extends AbstractAPI {
   ) {
     this.requireId(organizationId);
 
-    return this.request<OrganizationInvitation[]>({
+    return this.request<PaginatedResourceResponse<OrganizationInvitation[]>>({
       method: 'POST',
       path: joinPaths(basePath, organizationId, 'invitations', 'bulk'),
       bodyParams: params,


### PR DESCRIPTION
## Description

Fixes #8740

`clerkClient.organizations.createOrganizationInvitationBulk()` is typed as returning `Promise<OrganizationInvitation[]>`, but the Backend API endpoint it wraps returns a paginated `{ data, total_count }` envelope. The request goes through the same deserializer as every other list endpoint, so at runtime the method already resolves to `{ data, totalCount }` — only the type was wrong, which made the declared type impossible to use correctly.

This aligns the return type with `PaginatedResourceResponse<OrganizationInvitation[]>`, matching the sibling `getOrganizationInvitationList()` method directly above it.

**Verification of the API shape** — confirmed against the Backend API OpenAPI spec rather than assuming. The `CreateOrganizationInvitationBulk` operation's `200` response references the `OrganizationInvitations` component, which is:

```yaml
type: object
properties:
  data:
    type: array
    items:
      $ref: '#/components/schemas/OrganizationInvitation'
  total_count:
    type: integer
```

(Note: this is intentionally different from the instance-level `invitations.createInvitationBulk()`, whose response is a bare array — see #7702 — which is why the two bulk methods have different return types.)

This is consistent with the prior return-type corrections shipped as patches, e.g. `getOrganizationMembershipList()` (#2681) and `JwtTemplatesApi.list` (#7868).

### Note on impact

The runtime value is unchanged; this only corrects the static type. It is technically a type-level breaking change for anyone who wrote code against the old (non-functional) `OrganizationInvitation[]` type — but since that type never matched the value returned at runtime, such code could not have worked. Consumers now access the invitations via `.data` and the count via `.totalCount`, the same as the sibling list methods.

### How to test

A unit test was added at `packages/backend/src/api/__tests__/OrganizationApi.test.ts` that:

- mocks the bulk endpoint returning a `{ data, total_count }` payload,
- asserts the SDK forwards the invitations as a snake_cased array body,
- asserts the response is surfaced as `{ data, totalCount }`, and
- asserts (via `expectTypeOf`) the return type equals `PaginatedResourceResponse<OrganizationInvitation[]>` (this assertion fails type-check without the fix).

Full `pnpm test` for `@clerk/backend` passes across all three environments (node, edge-runtime, miniflare) and `pnpm build` succeeds.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) JSDoc comments have been added or updated for any package exports
- [ ] (If applicable) Documentation has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
