### PR TITLE
fix(clerk-js): Correct locale inconsistencies when creating SignUpFuture

### DIFF
--- a/.changeset/signup-future-password-browser-locale.md
+++ b/.changeset/signup-future-password-browser-locale.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix `signUp.password()` on the future SignUp API not defaulting the sign-up's `locale` to the browser locale when it creates a new sign-up, matching the documented behavior and `signUp.create()`. An explicitly passed `locale` still takes precedence, and updates to an existing sign-up remain unaffected.

--- a/.changeset/signup-future-password-browser-locale.md
+++ b/.changeset/signup-future-password-browser-locale.md
@@ -2,4 +2,7 @@
 '@clerk/clerk-js': patch
 ---
 
-Fix `signUp.password()` on the future SignUp API not defaulting the sign-up's `locale` to the browser locale when it creates a new sign-up, matching the documented behavior and `signUp.create()`. An explicitly passed `locale` still takes precedence, and updates to an existing sign-up remain unaffected.
+Fix the future SignUp API dropping documented params in some flows:
+
+- `signUp.password()` and `signUp.sso()` now default the sign-up's `locale` to the browser locale when they create a new sign-up, matching the documented behavior and `signUp.create()`. An explicitly passed `locale` still takes precedence, and updates to an existing sign-up remain unaffected.
+- `signUp.web3()` now forwards the `firstName`, `lastName`, and `locale` params to the created sign-up instead of silently ignoring them.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -1,7 +1,7 @@
 {
   "files": [
     { "path": "./dist/clerk.js", "maxSize": "549KB" },
-    { "path": "./dist/clerk.browser.js", "maxSize": "70KB" },
+    { "path": "./dist/clerk.browser.js", "maxSize": "71KB" },
     { "path": "./dist/clerk.legacy.browser.js", "maxSize": "112KB" },
     { "path": "./dist/clerk.no-rhc.js", "maxSize": "316KB" },
     { "path": "./dist/clerk.native.js", "maxSize": "70KB" },

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -906,6 +906,9 @@ class SignUpFuture implements SignUpFutureResource {
       if (this.#resource.id) {
         await this.#resource.__internal_basePatch({ body });
       } else {
+        // Inject browser locale only when creating the sign-up, so an existing
+        // sign-up's locale is not overwritten on update.
+        body.locale = params.locale ?? getBrowserLocale();
         await this.#resource.__internal_basePost({ path: this.#resource.pathRoot, body });
       }
     });

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -1004,6 +1004,7 @@ class SignUpFuture implements SignUpFutureResource {
       enterpriseConnectionId,
       emailAddress,
       popup,
+      locale,
     } = params;
     return runAsyncResourceTask(this.#resource, async () => {
       const { captchaToken, captchaWidgetType, captchaError } = await this.getCaptchaToken({ strategy });
@@ -1040,10 +1041,14 @@ class SignUpFuture implements SignUpFutureResource {
           captchaToken,
           captchaWidgetType,
           captchaError,
+          locale,
         };
         if (this.#resource.id) {
           return this.#resource.__internal_basePatch({ body });
         }
+        // Inject browser locale only when creating the sign-up, so an existing
+        // sign-up's locale is not overwritten on update.
+        body.locale = locale ?? getBrowserLocale();
         return this.#resource.__internal_basePost({ path: this.#resource.pathRoot, body });
       };
 
@@ -1071,7 +1076,7 @@ class SignUpFuture implements SignUpFutureResource {
   }
 
   async web3(params: SignUpFutureWeb3Params): Promise<{ error: ClerkError | null }> {
-    const { strategy, unsafeMetadata, legalAccepted } = params;
+    const { strategy, unsafeMetadata, legalAccepted, firstName, lastName, locale } = params;
     const provider = strategy.replace('web3_', '').replace('_signature', '') as Web3Provider;
 
     return runAsyncResourceTask(this.#resource, async () => {
@@ -1100,7 +1105,7 @@ class SignUpFuture implements SignUpFutureResource {
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const web3Wallet = identifier || this.#resource.web3wallet!;
-      await this._create({ web3Wallet, unsafeMetadata, legalAccepted });
+      await this._create({ web3Wallet, unsafeMetadata, legalAccepted, firstName, lastName, locale });
       await this.#resource.__internal_basePost({
         body: { strategy },
         action: 'prepare_verification',

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -1255,6 +1255,77 @@ describe('SignUp', () => {
 
         expect(result).toHaveProperty('error', null);
       });
+
+      it('includes browser locale when creating a new signup', async () => {
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.password({ password: 'test-password-123' });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              strategy: 'password',
+              locale: 'fr-FR',
+            }),
+          }),
+        );
+      });
+
+      it('prefers an explicitly provided locale over the browser locale', async () => {
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.password({ password: 'test-password-123', locale: 'el-GR' });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              strategy: 'password',
+              locale: 'el-GR',
+            }),
+          }),
+        );
+      });
+
+      it('does not inject browser locale when updating an existing signup', async () => {
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: { id: 'signup_123', status: 'missing_requirements' },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp({ id: 'signup_123' } as any);
+        await signUp.__internal_future.password({ password: 'test-password-123' });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'PATCH',
+            path: '/client/sign_ups/signup_123',
+            body: expect.not.objectContaining({
+              locale: expect.anything(),
+            }),
+          }),
+        );
+      });
     });
 
     describe('ticket', () => {

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -698,6 +698,147 @@ describe('SignUp', () => {
         );
       });
 
+      it('includes browser locale when creating a new signup', async () => {
+        vi.stubGlobal('window', { location: { origin: 'https://example.com' } });
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockBuildUrlWithAuth = vi.fn().mockReturnValue('https://example.com/sso-callback');
+        SignUp.clerk = {
+          buildUrlWithAuth: mockBuildUrlWithAuth,
+          __internal_environment: {
+            displayConfig: {
+              captchaOauthBypass: [],
+            },
+          },
+        } as any;
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: {
+            id: 'signup_123',
+            verifications: {
+              externalAccount: {
+                status: 'unverified',
+                externalVerificationRedirectURL: 'https://sso.example.com/auth',
+              },
+            },
+          },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.sso({
+          strategy: 'oauth_google',
+          redirectUrl: '/complete',
+          redirectCallbackUrl: '/sso-callback',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              strategy: 'oauth_google',
+              locale: 'fr-FR',
+            }),
+          }),
+        );
+      });
+
+      it('prefers an explicitly provided locale over the browser locale', async () => {
+        vi.stubGlobal('window', { location: { origin: 'https://example.com' } });
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockBuildUrlWithAuth = vi.fn().mockReturnValue('https://example.com/sso-callback');
+        SignUp.clerk = {
+          buildUrlWithAuth: mockBuildUrlWithAuth,
+          __internal_environment: {
+            displayConfig: {
+              captchaOauthBypass: [],
+            },
+          },
+        } as any;
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: {
+            id: 'signup_123',
+            verifications: {
+              externalAccount: {
+                status: 'unverified',
+                externalVerificationRedirectURL: 'https://sso.example.com/auth',
+              },
+            },
+          },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.sso({
+          strategy: 'oauth_google',
+          redirectUrl: '/complete',
+          redirectCallbackUrl: '/sso-callback',
+          locale: 'el-GR',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              strategy: 'oauth_google',
+              locale: 'el-GR',
+            }),
+          }),
+        );
+      });
+
+      it('does not inject browser locale when continuing an existing signup', async () => {
+        vi.stubGlobal('window', { location: { origin: 'https://example.com' } });
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockBuildUrlWithAuth = vi.fn().mockReturnValue('https://example.com/sso-callback');
+        SignUp.clerk = {
+          buildUrlWithAuth: mockBuildUrlWithAuth,
+          __internal_environment: {
+            displayConfig: {
+              captchaOauthBypass: [],
+            },
+          },
+        } as any;
+
+        const mockFetch = vi.fn().mockResolvedValue({
+          client: null,
+          response: {
+            id: 'signup_123',
+            verifications: {
+              externalAccount: {
+                status: 'unverified',
+                externalVerificationRedirectURL: 'https://sso.example.com/auth',
+              },
+            },
+          },
+        });
+        BaseResource._fetch = mockFetch;
+
+        const signUp = new SignUp({ id: 'signup_123' } as any);
+        await signUp.__internal_future.sso({
+          strategy: 'oauth_google',
+          redirectUrl: '/complete',
+          redirectCallbackUrl: '/sso-callback',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'PATCH',
+            path: '/client/sign_ups/signup_123',
+            body: expect.not.objectContaining({
+              locale: expect.anything(),
+            }),
+          }),
+        );
+      });
+
       it('continues an existing sign up via the resource URL', async () => {
         vi.stubGlobal('window', { location: { origin: 'https://example.com' } });
 
@@ -1179,6 +1320,63 @@ describe('SignUp', () => {
 
         // Verify error is returned without retry
         expect(result.error).toBeTruthy();
+      });
+
+      it('passes locale and name params through to the created signup', async () => {
+        vi.stubGlobal('navigator', { language: 'fr-FR' });
+
+        const mockFetch = vi
+          .fn()
+          .mockResolvedValueOnce({
+            client: null,
+            response: {
+              id: 'signup_123',
+              verifications: {
+                web3_wallet: { status: 'unverified' },
+              },
+            },
+          })
+          .mockResolvedValueOnce({
+            client: null,
+            response: {
+              id: 'signup_123',
+              verifications: {
+                web3_wallet: { status: 'unverified', message: 'nonce_123' },
+              },
+            },
+          })
+          .mockResolvedValueOnce({
+            client: null,
+            response: { id: 'signup_123', status: 'complete' },
+          });
+        BaseResource._fetch = mockFetch;
+
+        const utilsModule = await import('../../../utils');
+        vi.spyOn(utilsModule, 'web3').mockReturnValue({
+          getMetamaskIdentifier: vi.fn().mockResolvedValue('0x1234567890123456789012345678901234567890'),
+          generateSignatureWithMetamask: vi.fn().mockResolvedValue('signature_123'),
+        } as any);
+
+        const signUp = new SignUp();
+        await signUp.__internal_future.web3({
+          strategy: 'web3_metamask_signature',
+          firstName: 'Vitalik',
+          lastName: 'Nakamoto',
+          locale: 'el-GR',
+        });
+
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            method: 'POST',
+            path: '/client/sign_ups',
+            body: expect.objectContaining({
+              firstName: 'Vitalik',
+              lastName: 'Nakamoto',
+              locale: 'el-GR',
+            }),
+          }),
+        );
       });
     });
 


### PR DESCRIPTION
## Description

We have five different ways to create a `SignUp` with `SignUpFuture` and they have inconsistent handling of params and the browser locale:

- `create`: Uses a param or browser fallback to set locale.
- `password`: This does not apply the browser-locale fallback but does use the param. Fixed in this PR to use the fallback only on POST.
- `web3`: This delegates to `_create` but did not pass along `locale` or first or last name, meaning that it always got the fallback behavior. Fixed in this PR to pass all three params.
- `ticket`: Handles correctly
- `sso`: This doesn't apply any `locale` at all. (It also doesn't take first and last name but since we generally get this from the SSO provider I didn't include it.)

These changes now align our API with the contract in our types `SignUpFutureAdditionalParams` which lists `locale` as a parameter and says we will fall back to the browser's locale.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `signUp.password()` and `signUp.sso()` now default to the browser locale when creating new sign-ups, matching `signUp.create()`.
  * Explicitly provided locale values are preserved.
  * `signUp.web3()` now forwards `firstName`, `lastName`, and `locale` when creating a sign-up.

* **Tests**
  * Added coverage verifying locale behavior across create vs. update flows and web3 parameter forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->