### PR TITLE
feat(electron): Report SDK version to FAPI via query param

### DIFF
--- a/packages/electron/src/global.d.ts
+++ b/packages/electron/src/global.d.ts
@@ -1,10 +1,10 @@
 import type { TokenCache } from './shared/types';
 
-declare const PACKAGE_NAME: string;
-declare const PACKAGE_VERSION: string;
-declare const __DEV__: boolean;
-
 declare global {
+  const PACKAGE_NAME: string;
+  const PACKAGE_VERSION: string;
+  const __DEV__: boolean;
+
   interface Window {
     __clerk_internal_electron?: {
       tokenCache: TokenCache;

--- a/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
+++ b/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
@@ -90,8 +90,23 @@ describe('Electron ClerkProvider', () => {
 
     expect(request.credentials).toBe('omit');
     expect(request.url.searchParams.get('_is_native')).toBe('1');
+    expect(request.url.searchParams.get('_electron_sdk_version')).toBe('0.0.0-test');
     expect(request.headers.get('Authorization')).toBe('Bearer client-jwt');
     expect(tokenCache.getToken).toHaveBeenCalledWith('__clerk_client_jwt');
+  });
+
+  it('adds the Electron SDK version query param when there is no cached token', async () => {
+    tokenCache.getToken.mockResolvedValue(null);
+    renderToStaticMarkup(<ClerkProvider publishableKey='pk_test_version_header'>App</ClerkProvider>);
+
+    const request = {
+      headers: new Headers(),
+      url: new URL('https://api.clerk.test/v1/client'),
+    };
+    await beforeRequest?.(request);
+
+    expect(request.url.searchParams.get('_electron_sdk_version')).toBe('0.0.0-test');
+    expect(request.headers.has('Authorization')).toBe(false);
   });
 
   it('stores Authorization response headers in the Electron token cache', async () => {

--- a/packages/electron/src/react/create-clerk-instance.ts
+++ b/packages/electron/src/react/create-clerk-instance.ts
@@ -16,6 +16,7 @@ export function createClerkInstance(publishableKey: string): ClerkInstance {
   clerk.__internal_onBeforeRequest(async request => {
     request.credentials = 'omit';
     request.url?.searchParams.append('_is_native', '1');
+    request.url?.searchParams.append('_electron_sdk_version', PACKAGE_VERSION);
 
     const token = await window.__clerk_internal_electron?.tokenCache.getToken(CLERK_CLIENT_JWT_KEY);
     if (token) {

--- a/packages/electron/vitest.config.mts
+++ b/packages/electron/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: './vitest.setup.mts',
+  },
+});

--- a/packages/electron/vitest.setup.mts
+++ b/packages/electron/vitest.setup.mts
@@ -1,0 +1,3 @@
+globalThis.PACKAGE_NAME = '@clerk/electron';
+globalThis.PACKAGE_VERSION = '0.0.0-test';
+globalThis.__DEV__ = false;


### PR DESCRIPTION
## Description

Reports the Electron SDK version on every FAPI request via an `_electron_sdk_version` query
parameter (mirroring clerk-js's `_clerk_js_version`). A custom header was avoided since it isn't
in FAPI's CORS allowlist and would fail preflight in cross-origin renderer setups.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.

## Type of change

- [x] 🌟 New feature