### PR TITLE
fix(shared): emit unbundled type declarations at stable public paths

### DIFF
--- a/.changeset/shared-unbundled-declarations.md
+++ b/.changeset/shared-unbundled-declarations.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Restore resolvable TypeScript declarations. Type declarations are now emitted per-module at stable public paths instead of being bundled into content-hashed internal chunk files. This fixes type resolution failures (or silent `any` degradation) in packages whose declarations reference `@clerk/shared` types, such as `@clerk/vue`, `@clerk/react`, `@clerk/ui`, and `@clerk/testing`, which previously pointed at unresolvable `@clerk/shared/_chunks/*` specifiers.

--- a/packages/shared/tsdown.config.mts
+++ b/packages/shared/tsdown.config.mts
@@ -8,16 +8,12 @@ import sharedPackage from './package.json' with { type: 'json' };
 export default defineConfig(({ watch, env }) => {
   const shouldPublish = !!env?.publish;
 
-  return {
-    dts: true,
+  const common = {
     sourcemap: true,
-    clean: true,
     target: 'es2022',
     platform: 'neutral',
-    external: ['react', 'react-dom'],
     format: ['cjs', 'esm'],
     minify: false,
-    onSuccess: shouldPublish ? 'pkglab pub --ping' : undefined,
     define: {
       PACKAGE_NAME: `"${sharedPackage.name}"`,
       PACKAGE_VERSION: `"${sharedPackage.version}"`,
@@ -40,22 +36,57 @@ export default defineConfig(({ watch, env }) => {
       '!./src/**/*.{test,spec}.{ts,tsx}',
     ],
     outDir: './dist',
-    unbundle: false,
-    // Route rolldown's shared chunks into a nested `_chunks/` directory. The
-    // package's `"./*"` wildcard export resolves to `dist/*`, and break-check
-    // expands that surface with a single-segment `*`, so content-hashed internal
-    // chunks sitting flat in `dist` get enumerated as phantom public subpaths.
-    // Nesting them one level down keeps them out of that API-snapshot expansion;
-    // package subpath imports are blocked separately by the `./_chunks/*` null export.
-    outputOptions: options => {
-      const { chunkFileNames } = options;
-      return {
-        ...options,
-        chunkFileNames:
-          typeof chunkFileNames === 'function'
-            ? info => `_chunks/${chunkFileNames(info)}`
-            : `_chunks/${chunkFileNames ?? '[name]-[hash].js'}`,
-      };
-    },
   } satisfies Options;
+
+  return [
+    // Runtime build: bundled. Selected devDependencies (zxcvbn, zustand, ...) are
+    // intentionally inlined so consumers don't install them.
+    {
+      ...common,
+      dts: false,
+      clean: true,
+      external: ['react', 'react-dom'],
+      onSuccess: shouldPublish ? 'pkglab pub --ping' : undefined,
+      // Route rolldown's shared chunks into a nested `_chunks/` directory. The
+      // package's `"./*"` wildcard export resolves to `dist/*`, and break-check
+      // expands that surface with a single-segment `*`, so content-hashed internal
+      // chunks sitting flat in `dist` get enumerated as phantom public subpaths.
+      // Nesting them one level down keeps them out of that API-snapshot expansion;
+      // package subpath imports are blocked separately by the `./_chunks/*` null export.
+      outputOptions: options => {
+        const { chunkFileNames } = options;
+        return {
+          ...options,
+          chunkFileNames:
+            typeof chunkFileNames === 'function'
+              ? info => `_chunks/${chunkFileNames(info)}`
+              : `_chunks/${chunkFileNames ?? '[name]-[hash].js'}`,
+        };
+      },
+    },
+    // Declarations build: unbundled, separate from the runtime build. Every public
+    // symbol's declaration must live at a stable, real-named path that downstream
+    // declaration emit (tsc, vue-tsc, rolldown-plugin-dts) can reference through
+    // this package's public subpath exports. Bundled declarations instead hoist
+    // shared types into content-hashed chunks with mangled aliases, and downstream
+    // packages' d.ts then hardcode specifiers like `@clerk/shared/_chunks/index-<hash>`,
+    // which `"./_chunks/*": null` blocks and whose names churn on every build.
+    // All bare imports stay external so the inlined runtime deps above don't get
+    // their type modules mirrored into `dist/node_modules` (npm strips that path
+    // at pack time); their type imports resolve from the consumer's node_modules,
+    // matching how this package has always published its declarations.
+    {
+      ...common,
+      dts: { emitDtsOnly: true, sourcemap: false },
+      // Declaration sourcemaps are skipped: rolldown-plugin-dts can't produce them
+      // in this mode (SOURCEMAP_BROKEN warning), and they'd reference src files
+      // that aren't shipped in the tarball anyway.
+      sourcemap: false,
+      clean: false,
+      unbundle: true,
+      // Bare specifiers stay external, except the `@/*` tsconfig path alias,
+      // which must be resolved back to relative imports within this package.
+      external: [/^(?!@\/)[^./]/],
+    },
+  ] satisfies Options[];
 });


### PR DESCRIPTION
The 2 remaining breaking changes are actually fixes, since they are repairing the broken types, but break-check cannot verify the types are actually reachable so it fails-closed



break-check on #8177 flagged 8 breaking changes: after the tsdown 0.22 bump, rolldown-plugin-dts started code-splitting shared's declarations into content-hashed chunks with mangled aliases, so downstream declaration emit (vue, react, ui, testing) hardcoded specifiers like `@clerk/shared/_chunks/index-Cr_OtBLq`. That subpath is export-blocked, and the hash churns every build. Published `@clerk/shared@4.17.0` has none of this, so it would have shipped broken types in the next release.

The fix splits shared's build in two: the runtime build is unchanged (bundled, `_chunks/` routing intact), and a separate dts-only pass emits declarations unbundled, so every symbol lives at a real-named path that resolves through the existing `./*` export. Two spots deserve scrutiny: the `external` regex in the dts config (bare imports stay external, matching how 4.17.0 publishes, while the `@/*` alias is excluded so it resolves back to relative imports) and the dropped declaration sourcemaps (the plugin cannot emit them in this mode).

Verified by rebuilding every downstream package (zero `_chunks` references remain in any declaration) and by type-checking a consumer app against packed tarballs with `skipLibCheck: false`: `useClerk`, `UserButton`, and `SignInWithMetamaskButton` resolve to real types again, and attw/publint are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored proper TypeScript type resolution for packages dependent on Clerk shared utilities by fixing declaration emission to use stable public paths, preventing silent type degradation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->