### PR TITLE
fix(ui): Org profile domain subtitle alignment

### DIFF
--- a/.changeset/org-profile-domain-subtitle-alignment.md
+++ b/.changeset/org-profile-domain-subtitle-alignment.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix alignment of the domain section subtitle in the organization profile to match the button above it.

--- a/packages/ui/src/components/OrganizationProfile/OrganizationGeneralPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationGeneralPage.tsx
@@ -165,7 +165,7 @@ const OrganizationDomainsSection = () => {
               <Text
                 localizationKey={localizationKeys('organizationProfile.profilePage.domainSection.subtitle')}
                 sx={t => ({
-                  paddingInlineStart: t.space.$9,
+                  paddingInlineStart: t.space.$8x5,
                 })}
                 colorScheme='secondary'
               />


### PR DESCRIPTION
## Description

| BEFORE | AFTER |
|--------|--------|
| <img width="213" height="667" alt="Screenshot 2026-06-10 at 9 41 42 AM" src="https://github.com/user-attachments/assets/5a00bb35-0edf-4e87-aacb-c33064ce6c8e" /> | <img width="232" height="731" alt="Screenshot 2026-06-10 at 9 41 13 AM" src="https://github.com/user-attachments/assets/42fb3f1d-ab61-4bba-9623-d58cc4f6a8b6" /> | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment of the organization profile domain section subtitle to match the button above it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->