### PR TITLE
fix(expo): avoid AppCheckCore Google Sign-In regression

### DIFF
--- a/.changeset/expo-google-appcheckcore-pin.md
+++ b/.changeset/expo-google-appcheckcore-pin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Fixes iOS prebuild failures caused by newer Google Sign-In pod dependencies by avoiding the AppCheckCore version that requires additional CocoaPods modular header configuration.

--- a/packages/expo/ios/ClerkGoogleSignIn.podspec
+++ b/packages/expo/ios/ClerkGoogleSignIn.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'GoogleSignIn', '~> 9.0'
+  # AppCheckCore 11.3.0 introduces a RecaptchaInterop dependency that fails
+  # static CocoaPods integration unless apps opt into modular headers.
+  s.dependency 'AppCheckCore', '< 11.3.0'
 
   # Only include the Google Sign-In module files
   s.source_files = 'ClerkGoogleSignInModule.swift', 'ClerkGoogleSignInModule.m'


### PR DESCRIPTION
## Summary

Emergency unblock for iOS prebuild failures caused by the latest Google Sign-In pod graph.

Fresh pod installs can resolve `GoogleSignIn 9.2.0`, which allows `AppCheckCore 11.3.0`. `AppCheckCore 11.3.0` adds `RecaptchaInterop`; in Expo's default static CocoaPods setup that can fail unless apps add extra modular-header configuration.

Rather than mutating generated app Podfiles, this PR constrains `ClerkGoogleSignIn` away from the problematic AppCheckCore version for now:

- keep `GoogleSignIn ~> 9.0`
- add `AppCheckCore < 11.3.0`

This keeps fresh installs on the known-working AppCheckCore 11.2.x graph and avoids pulling in `RecaptchaInterop`.

## Why this shape

The earlier Podfile-mutation approach fixed the immediate failure, but it quickly became brittle because Podfiles can have custom targets, existing pod declarations, and `use_expo_modules!` variants. This emergency fix avoids editing user Podfiles entirely.

## Validation

- Previously reproduced the failing fresh pod graph: `GoogleSignIn 9.2.0`, `AppCheckCore 11.3.0`, `RecaptchaInterop 101.0.0`.
- Verified a fresh CocoaPods resolution with `GoogleSignIn ~> 9.0` plus `AppCheckCore < 11.3.0` resolves:
  - `GoogleSignIn 9.2.0`
  - `AppCheckCore 11.2.0`
  - no `RecaptchaInterop`
- Ran `ruby -c packages/expo/ios/ClerkGoogleSignIn.podspec`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS prebuild failures affecting Google Sign-In integration in the Expo package by adding a dependency constraint. This resolves build issues users may encounter during iOS app development and improves stability when implementing Google Sign-In authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->