### PR TITLE
fix(ui): Treat past_due subscriptions as active

### DIFF
--- a/packages/ui/src/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/ui/src/components/OrganizationProfile/InviteMembersForm.tsx
@@ -173,7 +173,10 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
               break;
             }
 
-            const activeSubscriptionItem = subscriptionItems.find(si => si.status === 'active');
+            // we want the "current" subscription item, which can have either "active" or "past_due" status
+            const activeSubscriptionItem = subscriptionItems.find(
+              si => si.status === 'active' || si.status === 'past_due',
+            );
             if (activeSubscriptionItem) {
               const currentPlan = activeSubscriptionItem.plan;
               const currentPlanAndPriceSupportsDesiredSeatQuantity = plans.some(


### PR DESCRIPTION
## Description

This PR updates the invite-to-checkout flow to consider subscription items with the "past_due" status as the active, current subscription item.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
