### PR TITLE
fix(electron): support loopback renderer passkeys

### DIFF
--- a/.changeset/electron-passkeys-loopback-webauthn.md
+++ b/.changeset/electron-passkeys-loopback-webauthn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/electron": patch
+---
+
+Allow Electron passkeys to use browser WebAuthn on loopback development origins and fall back to native passkeys when the renderer cannot handle public key credentials.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -163,8 +163,8 @@ app.whenReady().then(() => {
 
 Passkey support works in two modes, selected automatically per request:
 
-- **Renderer mode** — when your window loads content over `https://` from an origin that matches your passkey RP ID, the renderer's built-in Chromium WebAuthn is used. Credentials are synced by the OS/browser ecosystem (Windows Hello works out of the box; Touch ID on macOS requires Electron ≥ 42 and [`app.configureWebAuthn`](https://www.electronjs.org/docs/latest/api/app#appconfigurewebauthnoptions-macos)).
-- **Native mode** — when your window loads a local bundle (`file://` or a custom protocol), WebAuthn's origin checks reject the request, so the ceremony is routed over IPC to the main process and serviced by the OS WebAuthn APIs (AuthenticationServices on macOS, `webauthn.dll` on Windows) via the optional [`@clerk/electron-passkeys`](https://github.com/clerk/javascript/tree/main/packages/electron-passkeys) native module.
+- **Renderer mode**: when your window loads content over `https://` from an origin that matches your passkey RP (Relying Party) ID, the renderer's built-in Chromium WebAuthn is used. Credentials are synced by the OS/browser ecosystem (Windows Hello works out of the box; Touch ID on macOS requires Electron ≥ 42 and [`app.configureWebAuthn`](https://www.electronjs.org/docs/latest/api/app#appconfigurewebauthnoptions-macos)).
+- **Native mode**: when your window loads a local bundle (e.g. `scheme://host`), WebAuthn's origin checks reject the request, so the ceremony is routed over IPC to the main process and serviced by the OS WebAuthn APIs (AuthenticationServices on macOS, `webauthn.dll` on Windows) via the optional [`@clerk/electron-passkeys`](https://github.com/clerk/javascript/tree/main/packages/electron-passkeys) native module.
 
 ### Setup
 
@@ -218,16 +218,16 @@ await clerk.load();
 
 Like passkeys on iOS, the macOS platform APIs require a verified association between your app and your domain:
 
-1. Serve an `apple-app-site-association` file from `https://<rp-domain>/.well-known/apple-app-site-association` (https, no redirect, `application/json`) listing your app: `{"webcredentials": {"apps": ["<TEAMID>.<bundle-id>"]}}`. The RP domain must be publicly reachable — Apple's CDN fetches it.
-2. Sign your app with `com.apple.developer.associated-domains` containing `webcredentials:<rp-domain>`. This is a _restricted_ entitlement: the build must embed a provisioning profile with the Associated Domains capability for the bundle ID, and the entitlements must also include `com.apple.application-identifier` and `com.apple.developer.team-identifier` matching the profile.
+1. In the Clerk Dashboard, navigate to the [Native applications](https://dashboard.clerk.com/~/native-applications) page and ensure that the Native API is enabled. This is required to integrate Clerk in your Electron application.
+2. Add an iOS application to the [Native applications](https://dashboard.clerk.com/~/native-applications) page in the Clerk Dashboard. You will need your app's App ID Prefix and Bundle ID. An Electron macOS app uses the same configuration as iOS applications.
+3. Sign your app with `com.apple.developer.associated-domains` containing `webcredentials:<rp-domain>`. This is a _restricted_ entitlement: the build must embed a provisioning profile with the Associated Domains capability for the bundle ID, and the entitlements must also include `com.apple.application-identifier` and `com.apple.developer.team-identifier` matching the profile.
 
-Hard-won development-build checklist (each of these failure modes produces the same opaque "not associated with domain" error):
+Quick Tips (each of these failure modes produces the same opaque "not associated with domain" error):
 
 - Sign with an **Apple Development** identity (`mac.type: development` in electron-builder) and a **macOS App Development** profile that includes your Mac; also install the profile on the machine (`~/Library/Developer/Xcode/UserData/Provisioning Profiles/<UUID>.provisionprofile`).
-- Copy `.app` bundles with `ditto`, never `cp -R` — `cp` breaks the bundle seal, and macOS silently ignores the entitlements of an app whose signature fails `codesign --verify --deep --strict`.
+- Copy `.app` bundles with `ditto`. Other copy methods may break the app seal and macOS silently ignores the entitlements of an app whose signature fails `codesign --verify --deep --strict`.
 - The system registers the domain association via `swcd` when the app launches; verify with `sudo swcutil show`. If state gets stuck, `sudo swcutil reset` and relaunch.
-- Prefer the default (production/CDN) association route. `?mode=developer` + `sudo swcutil developer-mode -e true` exists but is flaky in practice.
-- The system log tells the truth: `log stream --predicate 'process == "swcd" OR composedMessage CONTAINS "your.domain"'` while launching, and look for `taskgated-helper: allowing entitlement(s) ... due to provisioning profile`.
+- Prefer the default (production/CDN) association route. `?mode=developer` + `sudo swcutil developer-mode -e true` exists but is often flaky.
 
 Windows has no equivalent requirement. On Linux there is no native path; passkeys work in renderer mode only (including external security keys).
 

--- a/packages/electron/src/passkeys/__tests__/index.test.ts
+++ b/packages/electron/src/passkeys/__tests__/index.test.ts
@@ -48,6 +48,18 @@ const requestOptions = () =>
     allowCredentials: [],
   }) as never;
 
+const creationOptionsForRpId = (rpId: string) =>
+  ({
+    ...creationOptions(),
+    rp: { id: rpId, name: 'Example' },
+  }) as never;
+
+const requestOptionsForRpId = (rpId: string) =>
+  ({
+    ...requestOptions(),
+    rpId,
+  }) as never;
+
 const registrationJSON = {
   id: HELLO_B64URL,
   rawId: HELLO_B64URL,
@@ -141,6 +153,23 @@ describe('createPasskeys', () => {
       expect(result.error).toBeNull();
     });
 
+    it('retries natively when browser WebAuthn does not support public key credentials', async () => {
+      const bridge = makeBridge();
+      stubEnvironment({ protocol: 'http:', hostname: 'localhost', bridge });
+      vi.mocked(webAuthnCreateCredential).mockResolvedValue({
+        publicKeyCredential: null,
+        error: Object.assign(new Error('The user agent does not support public key credentials.'), {
+          name: 'NotSupportedError',
+        }),
+      } as never);
+
+      const result = await createPasskeys().create(creationOptionsForRpId('localhost'));
+
+      expect(webAuthnCreateCredential).toHaveBeenCalled();
+      expect(bridge.create).toHaveBeenCalled();
+      expect(result.error).toBeNull();
+    });
+
     it('does not retry natively when the user cancels in the renderer', async () => {
       const bridge = makeBridge();
       stubEnvironment({ bridge });
@@ -153,6 +182,23 @@ describe('createPasskeys', () => {
       const result = await createPasskeys().create(creationOptions());
 
       expect(result).toBe(cancelled);
+      expect(bridge.create).not.toHaveBeenCalled();
+    });
+
+    it('does not retry natively for unsupported browser WebAuthn when renderer mode is forced', async () => {
+      const bridge = makeBridge();
+      stubEnvironment({ protocol: 'http:', hostname: 'localhost', bridge });
+      const unsupported = {
+        publicKeyCredential: null,
+        error: Object.assign(new Error('The user agent does not support public key credentials.'), {
+          name: 'NotSupportedError',
+        }),
+      };
+      vi.mocked(webAuthnCreateCredential).mockResolvedValue(unsupported as never);
+
+      const result = await createPasskeys({ mode: 'renderer' }).create(creationOptionsForRpId('localhost'));
+
+      expect(result).toBe(unsupported);
       expect(bridge.create).not.toHaveBeenCalled();
     });
 
@@ -227,6 +273,26 @@ describe('createPasskeys', () => {
       expect(bridge.get).toHaveBeenCalledWith(expect.objectContaining({ rpId: 'example.com', challenge: 'AQID' }));
       expect(result.error).toBeNull();
       expect(result.publicKeyCredential?.toJSON()).toEqual(authenticationJSON);
+    });
+
+    it('retries natively when browser WebAuthn authentication is unsupported', async () => {
+      const bridge = makeBridge();
+      stubEnvironment({ protocol: 'http:', hostname: 'localhost', bridge });
+      vi.mocked(webAuthnGetCredential).mockResolvedValue({
+        publicKeyCredential: null,
+        error: Object.assign(new Error('The user agent does not support public key credentials.'), {
+          name: 'NotSupportedError',
+        }),
+      } as never);
+
+      const result = await createPasskeys().get({ publicKeyOptions: requestOptionsForRpId('localhost') });
+
+      expect(webAuthnGetCredential).toHaveBeenCalledWith({
+        publicKeyOptions: expect.anything(),
+        conditionalUI: false,
+      });
+      expect(bridge.get).toHaveBeenCalled();
+      expect(result.error).toBeNull();
     });
   });
 

--- a/packages/electron/src/passkeys/__tests__/strategy.test.ts
+++ b/packages/electron/src/passkeys/__tests__/strategy.test.ts
@@ -23,6 +23,13 @@ describe('originSatisfiesRpId', () => {
     ['https:', 'badexample.com', 'example.com', false],
     ['https:', 'example.com.evil.com', 'example.com', false],
     ['https:', 'example.com', '', false],
+    ['http:', 'localhost', 'localhost', true],
+    ['http:', 'localhost', '', true],
+    ['http:', '127.0.0.1', '127.0.0.1', true],
+    ['http:', '::1', '::1', true],
+    ['http:', '[::1]', '::1', true],
+    ['http:', '[::1]', '[::1]', true],
+    ['http:', 'localhost', 'example.com', false],
     ['http:', 'example.com', 'example.com', false],
     ['file:', '', 'example.com', false],
     ['app:', 'bundle', 'example.com', false],
@@ -53,6 +60,22 @@ describe('decidePath', () => {
   describe('auto mode', () => {
     it('prefers the renderer when the origin satisfies the RP ID', () => {
       expect(decidePath(RP_ID, 'auto', env())).toBe('renderer');
+    });
+
+    it('prefers the renderer for localhost development origins when the RP ID matches', () => {
+      expect(decidePath('localhost', 'auto', env({ protocol: 'http:', hostname: 'localhost' }))).toBe('renderer');
+    });
+
+    it('prefers the renderer for 127.0.0.1 development origins when the RP ID matches', () => {
+      expect(decidePath('127.0.0.1', 'auto', env({ protocol: 'http:', hostname: '127.0.0.1' }))).toBe('renderer');
+    });
+
+    it('prefers the renderer for bracketed IPv6 localhost development origins when the RP ID matches', () => {
+      expect(decidePath('::1', 'auto', env({ protocol: 'http:', hostname: '[::1]' }))).toBe('renderer');
+    });
+
+    it('does not treat non-loopback http origins as renderer-eligible', () => {
+      expect(decidePath(RP_ID, 'auto', env({ protocol: 'http:', hostname: 'example.com' }))).toBe('native');
     });
 
     it('falls back to native for local bundles (file://)', () => {

--- a/packages/electron/src/passkeys/index.ts
+++ b/packages/electron/src/passkeys/index.ts
@@ -67,8 +67,18 @@ const unsupportedReturn = <T>(): CredentialReturn<T> =>
     ),
   }) as CredentialReturn<T>;
 
-const isRpIdMismatchError = (error: unknown): boolean =>
-  !!error && typeof error === 'object' && (error as { code?: string }).code === 'passkey_invalid_rpID_or_domain';
+const shouldRetryNativeAfterRendererError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code, message, name } = error as { code?: string; message?: string; name?: string };
+  return (
+    code === 'passkey_invalid_rpID_or_domain' ||
+    name === 'NotSupportedError' ||
+    message?.toLowerCase().includes('user agent does not support public key credentials') === true
+  );
+};
 
 /** Creates an Electron passkey provider for clerk-js. */
 export function createPasskeys(options?: CreatePasskeysOptions): PasskeySupport {
@@ -86,8 +96,7 @@ export function createPasskeys(options?: CreatePasskeysOptions): PasskeySupport 
     }
 
     const result = await webAuthnCreateCredential(publicKey);
-    // Retry with native WebAuthn when Chromium rejects the RP ID for the page origin.
-    if (result.error && isRpIdMismatchError(result.error) && mode === 'auto' && env.nativeAvailable) {
+    if (result.error && shouldRetryNativeAfterRendererError(result.error) && mode === 'auto' && env.nativeAvailable) {
       return nativeCreateCredential(publicKey);
     }
     return result;
@@ -105,7 +114,7 @@ export function createPasskeys(options?: CreatePasskeysOptions): PasskeySupport 
     }
 
     const result = await webAuthnGetCredential({ publicKeyOptions, conditionalUI: false });
-    if (result.error && isRpIdMismatchError(result.error) && mode === 'auto' && env.nativeAvailable) {
+    if (result.error && shouldRetryNativeAfterRendererError(result.error) && mode === 'auto' && env.nativeAvailable) {
       return nativeGetCredential(publicKeyOptions);
     }
     return result;

--- a/packages/electron/src/passkeys/renderer/strategy.ts
+++ b/packages/electron/src/passkeys/renderer/strategy.ts
@@ -10,7 +10,21 @@ export type StrategyEnv = {
   electronMajor: number;
 };
 
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+function normalizeLoopbackHostname(hostname: string): string {
+  return hostname === '[::1]' ? '::1' : hostname;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return LOOPBACK_HOSTNAMES.has(normalizeLoopbackHostname(hostname));
+}
+
 export function originSatisfiesRpId(env: Pick<StrategyEnv, 'protocol' | 'hostname'>, rpId: string): boolean {
+  if (env.protocol === 'http:' && isLoopbackHostname(env.hostname)) {
+    return !rpId || normalizeLoopbackHostname(env.hostname) === normalizeLoopbackHostname(rpId);
+  }
+
   if (env.protocol !== 'https:' || !rpId) {
     return false;
   }


### PR DESCRIPTION
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

- allow Electron passkeys to use renderer WebAuthn on loopback development origins
- normalize bracketed IPv6 loopback hostnames like `[::1]`
- retry native passkeys when renderer WebAuthn reports unsupported public key credentials

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
