### PR TITLE
fix(backend): return IdPOAuthAccessToken JWT timestamps in milliseconds

### DIFF
--- a/.changeset/idp-oauth-token-ms-timestamps.md
+++ b/.changeset/idp-oauth-token-ms-timestamps.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Return `IdPOAuthAccessToken` timestamps in milliseconds when an OAuth access token is verified as a JWT. The `expiration`, `createdAt`, and `updatedAt` fields were previously populated with the JWT's raw second-based `exp`/`iat` values, making them inconsistent with the same fields on `M2MToken` and with the values returned when the token is fetched from the API. Comparing `expiration` against `Date.now()` now behaves as expected. The `expired` flag was already computed correctly and is unaffected.

--- a/packages/backend/src/api/resources/IdPOAuthAccessToken.ts
+++ b/packages/backend/src/api/resources/IdPOAuthAccessToken.ts
@@ -57,9 +57,9 @@ export class IdPOAuthAccessToken {
       false,
       null,
       payload.exp * 1000 <= Date.now() - clockSkewInMs,
-      payload.exp,
-      payload.iat,
-      payload.iat,
+      payload.exp * 1000, // milliseconds: expiration, converted from JWT exp claim
+      payload.iat * 1000, // milliseconds: createdAt, converted from JWT iat claim
+      payload.iat * 1000, // milliseconds: updatedAt, no JWT equivalent, defaults to iat
     );
   }
 }

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -407,6 +407,10 @@ describe('tokens.verifyMachineAuthToken(token, options)', () => {
       expect(data.type).toBe('oauth_token');
       expect(data.subject).toBe('user_2vYVtestTESTtestTESTtestTESTtest');
       expect(data.scopes).toEqual(['read:foo', 'write:bar']);
+      // Timestamps are exposed in milliseconds, matching M2MToken and the API JSON shape
+      expect(data.expiration).toBe(mockOAuthAccessTokenJwtPayload.exp * 1000);
+      expect(data.createdAt).toBe(mockOAuthAccessTokenJwtPayload.iat * 1000);
+      expect(data.updatedAt).toBe(mockOAuthAccessTokenJwtPayload.iat * 1000);
     });
 
     it('fails if JWT type is not at+jwt or application/at+jwt', async () => {


### PR DESCRIPTION
`IdPOAuthAccessToken.fromJwtPayload` set `expiration`, `createdAt`, and `updatedAt` from the JWT's raw second-based `exp`/`iat`, but `M2MToken` and the API response expose those fields in milliseconds. So the same OAuth token's timestamps came out 1000x off depending on whether you verified it as a JWT or fetched it from the API, and `token.expiration < Date.now()` was always true.

The fix is the `* 1000` conversion that was already being done everywhere else:

```ts
payload.exp * 1000  // was: payload.exp
```

Token validity itself was never affected since the `expired` boolean already used `* 1000`, only the exposed timestamps were wrong. The OAuth-JWT verify test didn't assert these fields, which is why it slipped through, so I added that coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth access token verification now returns timestamp fields (expiration, createdAt, updatedAt) in milliseconds instead of seconds, ensuring consistency with other token types and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
