### PR TITLE
feat(backend): Add preferredSignInStrategyWhenPasswordRequired

### DIFF
--- a/.changeset/instance-preferred-sign-in-strategy.md
+++ b/.changeset/instance-preferred-sign-in-strategy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add support for the `preferredSignInStrategyWhenPasswordRequired` parameter to `clerkClient.instance.update()`. Accepts `'password'` or `'otp'` to override the preferred sign-in strategy when a password is required, or an empty string to clear the override.

--- a/packages/backend/src/api/endpoints/InstanceApi.ts
+++ b/packages/backend/src/api/endpoints/InstanceApi.ts
@@ -36,6 +36,12 @@ type UpdateParams = {
    * Whether the instance should use URL-based session syncing in development mode (i.e. without third-party cookies).
    */
   urlBasedSessionSyncing?: boolean | null | undefined;
+  /**
+   * Overrides the sign-in strategy that is preferred when a password is required.
+   *
+   * @remarks Accepts `'password'` or `'otp'`. Pass an empty string to clear the override. The value is only consulted when a password is required, and is dormant otherwise.
+   */
+  preferredSignInStrategyWhenPasswordRequired?: 'password' | 'otp' | '' | null | undefined;
 };
 
 type UpdateRestrictionsParams = {

--- a/packages/backend/src/api/endpoints/InstanceApi.ts
+++ b/packages/backend/src/api/endpoints/InstanceApi.ts
@@ -39,7 +39,7 @@ type UpdateParams = {
   /**
    * Overrides the sign-in strategy that is preferred when a password is required.
    *
-   * @remarks Accepts `'password'` or `'otp'`. Pass an empty string to clear the override. The value is only consulted when a password is required, and is dormant otherwise.
+   * @remarks Accepts `'password'` or `'otp'`. Pass an empty string to clear the override. Passing `null` or `undefined` leaves the current value unchanged. The value is only consulted when a password is required, and is dormant otherwise.
    */
   preferredSignInStrategyWhenPasswordRequired?: 'password' | 'otp' | '' | null | undefined;
 };


### PR DESCRIPTION
## Description

Adds the preferredSignInStrategyWhenPasswordRequired param to the instance.update() params, mirroring the BAPI option preferred_sign_in_strategy_when_password_required. Accepts 'password' or 'otp', or an empty string to clear the override.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to choose the preferred sign-in strategy when password authentication is required, allowing you to set it to **password** or **OTP**.
  * You can also clear the override to return to the default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->