### PR TITLE
fix(expo): make native client sync client-driven

### DIFF
--- a/.changeset/client-driven-native-sync.md
+++ b/.changeset/client-driven-native-sync.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Fix JS/native client syncing so native and JavaScript client or device-token changes refresh each other consistently.

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
@@ -35,16 +35,32 @@ private fun debugLog(tag: String, message: String) {
 class ClerkExpoModule : Module() {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
     private var clientStateObserverJob: Job? = null
-    private var lastObservedClient: Client? = null
+    private var lastObservedClientState: ClientStateSnapshot? = null
     private var jsOriginatedClientSyncDepth = 0
     private var configuredPublishableKey: String? = null
+
+    private data class ClientStateSnapshot(
+        val client: Client?,
+        val deviceToken: String?
+    )
+
+    private data class ClientStateChanges(
+        val client: Boolean,
+        val deviceToken: Boolean
+    )
 
     companion object {
         private var sharedInstance: ClerkExpoModule? = null
 
         fun emitClientChanged(sourceId: String? = null) {
             val instance = sharedInstance ?: return
-            instance.sendEvent(NATIVE_CLIENT_CHANGED_EVENT, instance.clientChangedPayload(sourceId))
+            instance.sendEvent(
+                NATIVE_CLIENT_CHANGED_EVENT,
+                instance.clientChangedPayload(
+                    sourceId = sourceId,
+                    changes = ClientStateChanges(client = true, deviceToken = true)
+                )
+            )
         }
     }
 
@@ -73,11 +89,17 @@ class ClerkExpoModule : Module() {
             getClientToken(promise)
         }
 
-        AsyncFunction("syncFromJsClientToken") { clientToken: String?, sourceId: String?, shouldRefreshClient: Boolean?, promise: Promise ->
-            syncFromJsClientToken(
-                clientToken,
+        AsyncFunction("syncClientStateFromJs") {
+                deviceToken: String?,
+                sourceId: String?,
+                didChangeClient: Boolean,
+                didChangeDeviceToken: Boolean,
+                promise: Promise ->
+            syncClientStateFromJs(
+                deviceToken,
                 sourceId,
-                shouldRefreshClient ?: clientToken.isNullOrBlank(),
+                didChangeClient,
+                didChangeDeviceToken,
                 promise
             )
         }
@@ -91,32 +113,59 @@ class ClerkExpoModule : Module() {
             return
         }
 
-        lastObservedClient = Clerk.clientFlow.value
+        lastObservedClientState = clientStateSnapshot()
 
         clientStateObserverJob = coroutineScope.launch {
             Clerk.clientFlow.collect { client ->
-                if (client == lastObservedClient) {
+                val previousClientState = lastObservedClientState
+                val newClientState = clientStateSnapshot(client)
+
+                if (newClientState == previousClientState) {
                     return@collect
                 }
 
-                lastObservedClient = client
+                lastObservedClientState = newClientState
                 if (jsOriginatedClientSyncDepth > 0) {
                     return@collect
                 }
 
-                emitClientChanged()
+                sendEvent(
+                    NATIVE_CLIENT_CHANGED_EVENT,
+                    clientChangedPayload(
+                        deviceToken = newClientState.deviceToken,
+                        changes = ClientStateChanges(
+                            client = newClientState.client != previousClientState?.client,
+                            deviceToken = newClientState.deviceToken != previousClientState?.deviceToken
+                        )
+                    )
+                )
             }
         }
     }
 
-    private fun clientChangedPayload(sourceId: String? = null): Map<String, Any?> {
-        val result = mutableMapOf<String, Any?>(
-            "clientToken" to try {
+    private fun clientStateSnapshot(client: Client? = Clerk.clientFlow.value): ClientStateSnapshot {
+        return ClientStateSnapshot(
+            client = client,
+            deviceToken = try {
                 Clerk.getDeviceToken()
             } catch (e: Exception) {
-                debugLog(TAG, "clientChangedPayload - getDeviceToken failed: ${e.message}")
+                debugLog(TAG, "clientStateSnapshot - getDeviceToken failed: ${e.message}")
                 null
             }
+        )
+    }
+
+    private fun clientChangedPayload(
+        sourceId: String? = null,
+        changes: ClientStateChanges,
+        deviceToken: String? = clientStateSnapshot().deviceToken
+    ): Map<String, Any?> {
+        val result = mutableMapOf<String, Any?>(
+            "changed" to mapOf(
+                "client" to changes.client,
+                "deviceToken" to changes.deviceToken
+            ),
+            "deviceToken" to deviceToken
         )
         if (!sourceId.isNullOrEmpty()) {
             result["sourceId"] = sourceId
@@ -124,9 +173,20 @@ class ClerkExpoModule : Module() {
         return result
     }
 
-    private fun emitSyncedClientChanged(sourceId: String?) {
-        lastObservedClient = Clerk.clientFlow.value
-        emitClientChanged(sourceId)
+    private fun emitSyncedClientChanged(
+        sourceId: String?,
+        changes: ClientStateChanges,
+        snapshot: ClientStateSnapshot = clientStateSnapshot()
+    ) {
+        lastObservedClientState = snapshot
+        sendEvent(
+            NATIVE_CLIENT_CHANGED_EVENT,
+            clientChangedPayload(
+                sourceId = sourceId,
+                changes = changes,
+                deviceToken = snapshot.deviceToken
+            )
+        )
     }
 
     // MARK: - configure
@@ -288,12 +348,13 @@ class ClerkExpoModule : Module() {
         }
     }
 
-    // MARK: - syncFromJsClientToken
+    // MARK: - syncClientStateFromJs
 
-    private fun syncFromJsClientToken(
-        clientToken: String?,
+    private fun syncClientStateFromJs(
+        deviceToken: String?,
         sourceId: String?,
-        shouldRefreshClient: Boolean,
+        didChangeClient: Boolean,
+        didChangeDeviceToken: Boolean,
         promise: Promise
     ) {
         if (!Clerk.isInitialized.value) {
@@ -304,25 +365,21 @@ class ClerkExpoModule : Module() {
         coroutineScope.launch {
             try {
                 jsOriginatedClientSyncDepth += 1
-                if (!clientToken.isNullOrBlank()) {
+                val previousClientState = clientStateSnapshot()
+
+                if (didChangeDeviceToken && !deviceToken.isNullOrBlank()) {
                     val currentDeviceToken = try {
                         Clerk.getDeviceToken()
                     } catch (_: Exception) {
                         null
                     }
 
-                    if (currentDeviceToken == clientToken) {
-                        if (!shouldRefreshClient) {
-                            emitSyncedClientChanged(sourceId)
-                            promise.resolve(null)
-                            return@launch
-                        }
-                    } else {
-                        when (val result = Clerk.updateDeviceToken(clientToken)) {
+                    if (currentDeviceToken != deviceToken) {
+                        when (val result = Clerk.updateDeviceToken(deviceToken)) {
                             is ClerkResult.Failure -> {
                                 promise.reject(
                                     "E_SYNC_FROM_JS_FAILED",
-                                    result.error?.firstMessage() ?: result.throwable?.message ?: "Client token sync failed",
+                                    result.error?.firstMessage() ?: result.throwable?.message ?: "Device token sync failed",
                                     null
                                 )
                                 return@launch
@@ -333,19 +390,14 @@ class ClerkExpoModule : Module() {
                                         Clerk.clientFlow.first { it != null }
                                     }
                                 } catch (_: TimeoutCancellationException) {
-                                    debugLog(TAG, "syncFromJsClientToken - client did not appear after token update")
-                                }
-                                if (!shouldRefreshClient) {
-                                    emitSyncedClientChanged(sourceId)
-                                    promise.resolve(null)
-                                    return@launch
+                                    debugLog(TAG, "syncClientStateFromJs - client did not appear after token update")
                                 }
                             }
                         }
                     }
                 }
 
-                if (shouldRefreshClient) {
+                if (didChangeClient || didChangeDeviceToken) {
                     when (val result = Clerk.refreshClient()) {
                         is ClerkResult.Failure -> {
                             promise.reject(
@@ -355,17 +407,33 @@ class ClerkExpoModule : Module() {
                             )
                         }
                         is ClerkResult.Success -> {
-                            emitSyncedClientChanged(sourceId)
+                            val newClientState = clientStateSnapshot()
+                            emitSyncedClientChanged(
+                                sourceId,
+                                ClientStateChanges(
+                                    client = newClientState.client != previousClientState.client,
+                                    deviceToken = newClientState.deviceToken != previousClientState.deviceToken
+                                ),
+                                newClientState
+                            )
                             promise.resolve(null)
                         }
                     }
                     return@launch
                 }
 
-                emitSyncedClientChanged(sourceId)
+                val newClientState = clientStateSnapshot()
+                emitSyncedClientChanged(
+                    sourceId,
+                    ClientStateChanges(
+                        client = newClientState.client != previousClientState.client,
+                        deviceToken = newClientState.deviceToken != previousClientState.deviceToken
+                    ),
+                    newClientState
+                )
                 promise.resolve(null)
             } catch (e: Exception) {
-                promise.reject("E_SYNC_FROM_JS_FAILED", e.message ?: "Client token sync failed", e)
+                promise.reject("E_SYNC_FROM_JS_FAILED", e.message ?: "Client state sync failed", e)
             } finally {
                 jsOriginatedClientSyncDepth = maxOf(0, jsOriginatedClientSyncDepth - 1)
             }

--- a/packages/expo/ios/ClerkExpoModule.m
+++ b/packages/expo/ios/ClerkExpoModule.m
@@ -11,9 +11,10 @@ RCT_EXTERN_METHOD(configure:(NSString *)publishableKey
 RCT_EXTERN_METHOD(getClientToken:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(syncFromJsClientToken:(id)clientToken
+RCT_EXTERN_METHOD(syncClientStateFromJs:(id)deviceToken
                   sourceId:(id)sourceId
-                  shouldRefreshClient:(id)shouldRefreshClient
+                  didChangeClient:(BOOL)didChangeClient
+                  didChangeDeviceToken:(BOOL)didChangeDeviceToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/expo/ios/ClerkExpoModule.swift
+++ b/packages/expo/ios/ClerkExpoModule.swift
@@ -86,23 +86,23 @@ class ClerkExpoModule: RCTEventEmitter {
     }
   }
 
-  // MARK: - syncFromJsClientToken
+  // MARK: - syncClientStateFromJs
 
-  @objc func syncFromJsClientToken(_ clientToken: Any?,
+  @objc func syncClientStateFromJs(_ deviceToken: Any?,
                                    sourceId: Any?,
-                                   shouldRefreshClient: Any?,
+                                   didChangeClient: Bool,
+                                   didChangeDeviceToken: Bool,
                                    resolve: @escaping RCTPromiseResolveBlock,
                                    reject: @escaping RCTPromiseRejectBlock) {
-    let normalizedClientToken = clientToken as? String
+    let normalizedDeviceToken = deviceToken as? String
     let normalizedSourceId = sourceId as? String
-    let defaultShouldRefreshClient = normalizedClientToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
-    let normalizedShouldRefreshClient = (shouldRefreshClient as? Bool) ?? defaultShouldRefreshClient
     Task {
       do {
-        try await ClerkNativeBridge.shared.syncFromJsClientToken(
-          normalizedClientToken,
+        try await ClerkNativeBridge.shared.syncClientStateFromJs(
+          deviceToken: normalizedDeviceToken,
           sourceId: normalizedSourceId,
-          shouldRefreshClient: normalizedShouldRefreshClient
+          didChangeClient: didChangeClient,
+          didChangeDeviceToken: didChangeDeviceToken
         )
         resolve(nil)
       } catch {

--- a/packages/expo/ios/ClerkNativeBridge.swift
+++ b/packages/expo/ios/ClerkNativeBridge.swift
@@ -56,6 +56,13 @@ final class ClerkNativeBridge {
     let deviceToken: String?
   }
 
+  private struct ClientStateChanges {
+    let client: Bool
+    let deviceToken: Bool
+
+    static let all = ClientStateChanges(client: true, deviceToken: true)
+  }
+
   /// Resolves the keychain service name, checking ClerkKeychainService in Info.plist first
   /// (for extension apps sharing a keychain group), then falling back to the bundle identifier.
   private static var keychainService: String? {
@@ -104,7 +111,7 @@ final class ClerkNativeBridge {
   @MainActor
   private static func emitClientChangedIfReceivedToken(_ bearerToken: String?) {
     guard let token = bearerToken, !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-    Self.emitClientChanged(Self.clientChangedPayload())
+    Self.emitClientChanged(Self.clientChangedPayload(changes: .init(client: false, deviceToken: true)))
   }
 
   @MainActor
@@ -130,9 +137,14 @@ final class ClerkNativeBridge {
         guard let self, generation == self.clientObservationGeneration else { return }
 
         let newClientState = Self.clientStateSnapshot()
-        if newClientState != self.lastObservedClientState {
+        if let previousClientState = self.lastObservedClientState, newClientState != previousClientState {
           self.lastObservedClientState = newClientState
-          let payload = Self.clientChangedPayload()
+          let payload = Self.clientChangedPayload(
+            changes: .init(
+              client: newClientState.client != previousClientState.client,
+              deviceToken: newClientState.deviceToken != previousClientState.deviceToken
+            )
+          )
           Self.emitClientChanged(payload)
         }
 
@@ -152,9 +164,13 @@ final class ClerkNativeBridge {
   }
 
   @MainActor
-  private static func clientChangedPayload(sourceId: String? = nil) -> [String: Any] {
+  private static func clientChangedPayload(sourceId: String? = nil, changes: ClientStateChanges = .all) -> [String: Any] {
     var payload: [String: Any] = [:]
-    payload["clientToken"] = Clerk.shared.deviceToken ?? NSNull()
+    payload["changed"] = [
+      "client": changes.client,
+      "deviceToken": changes.deviceToken,
+    ]
+    payload["deviceToken"] = Clerk.shared.deviceToken ?? NSNull()
     if let sourceId, !sourceId.isEmpty {
       payload["sourceId"] = sourceId
     }
@@ -187,7 +203,7 @@ final class ClerkNativeBridge {
   @MainActor
   private static func waitForLoadedClient() async {
     // Wait for Clerk to finish loading client state from cached data + API refresh.
-    // The bridge sync contract is client-token based, not session based.
+    // The bridge sync contract is device-token based, not session based.
     for _ in 0..<clerkLoadMaxAttempts {
       if Clerk.shared.isLoaded {
         return
@@ -256,23 +272,39 @@ final class ClerkNativeBridge {
   }
 
   @MainActor
-  func syncFromJsClientToken(_ clientToken: String?, sourceId: String?, shouldRefreshClient: Bool) async throws {
+  func syncClientStateFromJs(
+    deviceToken: String?,
+    sourceId: String?,
+    didChangeClient: Bool,
+    didChangeDeviceToken: Bool
+  ) async throws {
     guard Self.clerkConfigured else { return }
 
-    if let token = clientToken?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+    let previousClientState = Self.clientStateSnapshot()
+
+    if didChangeDeviceToken, let token = deviceToken?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
       if Clerk.shared.deviceToken != token {
         _ = try await Clerk.shared.updateDeviceToken(token)
         await Self.waitForLoadedClient()
       }
     }
 
-    if shouldRefreshClient {
+    if didChangeClient || didChangeDeviceToken {
       _ = try await Clerk.shared.refreshClient()
       await Self.waitForLoadedClient()
     }
 
-    lastObservedClientState = Self.clientStateSnapshot()
-    Self.emitClientChanged(Self.clientChangedPayload(sourceId: sourceId))
+    let newClientState = Self.clientStateSnapshot()
+    lastObservedClientState = newClientState
+    Self.emitClientChanged(
+      Self.clientChangedPayload(
+        sourceId: sourceId,
+        changes: .init(
+          client: newClientState.client != previousClientState.client,
+          deviceToken: newClientState.deviceToken != previousClientState.deviceToken
+        )
+      )
+    )
   }
 
   private static func postConfiguredNotification() {

--- a/packages/expo/src/hooks/__tests__/useNativeClientEvents.test.ts
+++ b/packages/expo/src/hooks/__tests__/useNativeClientEvents.test.ts
@@ -57,13 +57,21 @@ describe('useNativeClientEvents', () => {
 
     act(() => {
       mocks.nativeListener?.({
-        clientToken: 'client-token',
+        changed: {
+          client: false,
+          deviceToken: true,
+        },
+        deviceToken: 'device-token',
         sourceId: 'native-source',
       });
     });
 
     await waitFor(() => {
-      expect(result.current.nativeClientEvent?.clientToken).toBe('client-token');
+      expect(result.current.nativeClientEvent?.deviceToken).toBe('device-token');
+      expect(result.current.nativeClientEvent?.changed).toEqual({
+        client: false,
+        deviceToken: true,
+      });
       expect(result.current.nativeClientEvent?.sourceId).toBe('native-source');
     });
 
@@ -75,7 +83,7 @@ describe('useNativeClientEvents', () => {
     mocks.nativeModule = {
       configure: vi.fn(),
       getClientToken: vi.fn(),
-      syncFromJsClientToken: vi.fn(),
+      syncClientStateFromJs: vi.fn(),
     };
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
@@ -51,7 +51,7 @@ vi.mock('../../specs/NativeClerkModule', () => {
     default: {
       configure: vi.fn(),
       getClientToken: vi.fn(),
-      syncFromJsClientToken: vi.fn(),
+      syncClientStateFromJs: vi.fn(),
     },
   };
 });

--- a/packages/expo/src/hooks/useNativeClientEvents.ts
+++ b/packages/expo/src/hooks/useNativeClientEvents.ts
@@ -6,7 +6,11 @@ import { ClerkExpoModule as ClerkExpo, isNativeSupported } from '../utils/native
 const nativeClientChangedEvent = 'clerkNativeClientChanged';
 
 export interface NativeClientSnapshot {
-  clientToken?: string | null;
+  changed: {
+    client: boolean;
+    deviceToken: boolean;
+  };
+  deviceToken: string | null;
   sourceId?: string | null;
 }
 
@@ -44,6 +48,14 @@ function getNativeClientEventEmitter(): RefreshClientEventEmitter | null {
   return null;
 }
 
+function isNativeClientSnapshot(snapshot: NativeClientSnapshot | undefined): snapshot is NativeClientSnapshot {
+  return (
+    typeof snapshot?.changed?.client === 'boolean' &&
+    typeof snapshot.changed.deviceToken === 'boolean' &&
+    (typeof snapshot.deviceToken === 'string' || snapshot.deviceToken === null)
+  );
+}
+
 /**
  * Listens for native client events that should sync JS client state.
  */
@@ -65,6 +77,10 @@ export function useNativeClientEvents(): UseNativeClientEventsReturn {
       }
 
       subscription = eventEmitter.addListener(nativeClientChangedEvent, snapshot => {
+        if (!isNativeClientSnapshot(snapshot)) {
+          return;
+        }
+
         setNativeClientEvent({ issuedAt: Date.now(), ...snapshot });
       });
     } catch (error) {

--- a/packages/expo/src/provider/ClerkProvider.tsx
+++ b/packages/expo/src/provider/ClerkProvider.tsx
@@ -8,7 +8,7 @@ import type { TokenCache } from '../cache/types';
 import { isNative, isWeb } from '../utils/runtime';
 import { maybeCompleteAuthSession } from './maybeCompleteAuthSession';
 import {
-  type ClientTokenCacheListener,
+  type DeviceTokenCacheListener,
   NativeClientSync,
   type NativeRefreshFromJsController,
   useNativeClientBootstrap,
@@ -69,7 +69,7 @@ export function ClerkProvider<TUi extends Ui = Ui>(props: ClerkProviderProps<TUi
     ...rest
   } = props;
   const pk = publishableKey;
-  const tokenCacheListenersRef = useRef<Set<ClientTokenCacheListener>>(new Set());
+  const tokenCacheListenersRef = useRef<Set<DeviceTokenCacheListener>>(new Set());
   const suppressTokenCacheNotificationsRef = useRef(false);
   const nativeRefreshFromJsControllerRef = useRef<NativeRefreshFromJsController | null>(null);
   const syncableTokenCache = useSyncableTokenCache({

--- a/packages/expo/src/provider/ClerkProvider.tsx
+++ b/packages/expo/src/provider/ClerkProvider.tsx
@@ -70,7 +70,7 @@ export function ClerkProvider<TUi extends Ui = Ui>(props: ClerkProviderProps<TUi
   } = props;
   const pk = publishableKey;
   const tokenCacheListenersRef = useRef<Set<DeviceTokenCacheListener>>(new Set());
-  const suppressTokenCacheNotificationsRef = useRef(false);
+  const suppressTokenCacheNotificationsRef = useRef(0);
   const nativeRefreshFromJsControllerRef = useRef<NativeRefreshFromJsController | null>(null);
   const syncableTokenCache = useSyncableTokenCache({
     suppressTokenCacheNotificationsRef,

--- a/packages/expo/src/provider/__tests__/ClerkProvider.nativeClientSync.test.tsx
+++ b/packages/expo/src/provider/__tests__/ClerkProvider.nativeClientSync.test.tsx
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => {
     configure: vi.fn(),
     getClientToken: vi.fn(),
     nativeClientEvent: null as unknown,
-    syncFromJsClientToken: vi.fn(),
+    syncClientStateFromJs: vi.fn(),
     tokenCache: {
       clearToken: vi.fn(),
       getToken: vi.fn(),
@@ -90,7 +90,7 @@ vi.mock('../../specs/NativeClerkModule', () => {
       configure: mocks.configure,
       getClientToken: mocks.getClientToken,
       removeListeners: vi.fn(),
-      syncFromJsClientToken: mocks.syncFromJsClientToken,
+      syncClientStateFromJs: mocks.syncClientStateFromJs,
     },
   };
 });
@@ -117,7 +117,7 @@ describe('ClerkProvider native client sync', () => {
     mocks.nativeClientEvent = null;
     mocks.configure.mockResolvedValue(undefined);
     mocks.getClientToken.mockResolvedValue('native-client-token');
-    mocks.syncFromJsClientToken.mockResolvedValue(undefined);
+    mocks.syncClientStateFromJs.mockResolvedValue(undefined);
     mocks.tokenCache.getToken.mockResolvedValue('client-token');
     mocks.tokenCache.saveToken.mockResolvedValue(undefined);
     mocks.tokenCache.clearToken.mockResolvedValue(undefined);
@@ -142,7 +142,7 @@ describe('ClerkProvider native client sync', () => {
     });
   });
 
-  test('configures native with the cached JS client token during bootstrap', async () => {
+  test('configures native with the cached device token during bootstrap', async () => {
     render(
       <ClerkProvider
         publishableKey='pk_test_123'
@@ -164,18 +164,18 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalledWith('pk_test_123', null);
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
 
     await act(async () => {
       await mocks.clerkOptions?.tokenCache?.saveToken(CLERK_CLIENT_JWT_KEY, 'client-token');
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith('client-token', expect.any(String), false);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith('client-token', expect.any(String), false, true);
     });
   });
 
-  test('reloads JS resources after native emits a client change with a token', async () => {
+  test('reloads JS resources after native emits a device token change', async () => {
     mocks.tokenCache.getToken.mockResolvedValue(null);
     mocks.getClientToken.mockResolvedValue(null);
 
@@ -195,7 +195,11 @@ describe('ClerkProvider native client sync', () => {
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: 'native-client-token',
+      changed: {
+        client: false,
+        deviceToken: true,
+      },
+      deviceToken: 'native-client-token',
     };
     rerender(
       <ClerkProvider
@@ -211,7 +215,7 @@ describe('ClerkProvider native client sync', () => {
     expect(mocks.getClientToken).not.toHaveBeenCalled();
   });
 
-  test('reloads JS resources after native emits a client change without a token', async () => {
+  test('reloads JS resources after native clears the device token', async () => {
     const { rerender } = render(
       <ClerkProvider
         publishableKey='pk_test_123'
@@ -229,7 +233,11 @@ describe('ClerkProvider native client sync', () => {
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: null,
+      changed: {
+        client: false,
+        deviceToken: true,
+      },
+      deviceToken: null,
     };
     rerender(
       <ClerkProvider
@@ -245,6 +253,46 @@ describe('ClerkProvider native client sync', () => {
     expect(mocks.tokenCache.clearToken).toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY);
   });
 
+  test('reloads JS resources after a native client-only change without rewriting the token cache', async () => {
+    mocks.getClientToken.mockResolvedValue(null);
+
+    const { rerender } = render(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.configure).toHaveBeenCalled();
+    });
+
+    mocks.clerkInstance.__internal_reloadInitialResources.mockClear();
+    mocks.tokenCache.saveToken.mockClear();
+    mocks.tokenCache.clearToken.mockClear();
+
+    mocks.nativeClientEvent = {
+      issuedAt: 1,
+      changed: {
+        client: true,
+        deviceToken: false,
+      },
+      deviceToken: 'native-client-token',
+    };
+    rerender(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.clerkInstance.__internal_reloadInitialResources).toHaveBeenCalled();
+    });
+    expect(mocks.tokenCache.saveToken).not.toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY, expect.anything());
+    expect(mocks.tokenCache.clearToken).not.toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY);
+  });
+
   test('does not bounce a JS client listener event while applying a native client change', async () => {
     const { rerender } = render(
       <ClerkProvider
@@ -257,14 +305,18 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalled();
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
     mocks.clerkInstance.__internal_reloadInitialResources.mockImplementation(() => {
       mocks.clerkListener?.();
     });
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: 'native-client-token',
+      changed: {
+        client: true,
+        deviceToken: true,
+      },
+      deviceToken: 'native-client-token',
     };
     rerender(
       <ClerkProvider
@@ -276,7 +328,68 @@ describe('ClerkProvider native client sync', () => {
     await waitFor(() => {
       expect(mocks.clerkInstance.__internal_reloadInitialResources).toHaveBeenCalled();
     });
-    expect(mocks.syncFromJsClientToken).not.toHaveBeenCalled();
+    expect(mocks.syncClientStateFromJs).not.toHaveBeenCalled();
+  });
+
+  test('emits the refreshed JS client after a native client update keeps the active session', async () => {
+    const activeSession = {
+      id: 'session_1',
+      status: 'active',
+      user: { id: 'user_1', lastName: 'Before' },
+    };
+    const updatedActiveSession = {
+      id: 'session_1',
+      status: 'active',
+      user: { id: 'user_1', lastName: 'After' },
+    };
+    const refreshedClient = {
+      signedInSessions: [updatedActiveSession],
+      lastActiveSessionId: 'session_1',
+    };
+    const originalUpdateClient = mocks.clerkInstance.updateClient;
+
+    mocks.clerkInstance.client = {
+      signedInSessions: [activeSession],
+      lastActiveSessionId: 'session_1',
+      fetch: vi.fn().mockResolvedValue(refreshedClient),
+    };
+    mocks.clerkInstance.session = activeSession;
+    mocks.getClientToken.mockResolvedValue(null);
+
+    const { rerender } = render(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.configure).toHaveBeenCalled();
+    });
+
+    mocks.nativeClientEvent = {
+      issuedAt: 1,
+      changed: {
+        client: true,
+        deviceToken: false,
+      },
+      deviceToken: 'native-client-token',
+    };
+    rerender(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(originalUpdateClient).toHaveBeenCalledWith(refreshedClient);
+    });
+    expect(originalUpdateClient).not.toHaveBeenCalledWith(refreshedClient, {
+      __internal_dangerouslySkipEmit: true,
+    });
+    expect(mocks.clerkInstance.__internal_reloadInitialResources).not.toHaveBeenCalled();
+    expect(mocks.clerkInstance.setActive).not.toHaveBeenCalled();
   });
 
   test('sets the refreshed native last active session without emitting a stale signed-out JS state', async () => {
@@ -322,7 +435,11 @@ describe('ClerkProvider native client sync', () => {
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: 'native-client-token',
+      changed: {
+        client: true,
+        deviceToken: true,
+      },
+      deviceToken: 'native-client-token',
     };
     rerender(
       <ClerkProvider
@@ -378,7 +495,11 @@ describe('ClerkProvider native client sync', () => {
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: null,
+      changed: {
+        client: true,
+        deviceToken: true,
+      },
+      deviceToken: null,
     };
     rerender(
       <ClerkProvider
@@ -388,14 +509,18 @@ describe('ClerkProvider native client sync', () => {
     );
 
     await waitFor(() => {
-      expect(originalUpdateClient).toHaveBeenCalledWith(
-        {
-          signedInSessions: [],
-          lastActiveSessionId: null,
-        },
-        { __internal_dangerouslySkipEmit: false },
-      );
+      expect(originalUpdateClient).toHaveBeenCalledWith({
+        signedInSessions: [],
+        lastActiveSessionId: null,
+      });
     });
+    expect(originalUpdateClient).not.toHaveBeenCalledWith(
+      {
+        signedInSessions: [],
+        lastActiveSessionId: null,
+      },
+      { __internal_dangerouslySkipEmit: true },
+    );
     expect(mocks.clerkInstance.__internal_reloadInitialResources).not.toHaveBeenCalled();
     expect(mocks.clerkInstance.setActive).not.toHaveBeenCalled();
   });
@@ -607,7 +732,7 @@ describe('ClerkProvider native client sync', () => {
     expect(mocks.clerkInstance.setActive).toHaveBeenCalledWith({ session: remainingSession });
   });
 
-  test('does not fall back to JS sign-out when stale unauthenticated recovery still has a native client token', async () => {
+  test('does not fall back to JS sign-out when stale unauthenticated recovery still has a native device token', async () => {
     const removedSession = {
       id: 'session_1',
       status: 'active',
@@ -708,21 +833,21 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalledWith('pk_test_123', null);
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
     mocks.tokenCache.getToken.mockResolvedValue('client-token');
     act(() => {
       mocks.clerkListener?.();
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith(null, expect.any(String), true);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith(null, expect.any(String), true, false);
     });
   });
 
   test('continues processing queued native sync after a native sync failure', async () => {
     mocks.tokenCache.getToken.mockResolvedValue(null);
     let rejectFirstSync: ((error: Error) => void) | undefined;
-    mocks.syncFromJsClientToken.mockImplementationOnce(() => {
+    mocks.syncClientStateFromJs.mockImplementationOnce(() => {
       return new Promise((_resolve, reject) => {
         rejectFirstSync = reject;
       });
@@ -744,7 +869,7 @@ describe('ClerkProvider native client sync', () => {
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith(null, expect.any(String), true);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith(null, expect.any(String), true, false);
     });
 
     await act(async () => {
@@ -753,14 +878,14 @@ describe('ClerkProvider native client sync', () => {
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith('client-token', expect.any(String), false);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith('client-token', expect.any(String), false, true);
     });
   });
 
   test('keeps a pending native client refresh while a token sync is in flight', async () => {
     mocks.tokenCache.getToken.mockResolvedValue(null);
     let resolveFirstSync: (() => void) | undefined;
-    mocks.syncFromJsClientToken.mockImplementationOnce(() => {
+    mocks.syncClientStateFromJs.mockImplementationOnce(() => {
       return new Promise<void>(resolve => {
         resolveFirstSync = resolve;
       });
@@ -782,7 +907,7 @@ describe('ClerkProvider native client sync', () => {
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith('client-token', expect.any(String), false);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith('client-token', expect.any(String), false, true);
     });
 
     act(() => {
@@ -794,7 +919,7 @@ describe('ClerkProvider native client sync', () => {
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith(null, expect.any(String), true);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith(null, expect.any(String), true, false);
     });
   });
 
@@ -812,14 +937,14 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalledWith('pk_test_123', null);
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
 
     await act(async () => {
       await mocks.clerkOptions?.tokenCache?.saveToken(CLERK_CLIENT_JWT_KEY, 'client-token');
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith('client-token', expect.any(String), false);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith('client-token', expect.any(String), false, true);
     });
   });
 
@@ -837,22 +962,26 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalledWith('pk_test_123', null);
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
 
     await act(async () => {
       await mocks.clerkOptions?.tokenCache?.saveToken(CLERK_CLIENT_JWT_KEY, 'client-token');
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith('client-token', expect.any(String), false);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith('client-token', expect.any(String), false, true);
     });
 
-    const sourceId = mocks.syncFromJsClientToken.mock.calls[0]?.[1];
+    const sourceId = mocks.syncClientStateFromJs.mock.calls[0]?.[1];
     mocks.clerkInstance.__internal_reloadInitialResources.mockClear();
 
     mocks.nativeClientEvent = {
       issuedAt: 1,
-      clientToken: 'client-token',
+      changed: {
+        client: false,
+        deviceToken: true,
+      },
+      deviceToken: 'client-token',
       sourceId,
     };
     rerender(
@@ -879,14 +1008,14 @@ describe('ClerkProvider native client sync', () => {
       expect(mocks.configure).toHaveBeenCalled();
     });
 
-    mocks.syncFromJsClientToken.mockClear();
+    mocks.syncClientStateFromJs.mockClear();
 
     await act(async () => {
       await mocks.clerkOptions?.tokenCache?.clearToken?.(CLERK_CLIENT_JWT_KEY);
     });
 
     await waitFor(() => {
-      expect(mocks.syncFromJsClientToken).toHaveBeenCalledWith(null, expect.any(String), true);
+      expect(mocks.syncClientStateFromJs).toHaveBeenCalledWith(null, expect.any(String), false, true);
     });
   });
 });

--- a/packages/expo/src/provider/__tests__/ClerkProvider.nativeClientSync.test.tsx
+++ b/packages/expo/src/provider/__tests__/ClerkProvider.nativeClientSync.test.tsx
@@ -111,6 +111,14 @@ vi.mock('../singleton', () => {
   };
 });
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(innerResolve => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 describe('ClerkProvider native client sync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -327,6 +335,88 @@ describe('ClerkProvider native client sync', () => {
 
     await waitFor(() => {
       expect(mocks.clerkInstance.__internal_reloadInitialResources).toHaveBeenCalled();
+    });
+    expect(mocks.syncClientStateFromJs).not.toHaveBeenCalled();
+  });
+
+  test('keeps token cache notifications suppressed across overlapping native token writes', async () => {
+    mocks.tokenCache.getToken.mockResolvedValue(null);
+    mocks.getClientToken.mockResolvedValue(null);
+
+    const firstSave = deferred();
+    const secondSave = deferred();
+    mocks.tokenCache.saveToken
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockImplementationOnce(() => secondSave.promise);
+
+    const { rerender } = render(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.configure).toHaveBeenCalledWith('pk_test_123', null);
+    });
+
+    mocks.syncClientStateFromJs.mockClear();
+    mocks.clerkInstance.__internal_reloadInitialResources.mockClear();
+
+    mocks.nativeClientEvent = {
+      issuedAt: 1,
+      changed: {
+        client: false,
+        deviceToken: true,
+      },
+      deviceToken: 'native-client-token-1',
+    };
+    rerender(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.tokenCache.saveToken).toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY, 'native-client-token-1');
+    });
+
+    mocks.nativeClientEvent = {
+      issuedAt: 2,
+      changed: {
+        client: false,
+        deviceToken: true,
+      },
+      deviceToken: 'native-client-token-2',
+    };
+    rerender(
+      <ClerkProvider
+        publishableKey='pk_test_123'
+        tokenCache={mocks.tokenCache}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.tokenCache.saveToken).toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY, 'native-client-token-2');
+    });
+
+    await act(async () => {
+      firstSave.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.syncClientStateFromJs).not.toHaveBeenCalled();
+
+    await act(async () => {
+      secondSave.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.clerkInstance.__internal_reloadInitialResources).toHaveBeenCalledTimes(2);
     });
     expect(mocks.syncClientStateFromJs).not.toHaveBeenCalled();
   });

--- a/packages/expo/src/provider/nativeClientSync.tsx
+++ b/packages/expo/src/provider/nativeClientSync.tsx
@@ -5,16 +5,12 @@ import { Platform } from 'react-native';
 import { MemoryTokenCache } from '../cache';
 import type { TokenCache } from '../cache/types';
 import { CLERK_CLIENT_JWT_KEY } from '../constants';
-import {
-  type NativeClientEvent,
-  type NativeClientSnapshot,
-  useNativeClientEvents,
-} from '../hooks/useNativeClientEvents';
+import { type NativeClientEvent, useNativeClientEvents } from '../hooks/useNativeClientEvents';
 import { ClerkExpoModule as NativeClerkModule } from '../utils/native-module';
 
 const tokenCacheReadTimeoutMs = 1_000;
-const clientTokenPollIntervalMs = 100;
-const clientTokenAvailabilityTimeoutMs = 3_000;
+const nativeDeviceTokenPollIntervalMs = 100;
+const nativeDeviceTokenAvailabilityTimeoutMs = 3_000;
 const nativeClientSyncSourceIdPrefix = 'clerk-expo-js-sync';
 
 export type SyncableClerkInstance = {
@@ -34,15 +30,16 @@ type RefreshableClientResource = ClientResource & {
 };
 
 type NativeRefreshFromJsOptions = {
-  clientToken?: string | null;
-  shouldRefreshClient: boolean;
+  deviceToken?: string | null;
+  didChangeClient: boolean;
+  didChangeDeviceToken: boolean;
 };
 
 export type NativeRefreshFromJsController = {
   cancel: () => void;
 };
 
-export type ClientTokenCacheListener = (clientToken: string | null) => void;
+export type DeviceTokenCacheListener = (deviceToken: string | null) => void;
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -55,7 +52,7 @@ export function useSyncableTokenCache({
 }: {
   suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
-  tokenCacheListenersRef: MutableRefObject<Set<ClientTokenCacheListener>>;
+  tokenCacheListenersRef: MutableRefObject<Set<DeviceTokenCacheListener>>;
 }): TokenCache | undefined {
   return useMemo(() => {
     const effectiveTokenCache =
@@ -64,13 +61,13 @@ export function useSyncableTokenCache({
       return undefined;
     }
 
-    const notifyClientTokenListeners = (clientToken: string | null) => {
+    const notifyDeviceTokenListeners = (deviceToken: string | null) => {
       if (suppressTokenCacheNotificationsRef.current) {
         return;
       }
 
       for (const listener of tokenCacheListenersRef.current) {
-        listener(clientToken);
+        listener(deviceToken);
       }
     };
 
@@ -79,104 +76,94 @@ export function useSyncableTokenCache({
       saveToken: async (key, token) => {
         await effectiveTokenCache.saveToken(key, token);
         if (key === CLERK_CLIENT_JWT_KEY) {
-          notifyClientTokenListeners(token);
+          notifyDeviceTokenListeners(token);
         }
       },
       clearToken: async key => {
         await effectiveTokenCache.clearToken?.(key);
         if (key === CLERK_CLIENT_JWT_KEY) {
-          notifyClientTokenListeners(null);
+          notifyDeviceTokenListeners(null);
         }
       },
     };
   }, [suppressTokenCacheNotificationsRef, tokenCache, tokenCacheListenersRef]);
 }
 
-function getNativeClientTokenFromSnapshot(
-  snapshot: NativeClientSnapshot | null | undefined,
-): string | null | undefined {
-  if (!snapshot || !('clientToken' in snapshot)) {
-    return undefined;
-  }
-
-  return snapshot.clientToken ?? null;
-}
-
-async function readNativeClientToken({ waitForToken }: { waitForToken: boolean }): Promise<string | null> {
+async function readNativeDeviceToken({ waitForToken }: { waitForToken: boolean }): Promise<string | null> {
   const ClerkExpo = NativeClerkModule;
   if (!ClerkExpo?.getClientToken) {
     return null;
   }
 
   const startedAt = Date.now();
-  let remainingMs = clientTokenAvailabilityTimeoutMs;
+  let remainingMs = nativeDeviceTokenAvailabilityTimeoutMs;
 
   do {
-    const nativeClientToken = await ClerkExpo.getClientToken();
-    if (nativeClientToken) {
-      return nativeClientToken;
+    const nativeDeviceToken = await ClerkExpo.getClientToken();
+    if (nativeDeviceToken) {
+      return nativeDeviceToken;
     }
 
     if (!waitForToken) {
       return null;
     }
 
-    remainingMs = clientTokenAvailabilityTimeoutMs - (Date.now() - startedAt);
+    remainingMs = nativeDeviceTokenAvailabilityTimeoutMs - (Date.now() - startedAt);
     if (remainingMs <= 0) {
       return null;
     }
 
-    await delay(Math.min(clientTokenPollIntervalMs, remainingMs));
+    await delay(Math.min(nativeDeviceTokenPollIntervalMs, remainingMs));
   } while (remainingMs > 0);
 
   return null;
 }
 
-async function syncClientTokenToCache(tokenCache: TokenCache | undefined, clientToken: string | null): Promise<void> {
-  if (clientToken) {
-    await tokenCache?.saveToken(CLERK_CLIENT_JWT_KEY, clientToken);
+async function syncDeviceTokenToCache(tokenCache: TokenCache | undefined, deviceToken: string | null): Promise<void> {
+  if (deviceToken) {
+    await tokenCache?.saveToken(CLERK_CLIENT_JWT_KEY, deviceToken);
     return;
   }
 
   await tokenCache?.clearToken?.(CLERK_CLIENT_JWT_KEY);
 }
 
-async function syncClientTokenToCacheWithoutNotifying({
-  clientToken,
+async function syncDeviceTokenToCacheWithoutNotifying({
+  deviceToken,
   suppressTokenCacheNotificationsRef,
   tokenCache,
 }: {
-  clientToken: string | null;
+  deviceToken: string | null;
   suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
   suppressTokenCacheNotificationsRef.current = true;
   try {
-    await syncClientTokenToCache(tokenCache, clientToken);
+    await syncDeviceTokenToCache(tokenCache, deviceToken);
   } finally {
     suppressTokenCacheNotificationsRef.current = false;
   }
 }
 
-async function syncNativeTokenToCache({
-  clientToken,
+async function syncNativeDeviceTokenToCache({
+  deviceToken,
   suppressTokenCacheNotificationsRef,
   tokenCache,
 }: {
-  clientToken: string | null;
+  deviceToken: string | null;
   suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
   if (suppressTokenCacheNotificationsRef) {
-    await syncClientTokenToCacheWithoutNotifying({
-      clientToken,
+    await syncDeviceTokenToCacheWithoutNotifying({
+      deviceToken,
       suppressTokenCacheNotificationsRef,
       tokenCache,
     });
     return;
   }
 
-  await syncClientTokenToCache(tokenCache, clientToken);
+  await syncDeviceTokenToCache(tokenCache, deviceToken);
 }
 
 function getDefaultSignedInSession(client: ClientResource | null | undefined): SignedInSessionResource | null {
@@ -194,7 +181,7 @@ function getDefaultSignedInSession(client: ClientResource | null | undefined): S
   return client.signedInSessions[0] ?? null;
 }
 
-async function refreshJsClientWithoutEmitting(clerkInstance: SyncableClerkInstance): Promise<ClientResource | null> {
+async function refreshJsClientFromServer(clerkInstance: SyncableClerkInstance): Promise<ClientResource | null> {
   const client = clerkInstance.client as RefreshableClientResource | undefined;
 
   if (typeof client?.fetch !== 'function' || typeof clerkInstance.updateClient !== 'function') {
@@ -202,35 +189,35 @@ async function refreshJsClientWithoutEmitting(clerkInstance: SyncableClerkInstan
   }
 
   const refreshedClient = await client.fetch({ fetchMaxTries: 1 });
-  const nextSession = getDefaultSignedInSession(refreshedClient);
-
-  clerkInstance.updateClient(refreshedClient, {
-    __internal_dangerouslySkipEmit: Boolean(nextSession),
-  });
+  clerkInstance.updateClient(refreshedClient);
 
   return refreshedClient;
 }
 
 async function refreshJsClientFromNativeState({
   clerkInstance,
-  nativeClientToken,
+  nativeDeviceToken,
   reloadInitialResources,
+  shouldSyncDeviceToken = true,
   suppressTokenCacheNotificationsRef,
   tokenCache,
 }: {
   clerkInstance: SyncableClerkInstance;
-  nativeClientToken: string | null;
+  nativeDeviceToken: string | null;
   reloadInitialResources: boolean;
+  shouldSyncDeviceToken?: boolean;
   suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
-  await syncNativeTokenToCache({
-    clientToken: nativeClientToken,
-    suppressTokenCacheNotificationsRef,
-    tokenCache,
-  });
+  if (shouldSyncDeviceToken) {
+    await syncNativeDeviceTokenToCache({
+      deviceToken: nativeDeviceToken,
+      suppressTokenCacheNotificationsRef,
+      tokenCache,
+    });
+  }
 
-  const refreshedClient = await refreshJsClientWithoutEmitting(clerkInstance);
+  const refreshedClient = await refreshJsClientFromServer(clerkInstance);
   if (refreshedClient) {
     await reconcileJsActiveSessionFromClient({
       clerkInstance,
@@ -251,17 +238,17 @@ async function refreshJsClientFromNativeState({
 
 async function reloadJsClientFromNativeState({
   clerkInstance,
-  nativeClientToken,
+  nativeDeviceToken,
   suppressTokenCacheNotificationsRef,
   tokenCache,
 }: {
   clerkInstance: SyncableClerkInstance;
-  nativeClientToken: string;
+  nativeDeviceToken: string;
   suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
-  await syncNativeTokenToCache({
-    clientToken: nativeClientToken,
+  await syncNativeDeviceTokenToCache({
+    deviceToken: nativeDeviceToken,
     suppressTokenCacheNotificationsRef,
     tokenCache,
   });
@@ -273,7 +260,7 @@ async function reloadJsClientFromNativeState({
   return Boolean(getDefaultSignedInSession(clerkInstance.client));
 }
 
-async function recoverJsClientFromNativeToken({
+async function recoverJsClientFromNativeDeviceToken({
   clerkInstance,
   error,
   suppressTokenCacheNotificationsRef,
@@ -284,19 +271,19 @@ async function recoverJsClientFromNativeToken({
   suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
-  const nativeClientToken = await readNativeClientToken({ waitForToken: false });
-  if (!nativeClientToken) {
+  const nativeDeviceToken = await readNativeDeviceToken({ waitForToken: false });
+  if (!nativeDeviceToken) {
     return false;
   }
 
   if (__DEV__) {
-    console.warn('[NativeClientSync] Failed to refresh JS client with native client token:', error);
+    console.warn('[NativeClientSync] Failed to refresh JS client with native device token:', error);
   }
 
   try {
     return await reloadJsClientFromNativeState({
       clerkInstance,
-      nativeClientToken,
+      nativeDeviceToken,
       suppressTokenCacheNotificationsRef,
       tokenCache,
     });
@@ -355,21 +342,22 @@ function mergePendingNativeRefreshOptions(
   }
 
   const merged: NativeRefreshFromJsOptions = {
-    shouldRefreshClient: current.shouldRefreshClient || next.shouldRefreshClient,
+    didChangeClient: current.didChangeClient || next.didChangeClient,
+    didChangeDeviceToken: current.didChangeDeviceToken || next.didChangeDeviceToken,
   };
 
-  if ('clientToken' in current) {
-    merged.clientToken = current.clientToken ?? null;
+  if ('deviceToken' in current) {
+    merged.deviceToken = current.deviceToken ?? null;
   }
 
-  if ('clientToken' in next) {
-    merged.clientToken = next.clientToken ?? null;
+  if ('deviceToken' in next) {
+    merged.deviceToken = next.deviceToken ?? null;
   }
 
   return merged;
 }
 
-async function getCachedClientToken(tokenCache: TokenCache | undefined): Promise<string | null> {
+async function getCachedDeviceToken(tokenCache: TokenCache | undefined): Promise<string | null> {
   if (!tokenCache) {
     return null;
   }
@@ -406,15 +394,20 @@ async function syncNativeClientToJs({
   suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
-  const nativeClientTokenFromEvent = getNativeClientTokenFromSnapshot(nativeClientEvent);
-  const nativeClientToken =
-    nativeClientTokenFromEvent !== undefined
-      ? nativeClientTokenFromEvent
-      : await readNativeClientToken({
-          waitForToken: !nativeClientEvent,
-        });
+  const didChangeClient = nativeClientEvent?.changed.client ?? true;
+  const didChangeDeviceToken = nativeClientEvent?.changed.deviceToken ?? true;
 
-  if (!nativeClientToken && !nativeClientEvent) {
+  if (!didChangeClient && !didChangeDeviceToken) {
+    return;
+  }
+
+  const nativeDeviceToken = nativeClientEvent
+    ? nativeClientEvent.deviceToken
+    : await readNativeDeviceToken({
+        waitForToken: true,
+      });
+
+  if (!nativeDeviceToken && !nativeClientEvent) {
     return;
   }
 
@@ -423,8 +416,9 @@ async function syncNativeClientToJs({
 
     await refreshJsClientFromNativeState({
       clerkInstance,
-      nativeClientToken,
+      nativeDeviceToken,
       reloadInitialResources: true,
+      shouldSyncDeviceToken: didChangeDeviceToken,
       suppressTokenCacheNotificationsRef,
       tokenCache,
     });
@@ -451,7 +445,7 @@ export function NativeClientSync({
   suppressJsClientChangedRef: MutableRefObject<number>;
   suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
   tokenCache: TokenCache | undefined;
-  tokenCacheListenersRef: MutableRefObject<Set<ClientTokenCacheListener>>;
+  tokenCacheListenersRef: MutableRefObject<Set<DeviceTokenCacheListener>>;
 }): null {
   const isRefreshingNativeFromJsRef = useRef(false);
   const pendingNativeRefreshRef = useRef<NativeRefreshFromJsOptions | null>(null);
@@ -522,7 +516,12 @@ export function NativeClientSync({
         return;
       }
 
-      originalUpdateClient(newClient, options);
+      if (options) {
+        originalUpdateClient(newClient, options);
+        return;
+      }
+
+      originalUpdateClient(newClient);
     };
 
     clerkInstance.updateClient = updateClient;
@@ -554,13 +553,18 @@ export function NativeClientSync({
         return;
       }
 
-      const bearerToken = 'clientToken' in options ? (options.clientToken ?? null) : null;
+      const deviceToken = options.didChangeDeviceToken ? (options.deviceToken ?? null) : null;
       if (generation !== nativeRefreshGenerationRef.current) {
         return;
       }
 
       const sourceId = `${nativeClientSyncSourceIdPrefix}-${generation}`;
-      await ClerkExpo.syncFromJsClientToken(bearerToken, sourceId, options.shouldRefreshClient);
+      await ClerkExpo.syncClientStateFromJs(
+        deviceToken,
+        sourceId,
+        options.didChangeClient,
+        options.didChangeDeviceToken,
+      );
     };
 
     let latestRunGeneration = initialGeneration;
@@ -578,7 +582,10 @@ export function NativeClientSync({
             console.warn('[NativeClientSync] Failed to refresh native client from JS client change:', error);
           }
         }
-        pendingOptions = pendingNativeRefreshRef.current ?? { shouldRefreshClient: false };
+        pendingOptions = pendingNativeRefreshRef.current ?? {
+          didChangeClient: false,
+          didChangeDeviceToken: false,
+        };
         if (pendingNativeRefreshRef.current !== null) {
           generation = nativeRefreshGenerationRef.current + 1;
           nativeRefreshGenerationRef.current = generation;
@@ -592,8 +599,12 @@ export function NativeClientSync({
   }, []);
 
   useEffect(() => {
-    const listener: ClientTokenCacheListener = clientToken => {
-      queueNativeRefreshFromJs({ clientToken, shouldRefreshClient: clientToken === null });
+    const listener: DeviceTokenCacheListener = deviceToken => {
+      queueNativeRefreshFromJs({
+        deviceToken,
+        didChangeClient: false,
+        didChangeDeviceToken: true,
+      });
     };
     const tokenCacheListeners = tokenCacheListenersRef.current;
 
@@ -620,13 +631,13 @@ export function NativeClientSync({
       try {
         return await runWithSuppressedJsClientChanges(suppressJsClientChangedRef, async () => {
           try {
-            const nativeClientToken = await readNativeClientToken({ waitForToken: false });
+            const nativeDeviceToken = await readNativeDeviceToken({ waitForToken: false });
             // Native may have already moved the server-side client to a new
             // active session. Refresh JS before allowing Clerk JS' stale-session
             // 401 path to collapse the whole client to signed out.
             const didRecover = await refreshJsClientFromNativeState({
               clerkInstance,
-              nativeClientToken,
+              nativeDeviceToken,
               reloadInitialResources: false,
               suppressTokenCacheNotificationsRef,
               tokenCache,
@@ -635,7 +646,7 @@ export function NativeClientSync({
               return;
             }
           } catch (error) {
-            const didRecover = await recoverJsClientFromNativeToken({
+            const didRecover = await recoverJsClientFromNativeDeviceToken({
               clerkInstance,
               error,
               suppressTokenCacheNotificationsRef,
@@ -673,7 +684,10 @@ export function NativeClientSync({
           return;
         }
 
-        queueNativeRefreshFromJs({ shouldRefreshClient: true });
+        queueNativeRefreshFromJs({
+          didChangeClient: true,
+          didChangeDeviceToken: false,
+        });
       },
       { skipInitialEmit: true },
     );
@@ -723,17 +737,17 @@ export function useNativeClientBootstrap({
               return;
             }
 
-            let bearerToken: string | null = null;
+            let cachedDeviceToken: string | null = null;
             try {
-              bearerToken = await getCachedClientToken(tokenCache);
+              cachedDeviceToken = await getCachedDeviceToken(tokenCache);
             } catch (e) {
               if (__DEV__) {
                 console.warn('[ClerkProvider] Token cache read failed:', e);
               }
             }
 
-            if (bearerToken) {
-              await ClerkExpo.configure(publishableKey, bearerToken);
+            if (cachedDeviceToken) {
+              await ClerkExpo.configure(publishableKey, cachedDeviceToken);
 
               if (!isMountedRef.current) {
                 return;

--- a/packages/expo/src/provider/nativeClientSync.tsx
+++ b/packages/expo/src/provider/nativeClientSync.tsx
@@ -50,7 +50,7 @@ export function useSyncableTokenCache({
   tokenCache,
   tokenCacheListenersRef,
 }: {
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
   tokenCacheListenersRef: MutableRefObject<Set<DeviceTokenCacheListener>>;
 }): TokenCache | undefined {
@@ -62,7 +62,7 @@ export function useSyncableTokenCache({
     }
 
     const notifyDeviceTokenListeners = (deviceToken: string | null) => {
-      if (suppressTokenCacheNotificationsRef.current) {
+      if (suppressTokenCacheNotificationsRef.current > 0) {
         return;
       }
 
@@ -134,14 +134,14 @@ async function syncDeviceTokenToCacheWithoutNotifying({
   tokenCache,
 }: {
   deviceToken: string | null;
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
-  suppressTokenCacheNotificationsRef.current = true;
+  suppressTokenCacheNotificationsRef.current += 1;
   try {
     await syncDeviceTokenToCache(tokenCache, deviceToken);
   } finally {
-    suppressTokenCacheNotificationsRef.current = false;
+    suppressTokenCacheNotificationsRef.current = Math.max(0, suppressTokenCacheNotificationsRef.current - 1);
   }
 }
 
@@ -151,7 +151,7 @@ async function syncNativeDeviceTokenToCache({
   tokenCache,
 }: {
   deviceToken: string | null;
-  suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef?: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
   if (suppressTokenCacheNotificationsRef) {
@@ -206,7 +206,7 @@ async function refreshJsClientFromNativeState({
   nativeDeviceToken: string | null;
   reloadInitialResources: boolean;
   shouldSyncDeviceToken?: boolean;
-  suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef?: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
   if (shouldSyncDeviceToken) {
@@ -244,7 +244,7 @@ async function reloadJsClientFromNativeState({
 }: {
   clerkInstance: SyncableClerkInstance;
   nativeDeviceToken: string;
-  suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef?: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
   await syncNativeDeviceTokenToCache({
@@ -268,7 +268,7 @@ async function recoverJsClientFromNativeDeviceToken({
 }: {
   clerkInstance: SyncableClerkInstance;
   error: unknown;
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<boolean> {
   const nativeDeviceToken = await readNativeDeviceToken({ waitForToken: false });
@@ -391,7 +391,7 @@ async function syncNativeClientToJs({
   nativeRefreshFromJsControllerRef?: MutableRefObject<NativeRefreshFromJsController | null>;
   nativeClientEvent?: NativeClientEvent | null;
   suppressJsClientChangedRef?: MutableRefObject<number>;
-  suppressTokenCacheNotificationsRef?: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef?: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }): Promise<void> {
   const didChangeClient = nativeClientEvent?.changed.client ?? true;
@@ -443,7 +443,7 @@ export function NativeClientSync({
   clerkInstance: SyncableClerkInstance | null | undefined;
   nativeRefreshFromJsControllerRef: MutableRefObject<NativeRefreshFromJsController | null>;
   suppressJsClientChangedRef: MutableRefObject<number>;
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
   tokenCacheListenersRef: MutableRefObject<Set<DeviceTokenCacheListener>>;
 }): null {
@@ -707,7 +707,7 @@ export function useNativeClientBootstrap({
   clerkInstance,
 }: {
   publishableKey: string;
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
   clerkInstance: SyncableClerkInstance | null | undefined;
 }) {
@@ -826,7 +826,7 @@ export function useNativeClientEventSync({
   isMountedRef: MutableRefObject<boolean>;
   nativeRefreshFromJsControllerRef: MutableRefObject<NativeRefreshFromJsController | null>;
   suppressJsClientChangedRef: MutableRefObject<number>;
-  suppressTokenCacheNotificationsRef: MutableRefObject<boolean>;
+  suppressTokenCacheNotificationsRef: MutableRefObject<number>;
   tokenCache: TokenCache | undefined;
 }) {
   const { nativeClientEvent } = useNativeClientEvents();

--- a/packages/expo/src/specs/NativeClerkModule.android.ts
+++ b/packages/expo/src/specs/NativeClerkModule.android.ts
@@ -6,10 +6,11 @@ interface Spec {
   addListener?(eventName: string): void;
   configure(publishableKey: string, bearerToken: string | null): Promise<void>;
   getClientToken(): Promise<string | null>;
-  syncFromJsClientToken(
-    clientToken: string | null,
+  syncClientStateFromJs(
+    deviceToken: string | null,
     sourceId: string | null,
-    shouldRefreshClient?: boolean,
+    didChangeClient: boolean,
+    didChangeDeviceToken: boolean,
   ): Promise<void>;
   removeListeners?(count: number): void;
 }

--- a/packages/expo/src/specs/NativeClerkModule.ts
+++ b/packages/expo/src/specs/NativeClerkModule.ts
@@ -7,10 +7,11 @@ export interface Spec extends TurboModule {
   addListener(eventName: string): void;
   configure(publishableKey: string, bearerToken: string | null): Promise<void>;
   getClientToken(): Promise<string | null>;
-  syncFromJsClientToken(
-    clientToken: string | null,
+  syncClientStateFromJs(
+    deviceToken: string | null,
     sourceId: string | null,
-    shouldRefreshClient?: boolean,
+    didChangeClient: boolean,
+    didChangeDeviceToken: boolean,
   ): Promise<void>;
   // Required by NativeEventEmitter for internal native client change events.
   // This is not part of the public @clerk/expo API.

--- a/packages/expo/src/utils/__tests__/native-module.test.ts
+++ b/packages/expo/src/utils/__tests__/native-module.test.ts
@@ -15,7 +15,7 @@ const makeNativeModule = ({ includeEventMethods = true } = {}) => ({
     : {}),
   configure: vi.fn(),
   getClientToken: vi.fn(),
-  syncFromJsClientToken: vi.fn(),
+  syncClientStateFromJs: vi.fn(),
 });
 
 vi.mock('react-native', () => ({

--- a/packages/expo/src/utils/native-module.ts
+++ b/packages/expo/src/utils/native-module.ts
@@ -9,10 +9,11 @@ type ClerkExpoNativeModule = {
   configure(publishableKey: string, bearerToken: string | null): Promise<void>;
   getClientToken(): Promise<string | null>;
   removeListeners?(count: number): void;
-  syncFromJsClientToken(
-    clientToken: string | null,
+  syncClientStateFromJs(
+    deviceToken: string | null,
     sourceId: string | null,
-    shouldRefreshClient?: boolean,
+    didChangeClient: boolean,
+    didChangeDeviceToken: boolean,
   ): Promise<void>;
 };
 
@@ -25,7 +26,7 @@ function isClerkExpoModule(module: unknown): module is ClerkExpoNativeModule {
   return (
     typeof maybeModule.configure === 'function' &&
     typeof maybeModule.getClientToken === 'function' &&
-    typeof maybeModule.syncFromJsClientToken === 'function'
+    typeof maybeModule.syncClientStateFromJs === 'function'
   );
 }
 


### PR DESCRIPTION
## Summary
- rework Expo JS/native client sync so client and device-token changes are signaled explicitly in both directions
- refresh JS from native client changes without suppressing the JS client update emit
- update iOS/Android native module sync APIs and tests around the new client-driven contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between native and JavaScript client states in Expo.
  * Device-token updates now propagate more reliably across both platforms, triggering refreshes only when relevant state changes occur.
  * Native client change events now use a clearer “changed” breakdown and will ignore invalid payloads to prevent incorrect updates.
  * Native refresh/recovery behavior is aligned to use the device token consistently, reducing sync gaps and redundant refresh cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->