### PR TITLE
fix(expo): remove iOS codegen warnings from native auth views

### DIFF
--- a/.changeset/expo-native-view-codegen-warning.md
+++ b/.changeset/expo-native-view-codegen-warning.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Remove React Native codegen warnings from Expo native auth components on iOS.

--- a/packages/expo/src/specs/NativeClerkAuthView.ts
+++ b/packages/expo/src/specs/NativeClerkAuthView.ts
@@ -1,9 +1,7 @@
-/* eslint-disable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
-// These deep imports from react-native internals are required by codegen.
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { HostComponent, ViewProps } from 'react-native';
+import type { ViewProps } from 'react-native';
+import { requireNativeComponent } from 'react-native';
+// eslint-disable-next-line import/namespace
 import type { BubblingEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
-/* eslint-enable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
 
 type AuthEvent = Readonly<{ type: string }>;
 
@@ -13,4 +11,4 @@ interface NativeProps extends ViewProps {
   onAuthEvent?: BubblingEventHandler<AuthEvent>;
 }
 
-export default codegenNativeComponent<NativeProps>('ClerkAuthView') as HostComponent<NativeProps>;
+export default requireNativeComponent<NativeProps>('ClerkAuthView');

--- a/packages/expo/src/specs/NativeClerkAuthView.ts
+++ b/packages/expo/src/specs/NativeClerkAuthView.ts
@@ -1,14 +1,13 @@
-import type { ViewProps } from 'react-native';
+import type { NativeSyntheticEvent, ViewProps } from 'react-native';
 import { requireNativeComponent } from 'react-native';
-// eslint-disable-next-line import/namespace
-import type { BubblingEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type AuthEvent = Readonly<{ type: string }>;
+type AuthEventHandler = (event: NativeSyntheticEvent<AuthEvent>) => void | Promise<void>;
 
 interface NativeProps extends ViewProps {
   mode?: string;
   isDismissible?: boolean;
-  onAuthEvent?: BubblingEventHandler<AuthEvent>;
+  onAuthEvent?: AuthEventHandler;
 }
 
 export default requireNativeComponent<NativeProps>('ClerkAuthView');

--- a/packages/expo/src/specs/NativeClerkUserButtonView.ts
+++ b/packages/expo/src/specs/NativeClerkUserButtonView.ts
@@ -1,11 +1,8 @@
-/* eslint-disable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
-// These deep imports from react-native internals are required by codegen.
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { HostComponent, ViewProps } from 'react-native';
-/* eslint-enable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
+import type { ViewProps } from 'react-native';
+import { requireNativeComponent } from 'react-native';
 
 // Codegen requires an interface declaration here; a type alias fails Android codegen.
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface NativeProps extends ViewProps {}
 
-export default codegenNativeComponent<NativeProps>('ClerkUserButtonView') as HostComponent<NativeProps>;
+export default requireNativeComponent<NativeProps>('ClerkUserButtonView');

--- a/packages/expo/src/specs/NativeClerkUserButtonView.ts
+++ b/packages/expo/src/specs/NativeClerkUserButtonView.ts
@@ -1,7 +1,6 @@
 import type { ViewProps } from 'react-native';
 import { requireNativeComponent } from 'react-native';
 
-// Codegen requires an interface declaration here; a type alias fails Android codegen.
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface NativeProps extends ViewProps {}
 

--- a/packages/expo/src/specs/NativeClerkUserProfileView.ts
+++ b/packages/expo/src/specs/NativeClerkUserProfileView.ts
@@ -1,13 +1,12 @@
-import type { ViewProps } from 'react-native';
+import type { NativeSyntheticEvent, ViewProps } from 'react-native';
 import { requireNativeComponent } from 'react-native';
-// eslint-disable-next-line import/namespace
-import type { BubblingEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type ProfileEvent = Readonly<{ type: string }>;
+type ProfileEventHandler = (event: NativeSyntheticEvent<ProfileEvent>) => void | Promise<void>;
 
 interface NativeProps extends ViewProps {
   isDismissible?: boolean;
-  onProfileEvent?: BubblingEventHandler<ProfileEvent>;
+  onProfileEvent?: ProfileEventHandler;
 }
 
 export default requireNativeComponent<NativeProps>('ClerkUserProfileView');

--- a/packages/expo/src/specs/NativeClerkUserProfileView.ts
+++ b/packages/expo/src/specs/NativeClerkUserProfileView.ts
@@ -1,9 +1,7 @@
-/* eslint-disable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
-// These deep imports from react-native internals are required by codegen.
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { HostComponent, ViewProps } from 'react-native';
+import type { ViewProps } from 'react-native';
+import { requireNativeComponent } from 'react-native';
+// eslint-disable-next-line import/namespace
 import type { BubblingEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
-/* eslint-enable import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member, simple-import-sort/imports */
 
 type ProfileEvent = Readonly<{ type: string }>;
 
@@ -12,4 +10,4 @@ interface NativeProps extends ViewProps {
   onProfileEvent?: BubblingEventHandler<ProfileEvent>;
 }
 
-export default codegenNativeComponent<NativeProps>('ClerkUserProfileView') as HostComponent<NativeProps>;
+export default requireNativeComponent<NativeProps>('ClerkUserProfileView');


### PR DESCRIPTION
### Summary
- Switch the Expo native auth view specs on iOS to `requireNativeComponent` instead of `codegenNativeComponent`
- Keep the Android spec path unchanged because it already uses Expo `requireNativeView`
- Add a patch changeset for the `@clerk/expo` warning fix

### Fixed warnings
During a clean iOS run of the native-components Expo quickstart, React Native logged these runtime warnings after launch:

```text
Codegen didn't run for ClerkAuthView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.
Codegen didn't run for ClerkUserButtonView. This will be an error in the future.
Codegen didn't run for ClerkUserProfileView. This will be an error in the future.
```

Those warnings were coming from the iOS JS specs calling `codegenNativeComponent` for views that are registered through the existing legacy `RCTViewManager` path. The patched specs now resolve those same native view managers with `requireNativeComponent`, which removes the false codegen warning while preserving the native component lookup.

### Testing
- Packed the patched local `@clerk/expo` package and overlaid it into `NativeComponentQuickstart` without changing quickstart tracked files
- Ran `npx expo prebuild --clean --platform ios` successfully
- Ran `npx expo run:ios --device "iPhone Air + Watch" --port 8081` successfully with `0 error(s)`
- Opened the native `AuthView` in the simulator and confirmed the `Codegen didn't run for Clerk...` warnings no longer appear after launch or after rendering the native auth view
- Ran targeted ESLint for the changed spec files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed React Native codegen warnings from Expo native authentication components on iOS. This patch streamlines the development build process and reduces build output noise for developers integrating Clerk authentication into their Expo native applications. The update improves the overall development experience without introducing any breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->