### PR TITLE
fix(expo): align iOS Google sign-in defaults

### DIFF
--- a/.changeset/bright-lamps-sign.md
+++ b/.changeset/bright-lamps-sign.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Fixes iOS Google One Tap sign-in to reject blank Google client IDs and to default to filtering by previously authorized accounts.

--- a/packages/expo/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo/ios/ClerkGoogleSignInModule.swift
@@ -32,8 +32,8 @@ public class ClerkGoogleSignInModule: Module {
   // MARK: - configure
 
   private func configure(_ params: [String: Any?]) {
-    let webClientId = params["webClientId"] as? String ?? ""
-    let iosClientId = params["iosClientId"] as? String
+    let webClientId = self.nonEmptyClientId(params["webClientId"] as? String)
+    let iosClientId = self.nonEmptyClientId(params["iosClientId"] as? String)
     self.clientId = iosClientId ?? webClientId
     self.hostedDomain = params["hostedDomain"] as? String
 
@@ -59,7 +59,7 @@ public class ClerkGoogleSignInModule: Module {
       return
     }
 
-    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? false
+    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? true
     let hint: String? = filterByAuthorized
       ? GIDSignIn.sharedInstance.currentUser?.profile?.email
       : nil
@@ -136,6 +136,14 @@ public class ClerkGoogleSignInModule: Module {
   }
 
   // MARK: - Helpers
+
+  private func nonEmptyClientId(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+      return nil
+    }
+
+    return value.isEmpty ? nil : value
+  }
 
   private func getPresentingViewController() -> UIViewController? {
     guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,


### PR DESCRIPTION
## Summary

Follow-up to #8901 for the two CodeRabbit comments we deferred there.

- Treat blank or whitespace-only iOS Google client IDs as unconfigured so sign-in preserves the existing NOT_CONFIGURED path.
- Default iOS Google One Tap signIn to filter by previously authorized accounts, matching Android and the documented default.

## Testing

- pnpm --filter @clerk/expo format:check
- pnpm --filter @clerk/expo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS Google One Tap sign-in now properly validates and rejects blank Google client IDs.
  * Account filtering for iOS Google One Tap now defaults to enabled, prioritizing previously authorized accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->