### PR TITLE
test(e2e): Re-enable Billing E2E tests

### DIFF
--- a/integration/tests/billing-hooks.test.ts
+++ b/integration/tests/billing-hooks.test.ts
@@ -36,6 +36,7 @@ testAgainstRunningApps({})('billing hooks @billing', ({ app }) => {
 
   test.describe('when signed in', () => {
     test.describe.configure({ mode: 'serial' });
+
     test('subscribes to a plan', async ({ page, context }) => {
       const u = createTestUtils({ app, page, context });
       await u.po.signIn.goTo();
@@ -51,8 +52,6 @@ testAgainstRunningApps({})('billing hooks @billing', ({ app }) => {
     });
 
     test('renders billing hooks with plans, statements and subscription', async ({ page, context }) => {
-      // TODO: Re-enable once flaky statements endpoint is fixed
-      test.skip(true, 'Skipped due to flaky statements endpoint');
       const u = createTestUtils({ app, page, context });
       await u.po.signIn.goTo();
       await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeUser.email, password: fakeUser.password });

--- a/integration/tests/pricing-table.test.ts
+++ b/integration/tests/pricing-table.test.ts
@@ -673,8 +673,6 @@ testAgainstRunningApps({})('pricing table @billing', ({ app }) => {
       page,
       context,
     }) => {
-      // TODO: Re-enable once flaky statements endpoint is fixed
-      test.skip(true, 'Skipped due to flaky statements endpoint');
       const u = createTestUtils({ app, page, context });
 
       const fakeUser = u.services.users.createFakeUser();


### PR DESCRIPTION
We've reverted the PR that caused flakiness.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled Playwright coverage for billing hooks so the signed-in scenario validates plans, statements, and subscription UI, and confirms the signed-out view removes statements/subscription content.
  * Re-enabled the billing history flow to verify Statements and Payment Attempt details, including empty/non-empty states and successful/failed payment rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->