### PR TITLE
feat(electron): allow custom renderer scheme privileges

### DIFF
--- a/.changeset/rare-masks-check.md
+++ b/.changeset/rare-masks-check.md
@@ -1,0 +1,5 @@
+---
+"@clerk/electron": patch
+---
+
+Allow renderer scheme configuration to pass through Electron custom scheme privileges without registering the protocol separately.

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -77,6 +77,65 @@ describe('createClerkBridge', () => {
     ]);
   });
 
+  it('merges custom renderer scheme privileges with Clerk defaults', () => {
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+        privileges: {
+          allowExtensions: true,
+          allowServiceWorkers: true,
+          bypassCSP: true,
+          codeCache: true,
+        },
+      },
+    });
+
+    expect(protocol.registerSchemesAsPrivileged).toHaveBeenCalledWith([
+      {
+        scheme: 'my-app',
+        privileges: {
+          allowExtensions: true,
+          allowServiceWorkers: true,
+          bypassCSP: true,
+          codeCache: true,
+          corsEnabled: true,
+          secure: true,
+          standard: true,
+          stream: true,
+          supportFetchAPI: true,
+        },
+      },
+    ]);
+  });
+
+  it('allows custom renderer scheme privileges to override Clerk defaults', () => {
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+        privileges: {
+          stream: false,
+        },
+      },
+    });
+
+    expect(protocol.registerSchemesAsPrivileged).toHaveBeenCalledWith([
+      {
+        scheme: 'my-app',
+        privileges: {
+          corsEnabled: true,
+          secure: true,
+          standard: true,
+          stream: false,
+          supportFetchAPI: true,
+        },
+      },
+    ]);
+  });
+
   it('requires renderer.scheme to be a scheme name, not a URL', () => {
     expect(() =>
       createClerkBridge({

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -49,6 +49,7 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
           supportFetchAPI: true,
           corsEnabled: true,
           stream: true,
+          ...options.renderer.privileges,
         },
       },
     ]);

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -1,3 +1,5 @@
+import type { CustomScheme } from 'electron';
+
 type Awaitable<T> = T | Promise<T>;
 
 export type TokenStorage = {
@@ -36,7 +38,7 @@ export type ClerkBridge = {
   cleanup: () => void;
 };
 
-export type RendererSchemeOptions = {
+export type RendererSchemeOptions = CustomScheme & {
   /**
    * Custom scheme used for the renderer origin.
    */


### PR DESCRIPTION
Allows `createClerkBridge({ renderer })` to pass through Electron custom scheme privileges.

Custom privileges are merged with Clerk’s existing renderer defaults, so existing apps keep the same behavior while apps that need options like `allowServiceWorkers`, `bypassCSP`, `codeCache`, or `allowExtensions` can configure them without registering the scheme separately.