### PR TITLE
fix(expo): restore iOS Google sign-in default

### DIFF
--- a/.changeset/steady-google-signin.md
+++ b/.changeset/steady-google-signin.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Restores the previous iOS Google sign-in default so sign-in does not filter by previously authorized accounts unless explicitly requested.

--- a/packages/expo/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo/ios/ClerkGoogleSignInModule.swift
@@ -59,7 +59,7 @@ public class ClerkGoogleSignInModule: Module {
       return
     }
 
-    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? true
+    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? false
     let hint: String? = filterByAuthorized
       ? GIDSignIn.sharedInstance.currentUser?.profile?.email
       : nil


### PR DESCRIPTION
## Summary

Restore the previous iOS Google sign-in default for `filterByAuthorizedAccounts`.

On iOS, callers must now explicitly pass `filterByAuthorizedAccounts: true` to enable this behavior.

## Testing

- pnpm --filter @clerk/expo format:check
- pnpm --filter @clerk/expo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Restored iOS Google sign-in default behavior. Sign-in now displays all available accounts instead of filtering to only previously authorized ones. Users can explicitly enable account filtering if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->