### PR TITLE
fix(expo): make react-dom optional for native apps

### DIFF
--- a/.changeset/expo-optional-react-dom-peer.md
+++ b/.changeset/expo-optional-react-dom-peer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Make `react-dom` an optional peer dependency so native Expo apps can install Clerk without pulling in a React DOM version they do not use.

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -172,6 +172,9 @@
     },
     "expo-web-browser": {
       "optional": true
+    },
+    "react-dom": {
+      "optional": true
     }
   },
   "engines": {


### PR DESCRIPTION
## Summary

Make `react-dom` an optional peer dependency in `@clerk/expo` so native Expo apps that do not use React DOM are not blocked by npm peer resolution while installing Clerk.

## Why this is scoped to `@clerk/expo`

The direct install target for Expo apps is `@clerk/expo`, so this PR starts by marking `react-dom` optional on the Expo package itself. This mirrors the shape of Expo packages that expose both native and web entrypoints but should not require React DOM for native-only usage.

`@clerk/expo` also depends on `@clerk/react`, which still declares a `react-dom` peer. I tested the narrower Expo-only change first as requested. With only `@clerk/expo` patched, npm no longer fails the install with `--legacy-peer-deps` omitted, but npm still resolves `react-dom@19.2.7` through the remaining transitive peer chain and `npm ls` reports an invalid tree against the app's `react@19.2.3`.

## Root cause

Some native Expo apps do not install `react-dom`. When installing the current PR build of `@clerk/expo` into an Expo SDK 56 app with `react@19.2.3` and no `react-dom`, npm selects the latest compatible `react-dom`, currently `react-dom@19.2.7`. That package requires `react@^19.2.7`, which conflicts with the app's `react@19.2.3` and causes npm to fail unless `--legacy-peer-deps` is used.

The default SDK 56 template already includes `react-dom@19.2.3`, so it does not reproduce this particular resolver failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@clerk/expo` and `@clerk/react` with patch version bumps
  * Configured react-dom as an optional peer dependency to prevent unnecessary packages from being installed in native Expo applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->