### PR TITLE
chore(expo): bump clerk-ios to 1.2.1

### DIFF
--- a/.changeset/bump-expo-clerk-ios-1-2-1.md
+++ b/.changeset/bump-expo-clerk-ios-1-2-1.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Bump the `clerk-ios` version pulled into Expo projects to `1.2.1`.

--- a/packages/expo/app.plugin.js
+++ b/packages/expo/app.plugin.js
@@ -20,7 +20,7 @@ const path = require('path');
 const fs = require('fs');
 
 const CLERK_IOS_REPO = 'https://github.com/clerk/clerk-ios.git';
-const CLERK_IOS_VERSION = '1.2.0';
+const CLERK_IOS_VERSION = '1.2.1';
 
 const CLERK_MIN_IOS_VERSION = '17.0';
 


### PR DESCRIPTION
## Summary

Bumps the `clerk-ios` Swift package version pulled in by `@clerk/expo` from `1.2.0` to `1.2.1`.

Adds a patch changeset for the Expo package so consumers get the updated native iOS SDK version during prebuild.

## Validation

- `pnpm --filter @clerk/expo format:check`
- `pnpm --filter @clerk/expo exec vitest run src/__tests__/appPlugin.theme.test.js`
- `pnpm --filter @clerk/expo exec vitest run src/resource-cache/__tests__/secure-store.test.ts src/native/__tests__/AuthView.test.tsx`
- `node -e "const plugin=require('./packages/expo/app.plugin.js'); console.log(typeof plugin);"`

Full `pnpm --filter @clerk/expo test` currently fails on unresolved local workspace package exports (`@clerk/shared/error`, `@clerk/react/legacy`) unrelated to this version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped `@clerk/expo` package to version 1.2.1, including updates to the iOS native dependency for Expo projects to enhance stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->