### PR TITLE
chore(expo): bump clerk-ios to 1.2.2

### DIFF
--- a/.changeset/expo-bump-clerk-ios-1-2-2.md
+++ b/.changeset/expo-bump-clerk-ios-1-2-2.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-ios` SDK from `1.2.1` to `1.2.2`. See the Clerk iOS release: https://github.com/clerk/clerk-ios/releases/tag/1.2.2.

--- a/packages/expo/app.plugin.js
+++ b/packages/expo/app.plugin.js
@@ -20,7 +20,7 @@ const path = require('path');
 const fs = require('fs');
 
 const CLERK_IOS_REPO = 'https://github.com/clerk/clerk-ios.git';
-const CLERK_IOS_VERSION = '1.2.1';
+const CLERK_IOS_VERSION = '1.2.2';
 
 const CLERK_MIN_IOS_VERSION = '17.0';
 


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-ios` SDK in `@clerk/expo` from `1.2.1` to `1.2.2`.

Release: https://github.com/clerk/clerk-ios/releases/tag/1.2.2

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Clerk iOS SDK to version 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->