### PR TITLE
fix(shared,testing): ship self-contained published types for shared/cookie and testing/cypress

### DIFF
--- a/.changeset/shared-cookie-self-contained-types.md
+++ b/.changeset/shared-cookie-self-contained-types.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Ship a self-contained `CookieAttributes` interface from `@clerk/shared/cookie` and use it in `createCookieHandler`'s `set`/`remove` signatures. The published declarations previously referenced `Cookies.CookieAttributes` from js-cookie, which consumers could never resolve (the import was dropped from the declaration output and js-cookie ships no types), causing TS2503 errors under `skipLibCheck: false` and silently degrading the option types to `any` otherwise.

--- a/.changeset/testing-cypress-preserve-types-reference.md
+++ b/.changeset/testing-cypress-preserve-types-reference.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': patch
+---
+
+Preserve the `/// <reference types="cypress" />` directive in the published `@clerk/testing/cypress` type declarations. TypeScript's declaration emit previously dropped it, so the shipped types relied on the global `Cypress` namespace without declaring the dependency and failed to type-check under `skipLibCheck: false`.

--- a/packages/clerk-js/src/core/auth/getCookieDomain.ts
+++ b/packages/clerk-js/src/core/auth/getCookieDomain.ts
@@ -1,4 +1,4 @@
-import { createCookieHandler } from '@clerk/shared/cookie';
+import { type CookieAttributes, createCookieHandler } from '@clerk/shared/cookie';
 
 /**
  * Determines the eTLD+1 domain, which is where we want the cookies to be set.
@@ -19,7 +19,7 @@ const eTLDCookie = createCookieHandler('__clerk_test_etld');
 export function getCookieDomain(
   hostname = window.location.hostname,
   cookieHandler = eTLDCookie,
-  cookieAttributes?: { sameSite?: string; secure?: boolean },
+  cookieAttributes?: Pick<CookieAttributes, 'sameSite' | 'secure'>,
 ) {
   // only compute it once per session to avoid unnecessary cookie ops
   if (cachedETLDPlusOne) {

--- a/packages/shared/src/cookie.ts
+++ b/packages/shared/src/cookie.ts
@@ -1,6 +1,51 @@
 import Cookies from 'js-cookie';
 
 /**
+ * Mirrors js-cookie's `CookieAttributes`. Defined locally so the published d.ts is
+ * self-contained: the bundler drops the js-cookie import from the declaration output
+ * and `@types/js-cookie` is only a devDependency, so consumers could never resolve
+ * the original reference.
+ */
+export interface CookieAttributes {
+  /**
+   * Define when the cookie will be removed. Value can be a Number
+   * which will be interpreted as days from time of creation or a
+   * Date instance. If omitted, the cookie becomes a session cookie.
+   */
+  expires?: number | Date | undefined;
+
+  /**
+   * Define the path where the cookie is available. Defaults to '/'
+   */
+  path?: string | undefined;
+
+  /**
+   * Define the domain where the cookie is available. Defaults to
+   * the domain of the page where the cookie was created.
+   */
+  domain?: string | undefined;
+
+  /**
+   * A Boolean indicating if the cookie transmission requires a
+   * secure protocol (https). Defaults to false.
+   */
+  secure?: boolean | undefined;
+
+  /**
+   * Asserts that a cookie must not be sent with cross-origin requests,
+   * providing some protection against cross-site request forgery
+   * attacks (CSRF)
+   */
+  sameSite?: 'strict' | 'Strict' | 'lax' | 'Lax' | 'none' | 'None' | undefined;
+
+  /**
+   * An attribute which will be serialized, conformably to RFC 6265
+   * section 5.2.
+   */
+  [property: string]: any;
+}
+
+/**
  * Creates helper methods for dealing with a specific cookie.
  *
  * @example
@@ -20,7 +65,7 @@ export function createCookieHandler(cookieName: string) {
     /**
      * Setting a cookie will use some defaults such as path being set to "/".
      */
-    set(newValue: string, options: Cookies.CookieAttributes = {}): void {
+    set(newValue: string, options: CookieAttributes = {}): void {
       Cookies.set(cookieName, newValue, options);
     },
     /**
@@ -29,7 +74,7 @@ export function createCookieHandler(cookieName: string) {
      *
      * @see https://github.com/js-cookie/js-cookie#basic-usage
      */
-    remove(cookieAttributes?: Cookies.CookieAttributes) {
+    remove(cookieAttributes?: CookieAttributes) {
       Cookies.remove(cookieName, cookieAttributes);
     },
   };

--- a/packages/shared/src/cookie.ts
+++ b/packages/shared/src/cookie.ts
@@ -39,6 +39,13 @@ export interface CookieAttributes {
   sameSite?: 'strict' | 'Strict' | 'lax' | 'Lax' | 'none' | 'None' | undefined;
 
   /**
+   * A Boolean indicating whether the cookie is partitioned per top-level
+   * site (CHIPS). js-cookie serializes it through the attribute passthrough;
+   * declared explicitly because Clerk sets it at several call sites.
+   */
+  partitioned?: boolean | undefined;
+
+  /**
    * An attribute which will be serialized, conformably to RFC 6265
    * section 5.2.
    */
@@ -74,7 +81,7 @@ export function createCookieHandler(cookieName: string) {
      *
      * @see https://github.com/js-cookie/js-cookie#basic-usage
      */
-    remove(cookieAttributes?: CookieAttributes) {
+    remove(cookieAttributes?: CookieAttributes): void {
       Cookies.remove(cookieName, cookieAttributes);
     },
   };

--- a/packages/testing/src/cypress/agent-task.ts
+++ b/packages/testing/src/cypress/agent-task.ts
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+/// <reference types="cypress" preserve="true" />
 import { type CreateAgentTaskParams, createAgentTestingTask as _createAgentTestingTask } from '../common';
 
 /**

--- a/packages/testing/src/cypress/custom-commands.ts
+++ b/packages/testing/src/cypress/custom-commands.ts
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+/// <reference types="cypress" preserve="true" />
 import type { Clerk, SignOutOptions } from '@clerk/shared/types';
 
 import type { ClerkSignInParams } from '../common';

--- a/packages/testing/src/cypress/setup.ts
+++ b/packages/testing/src/cypress/setup.ts
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+/// <reference types="cypress" preserve="true" />
 import type { ClerkSetupOptions } from '../common';
 import { fetchEnvVars } from '../common';
 

--- a/packages/testing/src/cypress/setupClerkTestingToken.ts
+++ b/packages/testing/src/cypress/setupClerkTestingToken.ts
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+/// <reference types="cypress" preserve="true" />
 import type { SetupClerkTestingTokenOptions } from '../common';
 import { ERROR_MISSING_FRONTEND_API_URL, TESTING_TOKEN_PARAM } from '../common';
 


### PR DESCRIPTION
Break Check has been skipping `@clerk/shared` `./cookie` and `@clerk/testing` `./cypress` (see the report on #8827) because the published d.ts for both is not self-contained. For shared, the dts bundler drops the `import Cookies from 'js-cookie'` and ships bare `Cookies.CookieAttributes` references that no consumer can resolve, since `@types/js-cookie` is only a devDependency; `cookie.ts` now declares its own `CookieAttributes` (same shape as js-cookie's) and uses it in the public signatures. For testing, tsc drops the `/// <reference types="cypress" />` directives during declaration emit, so the emitted types lean on the global `Cypress` namespace without declaring it; `preserve="true"` carries the directive into the output.

One behavior change to weigh: importing `@clerk/testing/cypress` now loads cypress's ambient globals (chai/jquery/mocha) in the consumer's program. That is the intended semantics for a cypress-only subpath, and the directive lands only in the cypress d.ts files, but it is new. Verified by rebuilding both packages and re-running break-check: both subpaths snapshot cleanly, and the shipped files compile in isolation with skipLibCheck off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ship self-contained cookie attribute types so TypeScript declarations resolve correctly and consumer builds no longer fail under strict type-checking.
  * Update cookie-related type signatures used by auth utilities to prevent type errors in strict TS configurations.
* **Tests**
  * Preserve Cypress type references in testing packages so shipped test typings remain intact and type-safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->