### PR TITLE
refactor(electron): Rename bridge setup APIs

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -41,12 +41,12 @@ This package exposes entrypoints for Electron's distinct runtime contexts:
 ```ts
 // main.ts
 import { app, BrowserWindow, net, protocol } from 'electron';
-import { setupMain } from '@clerk/electron';
+import { createClerkBridge } from '@clerk/electron';
 import { storage } from '@clerk/electron/storage';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-setupMain({
+createClerkBridge({
   storage: storage(),
   renderer: {
     scheme: 'my-app',
@@ -73,6 +73,13 @@ app.whenReady().then(() => {
 ```
 
 In `my-app://renderer/sign-in`, `my-app` is the scheme, `renderer` is the host, `my-app://renderer` is the origin, and `/sign-in` is the path. If your renderer uses path-based routing, serve every route from the same origin and fall back to your renderer entrypoint as needed.
+
+```ts
+// preload.ts
+import { exposeClerkBridge } from '@clerk/electron/preload';
+
+exposeClerkBridge();
+```
 
 ```tsx
 // renderer.tsx

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -1,1 +1,2 @@
-export { setupMain } from './main/setup-main';
+export { createClerkBridge } from './main/create-clerk-bridge';
+export type { ClerkBridge, CreateClerkBridgeOptions } from './shared/types';

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAUTH_TRANSPORT_CHANNELS } from '../../shared/ipc';
 import type { TokenStorage } from '../../shared/types';
-import { setupMain } from '../setup-main';
+import { createClerkBridge } from '../create-clerk-bridge';
 
 vi.mock('electron', () => ({
   app: {
@@ -23,8 +23,8 @@ vi.mock('electron', () => ({
   },
 }));
 
-describe('setupMain', () => {
-  const missingStorage = {} as Parameters<typeof setupMain>[0];
+describe('createClerkBridge', () => {
+  const missingStorage = {} as Parameters<typeof createClerkBridge>[0];
   const storage: TokenStorage = {
     getItem: vi.fn(),
     setItem: vi.fn(),
@@ -36,17 +36,17 @@ describe('setupMain', () => {
   });
 
   it('requires a storage adapter', () => {
-    expect(() => setupMain(missingStorage)).toThrow('setupMain requires a storage adapter');
+    expect(() => createClerkBridge(missingStorage)).toThrow('createClerkBridge requires a storage adapter');
   });
 
   it('sets up token persistence IPC handlers with the provided storage', () => {
-    setupMain({ storage });
+    createClerkBridge({ storage });
 
     expect(ipcMain.handle).toHaveBeenCalledTimes(3);
   });
 
   it('registers the configured renderer scheme as privileged before app ready', () => {
-    setupMain({
+    createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',
@@ -70,7 +70,7 @@ describe('setupMain', () => {
 
   it('requires renderer.scheme to be a scheme name, not a URL', () => {
     expect(() =>
-      setupMain({
+      createClerkBridge({
         storage,
         renderer: {
           host: 'renderer',
@@ -82,7 +82,7 @@ describe('setupMain', () => {
 
   it('requires renderer.host to be a host name, not an origin', () => {
     expect(() =>
-      setupMain({
+      createClerkBridge({
         storage,
         renderer: {
           host: 'my-app://renderer',
@@ -93,7 +93,7 @@ describe('setupMain', () => {
   });
 
   it('returns a cleanup function for registered handlers', () => {
-    const clerk = setupMain({ storage });
+    const clerk = createClerkBridge({ storage });
 
     clerk.cleanup();
 
@@ -101,7 +101,7 @@ describe('setupMain', () => {
   });
 
   it('cleans up OAuth transport handlers when renderer origin is configured', () => {
-    const clerk = setupMain({
+    const clerk = createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',
@@ -118,7 +118,7 @@ describe('setupMain', () => {
   });
 
   it('sets up OAuth transport IPC handlers when renderer origin is configured', () => {
-    setupMain({
+    createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',
@@ -132,7 +132,7 @@ describe('setupMain', () => {
   });
 
   it('derives the OAuth callback URL from the renderer origin', () => {
-    setupMain({
+    createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',
@@ -149,7 +149,7 @@ describe('setupMain', () => {
 
   it('opens OAuth URLs externally and resolves with the matching deep-link callback URL', async () => {
     vi.mocked(shell.openExternal).mockResolvedValue(undefined);
-    setupMain({
+    createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -1,10 +1,10 @@
 import { protocol } from 'electron';
 
-import type { SetupMainOptions, SetupMainReturn } from '../shared/types';
+import type { ClerkBridge, CreateClerkBridgeOptions } from '../shared/types';
 import { setupTokenCacheIpcHandlers } from './ipc-handlers';
 import { setupOAuthTransportIpcHandlers } from './oauth-transport';
 
-function assertValidRendererOriginConfig(renderer: NonNullable<SetupMainOptions['renderer']>): void {
+function assertValidRendererOriginConfig(renderer: NonNullable<CreateClerkBridgeOptions['renderer']>): void {
   if (renderer.scheme.includes(':') || renderer.scheme.includes('/')) {
     throw new Error(
       'Clerk: renderer.scheme must be a scheme name like "my-app", not a URL or protocol like "my-app://".',
@@ -18,10 +18,17 @@ function assertValidRendererOriginConfig(renderer: NonNullable<SetupMainOptions[
   }
 }
 
-export function setupMain(options: SetupMainOptions): SetupMainReturn {
+/**
+ * Creates the Clerk bridge for Electron's main process.
+ *
+ * The bridge owns Clerk's main-process IPC handlers, token persistence, and OAuth deep-link
+ * transport. Call this before creating renderer windows, and call the returned `cleanup` method
+ * when tearing down the app or test environment.
+ */
+export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridge {
   if (!options.storage) {
     throw new Error(
-      'Clerk: setupMain requires a storage adapter. Pass setupMain({ storage: storage() }) from @clerk/electron/storage, or provide a custom storage adapter.',
+      'Clerk: createClerkBridge requires a storage adapter. Pass createClerkBridge({ storage: storage() }) from @clerk/electron/storage, or provide a custom storage adapter.',
     );
   }
 

--- a/packages/electron/src/preload/__tests__/index.test.ts
+++ b/packages/electron/src/preload/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAUTH_TRANSPORT_CHANNELS, TOKEN_CACHE_CHANNELS } from '../../shared/ipc';
-import { setupPreload } from '../index';
+import { exposeClerkBridge } from '../index';
 
 vi.mock('electron', () => ({
   contextBridge: {
@@ -13,7 +13,7 @@ vi.mock('electron', () => ({
   },
 }));
 
-describe('setupPreload', () => {
+describe('exposeClerkBridge', () => {
   const originalContextIsolated = process.contextIsolated;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('setupPreload', () => {
   });
 
   it('exposes the Clerk Electron bridge through contextBridge when context isolation is enabled', () => {
-    setupPreload();
+    exposeClerkBridge();
 
     expect(contextBridge.exposeInMainWorld).toHaveBeenCalledWith('__clerk_internal_electron', {
       tokenCache: {
@@ -49,7 +49,7 @@ describe('setupPreload', () => {
   it('exposes the Clerk Electron bridge on window when context isolation is disabled', () => {
     Object.defineProperty(process, 'contextIsolated', { configurable: true, value: false });
 
-    setupPreload();
+    exposeClerkBridge();
 
     expect(window.__clerk_internal_electron?.tokenCache).toEqual({
       getToken: expect.any(Function),
@@ -63,7 +63,7 @@ describe('setupPreload', () => {
   });
 
   it('forwards token cache calls over IPC', async () => {
-    setupPreload();
+    exposeClerkBridge();
 
     const bridge = vi.mocked(contextBridge.exposeInMainWorld).mock
       .calls[0][1] as typeof window.__clerk_internal_electron;
@@ -78,7 +78,7 @@ describe('setupPreload', () => {
   });
 
   it('forwards OAuth transport calls over IPC', async () => {
-    setupPreload();
+    exposeClerkBridge();
 
     const bridge = vi.mocked(contextBridge.exposeInMainWorld).mock
       .calls[0][1] as typeof window.__clerk_internal_electron;

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -3,7 +3,13 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { OAUTH_TRANSPORT_CHANNELS, TOKEN_CACHE_CHANNELS } from '../shared/ipc';
 import type { OAuthTransport, TokenCache } from '../shared/types';
 
-export function setupPreload(): void {
+/**
+ * Exposes Clerk's Electron bridge from the preload script to the renderer.
+ *
+ * Call this from an Electron preload script. It publishes a narrow internal bridge used by
+ * `@clerk/electron/react` for token storage and OAuth transport.
+ */
+export function exposeClerkBridge(): void {
   const tokenCache: TokenCache = {
     getToken: key => ipcRenderer.invoke(TOKEN_CACHE_CHANNELS.getToken, key),
     saveToken: (key, value) => ipcRenderer.invoke(TOKEN_CACHE_CHANNELS.saveToken, key, value),

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -6,7 +6,10 @@ export type TokenStorage = {
   removeItem: (key: string) => Awaitable<void>;
 };
 
-export type SetupMainOptions = {
+export type CreateClerkBridgeOptions = {
+  /**
+   * Storage adapter used by the main process to persist Clerk tokens.
+   */
   storage: TokenStorage;
   /**
    * Registers the custom scheme used to serve the Electron renderer from a stable origin.
@@ -14,7 +17,10 @@ export type SetupMainOptions = {
   renderer?: RendererSchemeOptions;
 };
 
-export type SetupMainReturn = {
+export type ClerkBridge = {
+  /**
+   * Removes IPC handlers and listeners registered by `createClerkBridge`.
+   */
   cleanup: () => void;
 };
 

--- a/packages/electron/src/storage/index.ts
+++ b/packages/electron/src/storage/index.ts
@@ -108,7 +108,7 @@ async function resolveCipher(): Promise<Cipher | null> {
  * {@link safeStorage} API, which is backed by the OS keystore (Keychain on macOS, DPAPI on
  * Windows, libsecret/kwallet on Linux). It uses Electron 42's async `safeStorage` API only when it
  * reports itself available (which generally requires a code-signed app) and otherwise falls back to
- * the synchronous API. Pass the result to `setupMain({ storage: storage() })`.
+ * the synchronous API. Pass the result to `createClerkBridge({ storage: storage() })`.
  *
  * Behavior is secure by default: when OS encryption is unavailable the adapter does not persist
  * tokens (the user will be signed out on restart) unless {@link StorageOptions.unencryptedFallback}
@@ -116,10 +116,10 @@ async function resolveCipher(): Promise<Cipher | null> {
  *
  * @example
  * ```ts
- * import { setupMain } from '@clerk/electron';
+ * import { createClerkBridge } from '@clerk/electron';
  * import { storage } from '@clerk/electron/storage';
  *
- * setupMain({ storage: storage({ name: 'my-app-tokens' }) });
+ * createClerkBridge({ storage: storage({ name: 'my-app-tokens' }) });
  * ```
  */
 export function storage(options: StorageOptions = {}): TokenStorage {


### PR DESCRIPTION
## Description

Renames the Electron bridge setup APIs to better match their roles and Clerk naming conventions.

- Renames `setupMain` to `createClerkBridge`
- Renames `setupPreload` to `exposeClerkBridge`
- Updates docs, exports, and tests to use the new names

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
