### PR TITLE
fix(react): Use globalThis instead of bare global in the browser Clerk loader

### DIFF
--- a/.changeset/silly-pumas-cheer.md
+++ b/.changeset/silly-pumas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/react': patch
+---
+
+Fix `ReferenceError: global is not defined` thrown from the browser Clerk loader during `<ClerkProvider>` startup in production builds (seen in TanStack Start and React Router apps). The loader now reads the Clerk global via `globalThis` instead of relying on a `window.global` polyfill side-effect, whose load order across bundler chunks was not guaranteed.

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -91,12 +91,10 @@ const SDK_METADATA = {
   environment: process.env.NODE_ENV,
 };
 
-export interface Global {
-  Clerk?: HeadlessBrowserClerk | BrowserClerk;
-  __internal_ClerkUICtor?: ClerkUIConstructor;
+declare global {
+  var Clerk: HeadlessBrowserClerk | BrowserClerk | undefined;
+  var __internal_ClerkUICtor: ClerkUIConstructor | undefined;
 }
-
-declare const global: Global;
 
 type GenericFunction<TArgs = never> = (...args: TArgs[]) => unknown;
 
@@ -548,19 +546,19 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
       });
     }
 
-    // Otherwise, set global.Clerk to the bundled ctor or instance
+    // Otherwise, set globalThis.Clerk to the bundled ctor or instance
     if (this.options.Clerk && !this.options.__internal_clerkJSUrl) {
-      global.Clerk = isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstructor>(this.options.Clerk)
+      globalThis.Clerk = isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstructor>(this.options.Clerk)
         ? new this.options.Clerk(this.#publishableKey, { proxyUrl: this.proxyUrl, domain: this.domain })
         : this.options.Clerk;
     }
 
-    if (!global.Clerk) {
+    if (!globalThis.Clerk) {
       // TODO @nikos: somehow throw if clerk ui failed to load but it was not headless
       throw new Error('Failed to download latest ClerkJS. Contact support@clerk.com.');
     }
 
-    return global.Clerk;
+    return globalThis.Clerk;
   }
 
   private async getClerkUIEntryChunk(): Promise<ClerkUIConstructor | undefined> {
@@ -587,11 +585,11 @@ export class IsomorphicClerk implements IsomorphicLoadedClerk {
         nonce: this.options.nonce,
       });
 
-      if (!global.__internal_ClerkUICtor) {
+      if (!globalThis.__internal_ClerkUICtor) {
         throw new Error('Failed to download latest Clerk UI. Contact support@clerk.com.');
       }
 
-      return global.__internal_ClerkUICtor;
+      return globalThis.__internal_ClerkUICtor;
     }
 
     return undefined;


### PR DESCRIPTION
Fixes #8871. `<ClerkProvider>` crashed in production builds (TanStack Start, React Router) with `ReferenceError: global is not defined`. The loader read a bare `global.Clerk` that only resolved via the `window.global` polyfill on the package's main entry, but the provider comes in through `@clerk/react/internal`, which never imports that polyfill; since the tsdown migration (#8177) split the package into chunks, a production bundle can reach the loader with the polyfill absent. Using `globalThis` drops the dependency.

The bit worth scrutiny is the type change: `declare const global` only typed the `global` name, so `globalThis.Clerk` needs a `declare global` augmentation. It's intentionally not emitted into the public `.d.ts`, so consumers don't gain an ambient `Clerk` global. The `window.global` polyfill is kept for older clerk-js runtimes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a runtime initialization error that occurred in production environments during ClerkProvider startup, particularly in applications using TanStack Start and React Router. The fix improves compatibility across different bundler configurations and ensures reliable operation in all supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->