### PR TITLE
feat(fastify): actionable error when registered on unsupported Fastify version

### DIFF
--- a/.changeset/fastify-actionable-version-error.md
+++ b/.changeset/fastify-actionable-version-error.md
@@ -1,0 +1,5 @@
+---
+'@clerk/fastify': patch
+---
+
+Registering `clerkPlugin` on Fastify <5 now throws an actionable error that tells you exactly how to resolve the mismatch — either upgrade to `fastify@^5` or pin `@clerk/fastify@^1` to stay on Fastify 4 LTS — instead of the generic `FST_ERR_PLUGIN_VERSION_MISMATCH` you would previously see during registration.

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -35,6 +35,8 @@
 - Node.js `>=20.9.0` or later
 - An existing Clerk application. [Create your account for free](https://dashboard.clerk.com/sign-up?utm_source=github&utm_medium=clerk_fastify).
 
+> **Still on Fastify 4 (LTS)?** Pin `@clerk/fastify@^1`. The current major requires Fastify 5; registering it on Fastify 4 throws at plugin registration time with an actionable error explaining your options.
+
 ### Installation
 
 The fastest way to get started with Clerk is by following the [Fastify Quickstart](https://clerk.com/docs/quickstarts/fastify?utm_source=github&utm_medium=clerk_fastify).

--- a/packages/fastify/src/__tests__/clerkPlugin.test.ts
+++ b/packages/fastify/src/__tests__/clerkPlugin.test.ts
@@ -59,4 +59,31 @@ describe('clerkPlugin()', () => {
     expect(fastify.decorateRequest).toHaveBeenCalledWith('clerk', null);
     expect(doneFn).toHaveBeenCalled();
   });
+
+  test.each(['4.28.0', '3.29.5', '2.0.0'])(
+    'throws an actionable error when registered on fastify@%s',
+    version => {
+      const doneFn = vi.fn();
+      const fastify = createFastifyInstanceMock({ version });
+
+      expect(() => {
+        clerkPlugin(fastify, {}, doneFn);
+      }).toThrowError(new RegExp(`requires fastify@>=5 but is being registered on fastify@${version.replace(/\./g, '\\.')}`));
+      expect(() => {
+        clerkPlugin(fastify, {}, doneFn);
+      }).toThrowError(/pin @clerk\/fastify@\^1/);
+      expect(doneFn).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['5.0.0', '5.8.5', '6.0.0-alpha.1'])(
+    'does not throw on supported fastify@%s',
+    version => {
+      const doneFn = vi.fn();
+      const fastify = createFastifyInstanceMock({ version });
+
+      expect(() => clerkPlugin(fastify, {}, doneFn)).not.toThrow();
+      expect(doneFn).toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/fastify/src/clerkPlugin.ts
+++ b/packages/fastify/src/clerkPlugin.ts
@@ -1,15 +1,32 @@
 import type { FastifyInstance, FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 
+import { incompatibleFastifyVersion } from './errors';
 import type { ClerkFastifyOptions } from './types';
 import { ALLOWED_HOOKS } from './types';
 import { withClerkMiddleware } from './withClerkMiddleware';
+
+const FASTIFY_MAJOR_MIN = 5;
+
+// Extracts the major version from a Fastify version string like "5.8.5"
+// without introducing a `semver` dependency for a single integer compare.
+const parseFastifyMajor = (version: string): number => {
+  const match = /^(\d+)/.exec(version);
+  return match ? Number.parseInt(match[1]!, 10) : 0;
+};
 
 const plugin: FastifyPluginCallback<ClerkFastifyOptions> = (
   instance: FastifyInstance,
   opts: ClerkFastifyOptions,
   done,
 ) => {
+  // Throw a Clerk-branded, actionable error instead of fastify-plugin's
+  // stock FST_ERR_PLUGIN_VERSION_MISMATCH, which doesn't tell the user
+  // what to do (upgrade fastify or pin @clerk/fastify@^1).
+  if (parseFastifyMajor(instance.version) < FASTIFY_MAJOR_MIN) {
+    throw new Error(incompatibleFastifyVersion(instance.version));
+  }
+
   instance.decorateRequest('auth', null);
   instance.decorateRequest('clerk', null as any);
 
@@ -26,5 +43,4 @@ const plugin: FastifyPluginCallback<ClerkFastifyOptions> = (
 
 export const clerkPlugin = fp(plugin, {
   name: '@clerk/fastify',
-  fastify: '5.x',
 });

--- a/packages/fastify/src/errors.ts
+++ b/packages/fastify/src/errors.ts
@@ -16,3 +16,14 @@ import { clerkPlugin } from '@clerk/fastify';
 const server: FastifyInstance = Fastify({ logger: true });
 server.register(clerkPlugin);
 `);
+
+export const incompatibleFastifyVersion = (foundVersion: string) =>
+  createErrorMessage(`@clerk/fastify requires fastify@>=5 but is being registered on fastify@${foundVersion}.
+
+To resolve this, either:
+  - upgrade your fastify dependency to ^5, or
+  - pin @clerk/fastify@^1 to keep using fastify@4 (LTS):
+
+      npm install @clerk/fastify@^1
+      # or: pnpm add @clerk/fastify@^1
+`);

--- a/packages/fastify/src/test/utils.ts
+++ b/packages/fastify/src/test/utils.ts
@@ -2,8 +2,9 @@ import type { FastifyInstance } from 'fastify';
 import { vi } from 'vitest';
 
 // expose decorated reply methods as methods in fastify instance
-export function createFastifyInstanceMock() {
+export function createFastifyInstanceMock(overrides: { version?: string } = {}) {
   const fastify = {
+    version: overrides.version ?? '5.8.5',
     decorateReply: vi.fn((name: string, fn) => {
       // @ts-expect-error - TS7053
       fastify[name] = fn;


### PR DESCRIPTION
Closes #8844.

## Description

When `@clerk/fastify` is registered against Fastify < 5, the failure mode today is `fastify-plugin`'s stock `FST_ERR_PLUGIN_VERSION_MISMATCH`. That error correctly identifies the mismatch but doesn't tell users what to do about it — and because Fastify 4 is still in LTS, this is a real footgun for teams that haven't migrated yet (and whose `pnpm install` warning got buried among other peer-dep noise). See #8844 for the full repro and motivation.

This PR replaces the stock error with a Clerk-branded one that spells out both resolution paths:

> 🔒 Clerk: @clerk/fastify requires fastify@>=5 but is being registered on fastify@4.28.0.
>
> To resolve this, either:
>   - upgrade your fastify dependency to ^5, or
>   - pin @clerk/fastify@^1 to keep using fastify@4 (LTS):
>
>       npm install @clerk/fastify@^1
>       # or: pnpm add @clerk/fastify@^1

I hit this firsthand while bootstrapping a Fastify 4 LTS app — the peer-dep warning at install time was easy to miss, and registration failed with the stock error which left me unsure whether to upgrade Fastify or downgrade `@clerk/fastify`.

## Implementation

- `packages/fastify/src/clerkPlugin.ts` — adds a major-version guard at the top of the plugin callback. The check is a one-line integer parse (`^(\d+)`) to avoid pulling `semver` for a single comparison.
- The `fastify: '5.x'` field is removed from the `fastify-plugin` metadata so our actionable error wins instead of `fastify-plugin`'s. Functionally identical outcome (registration fails on Fastify <5), better message.
- `packages/fastify/src/errors.ts` — new `incompatibleFastifyVersion(version)` builder using the existing `createErrorMessage` helper so the 🔒 Clerk prefix and docs/discord links stay consistent.
- `packages/fastify/src/test/utils.ts` — `createFastifyInstanceMock` accepts an optional `{ version }` override; defaults to `'5.8.5'` so existing tests are unchanged.
- `packages/fastify/README.md` — adds one note in the existing Prerequisites section explaining the `@clerk/fastify@^1` pin path for Fastify 4 LTS users.
- Changeset added (`patch`).

## Tests

`packages/fastify/src/__tests__/clerkPlugin.test.ts`:

- `test.each(['4.28.0', '3.29.5', '2.0.0'])` — verifies the error fires on multiple sub-5 versions, checks both the version mention and the pin guidance appear in the message, and confirms `done()` is never called.
- `test.each(['5.0.0', '5.8.5', '6.0.0-alpha.1'])` — verifies normal registration on supported versions (and the open-ended ≥5 future-proofs against 6.x).

All 13 tests in `clerkPlugin.test.ts` pass locally (the rest of the suite fails on my machine because `@clerk/backend` workspace dep isn't built — should pass on CI where workspaces are pre-built).

## Compatibility

- No new dependencies.
- No API changes for users on Fastify ≥5.
- Behaviour for users on Fastify <5 changes from one error message to another (both fail at registration time, both are throws). No silent change.