### PR TITLE
docs(shared): fix broken Clerk docs links in organization JSDoc

### DIFF
--- a/.changeset/fix-organization-jsdoc-links.md
+++ b/.changeset/fix-organization-jsdoc-links.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix broken Clerk documentation links in JSDoc comments on `OrganizationDomainResource`, `OrganizationMembershipResource`, `OrganizationSettingsResource`, and `UpdateEnrollmentModeParams`. Hover documentation in IDEs now points at the correct `organization-invitation`, `organization-suggestion`, and `objects/organization` pages instead of 404ing.

--- a/.changeset/fix-organization-jsdoc-links.md
+++ b/.changeset/fix-organization-jsdoc-links.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/shared': patch
 ---
-
-Fix broken Clerk documentation links in JSDoc comments on `OrganizationDomainResource`, `OrganizationMembershipResource`, `OrganizationSettingsResource`, and `UpdateEnrollmentModeParams`. Hover documentation in IDEs now points at the correct `organization-invitation`, `organization-suggestion`, and `objects/organization` pages instead of 404ing.

--- a/packages/shared/src/types/billing.ts
+++ b/packages/shared/src/types/billing.ts
@@ -157,9 +157,7 @@ export type GetPlansParams = ClerkPaginationParams<{
    */
   for?: ForPayerType;
   /**
-   * The organization ID to fetch plans for (needs to match the current active organization ID). Providing this
-   * parameter will populate the `availablePrices` field with the prices that are available to the
-   * authenticated organization.
+   * The organization ID to fetch plans for (needs to match the current [Active Organization](!active-organization) ID). Providing this parameter will populate the `availablePrices` field with the prices that are available to the authenticated organization.
    */
   orgId?: string;
   /**
@@ -1223,31 +1221,31 @@ export type CreateCheckoutParams = WithOptionalOrgType<{
  */
 export type ConfirmCheckoutParams =
   | {
-      /**
-       * The ID of a saved payment method to use for this checkout.
-       */
-      paymentMethodId?: string;
-    }
+    /**
+     * The ID of a saved payment method to use for this checkout.
+     */
+    paymentMethodId?: string;
+  }
   | {
-      /**
-       * A token representing payment details, usually from a payment form. **Requires** `gateway` to be provided.
-       */
-      paymentToken?: string;
-      /**
-       * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
-       */
-      gateway?: PaymentGateway;
-    }
+    /**
+     * A token representing payment details, usually from a payment form. **Requires** `gateway` to be provided.
+     */
+    paymentToken?: string;
+    /**
+     * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
+     */
+    gateway?: PaymentGateway;
+  }
   | {
-      /**
-       * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
-       */
-      gateway?: PaymentGateway;
-      /**
-       * If true, uses a test card for the checkout. **Requires** `gateway` to be provided.
-       */
-      useTestCard?: boolean;
-    };
+    /**
+     * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
+     */
+    gateway?: PaymentGateway;
+    /**
+     * If true, uses a test card for the checkout. **Requires** `gateway` to be provided.
+     */
+    useTestCard?: boolean;
+  };
 
 /**
  * The `BillingCheckoutResource` type represents information about a checkout session.

--- a/packages/shared/src/types/billing.ts
+++ b/packages/shared/src/types/billing.ts
@@ -1221,31 +1221,31 @@ export type CreateCheckoutParams = WithOptionalOrgType<{
  */
 export type ConfirmCheckoutParams =
   | {
-    /**
-     * The ID of a saved payment method to use for this checkout.
-     */
-    paymentMethodId?: string;
-  }
+      /**
+       * The ID of a saved payment method to use for this checkout.
+       */
+      paymentMethodId?: string;
+    }
   | {
-    /**
-     * A token representing payment details, usually from a payment form. **Requires** `gateway` to be provided.
-     */
-    paymentToken?: string;
-    /**
-     * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
-     */
-    gateway?: PaymentGateway;
-  }
+      /**
+       * A token representing payment details, usually from a payment form. **Requires** `gateway` to be provided.
+       */
+      paymentToken?: string;
+      /**
+       * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
+       */
+      gateway?: PaymentGateway;
+    }
   | {
-    /**
-     * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
-     */
-    gateway?: PaymentGateway;
-    /**
-     * If true, uses a test card for the checkout. **Requires** `gateway` to be provided.
-     */
-    useTestCard?: boolean;
-  };
+      /**
+       * The payment gateway to use. **Required** if `paymentToken` or `useTestCard` is provided.
+       */
+      gateway?: PaymentGateway;
+      /**
+       * If true, uses a test card for the checkout. **Requires** `gateway` to be provided.
+       */
+      useTestCard?: boolean;
+    };
 
 /**
  * The `BillingCheckoutResource` type represents information about a checkout session.

--- a/packages/shared/src/types/organizationDomain.ts
+++ b/packages/shared/src/types/organizationDomain.ts
@@ -54,7 +54,7 @@ export interface OrganizationDomainResource extends ClerkResource {
    *
    * <ul>
    *  <li>`manual_invitation`: No automatic enrollment. Users with a matching email domain are not given any [invitation](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-invitations) or [suggestion](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-suggestions); an admin must invite them manually.</li>
-   *  <li>`automatic_invitation`: Users with a matching email domain automatically receive a pending [invitation](https://clerk.com/docs/reference/types/organizationinvitation) (assigned the Organization's default role) which they can accept to join.</li>
+   *  <li>`automatic_invitation`: Users with a matching email domain automatically receive a pending [invitation](https://clerk.com/docs/reference/types/organization-invitation) (assigned the Organization's default role) which they can accept to join.</li>
    *  <li>`automatic_suggestion`: Users with a matching email domain automatically receive a [suggestion](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-suggestions) to join, which they can request.</li>
    * </ul>
    */
@@ -76,7 +76,7 @@ export interface OrganizationDomainResource extends ClerkResource {
    */
   affiliationEmailAddress: string | null;
   /**
-   * The total number of pending [invitations](https://clerk.com/docs/reference/types/organizationinvitation) associated with this domain.
+   * The total number of pending [invitations](https://clerk.com/docs/reference/types/organization-invitation) associated with this domain.
    */
   totalPendingInvitations: number;
   /**
@@ -132,7 +132,7 @@ export type AttemptAffiliationVerificationParams = {
 /** @generateWithEmptyComment */
 export type UpdateEnrollmentModeParams = Pick<OrganizationDomainResource, 'enrollmentMode'> & {
   /**
-   * Whether to delete any pending [invitations](https://clerk.com/docs/reference/types/organizationinvitation) or [suggestions](https://clerk.com/docs/reference/types/organizationsuggestion) that were created by the previous enrollment mode.
+   * Whether to delete any pending [invitations](https://clerk.com/docs/reference/types/organization-invitation) or [suggestions](https://clerk.com/docs/reference/types/organization-suggestion) that were created by the previous enrollment mode.
    */
   deletePending?: boolean;
 };

--- a/packages/shared/src/types/organizationMembership.ts
+++ b/packages/shared/src/types/organizationMembership.ts
@@ -46,7 +46,7 @@ export interface OrganizationMembershipResource extends ClerkResource {
    */
   id: string;
   /**
-   * The [`Organization`](https://clerk.com/docs/reference/types/organization) object the membership belongs to.
+   * The [`Organization`](https://clerk.com/docs/reference/objects/organization) object the membership belongs to.
    */
   organization: OrganizationResource;
   /**

--- a/packages/shared/src/types/organizationSettings.ts
+++ b/packages/shared/src/types/organizationSettings.ts
@@ -65,7 +65,7 @@ export interface OrganizationSettingsResource extends ClerkResource {
      *
      * <ul>
      *  <li>`manual_invitation`: No automatic enrollment. Users with a matching email domain are not given any [invitation](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-invitations) or [suggestion](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-suggestions); an admin must invite them manually.</li>
-     *  <li>`automatic_invitation`: Users with a matching email domain automatically receive a pending [invitation](https://clerk.com/docs/reference/types/organizationinvitation) (assigned the Organization's default role) which they can accept to join.</li>
+     *  <li>`automatic_invitation`: Users with a matching email domain automatically receive a pending [invitation](https://clerk.com/docs/reference/types/organization-invitation) (assigned the Organization's default role) which they can accept to join.</li>
      *  <li>`automatic_suggestion`: Users with a matching email domain automatically receive a [suggestion](https://clerk.com/docs/guides/organizations/add-members/verified-domains#automatic-suggestions) to join, which they can request.</li>
      * </ul>
      */


### PR DESCRIPTION
## Summary
- Fix four JSDoc-linked URLs that 404'd: `types/organizationinvitation` → `types/organization-invitation`, `types/organizationsuggestion` → `types/organization-suggestion`, and `types/organization` → `objects/organization`.
- Affects `OrganizationDomainResource`, `OrganizationMembershipResource`, `OrganizationSettingsResource`, and `UpdateEnrollmentModeParams`.

## Test plan
- [ ] Hover any of the touched fields in an IDE; confirm the link target resolves on clerk.com instead of 404ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed and standardized reference links in JSDoc for organization and billing resources across the codebase.
* **Chores**
  * Added a changeset recording the documentation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->