### PR TITLE
feat(clerk-js): Backport interactive captcha spotlight for Core 2

### DIFF
--- a/.changeset/captcha-interactive-spotlight.md
+++ b/.changeset/captcha-interactive-spotlight.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Spotlight interactive bot-protection (Cloudflare Turnstile) challenges during sign-in and sign-up. When a challenge escalates to an interactive "Verify you are human" check, the start card now brings it to the foreground — collapsing and `inert`-ing the rest of the form until the challenge is solved — while keeping the header, footer, and passkey action reachable. Invisible challenges are unaffected.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -155,6 +155,9 @@ function SignInStartInternal(): JSX.Element {
   const hasSocialOrWeb3Buttons =
     !!authenticatableSocialStrategies.length || !!web3FirstFactors.length || !!alternativePhoneCodeChannels.length;
   const [shouldAutofocus, setShouldAutofocus] = useState(!isMobileDevice() && !hasSocialOrWeb3Buttons);
+  // When the captcha escalates to an interactive challenge, spotlight it by collapsing/inerting the
+  // rest of the card (see the descriptors.main column below).
+  const [captchaIsInteractive, setCaptchaIsInteractive] = useState(false);
   const textIdentifierField = useFormControl('identifier', initialValues[identifierAttribute] || '', {
     ...currentIdentifier,
     isRequired: true,
@@ -574,6 +577,13 @@ function SignInStartInternal(): JSX.Element {
             <Col
               elementDescriptor={descriptors.main}
               gap={6}
+              // @ts-ignore - `inert` is not yet in the installed React types
+              inert={captchaIsInteractive ? '' : undefined}
+              // `display:none` (not `visibility:hidden`) so the collapsed column leaves flex flow and
+              // contributes no `gap` gutter to `Card.Content` — otherwise it injects empty space above
+              // the spotlighted captcha. Subtree stays mounted (form state preserved); `inert` is then
+              // redundant-but-harmless.
+              sx={captchaIsInteractive ? { display: 'none' } : undefined}
             >
               <SocialButtonsReversibleContainerWithDivider>
                 {hasSocialOrWeb3Buttons && (
@@ -603,24 +613,27 @@ function SignInStartInternal(): JSX.Element {
                       <InstantPasswordRow field={passwordBasedInstance ? instantPasswordField : undefined} />
                     </Col>
                     <Col center>
-                      <CaptchaElement />
                       <Form.SubmitButton hasArrow />
                     </Col>
                   </Form.Root>
                 ) : null}
               </SocialButtonsReversibleContainerWithDivider>
-              {!standardFormAttributes.length && <CaptchaElement />}
-              {userSettings.attributes.passkey?.enabled &&
-                userSettings.passkeySettings.show_sign_in_button &&
-                isWebSupported && (
-                  <Card.Action elementId={'usePasskey'}>
-                    <Card.ActionLink
-                      localizationKey={localizationKeys('signIn.start.actionLink__use_passkey')}
-                      onClick={() => authenticateWithPasskey({ flow: 'discoverable' })}
-                    />
-                  </Card.Action>
-                )}
             </Col>
+            <CaptchaElement
+              gapless
+              onInteractiveChange={setCaptchaIsInteractive}
+            />
+            {/* Kept outside descriptors.main so the spotlight's `inert` leaves this alternative action reachable. */}
+            {userSettings.attributes.passkey?.enabled &&
+              userSettings.passkeySettings.show_sign_in_button &&
+              isWebSupported && (
+                <Card.Action elementId={'usePasskey'}>
+                  <Card.ActionLink
+                    localizationKey={localizationKeys('signIn.start.actionLink__use_passkey')}
+                    onClick={() => authenticateWithPasskey({ flow: 'discoverable' })}
+                  />
+                </Card.Action>
+              )}
           </Card.Content>
           <Card.Footer>
             {userSettings.signUp.mode === SIGN_UP_MODES.PUBLIC && !isCombinedFlow && (

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -5,7 +5,6 @@ import { LegalCheckbox } from '@/ui/elements/LegalConsentCheckbox';
 import type { FormControlState } from '@/ui/utils/useFormControl';
 
 import { Col, localizationKeys, useAppearance } from '../../customizables';
-import { CaptchaElement } from '../../elements/CaptchaElement';
 import { mqu } from '../../styledSystem';
 import type { ActiveIdentifier, Fields } from './signUpFormHelpers';
 
@@ -115,7 +114,6 @@ export const SignUpForm = (props: SignUpFormProps) => {
         </Col>
       )}
       <Col center>
-        <CaptchaElement />
         <Col
           gap={6}
           sx={{

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -65,6 +65,9 @@ function SignUpStartInternal(): JSX.Element {
   );
 
   const [missingRequirementsWithTicket, setMissingRequirementsWithTicket] = React.useState(false);
+  // When the captcha escalates to an interactive challenge, spotlight it by collapsing/inerting the
+  // rest of the card (see the descriptors.main column below).
+  const [captchaIsInteractive, setCaptchaIsInteractive] = React.useState(false);
 
   const {
     userSettings: { passwordSettings, usernameSettings },
@@ -428,6 +431,13 @@ function SignUpStartInternal(): JSX.Element {
               direction='col'
               elementDescriptor={descriptors.main}
               gap={6}
+              // @ts-ignore - `inert` is not yet in the installed React types
+              inert={captchaIsInteractive ? '' : undefined}
+              // `display:none` (not `visibility:hidden`) so the collapsed column leaves flex flow and
+              // contributes no `gap` gutter to `Card.Content` — otherwise it injects empty space above
+              // the spotlighted captcha. Subtree stays mounted (form state preserved); `inert` is then
+              // redundant-but-harmless.
+              sx={captchaIsInteractive ? { display: 'none' } : undefined}
             >
               <SocialButtonsReversibleContainerWithDivider>
                 {(showOauthProviders || showWeb3Providers || showAlternativePhoneCodeProviders) && (
@@ -450,8 +460,11 @@ function SignUpStartInternal(): JSX.Element {
                   />
                 )}
               </SocialButtonsReversibleContainerWithDivider>
-              {!shouldShowForm && <CaptchaElement />}
             </Flex>
+            <CaptchaElement
+              gapless
+              onInteractiveChange={setCaptchaIsInteractive}
+            />
           </Card.Content>
 
           <Card.Footer>

--- a/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
+++ b/packages/clerk-js/src/ui/elements/CaptchaElement.tsx
@@ -1,19 +1,41 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { CAPTCHA_ELEMENT_ID } from '../../utils/captcha/constants';
 import { Box, useAppearance, useLocalizations } from '../customizables';
 
 /**
  * This component uses a MutationObserver to listen for DOM changes made by our Turnstile logic,
- * which operates outside the React lifecycle. It stores the observed state in ref to ensure that
+ * which operates outside the React lifecycle. It stores the observed state in refs to ensure that
  * any external style changes, such as updates to max-height, min-height, or margin-bottom persist across re-renders,
  * preventing unwanted layout resets.
+ *
+ * When Turnstile escalates to an interactive "Verify you are human" challenge it sets
+ * `data-cl-interactive="true"` on the element (removed on resolve/error). `onInteractiveChange`
+ * surfaces that signal so a parent can react (e.g. spotlight the challenge); it never fires on mount.
  */
-export const CaptchaElement = () => {
-  const elementRef = useRef(null);
+export const CaptchaElement = ({
+  onInteractiveChange,
+  gapless,
+}: {
+  onInteractiveChange?: (interactive: boolean) => void;
+  /**
+   * When true, the element is removed from flow (`position:absolute`) while collapsed so it adds no
+   * gap gutter to a flex parent, switching to `position:static` while interactive. Opt-in so the
+   * other (non-spotlight) render sites keep their current positioning.
+   */
+  gapless?: boolean;
+}) => {
+  const elementRef = useRef<HTMLDivElement>(null);
   const maxHeightValueRef = useRef('0');
   const minHeightValueRef = useRef('unset');
   const marginBottomValueRef = useRef('unset');
+  // State forces a re-render on the interactive transition, which re-applies the ref-held styles
+  // above (preserving Turnstile's injected values) and drives the `gapless` position toggle.
+  const [isInteractive, setIsInteractive] = useState(false);
+  // The observer is set up once (`[]` deps), so it reads the latest callback through a ref.
+  const onInteractiveChangeRef = useRef(onInteractiveChange);
+  onInteractiveChangeRef.current = onInteractiveChange;
+  const isInteractiveRef = useRef(false);
   const { parsedCaptcha } = useAppearance();
   const { locale } = useLocalizations();
   const captchaTheme = parsedCaptcha?.theme;
@@ -30,17 +52,46 @@ export const CaptchaElement = () => {
     const observer = new MutationObserver(mutations => {
       mutations.forEach(mutation => {
         const target = mutation.target as HTMLDivElement;
-        if (mutation.type === 'attributes' && mutation.attributeName === 'style' && elementRef.current) {
+        if (mutation.type !== 'attributes' || !elementRef.current) {
+          return;
+        }
+        if (mutation.attributeName === 'style') {
+          // Keep refs in sync so Turnstile's injected styles survive React re-renders.
           maxHeightValueRef.current = target.style.maxHeight || '0';
           minHeightValueRef.current = target.style.minHeight || 'unset';
           marginBottomValueRef.current = target.style.marginBottom || 'unset';
+          // Fallback for old clerk-js that never writes data-cl-interactive: infer
+          // interactive state from maxHeight. When the MutationObserver callback fires,
+          // the DOM already reflects all mutations from the same microtask, so
+          // `target.dataset.clInteractive` is up-to-date — new clerk-js (which sets
+          // the attribute alongside the style) passes the guard and is handled below.
+          if (!('clInteractive' in target.dataset)) {
+            const mh = target.style.maxHeight;
+            const nowInteractive = mh !== '' && mh !== '0' && mh !== '0px';
+            if (nowInteractive !== isInteractiveRef.current) {
+              isInteractiveRef.current = nowInteractive;
+              setIsInteractive(nowInteractive);
+              onInteractiveChangeRef.current?.(nowInteractive);
+            }
+          }
+        }
+        if (mutation.attributeName === 'data-cl-interactive') {
+          // ORDERING IS LOAD-BEARING: style mutations from the same turnstile.ts call are
+          // delivered before this one (DOM mutations are batched and replayed in order), so
+          // the refs above are already up-to-date when the re-render triggered below runs.
+          const nowInteractive = target.dataset.clInteractive === 'true';
+          if (nowInteractive !== isInteractiveRef.current) {
+            isInteractiveRef.current = nowInteractive;
+            setIsInteractive(nowInteractive);
+            onInteractiveChangeRef.current?.(nowInteractive);
+          }
         }
       });
     });
 
     observer.observe(elementRef.current, {
       attributes: true,
-      attributeFilter: ['style'],
+      attributeFilter: ['style', 'data-cl-interactive'],
     });
 
     return () => observer.disconnect();
@@ -56,6 +107,9 @@ export const CaptchaElement = () => {
         maxHeight: maxHeightValueRef.current,
         minHeight: minHeightValueRef.current,
         marginBottom: marginBottomValueRef.current,
+        // When `gapless`, drop out of flow while collapsed so the element contributes no gap gutter
+        // to its flex parent; rejoin flow once the interactive challenge expands it.
+        position: gapless ? (isInteractive ? 'static' : 'absolute') : undefined,
       }}
       data-cl-theme={captchaTheme}
       data-cl-size={captchaSize}

--- a/packages/clerk-js/src/utils/captcha/turnstile.ts
+++ b/packages/clerk-js/src/utils/captcha/turnstile.ts
@@ -194,6 +194,7 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
                 // and then expands to the correct height
                 visibleWidget.style.minHeight = captchaSize === 'compact' ? '140px' : '68px';
                 visibleWidget.style.marginBottom = '1.5rem';
+                visibleWidget.dataset.clInteractive = 'true';
               }
             }
           },
@@ -291,6 +292,7 @@ export const getTurnstileToken = async (opts: CaptchaOptions) => {
     if (captchaTypeUsed === 'smart') {
       const visibleWidget = document.getElementById(CAPTCHA_ELEMENT_ID);
       if (visibleWidget) {
+        delete visibleWidget.dataset.clInteractive;
         visibleWidget.style.maxHeight = '0';
         visibleWidget.style.minHeight = 'unset';
         visibleWidget.style.marginBottom = 'unset';


### PR DESCRIPTION
Backports the interactive-captcha spotlight from #8907 to the Core 2 release line.

There is no `@clerk/ui` package in Core 2 — the sign-in/sign-up UI lives entirely inside `clerk-js` (`packages/clerk-js/src/ui`). So the UI changes from the original PR are applied directly to clerk-js's bundled components here, alongside the clerk-js runtime change.

## What it does

When a Cloudflare Turnstile challenge escalates to an interactive "Verify you are human" check, the start card brings it to the foreground: the rest of the card (social buttons, form) collapses and is `inert`-ed until the challenge is solved, while the header, footer, and passkey action stay reachable. Invisible challenges — the vast majority — are unaffected.

## Changes

- **`utils/captcha/turnstile.ts`** — sets a `data-cl-interactive` attribute on `#clerk-captcha` when a challenge becomes interactive (removed on resolve), giving the UI a reliable signal.
- **`ui/elements/CaptchaElement.tsx`** — new optional `onInteractiveChange` and `gapless` props; the MutationObserver now also reads `data-cl-interactive`, with a `maxHeight` fallback for older runtimes. Other render sites that use a bare `<CaptchaElement />` are unaffected.
- **`ui/components/SignIn/SignInStart.tsx`** and **`ui/components/SignUp/SignUpStart.tsx`** — hoist the captcha into a single slot outside the collapsing column and wire up the spotlight.
- **`ui/components/SignUp/SignUpForm.tsx`** — no longer renders its own captcha; the start card's slot owns it now.

## Note

`SignUpForm` is shared by the start and continue flows, so removing its captcha means `SignUpContinue` no longer renders a captcha element. This matches the original PR's behavior — the captcha is only needed on the initial sign-up create.
