### PR TITLE
chore(shared,ui): Add telemetry event for flow steps

### DIFF
--- a/.changeset/gold-ends-throw.md
+++ b/.changeset/gold-ends-throw.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Add a generic `FLOW_STEP_MOUNTED` telemetry event (`eventFlowStepMounted`) for measuring multi-step flow funnels, and wire it into the self-serve SSO flow

--- a/packages/shared/src/telemetry/events/flow-step.ts
+++ b/packages/shared/src/telemetry/events/flow-step.ts
@@ -8,24 +8,24 @@ type EventFlowStepMounted = {
   flow: string;
   /** The step/part that mounted, e.g. `verify-domain` */
   step: string;
-  /** ISO-8601 timestamp, used to measure the time between steps of the same flow. */
-  timestamp: string;
+  /** Free-form, flow-specific metadata supplied by the caller (e.g. `timestamp`, `connectionStatus`). */
+  metadata: TelemetryEventRaw['payload'];
 } & TelemetryEventRaw['payload'];
 
 /**
- * Fires an event when a part of a multi-step flow becomes visible.
+ * Fires an event from a part of a multi-step flow.
  *
  * @param flow - The flow identifier (matches `Flow.Root`'s `flow`).
  * @param step - The step/part that mounted.
- * @param payload - Extra, flow-specific metadata
+ * @param metadata - Flow-specific metadata sent under `payload.metadata`.
  * @param eventSamplingRate - Override the default full-capture sampling rate.
  * @example
- * telemetry.record(eventFlowStepMounted('configureSSO', 'verify-domain', { connectionStatus: 'unconfigured' }));
+ * telemetry.record(eventFlowStepMounted('configureSSO', 'verify-domain', { timestamp: new Date().toISOString(), connectionStatus: 'unconfigured' }));
  */
 export function eventFlowStepMounted(
   flow: string,
   step: string,
-  payload: TelemetryEventRaw['payload'] = {},
+  metadata: TelemetryEventRaw['payload'] = {},
   eventSamplingRate: number = EVENT_SAMPLING_RATE,
 ): TelemetryEventRaw<EventFlowStepMounted> {
   return {
@@ -34,8 +34,7 @@ export function eventFlowStepMounted(
     payload: {
       flow,
       step,
-      timestamp: new Date().toISOString(),
-      ...payload,
+      metadata,
     },
   };
 }

--- a/packages/shared/src/telemetry/events/flow-step.ts
+++ b/packages/shared/src/telemetry/events/flow-step.ts
@@ -1,0 +1,41 @@
+import type { TelemetryEventRaw } from '../../types';
+
+const EVENT_FLOW_STEP_MOUNTED = 'FLOW_STEP_MOUNTED';
+const EVENT_SAMPLING_RATE = 1;
+
+type EventFlowStepMounted = {
+  /** The flow the step belongs to, e.g. `configureSSO` (mirrors `Flow.Root`'s `flow`). */
+  flow: string;
+  /** The step/part that mounted, e.g. `verify-domain` */
+  step: string;
+  /** ISO-8601 timestamp, used to measure the time between steps of the same flow. */
+  timestamp: string;
+} & TelemetryEventRaw['payload'];
+
+/**
+ * Fires an event when a part of a multi-step flow becomes visible.
+ *
+ * @param flow - The flow identifier (matches `Flow.Root`'s `flow`).
+ * @param step - The step/part that mounted.
+ * @param payload - Extra, flow-specific metadata
+ * @param eventSamplingRate - Override the default full-capture sampling rate.
+ * @example
+ * telemetry.record(eventFlowStepMounted('configureSSO', 'verify-domain', { connectionStatus: 'unconfigured' }));
+ */
+export function eventFlowStepMounted(
+  flow: string,
+  step: string,
+  payload: TelemetryEventRaw['payload'] = {},
+  eventSamplingRate: number = EVENT_SAMPLING_RATE,
+): TelemetryEventRaw<EventFlowStepMounted> {
+  return {
+    event: EVENT_FLOW_STEP_MOUNTED,
+    eventSamplingRate,
+    payload: {
+      flow,
+      step,
+      timestamp: new Date().toISOString(),
+      ...payload,
+    },
+  };
+}

--- a/packages/shared/src/telemetry/events/index.ts
+++ b/packages/shared/src/telemetry/events/index.ts
@@ -1,4 +1,5 @@
 export * from './component-mounted';
+export * from './flow-step';
 export * from './method-called';
 export * from './framework-metadata';
 export * from './theme-usage';

--- a/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
@@ -1,4 +1,4 @@
-import { useClerk } from '@clerk/shared/react';
+import { useClerk, useOrganization } from '@clerk/shared/react';
 import { eventFlowStepMounted } from '@clerk/shared/telemetry';
 
 import { Button, Col, descriptors, Flex, Flow, Heading, Icon, localizationKeys, Text } from '@/customizables';
@@ -19,6 +19,7 @@ export const ActivateStep = (): JSX.Element => {
   } = useConfigureSSO();
   const card = useCardState();
   const clerk = useClerk();
+  const { organization } = useOrganization();
 
   // The activate step is only reachable with a configured connection, so the
   // domains are set; join multiples for the subtitle copy.
@@ -35,7 +36,13 @@ export const ActivateStep = (): JSX.Element => {
 
     try {
       await setConnectionActive(enterpriseConnection.id, true);
-      clerk.telemetry?.record(eventFlowStepMounted('configureSSO', 'activate', { connectionStatus: 'active' }));
+      clerk.telemetry?.record(
+        eventFlowStepMounted('configureSSO', 'activate', {
+          connectionStatus: 'active',
+          connectionId: enterpriseConnection.id,
+          organizationId: organization?.id ?? null,
+        }),
+      );
       onExit?.();
     } catch (err) {
       handleError(err as Error, [], card.setError);

--- a/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
@@ -38,6 +38,7 @@ export const ActivateStep = (): JSX.Element => {
       await setConnectionActive(enterpriseConnection.id, true);
       clerk.telemetry?.record(
         eventFlowStepMounted('configureSSO', 'activate', {
+          timestamp: new Date().toISOString(),
           connectionStatus: 'active',
           connectionId: enterpriseConnection.id,
           organizationId: organization?.id ?? null,

--- a/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/ActivateStep.tsx
@@ -1,3 +1,6 @@
+import { useClerk } from '@clerk/shared/react';
+import { eventFlowStepMounted } from '@clerk/shared/telemetry';
+
 import { Button, Col, descriptors, Flex, Flow, Heading, Icon, localizationKeys, Text } from '@/customizables';
 import { useCardState } from '@/elements/contexts';
 import { ChevronRight, DuotoneShieldCheck } from '@/icons';
@@ -15,6 +18,7 @@ export const ActivateStep = (): JSX.Element => {
     onExit,
   } = useConfigureSSO();
   const card = useCardState();
+  const clerk = useClerk();
 
   // The activate step is only reachable with a configured connection, so the
   // domains are set; join multiples for the subtitle copy.
@@ -31,6 +35,7 @@ export const ActivateStep = (): JSX.Element => {
 
     try {
       await setConnectionActive(enterpriseConnection.id, true);
+      clerk.telemetry?.record(eventFlowStepMounted('configureSSO', 'activate', { connectionStatus: 'active' }));
       onExit?.();
     } catch (err) {
       handleError(err as Error, [], card.setError);

--- a/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
@@ -1,4 +1,4 @@
-import { useClerk, useUser } from '@clerk/shared/react';
+import { useClerk, useOrganization, useUser } from '@clerk/shared/react';
 import { eventFlowStepMounted } from '@clerk/shared/telemetry';
 import type { OrganizationDomainResource } from '@clerk/shared/types';
 import type React from 'react';
@@ -49,6 +49,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
   const { goPrev, goNext, isFirstStep, isLastStep } = useWizard();
   const card = useCardState();
   const clerk = useClerk();
+  const { organization } = useOrganization();
   const [domainToRemove, setDomainToRemove] = useState<OrganizationDomainResource | null>(null);
 
   const hasRecordedTelemetryEvent = useRef(false);
@@ -61,6 +62,8 @@ export const OrganizationDomainsStep = (): JSX.Element => {
     clerk.telemetry?.record(
       eventFlowStepMounted('configureSSO', 'verify-domain', {
         connectionStatus: organizationEnterpriseConnection.status,
+        connectionId: enterpriseConnection?.id ?? null,
+        organizationId: organization?.id ?? null,
       }),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
@@ -1,7 +1,8 @@
-import { useUser } from '@clerk/shared/react';
+import { useClerk, useUser } from '@clerk/shared/react';
+import { eventFlowStepMounted } from '@clerk/shared/telemetry';
 import type { OrganizationDomainResource } from '@clerk/shared/types';
 import type React from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   Badge,
@@ -40,13 +41,30 @@ export const OrganizationDomainsStep = (): JSX.Element => {
   const {
     enterpriseConnection,
     organizationDomains,
+    organizationEnterpriseConnection,
     contentRef,
     organizationDomainMutations: { createDomain, revalidate },
     enterpriseConnectionMutations: { updateConnection },
   } = useConfigureSSO();
   const { goPrev, goNext, isFirstStep, isLastStep } = useWizard();
   const card = useCardState();
+  const clerk = useClerk();
   const [domainToRemove, setDomainToRemove] = useState<OrganizationDomainResource | null>(null);
+
+  const hasRecordedTelemetryEvent = useRef(false);
+  useEffect(() => {
+    if (hasRecordedTelemetryEvent.current) {
+      return;
+    }
+
+    hasRecordedTelemetryEvent.current = true;
+    clerk.telemetry?.record(
+      eventFlowStepMounted('configureSSO', 'verify-domain', {
+        connectionStatus: organizationEnterpriseConnection.status,
+      }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleCreateDomain = async (domain: string) => {
     card.setError(undefined);

--- a/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
@@ -61,6 +61,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
     hasRecordedTelemetryEvent.current = true;
     clerk.telemetry?.record(
       eventFlowStepMounted('configureSSO', 'verify-domain', {
+        timestamp: new Date().toISOString(),
         connectionStatus: organizationEnterpriseConnection.status,
         connectionId: enterpriseConnection?.id ?? null,
         organizationId: organization?.id ?? null,


### PR DESCRIPTION
## Description

This PR adds a new telemetry event to track when a flow step gets mounted, so we can leverage it on multi step flows such as self-serve SSO.

We want to leverage those events to later query the average time between when the user lands on the first step and actually ends up activating the connection.

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `pnpm test` runs as expected.
- [X] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a generic flow-step telemetry event builder to support multi-step funnel measurement.
  * Extended self-serve SSO telemetry to record events when key steps mount and when SSO activation completes, including timestamps and relevant connection and organization identifiers.
* **Chores**
  * Improved end-to-end observability across the SSO flow lifecycle with broader telemetry coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->