### PR TITLE
fix(ui): remove subtotal lines

### DIFF
--- a/packages/clerk-js/src/core/resources/BillingSubscription.ts
+++ b/packages/clerk-js/src/core/resources/BillingSubscription.ts
@@ -19,6 +19,7 @@ import { unixEpochToDate } from '@/utils/date';
 import {
   billingCreditsFromJSON,
   billingMoneyAmountFromJSON,
+  billingPerUnitTotalTierFromJSON,
   billingSubscriptionItemNextPaymentFromJSON,
   billingSubscriptionNextPaymentFromJSON,
 } from '../../utils';

--- a/packages/ui/src/components/Checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/Checkout/CheckoutForm.tsx
@@ -120,13 +120,6 @@ export const CheckoutForm = withCardStateProvider(() => {
               />
             </LineItems.Group>
           )}
-          <LineItems.Group
-            borderTop
-            variant='tertiary'
-          >
-            <LineItems.Title title={localizationKeys('billing.subtotal')} />
-            <LineItems.Description text={`${totals.subtotal.currencySymbol}${totals.subtotal.amountFormatted}`} />
-          </LineItems.Group>
           {showProratedDiscount && (
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.proratedDiscount')} />
@@ -178,7 +171,10 @@ export const CheckoutForm = withCardStateProvider(() => {
               />
             </LineItems.Group>
           ) : showRenewalTotals ? null : (
-            <LineItems.Group variant='tertiary'>
+            <LineItems.Group
+              borderTop
+              variant='tertiary'
+            >
               <LineItems.Title title={localizationKeys('billing.checkout.totalDuePerPeriod')} />
               <LineItems.Description
                 text={`${totals.totalDuePerPeriod.currencySymbol}${totals.totalDuePerPeriod.amountFormatted}`}
@@ -193,15 +189,6 @@ export const CheckoutForm = withCardStateProvider(() => {
 
           {showRenewalTotals && (
             <>
-              <LineItems.Group
-                borderTop
-                variant='tertiary'
-              >
-                <LineItems.Title title={localizationKeys('billing.subtotalRenewal')} />
-                <LineItems.Description
-                  text={`${totals.totalsDuePerPeriod?.subtotal.currencySymbol}${totals.totalsDuePerPeriod?.subtotal.amountFormatted}`}
-                />
-              </LineItems.Group>
               <LineItems.Group borderTop>
                 <LineItems.Title title={localizationKeys('billing.totalDuePerPeriod')} />
                 <LineItems.Description


### PR DESCRIPTION
## Description

This PR removes the subtotal lines from checkout as currently the subtotal will always equal the grand total. In the future when we support taxes (which are added after the subtotal) we can restore these lines, but as they are now they're just redundant information.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
