### PR TITLE
feat(expo): add iOS Google sign-in hint

### DIFF
--- a/.changeset/bright-google-docs.md
+++ b/.changeset/bright-google-docs.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Adds an iOS Google sign-in `hint` option and clarifies that Android account filtering is platform-specific.

--- a/packages/expo/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo/ios/ClerkGoogleSignInModule.swift
@@ -59,10 +59,7 @@ public class ClerkGoogleSignInModule: Module {
       return
     }
 
-    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? false
-    let hint: String? = filterByAuthorized
-      ? GIDSignIn.sharedInstance.currentUser?.profile?.email
-      : nil
+    let hint = params?["hint"] as? String
     let nonce = params?["nonce"] as? String
 
     GIDSignIn.sharedInstance.signIn(

--- a/packages/expo/src/google-one-tap/ClerkGoogleOneTapSignIn.ts
+++ b/packages/expo/src/google-one-tap/ClerkGoogleOneTapSignIn.ts
@@ -85,7 +85,8 @@ export const ClerkGoogleOneTapSignIn = {
    *
    * @param params - Sign-in parameters
    * @param params.nonce - Cryptographic nonce for replay protection
-   * @param params.filterByAuthorizedAccounts - Only show previously authorized accounts (default: true)
+   * @param params.filterByAuthorizedAccounts - Android only. Filter to previously authorized accounts.
+   * @param params.hint - iOS only. Hint for Google Sign-In.
    *
    * @returns Promise resolving to OneTapResponse
    */

--- a/packages/expo/src/google-one-tap/types.ts
+++ b/packages/expo/src/google-one-tap/types.ts
@@ -41,11 +41,28 @@ export type SignInParams = {
   nonce?: string;
 
   /**
-   * Whether to filter credentials to only show accounts that have been
-   * previously authorized for this app.
+   * Android only. Whether to filter credentials to only show accounts that have
+   * previously authorized this app.
+   *
+   * No-op on iOS.
+   *
+   * @platform Android
    * @default true
    */
   filterByAuthorizedAccounts?: boolean;
+
+  /**
+   * iOS only. Hint passed to Google Sign-In, such as a user ID or email
+   * address.
+   *
+   * This may prefill or prioritize an account when possible, but does not
+   * restrict the account picker.
+   *
+   * No-op on Android.
+   *
+   * @platform iOS
+   */
+  hint?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds an iOS-only `hint` option for Google Sign-In and documents `filterByAuthorizedAccounts` as Android-only.

## Reasoning

Google does not document these as one shared cross-platform option. The Android Credential Manager API exposes `setFilterByAuthorizedAccounts(boolean)` on `GetGoogleIdOption.Builder`, where it controls whether the account picker is limited to accounts already authorized for the app. The iOS Google Sign-In API exposes `hint` on `GIDSignIn.signIn(...)`, where it can prefill or prioritize a user ID or email address but does not strictly filter the account picker.

This keeps the Expo API usable from one shared call site: apps can pass both options, Android consumes `filterByAuthorizedAccounts` and ignores `hint`, and iOS consumes `hint` and ignores `filterByAuthorizedAccounts`.

## Backward compatibility

This is additive for JavaScript callers: existing `signIn` calls continue to work, and Android keeps the existing `filterByAuthorizedAccounts` behavior and default. On iOS, `filterByAuthorizedAccounts` is now treated as an Android-only option. A previous implementation briefly mapped that option to an implicit restored-user email hint on iOS, but that did not match Google’s platform APIs because `hint` does not strictly filter the account picker. Use the new `hint` option when an iOS sign-in hint is desired.
