### PR TITLE
feat(ui): wire the Security page navigation into the ConfigureSSO wizard

### DIFF
--- a/.changeset/whole-parents-care.md
+++ b/.changeset/whole-parents-care.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+The Security page's SSO wizard now has a back-to-Security control, and Start/Edit open the wizard at the first step (Continue resumes where you left off).

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -25,6 +25,8 @@ export interface ConfigureSSOData {
   organizationEnterpriseConnection: OrganizationEnterpriseConnection;
   testRuns: TestRunsView;
   organizationDomains: OrganizationDomainResource[] | undefined;
+  /** Exits the wizard back to the host; absent on the standalone mount. Reused by the back control and the future "Skip for now". */
+  onExit?: () => void;
 }
 
 interface ConfigureSSOProviderProps {
@@ -35,6 +37,7 @@ interface ConfigureSSOProviderProps {
   contentRef: React.RefObject<HTMLDivElement>;
   enterpriseConnectionMutations: EnterpriseConnectionMutations;
   organizationDomainMutations: OrganizationDomainMutations;
+  onExit?: () => void;
 }
 
 const ConfigureSSOContext = React.createContext<ConfigureSSOData | null>(null);
@@ -48,6 +51,7 @@ export const ConfigureSSOProvider = ({
   contentRef,
   enterpriseConnectionMutations,
   organizationDomainMutations,
+  onExit,
   children,
 }: PropsWithChildren<ConfigureSSOProviderProps>): JSX.Element => {
   const value = React.useMemo<ConfigureSSOData>(
@@ -59,6 +63,7 @@ export const ConfigureSSOProvider = ({
       organizationDomains,
       enterpriseConnectionMutations,
       organizationDomainMutations,
+      onExit,
     }),
     [
       contentRef,
@@ -68,6 +73,7 @@ export const ConfigureSSOProvider = ({
       testRuns,
       organizationDomains,
       enterpriseConnection,
+      onExit,
     ],
   );
 

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOContext.tsx
@@ -25,7 +25,6 @@ export interface ConfigureSSOData {
   organizationEnterpriseConnection: OrganizationEnterpriseConnection;
   testRuns: TestRunsView;
   organizationDomains: OrganizationDomainResource[] | undefined;
-  /** Exits the wizard back to the host; absent on the standalone mount. Reused by the back control and the future "Skip for now". */
   onExit?: () => void;
 }
 

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOHeader.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOHeader.tsx
@@ -1,8 +1,13 @@
-import { useLocalizations } from '@/customizables';
+import { Flex, useLocalizations } from '@/customizables';
 
 import { ProfileCardHeader } from './elements/ProfileCard';
 import { Stepper } from './elements/Stepper';
 import { useWizard } from './elements/Wizard';
+
+type ConfigureSSOHeaderProps = {
+  /** Host-built leading content (e.g. a back control); right-aligns the stepper when present. */
+  title?: React.ReactNode;
+};
 
 /**
  * The wizard breadcrumb, driven entirely by the generic entry-guard wizard
@@ -16,8 +21,11 @@ import { useWizard } from './elements/Wizard';
  * positional. The reset affordance now lives in the step footers
  * (`Step.Footer.Reset`), which delete the connection via the context mutation
  * rather than a wizard binding.
+ *
+ * `title` is host-owned content rendered as-is in the leading slot; when present
+ * the stepper right-aligns, otherwise it stays left-aligned (standalone mount).
  */
-export const ConfigureSSOHeader = (): JSX.Element => {
+export const ConfigureSSOHeader = ({ title }: ConfigureSSOHeaderProps): JSX.Element => {
   const { activeSteps, currentIndex, goToStep } = useWizard();
   const { t } = useLocalizations();
 
@@ -28,27 +36,31 @@ export const ConfigureSSOHeader = (): JSX.Element => {
 
   return (
     <ProfileCardHeader>
-      <Stepper>
-        {visibleSteps.map((step, index) => {
-          const isCurrent = index === currentVisibleIndex;
-          const labelText = step.label ? (typeof step.label === 'string' ? step.label : t(step.label)) : '';
+      {title}
 
-          return (
-            <Stepper.Item
-              key={step.id}
-              bullet={index + 1}
-              isCurrent={isCurrent}
-              isCompleted={step.isCompleted}
-              // Guard-driven: bind directly to the wizard's reachability flag so
-              // a disabled breadcrumb item and a blocked `goToStep` agree.
-              isReachable={step.isReachable}
-              onClick={() => goToStep(step.id)}
-            >
-              {labelText}
-            </Stepper.Item>
-          );
-        })}
-      </Stepper>
+      <Flex sx={title ? { marginInlineStart: 'auto' } : undefined}>
+        <Stepper>
+          {visibleSteps.map((step, index) => {
+            const isCurrent = index === currentVisibleIndex;
+            const labelText = step.label ? (typeof step.label === 'string' ? step.label : t(step.label)) : '';
+
+            return (
+              <Stepper.Item
+                key={step.id}
+                bullet={index + 1}
+                isCurrent={isCurrent}
+                isCompleted={step.isCompleted}
+                // Guard-driven: bind directly to the wizard's reachability flag so
+                // a disabled breadcrumb item and a blocked `goToStep` agree.
+                isReachable={step.isReachable}
+                onClick={() => goToStep(step.id)}
+              >
+                {labelText}
+              </Stepper.Item>
+            );
+          })}
+        </Stepper>
+      </Flex>
     </ProfileCardHeader>
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOHeader.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOHeader.tsx
@@ -5,26 +5,9 @@ import { Stepper } from './elements/Stepper';
 import { useWizard } from './elements/Wizard';
 
 type ConfigureSSOHeaderProps = {
-  /** Host-built leading content (e.g. a back control); right-aligns the stepper when present. */
   title?: React.ReactNode;
 };
 
-/**
- * The wizard breadcrumb, driven entirely by the generic entry-guard wizard
- * facade.
- *
- * Breadcrumb membership is the labelled steps in declaration order — the
- * provider-selection step carries no `label`, so it never appears (it replaced
- * the old `hidden` provider step). Each item's reachability comes straight from
- * the guard-driven `isReachable` flag (the same predicate `goToStep` checks), so
- * a disabled breadcrumb item and a blocked jump always agree. Completion stays
- * positional. The reset affordance now lives in the step footers
- * (`Step.Footer.Reset`), which delete the connection via the context mutation
- * rather than a wizard binding.
- *
- * `title` is host-owned content rendered as-is in the leading slot; when present
- * the stepper right-aligns, otherwise it stays left-aligned (standalone mount).
- */
 export const ConfigureSSOHeader = ({ title }: ConfigureSSOHeaderProps): JSX.Element => {
   const { activeSteps, currentIndex, goToStep } = useWizard();
   const { t } = useLocalizations();

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOWizard.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOWizard.tsx
@@ -14,10 +14,12 @@ import {
   TestConfigurationStep,
 } from './steps';
 
-export type ConfigureSSOWizardProps = Omit<ComponentProps<typeof ConfigureSSOProvider>, 'children'>;
+export type ConfigureSSOWizardProps = Omit<ComponentProps<typeof ConfigureSSOProvider>, 'children'> & {
+  title?: React.ReactNode;
+  forceInitialStep?: boolean;
+};
 
-/** Pure, data-injected ConfigureSSO flow — hosts own fetching, loading, and permission gating. */
-export const ConfigureSSOWizard = (props: ConfigureSSOWizardProps): JSX.Element => {
+export const ConfigureSSOWizard = ({ title, forceInitialStep, ...props }: ConfigureSSOWizardProps): JSX.Element => {
   const { organizationEnterpriseConnection: c, organizationDomains } = props;
 
   const allDomainsVerified = areAllOrganizationDomainsVerified(organizationDomains);
@@ -33,11 +35,15 @@ export const ConfigureSSOWizard = (props: ConfigureSSOWizardProps): JSX.Element 
     [c, allDomainsVerified],
   );
 
-  // Each step owns a `CardStateProvider` so card errors stay scoped to their step and clear when it unmounts.
+  const initialStepId = forceInitialStep ? steps[0].id : undefined;
+
   return (
     <ConfigureSSOProvider {...props}>
-      <Wizard steps={steps}>
-        <ConfigureSSOHeader />
+      <Wizard
+        steps={steps}
+        initialStepId={initialStepId}
+      >
+        <ConfigureSSOHeader title={title} />
 
         <Wizard.Match id='verify-domain'>
           <CardStateProvider>

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.test.tsx
@@ -71,6 +71,31 @@ describe('ConfigureSSO', () => {
     });
   });
 
+  describe('standalone mount header', () => {
+    it('renders the stepper without a back control (no host title / onExit)', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEnterpriseSso({ selfServeSSO: true });
+        f.withEmailAddress();
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          organization_memberships: [{ name: 'Org1', permissions: ['org:sys_entconns:manage'] }],
+        });
+      });
+
+      fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([]);
+      mockOrganizationDomains(fixtures, [verifiedDomain]);
+
+      const { findByText, queryByRole } = render(<ConfigureSSO />, { wrapper });
+
+      await findByText(/select your identity provider/i);
+
+      // The standalone wizard is mounted without `title`/`onExit`, so the header
+      // exposes no "Security" back control.
+      expect(queryByRole('button', { name: 'Security' })).not.toBeInTheDocument();
+    });
+  });
+
   describe('in a personal workspace', () => {
     it('renders the wizard without checking the manage enterprise connections permission', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {

--- a/packages/ui/src/components/OrganizationProfile/OrganizationSecurityPage.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationSecurityPage.tsx
@@ -1,11 +1,11 @@
 import { useOrganization } from '@clerk/shared/react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import { Header } from '@/ui/elements/Header';
 import { ProfileCard } from '@/ui/elements/ProfileCard';
 
-import React from 'react';
-import { Col, descriptors, localizationKeys } from '../../customizables';
+import { Col, descriptors, Icon, localizationKeys, SimpleButton, Text } from '../../customizables';
+import { ChevronLeft } from '../../icons';
 import { ConfigureSSOProtect } from '../ConfigureSSO/ConfigureSSO';
 import { ConfigureSSOSkeleton } from '../ConfigureSSO/ConfigureSSOSkeleton';
 import { ConfigureSSOWizard } from '../ConfigureSSO/ConfigureSSOWizard';
@@ -27,7 +27,6 @@ export const OrganizationSecurityPage = ({ contentRef }: OrganizationSecurityPag
   return <OrganizationSecurityPageContent contentRef={contentRef} />;
 };
 
-/** Separate from the page so the connection hook only runs behind the organization check. */
 const OrganizationSecurityPageContent = ({ contentRef }: OrganizationSecurityPageProps) => {
   const {
     organization,
@@ -41,11 +40,39 @@ const OrganizationSecurityPageContent = ({ contentRef }: OrganizationSecurityPag
   } = useOrganizationEnterpriseConnection();
 
   const [view, setView] = useState<'overview' | 'wizard'>('overview');
+  const [forceFirstStep, setForceFirstStep] = useState(false);
 
-  // Gate loading above the provider so the context never observes a loading state.
+  const exitWizard = () => setView('overview');
+
+  const openWizard = (forceInitialStep = false) => {
+    setForceFirstStep(forceInitialStep);
+    setView('wizard');
+  };
+
   if (isLoading) {
     return <ConfigureSSOSkeleton />;
   }
+
+  const backControl = (
+    <SimpleButton
+      elementDescriptor={descriptors.configureSSOHeaderBackButton}
+      variant='unstyled'
+      onClick={exitWizard}
+      sx={t => ({
+        gap: t.space.$1,
+        padding: 0,
+        color: t.colors.$colorMutedForeground,
+        '&:hover': { color: t.colors.$colorForeground },
+      })}
+    >
+      <Icon icon={ChevronLeft} />
+      <Text
+        as='span'
+        variant='body'
+        localizationKey={localizationKeys('organizationProfile.navbar.security')}
+      />
+    </SimpleButton>
+  );
 
   return (
     <ConfigureSSOProtect>
@@ -73,7 +100,7 @@ const OrganizationSecurityPageContent = ({ contentRef }: OrganizationSecurityPag
                 deleteConnection={enterpriseConnectionMutations.deleteConnection}
                 organizationName={organization?.name ?? ''}
                 contentRef={contentRef}
-                onConfigure={() => setView('wizard')}
+                onConfigure={openWizard}
               />
             </Col>
           </Col>
@@ -87,6 +114,9 @@ const OrganizationSecurityPageContent = ({ contentRef }: OrganizationSecurityPag
           enterpriseConnectionMutations={enterpriseConnectionMutations}
           organizationDomainMutations={organizationDomainMutations}
           organizationDomains={organizationDomains}
+          forceInitialStep={forceFirstStep}
+          title={backControl}
+          onExit={exitWizard}
         />
       )}
     </ConfigureSSOProtect>

--- a/packages/ui/src/components/OrganizationProfile/SecuritySsoSection.tsx
+++ b/packages/ui/src/components/OrganizationProfile/SecuritySsoSection.tsx
@@ -28,7 +28,7 @@ type SecuritySsoSectionProps = {
   deleteConnection: EnterpriseConnectionMutations['deleteConnection'];
   organizationName: string;
   contentRef: React.RefObject<HTMLDivElement>;
-  onConfigure: () => void;
+  onConfigure: (forceInitialStep?: boolean) => void;
 };
 
 const STATUS_BADGES: Record<
@@ -95,7 +95,7 @@ export const SecuritySsoSection = (props: SecuritySsoSectionProps): JSX.Element 
             'organizationProfile.securityPage.ssoSection.primaryButton__startConfiguration',
           )}
           primaryButtonId='start'
-          onConfigure={onConfigure}
+          onConfigure={() => onConfigure(true)}
         />
       )}
 
@@ -105,7 +105,7 @@ export const SecuritySsoSection = (props: SecuritySsoSectionProps): JSX.Element 
             'organizationProfile.securityPage.ssoSection.primaryButton__continueConfiguration',
           )}
           primaryButtonId='continue'
-          onConfigure={onConfigure}
+          onConfigure={() => onConfigure()}
         />
       )}
 
@@ -205,7 +205,7 @@ const ConfiguredContent = (props: ConfiguredContentProps): JSX.Element => {
           actions={[
             {
               label: localizationKeys('organizationProfile.securityPage.ssoSection.menuAction__edit'),
-              onClick: onConfigure,
+              onClick: () => onConfigure(true),
             },
             isActive
               ? {

--- a/packages/ui/src/components/OrganizationProfile/__tests__/OrganizationSecurityPage.test.tsx
+++ b/packages/ui/src/components/OrganizationProfile/__tests__/OrganizationSecurityPage.test.tsx
@@ -195,7 +195,7 @@ describe('OrganizationSecurityPage', () => {
   });
 
   describe('view switching', () => {
-    it('switches to the wizard when Start configuration is clicked', async () => {
+    it('opens the wizard at the first step when Start configuration is clicked', async () => {
       const { wrapper, fixtures } = await createFixtures(withSecurityPageFixtures);
 
       fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([]);
@@ -205,11 +205,39 @@ describe('OrganizationSecurityPage', () => {
 
       await userEvent.click(await screen.findByRole('button', { name: 'Start configuration' }));
 
-      expect(await screen.findByText(/select your identity provider/i)).toBeInTheDocument();
+      // Start forces the first step. The fixture domain is already verified, so
+      // without the forced entry the wizard would skip to select-provider —
+      // proving Start threads `forceInitialStep`.
+      expect(await screen.findByRole('heading', { name: /add SSO domains/i })).toBeInTheDocument();
+      expect(screen.queryByText(/select your identity provider/i)).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Start configuration' })).not.toBeInTheDocument();
     });
 
-    it('switches to the wizard when Edit is selected from the actions menu', async () => {
+    it('resumes the wizard at the reachable step when Continue configuration is clicked', async () => {
+      const { wrapper, fixtures } = await createFixtures(withSecurityPageFixtures);
+
+      // A connection without SAML configuration is mid-setup (in_progress).
+      fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([
+        configuredConnection({ samlConnection: null }),
+      ]);
+      fixtures.clerk.organization?.getEnterpriseConnectionTestRuns.mockResolvedValue({
+        data: [],
+        total_count: 0,
+      } as any);
+      fixtures.clerk.organization?.getDomains.mockResolvedValue({ data: [verifiedDomain], total_count: 1 } as any);
+
+      const { userEvent } = renderPage(wrapper);
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Continue configuration' }));
+
+      // Continue passes no forced step, so the wizard resumes at the furthest-
+      // reachable step for this connection (configure, since a provider connection
+      // exists and the domain is verified) rather than the forced first step.
+      expect(await screen.findByRole('heading', { name: /configure okta workforce/i })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: /add SSO domains/i })).not.toBeInTheDocument();
+    });
+
+    it('opens the wizard at the first step when Edit is selected from the actions menu', async () => {
       const { wrapper, fixtures } = await createFixtures(withSecurityPageFixtures);
 
       fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([configuredConnection({ active: true })]);
@@ -224,9 +252,33 @@ describe('OrganizationSecurityPage', () => {
       await userEvent.click(await screen.findByRole('button', { name: /open menu/i }));
       await userEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
 
-      // An active connection short-circuits the wizard to the confirmation step.
-      expect(await screen.findByText(/configuration details/i)).toBeInTheDocument();
+      // Edit forces the first step rather than the connection's furthest-reachable
+      // step (confirmation, for an active connection).
+      expect(await screen.findByRole('heading', { name: /add SSO domains/i })).toBeInTheDocument();
+      expect(screen.queryByText(/configuration details/i)).not.toBeInTheDocument();
       expect(screen.queryByText(DESCRIPTION_LINE_1)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('wizard back control', () => {
+    it('renders a Security back control in the wizard that returns to the overview', async () => {
+      const { wrapper, fixtures } = await createFixtures(withSecurityPageFixtures);
+
+      fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([]);
+      fixtures.clerk.organization?.getDomains.mockResolvedValue({ data: [verifiedDomain], total_count: 1 } as any);
+
+      const { userEvent } = renderPage(wrapper);
+
+      // Enter the wizard from the overview.
+      await userEvent.click(await screen.findByRole('button', { name: 'Start configuration' }));
+      const backControl = await screen.findByRole('button', { name: 'Security' });
+      expect(backControl).toBeInTheDocument();
+
+      // The back control exits to the overview (the Start action returns).
+      await userEvent.click(backControl);
+
+      expect(await screen.findByRole('button', { name: 'Start configuration' })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: /add SSO domains/i })).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/customizables/elementDescriptors.ts
+++ b/packages/ui/src/customizables/elementDescriptors.ts
@@ -548,6 +548,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'enterpriseConnectionButtonText',
 
   'configureSSOHeader',
+  'configureSSOHeaderBackButton',
   'configureSSOMobileNavbar',
   'configureSSOStepper',
   'configureSSOStepperItem',

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -684,6 +684,7 @@ export type ElementsConfig = {
   enterpriseConnectionButtonText: WithOptions;
 
   configureSSOHeader: WithOptions;
+  configureSSOHeaderBackButton: WithOptions;
   configureSSOMobileNavbar: WithOptions;
   configureSSOStepper: WithOptions;
   configureSSOStepperItem: WithOptions<string, ActiveState>;


### PR DESCRIPTION
Wires the `<OrganizationProfile />` Security page to the ConfigureSSO wizard:

- **Back to Security** — the wizard header now has a back control (chevron + "Security") that returns to the Security overview from anywhere in the flow. The stepper right-aligns when the control is present.
- **Start / Edit open at the first step** — re-entering the wizard via "Start configuration" or the "Edit" menu opens it at Verify domain instead of resuming mid-flow, so the connection is never configured against an assumed domain. "Continue configuration" still resumes where you left off.
- The exit behavior is exposed on the ConfigureSSO context (`onExit`), so the back control — and future in-flow exits like a skip action — share one host-provided callback instead of prop-drilling through the wizard.

The wizard stays host-agnostic: the label and the exit behavior are supplied by the host (the Security page), so the standalone mount renders just the stepper with no back control, and the generic wizard primitive is unchanged.

ORGS-1607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSO configuration wizard now includes a back button to return to the Security page.
  * Improved SSO setup flow: Start and Edit actions open the wizard at the initial step, while Continue resumes from the user's last position.
  * Added customization support for the SSO wizard back button appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->