### PR TITLE
feat(ui): Use next_payment.totals.grand_total for overview

### DIFF
--- a/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
@@ -196,6 +196,10 @@ function SubscriptionOverviewRow({
   nextPayment: NonNullable<BillingSubscriptionResource['nextPayment']>;
   localizationRoot: ReturnType<typeof useSubscriberTypeLocalizationRoot>;
 }) {
+  if (!nextPayment.totals) {
+    return null;
+  }
+
   return (
     <Tr
       sx={t => ({
@@ -223,8 +227,8 @@ function SubscriptionOverviewRow({
               color: t.colors.$colorForeground,
             })}
           >
-            {nextPayment.amount.currencySymbol}
-            {nextPayment.amount.amountFormatted}
+            {nextPayment.totals.grandTotal.currencySymbol}
+            {nextPayment.totals.grandTotal.amountFormatted}
           </Text>
           <Text
             variant='subtitle'


### PR DESCRIPTION
## Description

This PR updates the `Overview` section of the subscription items list to use `next_payment.totals.grand_total` in lieu of `next_payment.amount`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
