### PR TITLE
fix(expo): declare Google Sign-In ExpoModulesCore dependency

### DIFF
--- a/.changeset/tiny-google-pods.md
+++ b/.changeset/tiny-google-pods.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Fixes iOS builds for Expo apps by explicitly declaring the native Google Sign-In module's dependency on ExpoModulesCore.

--- a/packages/expo/ios/ClerkGoogleSignIn.podspec
+++ b/packages/expo/ios/ClerkGoogleSignIn.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/clerk/javascript.git' }
   s.static_framework = true
 
+  s.dependency 'ExpoModulesCore'
   s.dependency 'GoogleSignIn', '~> 9.0'
   s.dependency 'GoogleUtilities'
   s.dependency 'RecaptchaInterop'


### PR DESCRIPTION
## Summary

Adds `ExpoModulesCore` as an explicit dependency of the iOS `ClerkGoogleSignIn` pod.

## Why

After #8901, `ClerkGoogleSignInModule.swift` became an Expo module and now imports `ExpoModulesCore`:

```swift
import ExpoModulesCore
```

The `ClerkGoogleSignIn` podspec did not declare `ExpoModulesCore` directly, so the generated Podfile could include `ExpoModulesCore` elsewhere in the app while the `ClerkGoogleSignIn` pod target still could not import it.

This shows up at Xcode compile time, not during prebuild or pod install:

```txt
node_modules/@clerk/expo/ios/ClerkGoogleSignInModule.swift:1:8: error: no such module 'ExpoModulesCore'
import ExpoModulesCore
       ^
```

Declaring the dependency on the pod that imports it makes CocoaPods wire the module search path correctly for `ClerkGoogleSignIn`.

## Validation

I reproduced the failure locally by installing a test package that matched 3.4.4 but removed only the `ExpoModulesCore` dependency from `ClerkGoogleSignIn.podspec`.

Without this change:

- `npx expo prebuild --clean --platform ios` passed
- `npx expo run:ios --no-bundler` failed with `no such module 'ExpoModulesCore'`
- `Podfile.lock` showed `ExpoModulesCore` existed globally, but not under `ClerkGoogleSignIn`

With this change:

- `npx expo prebuild --clean --platform ios` passed
- `Podfile.lock` showed `ClerkGoogleSignIn` directly depends on `ExpoModulesCore`
- `npx expo run:ios --no-bundler` passed
- The app loaded in the iOS simulator through Metro

Also ran:

- `pnpm --filter @clerk/expo format:check`
- `git diff --check`

Note: local shell reports Node `v22.12.0`, while the repo asks for `>=24.15.0`.
