### PR TITLE
fix(ui): show user:org:read scope in OAuth Consent list

### DIFF
--- a/.changeset/brown-wolves-reply.md
+++ b/.changeset/brown-wolves-reply.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Display the scope description for `user:org:read` organization access in the OAuth Consent dialog so users understand organization membership information is being shared with the OAuth client.

--- a/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/ui/src/components/OAuthConsent/OAuthConsent.tsx
@@ -142,7 +142,7 @@ function _OAuthConsent() {
 
   const primaryIdentifier = user?.primaryEmailAddress?.emailAddress || user?.primaryPhoneNumber?.phoneNumber;
 
-  const displayedScopes = scopes.filter(item => ![OFFLINE_ACCESS_SCOPE, USER_ORG_READ_SCOPE].includes(item.scope));
+  const displayedScopes = scopes.filter(item => item.scope !== OFFLINE_ACCESS_SCOPE);
   const hasOfflineAccess = scopes.some(item => item.scope === OFFLINE_ACCESS_SCOPE);
 
   return (

--- a/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
+++ b/packages/ui/src/components/OAuthConsent/__tests__/OAuthConsent.test.tsx
@@ -393,7 +393,7 @@ describe('OAuthConsent', () => {
       });
     });
 
-    it('does not display user:org:read in the scopes list', async () => {
+    it('displays user:org:read in the scopes list', async () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withUser({
           email_addresses: ['jane@example.com'],
@@ -410,7 +410,7 @@ describe('OAuthConsent', () => {
       const { queryByText } = render(<OAuthConsent />, { wrapper });
 
       await waitFor(() => {
-        expect(queryByText('Access your organizations')).toBeNull();
+        expect(queryByText('Access your organizations')).toBeVisible();
       });
     });
 


### PR DESCRIPTION
so that the user is made aware that they are sharing org information with 3rd party

Fixes USER-5442

The OAuth Consent dialog shows a list of scope descriptions so that the user is clearly informed about what they are granting access to.  We were omitting the display of the `user:org:read` scope because we show an org selector in that case.

We determined that is not clear enough to users. Users should be explicitly informed that org information is being shared.

<img width="680" height="708" alt="CleanShot 2026-06-10 at 09 50 06@2x" src="https://github.com/user-attachments/assets/32c2cccf-2569-4a6b-a0da-4510f08a6d08" />

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth consent scope display to show additional relevant scopes, including the `user:org:read` scope when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->