### PR TITLE
fix(ui): re-seat nested SSO wizard to provider selection when connection is reset

### DIFF
--- a/.changeset/silly-insects-hug.md
+++ b/.changeset/silly-insects-hug.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/ui': patch
+---
+
+Self-serve SSO: fix the configuration wizard rendering a blank step when a connection is reset from the first configuration step. Resetting now returns to the provider selection step.

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
@@ -163,13 +163,6 @@ describe('ConfigureSSO wizard navigation (integration)', () => {
     expect(queryByText(/test your sso connection/i)).not.toBeInTheDocument();
   });
 
-  // ORGS-1675: resetting from the FIRST per-provider configure step (not the test
-  // step) must also land on select-provider. The configure sub-flow runs inside a
-  // NESTED wizard whose `configure-provider` step is gated on `hasConnection`;
-  // deleting the connection breaks that guard. Before the fix the nested clamp was
-  // skipped (gated on `!isNested`), so the wizard stranded on `configure-provider`
-  // — which renders nothing without a provider — leaving a blank pane. The clamp
-  // now runs for the nested wizard too and re-seats it in place to select-provider.
   it('reset → re-derive: deleting from the first configure step lands on select-provider (no blank)', async () => {
     const { wrapper, fixtures } = await createFixtures(withAdminOrgUser);
 

--- a/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/__tests__/ConfigureSSO.navigation.test.tsx
@@ -163,6 +163,52 @@ describe('ConfigureSSO wizard navigation (integration)', () => {
     expect(queryByText(/test your sso connection/i)).not.toBeInTheDocument();
   });
 
+  // ORGS-1675: resetting from the FIRST per-provider configure step (not the test
+  // step) must also land on select-provider. The configure sub-flow runs inside a
+  // NESTED wizard whose `configure-provider` step is gated on `hasConnection`;
+  // deleting the connection breaks that guard. Before the fix the nested clamp was
+  // skipped (gated on `!isNested`), so the wizard stranded on `configure-provider`
+  // — which renders nothing without a provider — leaving a blank pane. The clamp
+  // now runs for the nested wizard too and re-seats it in place to select-provider.
+  it('reset → re-derive: deleting from the first configure step lands on select-provider (no blank)', async () => {
+    const { wrapper, fixtures } = await createFixtures(withAdminOrgUser);
+
+    // First settle: an unconfigured connection ⇒ mounts on the first configure
+    // step (Configure Okta Workforce, step 1 of 4). After the delete's revalidate:
+    // no connection ⇒ the nested clamp re-seats to select-provider.
+    fixtures.clerk.organization?.getEnterpriseConnections
+      .mockResolvedValueOnce([unconfiguredConnection] as any)
+      .mockResolvedValue([] as any);
+    fixtures.clerk.organization?.deleteEnterpriseConnection.mockResolvedValue({ id: 'ent_new' } as any);
+    fixtures.clerk.organization?.getEnterpriseConnectionTestRuns.mockResolvedValue({
+      data: [],
+      total_count: 0,
+    } as any);
+    mockVerifiedDomains(fixtures);
+
+    const { findByText, getByRole, getByLabelText, findByRole, userEvent, queryByRole } = render(<ConfigureSSO />, {
+      wrapper,
+    });
+
+    // Mounts directly on the first configure step (existing connection resumes here).
+    await findByRole('heading', { name: /configure okta workforce/i });
+
+    // Reset from the configure-step footer: type-to-confirm with the organization
+    // name and confirm.
+    await userEvent.click(getByRole('button', { name: /reset connection/i }));
+    await userEvent.type(getByLabelText(/below to continue/i), 'Org1');
+    const confirmButton = await findByRole('button', { name: /reset connection/i });
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+    await userEvent.click(confirmButton);
+
+    // The nested wizard self-corrects to select-provider — a real rendered step,
+    // not the blank pane the unguarded nested clamp used to strand on.
+    await findByText(/select your identity provider/i);
+    await waitFor(() => {
+      expect(queryByRole('heading', { name: /configure okta workforce/i })).not.toBeInTheDocument();
+    });
+  });
+
   // A card error surfaced on one step must not leak into the next. Each top-level
   // step owns its own `CardStateProvider`, so the error lives in the departed
   // step's scope only — leaving that step unmounts the provider and the error

--- a/packages/ui/src/components/ConfigureSSO/elements/Wizard/__tests__/useWizardMachine.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/elements/Wizard/__tests__/useWizardMachine.test.tsx
@@ -551,12 +551,6 @@ describe('useWizardMachine — reachability clamp (self-correct on a broken isRe
   });
 
   it('re-seats a nested wizard in place when its active isReachable breaks (does not bubble)', () => {
-    // ConfigureSSO's middle wizard is nested AND has a guarded step
-    // (`configure-provider`, reachable only while a connection exists). When that
-    // connection is deleted from inside the flow, the guard breaks; the clamp must
-    // re-seat to the furthest LOCAL reachable step (n0 here, select-provider in the
-    // app) IN PLACE rather than bubbling to the parent — otherwise the nested
-    // wizard strands on an impossible step (the ORGS-1675 blank pane).
     const parent = makeParent();
     let open = true;
     const gate = () => open;

--- a/packages/ui/src/components/ConfigureSSO/elements/Wizard/__tests__/useWizardMachine.test.tsx
+++ b/packages/ui/src/components/ConfigureSSO/elements/Wizard/__tests__/useWizardMachine.test.tsx
@@ -550,14 +550,19 @@ describe('useWizardMachine — reachability clamp (self-correct on a broken isRe
     expect(result.current.current).toBe('b');
   });
 
-  it('does not clamp a nested wizard (isNested) even when its active isReachable breaks', () => {
-    // A nested machine has no isReachable in practice, but the clamp is gated on
-    // !isNested regardless: a nested wizard never re-seats, it bubbles instead.
+  it('re-seats a nested wizard in place when its active isReachable breaks (does not bubble)', () => {
+    // ConfigureSSO's middle wizard is nested AND has a guarded step
+    // (`configure-provider`, reachable only while a connection exists). When that
+    // connection is deleted from inside the flow, the guard breaks; the clamp must
+    // re-seat to the furthest LOCAL reachable step (n0 here, select-provider in the
+    // app) IN PLACE rather than bubbling to the parent — otherwise the nested
+    // wizard strands on an impossible step (the ORGS-1675 blank pane).
+    const parent = makeParent();
     let open = true;
     const gate = () => open;
     const { result, rerender } = renderMachine({
       config: cfg([{ id: 'n0' }, { id: 'n1', isReachable: gate }]),
-      parentWizard: makeParent(),
+      parentWizard: parent,
     });
     expect(result.current.current).toBe('n1');
 
@@ -565,11 +570,15 @@ describe('useWizardMachine — reachability clamp (self-correct on a broken isRe
     act(() => {
       rerender({
         config: cfg([{ id: 'n0' }, { id: 'n1', isReachable: gate }]),
-        parentWizard: makeParent(),
+        parentWizard: parent,
         initialStepId: undefined,
       });
     });
-    // Nested: no clamp. current stays put despite the broken isReachable.
-    expect(result.current.current).toBe('n1');
+    // Nested clamp: re-seats to the furthest LOCAL reachable step (n0), in place.
+    expect(result.current.current).toBe('n0');
+    // The re-seat is a local setState — it must NOT bubble to the parent.
+    expect(parent.goNext).not.toHaveBeenCalled();
+    expect(parent.goPrev).not.toHaveBeenCalled();
+    expect(parent.goToStep).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/ConfigureSSO/elements/Wizard/useWizardMachine.ts
+++ b/packages/ui/src/components/ConfigureSSO/elements/Wizard/useWizardMachine.ts
@@ -101,19 +101,22 @@ export const useWizardMachine = ({ config, parentWizard, initialStepId }: UseWiz
   // deleted from a footer reset, or revoked elsewhere), OR the active id names no
   // descriptor at all (an invalid seed, or a step removed from the graph), the
   // wizard is sitting on an impossible step. Re-seat to the furthest-reachable
-  // step — the SAME derivation used on mount (initialState). React discards this
-  // render and re-renders before paint, so the impossible frame never shows. Do
-  // NOT "fix" this by adding a goToStep: navigation here is emergent from the
-  // guard state, by design. The condition (current descriptor is missing or its
-  // guard is false, and the re-seated step differs) makes it a provably one-shot
-  // — initialState always lands on a guard-passing step, so it cannot loop.
-  if (!isNested) {
-    const currentDescriptor = config.descriptors.find(d => d.id === state.current);
-    if (!currentDescriptor || !isStepReachable(currentDescriptor)) {
-      const seated = initialState(config);
-      if (seated.current !== state.current) {
-        setState(seated);
-      }
+  // step — the SAME derivation used on mount (initialState), over the LOCAL
+  // descriptors. Runs for nested wizards too: ConfigureSSO's middle wizard has a
+  // guarded `configure-provider` step that breaks when its connection is deleted
+  // from inside the flow, and the re-seat must happen IN PLACE (the local
+  // setState, never bubbling to the parent) so it falls back to select-provider
+  // instead of stranding on a blank pane. React discards this render and
+  // re-renders before paint, so the impossible frame never shows. Do NOT "fix"
+  // this by adding a goToStep: navigation here is emergent from the guard state,
+  // by design. The condition (current descriptor is missing or its guard is
+  // false, and the re-seated step differs) makes it a provably one-shot —
+  // initialState always lands on a guard-passing step, so it cannot loop.
+  const currentDescriptor = config.descriptors.find(d => d.id === state.current);
+  if (!currentDescriptor || !isStepReachable(currentDescriptor)) {
+    const seated = initialState(config);
+    if (seated.current !== state.current) {
+      setState(seated);
     }
   }
 


### PR DESCRIPTION
## What

Resetting (deleting) a connection from the **first** per-provider configure step in `<ConfigureSSO />` left the user on a blank screen instead of returning to provider selection.

## Why

The wizard self-corrects to the furthest-reachable step when the active step's reachability predicate breaks, but that correction was gated to top-level (non-nested) wizards only. The provider-selection → per-provider-config flow runs as a nested wizard whose `configure-provider` step is reachable only while a connection exists. On reset the connection is deleted and that step becomes unreachable, but because the wizard is nested the correction never ran — it stayed on `configure-provider`, which renders nothing without a connection, producing the blank.

Resetting from a later step (e.g. Test) already worked, because that path re-seats the outer wizard and remounts the nested wizard fresh. Resetting from inside the nested wizard needed the nested wizard itself to re-seat in place.

## How

Remove the `!isNested` gate on the reachability clamp in `useWizardMachine.ts` so the clamp runs for nested wizards too. The nested wizard re-derives to its furthest reachable local step (`select-provider`) in place, via the same `initialState` derivation used on mount — a local state update, never bubbling to the parent. Scope is contained: the only nested step today with a reachability predicate is `configure-provider`; the per-provider inner wizards are guard-less, so the clamp is inert for them.

## Testing

- New integration test: resetting from the first configure step lands on `select-provider` (no blank), mirroring the existing reset-from-test-step case.
- Updated the nested-clamp unit test to assert the wizard re-seats in place **and** does not call the parent's navigation (proving it's local, not a bubble).
- Full `ConfigureSSO` + `OrganizationSecurityPage` suites pass (193 tests); existing flows confirmed unchanged (reset-from-test, resume-skips-selection, forward nav, change-provider).
- Manually verified in the sandbox: reset from the first configure step now returns to provider selection with a fresh card.

Resolves ORGS-1675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the self-serve SSO configuration wizard where resetting from the initial setup step could show a blank page. The wizard now reliably returns to the provider selection step.
* **Tests**
  * Added an integration test covering the reset-from-first configure-step flow and verifying the correct step is displayed after reset.
* **Behavior Updates**
  * Updated nested wizard reachability handling so the wizard re-seats to the furthest locally reachable step instead of leaving it on an unreachable step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->