### PR TITLE
feat(ui,shared,localizations): Allow changing provider in self-serve SSO

### DIFF
--- a/.changeset/nine-lies-eat.md
+++ b/.changeset/nine-lies-eat.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Allow changing enterprise connection provider between self-serve SSO steps

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -231,6 +231,7 @@ export const enUS: LocalizationResource = {
       activeConnectionWarning: {
         title:
           'This connection is active. Saving changes applies immediately and may disrupt sign-in for current members.',
+        dismiss: 'Dismiss',
       },
       attributeMappingTable: {
         badges: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -221,6 +221,12 @@ export const enUS: LocalizationResource = {
         'Your SSO connection is ready. Once activated, anyone signing in with {{domain}} must use your identity provider.',
       title: 'SSO connection configured',
     },
+    changeProviderDialog: {
+      cancelButton: 'Cancel',
+      confirmButton: 'Change provider',
+      subtitle: 'Switching to {{provider}} will remove your {{currentProvider}} connection and require a new setup.',
+      title: 'Change provider to {{provider}}',
+    },
     configureStep: {
       attributeMappingTable: {
         badges: {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -424,6 +424,8 @@ export const enUS: LocalizationResource = {
               claimName: 'Claim name',
               value: 'Value',
             },
+            copyClaimName: 'Copy claim name',
+            copyClaimNameCopied: 'Copied',
             rows: {
               email: {
                 attribute: 'Email address',
@@ -485,7 +487,7 @@ export const enUS: LocalizationResource = {
               placeholder: 'Paste URL here...',
             },
             signOnUrl: {
-              label: 'Single Sign-On URL',
+              label: 'Sign on URL',
               placeholder: 'Paste URL here...',
             },
             signingCertificate: {
@@ -498,7 +500,7 @@ export const enUS: LocalizationResource = {
           },
           metadataUrl: {
             description:
-              'On the <bold>SAML-based Sign-on</bold> page, find the <bold>SAML Certificates</bold> section. Add the <bold>App Federation Metadata Url</bold> below.',
+              'On the <bold>SAML-based Sign-on</bold> page, find the <bold>SAML Certificates</bold> section and copy the <bold>App Federation Metadata Url</bold>. Paste below.',
             label: 'Metadata URL',
             placeholder: 'Paste URL here...',
           },
@@ -506,7 +508,6 @@ export const enUS: LocalizationResource = {
             ariaLabel: 'Configuration ',
             manual: 'Configure manually',
             metadataUrl: 'Add via metadata',
-            title: 'Fill in your Microsoft Entra application details',
           },
         },
         mainHeaderTitle: 'Configure Microsoft Entra',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -362,7 +362,7 @@ export const enUS: LocalizationResource = {
           headerSubtitle: 'Create a new SAML application in Google Workspace',
         },
         identityProviderMetadataStep: {
-          headerSubtitle: 'Configure identity provider metadata',
+          headerSubtitle: 'Add your Google Workspace application metadata',
           manual: {
             description: 'In your Google Workspace app, retrieve these values.',
             issuer: {
@@ -478,7 +478,7 @@ export const enUS: LocalizationResource = {
           headerSubtitle: 'Create a new enterprise application in your Azure Portal',
         },
         identityProviderMetadataStep: {
-          headerSubtitle: 'Configure identity provider metadata',
+          headerSubtitle: 'Add your Microsoft Entra application metadata',
           manual: {
             description:
               'On the <bold>SAML-based Sign-on</bold> page, find the <bold>SAML Certificates</bold> section. Retrieve these values and add them below.',
@@ -697,12 +697,12 @@ export const enUS: LocalizationResource = {
     },
     testConfigurationStep: {
       error__noSuccessfulTestRun:
-        'You need at least one successful test run before you can continue. Generate a test SSO URL and complete the sign-in flow.',
-      subtitle: 'Authenticate using the test SSO URL to verify you configured the connection correctly.',
+        'You need at least one successful test run before you can continue. Generate a test URL and complete the sign-in flow.',
+      subtitle: 'Sign in through the test URL to verify your SSO connection is configured correctly',
       testResults: {
         actionLabel__refresh: 'Refresh logs',
         empty: {
-          subtitle: 'Use the button above to start running tests',
+          subtitle: 'Select <bold>Open test URL</bold> to run your first test',
           title: 'No test results',
         },
         polling: 'Waiting for the test run to complete…',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -236,42 +236,39 @@ export const enUS: LocalizationResource = {
       },
       samlCustom: {
         assignUsersStep: {
-          headerSubtitle: 'Assign users to the enterprise application',
-          paragraph:
-            'You need to assign users or groups to your enterprise application before they can use it to sign in.',
-          title: 'Assign selected user or group',
+          headerSubtitle: 'Assign users or groups to your SAML application',
+          paragraph: 'Assign users or groups to your app before they can sign in with SSO.',
         },
         attributeMappingStep: {
           attributeMappingTable: {
             columns: {
               attributeName: 'Attribute Name',
-              userProfile: 'Identity Provider User Profile',
+              userAttribute: 'User Attribute',
             },
             rows: {
               email: {
-                attributeName: 'email',
-                userProfile: 'Primary email',
+                attributeName: 'Primary email',
+                userAttribute: 'mail',
               },
               firstName: {
-                attributeName: 'firstName',
-                userProfile: 'First name',
+                attributeName: 'First name',
+                userAttribute: 'firstName',
               },
               lastName: {
-                attributeName: 'lastName',
-                userProfile: 'Last name',
+                attributeName: 'Last name',
+                userAttribute: 'lastName',
               },
             },
           },
           headerSubtitle: 'Map user attributes from your identity provider to your application.',
-          paragraph: 'We expect your SAML response to return the user’s email, first name and last name.',
+          paragraph: 'Your SAML response must include the following attributes:',
         },
         createAppStep: {
           createAppInstructions: {
             paragraph:
-              'In your identity provider’s admin dashboard, create a new SAML 2.0 application and use the following service provider details:',
-            title: 'Create a SAML application on your identity provider',
+              'In your identity provider’s dashboard, create a new SAML 2.0 application and use the following service provider details:',
           },
-          headerSubtitle: 'Create a new enterprise application in your identity provider’s admin dashboard',
+          headerSubtitle: 'Create a new SAML application in your identity provider’s dashboard',
           serviceProviderFields: {
             acsUrl: {
               label: 'Assertion consumer service (ACS) URL',
@@ -284,25 +281,25 @@ export const enUS: LocalizationResource = {
         identityProviderMetadataStep: {
           headerSubtitle: 'Configure identity provider metadata',
           manual: {
-            description: 'In your SAML application, retrieve these values.',
+            description: 'In your identity provider SAML application, retrieve these values.',
             issuer: {
               label: 'Issuer',
               placeholder: 'Paste URL here...',
             },
             signOnUrl: {
-              label: 'Single Sign-On URL',
+              label: 'Sign on URL',
               placeholder: 'Paste URL here...',
             },
             signingCertificate: {
               fileUploaded: 'File uploaded',
-              label: 'X.509 certificate',
+              label: 'Signing certificate',
               removeFile: 'Remove file',
               replaceFile: 'Replace file',
               uploadFile: 'Upload file',
             },
           },
           metadataUrl: {
-            description: 'In your enterprise application, retrieve the metadata URL. Paste it below.',
+            description: 'In your identity provider SAML application, retrieve the metadata URL. Paste it below.',
             label: 'Metadata URL',
             placeholder: 'Paste URL here...',
           },
@@ -310,10 +307,9 @@ export const enUS: LocalizationResource = {
             ariaLabel: 'Configuration ',
             manual: 'Configure manually',
             metadataUrl: 'Add via metadata',
-            title: 'Fill in your SAML application details',
           },
         },
-        mainHeaderTitle: 'Configure your identity provider (IdP)',
+        mainHeaderTitle: 'Configure your identity provider',
       },
       samlGoogle: {
         attributeMappingStep: {
@@ -357,19 +353,18 @@ export const enUS: LocalizationResource = {
         },
         createAppStep: {
           createAppInstructions: {
-            step1: 'Sign in to Google Admin Portal.',
-            step2: 'In the side navigation, under <bold>Apps</bold>, select <bold>Web and mobile apps.</bold>',
-            step3: 'Click on the <bold>Add</bold> app button, and select <bold>Add custom SAML app.</bold>',
-            step4: 'In the <bold>App details</bold> section, fill out the required <bold>App name</bold>.',
-            step5: 'Select the <bold>Continue</bold> button.',
-            title: 'Create a new enterprise application in Google Workspace',
+            step1: 'In the side navigation, under <bold>Apps</bold>, select <bold>Web and mobile apps.</bold>',
+            step2: 'In Select <bold>Add app</bold>, then <bold>Add custom SAML app.</bold>',
+            step3: 'Enter an <bold>App name.</bold>',
+            step4: 'Select <bold>Continue</bold>.',
+            title: 'In Google Workspace, create a new SAML application:',
           },
-          headerSubtitle: 'Create a new enterprise application in your Google Workspace',
+          headerSubtitle: 'Create a new SAML application in Google Workspace',
         },
         identityProviderMetadataStep: {
           headerSubtitle: 'Configure identity provider metadata',
           manual: {
-            description: 'In your Google Workspace application, retrieve these values.',
+            description: 'In your Google Workspace app, retrieve these values.',
             issuer: {
               label: 'Entity ID',
               placeholder: 'Paste URL here...',
@@ -387,7 +382,7 @@ export const enUS: LocalizationResource = {
             },
           },
           metadataFile: {
-            description: 'In your Google Workspace application, download the IdP metadata and upload it below.',
+            description: 'In your Google Workspace app, download the IdP metadata and upload it below.',
             fileUploaded: 'File uploaded',
             label: 'IdP metadata',
             removeFile: 'Remove file',
@@ -395,10 +390,9 @@ export const enUS: LocalizationResource = {
             uploadFile: 'Upload file',
           },
           modes: {
-            ariaLabel: 'Configuration ',
+            ariaLabel: 'Configuration',
             manual: 'Configure manually',
             metadataFile: 'Add via metadata',
-            title: 'Fill in your Google Workspace application details',
           },
         },
         mainHeaderTitle: 'Configure Google Workspace',
@@ -448,25 +442,19 @@ export const enUS: LocalizationResource = {
               },
             },
           },
-          headerSubtitle: 'Map user attributes from Microsoft Entra to your application',
-          paragraph:
-            "These are the defaults and probably won't need you to change them. However, many SAML configuration errors are due to incorrect attribute mappings, so it's worth double-checking. Here's how:",
+          headerSubtitle: 'Set the attributes Microsoft Entra includes in your SAML response',
           step1: 'On the <bold>SAML-based Sign-on</bold> page, find the <bold>Attributes & Claims</bold> section.',
-          step2: 'Select <bold>Edit</bold>',
-          step3: 'Verify that the above three attributes and values are present.',
-          title: 'We expect your SAML responses to have the following specific attributes:',
+          step2: 'Select <bold>Edit.</bold>',
+          title: 'Your SAML response must include the following attributes:',
         },
         createAppStep: {
           assignUsersInstructions: {
-            paragraph1: 'You need to assign users or groups before they can use it to log in.',
             step1: 'In the <bold>Getting Started</bold> section, select the <bold>Assign users and groups.</bold>',
             step2: "Select <bold>Add user/group.</bold> You'll be redirected to the <bold>Add Assignment page.</bold>",
             step3: 'Select the <bold>None Selected link.</bold>',
             step4:
-              'To assign a user to the enterprise app, you can either use the search field to find a user or select the checkbox next to the user in the table.',
-            step5:
               "Select <bold>Select</bold> at the bottom of the page. You'll be redirected to the <bold>Add Assignment</bold> page.",
-            step6: 'Select <bold>Assign</bold> at the bottom of the page.',
+            step5: 'Select <bold>Assign</bold>',
             title: 'Assign your users or groups in Microsoft',
           },
           createAppInstructions: {
@@ -483,9 +471,9 @@ export const enUS: LocalizationResource = {
                   "Select <bold>Integrate any other application you don't find in the gallery (Non-gallery)</bold>.",
               },
             },
-            title: 'Create a new enterprise application in Microsoft Entra',
+            title: 'Create a new enterprise application',
           },
-          headerSubtitle: 'Create a new enterprise application in your Azure portal',
+          headerSubtitle: 'Create a new enterprise application in your Azure Portal',
         },
         identityProviderMetadataStep: {
           headerSubtitle: 'Configure identity provider metadata',
@@ -533,30 +521,27 @@ export const enUS: LocalizationResource = {
             },
           },
           step1: 'In the side navigation, open the <bold>Manage</bold> dropdown and select Single sign-on.',
-          step2:
-            "In the <bold>Select a single sign-on</bold> method section, select <bold>SAML</bold>. You'll be redirected to the <bold>Set up Single Sign-On with SAML</bold> page.",
+          step2: 'In the <bold>Select a single sign-on method</bold> section, select <bold>SAML</bold>.',
           step3: 'Find the <bold>Basic SAML Configuration</bold> section.',
           step4: 'Select <bold>Edit</bold>. The <bold>Basic SAML Configuration</bold> panel will open.',
           step5:
-            'Add the following <bold>Identifier (Entity ID)</bold> and <bold>Reply URL (Assertion Consumer Service URL)</bold> values. These values will be saved automatically.',
+            'Copy the following values into <bold>Identifier (Entity ID)</bold> and <bold>Reply URL (ACS URL)</bold>:',
           step6: 'Select <bold>Save</bold> at the top of the panel. Close the panel.',
-          title: 'Configure service provider',
+          title: 'Add service provider details',
         },
       },
       samlOkta: {
         assignUsersStep: {
           assignUsersInstructions: {
-            paragraph:
-              'You need to assign users or groups to your enterprise application before they can use it to sign in.',
+            paragraph: 'Assign users or groups to your Okta application before they can sign in with SSO',
             step1: 'In the Okta dashboard, select the <bold>Assignments</bold> tab.',
             step2:
-              'Select the <bold>Assign</bold> dropdown. You can either select <bold>Assign to people</bold> or <bold>Assign to groups</bold>.',
-            step3: 'In the search field, enter the user or group of users that you want to assign to the application.',
-            step4: 'Select the <bold>Assign</bold> button next to the user or group that you want to assign.',
-            step5: 'Select the <bold>Done</bold> button to complete the assignment.',
-            title: 'Assign selected user or group in Okta',
+              'Open the <bold>Assign</bold> dropdown and select <bold>Assign to people</bold> or <bold>Assign to groups</bold>.',
+            step3: 'Search for the user or group to assign.',
+            step4: 'Click <bold>Assign</bold> next to the user or group.',
+            step5: 'Click <bold>Done.</bold>',
           },
-          headerSubtitle: 'Assign users to the enterprise application',
+          headerSubtitle: 'Assign users to your Okta application',
         },
         attributeMappingStep: {
           attributeMappingTable: {
@@ -579,32 +564,30 @@ export const enUS: LocalizationResource = {
               },
             },
           },
-          headerSubtitle: 'Map user attributes from Okta to your application',
-          paragraph: 'We expect your SAML responses to have the following specific attributes:',
-          step1:
-            'Open the <bold>Sign On</bold> tab of your Okta application and locate the <bold>Attribute Statements</bold> section. If you don’t see it, click <bold>Show legacy configuration</bold>, then <bold>Edit</bold>.',
-          step2: 'Select <bold>Add Expression</bold> for each row below, then enter the matching name and value:',
+          headerSubtitle: 'Set the attributes Okta includes in your SAML response',
+          paragraph: 'Your SAML response must include the following attributes:',
+          step1: 'In the Okta dashboard, find the <bold>Attribute Statements</bold> section.',
+          step2:
+            'Select <bold>Add Expression</bold> for each attribute, and enter the following name and expression pairs:',
         },
         createAppStep: {
           completeSamlIntegrationInstructions: {
-            step1: 'Select <bold>This is an internal app that we have created</bold> from the options menu.',
-            step2: 'Complete the form with any comments and select <bold>"Finish"</bold>.',
-            title: 'Complete SAML integration',
+            step1: 'From the options menu, select <bold>This is an internal app that we have created.</bold>',
+            step2: 'Click <bold>Finish</bold> to complete the integration.',
+            title: 'Complete the SAML integration',
           },
           createAppInstructions: {
             step1: 'Sign in to Okta and go to <bold>Admin → Applications.</bold>',
-            step2: 'Click <bold>Create App Integration.</bold>',
-            step3: 'Select <bold>SAML 2.0.</bold>',
-            step4: 'Fill in the General Settings (App name is required).',
-            step5: 'Click <bold>Next</bold> to complete creating the application.',
-            title: 'Create a new enterprise application in Okta',
+            step2: 'Click <bold>Create App Integration.</bold> and select <bold>SAML 2.0.</bold>',
+            step3: 'Fill in the General Settings. The app name is required.',
+            step4: 'Click <bold>Next</bold> to finish creating the application.',
+            title: 'Create a new SAML application in Okta',
           },
-          headerSubtitle: 'Create a new enterprise application in your Okta Dashboard',
+          headerSubtitle: 'Create and configure a SAML application in your Okta Dashboard',
           serviceProviderInstructions: {
             paragraph1:
-              'Once you have moved forward from the General Settings instructions, you will be presented with the Configure SAML page.',
-            paragraph2:
-              'To configure your service provider, you must add these two fields to your Okta SAML application:',
+              "After completing <bold>General Settings</bold>, you'll see the <bold>Configure SAML</bold> page.",
+            paragraph2: 'Add these two fields to your Okta application to configure your service provider.',
             serviceProviderFields: {
               acsUrl: {
                 label: 'Single sign-on URL',
@@ -613,39 +596,39 @@ export const enUS: LocalizationResource = {
                 label: 'Audience URI (SP Entity ID)',
               },
             },
-            title: 'Add service provider configuration to Okta',
+            title: 'Configure service provider',
           },
         },
         identityProviderMetadataStep: {
-          headerSubtitle: 'Configure identity provider metadata',
+          headerSubtitle: 'Add your Okta application metadata',
           manual: {
-            description: 'In your Okta SAML app, go to the Sign On tab and retrieve these values.',
+            description: 'In your Okta SAML application, go to the Sign On tab and retrieve these values.',
             issuer: {
               label: 'Issuer',
               placeholder: 'Paste URL here...',
             },
             signOnUrl: {
-              label: 'Single Sign-On URL',
+              label: 'Sign on URL',
               placeholder: 'Paste URL here...',
             },
             signingCertificate: {
               fileUploaded: 'File uploaded',
-              label: 'X.509 certificate',
+              label: 'Signing certificate',
               removeFile: 'Remove file',
               replaceFile: 'Replace file',
               uploadFile: 'Upload file',
             },
           },
           metadataUrl: {
-            description: 'In your Okta SAML app, go to the Sign On tab and retrieve the metadata URL. Paste it below.',
+            description:
+              'In your Okta SAML application, go to the Sign On tab and retrieve the metadata URL. Paste it below.',
             label: 'Metadata URL',
             placeholder: 'Paste URL here...',
           },
           modes: {
-            ariaLabel: 'Configuration ',
+            ariaLabel: 'Configuration',
             manual: 'Configure manually',
             metadataUrl: 'Add via metadata',
-            title: 'Fill in your Okta SAML application details',
           },
         },
         mainHeaderTitle: 'Configure Okta Workforce',
@@ -707,7 +690,7 @@ export const enUS: LocalizationResource = {
         microsoft: 'Microsoft Entra (formerly AD)',
         okta: 'Okta Workforce',
       },
-      subtitle: 'We’ll guide you through the detailed setup process next.',
+      subtitle: "You'll configure the connection details in the next step",
       title: 'Select your identity provider',
       warning: 'Once a provider is selected you cannot change again until the configuration is over',
     },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -228,6 +228,10 @@ export const enUS: LocalizationResource = {
       title: 'Change provider to {{provider}}',
     },
     configureStep: {
+      activeConnectionWarning: {
+        title:
+          'This connection is active. Saving changes applies immediately and may disrupt sign-in for current members.',
+      },
       attributeMappingTable: {
         badges: {
           optional: 'Optional',
@@ -354,7 +358,7 @@ export const enUS: LocalizationResource = {
         createAppStep: {
           createAppInstructions: {
             step1: 'In the side navigation, under <bold>Apps</bold>, select <bold>Web and mobile apps.</bold>',
-            step2: 'In Select <bold>Add app</bold>, then <bold>Add custom SAML app.</bold>',
+            step2: 'Select <bold>Add app</bold>, then <bold>Add custom SAML app.</bold>',
             step3: 'Enter an <bold>App name.</bold>',
             step4: 'Select <bold>Continue</bold>.',
             title: 'In Google Workspace, create a new SAML application:',

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1480,6 +1480,7 @@ export type __internal_LocalizationResource = {
       };
       activeConnectionWarning: {
         title: LocalizationValue;
+        dismiss: LocalizationValue;
       };
       samlOkta: {
         mainHeaderTitle: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1370,6 +1370,12 @@ export type __internal_LocalizationResource = {
       };
       warning: LocalizationValue;
     };
+    changeProviderDialog: {
+      title: LocalizationValue<'provider'>;
+      subtitle: LocalizationValue<'provider' | 'currentProvider'>;
+      cancelButton: LocalizationValue;
+      confirmButton: LocalizationValue;
+    };
     organizationDomainsStep: {
       title: LocalizationValue;
       subtitle: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1488,7 +1488,6 @@ export type __internal_LocalizationResource = {
             step2: LocalizationValue;
             step3: LocalizationValue;
             step4: LocalizationValue;
-            step5: LocalizationValue;
           };
           serviceProviderInstructions: {
             title: LocalizationValue;
@@ -1529,7 +1528,6 @@ export type __internal_LocalizationResource = {
         assignUsersStep: {
           headerSubtitle: LocalizationValue;
           assignUsersInstructions: {
-            title: LocalizationValue;
             paragraph: LocalizationValue;
             step1: LocalizationValue;
             step2: LocalizationValue;
@@ -1541,7 +1539,6 @@ export type __internal_LocalizationResource = {
         identityProviderMetadataStep: {
           headerSubtitle: LocalizationValue;
           modes: {
-            title: LocalizationValue;
             ariaLabel: LocalizationValue;
             metadataUrl: LocalizationValue;
             manual: LocalizationValue;
@@ -1576,7 +1573,6 @@ export type __internal_LocalizationResource = {
         createAppStep: {
           headerSubtitle: LocalizationValue;
           createAppInstructions: {
-            title: LocalizationValue;
             paragraph: LocalizationValue;
           };
           serviceProviderFields: {
@@ -1594,25 +1590,23 @@ export type __internal_LocalizationResource = {
           attributeMappingTable: {
             title: LocalizationValue;
             columns: {
-              userProfile: LocalizationValue;
               attributeName: LocalizationValue;
+              userAttribute: LocalizationValue;
             };
             rows: {
-              email: { userProfile: LocalizationValue; attributeName: LocalizationValue };
-              firstName: { userProfile: LocalizationValue; attributeName: LocalizationValue };
-              lastName: { userProfile: LocalizationValue; attributeName: LocalizationValue };
+              email: { attributeName: LocalizationValue; userAttribute: LocalizationValue };
+              firstName: { attributeName: LocalizationValue; userAttribute: LocalizationValue };
+              lastName: { attributeName: LocalizationValue; userAttribute: LocalizationValue };
             };
           };
         };
         assignUsersStep: {
           headerSubtitle: LocalizationValue;
-          title: LocalizationValue;
           paragraph: LocalizationValue;
         };
         identityProviderMetadataStep: {
           headerSubtitle: LocalizationValue;
           modes: {
-            title: LocalizationValue;
             ariaLabel: LocalizationValue;
             metadataUrl: LocalizationValue;
             manual: LocalizationValue;
@@ -1652,7 +1646,6 @@ export type __internal_LocalizationResource = {
             step2: LocalizationValue;
             step3: LocalizationValue;
             step4: LocalizationValue;
-            step5: LocalizationValue;
           };
         };
         identityProviderMetadataStep: {
@@ -1755,13 +1748,11 @@ export type __internal_LocalizationResource = {
           };
           assignUsersInstructions: {
             title: LocalizationValue;
-            paragraph1: LocalizationValue;
             step1: LocalizationValue;
             step2: LocalizationValue;
             step3: LocalizationValue;
             step4: LocalizationValue;
             step5: LocalizationValue;
-            step6: LocalizationValue;
           };
         };
         serviceProviderStep: {
@@ -1817,10 +1808,8 @@ export type __internal_LocalizationResource = {
         attributeMappingStep: {
           headerSubtitle: LocalizationValue;
           title: LocalizationValue;
-          paragraph: LocalizationValue;
           step1: LocalizationValue;
           step2: LocalizationValue;
-          step3: LocalizationValue;
           attributeMappingTable: {
             columns: {
               attribute: LocalizationValue;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1651,7 +1651,6 @@ export type __internal_LocalizationResource = {
         identityProviderMetadataStep: {
           headerSubtitle: LocalizationValue;
           modes: {
-            title: LocalizationValue;
             ariaLabel: LocalizationValue;
             metadataFile: LocalizationValue;
             manual: LocalizationValue;
@@ -1776,7 +1775,6 @@ export type __internal_LocalizationResource = {
         identityProviderMetadataStep: {
           headerSubtitle: LocalizationValue;
           modes: {
-            title: LocalizationValue;
             ariaLabel: LocalizationValue;
             metadataUrl: LocalizationValue;
             manual: LocalizationValue;
@@ -1816,6 +1814,8 @@ export type __internal_LocalizationResource = {
               claimName: LocalizationValue;
               value: LocalizationValue;
             };
+            copyClaimName: LocalizationValue;
+            copyClaimNameCopied: LocalizationValue;
             rows: {
               email: { attribute: LocalizationValue; claimName: LocalizationValue; value: LocalizationValue };
               firstName: { attribute: LocalizationValue; claimName: LocalizationValue; value: LocalizationValue };

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1478,6 +1478,9 @@ export type __internal_LocalizationResource = {
           optional: LocalizationValue;
         };
       };
+      activeConnectionWarning: {
+        title: LocalizationValue;
+      };
       samlOkta: {
         mainHeaderTitle: LocalizationValue;
         createAppStep: {

--- a/packages/ui/src/components/ConfigureSSO/ChangeProviderDialog.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ChangeProviderDialog.tsx
@@ -1,0 +1,97 @@
+import type { LocalizationKey } from '@/customizables';
+import { Button, Col, descriptors, Flex, Heading, localizationKeys, Text, useLocalizations } from '@/customizables';
+import { Card } from '@/elements/Card';
+import { withCardStateProvider } from '@/elements/contexts';
+import { Modal } from '@/elements/Modal';
+
+type ChangeProviderDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isSubmitting?: boolean;
+  nextProviderLabel: LocalizationKey;
+  currentProviderLabel: LocalizationKey;
+  contentRef: React.RefObject<HTMLDivElement>;
+};
+
+export const ChangeProviderDialog = (props: ChangeProviderDialogProps): JSX.Element | null => {
+  if (!props.isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      handleClose={props.onClose}
+      canCloseModal={false}
+      portalRoot={props.contentRef}
+      containerSx={t => ({
+        alignItems: 'center',
+        position: 'absolute',
+        inset: 0,
+        width: 'auto',
+        height: 'auto',
+        backgroundColor: 'inherit',
+        backdropFilter: `blur(${t.sizes.$2})`,
+      })}
+    >
+      <ChangeProviderDialogContent {...props} />
+    </Modal>
+  );
+};
+
+const ChangeProviderDialogContent = withCardStateProvider((props: ChangeProviderDialogProps) => {
+  const { onClose, onConfirm, isSubmitting, nextProviderLabel, currentProviderLabel } = props;
+  const { t } = useLocalizations();
+
+  const nextProvider = t(nextProviderLabel);
+  const currentProvider = t(currentProviderLabel);
+
+  return (
+    <Card.Root
+      elementDescriptor={descriptors.configureSSOChangeProviderDialog}
+      sx={t => ({ borderRadius: t.radii.$md })}
+    >
+      <Card.Content sx={t => ({ textAlign: 'start', padding: t.sizes.$5 })}>
+        <Col sx={t => ({ gap: t.space.$4 })}>
+          <Col sx={t => ({ gap: t.space.$2 })}>
+            <Heading
+              textVariant='h2'
+              localizationKey={localizationKeys('configureSSO.changeProviderDialog.title', {
+                provider: nextProvider,
+              })}
+              sx={t => ({ fontSize: t.fontSizes.$md })}
+            />
+            <Text
+              as='p'
+              colorScheme='secondary'
+              localizationKey={localizationKeys('configureSSO.changeProviderDialog.subtitle', {
+                provider: nextProvider,
+                currentProvider,
+              })}
+            />
+          </Col>
+
+          <Flex
+            justify='end'
+            sx={t => ({ gap: t.space.$3 })}
+          >
+            <Button
+              elementDescriptor={descriptors.configureSSOChangeProviderDialogCancelButton}
+              variant='ghost'
+              isDisabled={isSubmitting}
+              onClick={onClose}
+              localizationKey={localizationKeys('configureSSO.changeProviderDialog.cancelButton')}
+            />
+            <Button
+              elementDescriptor={descriptors.configureSSOChangeProviderDialogConfirmButton}
+              variant='solid'
+              isLoading={isSubmitting}
+              onClick={onConfirm}
+              localizationKey={localizationKeys('configureSSO.changeProviderDialog.confirmButton')}
+            />
+          </Flex>
+        </Col>
+      </Card.Content>
+    </Card.Root>
+  );
+});

--- a/packages/ui/src/components/ConfigureSSO/ConfigureSSOWizard.tsx
+++ b/packages/ui/src/components/ConfigureSSO/ConfigureSSOWizard.tsx
@@ -6,13 +6,7 @@ import { ConfigureSSOProvider } from './ConfigureSSOContext';
 import { ConfigureSSOHeader } from './ConfigureSSOHeader';
 import { areAllOrganizationDomainsVerified } from './domain/organizationEnterpriseConnection';
 import { Wizard, type WizardStepConfig } from './elements/Wizard';
-import {
-  ActivateStep,
-  ConfigureStep,
-  OrganizationDomainsStep,
-  SelectProviderStep,
-  TestConfigurationStep,
-} from './steps';
+import { ActivateStep, ConfigureStep, OrganizationDomainsStep, TestConfigurationStep } from './steps';
 
 export type ConfigureSSOWizardProps = Omit<ComponentProps<typeof ConfigureSSOProvider>, 'children'> & {
   title?: React.ReactNode;
@@ -27,8 +21,10 @@ export const ConfigureSSOWizard = ({ title, forceInitialStep, ...props }: Config
   const steps = React.useMemo<WizardStepConfig[]>(
     () => [
       { id: 'verify-domain', label: 'Domains' },
-      { id: 'select-provider', guard: () => allDomainsVerified },
-      { id: 'configure', label: 'Connection', guard: () => c.hasConnection },
+      // `select-provider` now lives inside `configure` as its first sub-step, so
+      // reaching `configure` only requires verified domains (fresh start) or an
+      // existing connection (resume / change-provider).
+      { id: 'configure', label: 'Connection', guard: () => allDomainsVerified || c.hasConnection },
       { id: 'test', label: 'Test', guard: () => c.hasMinimumConfiguration || c.isActive },
       { id: 'activate', label: 'Activate', guard: () => c.hasSuccessfulTestRun || c.isActive },
     ],
@@ -48,12 +44,6 @@ export const ConfigureSSOWizard = ({ title, forceInitialStep, ...props }: Config
         <Wizard.Match id='verify-domain'>
           <CardStateProvider>
             <OrganizationDomainsStep />
-          </CardStateProvider>
-        </Wizard.Match>
-
-        <Wizard.Match id='select-provider'>
-          <CardStateProvider>
-            <SelectProviderStep />
           </CardStateProvider>
         </Wizard.Match>
 

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
@@ -107,6 +107,24 @@ describe('ConfigureSSO wizard navigation (integration)', () => {
     });
   });
 
+  it('shows select-provider when entering configure with an existing in-progress connection', async () => {
+    const { wrapper, fixtures } = await createFixtures(withAdminOrgUser);
+
+    fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([unconfiguredConnection] as any);
+    fixtures.clerk.organization?.getEnterpriseConnectionTestRuns.mockResolvedValue({
+      data: [],
+      total_count: 0,
+    } as any);
+    mockVerifiedDomains(fixtures);
+
+    const { findByText, queryByRole } = render(<ConfigureSSO />, { wrapper });
+
+    // Verified domains + a connection ⇒ the outer wizard seeds to `configure`,
+    // whose sub-wizard starts on `select-provider` rather than the Okta config.
+    await findByText(/select your identity provider/i);
+    expect(queryByRole('heading', { name: /configure okta workforce/i })).not.toBeInTheDocument();
+  });
+
   // Contract rules 7 + 10: reset deletes the connection, then the wizard
   // re-derives to the furthest-reachable step for the now-no-connection state
   // (select-provider, since the email is verified) and renders a real step body —

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
@@ -107,7 +107,7 @@ describe('ConfigureSSO wizard navigation (integration)', () => {
     });
   });
 
-  it('shows select-provider when entering configure with an existing in-progress connection', async () => {
+  it('resumes the provider configuration when entering configure with an existing in-progress connection', async () => {
     const { wrapper, fixtures } = await createFixtures(withAdminOrgUser);
 
     fixtures.clerk.organization?.getEnterpriseConnections.mockResolvedValue([unconfiguredConnection] as any);
@@ -117,12 +117,10 @@ describe('ConfigureSSO wizard navigation (integration)', () => {
     } as any);
     mockVerifiedDomains(fixtures);
 
-    const { findByText, queryByRole } = render(<ConfigureSSO />, { wrapper });
+    const { findByRole, queryByText } = render(<ConfigureSSO />, { wrapper });
 
-    // Verified domains + a connection ⇒ the outer wizard seeds to `configure`,
-    // whose sub-wizard starts on `select-provider` rather than the Okta config.
-    await findByText(/select your identity provider/i);
-    expect(queryByRole('heading', { name: /configure okta workforce/i })).not.toBeInTheDocument();
+    await findByRole('heading', { name: /configure okta workforce/i });
+    expect(queryByText(/select your identity provider/i)).not.toBeInTheDocument();
   });
 
   // Contract rules 7 + 10: reset deletes the connection, then the wizard

--- a/packages/ui/src/components/ConfigureSSO/hooks/useOrganizationEnterpriseConnection.ts
+++ b/packages/ui/src/components/ConfigureSSO/hooks/useOrganizationEnterpriseConnection.ts
@@ -234,9 +234,11 @@ export const useOrganizationEnterpriseConnection = (): UseOrganizationEnterprise
         await deleteEnterpriseConnection(enterpriseConnection.id);
       }
 
+      const domains = enterpriseConnection?.domains ?? organizationDomains?.map(domain => domain.name);
+
       return createEnterpriseConnection({
         provider,
-        domains: organizationDomains?.map(domain => domain.name),
+        domains,
       });
     };
 

--- a/packages/ui/src/components/ConfigureSSO/hooks/useOrganizationEnterpriseConnection.ts
+++ b/packages/ui/src/components/ConfigureSSO/hooks/useOrganizationEnterpriseConnection.ts
@@ -46,6 +46,11 @@ export interface EnterpriseConnectionMutations {
    * never thread them through.
    */
   createConnection: (provider: ProviderType) => Promise<EnterpriseConnectionResource | undefined>;
+  /**
+   * Swaps the active organization's connection to a different provider. This removes the existing
+   * connection and creates a fresh one.
+   */
+  changeProvider: (provider: ProviderType) => Promise<EnterpriseConnectionResource | undefined>;
   updateConnection: (
     id: string,
     params: UpdateOrganizationEnterpriseConnectionParams,
@@ -222,6 +227,19 @@ export const useOrganizationEnterpriseConnection = (): UseOrganizationEnterprise
       });
     };
 
+    const changeProvider: EnterpriseConnectionMutations['changeProvider'] = async provider => {
+      // Currently it's not possible to change the provider of an existing connection,
+      // so we need to delete the existing connection and create a new one.
+      if (enterpriseConnection) {
+        await deleteEnterpriseConnection(enterpriseConnection.id);
+      }
+
+      return createEnterpriseConnection({
+        provider,
+        domains: organizationDomains?.map(domain => domain.name),
+      });
+    };
+
     const updateConnection: EnterpriseConnectionMutations['updateConnection'] = (id, params) =>
       updateEnterpriseConnection(id, params);
 
@@ -244,6 +262,7 @@ export const useOrganizationEnterpriseConnection = (): UseOrganizationEnterprise
 
     return {
       createConnection,
+      changeProvider,
       updateConnection,
       setConnectionActive,
       deleteConnection,
@@ -253,6 +272,7 @@ export const useOrganizationEnterpriseConnection = (): UseOrganizationEnterprise
     user,
     organization,
     organizationDomains,
+    enterpriseConnection,
     createEnterpriseConnection,
     updateEnterpriseConnection,
     deleteEnterpriseConnection,

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
@@ -1,10 +1,13 @@
-import { type JSX } from 'react';
+import React, { type JSX } from 'react';
 
 import { descriptors, Flow } from '@/customizables';
+import { CardStateProvider } from '@/elements/contexts';
 
 import { useConfigureSSO } from '../../ConfigureSSOContext';
 import { Step } from '../../elements/Step';
+import { Wizard, type WizardStepConfig } from '../../elements/Wizard';
 import type { ProviderType } from '../../types';
+import { SelectProviderStep } from '../SelectProviderStep';
 import {
   SamlCustomConfigureSteps,
   SamlGoogleConfigureSteps,
@@ -19,7 +22,32 @@ const STEPS_BY_PROVIDER: Record<ProviderType, () => JSX.Element> = {
   saml_microsoft: SamlMicrosoftConfigureSteps,
 };
 
-export const ConfigureStep = (): JSX.Element | null => {
+export const ConfigureStep = (): JSX.Element => {
+  const { organizationEnterpriseConnection: c } = useConfigureSSO();
+
+  const steps = React.useMemo<WizardStepConfig[]>(
+    () => [{ id: 'select-provider' }, { id: 'configure-provider', guard: () => c.hasConnection }],
+    [c],
+  );
+
+  return (
+    <Wizard steps={steps}>
+      <Wizard.Match id='select-provider'>
+        <CardStateProvider>
+          <SelectProviderStep />
+        </CardStateProvider>
+      </Wizard.Match>
+
+      <Wizard.Match id='configure-provider'>
+        <CardStateProvider>
+          <ConfigureProviderStep />
+        </CardStateProvider>
+      </Wizard.Match>
+    </Wizard>
+  );
+};
+
+const ConfigureProviderStep = (): JSX.Element | null => {
   const { organizationEnterpriseConnection: c } = useConfigureSSO();
 
   // Type guard: the provider should be defined by the time we reach configure.

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
@@ -5,7 +5,7 @@ import { CardStateProvider } from '@/elements/contexts';
 
 import { useConfigureSSO } from '../../ConfigureSSOContext';
 import { Step } from '../../elements/Step';
-import { Wizard, type WizardStepConfig } from '../../elements/Wizard';
+import { useWizard, Wizard, type WizardStepConfig } from '../../elements/Wizard';
 import type { ProviderType } from '../../types';
 import { SelectProviderStep } from '../SelectProviderStep';
 import {
@@ -24,14 +24,23 @@ const STEPS_BY_PROVIDER: Record<ProviderType, () => JSX.Element> = {
 
 export const ConfigureStep = (): JSX.Element => {
   const { organizationEnterpriseConnection: c } = useConfigureSSO();
+  const { direction } = useWizard();
 
   const steps = React.useMemo<WizardStepConfig[]>(
     () => [{ id: 'select-provider' }, { id: 'configure-provider', guard: () => c.hasConnection }],
     [c],
   );
 
+  // Entering `configure` lands on its first sub-step, `select-provider`, so advancing into configuration
+  // always shows provider selection first, even when a connection already
+  // exists
+  const initialStepId = direction === -1 ? undefined : 'select-provider';
+
   return (
-    <Wizard steps={steps}>
+    <Wizard
+      steps={steps}
+      initialStepId={initialStepId}
+    >
       <Wizard.Match id='select-provider'>
         <CardStateProvider>
           <SelectProviderStep />

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/index.tsx
@@ -31,10 +31,7 @@ export const ConfigureStep = (): JSX.Element => {
     [c],
   );
 
-  // Entering `configure` lands on its first sub-step, `select-provider`, so advancing into configuration
-  // always shows provider selection first, even when a connection already
-  // exists
-  const initialStepId = direction === -1 ? undefined : 'select-provider';
+  const initialStepId = direction === 1 ? 'select-provider' : undefined;
 
   return (
     <Wizard

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlCustomConfigureSteps.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlCustomConfigureSteps.tsx
@@ -5,7 +5,6 @@ import {
   Col,
   descriptors,
   Flex,
-  Heading,
   localizationKeys,
   Table,
   Tbody,
@@ -102,14 +101,6 @@ const SamlCustomCreateAppStep = (): JSX.Element => {
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$5 })}>
           <Col sx={theme => ({ gap: theme.space.$1x5 })}>
-            <Heading
-              elementDescriptor={descriptors.configureSSOInstructionsHeading}
-              as='h3'
-              textVariant='subtitle'
-              localizationKey={localizationKeys(
-                'configureSSO.configureStep.samlCustom.createAppStep.createAppInstructions.title',
-              )}
-            />
             <Text
               as='p'
               colorScheme='secondary'
@@ -221,7 +212,7 @@ const CustomAttributeMappingTable = (): JSX.Element => (
           <Text
             sx={theme => ({ fontSize: theme.fontSizes.$xs })}
             localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.columns.userProfile',
+              'configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.columns.attributeName',
             )}
           />
         </Th>
@@ -229,7 +220,7 @@ const CustomAttributeMappingTable = (): JSX.Element => (
           <Text
             sx={theme => ({ fontSize: theme.fontSizes.$xs })}
             localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.columns.attributeName',
+              'configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.columns.userAttribute',
             )}
           />
         </Th>
@@ -247,8 +238,9 @@ const CustomAttributeMappingTable = (): JSX.Element => (
               <Text
                 as='span'
                 colorScheme='secondary'
+                sx={{ fontFamily: 'monospace' }}
                 localizationKey={localizationKeys(
-                  `configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.rows.${row.id}.userProfile`,
+                  `configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.rows.${row.id}.userAttribute`,
                 )}
               />
               <Badge
@@ -268,7 +260,6 @@ const CustomAttributeMappingTable = (): JSX.Element => (
           <Td>
             <Text
               as='span'
-              sx={{ fontFamily: 'monospace' }}
               localizationKey={localizationKeys(
                 `configureSSO.configureStep.samlCustom.attributeMappingStep.attributeMappingTable.rows.${row.id}.attributeName`,
               )}
@@ -294,12 +285,6 @@ const SamlCustomAssignUsersStep = (): JSX.Element => {
 
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlCustom.assignUsersStep.title')}
-          />
           <Text
             as='p'
             colorScheme='secondary'
@@ -488,14 +473,6 @@ const SamlCustomIdentityProviderMetadataStep = (): JSX.Element => {
           fill
           gap={5}
         >
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlCustom.identityProviderMetadataStep.modes.title',
-            )}
-          />
           <IdentityProviderConfigurationModes
             modes={CUSTOM_SAML_IDP_MODES}
             value={mode}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlGoogleConfigureSteps.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlGoogleConfigureSteps.tsx
@@ -73,10 +73,9 @@ const SamlGoogleCreateAppStep = (): JSX.Element => {
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$5 })}>
           <Col sx={theme => ({ gap: theme.space.$1x5 })}>
-            <Heading
-              elementDescriptor={descriptors.configureSSOInstructionsHeading}
-              as='h3'
-              textVariant='subtitle'
+            <Text
+              as='p'
+              colorScheme='secondary'
               localizationKey={localizationKeys(
                 'configureSSO.configureStep.samlGoogle.createAppStep.createAppInstructions.title',
               )}
@@ -122,14 +121,6 @@ const SamlGoogleCreateAppStep = (): JSX.Element => {
                 colorScheme='secondary'
                 localizationKey={localizationKeys(
                   'configureSSO.configureStep.samlGoogle.createAppStep.createAppInstructions.step4',
-                )}
-              />
-              <Text
-                elementDescriptor={descriptors.configureSSOInstructionsListItem}
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys(
-                  'configureSSO.configureStep.samlGoogle.createAppStep.createAppInstructions.step5',
                 )}
               />
             </Col>
@@ -328,14 +319,6 @@ const SamlGoogleIdentityProviderMetadataStep = (): JSX.Element => {
           fill
           gap={5}
         >
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlGoogle.identityProviderMetadataStep.modes.title',
-            )}
-          />
           <IdentityProviderConfigurationModes
             modes={GOOGLE_IDP_MODES}
             value={mode}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlMicrosoftConfigureSteps.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlMicrosoftConfigureSteps.tsx
@@ -192,13 +192,6 @@ const SamlMicrosoftCreateAppStep = (): JSX.Element => {
                 'configureSSO.configureStep.samlMicrosoft.createAppStep.assignUsersInstructions.title',
               )}
             />
-            <Text
-              as='p'
-              colorScheme='secondary'
-              localizationKey={localizationKeys(
-                'configureSSO.configureStep.samlMicrosoft.createAppStep.assignUsersInstructions.paragraph1',
-              )}
-            />
 
             <Col
               elementDescriptor={descriptors.configureSSOInstructionsList}
@@ -248,14 +241,6 @@ const SamlMicrosoftCreateAppStep = (): JSX.Element => {
                 colorScheme='secondary'
                 localizationKey={localizationKeys(
                   'configureSSO.configureStep.samlMicrosoft.createAppStep.assignUsersInstructions.step5',
-                )}
-              />
-              <Text
-                elementDescriptor={descriptors.configureSSOInstructionsListItem}
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys(
-                  'configureSSO.configureStep.samlMicrosoft.createAppStep.assignUsersInstructions.step6',
                 )}
               />
             </Col>
@@ -353,53 +338,55 @@ const SamlMicrosoftServiceProviderStep = (): JSX.Element => {
                 colorScheme='secondary'
                 localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.serviceProviderStep.step4')}
               />
+
+              <Box
+                elementDescriptor={descriptors.configureSSOInstructionsListItem}
+                as='li'
+                sx={theme => ({
+                  fontSize: theme.fontSizes.$md,
+                  lineHeight: theme.lineHeights.$small,
+                  color: theme.colors.$colorMutedForeground,
+                })}
+              >
+                <Text
+                  as='span'
+                  colorScheme='secondary'
+                  localizationKey={localizationKeys(
+                    'configureSSO.configureStep.samlMicrosoft.serviceProviderStep.step5',
+                  )}
+                />
+                <Col sx={theme => ({ gap: theme.space.$4, marginBlock: theme.space.$3 })}>
+                  <Form.ControlRow elementId={spEntityIdField.id}>
+                    <Form.CommonInputWrapper {...spEntityIdField.props}>
+                      <ClipboardInput
+                        value={spEntityId}
+                        readOnly
+                        copyIcon={Clipboard}
+                        copiedIcon={Checkmark}
+                      />
+                    </Form.CommonInputWrapper>
+                  </Form.ControlRow>
+
+                  <Form.ControlRow elementId={acsUrlField.id}>
+                    <Form.CommonInputWrapper {...acsUrlField.props}>
+                      <ClipboardInput
+                        value={acsUrl}
+                        readOnly
+                        copyIcon={Clipboard}
+                        copiedIcon={Checkmark}
+                      />
+                    </Form.CommonInputWrapper>
+                  </Form.ControlRow>
+                </Col>
+              </Box>
+
               <Text
                 elementDescriptor={descriptors.configureSSOInstructionsListItem}
                 as='li'
                 colorScheme='secondary'
-                localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.serviceProviderStep.step5')}
+                localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.serviceProviderStep.step6')}
               />
             </Col>
-          </Col>
-
-          <Form.ControlRow elementId={spEntityIdField.id}>
-            <Form.CommonInputWrapper {...spEntityIdField.props}>
-              <ClipboardInput
-                value={spEntityId}
-                readOnly
-                copyIcon={Clipboard}
-                copiedIcon={Checkmark}
-              />
-            </Form.CommonInputWrapper>
-          </Form.ControlRow>
-
-          <Form.ControlRow elementId={acsUrlField.id}>
-            <Form.CommonInputWrapper {...acsUrlField.props}>
-              <ClipboardInput
-                value={acsUrl}
-                readOnly
-                copyIcon={Clipboard}
-                copiedIcon={Checkmark}
-              />
-            </Form.CommonInputWrapper>
-          </Form.ControlRow>
-
-          <Col
-            elementDescriptor={descriptors.configureSSOInstructionsList}
-            as='ul'
-            sx={theme => ({
-              gap: theme.space.$1x5,
-              margin: 0,
-              paddingInlineStart: theme.space.$5,
-              listStyleType: 'disc',
-            })}
-          >
-            <Text
-              elementDescriptor={descriptors.configureSSOInstructionsListItem}
-              as='li'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.serviceProviderStep.step6')}
-            />
           </Col>
         </Step.Section>
       </Step.Body>
@@ -557,31 +544,21 @@ const SamlMicrosoftAttributeMappingStep = (): JSX.Element => {
 
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.attributeMappingStep.title')}
-          />
-
-          <MicrosoftAttributeMappingTable />
-
           <Text
             as='p'
             colorScheme='secondary'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.paragraph',
-            )}
+            elementDescriptor={descriptors.configureSSOInstructionsHeading}
+            localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.attributeMappingStep.title')}
           />
 
           <Col
             elementDescriptor={descriptors.configureSSOInstructionsList}
-            as='ul'
+            as='ol'
             sx={theme => ({
               gap: theme.space.$1x5,
               margin: 0,
               paddingInlineStart: theme.space.$5,
-              listStyleType: 'disc',
+              listStyleType: 'decimal',
             })}
           >
             <Text
@@ -596,13 +573,9 @@ const SamlMicrosoftAttributeMappingStep = (): JSX.Element => {
               colorScheme='secondary'
               localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.attributeMappingStep.step2')}
             />
-            <Text
-              elementDescriptor={descriptors.configureSSOInstructionsListItem}
-              as='li'
-              colorScheme='secondary'
-              localizationKey={localizationKeys('configureSSO.configureStep.samlMicrosoft.attributeMappingStep.step3')}
-            />
           </Col>
+
+          <MicrosoftAttributeMappingTable />
         </Step.Section>
       </Step.Body>
 

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlMicrosoftConfigureSteps.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlMicrosoftConfigureSteps.tsx
@@ -3,10 +3,13 @@ import React, { type JSX } from 'react';
 import {
   Badge,
   Box,
+  Button,
   Col,
   descriptors,
   Flex,
   Heading,
+  Icon,
+  type LocalizationKey,
   localizationKeys,
   Table,
   Tbody,
@@ -15,12 +18,15 @@ import {
   Th,
   Thead,
   Tr,
+  useLocalizations,
 } from '@/customizables';
 import { ClipboardInput } from '@/elements/ClipboardInput';
 import { useCardState } from '@/elements/contexts';
 import { Form } from '@/elements/Form';
 import { Tooltip } from '@/elements/Tooltip';
+import { useClipboard } from '@/hooks';
 import { Checkmark, Clipboard } from '@/icons';
+import { truncateWithEndVisible } from '@/ui/utils/truncateTextWithEndVisible';
 import { useFormControl } from '@/ui/utils/useFormControl';
 
 import { useConfigureSSO } from '../../../ConfigureSSOContext';
@@ -417,118 +423,154 @@ const MICROSOFT_ATTRIBUTE_ROWS: ReadonlyArray<MicrosoftAttributeRow> = [
   { id: 'lastName', isRequired: false },
 ];
 
-const MicrosoftAttributeMappingTable = (): JSX.Element => (
-  <Table
-    elementDescriptor={descriptors.configureSSOAttributeMappingTable}
-    sx={theme => ({
-      'tr > th:first-of-type': { paddingInlineStart: theme.space.$4 },
-    })}
-  >
-    <Thead>
-      <Tr>
-        <Th>
-          <Text
-            sx={theme => ({ fontSize: theme.fontSizes.$xs })}
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.attribute',
-            )}
-          />
-        </Th>
-        <Th>
-          <Text
-            sx={theme => ({ fontSize: theme.fontSizes.$xs })}
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.claimName',
-            )}
-          />
-        </Th>
-        <Th>
-          <Text
-            sx={theme => ({ fontSize: theme.fontSizes.$xs })}
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.value',
-            )}
-          />
-        </Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      {MICROSOFT_ATTRIBUTE_ROWS.map(row => {
-        const claimNameKey = localizationKeys(
-          `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.claimName`,
-        );
+const MicrosoftClaimNameCell = ({ claimNameKey }: { claimNameKey: LocalizationKey }): JSX.Element => {
+  const { t } = useLocalizations();
+  const claimName = t(claimNameKey);
+  const { onCopy, hasCopied } = useClipboard(claimName);
 
-        return (
-          <Tr key={row.id}>
-            {/*
-             * Keep the attribute name + badge on a single line. Without this,
-             * the next cell's `width: 100%` squeezes this one to its minimum
-             * intrinsic width, which causes "Email address" / "First name" /
-             * "Last name" to wrap onto two lines.
-             */}
-            <Td sx={{ whiteSpace: 'nowrap' }}>
-              <Flex
-                as='span'
-                align='center'
-                sx={theme => ({ gap: theme.space.$2 })}
-              >
-                <Text
+  return (
+    <Td sx={{ maxWidth: 0, width: '100%' }}>
+      <Flex
+        as='span'
+        align='center'
+        sx={theme => ({ gap: theme.space.$1 })}
+      >
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <Text
+              as='span'
+              sx={{
+                fontFamily: 'monospace',
+                display: 'block',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {/* Middle-truncate so the meaningful end of the claim URI (e.g. "emailaddress") stays visible. */}
+              {truncateWithEndVisible(claimName, 32, 12)}
+            </Text>
+          </Tooltip.Trigger>
+          <Tooltip.Content
+            text={claimNameKey}
+            textSx={{ overflowWrap: 'anywhere' }}
+          />
+        </Tooltip.Root>
+        <Button
+          variant='ghost'
+          onClick={() => onCopy()}
+          aria-label={t(
+            localizationKeys(
+              hasCopied
+                ? 'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.copyClaimNameCopied'
+                : 'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.copyClaimName',
+            ),
+          )}
+          sx={theme => ({
+            padding: 0,
+            height: theme.sizes.$5,
+            aspectRatio: 1,
+            borderRadius: theme.radii.$sm,
+            color: theme.colors.$colorMutedForeground,
+          })}
+        >
+          <Icon
+            size='sm'
+            icon={hasCopied ? Checkmark : Clipboard}
+            aria-hidden
+          />
+        </Button>
+      </Flex>
+    </Td>
+  );
+};
+
+const MicrosoftAttributeMappingTable = (): JSX.Element => {
+  return (
+    <Table
+      elementDescriptor={descriptors.configureSSOAttributeMappingTable}
+      sx={theme => ({
+        'tr > th:first-of-type': { paddingInlineStart: theme.space.$4 },
+      })}
+    >
+      <Thead>
+        <Tr>
+          <Th>
+            <Text
+              sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+              localizationKey={localizationKeys(
+                'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.attribute',
+              )}
+            />
+          </Th>
+          <Th>
+            <Text
+              sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+              localizationKey={localizationKeys(
+                'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.claimName',
+              )}
+            />
+          </Th>
+          <Th>
+            <Text
+              sx={theme => ({ fontSize: theme.fontSizes.$xs })}
+              localizationKey={localizationKeys(
+                'configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.columns.value',
+              )}
+            />
+          </Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {MICROSOFT_ATTRIBUTE_ROWS.map(row => {
+          const claimNameKey = localizationKeys(
+            `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.claimName`,
+          );
+
+          return (
+            <Tr key={row.id}>
+              <Td sx={{ whiteSpace: 'nowrap' }}>
+                <Flex
                   as='span'
-                  colorScheme='secondary'
-                  localizationKey={localizationKeys(
-                    `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.attribute`,
-                  )}
-                />
-                <Badge
-                  elementDescriptor={descriptors.configureSSOAttributeMappingBadge}
-                  elementId={descriptors.configureSSOAttributeMappingBadge.setId(
-                    row.isRequired ? 'required' : 'optional',
-                  )}
-                  colorScheme={row.isRequired ? 'warning' : 'primary'}
-                  localizationKey={localizationKeys(
-                    row.isRequired
-                      ? 'configureSSO.configureStep.attributeMappingTable.badges.required'
-                      : 'configureSSO.configureStep.attributeMappingTable.badges.optional',
-                  )}
-                />
-              </Flex>
-            </Td>
-            <Td sx={{ maxWidth: 0, width: '100%' }}>
-              <Tooltip.Root>
-                <Tooltip.Trigger>
+                  align='center'
+                  sx={theme => ({ gap: theme.space.$2 })}
+                >
                   <Text
                     as='span'
-                    sx={{
-                      fontFamily: 'monospace',
-                      display: 'block',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                    localizationKey={claimNameKey}
+                    colorScheme='secondary'
+                    localizationKey={localizationKeys(
+                      `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.attribute`,
+                    )}
                   />
-                </Tooltip.Trigger>
-                <Tooltip.Content
-                  text={claimNameKey}
-                  textSx={{ overflowWrap: 'anywhere' }}
+                  <Badge
+                    elementDescriptor={descriptors.configureSSOAttributeMappingBadge}
+                    elementId={descriptors.configureSSOAttributeMappingBadge.setId(
+                      row.isRequired ? 'required' : 'optional',
+                    )}
+                    colorScheme={row.isRequired ? 'warning' : 'primary'}
+                    localizationKey={localizationKeys(
+                      row.isRequired
+                        ? 'configureSSO.configureStep.attributeMappingTable.badges.required'
+                        : 'configureSSO.configureStep.attributeMappingTable.badges.optional',
+                    )}
+                  />
+                </Flex>
+              </Td>
+              <MicrosoftClaimNameCell claimNameKey={claimNameKey} />
+              <Td>
+                <Text
+                  as='span'
+                  sx={{ fontFamily: 'monospace' }}
+                  localizationKey={localizationKeys(
+                    `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.value`,
+                  )}
                 />
-              </Tooltip.Root>
-            </Td>
-            <Td>
-              <Text
-                as='span'
-                sx={{ fontFamily: 'monospace' }}
-                localizationKey={localizationKeys(
-                  `configureSSO.configureStep.samlMicrosoft.attributeMappingStep.attributeMappingTable.rows.${row.id}.value`,
-                )}
-              />
-            </Td>
-          </Tr>
-        );
-      })}
-    </Tbody>
-  </Table>
-);
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+};
 
 const SamlMicrosoftAttributeMappingStep = (): JSX.Element => {
   const { goNext, goPrev, isFirstStep, isLastStep } = useWizard();
@@ -615,12 +657,6 @@ const SamlMicrosoftIdentityProviderMetadataStep = (): JSX.Element => {
 
   const [mode, setMode] = React.useState<IdpConfigurationMode>(hasExistingConfig ? 'manual' : 'metadataUrl');
   const [certFile, setCertFile] = React.useState<File | null>(null);
-  // Step-LOCAL submit state for the Continue button. `goNext` bubbles to the
-  // parent (this is the terminal nested step) and the parent DEFERS the
-  // configure→test advance until the updateConnection revalidate lands. Keeping
-  // the loading local — and NOT resetting it on success — holds the button
-  // loading straight through that deferred transition; the advance unmounts this
-  // nested step, ending the loading with no idle flash on the shared card.
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const metadataUrlField = useFormControl('idpMetadataUrl', samlConnection?.idpMetadataUrl ?? '', {
@@ -761,14 +797,6 @@ const SamlMicrosoftIdentityProviderMetadataStep = (): JSX.Element => {
           fill
           gap={5}
         >
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlMicrosoft.identityProviderMetadataStep.modes.title',
-            )}
-          />
           <IdentityProviderConfigurationModes
             modes={MICROSOFT_SAML_IDP_MODES}
             value={mode}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlOktaConfigureSteps.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/SamlOktaConfigureSteps.tsx
@@ -152,14 +152,6 @@ const SamlOktaCreateAppStep = (): JSX.Element => {
                   'configureSSO.configureStep.samlOkta.createAppStep.createAppInstructions.step4',
                 )}
               />
-              <Text
-                elementDescriptor={descriptors.configureSSOInstructionsListItem}
-                as='li'
-                colorScheme='secondary'
-                localizationKey={localizationKeys(
-                  'configureSSO.configureStep.samlOkta.createAppStep.createAppInstructions.step5',
-                )}
-              />
             </Col>
           </Col>
 
@@ -425,14 +417,6 @@ const SamlOktaAssignUsersStep = (): JSX.Element => {
 
       <Step.Body>
         <Step.Section sx={theme => ({ gap: theme.space.$3 })}>
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlOkta.assignUsersStep.assignUsersInstructions.title',
-            )}
-          />
           <Text
             as='p'
             colorScheme='secondary'
@@ -672,14 +656,6 @@ const SamlOktaIdentityProviderMetadataStep = (): JSX.Element => {
           fill
           gap={5}
         >
-          <Heading
-            elementDescriptor={descriptors.configureSSOInstructionsHeading}
-            as='h3'
-            textVariant='subtitle'
-            localizationKey={localizationKeys(
-              'configureSSO.configureStep.samlOkta.identityProviderMetadataStep.modes.title',
-            )}
-          />
           <IdentityProviderConfigurationModes
             modes={OKTA_IDP_MODES}
             value={mode}

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/__tests__/SamlConfigureSteps.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/__tests__/SamlConfigureSteps.test.tsx
@@ -41,8 +41,6 @@ describe('SAML provider sub-flow — synchronous step derivation', () => {
     // the first derived step rather than a null first frame. Asserting on the
     // step-body instruction heading proves the body (not just the shared header)
     // is mounted.
-    expect(
-      await screen.findByRole('heading', { name: /create a new enterprise application in google workspace/i }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/in google workspace, create a new saml application/i)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/ActiveConnectionAlert.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/ActiveConnectionAlert.tsx
@@ -1,0 +1,21 @@
+import { type JSX } from 'react';
+
+import { localizationKeys } from '@/customizables';
+import { Alert } from '@/elements/Alert';
+
+import { useConfigureSSO } from '../../../../ConfigureSSOContext';
+
+export const ActiveConnectionAlert = (): JSX.Element | null => {
+  const { enterpriseConnection } = useConfigureSSO();
+
+  if (!enterpriseConnection?.active) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant='warning'
+      title={localizationKeys('configureSSO.configureStep.activeConnectionWarning.title')}
+    />
+  );
+};

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/ActiveConnectionAlert.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/ActiveConnectionAlert.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from 'react';
+import React, { type JSX } from 'react';
 
 import { localizationKeys } from '@/customizables';
 import { Alert } from '@/elements/Alert';
@@ -7,8 +7,9 @@ import { useConfigureSSO } from '../../../../ConfigureSSOContext';
 
 export const ActiveConnectionAlert = (): JSX.Element | null => {
   const { enterpriseConnection } = useConfigureSSO();
+  const [isDismissed, setIsDismissed] = React.useState(false);
 
-  if (!enterpriseConnection?.active) {
+  if (!enterpriseConnection?.active || isDismissed) {
     return null;
   }
 
@@ -16,6 +17,8 @@ export const ActiveConnectionAlert = (): JSX.Element | null => {
     <Alert
       variant='warning'
       title={localizationKeys('configureSSO.configureStep.activeConnectionWarning.title')}
+      dismissLabel={localizationKeys('configureSSO.configureStep.activeConnectionWarning.dismiss')}
+      onDismiss={() => setIsDismissed(true)}
     />
   );
 };

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/IdentityProviderConfigurationForm.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/IdentityProviderConfigurationForm.tsx
@@ -21,6 +21,7 @@ import { ArrowUpTray, Close } from '@/icons';
 import type { FormControlState } from '@/ui/utils/useFormControl';
 import { handleError } from '@/utils/errorHandler';
 
+import { ActiveConnectionAlert } from './ActiveConnectionAlert';
 import type { IdpConfigurationMode } from './IdentityProviderConfigurationModes';
 
 type CardState = ReturnType<typeof useCardState>;
@@ -70,7 +71,7 @@ export type IdentityProviderConfigurationFormProps =
   | { mode: 'metadataFile'; form: MetadataFileForm; labels: MetadataFileLabels }
   | { mode: 'manual'; form: ManualConfigurationForm; labels: ManualConfigurationLabels };
 
-export const IdentityProviderConfigurationForm = (config: IdentityProviderConfigurationFormProps): JSX.Element => {
+const ConfigurationPanel = (config: IdentityProviderConfigurationFormProps): JSX.Element => {
   switch (config.mode) {
     case 'metadataUrl':
       return (
@@ -94,6 +95,15 @@ export const IdentityProviderConfigurationForm = (config: IdentityProviderConfig
         />
       );
   }
+};
+
+export const IdentityProviderConfigurationForm = (config: IdentityProviderConfigurationFormProps): JSX.Element => {
+  return (
+    <>
+      <ConfigurationPanel {...config} />
+      <ActiveConnectionAlert />
+    </>
+  );
 };
 
 type MetadataUrlPanelProps = {

--- a/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/IdentityProviderConfigurationModes.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ConfigureStep/saml/shared/IdentityProviderConfigurationModes.tsx
@@ -37,6 +37,7 @@ export const IdentityProviderConfigurationModes = ({
       value={value}
       onChange={next => onChange(next as IdpConfigurationMode)}
       fullWidth
+      size='lg'
     >
       {modes.map(mode => {
         const label = labels[mode];

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -61,6 +61,7 @@ export const SelectProviderStep = (): JSX.Element => {
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isChangeDialogOpen, setIsChangeDialogOpen] = React.useState(false);
+  const [changeFromProvider, setChangeFromProvider] = React.useState<ProviderType | null>(null);
 
   const handleSelect = (next: ProviderType) => {
     setSelected(next);
@@ -79,6 +80,7 @@ export const SelectProviderStep = (): JSX.Element => {
     }
 
     if (isChangingProvider) {
+      setChangeFromProvider(c.provider ?? null);
       setIsChangeDialogOpen(true);
       return;
     }
@@ -105,16 +107,16 @@ export const SelectProviderStep = (): JSX.Element => {
 
     try {
       await changeProvider(selected);
-      setIsChangeDialogOpen(false);
       void goNext();
     } catch (err) {
       handleError(err as Error, [], card.setError);
       setIsChangeDialogOpen(false);
+      setChangeFromProvider(null);
       setIsSubmitting(false);
     }
   };
 
-  const currentProviderLabel = c.provider ? providerLabel(c.provider) : undefined;
+  const currentProviderLabel = changeFromProvider ? providerLabel(changeFromProvider) : undefined;
   const nextProviderLabel = selected ? providerLabel(selected) : undefined;
 
   return (
@@ -197,7 +199,10 @@ export const SelectProviderStep = (): JSX.Element => {
         {currentProviderLabel && nextProviderLabel ? (
           <ChangeProviderDialog
             isOpen={isChangeDialogOpen}
-            onClose={() => setIsChangeDialogOpen(false)}
+            onClose={() => {
+              setIsChangeDialogOpen(false);
+              setChangeFromProvider(null);
+            }}
             onConfirm={() => {
               void handleConfirmChangeProvider();
             }}

--- a/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/SelectProviderStep.tsx
@@ -2,23 +2,13 @@ import { iconImageUrl } from '@clerk/shared/constants';
 import React from 'react';
 
 import type { LocalizationKey } from '@/customizables';
-import {
-  Box,
-  Col,
-  descriptors,
-  Flow,
-  Grid,
-  localizationKeys,
-  RadioInput,
-  Span,
-  Text,
-  useLocalizations,
-} from '@/customizables';
+import { Box, Col, descriptors, Flow, Grid, localizationKeys, Span, Text, useLocalizations } from '@/customizables';
 import { useCardState } from '@/elements/contexts';
 import { common, mqu } from '@/styledSystem';
 import { Alert } from '@/ui/elements/Alert';
 import { handleError } from '@/utils/errorHandler';
 
+import { ChangeProviderDialog } from '../ChangeProviderDialog';
 import { useConfigureSSO } from '../ConfigureSSOContext';
 import { Step } from '../elements/Step';
 import { useWizard } from '../elements/Wizard';
@@ -54,30 +44,42 @@ const PROVIDER_GROUPS: ReadonlyArray<{
   },
 ];
 
+const providerLabel = (provider: ProviderType): LocalizationKey | undefined =>
+  PROVIDER_GROUPS.flatMap(group => group.options).find(option => option.id === provider)?.label;
+
 export const SelectProviderStep = (): JSX.Element => {
   const {
     organizationEnterpriseConnection: c,
-    enterpriseConnectionMutations: { createConnection },
+    enterpriseConnectionMutations: { createConnection, changeProvider },
+    contentRef,
   } = useConfigureSSO();
   const { goNext, goPrev, isFirstStep } = useWizard();
+  const { t } = useLocalizations();
 
   const [selected, setSelected] = React.useState<ProviderType | null>(c.provider ?? null);
   const card = useCardState();
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [isChangeDialogOpen, setIsChangeDialogOpen] = React.useState(false);
 
   const handleSelect = (next: ProviderType) => {
     setSelected(next);
   };
+
+  const isChangingProvider = c.hasConnection && selected !== null && selected !== c.provider;
 
   const handleContinue = async (): Promise<void> => {
     if (!selected) {
       return;
     }
 
-    if (c.hasConnection) {
-      // TODO ORGS-1607 - Support changing the provider
+    if (c.hasConnection && selected === c.provider) {
       void goNext();
+      return;
+    }
+
+    if (isChangingProvider) {
+      setIsChangeDialogOpen(true);
       return;
     }
 
@@ -92,6 +94,28 @@ export const SelectProviderStep = (): JSX.Element => {
       setIsSubmitting(false);
     }
   };
+
+  const handleConfirmChangeProvider = async (): Promise<void> => {
+    if (!selected) {
+      return;
+    }
+
+    card.setError(undefined);
+    setIsSubmitting(true);
+
+    try {
+      await changeProvider(selected);
+      setIsChangeDialogOpen(false);
+      void goNext();
+    } catch (err) {
+      handleError(err as Error, [], card.setError);
+      setIsChangeDialogOpen(false);
+      setIsSubmitting(false);
+    }
+  };
+
+  const currentProviderLabel = c.provider ? providerLabel(c.provider) : undefined;
+  const nextProviderLabel = selected ? providerLabel(selected) : undefined;
 
   return (
     <Flow.Part part='selectProvider'>
@@ -122,6 +146,8 @@ export const SelectProviderStep = (): JSX.Element => {
                 />
 
                 <Grid
+                  role='radiogroup'
+                  aria-label={t(group.label)}
                   elementDescriptor={descriptors.configureSSOProviderGrid}
                   gap={3}
                   sx={{
@@ -134,22 +160,16 @@ export const SelectProviderStep = (): JSX.Element => {
                   {group.options.map(option => (
                     <ProviderCard
                       key={option.id}
-                      name='configure-sso-provider'
                       value={option.id}
                       iconId={option.iconId}
                       label={option.label}
-                      checked={selected === option.id}
-                      onChange={() => handleSelect(option.id)}
+                      isSelected={selected === option.id}
+                      onSelect={() => handleSelect(option.id)}
                     />
                   ))}
                 </Grid>
               </Col>
             ))}
-
-            <Alert
-              variant='warning'
-              title={localizationKeys('configureSSO.selectProviderStep.warning')}
-            />
 
             {card.error && (
               <Alert
@@ -164,39 +184,56 @@ export const SelectProviderStep = (): JSX.Element => {
         <Step.Footer>
           <Step.Footer.Previous
             onClick={() => goPrev()}
-            isDisabled={isFirstStep}
+            isDisabled={isFirstStep || isSubmitting}
           />
 
           <Step.Footer.Continue
             onClick={handleContinue}
-            isLoading={isSubmitting}
+            isLoading={isSubmitting && !isChangeDialogOpen}
             isDisabled={!selected || isSubmitting}
           />
         </Step.Footer>
+
+        {currentProviderLabel && nextProviderLabel ? (
+          <ChangeProviderDialog
+            isOpen={isChangeDialogOpen}
+            onClose={() => setIsChangeDialogOpen(false)}
+            onConfirm={() => {
+              void handleConfirmChangeProvider();
+            }}
+            isSubmitting={isSubmitting}
+            nextProviderLabel={nextProviderLabel}
+            currentProviderLabel={currentProviderLabel}
+            contentRef={contentRef}
+          />
+        ) : null}
       </Step>
     </Flow.Part>
   );
 };
 
 type ProviderCardProps = {
-  name: string;
   value: string;
   iconId: string;
   label: LocalizationKey;
-  checked?: boolean;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isSelected?: boolean;
+  onSelect: () => void;
 };
 
-const ProviderCard = ({ name, value, iconId, label, checked, onChange }: ProviderCardProps): JSX.Element => {
+const ProviderCard = ({ value, iconId, label, isSelected, onSelect }: ProviderCardProps): JSX.Element => {
   const { t } = useLocalizations();
   const labelText = t(label);
 
   return (
     <Box
-      as='label'
+      as='button'
+      role='radio'
+      aria-checked={isSelected}
+      aria-label={labelText}
       elementDescriptor={descriptors.configureSSOProviderCard}
       elementId={descriptors.configureSSOProviderCard.setId(value)}
-      isActive={checked}
+      isActive={isSelected}
+      onClick={onSelect}
       sx={t => ({
         display: 'flex',
         flexDirection: 'column',
@@ -207,38 +244,19 @@ const ProviderCard = ({ name, value, iconId, label, checked, onChange }: Provide
         padding: t.space.$1x5,
         cursor: 'pointer',
         position: 'relative',
+        appearance: 'none',
+        textAlign: 'center',
+        backgroundColor: isSelected ? t.colors.$neutralAlpha50 : 'transparent',
         ...common.borderVariants(t).normal,
-        '&:has(input:focus-visible)': {
+        '&:focus-visible': {
           ...common.focusRingStyles(t),
           borderColor: t.colors.$borderAlpha300,
         },
         '&:hover': {
           backgroundColor: t.colors.$neutralAlpha50,
         },
-        '&:has(input:checked)': {
-          backgroundColor: t.colors.$neutralAlpha50,
-        },
       })}
     >
-      <RadioInput
-        elementDescriptor={descriptors.configureSSOProviderCardRadio}
-        elementId={descriptors.configureSSOProviderCardRadio.setId(value)}
-        name={name}
-        value={value}
-        checked={checked}
-        onChange={onChange}
-        focusRing={false}
-        sx={theme => ({
-          position: 'absolute',
-          top: theme.space.$1x5,
-          insetInlineStart: theme.space.$1x5,
-          margin: 0,
-          width: 'fit-content',
-          boxShadow: 'none',
-          '&:hover': { boxShadow: 'none' },
-        })}
-      />
-
       <Span
         elementDescriptor={descriptors.configureSSOProviderCardIcon}
         elementId={descriptors.configureSSOProviderCardIcon.setId(value)}

--- a/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/TestConfigurationStep.tsx
@@ -94,6 +94,7 @@ export const TestConfigurationStep = (): JSX.Element => {
             <Col gap={3}>
               <Text
                 as='p'
+                colorScheme='secondary'
                 localizationKey={localizationKeys('configureSSO.testConfigurationStep.subtitle')}
               />
 

--- a/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
@@ -17,22 +17,27 @@ vi.mock('../../elements/Wizard', () => ({
 }));
 
 const createEnterpriseConnection = vi.fn();
+const changeProvider = vi.fn();
 
 // Provider is sourced from the connection entity
 // (organizationEnterpriseConnection.provider) rather than a context-level
 // setProvider. The step uses goNext (not goToStep) after a successful create.
 const contextState = vi.hoisted(() => ({
-  provider: undefined as 'saml_okta' | 'saml_custom' | undefined,
+  provider: undefined as 'saml_okta' | 'saml_custom' | 'saml_google' | undefined,
+  hasConnection: false,
 }));
 
 vi.mock('../../ConfigureSSOContext', () => ({
   useConfigureSSO: () => ({
-    enterpriseConnection: undefined,
+    enterpriseConnection: contextState.hasConnection ? { id: 'ent_1' } : undefined,
+    contentRef: { current: null },
     enterpriseConnectionMutations: {
       createConnection: createEnterpriseConnection,
+      changeProvider,
     },
     organizationEnterpriseConnection: {
       provider: contextState.provider,
+      hasConnection: contextState.hasConnection,
     },
   }),
 }));
@@ -53,7 +58,10 @@ const resetMocks = () => {
   goPrev.mockReset();
   createEnterpriseConnection.mockReset();
   createEnterpriseConnection.mockResolvedValue(undefined);
+  changeProvider.mockReset();
+  changeProvider.mockResolvedValue(undefined);
   contextState.provider = undefined;
+  contextState.hasConnection = false;
 };
 
 describe('SelectProviderStep', () => {
@@ -82,7 +90,7 @@ describe('SelectProviderStep', () => {
     const { container } = renderStep(wrapper);
 
     // Emotion serializes sx into stylesheets, so we check both inline + the document's collected styles
-    const iconSpans = Array.from(container.querySelectorAll('label span[aria-hidden]'));
+    const iconSpans = Array.from(container.querySelectorAll('[role="radio"] span[aria-hidden]'));
     expect(iconSpans).toHaveLength(4);
 
     const collectedStyles = [
@@ -204,5 +212,79 @@ describe('SelectProviderStep', () => {
     renderStep(wrapper);
 
     expect(screen.getByRole('button', { name: /Previous/i })).toBeDisabled();
+  });
+
+  describe('changing provider when a connection already exists', () => {
+    it('advances without creating or changing when the connected provider is re-selected', async () => {
+      resetMocks();
+      contextState.provider = 'saml_okta';
+      contextState.hasConnection = true;
+      const { wrapper } = await createFixtures();
+      const { userEvent } = renderStep(wrapper);
+
+      // The connected provider is preselected, so Continue just walks forward.
+      await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+      await waitFor(() => {
+        expect(goNext).toHaveBeenCalled();
+      });
+      expect(createEnterpriseConnection).not.toHaveBeenCalled();
+      expect(changeProvider).not.toHaveBeenCalled();
+    });
+
+    it('opens the confirmation dialog when a different provider is selected', async () => {
+      resetMocks();
+      contextState.provider = 'saml_okta';
+      contextState.hasConnection = true;
+      const { wrapper } = await createFixtures();
+      const { userEvent } = renderStep(wrapper);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Google Workspace' }));
+      await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+      expect(await screen.findByRole('heading', { name: /change provider to google workspace/i })).toBeInTheDocument();
+      // Nothing is mutated until the user confirms.
+      expect(changeProvider).not.toHaveBeenCalled();
+      expect(goNext).not.toHaveBeenCalled();
+    });
+
+    it('changes the provider and advances when the dialog is confirmed', async () => {
+      resetMocks();
+      contextState.provider = 'saml_okta';
+      contextState.hasConnection = true;
+      const { wrapper } = await createFixtures();
+      const { userEvent } = renderStep(wrapper);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Google Workspace' }));
+      await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Change provider' }));
+
+      await waitFor(() => {
+        expect(changeProvider).toHaveBeenCalledWith('saml_google');
+      });
+      await waitFor(() => {
+        expect(goNext).toHaveBeenCalled();
+      });
+    });
+
+    it('keeps the connection and stays put when the dialog is cancelled', async () => {
+      resetMocks();
+      contextState.provider = 'saml_okta';
+      contextState.hasConnection = true;
+      const { wrapper } = await createFixtures();
+      const { userEvent } = renderStep(wrapper);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Google Workspace' }));
+      await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('heading', { name: /change provider to/i })).not.toBeInTheDocument();
+      });
+      expect(changeProvider).not.toHaveBeenCalled();
+      expect(goNext).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/__tests__/SelectProviderStep.test.tsx
@@ -71,7 +71,7 @@ describe('SelectProviderStep', () => {
     renderStep(wrapper);
 
     expect(screen.getByRole('heading', { name: 'Select your identity provider' })).toBeInTheDocument();
-    expect(screen.getByText(/We.*ll guide you through the detailed setup process next\./)).toBeInTheDocument();
+    expect(screen.getByText(/You.*ll configure the connection details in the next step/)).toBeInTheDocument();
   });
 
   it('renders all SAML provider radios with their labels', async () => {

--- a/packages/ui/src/components/ConfigureSSO/types.ts
+++ b/packages/ui/src/components/ConfigureSSO/types.ts
@@ -1,3 +1,9 @@
 export type ProviderType = 'saml_okta' | 'saml_custom' | 'saml_google' | 'saml_microsoft';
 
-export type WizardStepId = 'select-provider' | 'verify-domain' | 'configure' | 'test' | 'activate';
+export type WizardStepId =
+  | 'verify-domain'
+  | 'configure'
+  | 'select-provider'
+  | 'configure-provider'
+  | 'test'
+  | 'activate';

--- a/packages/ui/src/components/OrganizationProfile/__tests__/OrganizationSecurityPage.test.tsx
+++ b/packages/ui/src/components/OrganizationProfile/__tests__/OrganizationSecurityPage.test.tsx
@@ -225,7 +225,11 @@ describe('OrganizationSecurityPage', () => {
       // Continue passes no forced step, so the wizard resumes at the furthest-
       // reachable step for this connection (configure, since a provider connection
       // exists and the domain is verified) rather than the forced first step.
+      // Resuming into `configure` (direction 0) falls through to its furthest-
+      // reachable sub-step: a provider already exists, so it lands on
+      // `configure-provider` rather than re-showing `select-provider`.
       expect(await screen.findByRole('heading', { name: /configure okta workforce/i })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: /select your identity provider/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: /add SSO domains/i })).not.toBeInTheDocument();
     });
 

--- a/packages/ui/src/customizables/elementDescriptors.ts
+++ b/packages/ui/src/customizables/elementDescriptors.ts
@@ -629,6 +629,10 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'configureSSOResetConnectionDialogConfirmationInput',
   'configureSSOResetConnectionDialogSubmitButton',
 
+  'configureSSOChangeProviderDialog',
+  'configureSSOChangeProviderDialogCancelButton',
+  'configureSSOChangeProviderDialogConfirmButton',
+
   'configureSSORemoveDomainDialog',
   'configureSSORemoveDomainDialogCancelButton',
   'configureSSORemoveDomainDialogSubmitButton',

--- a/packages/ui/src/elements/Alert.tsx
+++ b/packages/ui/src/elements/Alert.tsx
@@ -1,23 +1,39 @@
 import type { LocalizationKey } from '../customizables';
-import { Alert as AlertCust, AlertIcon, Col, descriptors, Text } from '../customizables';
+import {
+  Alert as AlertCust,
+  AlertIcon,
+  Button,
+  Col,
+  descriptors,
+  Icon,
+  Text,
+  useLocalizations,
+} from '../customizables';
+import { Close } from '../icons';
 import type { PropsOfComponent } from '../styledSystem';
+
+type DismissProps =
+  | { onDismiss: () => void; dismissLabel: LocalizationKey | string }
+  | { onDismiss?: undefined; dismissLabel?: undefined };
 
 type _AlertProps = {
   variant?: 'danger' | 'warning' | 'info';
   title?: LocalizationKey | string;
   subtitle?: LocalizationKey | string;
-};
+} & DismissProps;
 
 type AlertProps = Omit<PropsOfComponent<typeof AlertCust>, keyof _AlertProps> & _AlertProps;
 
 export const Alert = (props: AlertProps): JSX.Element | null => {
-  const { children, title, subtitle, variant = 'warning', ...rest } = props;
+  const { children, title, subtitle, variant = 'warning', onDismiss, dismissLabel, ...rest } = props;
+  const { t } = useLocalizations();
 
   if (!children && !title && !subtitle) {
     return null;
   }
 
   const textColorScheme = variant === 'danger' ? 'danger' : variant === 'warning' ? 'warning' : 'secondary';
+  const dismissIconColorScheme = variant === 'info' ? 'neutral' : variant;
 
   return (
     <AlertCust
@@ -25,6 +41,7 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
       elementId={descriptors.alert.setId(variant)}
       colorScheme={variant}
       align='start'
+      gap={2}
       {...rest}
       sx={[rest.sx]}
     >
@@ -60,6 +77,26 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
           />
         )}
       </Col>
+      {onDismiss && (
+        <Button
+          variant='ghost'
+          colorScheme={variant === 'danger' ? 'danger' : 'neutral'}
+          aria-label={typeof dismissLabel === 'string' ? dismissLabel : dismissLabel ? t(dismissLabel) : undefined}
+          onClick={onDismiss}
+          sx={theme => ({
+            flexShrink: 0,
+            padding: theme.space.$1,
+            marginInlineStart: 'auto',
+            marginBlockStart: `calc(-1 * ${theme.space.$1})`,
+          })}
+        >
+          <Icon
+            icon={Close}
+            size='md'
+            colorScheme={dismissIconColorScheme}
+          />
+        </Button>
+      )}
     </AlertCust>
   );
 };

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -765,6 +765,10 @@ export type ElementsConfig = {
   configureSSOResetConnectionDialogConfirmationInput: WithOptions;
   configureSSOResetConnectionDialogSubmitButton: WithOptions;
 
+  configureSSOChangeProviderDialog: WithOptions;
+  configureSSOChangeProviderDialogCancelButton: WithOptions;
+  configureSSOChangeProviderDialogConfirmButton: WithOptions;
+
   configureSSORemoveDomainDialog: WithOptions;
   configureSSORemoveDomainDialogCancelButton: WithOptions;
   configureSSORemoveDomainDialogSubmitButton: WithOptions;


### PR DESCRIPTION
## Description

This PR introduces the ability to change the provider on the self-serve SSO flow, which creates a new enterprise connection. 

It allows going back from configure to the select provider step, as well as navigating from the domains step to the select provider again.



https://github.com/user-attachments/assets/3ae6d879-1467-40aa-a72f-8825fc67d672

### Other changes

- Update the copy of all steps to align with current state of Figma prototype.
- Fix size of segment controls for Identity Provider Metadata steps 
- Introduce alert on Identity Provider Metadata step, when connection is already active but user comes back to change metadata



<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “change provider” confirmation dialog to enterprise SSO setup.
  * Added a dismissible warning alert when an active enterprise connection already exists.
* **Improvements**
  * Refreshed SSO/SAML guidance copy across providers, including updated “Sign on URL” and “test URL” terminology.
  * Improved SAML attribute-mapping UX, including Microsoft claim-name truncation with copy interaction and updated mapping table labels.
* **Bug Fixes**
  * Improved wizard resume behavior to skip provider selection when an in-progress connection is already present.
* **Chores**
  * Patch version updates for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->