### PR TITLE
feat(clerk-js,ui): Auto-activate exclusive organization in choose-organization task

### DIFF
--- a/.changeset/exclusive-membership-auto-activate.md
+++ b/.changeset/exclusive-membership-auto-activate.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+When the `choose-organization` session task is triggered for a member of an organization that enforces exclusive membership, Clerk now automatically activates that organization instead of rendering the organization picker. The user sees a loading spinner while the organization is set as active; if activation fails, the regular picker is shown so they can recover. The generic force-choose-organization flow is unchanged for everyone else.
+
+Additionally, `Organization.exclusiveMembership` is now exposed on the Organization resource, reflecting the `exclusive_membership` field returned by the Frontend API.

--- a/.changeset/exclusive-membership-auto-activate.md
+++ b/.changeset/exclusive-membership-auto-activate.md
@@ -1,9 +1,9 @@
 ---
-'@clerk/clerk-js': patch
-'@clerk/shared': patch
-'@clerk/ui': patch
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/ui': minor
 ---
 
-When the `choose-organization` session task is triggered for a member of an organization that enforces exclusive membership, Clerk now automatically activates that organization instead of rendering the organization picker. The user sees a loading spinner while the organization is set as active; if activation fails, the regular picker is shown so they can recover. The generic force-choose-organization flow is unchanged for everyone else.
+Introduces organization membership feature.
 
-Additionally, `Organization.exclusiveMembership` is now exposed on the Organization resource, reflecting the `exclusive_membership` field returned by the Frontend API.
+Organizations can enforce exclusive membership, limiting users to a single organization. During the `choose-organization` session task, members of such an organization are automatically activated instead of seeing the picker. `Organization.exclusiveMembership` is now exposed on the Organization resource.

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -74,6 +74,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   pendingInvitationsCount = 0;
   maxAllowedMemberships!: number;
   selfServeSSOEnabled = false;
+  exclusiveMembership?: boolean;
 
   constructor(data: OrganizationJSON | OrganizationJSONSnapshot) {
     super();
@@ -474,6 +475,7 @@ export class Organization extends BaseResource implements OrganizationResource {
     this.maxAllowedMemberships = data.max_allowed_memberships || 0;
     this.adminDeleteEnabled = data.admin_delete_enabled || false;
     this.selfServeSSOEnabled = data.self_serve_sso_enabled || false;
+    this.exclusiveMembership = data.exclusive_membership;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;
@@ -493,6 +495,7 @@ export class Organization extends BaseResource implements OrganizationResource {
       max_allowed_memberships: this.maxAllowedMemberships,
       admin_delete_enabled: this.adminDeleteEnabled,
       self_serve_sso_enabled: this.selfServeSSOEnabled,
+      exclusive_membership: this.exclusiveMembership,
       created_at: this.createdAt.getTime(),
       updated_at: this.updatedAt.getTime(),
     };

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -74,7 +74,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   pendingInvitationsCount = 0;
   maxAllowedMemberships!: number;
   selfServeSSOEnabled = false;
-  exclusiveMembership?: boolean;
+  exclusiveMembership = false;
 
   constructor(data: OrganizationJSON | OrganizationJSONSnapshot) {
     super();
@@ -475,7 +475,7 @@ export class Organization extends BaseResource implements OrganizationResource {
     this.maxAllowedMemberships = data.max_allowed_memberships || 0;
     this.adminDeleteEnabled = data.admin_delete_enabled || false;
     this.selfServeSSOEnabled = data.self_serve_sso_enabled || false;
-    this.exclusiveMembership = data.exclusive_membership;
+    this.exclusiveMembership = data.exclusive_membership || false;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;

--- a/packages/shared/src/types/json.ts
+++ b/packages/shared/src/types/json.ts
@@ -398,6 +398,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   admin_delete_enabled: boolean;
   max_allowed_memberships: number;
   self_serve_sso_enabled?: boolean;
+  exclusive_membership?: boolean;
 }
 
 export interface OrganizationMembershipJSON extends ClerkResourceJSON {

--- a/packages/shared/src/types/organization.ts
+++ b/packages/shared/src/types/organization.ts
@@ -98,6 +98,10 @@ export interface OrganizationResource extends ClerkResource, BillingPayerMethods
    */
   selfServeSSOEnabled: boolean;
   /**
+   * Whether the Organization enforces exclusive membership, meaning members must have it set as their active Organization. This is `undefined` for instances that have not adopted the feature.
+   */
+  exclusiveMembership?: boolean;
+  /**
    * The date when the Organization was first created.
    */
   createdAt: Date;

--- a/packages/shared/src/types/organization.ts
+++ b/packages/shared/src/types/organization.ts
@@ -98,9 +98,9 @@ export interface OrganizationResource extends ClerkResource, BillingPayerMethods
    */
   selfServeSSOEnabled: boolean;
   /**
-   * Whether the Organization enforces exclusive membership, meaning members must have it set as their active Organization. This is `undefined` for instances that have not adopted the feature.
+   * Whether the Organization enforces exclusive membership, meaning members must have it set as their active Organization. Defaults to `false` for instances that have not adopted the feature.
    */
-  exclusiveMembership?: boolean;
+  exclusiveMembership: boolean;
   /**
    * The date when the Organization was first created.
    */

--- a/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -1,23 +1,89 @@
-import { useClerk, useOrganizationCreationDefaults, useSession, useUser } from '@clerk/shared/react';
+import {
+  useClerk,
+  useOrganizationCreationDefaults,
+  useOrganizationList,
+  useSession,
+  useUser,
+} from '@clerk/shared/react';
 import type { OrganizationCreationDefaultsResource } from '@clerk/shared/types';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useSignOutContext, withCoreSessionSwitchGuard } from '@/ui/contexts';
+import { useSessionTasksContext, useTaskChooseOrganizationContext } from '@/ui/contexts/components/SessionTasks';
 import { descriptors, Flex, Flow, localizationKeys, Spinner } from '@/ui/customizables';
 import { Card } from '@/ui/elements/Card';
-import { withCardStateProvider } from '@/ui/elements/contexts';
+import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { Header } from '@/ui/elements/Header';
 import { useMultipleSessions } from '@/ui/hooks/useMultipleSessions';
 import { useOrganizationListInView } from '@/ui/hooks/useOrganizationListInView';
+import { handleError } from '@/ui/utils/errorHandler';
 
 import { withTaskGuard } from '../shared';
 import { ChooseOrganizationScreen } from './ChooseOrganizationScreen';
 import { CreateOrganizationScreen } from './CreateOrganizationScreen';
 
+const LoadingCardContent = () => (
+  <Flex
+    direction={'row'}
+    align={'center'}
+    justify={'center'}
+    sx={t => ({
+      height: '100%',
+      minHeight: t.sizes.$100,
+    })}
+  >
+    <Spinner
+      size={'lg'}
+      colorScheme={'primary'}
+      elementDescriptor={descriptors.spinner}
+    />
+  </Flex>
+);
+
 const TaskChooseOrganizationInternal = () => {
+  const card = useCardState();
   const { user } = useUser();
   const { userMemberships, userSuggestions, userInvitations } = useOrganizationListInView();
   const organizationCreationDefaults = useOrganizationCreationDefaults();
+  const { isLoaded: isOrganizationListLoaded, setActive } = useOrganizationList();
+  const { navigateOnSetActive } = useSessionTasksContext();
+  const { redirectUrlComplete } = useTaskChooseOrganizationContext();
+
+  // An exclusive member belongs to exactly one organization, so find-first is correct.
+  const exclusiveOrganization = user?.organizationMemberships?.find(
+    membership => membership.organization.exclusiveMembership === true,
+  )?.organization;
+
+  // Guards against the auto-activation effect firing more than once.
+  const hasAutoActivated = useRef(false);
+  // When auto-activation fails we fall back to the regular flows so the user can recover.
+  const [autoActivateFailed, setAutoActivateFailed] = useState(false);
+  const shouldAutoActivate = !!exclusiveOrganization && !autoActivateFailed;
+
+  useEffect(() => {
+    if (!exclusiveOrganization || autoActivateFailed || !isOrganizationListLoaded || hasAutoActivated.current) {
+      return;
+    }
+
+    hasAutoActivated.current = true;
+
+    void (async () => {
+      try {
+        await setActive({
+          organization: exclusiveOrganization,
+          navigate: async ({ session, decorateUrl }) => {
+            await navigateOnSetActive?.({ session, redirectUrlComplete, decorateUrl });
+          },
+        });
+      } catch (err: any) {
+        // Surface the error through card state, mirroring ChooseOrganizationScreen's handling.
+        handleError(err, [], card.setError);
+        // Don't leave the user stuck on an infinite spinner; fall back to the regular flows.
+        setAutoActivateFailed(true);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exclusiveOrganization, autoActivateFailed, isOrganizationListLoaded]);
 
   const isLoading =
     userMemberships?.isLoading ||
@@ -31,7 +97,7 @@ const TaskChooseOrganizationInternal = () => {
     user?.organizationMemberships?.length === 0 &&
     !hasExistingResources;
 
-  if (isOrganizationCreationDisabled) {
+  if (isOrganizationCreationDisabled && !shouldAutoActivate) {
     return <OrganizationCreationDisabledScreen />;
   }
 
@@ -40,22 +106,8 @@ const TaskChooseOrganizationInternal = () => {
       <Flow.Part part='chooseOrganization'>
         <Card.Root>
           <Card.Content sx={t => ({ padding: `${t.space.$8} ${t.space.$none} ${t.space.$none}`, gap: t.space.$7 })}>
-            {isLoading ? (
-              <Flex
-                direction={'row'}
-                align={'center'}
-                justify={'center'}
-                sx={t => ({
-                  height: '100%',
-                  minHeight: t.sizes.$100,
-                })}
-              >
-                <Spinner
-                  size={'lg'}
-                  colorScheme={'primary'}
-                  elementDescriptor={descriptors.spinner}
-                />
-              </Flex>
+            {shouldAutoActivate || isLoading ? (
+              <LoadingCardContent />
             ) : (
               <TaskChooseOrganizationFlows
                 initialFlow={hasExistingResources ? 'choose' : 'create'}

--- a/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
+++ b/packages/ui/src/components/SessionTasks/tasks/TaskChooseOrganization/index.tsx
@@ -49,17 +49,16 @@ const TaskChooseOrganizationInternal = () => {
   const { navigateOnSetActive } = useSessionTasksContext();
   const { redirectUrlComplete } = useTaskChooseOrganizationContext();
 
-  // An exclusive member belongs to exactly one organization, so find-first is correct.
   const exclusiveOrganization = user?.organizationMemberships?.find(
     membership => membership.organization.exclusiveMembership === true,
   )?.organization;
 
-  // Guards against the auto-activation effect firing more than once.
   const hasAutoActivated = useRef(false);
-  // When auto-activation fails we fall back to the regular flows so the user can recover.
   const [autoActivateFailed, setAutoActivateFailed] = useState(false);
   const shouldAutoActivate = !!exclusiveOrganization && !autoActivateFailed;
 
+  // Exclusive members belong to a single org — skip the picker and activate it once the org list is ready.
+  // On failure, surface the error and fall back to the normal choose/create flows.
   useEffect(() => {
     if (!exclusiveOrganization || autoActivateFailed || !isOrganizationListLoaded || hasAutoActivated.current) {
       return;
@@ -76,9 +75,7 @@ const TaskChooseOrganizationInternal = () => {
           },
         });
       } catch (err: any) {
-        // Surface the error through card state, mirroring ChooseOrganizationScreen's handling.
         handleError(err, [], card.setError);
-        // Don't leave the user stuck on an infinite spinner; fall back to the regular flows.
         setAutoActivateFailed(true);
       }
     })();


### PR DESCRIPTION
## What

When the `choose-organization` session task fires for a member of an **exclusive-membership** organization, clerk-js now skips the org picker entirely: it shows the loading spinner and auto-calls `setActive` on that org. The generic instance-wide force-choose-org flow is unchanged for everyone else.

Implements the clerk-js half of exclusive membership "after-auth".


## Changes

- **Expose `Organization.exclusiveMembership`** — parse the FAPI `exclusive_membership` field (`@clerk/shared` types + `clerk-js` Organization resource `fromJSON` / `__internal_toSnapshot`). Field is `undefined` for non-adopting instances.
- **`TaskChooseOrganization`** — detect the membership whose `organization.exclusiveMembership === true` (an exclusive member belongs to exactly one org). If found: render only the spinner and auto-`setActive` once (`useRef` single-fire guard), reusing the existing `navigateOnSetActive` / `redirectUrlComplete` wiring. On failure, surface the error via card state and fall back to the normal flows so the user can recover. No exclusive membership → existing behavior, zero change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Organizations can now enforce exclusive membership, restricting users to a single organization at a time
* Users in exclusive-membership organizations are automatically activated during sign-in, eliminating the need to manually select an organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->