### PR TITLE
fix(expo): Preserve platform-specific imports in tsdown builds

### DIFF
--- a/.changeset/expo-platform-imports.md
+++ b/.changeset/expo-platform-imports.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Fix platform-specific module resolution for Expo builds so native and web implementations are selected correctly.

--- a/packages/expo/scripts/__tests__/preservePlatformSpecifiers.test.ts
+++ b/packages/expo/scripts/__tests__/preservePlatformSpecifiers.test.ts
@@ -87,4 +87,24 @@ describe('preservePlatformSpecifiers', () => {
 
     expect(result).toBeNull();
   });
+
+  test('does not preserve explicitly extensioned specifiers', async () => {
+    const importer = createFile('src/index.ts');
+    createFile('src/foo.ts');
+    createFile('src/foo.ios.ts');
+    const plugin = preservePlatformSpecifiers();
+
+    const result = await (plugin.resolveId as Function).call(
+      {
+        resolve: async () => {
+          throw new Error('explicitly extensioned specifiers should not be resolved');
+        },
+      },
+      './foo.ts',
+      importer,
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
 });

--- a/packages/expo/scripts/__tests__/preservePlatformSpecifiers.test.ts
+++ b/packages/expo/scripts/__tests__/preservePlatformSpecifiers.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { preservePlatformSpecifiers } from '../preservePlatformSpecifiers.mts';
+
+describe('preservePlatformSpecifiers', () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  function createFile(relativePath: string) {
+    if (!tmpDir) {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clerk-expo-platform-specifiers-'));
+    }
+
+    const filePath = path.join(tmpDir, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '');
+
+    return filePath;
+  }
+
+  test('preserves extensionless relative specifiers when the resolved file has platform siblings', async () => {
+    const importer = createFile('src/index.ts');
+    const resolvedId = createFile('src/foo.ts');
+    createFile('src/foo.ios.ts');
+    const plugin = preservePlatformSpecifiers();
+
+    const result = await (plugin.resolveId as Function).call(
+      {
+        resolve: async (source: string, importerId: string, options: { skipSelf?: boolean }) => {
+          expect(source).toBe('./foo');
+          expect(importerId).toBe(importer);
+          expect(options.skipSelf).toBe(true);
+
+          return { id: resolvedId };
+        },
+      },
+      './foo',
+      importer,
+      {},
+    );
+
+    expect(result).toEqual({ id: './foo', external: true });
+  });
+
+  test('does not preserve relative specifiers without platform siblings', async () => {
+    const importer = createFile('src/index.ts');
+    const resolvedId = createFile('src/foo.ts');
+    const plugin = preservePlatformSpecifiers();
+
+    const result = await (plugin.resolveId as Function).call(
+      {
+        resolve: async () => ({ id: resolvedId }),
+      },
+      './foo',
+      importer,
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test('does not preserve explicitly platform-suffixed specifiers', async () => {
+    const importer = createFile('src/index.ts');
+    createFile('src/foo.ios.ts');
+    const plugin = preservePlatformSpecifiers();
+
+    const result = await (plugin.resolveId as Function).call(
+      {
+        resolve: async () => {
+          throw new Error('explicit platform specifiers should not be resolved');
+        },
+      },
+      './foo.ios',
+      importer,
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/expo/scripts/preservePlatformSpecifiers.mts
+++ b/packages/expo/scripts/preservePlatformSpecifiers.mts
@@ -9,6 +9,10 @@ function hasPlatformSuffix(specifier: string) {
   return platformSuffixes.some(suffix => specifier.endsWith(suffix));
 }
 
+function hasSourceExtension(specifier: string) {
+  return sourceExtensions.some(extension => specifier.endsWith(extension));
+}
+
 function hasPlatformSibling(id: string) {
   const extension = sourceExtensions.find(ext => id.endsWith(ext));
 
@@ -42,7 +46,7 @@ export function preservePlatformSpecifiers(): Plugin {
   return {
     name: 'preserve-platform-specifiers',
     async resolveId(source, importer, options) {
-      if (!importer || !source.startsWith('.') || hasPlatformSuffix(source)) {
+      if (!importer || !source.startsWith('.') || hasSourceExtension(source) || hasPlatformSuffix(source)) {
         return null;
       }
 

--- a/packages/expo/scripts/preservePlatformSpecifiers.mts
+++ b/packages/expo/scripts/preservePlatformSpecifiers.mts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+
+import type { Plugin } from 'rolldown';
+
+const platformSuffixes = ['.ios', '.android', '.web', '.native'] as const;
+const sourceExtensions = ['.ts', '.tsx', '.js', '.jsx'] as const;
+
+function hasPlatformSuffix(specifier: string) {
+  return platformSuffixes.some(suffix => specifier.endsWith(suffix));
+}
+
+function hasPlatformSibling(id: string) {
+  const extension = sourceExtensions.find(ext => id.endsWith(ext));
+
+  if (!extension) {
+    return false;
+  }
+
+  const basename = id.slice(0, -extension.length);
+  const platformlessBasename = platformSuffixes.reduce(
+    (current, suffix) => (current.endsWith(suffix) ? current.slice(0, -suffix.length) : current),
+    basename,
+  );
+
+  return platformSuffixes.some(suffix => fs.existsSync(`${platformlessBasename}${suffix}${extension}`));
+}
+
+/**
+ * Preserves Metro platform resolution for Expo's bundleless tsdown build.
+ *
+ * Rolldown's `preserveModules` output rewrites internal chunk imports to emitted
+ * filenames, for example `../hooks/useSignInWithApple.js`. That bypasses Metro's
+ * platform resolver, which needs the extensionless specifier so it can pick
+ * `useSignInWithApple.ios.js`, `NativeClerkModule.web.js`, and similar files.
+ *
+ * This plugin only externalizes relative imports whose resolved source file has
+ * a platform-specific sibling. Returning the original relative `source` as an
+ * external id makes Rolldown render that specifier unchanged while all normal
+ * internal imports continue to point at emitted `.js` chunks.
+ */
+export function preservePlatformSpecifiers(): Plugin {
+  return {
+    name: 'preserve-platform-specifiers',
+    async resolveId(source, importer, options) {
+      if (!importer || !source.startsWith('.') || hasPlatformSuffix(source)) {
+        return null;
+      }
+
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+
+      if (!resolved || resolved.external || !hasPlatformSibling(resolved.id)) {
+        return null;
+      }
+
+      return { id: source, external: true };
+    },
+  };
+}

--- a/packages/expo/tsdown.config.mts
+++ b/packages/expo/tsdown.config.mts
@@ -4,6 +4,7 @@ import { defineConfig } from 'tsdown';
 import { runAfterLast } from '../../scripts/utils.ts';
 import clerkJsPkgJson from '../clerk-js/package.json' with { type: 'json' };
 import pkgJson from './package.json' with { type: 'json' };
+import { preservePlatformSpecifiers } from './scripts/preservePlatformSpecifiers.mts';
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
@@ -14,7 +15,7 @@ export default defineConfig(overrideOptions => {
     fixedExtension: false,
     outDir: './dist',
     entry: ['./src/**/*.{ts,tsx,js,jsx}', '!./src/**/*.test.{ts,tsx}', '!./src/**/__tests__/**'],
-    bundle: false,
+    unbundle: true,
     clean: true,
     minify: false,
     sourcemap: true,
@@ -24,6 +25,7 @@ export default defineConfig(overrideOptions => {
       JS_PACKAGE_VERSION: `"${clerkJsPkgJson.version}"`,
       __DEV__: `${isWatch}`,
     },
+    plugins: [preservePlatformSpecifiers()],
   };
 
   return runAfterLast(['pnpm build:declarations', shouldPublish && 'pkglab pub --ping'])(options);


### PR DESCRIPTION
## Description

Fixes Expo platform-specific module resolution regression introduced by the tsup to tsdown migration ([ref](https://github.com/clerk/javascript/pull/8177)).

With tsup, bundleless CJS output preserved extensionless internal imports ([ref](https://npmx.dev/package-code/@clerk/expo/v/3.4.1/dist%2Fapple%2Findex.js)):

```js
require("../hooks/useSignInWithApple")
```

After the tsdown migration, Rolldown's preserveModules output rewrites those imports to emitted filenames ([ref](https://npmx.dev/package-code/@clerk/expo/v/3.4.2/dist%2Fapple%2Findex.js)):

```js
require("../hooks/useSignInWithApple.js")
```

That bypasses Metro's platform-specific resolution ([ref](https://reactnative.dev/docs/platform-specific-code#platform-specific-extensions)), which needs the extensionless specifier so it can select files like `useSignInWithApple.ios.js`, `NativeClerkModule.web.js`, etc.

This PR keeps the tsdown build and adds an Expo-local Rolldown plugin that preserves only the relative imports whose resolved source has platform-specific siblings. Normal internal imports still point at emitted `.js` chunks.

The alternative would be reverting `@clerk/expo` to tsup

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed platform-specific module resolution during Expo builds to ensure correct native vs web implementations are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->