### PR TITLE
fix(backend): Enforce azp when configured

### DIFF
--- a/.changeset/warm-spies-double.md
+++ b/.changeset/warm-spies-double.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Enforce the `azp` (authorized party) claim when `authorizedParties` is configured. Previously, a session token that was missing the `azp` claim was accepted even when `authorizedParties` was set, allowing the authorized-parties check to be bypassed by omitting the claim. Now, when `authorizedParties` is configured, a token with a missing or empty `azp` claim is rejected. Tokens without `azp` continue to be accepted when no `authorizedParties` are configured.

--- a/packages/backend/src/jwt/__tests__/assertions.test.ts
+++ b/packages/backend/src/jwt/__tests__/assertions.test.ts
@@ -204,10 +204,21 @@ describe('assertSubClaim(sub?)', () => {
 });
 
 describe('assertAuthorizedPartiesClaim(azp?, authorizedParties?)', () => {
-  it('does not throw if azp missing or empty', () => {
+  it('does not throw if azp missing or empty and no authorizedParties are configured', () => {
     expect(() => assertAuthorizedPartiesClaim()).not.toThrow();
     expect(() => assertAuthorizedPartiesClaim('')).not.toThrow();
     expect(() => assertAuthorizedPartiesClaim(undefined)).not.toThrow();
+    expect(() => assertAuthorizedPartiesClaim('', [])).not.toThrow();
+    expect(() => assertAuthorizedPartiesClaim(undefined, [])).not.toThrow();
+  });
+
+  it('throws error if azp is missing or empty but authorizedParties are configured', () => {
+    expect(() => assertAuthorizedPartiesClaim('', ['azp-1'])).toThrow(
+      `Invalid JWT Authorized party claim (azp) "". Expected "azp-1".`,
+    );
+    expect(() => assertAuthorizedPartiesClaim(undefined, ['azp-1'])).toThrow(
+      `Invalid JWT Authorized party claim (azp) undefined. Expected "azp-1".`,
+    );
   });
 
   it('does not throw if authorizedParties missing or empty', () => {

--- a/packages/backend/src/jwt/assertions.ts
+++ b/packages/backend/src/jwt/assertions.ts
@@ -84,11 +84,17 @@ export const assertSubClaim = (sub?: string) => {
 };
 
 export const assertAuthorizedPartiesClaim = (azp?: string, authorizedParties?: string[]) => {
-  if (!azp || !authorizedParties || authorizedParties.length === 0) {
+  // When no authorized parties are configured there is nothing to enforce, so
+  // an azp-less token is accepted (a warning is surfaced elsewhere).
+  if (!authorizedParties || authorizedParties.length === 0) {
     return;
   }
 
-  if (!authorizedParties.includes(azp)) {
+  // Once authorized parties are configured the azp claim must be present and
+  // match one of them. Returning early on a missing/empty azp would let any
+  // token bypass the authorized-parties check simply by omitting the claim,
+  // defeating the purpose of configuring them.
+  if (!azp || !authorizedParties.includes(azp)) {
     throw new TokenVerificationError({
       reason: TokenVerificationErrorReason.TokenInvalidAuthorizedParties,
       message: `Invalid JWT Authorized party claim (azp) ${JSON.stringify(azp)}. Expected "${authorizedParties}".`,


### PR DESCRIPTION
## Description

Enforce the `azp` (authorized party) claim when `authorizedParties` is configured. Previously, a session token that was missing the `azp` claim was accepted even when `authorizedParties` was set, allowing the authorized-parties check to be bypassed by omitting the claim. Now, when `authorizedParties` is configured, a token with a missing or empty `azp` claim is rejected. Tokens without `azp` continue to be accepted when no `authorizedParties` are configured.

Related to SEC-313

To be a problem this needs a system emitting `azp`-less tokens in an environment where an app expects `azp` to be set. Attackers can't just drop the `azp` claim as this would make the signature invalid.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session token validation security: when authorized parties are configured, session tokens missing the authorized party claim (or with an empty value) are now rejected, preventing an authorization bypass.  
  * Tokens without this claim continue to be accepted when authorized parties are not configured.  
  * Updated validation coverage to reflect the new behavior across configured vs. unconfigured cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->