### PR TITLE
test(e2e): skip flaky billing statements tests

### DIFF
--- a/integration/tests/billing-hooks.test.ts
+++ b/integration/tests/billing-hooks.test.ts
@@ -51,6 +51,8 @@ testAgainstRunningApps({})('billing hooks @billing', ({ app }) => {
     });
 
     test('renders billing hooks with plans, statements and subscription', async ({ page, context }) => {
+      // TODO: Re-enable once flaky statements endpoint is fixed
+      test.skip(true, 'Skipped due to flaky statements endpoint');
       const u = createTestUtils({ app, page, context });
       await u.po.signIn.goTo();
       await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });

--- a/integration/tests/pricing-table.test.ts
+++ b/integration/tests/pricing-table.test.ts
@@ -673,6 +673,8 @@ testAgainstRunningApps({})('pricing table @billing', ({ app }) => {
       page,
       context,
     }) => {
+      // TODO: Re-enable once flaky statements endpoint is fixed
+      test.skip(true, 'Skipped due to flaky statements endpoint');
       const u = createTestUtils({ app, page, context });
 
       const fakeUser = u.services.users.createFakeUser();


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled integration tests for billing features due to a known issue with the statements endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->