### PR TITLE
chore(localizations): Update labels from self-serve SSO steps

### DIFF
--- a/.changeset/witty-melons-stop.md
+++ b/.changeset/witty-melons-stop.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+---
+
+Update the SSO domains step copy across all supported languages:
+
+- `organizationDomainsStep.formFieldLabel__domain` changed from the plural "Domains" to the singular "Domain".
+- `organizationDomainsStep.formFieldInputPlaceholder__domain` changed to a shorter "Add domain".

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -673,7 +673,7 @@ export const arSA: LocalizationResource = {
         messageLabel: 'بريدك الإلكتروني يستخدم {{domain}}. هل تريد إضافته؟',
       },
       formButtonPrimary__add: 'إضافة',
-      formFieldInputPlaceholder__domain: 'اكتب نطاقك هنا وانقر على إضافة للبدء',
+      formFieldInputPlaceholder__domain: 'إضافة نطاق',
       formFieldLabel__domain: 'النطاق',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -674,7 +674,7 @@ export const arSA: LocalizationResource = {
       },
       formButtonPrimary__add: 'إضافة',
       formFieldInputPlaceholder__domain: 'اكتب نطاقك هنا وانقر على إضافة للبدء',
-      formFieldLabel__domain: 'النطاقات',
+      formFieldLabel__domain: 'النطاق',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -674,7 +674,7 @@ export const beBY: LocalizationResource = {
         messageLabel: 'Ваша электронная пошта выкарыстоўвае {{domain}}. Хочаце дадаць яго?',
       },
       formButtonPrimary__add: 'Дадаць',
-      formFieldInputPlaceholder__domain: 'Увядзіце свой дамен тут і націсніце «Дадаць», каб пачаць',
+      formFieldInputPlaceholder__domain: 'Дадаць дамен',
       formFieldLabel__domain: 'Дамен',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -675,7 +675,7 @@ export const beBY: LocalizationResource = {
       },
       formButtonPrimary__add: 'Дадаць',
       formFieldInputPlaceholder__domain: 'Увядзіце свой дамен тут і націсніце «Дадаць», каб пачаць',
-      formFieldLabel__domain: 'Дамены',
+      formFieldLabel__domain: 'Дамен',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -676,7 +676,7 @@ export const bgBG: LocalizationResource = {
       },
       formButtonPrimary__add: 'Добави',
       formFieldInputPlaceholder__domain: 'Въведете домейна си тук и щракнете върху добавяне, за да започнете',
-      formFieldLabel__domain: 'Домейни',
+      formFieldLabel__domain: 'Домейн',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -675,7 +675,7 @@ export const bgBG: LocalizationResource = {
         messageLabel: 'Вашият имейл използва {{domain}}. Искате ли да го добавите?',
       },
       formButtonPrimary__add: 'Добави',
-      formFieldInputPlaceholder__domain: 'Въведете домейна си тук и щракнете върху добавяне, за да започнете',
+      formFieldInputPlaceholder__domain: 'Добавяне на домейн',
       formFieldLabel__domain: 'Домейн',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -680,7 +680,7 @@ export const bnIN: LocalizationResource = {
         messageLabel: 'আপনার ইমেল {{domain}} ব্যবহার করে। আপনি কি এটি যোগ করতে চান?',
       },
       formButtonPrimary__add: 'যোগ করুন',
-      formFieldInputPlaceholder__domain: 'আপনার ডোমেইন এখানে টাইপ করুন এবং শুরু করতে যোগ করুন-এ ক্লিক করুন',
+      formFieldInputPlaceholder__domain: 'ডোমেইন যোগ করুন',
       formFieldLabel__domain: 'ডোমেইন',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -681,7 +681,7 @@ export const caES: LocalizationResource = {
         messageLabel: 'El teu correu electrònic utilitza {{domain}}. Vols afegir-lo?',
       },
       formButtonPrimary__add: 'Afegeix',
-      formFieldInputPlaceholder__domain: 'Escriu aquí el teu domini i fes clic a Afegeix per començar',
+      formFieldInputPlaceholder__domain: 'Afegeix un domini',
       formFieldLabel__domain: 'Domini',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -682,7 +682,7 @@ export const caES: LocalizationResource = {
       },
       formButtonPrimary__add: 'Afegeix',
       formFieldInputPlaceholder__domain: 'Escriu aquí el teu domini i fes clic a Afegeix per començar',
-      formFieldLabel__domain: 'Dominis',
+      formFieldLabel__domain: 'Domini',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -679,7 +679,7 @@ export const csCZ: LocalizationResource = {
       },
       formButtonPrimary__add: 'Přidat',
       formFieldInputPlaceholder__domain: 'Zde zadejte svou doménu a kliknutím na přidat začněte',
-      formFieldLabel__domain: 'Domény',
+      formFieldLabel__domain: 'Doména',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -678,7 +678,7 @@ export const csCZ: LocalizationResource = {
         messageLabel: 'Váš e-mail používá {{domain}}. Chcete jej přidat?',
       },
       formButtonPrimary__add: 'Přidat',
-      formFieldInputPlaceholder__domain: 'Zde zadejte svou doménu a kliknutím na přidat začněte',
+      formFieldInputPlaceholder__domain: 'Přidat doménu',
       formFieldLabel__domain: 'Doména',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -673,7 +673,7 @@ export const daDK: LocalizationResource = {
         messageLabel: 'Din e-mail bruger {{domain}}. Vil du tilføje det?',
       },
       formButtonPrimary__add: 'Tilføj',
-      formFieldInputPlaceholder__domain: 'Skriv dit domæne her, og klik på tilføj for at starte',
+      formFieldInputPlaceholder__domain: 'Tilføj domæne',
       formFieldLabel__domain: 'Domæne',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -674,7 +674,7 @@ export const daDK: LocalizationResource = {
       },
       formButtonPrimary__add: 'Tilføj',
       formFieldInputPlaceholder__domain: 'Skriv dit domæne her, og klik på tilføj for at starte',
-      formFieldLabel__domain: 'Domæner',
+      formFieldLabel__domain: 'Domæne',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -681,7 +681,7 @@ export const deDE: LocalizationResource = {
       },
       formButtonPrimary__add: 'Hinzufügen',
       formFieldInputPlaceholder__domain: 'Geben Sie hier Ihre Domain ein und klicken Sie zum Starten auf „Hinzufügen"',
-      formFieldLabel__domain: 'Domains',
+      formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -680,7 +680,7 @@ export const deDE: LocalizationResource = {
         messageLabel: 'Ihre E-Mail verwendet {{domain}}. Möchten Sie sie hinzufügen?',
       },
       formButtonPrimary__add: 'Hinzufügen',
-      formFieldInputPlaceholder__domain: 'Geben Sie hier Ihre Domain ein und klicken Sie zum Starten auf „Hinzufügen"',
+      formFieldInputPlaceholder__domain: 'Domain hinzufügen',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -674,8 +674,7 @@ export const elGR: LocalizationResource = {
         messageLabel: 'Το email σας χρησιμοποιεί {{domain}}. Θέλετε να το προσθέσετε;',
       },
       formButtonPrimary__add: 'Προσθήκη',
-      formFieldInputPlaceholder__domain:
-        'Πληκτρολογήστε τον τομέα σας εδώ και κάντε κλικ στο «Προσθήκη» για να ξεκινήσετε',
+      formFieldInputPlaceholder__domain: 'Προσθήκη τομέα',
       formFieldLabel__domain: 'Τομέας',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -676,7 +676,7 @@ export const elGR: LocalizationResource = {
       formButtonPrimary__add: 'Προσθήκη',
       formFieldInputPlaceholder__domain:
         'Πληκτρολογήστε τον τομέα σας εδώ και κάντε κλικ στο «Προσθήκη» για να ξεκινήσετε',
-      formFieldLabel__domain: 'Τομείς',
+      formFieldLabel__domain: 'Τομέας',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -674,7 +674,7 @@ export const enGB: LocalizationResource = {
       },
       formButtonPrimary__add: 'Add',
       formFieldInputPlaceholder__domain: 'Type your domain here and click add to start',
-      formFieldLabel__domain: 'Domains',
+      formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -673,7 +673,7 @@ export const enGB: LocalizationResource = {
         messageLabel: 'Your email uses {{domain}}. Do you want to add it?',
       },
       formButtonPrimary__add: 'Add',
-      formFieldInputPlaceholder__domain: 'Type your domain here and click add to start',
+      formFieldInputPlaceholder__domain: 'Add domain',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -666,7 +666,7 @@ export const enUS: LocalizationResource = {
         messageLabel: 'Your email uses {{domain}}. Do you want to add it?',
       },
       formButtonPrimary__add: 'Add',
-      formFieldInputPlaceholder__domain: 'Type your domain here and click add to start',
+      formFieldInputPlaceholder__domain: 'Add domain',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: 'Cancel',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -667,7 +667,7 @@ export const enUS: LocalizationResource = {
       },
       formButtonPrimary__add: 'Add',
       formFieldInputPlaceholder__domain: 'Type your domain here and click add to start',
-      formFieldLabel__domain: 'Domains',
+      formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: 'Cancel',
         removeButton: 'Remove domain',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -279,7 +279,7 @@ export const enUS: LocalizationResource = {
               label: 'Assertion consumer service (ACS) URL',
             },
             spEntityId: {
-              label: 'Service provider entity ID',
+              label: 'Entity ID',
             },
           },
         },
@@ -666,7 +666,7 @@ export const enUS: LocalizationResource = {
         messageLabel: 'Your email uses {{domain}}. Do you want to add it?',
       },
       formButtonPrimary__add: 'Add',
-      formFieldInputPlaceholder__domain: 'Add domain',
+      formFieldInputPlaceholder__domain: 'Type your domain here and click add to start',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: 'Cancel',

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -674,7 +674,7 @@ export const esCR: LocalizationResource = {
         messageLabel: 'Tu correo electrónico usa {{domain}}. ¿Quieres agregarlo?',
       },
       formButtonPrimary__add: 'Agregar',
-      formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Agregar para empezar',
+      formFieldInputPlaceholder__domain: 'Agregar dominio',
       formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -675,7 +675,7 @@ export const esCR: LocalizationResource = {
       },
       formButtonPrimary__add: 'Agregar',
       formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Agregar para empezar',
-      formFieldLabel__domain: 'Dominios',
+      formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -681,7 +681,7 @@ export const esES: LocalizationResource = {
       },
       formButtonPrimary__add: 'Añadir',
       formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Añadir para empezar',
-      formFieldLabel__domain: 'Dominios',
+      formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -680,7 +680,7 @@ export const esES: LocalizationResource = {
         messageLabel: 'Tu correo electrónico usa {{domain}}. ¿Quieres añadirlo?',
       },
       formButtonPrimary__add: 'Añadir',
-      formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Añadir para empezar',
+      formFieldInputPlaceholder__domain: 'Añadir dominio',
       formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -675,7 +675,7 @@ export const esMX: LocalizationResource = {
         messageLabel: 'Tu correo electrónico usa {{domain}}. ¿Quieres agregarlo?',
       },
       formButtonPrimary__add: 'Agregar',
-      formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Agregar para empezar',
+      formFieldInputPlaceholder__domain: 'Agregar dominio',
       formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -676,7 +676,7 @@ export const esMX: LocalizationResource = {
       },
       formButtonPrimary__add: 'Agregar',
       formFieldInputPlaceholder__domain: 'Escribe aquí tu dominio y haz clic en Agregar para empezar',
-      formFieldLabel__domain: 'Dominios',
+      formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -674,7 +674,7 @@ export const esUY: LocalizationResource = {
         messageLabel: 'Tu correo electrónico usa {{domain}}. ¿Querés agregarlo?',
       },
       formButtonPrimary__add: 'Agregar',
-      formFieldInputPlaceholder__domain: 'Escribí aquí tu dominio y hacé clic en Agregar para empezar',
+      formFieldInputPlaceholder__domain: 'Agregar dominio',
       formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -675,7 +675,7 @@ export const esUY: LocalizationResource = {
       },
       formButtonPrimary__add: 'Agregar',
       formFieldInputPlaceholder__domain: 'Escribí aquí tu dominio y hacé clic en Agregar para empezar',
-      formFieldLabel__domain: 'Dominios',
+      formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -680,7 +680,7 @@ export const faIR: LocalizationResource = {
       },
       formButtonPrimary__add: 'افزودن',
       formFieldInputPlaceholder__domain: 'دامنه خود را اینجا تایپ کنید و برای شروع روی افزودن کلیک کنید',
-      formFieldLabel__domain: 'دامنه‌ها',
+      formFieldLabel__domain: 'دامنه',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -679,7 +679,7 @@ export const faIR: LocalizationResource = {
         messageLabel: 'ایمیل شما از {{domain}} استفاده می‌کند. آیا می‌خواهید آن را اضافه کنید؟',
       },
       formButtonPrimary__add: 'افزودن',
-      formFieldInputPlaceholder__domain: 'دامنه خود را اینجا تایپ کنید و برای شروع روی افزودن کلیک کنید',
+      formFieldInputPlaceholder__domain: 'افزودن دامنه',
       formFieldLabel__domain: 'دامنه',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -680,7 +680,7 @@ export const fiFI: LocalizationResource = {
         messageLabel: 'Sähköpostisi käyttää osoitetta {{domain}}. Haluatko lisätä sen?',
       },
       formButtonPrimary__add: 'Lisää',
-      formFieldInputPlaceholder__domain: 'Kirjoita verkkotunnuksesi tähän ja aloita napsauttamalla Lisää',
+      formFieldInputPlaceholder__domain: 'Lisää verkkotunnus',
       formFieldLabel__domain: 'Verkkotunnus',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -681,7 +681,7 @@ export const fiFI: LocalizationResource = {
       },
       formButtonPrimary__add: 'Lisää',
       formFieldInputPlaceholder__domain: 'Kirjoita verkkotunnuksesi tähän ja aloita napsauttamalla Lisää',
-      formFieldLabel__domain: 'Verkkotunnukset',
+      formFieldLabel__domain: 'Verkkotunnus',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -682,7 +682,7 @@ export const frFR: LocalizationResource = {
         messageLabel: 'Votre e-mail utilise {{domain}}. Voulez-vous l’ajouter ?',
       },
       formButtonPrimary__add: 'Ajouter',
-      formFieldInputPlaceholder__domain: 'Saisissez votre domaine ici et cliquez sur Ajouter pour commencer',
+      formFieldInputPlaceholder__domain: 'Ajouter un domaine',
       formFieldLabel__domain: 'Domaine',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -683,7 +683,7 @@ export const frFR: LocalizationResource = {
       },
       formButtonPrimary__add: 'Ajouter',
       formFieldInputPlaceholder__domain: 'Saisissez votre domaine ici et cliquez sur Ajouter pour commencer',
-      formFieldLabel__domain: 'Domaines',
+      formFieldLabel__domain: 'Domaine',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -674,7 +674,7 @@ export const heIL: LocalizationResource = {
       },
       formButtonPrimary__add: 'הוסף',
       formFieldInputPlaceholder__domain: 'הקלד את הדומיין שלך כאן ולחץ על הוסף כדי להתחיל',
-      formFieldLabel__domain: 'דומיינים',
+      formFieldLabel__domain: 'דומיין',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -673,7 +673,7 @@ export const heIL: LocalizationResource = {
         messageLabel: 'האימייל שלך משתמש ב-{{domain}}. האם ברצונך להוסיף אותו?',
       },
       formButtonPrimary__add: 'הוסף',
-      formFieldInputPlaceholder__domain: 'הקלד את הדומיין שלך כאן ולחץ על הוסף כדי להתחיל',
+      formFieldInputPlaceholder__domain: 'הוסף דומיין',
       formFieldLabel__domain: 'דומיין',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -680,7 +680,7 @@ export const hiIN: LocalizationResource = {
         messageLabel: 'आपका ईमेल {{domain}} का उपयोग करता है। क्या आप इसे जोड़ना चाहते हैं?',
       },
       formButtonPrimary__add: 'जोड़ें',
-      formFieldInputPlaceholder__domain: 'अपना डोमेन यहाँ टाइप करें और शुरू करने के लिए जोड़ें पर क्लिक करें',
+      formFieldInputPlaceholder__domain: 'डोमेन जोड़ें',
       formFieldLabel__domain: 'डोमेन',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -682,7 +682,7 @@ export const hrHR: LocalizationResource = {
       },
       formButtonPrimary__add: 'Dodaj',
       formFieldInputPlaceholder__domain: 'Ovdje upišite svoju domenu i kliknite dodaj za početak',
-      formFieldLabel__domain: 'Domene',
+      formFieldLabel__domain: 'Domena',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -681,7 +681,7 @@ export const hrHR: LocalizationResource = {
         messageLabel: 'Vaša e-pošta koristi {{domain}}. Želite li ga dodati?',
       },
       formButtonPrimary__add: 'Dodaj',
-      formFieldInputPlaceholder__domain: 'Ovdje upišite svoju domenu i kliknite dodaj za početak',
+      formFieldInputPlaceholder__domain: 'Dodaj domenu',
       formFieldLabel__domain: 'Domena',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -682,7 +682,7 @@ export const huHU: LocalizationResource = {
       },
       formButtonPrimary__add: 'Hozzáadás',
       formFieldInputPlaceholder__domain: 'Írja be ide a tartományát, majd kattintson a Hozzáadás gombra a kezdéshez',
-      formFieldLabel__domain: 'Tartományok',
+      formFieldLabel__domain: 'Tartomány',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -681,7 +681,7 @@ export const huHU: LocalizationResource = {
         messageLabel: 'Az e-mail-címe a következőt használja: {{domain}}. Szeretné hozzáadni?',
       },
       formButtonPrimary__add: 'Hozzáadás',
-      formFieldInputPlaceholder__domain: 'Írja be ide a tartományát, majd kattintson a Hozzáadás gombra a kezdéshez',
+      formFieldInputPlaceholder__domain: 'Tartomány hozzáadása',
       formFieldLabel__domain: 'Tartomány',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -674,7 +674,7 @@ export const idID: LocalizationResource = {
         messageLabel: 'Email Anda menggunakan {{domain}}. Apakah Anda ingin menambahkannya?',
       },
       formButtonPrimary__add: 'Tambah',
-      formFieldInputPlaceholder__domain: 'Ketik domain Anda di sini dan klik tambah untuk memulai',
+      formFieldInputPlaceholder__domain: 'Tambah domain',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -680,7 +680,7 @@ export const isIS: LocalizationResource = {
         messageLabel: 'Tölvupósturinn þinn notar {{domain}}. Viltu bæta því við?',
       },
       formButtonPrimary__add: 'Bæta við',
-      formFieldInputPlaceholder__domain: 'Skrifaðu lénið þitt hér og smelltu á bæta við til að byrja',
+      formFieldInputPlaceholder__domain: 'Bæta við léni',
       formFieldLabel__domain: 'Lén',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -681,7 +681,7 @@ export const itIT: LocalizationResource = {
       },
       formButtonPrimary__add: 'Aggiungi',
       formFieldInputPlaceholder__domain: 'Digita qui il tuo dominio e clicca su Aggiungi per iniziare',
-      formFieldLabel__domain: 'Domini',
+      formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -680,7 +680,7 @@ export const itIT: LocalizationResource = {
         messageLabel: 'La tua email usa {{domain}}. Vuoi aggiungerlo?',
       },
       formButtonPrimary__add: 'Aggiungi',
-      formFieldInputPlaceholder__domain: 'Digita qui il tuo dominio e clicca su Aggiungi per iniziare',
+      formFieldInputPlaceholder__domain: 'Aggiungi dominio',
       formFieldLabel__domain: 'Dominio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -681,7 +681,7 @@ export const jaJP: LocalizationResource = {
         messageLabel: 'あなたのメールは {{domain}} を使用しています。追加しますか？',
       },
       formButtonPrimary__add: '追加',
-      formFieldInputPlaceholder__domain: 'ここにドメインを入力し、「追加」をクリックして開始します',
+      formFieldInputPlaceholder__domain: 'ドメインを追加',
       formFieldLabel__domain: 'ドメイン',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -674,7 +674,7 @@ export const kkKZ: LocalizationResource = {
         messageLabel: 'Электрондық поштаңыз {{domain}} пайдаланады. Оны қосқыңыз келе ме?',
       },
       formButtonPrimary__add: 'Қосу',
-      formFieldInputPlaceholder__domain: 'Доменіңізді осы жерге енгізіп, бастау үшін «Қосу» түймесін басыңыз',
+      formFieldInputPlaceholder__domain: 'Домен қосу',
       formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -675,7 +675,7 @@ export const kkKZ: LocalizationResource = {
       },
       formButtonPrimary__add: 'Қосу',
       formFieldInputPlaceholder__domain: 'Доменіңізді осы жерге енгізіп, бастау үшін «Қосу» түймесін басыңыз',
-      formFieldLabel__domain: 'Домендер',
+      formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -677,7 +677,7 @@ export const koKR: LocalizationResource = {
         messageLabel: '이메일이 {{domain}}을(를) 사용합니다. 추가하시겠습니까?',
       },
       formButtonPrimary__add: '추가',
-      formFieldInputPlaceholder__domain: '여기에 도메인을 입력하고 추가를 클릭하여 시작하세요',
+      formFieldInputPlaceholder__domain: '도메인 추가',
       formFieldLabel__domain: '도메인',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -674,7 +674,7 @@ export const mnMN: LocalizationResource = {
         messageLabel: 'Таны имэйл {{domain}}-г ашиглаж байна. Үүнийг нэмэх үү?',
       },
       formButtonPrimary__add: 'Нэмэх',
-      formFieldInputPlaceholder__domain: 'Домэйнээ энд бичээд эхлэхийн тулд нэмэх дээр дарна уу',
+      formFieldInputPlaceholder__domain: 'Домэйн нэмэх',
       formFieldLabel__domain: 'Домэйн',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -682,7 +682,7 @@ export const msMY: LocalizationResource = {
         messageLabel: 'E-mel anda menggunakan {{domain}}. Adakah anda mahu menambahkannya?',
       },
       formButtonPrimary__add: 'Tambah',
-      formFieldInputPlaceholder__domain: 'Taip domain anda di sini dan klik tambah untuk bermula',
+      formFieldInputPlaceholder__domain: 'Tambah domain',
       formFieldLabel__domain: 'Domain',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -682,7 +682,7 @@ export const nbNO: LocalizationResource = {
       },
       formButtonPrimary__add: 'Legg til',
       formFieldInputPlaceholder__domain: 'Skriv inn domenet ditt her, og klikk på legg til for å starte',
-      formFieldLabel__domain: 'Domener',
+      formFieldLabel__domain: 'Domene',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -681,7 +681,7 @@ export const nbNO: LocalizationResource = {
         messageLabel: 'E-posten din bruker {{domain}}. Vil du legge den til?',
       },
       formButtonPrimary__add: 'Legg til',
-      formFieldInputPlaceholder__domain: 'Skriv inn domenet ditt her, og klikk på legg til for å starte',
+      formFieldInputPlaceholder__domain: 'Legg til domene',
       formFieldLabel__domain: 'Domene',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -674,7 +674,7 @@ export const nlBE: LocalizationResource = {
         messageLabel: 'Je e-mailadres gebruikt {{domain}}. Wil je het toevoegen?',
       },
       formButtonPrimary__add: 'Toevoegen',
-      formFieldInputPlaceholder__domain: 'Typ hier uw domein en klik op toevoegen om te beginnen',
+      formFieldInputPlaceholder__domain: 'Domein toevoegen',
       formFieldLabel__domain: 'Domein',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -675,7 +675,7 @@ export const nlBE: LocalizationResource = {
       },
       formButtonPrimary__add: 'Toevoegen',
       formFieldInputPlaceholder__domain: 'Typ hier uw domein en klik op toevoegen om te beginnen',
-      formFieldLabel__domain: 'Domeinen',
+      formFieldLabel__domain: 'Domein',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -675,7 +675,7 @@ export const nlNL: LocalizationResource = {
       },
       formButtonPrimary__add: 'Toevoegen',
       formFieldInputPlaceholder__domain: 'Typ hier uw domein en klik op toevoegen om te beginnen',
-      formFieldLabel__domain: 'Domeinen',
+      formFieldLabel__domain: 'Domein',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -674,7 +674,7 @@ export const nlNL: LocalizationResource = {
         messageLabel: 'Je e-mailadres gebruikt {{domain}}. Wil je het toevoegen?',
       },
       formButtonPrimary__add: 'Toevoegen',
-      formFieldInputPlaceholder__domain: 'Typ hier uw domein en klik op toevoegen om te beginnen',
+      formFieldInputPlaceholder__domain: 'Domein toevoegen',
       formFieldLabel__domain: 'Domein',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -675,7 +675,7 @@ export const plPL: LocalizationResource = {
       },
       formButtonPrimary__add: 'Dodaj',
       formFieldInputPlaceholder__domain: 'Wpisz tutaj swoją domenę i kliknij dodaj, aby rozpocząć',
-      formFieldLabel__domain: 'Domeny',
+      formFieldLabel__domain: 'Domena',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -674,7 +674,7 @@ export const plPL: LocalizationResource = {
         messageLabel: 'Twój e-mail używa {{domain}}. Czy chcesz go dodać?',
       },
       formButtonPrimary__add: 'Dodaj',
-      formFieldInputPlaceholder__domain: 'Wpisz tutaj swoją domenę i kliknij dodaj, aby rozpocząć',
+      formFieldInputPlaceholder__domain: 'Dodaj domenę',
       formFieldLabel__domain: 'Domena',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -680,7 +680,7 @@ export const ptBR: LocalizationResource = {
         messageLabel: 'Seu e-mail usa {{domain}}. Deseja adicioná-lo?',
       },
       formButtonPrimary__add: 'Adicionar',
-      formFieldInputPlaceholder__domain: 'Digite seu domínio aqui e clique em Adicionar para começar',
+      formFieldInputPlaceholder__domain: 'Adicionar domínio',
       formFieldLabel__domain: 'Domínio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -681,7 +681,7 @@ export const ptBR: LocalizationResource = {
       },
       formButtonPrimary__add: 'Adicionar',
       formFieldInputPlaceholder__domain: 'Digite seu domínio aqui e clique em Adicionar para começar',
-      formFieldLabel__domain: 'Domínios',
+      formFieldLabel__domain: 'Domínio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -683,7 +683,7 @@ export const ptPT: LocalizationResource = {
       },
       formButtonPrimary__add: 'Adicionar',
       formFieldInputPlaceholder__domain: 'Escreva aqui o seu domínio e clique em adicionar para começar',
-      formFieldLabel__domain: 'Domínios',
+      formFieldLabel__domain: 'Domínio',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -682,7 +682,7 @@ export const ptPT: LocalizationResource = {
         messageLabel: 'O seu e-mail utiliza {{domain}}. Pretende adicioná-lo?',
       },
       formButtonPrimary__add: 'Adicionar',
-      formFieldInputPlaceholder__domain: 'Escreva aqui o seu domínio e clique em adicionar para começar',
+      formFieldInputPlaceholder__domain: 'Adicionar domínio',
       formFieldLabel__domain: 'Domínio',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -681,7 +681,7 @@ export const roRO: LocalizationResource = {
       },
       formButtonPrimary__add: 'Adaugă',
       formFieldInputPlaceholder__domain: 'Scrie aici domeniul tău și fă clic pe adaugă pentru a începe',
-      formFieldLabel__domain: 'Domenii',
+      formFieldLabel__domain: 'Domeniu',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -680,7 +680,7 @@ export const roRO: LocalizationResource = {
         messageLabel: 'E-mailul tău folosește {{domain}}. Vrei să-l adaugi?',
       },
       formButtonPrimary__add: 'Adaugă',
-      formFieldInputPlaceholder__domain: 'Scrie aici domeniul tău și fă clic pe adaugă pentru a începe',
+      formFieldInputPlaceholder__domain: 'Adaugă domeniu',
       formFieldLabel__domain: 'Domeniu',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -674,7 +674,7 @@ export const ruRU: LocalizationResource = {
         messageLabel: 'Ваша электронная почта использует {{domain}}. Хотите добавить его?',
       },
       formButtonPrimary__add: 'Добавить',
-      formFieldInputPlaceholder__domain: 'Введите домен здесь и нажмите «Добавить», чтобы начать',
+      formFieldInputPlaceholder__domain: 'Добавить домен',
       formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -675,7 +675,7 @@ export const ruRU: LocalizationResource = {
       },
       formButtonPrimary__add: 'Добавить',
       formFieldInputPlaceholder__domain: 'Введите домен здесь и нажмите «Добавить», чтобы начать',
-      formFieldLabel__domain: 'Домены',
+      formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -675,7 +675,7 @@ export const skSK: LocalizationResource = {
       },
       formButtonPrimary__add: 'Pridať',
       formFieldInputPlaceholder__domain: 'Sem zadajte svoju doménu a kliknutím na pridať začnite',
-      formFieldLabel__domain: 'Domény',
+      formFieldLabel__domain: 'Doména',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -674,7 +674,7 @@ export const skSK: LocalizationResource = {
         messageLabel: 'Váš e-mail používa {{domain}}. Chcete ho pridať?',
       },
       formButtonPrimary__add: 'Pridať',
-      formFieldInputPlaceholder__domain: 'Sem zadajte svoju doménu a kliknutím na pridať začnite',
+      formFieldInputPlaceholder__domain: 'Pridať doménu',
       formFieldLabel__domain: 'Doména',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -674,7 +674,7 @@ export const srRS: LocalizationResource = {
         messageLabel: 'Vaša e-pošta koristi {{domain}}. Želite li da ga dodate?',
       },
       formButtonPrimary__add: 'Dodaj',
-      formFieldInputPlaceholder__domain: 'Ovde unesite svoj domen i kliknite na dodaj da biste počeli',
+      formFieldInputPlaceholder__domain: 'Dodaj domen',
       formFieldLabel__domain: 'Domen',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -675,7 +675,7 @@ export const srRS: LocalizationResource = {
       },
       formButtonPrimary__add: 'Dodaj',
       formFieldInputPlaceholder__domain: 'Ovde unesite svoj domen i kliknite na dodaj da biste počeli',
-      formFieldLabel__domain: 'Domeni',
+      formFieldLabel__domain: 'Domen',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -675,7 +675,7 @@ export const svSE: LocalizationResource = {
       },
       formButtonPrimary__add: 'Lägg till',
       formFieldInputPlaceholder__domain: 'Skriv din domän här och klicka på lägg till för att börja',
-      formFieldLabel__domain: 'Domäner',
+      formFieldLabel__domain: 'Domän',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -674,7 +674,7 @@ export const svSE: LocalizationResource = {
         messageLabel: 'Din e-post använder {{domain}}. Vill du lägga till den?',
       },
       formButtonPrimary__add: 'Lägg till',
-      formFieldInputPlaceholder__domain: 'Skriv din domän här och klicka på lägg till för att börja',
+      formFieldInputPlaceholder__domain: 'Lägg till domän',
       formFieldLabel__domain: 'Domän',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -682,7 +682,7 @@ export const taIN: LocalizationResource = {
         messageLabel: 'உங்கள் மின்னஞ்சல் {{domain}} ஐப் பயன்படுத்துகிறது. அதைச் சேர்க்க விரும்புகிறீர்களா?',
       },
       formButtonPrimary__add: 'சேர்',
-      formFieldInputPlaceholder__domain: 'உங்கள் டொமைனை இங்கே தட்டச்சு செய்து, தொடங்க சேர் என்பதைக் கிளிக் செய்யவும்',
+      formFieldInputPlaceholder__domain: 'டொமைனைச் சேர்',
       formFieldLabel__domain: 'டொமைன்',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -683,7 +683,7 @@ export const taIN: LocalizationResource = {
       },
       formButtonPrimary__add: 'சேர்',
       formFieldInputPlaceholder__domain: 'உங்கள் டொமைனை இங்கே தட்டச்சு செய்து, தொடங்க சேர் என்பதைக் கிளிக் செய்யவும்',
-      formFieldLabel__domain: 'டொமைன்கள்',
+      formFieldLabel__domain: 'டொமைன்',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -682,7 +682,7 @@ export const teIN: LocalizationResource = {
       },
       formButtonPrimary__add: 'జోడించు',
       formFieldInputPlaceholder__domain: 'మీ డొమైన్‌ను ఇక్కడ టైప్ చేసి, ప్రారంభించడానికి జోడించు క్లిక్ చేయండి',
-      formFieldLabel__domain: 'డొమైన్‌లు',
+      formFieldLabel__domain: 'డొమైన్',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -681,7 +681,7 @@ export const teIN: LocalizationResource = {
         messageLabel: 'మీ ఇమెయిల్ {{domain}} ను ఉపయోగిస్తుంది. మీరు దీన్ని జోడించాలనుకుంటున్నారా?',
       },
       formButtonPrimary__add: 'జోడించు',
-      formFieldInputPlaceholder__domain: 'మీ డొమైన్‌ను ఇక్కడ టైప్ చేసి, ప్రారంభించడానికి జోడించు క్లిక్ చేయండి',
+      formFieldInputPlaceholder__domain: 'డొమైన్‌ను జోడించు',
       formFieldLabel__domain: 'డొమైన్',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -677,7 +677,7 @@ export const thTH: LocalizationResource = {
         messageLabel: 'อีเมลของคุณใช้ {{domain}} คุณต้องการเพิ่มหรือไม่?',
       },
       formButtonPrimary__add: 'เพิ่ม',
-      formFieldInputPlaceholder__domain: 'พิมพ์โดเมนของคุณที่นี่แล้วคลิกเพิ่มเพื่อเริ่มต้น',
+      formFieldInputPlaceholder__domain: 'เพิ่มโดเมน',
       formFieldLabel__domain: 'โดเมน',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -674,7 +674,7 @@ export const trTR: LocalizationResource = {
         messageLabel: 'E-postanız {{domain}} kullanıyor. Eklemek ister misiniz?',
       },
       formButtonPrimary__add: 'Ekle',
-      formFieldInputPlaceholder__domain: 'Alan adınızı buraya yazın ve başlamak için Ekle düğmesine tıklayın',
+      formFieldInputPlaceholder__domain: 'Alan adı ekle',
       formFieldLabel__domain: 'Alan adı',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -675,7 +675,7 @@ export const trTR: LocalizationResource = {
       },
       formButtonPrimary__add: 'Ekle',
       formFieldInputPlaceholder__domain: 'Alan adınızı buraya yazın ve başlamak için Ekle düğmesine tıklayın',
-      formFieldLabel__domain: 'Alan adları',
+      formFieldLabel__domain: 'Alan adı',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -675,7 +675,7 @@ export const ukUA: LocalizationResource = {
       },
       formButtonPrimary__add: 'Додати',
       formFieldInputPlaceholder__domain: 'Введіть свій домен тут і натисніть «Додати», щоб почати',
-      formFieldLabel__domain: 'Домени',
+      formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,
         removeButton: undefined,

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -674,7 +674,7 @@ export const ukUA: LocalizationResource = {
         messageLabel: 'Ваша електронна пошта використовує {{domain}}. Бажаєте додати його?',
       },
       formButtonPrimary__add: 'Додати',
-      formFieldInputPlaceholder__domain: 'Введіть свій домен тут і натисніть «Додати», щоб почати',
+      formFieldInputPlaceholder__domain: 'Додати домен',
       formFieldLabel__domain: 'Домен',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -680,7 +680,7 @@ export const viVN: LocalizationResource = {
         messageLabel: 'Email của bạn sử dụng {{domain}}. Bạn có muốn thêm nó không?',
       },
       formButtonPrimary__add: 'Thêm',
-      formFieldInputPlaceholder__domain: 'Nhập tên miền của bạn vào đây và nhấp vào thêm để bắt đầu',
+      formFieldInputPlaceholder__domain: 'Thêm tên miền',
       formFieldLabel__domain: 'Tên miền',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -673,7 +673,7 @@ export const zhCN: LocalizationResource = {
         messageLabel: '您的邮箱使用了 {{domain}}。是否要添加它？',
       },
       formButtonPrimary__add: '添加',
-      formFieldInputPlaceholder__domain: '在此输入您的域名，然后点击添加即可开始',
+      formFieldInputPlaceholder__domain: '添加域名',
       formFieldLabel__domain: '域名',
       removeDomainDialog: {
         cancelButton: undefined,

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -676,7 +676,7 @@ export const zhTW: LocalizationResource = {
         messageLabel: '您的電子郵件使用了 {{domain}}。是否要新增它？',
       },
       formButtonPrimary__add: '新增',
-      formFieldInputPlaceholder__domain: '在此輸入您的網域，然後點選新增即可開始',
+      formFieldInputPlaceholder__domain: '新增網域',
       formFieldLabel__domain: '網域',
       removeDomainDialog: {
         cancelButton: undefined,


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed SSO domain-entry text across many supported languages for a more consistent, concise experience.
  * Updated several labels from plural to singular and shortened domain input prompts.

* **Bug Fixes**
  * Improved localization consistency for domain-related screens, including clearer wording in multiple languages.
  * Standardized one English label from “Service provider entity ID” to “Entity ID” for simpler terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->