### PR TITLE
feat(ui): Hide base fee when it's not being charged

### DIFF
--- a/packages/ui/src/components/Checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/Checkout/CheckoutForm.tsx
@@ -51,13 +51,6 @@ export const CheckoutForm = withCardStateProvider(() => {
     totals.totalsDuePerPeriod.grandTotal.amount !== totals.totalDueNow.amount;
   const showDowngradeInfo = !isImmediatePlanChange;
 
-  const fee =
-    planPeriod === 'month'
-      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        plan.fee!
-      : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        plan.annualMonthlyFee!;
-
   const seatPerUnitTotal = getCheckoutSeatUnitTotal(totals);
   const includedSeatsTier = getIncludedSeatsUnitTotalTier(seatPerUnitTotal);
   const paidSeatsTier = getPaidSeatsUnitTotalTier(seatPerUnitTotal);
@@ -106,11 +99,13 @@ export const CheckoutForm = withCardStateProvider(() => {
                 ) : null
               }
             />
-            <LineItems.Description
-              prefix={planPeriod === 'annual' ? 'x12' : undefined}
-              text={`${fee.currencySymbol}${fee.amountFormatted}`}
-              suffix={localizationKeys('billing.checkout.perMonth')}
-            />
+            {totals.baseFee ? (
+              <LineItems.Description
+                prefix={planPeriod === 'annual' ? 'x12' : undefined}
+                text={`${totals.baseFee.currencySymbol}${totals.baseFee.amountFormatted}`}
+                suffix={localizationKeys('billing.checkout.perMonth')}
+              />
+            ) : null}
           </LineItems.Group>
           {paidSeatsTier && paidSeatsTier.quantity !== null && (
             <LineItems.Group borderTop>


### PR DESCRIPTION
## Description

This PR hides the base fee display during checkout when `checkout.totals.baseFee` is null.

<img width="1824" height="1462" alt="CleanShot 2026-06-08 at 11 09 04@2x" src="https://github.com/user-attachments/assets/544c295a-c883-4635-ad77-167d10eb4695" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
