### PR TITLE
chore(expo): Revert iOS Google Sign-In Expo module registration

### DIFF
--- a/.changeset/tall-cameras-laugh.md
+++ b/.changeset/tall-cameras-laugh.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Revert the iOS Google Sign-In module registration to restore the previous iOS build behavior.

--- a/packages/expo/expo-module.config.json
+++ b/packages/expo/expo-module.config.json
@@ -1,8 +1,5 @@
 {
   "platforms": ["apple", "android"],
-  "apple": {
-    "modules": ["ClerkGoogleSignInModule"]
-  },
   "android": {
     "modules": [
       "expo.modules.clerk.ClerkExpoModule",

--- a/packages/expo/ios/ClerkGoogleSignIn.podspec
+++ b/packages/expo/ios/ClerkGoogleSignIn.podspec
@@ -16,11 +16,9 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'GoogleSignIn', '~> 9.0'
-  s.dependency 'GoogleUtilities'
-  s.dependency 'RecaptchaInterop'
 
   # Only include the Google Sign-In module files
-  s.source_files = 'ClerkGoogleSignInModule.swift'
+  s.source_files = 'ClerkGoogleSignInModule.swift', 'ClerkGoogleSignInModule.m'
 
   install_modules_dependencies(s)
 end

--- a/packages/expo/ios/ClerkGoogleSignInModule.m
+++ b/packages/expo/ios/ClerkGoogleSignInModule.m
@@ -1,0 +1,22 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(ClerkGoogleSignIn, NSObject)
+
+RCT_EXTERN_METHOD(configure:(NSDictionary *)params)
+
+RCT_EXTERN_METHOD(signIn:(NSDictionary *)params
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(createAccount:(NSDictionary *)params
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(presentExplicitSignIn:(NSDictionary *)params
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(signOut:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/packages/expo/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo/ios/ClerkGoogleSignInModule.swift
@@ -1,37 +1,23 @@
-import ExpoModulesCore
+import React
 import GoogleSignIn
 
-public class ClerkGoogleSignInModule: Module {
+@objc(ClerkGoogleSignIn)
+class ClerkGoogleSignInModule: NSObject, RCTBridgeModule {
+
+  static func moduleName() -> String! {
+    return "ClerkGoogleSignIn"
+  }
+
+  @objc static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
   private var clientId: String?
   private var hostedDomain: String?
 
-  public func definition() -> ModuleDefinition {
-    Name("ClerkGoogleSignIn")
-
-    Function("configure") { (params: [String: Any?]) in
-      self.configure(params)
-    }
-
-    AsyncFunction("signIn") { (params: [String: Any?]?, promise: Promise) in
-      self.signIn(params, promise: promise)
-    }.runOnQueue(.main)
-
-    AsyncFunction("createAccount") { (params: [String: Any?]?, promise: Promise) in
-      self.createAccount(params, promise: promise)
-    }.runOnQueue(.main)
-
-    AsyncFunction("presentExplicitSignIn") { (params: [String: Any?]?, promise: Promise) in
-      self.presentExplicitSignIn(params, promise: promise)
-    }.runOnQueue(.main)
-
-    AsyncFunction("signOut") { (promise: Promise) in
-      self.signOut(promise: promise)
-    }.runOnQueue(.main)
-  }
-
   // MARK: - configure
 
-  private func configure(_ params: [String: Any?]) {
+  @objc func configure(_ params: NSDictionary) {
     let webClientId = self.nonEmptyClientId(params["webClientId"] as? String)
     let iosClientId = self.nonEmptyClientId(params["iosClientId"] as? String)
     self.clientId = iosClientId ?? webClientId
@@ -48,91 +34,101 @@ public class ClerkGoogleSignInModule: Module {
 
   // MARK: - signIn
 
-  private func signIn(_ params: [String: Any?]?, promise: Promise) {
+  @objc func signIn(_ params: NSDictionary?,
+                     resolve: @escaping RCTPromiseResolveBlock,
+                     reject: @escaping RCTPromiseRejectBlock) {
     guard self.clientId != nil else {
-      promise.reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.")
+      reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.", nil)
       return
     }
 
-    guard let presentingVC = self.getPresentingViewController() else {
-      promise.reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available")
-      return
-    }
-
-    let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? false
-    let hint: String? = filterByAuthorized
-      ? GIDSignIn.sharedInstance.currentUser?.profile?.email
-      : nil
-    let nonce = params?["nonce"] as? String
-
-    GIDSignIn.sharedInstance.signIn(
-      withPresenting: presentingVC,
-      hint: hint,
-      additionalScopes: nil,
-      nonce: nonce,
-      completion: { result, error in
-        self.handleSignInResult(result: result, error: error, promise: promise)
+    DispatchQueue.main.async {
+      guard let presentingVC = self.getPresentingViewController() else {
+        reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available", nil)
+        return
       }
-    )
+
+      let filterByAuthorized = params?["filterByAuthorizedAccounts"] as? Bool ?? false
+      let hint: String? = filterByAuthorized
+        ? GIDSignIn.sharedInstance.currentUser?.profile?.email
+        : nil
+      let nonce = params?["nonce"] as? String
+
+      GIDSignIn.sharedInstance.signIn(
+        withPresenting: presentingVC,
+        hint: hint,
+        additionalScopes: nil,
+        nonce: nonce
+      ) { result, error in
+        self.handleSignInResult(result: result, error: error, resolve: resolve, reject: reject)
+      }
+    }
   }
 
   // MARK: - createAccount
 
-  private func createAccount(_ params: [String: Any?]?, promise: Promise) {
+  @objc func createAccount(_ params: NSDictionary?,
+                             resolve: @escaping RCTPromiseResolveBlock,
+                             reject: @escaping RCTPromiseRejectBlock) {
     guard self.clientId != nil else {
-      promise.reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.")
+      reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.", nil)
       return
     }
 
-    guard let presentingVC = self.getPresentingViewController() else {
-      promise.reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available")
-      return
-    }
-
-    let nonce = params?["nonce"] as? String
-
-    GIDSignIn.sharedInstance.signIn(
-      withPresenting: presentingVC,
-      hint: nil,
-      additionalScopes: nil,
-      nonce: nonce,
-      completion: { result, error in
-        self.handleSignInResult(result: result, error: error, promise: promise)
+    DispatchQueue.main.async {
+      guard let presentingVC = self.getPresentingViewController() else {
+        reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available", nil)
+        return
       }
-    )
+
+      let nonce = params?["nonce"] as? String
+
+      GIDSignIn.sharedInstance.signIn(
+        withPresenting: presentingVC,
+        hint: nil,
+        additionalScopes: nil,
+        nonce: nonce
+      ) { result, error in
+        self.handleSignInResult(result: result, error: error, resolve: resolve, reject: reject)
+      }
+    }
   }
 
   // MARK: - presentExplicitSignIn
 
-  private func presentExplicitSignIn(_ params: [String: Any?]?, promise: Promise) {
+  @objc func presentExplicitSignIn(_ params: NSDictionary?,
+                                     resolve: @escaping RCTPromiseResolveBlock,
+                                     reject: @escaping RCTPromiseRejectBlock) {
     guard self.clientId != nil else {
-      promise.reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.")
+      reject("NOT_CONFIGURED", "Google Sign-In is not configured. Call configure() first.", nil)
       return
     }
 
-    guard let presentingVC = self.getPresentingViewController() else {
-      promise.reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available")
-      return
-    }
-
-    let nonce = params?["nonce"] as? String
-
-    GIDSignIn.sharedInstance.signIn(
-      withPresenting: presentingVC,
-      hint: nil,
-      additionalScopes: nil,
-      nonce: nonce,
-      completion: { result, error in
-        self.handleSignInResult(result: result, error: error, promise: promise)
+    DispatchQueue.main.async {
+      guard let presentingVC = self.getPresentingViewController() else {
+        reject("GOOGLE_SIGN_IN_ERROR", "No presenting view controller available", nil)
+        return
       }
-    )
+
+      let nonce = params?["nonce"] as? String
+
+      GIDSignIn.sharedInstance.signIn(
+        withPresenting: presentingVC,
+        hint: nil,
+        additionalScopes: nil,
+        nonce: nonce
+      ) { result, error in
+        self.handleSignInResult(result: result, error: error, resolve: resolve, reject: reject)
+      }
+    }
   }
 
   // MARK: - signOut
 
-  private func signOut(promise: Promise) {
+  @objc func signOut(_ resolve: @escaping RCTPromiseResolveBlock,
+                      reject: @escaping RCTPromiseRejectBlock) {
     GIDSignIn.sharedInstance.signOut()
-    promise.resolve()
+    resolve(nil)
   }
 
   // MARK: - Helpers
@@ -159,23 +155,25 @@ public class ClerkGoogleSignInModule: Module {
     return topVC
   }
 
-  private func handleSignInResult(result: GIDSignInResult?, error: Error?, promise: Promise) {
+  private func handleSignInResult(result: GIDSignInResult?, error: Error?,
+                                   resolve: @escaping RCTPromiseResolveBlock,
+                                   reject: @escaping RCTPromiseRejectBlock) {
     if let error = error {
       let nsError = error as NSError
 
       // Check for user cancellation
       if nsError.domain == kGIDSignInErrorDomain && nsError.code == GIDSignInError.canceled.rawValue {
-        promise.reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow")
+        reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow", error)
         return
       }
 
-      promise.reject("GOOGLE_SIGN_IN_ERROR", error.localizedDescription)
+      reject("GOOGLE_SIGN_IN_ERROR", error.localizedDescription, error)
       return
     }
 
     guard let result = result,
           let idToken = result.user.idToken?.tokenString else {
-      promise.reject("GOOGLE_SIGN_IN_ERROR", "No ID token received")
+      reject("GOOGLE_SIGN_IN_ERROR", "No ID token received", nil)
       return
     }
 
@@ -197,6 +195,6 @@ public class ClerkGoogleSignInModule: Module {
       ] as [String: Any]
     ]
 
-    promise.resolve(response)
+    resolve(response)
   }
 }

--- a/packages/expo/src/specs/NativeClerkGoogleSignIn.ts
+++ b/packages/expo/src/specs/NativeClerkGoogleSignIn.ts
@@ -1,13 +1,13 @@
-import { requireOptionalNativeModule } from 'expo';
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypesNamespace';
 
-type NativeMap = Record<string, unknown>;
-
-interface Spec {
-  configure(params: NativeMap): void;
-  signIn(params: NativeMap | null): Promise<NativeMap>;
-  createAccount(params: NativeMap | null): Promise<NativeMap>;
-  presentExplicitSignIn(params: NativeMap | null): Promise<NativeMap>;
+export interface Spec extends TurboModule {
+  configure(params: UnsafeObject): void;
+  signIn(params: UnsafeObject | null): Promise<UnsafeObject>;
+  createAccount(params: UnsafeObject | null): Promise<UnsafeObject>;
+  presentExplicitSignIn(params: UnsafeObject | null): Promise<UnsafeObject>;
   signOut(): Promise<void>;
 }
 
-export default requireOptionalNativeModule<Spec>('ClerkGoogleSignIn');
+export default TurboModuleRegistry.get<Spec>('ClerkGoogleSignIn');


### PR DESCRIPTION
## Description

Reverts the iOS Google Sign-In module registration added in #8901

The Expo module registration caused iOS builds to compile `ClerkGoogleSignInModule.swift` as an Expo module, which introduced build failures for apps that do not use native Google Sign-In:

```txt
node_modules/@clerk/expo/ios/ClerkGoogleSignInModule.swift:1:8: error: no such module
'ExpoModulesCore'
import ExpoModulesCore
```

This restores the previous React bridge setup for the iOS Google Sign-In module and removes
the added Google pod dependencies that were part of the Expo module registration change.

The follow-up behavior fixes from #8903/#8905 are intentionally kept.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored iOS Google Sign-In module registration to fix iOS build behavior and re-enable sign-in, account creation, and sign-out functionality on iOS.

* **Chores**
  * Released patch update to `@clerk/expo` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->