### PR TITLE
fix(ui): break circular import between styled-system and primitives

### DIFF
--- a/.changeset/fix-ui-styledsystem-circular-import.md
+++ b/.changeset/fix-ui-styledsystem-circular-import.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix a circular import in the styled-system that could crash module initialization under bundler configurations with tree-shaking disabled.

--- a/packages/ui/src/styledSystem/InternalThemeProvider.tsx
+++ b/packages/ui/src/styledSystem/InternalThemeProvider.tsx
@@ -2,7 +2,7 @@
 import { ThemeProvider } from '@emotion/react';
 import React from 'react';
 
-import { useAppearance } from '../customizables';
+import { useAppearance } from '../customizables/AppearanceContext';
 import type { InternalTheme } from './types';
 
 type InternalThemeProviderProps = React.PropsWithChildren<{


### PR DESCRIPTION
Breaks a latent circular import in the styled-system that started crashing the Dashboard dev build once the dev Rspack config turned off tree-shaking (`providedExports`/`usedExports`).

The loop: `InternalThemeProvider` imports `useAppearance` from the `customizables` barrel, which eagerly loads `primitives`, whose `Box` calls `createVariants` from the `styledSystem` barrel at module-eval time, re-entering a barrel that hasn't finished initializing. `useAppearance` actually lives in the `customizables/AppearanceContext` leaf, and that leaf's subtree only references `styledSystem` through a type-only import, so pointing the import there directly pulls nothing back in and severs the cycle.
