### PR TITLE
feat(electron): harden token storage encryption

### DIFF
--- a/packages/electron/src/storage/__tests__/index.test.ts
+++ b/packages/electron/src/storage/__tests__/index.test.ts
@@ -8,11 +8,11 @@ const storeGet = vi.fn();
 const storeSet = vi.fn();
 const storeDelete = vi.fn();
 
+// `safeStorage` starts empty; each test installs only the methods for the backend it exercises.
+// This mirrors reality: Electron < 42 has no async methods at all, so `resolveCipher` only takes the
+// async path when both the methods exist and `isAsyncEncryptionAvailable()` confirms it.
 vi.mock('electron', () => ({
-  safeStorage: {
-    decryptString: vi.fn(),
-    encryptString: vi.fn(),
-  },
+  safeStorage: {},
 }));
 
 vi.mock('electron-store', () => ({
@@ -23,10 +23,32 @@ vi.mock('electron-store', () => ({
   })),
 }));
 
-describe('storage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+const ss = safeStorage as unknown as Record<string, unknown>;
+
+/** Installs the synchronous `safeStorage` API. */
+function installSync({ available = true }: { available?: boolean } = {}) {
+  ss.isEncryptionAvailable = vi.fn(() => available);
+  ss.encryptString = vi.fn((value: string) => Buffer.from(`enc(${value})`));
+  ss.decryptString = vi.fn();
+}
+
+/** Adds the Electron 42+ asynchronous `safeStorage` API. */
+function installAsync({ available = true }: { available?: boolean } = {}) {
+  ss.isAsyncEncryptionAvailable = vi.fn(() => Promise.resolve(available));
+  ss.encryptStringAsync = vi.fn((value: string) => Promise.resolve(Buffer.from(`enc(${value})`)));
+  ss.decryptStringAsync = vi.fn();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset the mocked `safeStorage` shape so backend detection starts from a clean slate.
+  for (const key of Object.keys(ss)) {
+    delete ss[key];
+  }
+});
+
+describe('storage options', () => {
+  beforeEach(() => installSync());
 
   it('creates an electron-store instance with the default store name', () => {
     storage();
@@ -40,38 +62,239 @@ describe('storage', () => {
     expect(Store).toHaveBeenCalledWith({ name: 'custom-clerk-tokens' });
   });
 
-  it('returns null when a token is missing', () => {
+  it('forwards a custom path as electron-store `cwd`', () => {
+    storage({ path: '/tmp/clerk' });
+
+    expect(Store).toHaveBeenCalledWith({ name: 'clerk-tokens', cwd: '/tmp/clerk' });
+  });
+
+  it('omits `cwd` when no path is provided', () => {
+    storage();
+
+    expect(Store).toHaveBeenCalledWith(expect.not.objectContaining({ cwd: expect.anything() }));
+  });
+});
+
+describe('getItem', () => {
+  it('returns null when a token is missing', async () => {
+    installSync();
     storeGet.mockReturnValue(undefined);
 
-    expect(storage().getItem('token-key')).toBeNull();
+    await expect(storage().getItem('token-key')).resolves.toBeNull();
   });
 
-  it('decrypts stored tokens', () => {
-    storeGet.mockReturnValue(Buffer.from('encrypted-token').toString('base64'));
-    vi.mocked(safeStorage.decryptString).mockReturnValue('jwt');
+  it('returns an unencrypted (raw:) value as-is without decrypting', async () => {
+    installSync();
+    storeGet.mockReturnValue('raw:jwt');
 
-    expect(storage().getItem('token-key')).toBe('jwt');
-    expect(safeStorage.decryptString).toHaveBeenCalledWith(Buffer.from('encrypted-token'));
+    await expect(storage().getItem('token-key')).resolves.toBe('jwt');
+    expect(safeStorage.decryptString).not.toHaveBeenCalled();
   });
 
-  it('returns null when token decryption fails', () => {
-    storeGet.mockReturnValue(Buffer.from('encrypted-token').toString('base64'));
-    vi.mocked(safeStorage.decryptString).mockImplementation(() => {
-      throw new Error('decrypt failed');
+  it('deletes and returns null for an unrecognized value format', async () => {
+    installSync();
+    storeGet.mockReturnValue('garbage-without-prefix');
+
+    await expect(storage().getItem('token-key')).resolves.toBeNull();
+    expect(storeDelete).toHaveBeenCalledWith('token-key');
+  });
+
+  it('preserves the entry and returns null when no OS encryption is available', async () => {
+    installSync({ available: false });
+    storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+
+    await expect(storage().getItem('token-key')).resolves.toBeNull();
+    expect(storeDelete).not.toHaveBeenCalled();
+  });
+
+  describe('sync backend', () => {
+    it('decrypts stored tokens', async () => {
+      installSync();
+      storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptString).mockReturnValue('jwt');
+
+      await expect(storage().getItem('token-key')).resolves.toBe('jwt');
+      expect(safeStorage.decryptString).toHaveBeenCalledWith(Buffer.from('cipher'));
     });
 
-    expect(storage().getItem('token-key')).toBeNull();
+    it('returns null without deleting the entry when decryption fails', async () => {
+      installSync();
+      storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptString).mockImplementation(() => {
+        throw new Error('decrypt failed');
+      });
+
+      await expect(storage().getItem('token-key')).resolves.toBeNull();
+      expect(storeDelete).not.toHaveBeenCalled();
+    });
   });
 
-  it('encrypts tokens before storing them', async () => {
-    vi.mocked(safeStorage.encryptString).mockReturnValue(Buffer.from('encrypted-token'));
+  describe('async backend', () => {
+    it('decrypts stored tokens', async () => {
+      installSync();
+      installAsync();
+      storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptStringAsync).mockResolvedValue({ result: 'jwt', shouldReEncrypt: false });
+
+      await expect(storage().getItem('token-key')).resolves.toBe('jwt');
+      expect(safeStorage.decryptStringAsync).toHaveBeenCalledWith(Buffer.from('cipher'));
+    });
+
+    it('re-encrypts and re-saves when the OS key has rotated (shouldReEncrypt)', async () => {
+      installSync();
+      installAsync();
+      storeGet.mockReturnValue(`enc:${Buffer.from('old-cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptStringAsync).mockResolvedValue({ result: 'jwt', shouldReEncrypt: true });
+
+      await expect(storage().getItem('token-key')).resolves.toBe('jwt');
+      expect(safeStorage.encryptStringAsync).toHaveBeenCalledWith('jwt');
+      expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+    });
+
+    it('returns null without deleting the entry when decryption rejects', async () => {
+      installSync();
+      installAsync();
+      storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptStringAsync).mockRejectedValue(new Error('decrypt failed'));
+
+      await expect(storage().getItem('token-key')).resolves.toBeNull();
+      expect(storeDelete).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the sync API (never calling the async crypto) when async encryption is unavailable', async () => {
+      installSync();
+      installAsync({ available: false });
+      storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+      vi.mocked(safeStorage.decryptString).mockReturnValue('jwt');
+
+      await expect(storage().getItem('token-key')).resolves.toBe('jwt');
+      expect(safeStorage.decryptString).toHaveBeenCalledWith(Buffer.from('cipher'));
+      // Critical: calling the async crypto while unavailable crashes the process on Electron 42.x.
+      expect(safeStorage.decryptStringAsync).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('setItem', () => {
+  it('encrypts tokens before storing them (sync backend)', async () => {
+    installSync();
 
     await storage().setItem('token-key', 'jwt');
 
     expect(safeStorage.encryptString).toHaveBeenCalledWith('jwt');
-    expect(storeSet).toHaveBeenCalledWith('token-key', Buffer.from('encrypted-token').toString('base64'));
+    expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
   });
 
+  it('encrypts tokens before storing them (async backend)', async () => {
+    installSync();
+    installAsync();
+
+    await storage().setItem('token-key', 'jwt');
+
+    expect(safeStorage.encryptStringAsync).toHaveBeenCalledWith('jwt');
+    expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+  });
+
+  it('falls back to the sync API (never calling the async crypto) when async encryption is unavailable', async () => {
+    installSync();
+    installAsync({ available: false });
+
+    await storage().setItem('token-key', 'jwt');
+
+    expect(safeStorage.encryptString).toHaveBeenCalledWith('jwt');
+    expect(safeStorage.encryptStringAsync).not.toHaveBeenCalled();
+    expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+  });
+
+  it('does not persist when no encryption is available and no fallback is configured', async () => {
+    installSync({ available: false });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await storage().setItem('token-key', 'jwt');
+
+    expect(storeSet).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('persists unencrypted when no encryption is available and unencryptedFallback is enabled', async () => {
+    installSync({ available: false });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await storage({ unencryptedFallback: true }).setItem('token-key', 'jwt');
+
+    expect(storeSet).toHaveBeenCalledWith('token-key', 'raw:jwt');
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('only warns once across repeated saves', async () => {
+    installSync({ available: false });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const adapter = storage();
+    await adapter.setItem('a', '1');
+    await adapter.setItem('b', '2');
+
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('does not downgrade to plaintext when encryption is available but encrypt() fails', async () => {
+    ss.isEncryptionAvailable = vi.fn(() => true);
+    ss.encryptString = vi.fn(() => {
+      throw new Error('encrypt failed');
+    });
+    ss.decryptString = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Even with the fallback enabled, a *failed encrypt* (vs. unavailable encryption) must not be
+    // persisted in the clear.
+    await storage({ unencryptedFallback: true }).setItem('token-key', 'jwt');
+
+    expect(storeSet).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('resolves the cipher lazily and retries when it was initially unavailable (e.g. before app ready)', async () => {
+    // Unavailable on the first probe (pre-`ready`), available afterwards.
+    ss.isEncryptionAvailable = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+    ss.encryptString = vi.fn((value: string) => Buffer.from(`enc(${value})`));
+    ss.decryptString = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const adapter = storage();
+
+    await adapter.setItem('token-key', 'jwt');
+    expect(storeSet).not.toHaveBeenCalled(); // not persisted while unavailable
+
+    await adapter.setItem('token-key', 'jwt');
+    expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+
+    warn.mockRestore();
+  });
+
+  it('ignores a partial async surface and uses the sync API', async () => {
+    // `encryptStringAsync` exists but the rest of the async trio does not — must not take the async
+    // path (and must not call the async crypto).
+    ss.encryptStringAsync = vi.fn();
+    ss.isEncryptionAvailable = vi.fn(() => true);
+    ss.encryptString = vi.fn((value: string) => Buffer.from(`enc(${value})`));
+    ss.decryptString = vi.fn();
+
+    await storage().setItem('token-key', 'jwt');
+
+    expect(safeStorage.encryptString).toHaveBeenCalledWith('jwt');
+    expect(safeStorage.encryptStringAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeItem', () => {
   it('removes stored tokens', async () => {
     await storage().removeItem('token-key');
 

--- a/packages/electron/src/storage/index.ts
+++ b/packages/electron/src/storage/index.ts
@@ -4,29 +4,223 @@ import Store from 'electron-store';
 import type { TokenStorage } from '../shared/types';
 
 type StorageOptions = {
+  /**
+   * The name of the file (without extension) used to persist tokens.
+   *
+   * @default 'clerk-tokens'
+   */
   name?: string;
+  /**
+   * The directory in which the token file is stored. Maps to `electron-store`'s `cwd` option.
+   * When omitted, the OS default user config directory is used.
+   */
+  path?: string;
+  /**
+   * When OS-level encryption is unavailable (e.g. a Linux machine without a keyring), tokens are
+   * not persisted by default, which signs the user out on the next app launch. Set this to `true`
+   * to instead persist tokens **unencrypted** in that scenario, keeping the user signed in across
+   * restarts at the cost of storing tokens in plaintext on disk.
+   *
+   * @default false
+   */
+  unencryptedFallback?: boolean;
 };
 
+/**
+ * Marks a value that was encrypted via {@link safeStorage}; the remainder is base64 ciphertext.
+ * values will be stored as: `enc:<encrypted value>`
+ */
+const ENCRYPTED_PREFIX = 'enc:';
+/**
+ * Marks a value persisted unencrypted via the `unencryptedFallback` option.
+ * values will be stored as: `raw:<value>`
+ */
+const RAW_PREFIX = 'raw:';
+
+type Cipher = {
+  encrypt: (value: string) => Promise<string>;
+  /**
+   * Decrypts a base64 payload. `shouldReEncrypt` is `true` (async backend only) when the OS key
+   * has rotated and the payload should be re-encrypted with the new key.
+   */
+  decrypt: (payload: string) => Promise<{ value: string; shouldReEncrypt: boolean }>;
+};
+
+type AsyncSafeStorage = {
+  encryptStringAsync: (plainText: string) => Promise<Buffer>;
+  decryptStringAsync: (encrypted: Buffer) => Promise<{ result: string; shouldReEncrypt: boolean }>;
+  isAsyncEncryptionAvailable: () => Promise<boolean>;
+};
+
+const syncCipher: Cipher = {
+  encrypt: value => Promise.resolve(safeStorage.encryptString(value).toString('base64')),
+  decrypt: payload =>
+    Promise.resolve({ value: safeStorage.decryptString(Buffer.from(payload, 'base64')), shouldReEncrypt: false }),
+};
+
+function hasAsyncSafeStorage(storage: typeof safeStorage): storage is typeof safeStorage & AsyncSafeStorage {
+  const candidate = storage as Partial<AsyncSafeStorage>;
+
+  return (
+    typeof candidate.encryptStringAsync === 'function' &&
+    typeof candidate.decryptStringAsync === 'function' &&
+    typeof candidate.isAsyncEncryptionAvailable === 'function'
+  );
+}
+
+function createAsyncCipher(storage: AsyncSafeStorage): Cipher {
+  return {
+    encrypt: async value => (await storage.encryptStringAsync(value)).toString('base64'),
+    decrypt: async payload => {
+      const { result, shouldReEncrypt } = await storage.decryptStringAsync(Buffer.from(payload, 'base64'));
+      return { value: result, shouldReEncrypt };
+    },
+  };
+}
+
+/**
+ * Resolves the crypto backend to use, or `null` when no OS encryption is currently available.
+ */
+async function resolveCipher(): Promise<Cipher | null> {
+  // Prefer the async API, but only when the full optional function surface exists.
+  if (hasAsyncSafeStorage(safeStorage)) {
+    try {
+      if (await safeStorage.isAsyncEncryptionAvailable()) {
+        return createAsyncCipher(safeStorage);
+      }
+    } catch {
+      /* fall through to the synchronous API */
+    }
+  }
+
+  // The synchronous API blocks the calling thread on the OS prompt during the first encrypt/decrypt,
+  if (typeof safeStorage.isEncryptionAvailable === 'function' && safeStorage.isEncryptionAvailable()) {
+    return syncCipher;
+  }
+
+  return null;
+}
+
+/**
+ * Creates a secure {@link TokenStorage} adapter for the Electron main process.
+ *
+ * Tokens are persisted with `electron-store` and encrypted at rest using Electron's
+ * {@link safeStorage} API, which is backed by the OS keystore (Keychain on macOS, DPAPI on
+ * Windows, libsecret/kwallet on Linux). It uses Electron 42's async `safeStorage` API only when it
+ * reports itself available (which generally requires a code-signed app) and otherwise falls back to
+ * the synchronous API. Pass the result to `setupMain({ storage: storage() })`.
+ *
+ * Behavior is secure by default: when OS encryption is unavailable the adapter does not persist
+ * tokens (the user will be signed out on restart) unless {@link StorageOptions.unencryptedFallback}
+ * is enabled. Undecryptable entries return `null`.
+ *
+ * @example
+ * ```ts
+ * import { setupMain } from '@clerk/electron';
+ * import { storage } from '@clerk/electron/storage';
+ *
+ * setupMain({ storage: storage({ name: 'my-app-tokens' }) });
+ * ```
+ */
 export function storage(options: StorageOptions = {}): TokenStorage {
-  const store = new Store<Record<string, string>>({ name: options.name ?? 'clerk-tokens' });
+  const store = new Store<Record<string, string>>({
+    name: options.name ?? 'clerk-tokens',
+    ...(options.path ? { cwd: options.path } : {}),
+  });
+
+  let cachedCipher: Cipher | null = null;
+  let resolving: Promise<Cipher | null> | null = null;
+  const getCipher = (): Promise<Cipher | null> => {
+    if (cachedCipher) {
+      return Promise.resolve(cachedCipher);
+    }
+    resolving ??= resolveCipher().then(resolved => {
+      resolving = null;
+      if (resolved) {
+        cachedCipher = resolved;
+      }
+      return resolved;
+    });
+    return resolving;
+  };
+
+  let warned = false;
+  const warnOnce = (message: string) => {
+    if (warned) {
+      return;
+    }
+    warned = true;
+    console.warn(message);
+  };
 
   return {
-    getItem(key) {
-      const encrypted = store.get(key);
+    async getItem(key) {
+      const stored = store.get(key);
 
-      if (!encrypted) {
+      if (!stored) {
         return null;
+      }
+
+      if (stored.startsWith(RAW_PREFIX)) {
+        return stored.slice(RAW_PREFIX.length);
+      }
+
+      if (stored.startsWith(ENCRYPTED_PREFIX)) {
+        const cipher = await getCipher();
+
+        // No usable OS encryption, preserve entry.
+        if (!cipher) {
+          return null;
+        }
+
+        const payload = stored.slice(ENCRYPTED_PREFIX.length);
+
+        try {
+          const { value, shouldReEncrypt } = await cipher.decrypt(payload);
+
+          if (shouldReEncrypt) {
+            // OS key has rotated, persist with new value
+            try {
+              store.set(key, ENCRYPTED_PREFIX + (await cipher.encrypt(value)));
+            } catch {
+              // keep the existing payload; it still decrypts for now
+            }
+          }
+
+          return value;
+        } catch {
+          // Decryption failed, preserve the entry, new write on next sign-in.
+          return null;
+        }
+      }
+
+      // Unknown or unrecognized format, drop the entry so we don't repeatedly fail on it.
+      store.delete(key);
+      return null;
+    },
+    async setItem(key, value) {
+      const cipher = await getCipher();
+
+      if (!cipher) {
+        if (options.unencryptedFallback) {
+          warnOnce(
+            'Clerk: OS encryption is unavailable; falling back to unencrypted storage. Session tokens are being stored unencrypted on local disk.',
+          );
+          store.set(key, RAW_PREFIX + value);
+        } else {
+          warnOnce(
+            'Clerk: OS encryption is unavailable and unencryptedFallback is not enabled, so tokens are not being persisted. The user will be signed out on the next launch. Pass `storage({ unencryptedFallback: true })` to persist unencrypted (less secure).',
+          );
+        }
+        return;
       }
 
       try {
-        return safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
+        store.set(key, ENCRYPTED_PREFIX + (await cipher.encrypt(value)));
       } catch {
-        return null;
+        // Encryption is available but encryption failed
+        warnOnce('Clerk: failed to encrypt the session token; it was not persisted.');
       }
-    },
-    setItem(key, value) {
-      const encrypted = safeStorage.encryptString(value);
-      store.set(key, encrypted.toString('base64'));
     },
     removeItem(key) {
       store.delete(key);


### PR DESCRIPTION
Adds guarded async `safeStorage` support for Electron versions that expose it.

Preserves encrypted token entries when decryption is temporarily unavailable or fails, avoids downgrading to plaintext when encryption is available but encryption fails, and adds explicit raw/encrypted storage prefixes with fallback behavior coverage.