### PR TITLE
fix(ui): Simple theme checkbox styles

### DIFF
--- a/.changeset/kind-melons-own.md
+++ b/.changeset/kind-melons-own.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix checkbox default styles when using the simple theme.

--- a/packages/ui/src/baseTheme.ts
+++ b/packages/ui/src/baseTheme.ts
@@ -60,6 +60,21 @@ const checkboxShadowStyles = (
   };
 };
 
+const checkboxBaseStyles = (theme: InternalTheme) => ({
+  padding: theme.space.$1,
+  width: theme.sizes.$3x5,
+  height: theme.sizes.$3x5,
+  appearance: 'none' as const,
+  borderRadius: theme.radii.$sm,
+  backgroundSize: `${theme.sizes.$2} ${theme.sizes.$2}`,
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  '&:checked': {
+    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 8 8'%3E%3Cpath fill='${theme.colors.$white}' fill-rule='evenodd' d='M7.712.233a.889.889 0 0 1 .055 1.256C6.742 2.61 6.249 3.291 5.508 4.615c-.279.5-.589 1.194-.835 1.784a36.761 36.761 0 0 0-.382.95l-.021.057-.006.014-.001.003a.89.89 0 0 1-1.504.27L.218 4.765A.889.889 0 1 1 1.56 3.6l1.591 1.834c.235-.548.524-1.181.806-1.685.807-1.445 1.38-2.239 2.499-3.46A.889.889 0 0 1 7.712.234Z' clip-rule='evenodd'/%3E%3C/svg%3E")`,
+    backgroundColor: theme.colors.$primary500,
+  },
+});
+
 const inputStyles = (theme: InternalTheme) => ({
   borderWidth: 0,
   ...inputShadowStyles(theme, {
@@ -177,6 +192,7 @@ const clerkTheme: Appearance = {
         },
       },
       checkbox: {
+        ...checkboxBaseStyles(theme),
         ...checkboxShadowStyles(theme, {
           idle1: theme.colors.$neutralAlpha150,
           idle2: theme.colors.$neutralAlpha100,
@@ -184,19 +200,10 @@ const clerkTheme: Appearance = {
           hover2: theme.colors.$neutralAlpha150,
           focus: theme.colors.$neutralAlpha150,
         }),
-        padding: theme.space.$1,
-        width: theme.sizes.$3x5,
-        height: theme.sizes.$3x5,
-        appearance: 'none',
-        borderRadius: theme.radii.$sm,
         border: 'none',
-        backgroundSize: `${theme.sizes.$2} ${theme.sizes.$2}`,
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
         '&:checked': {
-          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 8 8'%3E%3Cpath fill='${theme.colors.$white}' fill-rule='evenodd' d='M7.712.233a.889.889 0 0 1 .055 1.256C6.742 2.61 6.249 3.291 5.508 4.615c-.279.5-.589 1.194-.835 1.784a36.761 36.761 0 0 0-.382.95l-.021.057-.006.014-.001.003a.89.89 0 0 1-1.504.27L.218 4.765A.889.889 0 1 1 1.56 3.6l1.591 1.834c.235-.548.524-1.181.806-1.685.807-1.445 1.38-2.239 2.499-3.46A.889.889 0 0 1 7.712.234Z' clip-rule='evenodd'/%3E%3C/svg%3E")`,
+          ...checkboxBaseStyles(theme)['&:checked'],
           borderColor: theme.colors.$transparent,
-          backgroundColor: theme.colors.$primary500,
         },
       },
       tagInputContainer: {

--- a/packages/ui/src/elements/FieldControl.tsx
+++ b/packages/ui/src/elements/FieldControl.tsx
@@ -230,7 +230,6 @@ const CheckboxIndicator = forwardRef<HTMLInputElement, CheckboxIndicatorProps>(
         elementId={elementId || descriptors.formFieldInput.setId(formField.fieldId)}
         focusRing={false}
         sx={t => ({
-          width: 'fit-content',
           flexShrink: 0,
           marginTop: t.space.$0x5,
         })}

--- a/packages/ui/src/primitives/Input.tsx
+++ b/packages/ui/src/primitives/Input.tsx
@@ -18,8 +18,21 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     outlineOffset: '2px',
     maxHeight: theme.sizes.$9,
     width: props.type === 'checkbox' ? theme.sizes.$4 : '100%',
-    aspectRatio: props.type === 'checkbox' ? '1/1' : 'unset',
     accentColor: theme.colors.$primary500,
+    ...(props.type === 'checkbox'
+      ? {
+          appearance: 'none',
+          height: theme.sizes.$4,
+          padding: theme.space.$1,
+          backgroundSize: `${theme.sizes.$2} ${theme.sizes.$2}`,
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+          '&:checked': {
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 8 8'%3E%3Cpath fill='${theme.colors.$white}' fill-rule='evenodd' d='M7.712.233a.889.889 0 0 1 .055 1.256C6.742 2.61 6.249 3.291 5.508 4.615c-.279.5-.589 1.194-.835 1.784a36.761 36.761 0 0 0-.382.95l-.021.057-.006.014-.001.003a.89.89 0 0 1-1.504.27L.218 4.765A.889.889 0 1 1 1.56 3.6l1.591 1.834c.235-.548.524-1.181.806-1.685.807-1.445 1.38-2.239 2.499-3.46A.889.889 0 0 1 7.712.234Z' clip-rule='evenodd'/%3E%3C/svg%3E")`,
+            backgroundColor: theme.colors.$primary500,
+          },
+        }
+      : {}),
     ...common.textVariants(theme).body,
     ...common.disabled(theme),
     // This is a workaround to prevent zooming on iOS when focusing an input
@@ -40,6 +53,7 @@ const { applyVariants, filterProps } = createVariants((theme, props) => ({
     variant: {
       default: {
         ...common.borderVariants(theme, props).normal,
+        ...(props.type === 'checkbox' ? { borderRadius: theme.radii.$sm } : {}),
       },
       unstyled: {
         borderWidth: 0,


### PR DESCRIPTION
## Description

Fixes an issue in simple theme usage where checkboxes where not preserving their default styles.

| BEFORE | AFTER |
|--------|--------|
| <img width="503" height="200" alt="Screenshot 2026-06-18 at 4 53 29 PM" src="https://github.com/user-attachments/assets/4ab21089-910b-43e5-81de-46daedca6946" /> | <img width="528" height="250" alt="Screenshot 2026-06-18 at 4 52 54 PM" src="https://github.com/user-attachments/assets/4769fae4-7f75-4e7e-b29e-49ab0648a231" /> |
| <img width="487" height="255" alt="Screenshot 2026-06-18 at 4 53 55 PM" src="https://github.com/user-attachments/assets/6509691a-c774-470c-991f-5f4ec31af560" /> | <img width="483" height="244" alt="Screenshot 2026-06-18 at 4 54 20 PM" src="https://github.com/user-attachments/assets/ab44a5af-388f-4068-b93e-7bdc420a373e" /> |

BEFORE

https://github.com/user-attachments/assets/ee1adfe1-ebfd-4475-acba-d5419411fee0

AFTER

https://github.com/user-attachments/assets/89ccca2b-33c4-4684-93ed-5b41fadc45c9

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
