### PR TITLE
fix(backend): expose externalAccountId on ExternalAccount resource

### DIFF
--- a/.changeset/external-account-id.md
+++ b/.changeset/external-account-id.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add `externalAccountId` to the backend `ExternalAccount` resource. This exposes the external account's `eac_`-prefixed id returned by `getUser()`, which is the id `users.deleteUserExternalAccount()` expects. Previously only the `idn_`-prefixed identification id was reachable through `id`, so deleting an external account fetched from `getUser()` failed with a 404.

--- a/.changeset/external-account-id.md
+++ b/.changeset/external-account-id.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-Add `externalAccountId` to the backend `ExternalAccount` resource. This exposes the external account's `eac_`-prefixed id returned by `getUser()`, which is the id `users.deleteUserExternalAccount()` expects. Previously only the `idn_`-prefixed identification id was reachable through `id`, so deleting an external account fetched from `getUser()` failed with a 404.
+Add an optional `externalAccountId` to the backend `ExternalAccount` resource. For Google and Facebook accounts the resource `id` is the `idn_`-prefixed identification id, which `users.deleteUserExternalAccount()` rejects; `externalAccountId` now exposes the `eac_`-prefixed id those calls expect. For all other providers `id` is already the `eac_` id and `externalAccountId` is `undefined`, so use `externalAccountId ?? id` to get an id you can delete with.

--- a/packages/backend/src/api/resources/ExternalAccount.ts
+++ b/packages/backend/src/api/resources/ExternalAccount.ts
@@ -13,6 +13,11 @@ export class ExternalAccount {
      */
     readonly id: string,
     /**
+     * The unique identifier for the external account resource (prefixed with `eac_`).
+     * This is the value expected by methods such as `users.deleteUserExternalAccount()`.
+     */
+    readonly externalAccountId: string,
+    /**
      * The provider name (e.g., `google`).
      */
     readonly provider: string,
@@ -74,6 +79,7 @@ export class ExternalAccount {
   static fromJSON(data: ExternalAccountJSON): ExternalAccount {
     return new ExternalAccount(
       data.id,
+      data.external_account_id,
       data.provider,
       data.provider_user_id,
       data.identification_id,

--- a/packages/backend/src/api/resources/ExternalAccount.ts
+++ b/packages/backend/src/api/resources/ExternalAccount.ts
@@ -13,11 +13,6 @@ export class ExternalAccount {
      */
     readonly id: string,
     /**
-     * The unique identifier for the external account resource (prefixed with `eac_`).
-     * This is the value expected by methods such as `users.deleteUserExternalAccount()`.
-     */
-    readonly externalAccountId: string,
-    /**
      * The provider name (e.g., `google`).
      */
     readonly provider: string,
@@ -74,12 +69,19 @@ export class ExternalAccount {
      * An object holding information on the verification of this external account.
      */
     readonly verification: Verification | null,
+    /**
+     * The `eac_`-prefixed id of the external account resource, which is the id
+     * `users.deleteUserExternalAccount()` expects. Only returned for Google and
+     * Facebook accounts, where `id` holds the `idn_` identification id instead;
+     * for other providers it is `undefined` and `id` is already the `eac_` value.
+     * Use `externalAccountId ?? id` to get an id you can delete with.
+     */
+    readonly externalAccountId?: string,
   ) {}
 
   static fromJSON(data: ExternalAccountJSON): ExternalAccount {
     return new ExternalAccount(
       data.id,
-      data.external_account_id,
       data.provider,
       data.provider_user_id,
       data.identification_id,
@@ -94,6 +96,7 @@ export class ExternalAccount {
       data.public_metadata,
       data.label,
       data.verification && Verification.fromJSON(data.verification),
+      data.external_account_id,
     );
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -231,7 +231,10 @@ export interface EnterpriseAccountJSON extends ClerkResourceJSON {
 
 export interface ExternalAccountJSON extends ClerkResourceJSON {
   object: typeof ObjectType.ExternalAccount;
-  external_account_id: string;
+  /**
+   * The `eac_`-prefixed external account id. Only present for Google and Facebook accounts.
+   */
+  external_account_id?: string;
   provider: string;
   identification_id: string;
   provider_user_id: string;

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -231,6 +231,7 @@ export interface EnterpriseAccountJSON extends ClerkResourceJSON {
 
 export interface ExternalAccountJSON extends ClerkResourceJSON {
   object: typeof ObjectType.ExternalAccount;
+  external_account_id: string;
   provider: string;
   identification_id: string;
   provider_user_id: string;

--- a/packages/backend/src/api/resources/__tests__/ExternalAccount.test.ts
+++ b/packages/backend/src/api/resources/__tests__/ExternalAccount.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { ExternalAccount } from '../ExternalAccount';
+import type { ExternalAccountJSON } from '../JSON';
+
+describe('ExternalAccount', () => {
+  describe('fromJSON', () => {
+    const data: ExternalAccountJSON = {
+      object: 'external_account',
+      id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
+      external_account_id: 'eac_2ABXLObDmeHsnLsLgOd5panvOPJ',
+      identification_id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
+      provider: 'oauth_google',
+      provider_user_id: '1029384756',
+      approved_scopes: 'email profile',
+      email_address: 'jane@example.com',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      image_url: 'https://img.clerk.com/jane.png',
+      username: 'jane',
+      phone_number: null,
+      public_metadata: {},
+      label: null,
+      verification: null,
+    } as ExternalAccountJSON;
+
+    it('maps external_account_id to externalAccountId', () => {
+      const externalAccount = ExternalAccount.fromJSON(data);
+
+      expect(externalAccount.externalAccountId).toBe('eac_2ABXLObDmeHsnLsLgOd5panvOPJ');
+    });
+
+    it('keeps id and identificationId pointing at the identification id', () => {
+      const externalAccount = ExternalAccount.fromJSON(data);
+
+      expect(externalAccount.id).toBe('idn_2ABXLLckIF5kLikvzAVRxuuN31M');
+      expect(externalAccount.identificationId).toBe('idn_2ABXLLckIF5kLikvzAVRxuuN31M');
+    });
+  });
+});

--- a/packages/backend/src/api/resources/__tests__/ExternalAccount.test.ts
+++ b/packages/backend/src/api/resources/__tests__/ExternalAccount.test.ts
@@ -5,11 +5,8 @@ import type { ExternalAccountJSON } from '../JSON';
 
 describe('ExternalAccount', () => {
   describe('fromJSON', () => {
-    const data: ExternalAccountJSON = {
+    const base = {
       object: 'external_account',
-      id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
-      external_account_id: 'eac_2ABXLObDmeHsnLsLgOd5panvOPJ',
-      identification_id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
       provider: 'oauth_google',
       provider_user_id: '1029384756',
       approved_scopes: 'email profile',
@@ -22,19 +19,38 @@ describe('ExternalAccount', () => {
       public_metadata: {},
       label: null,
       verification: null,
-    } as ExternalAccountJSON;
+    };
 
-    it('maps external_account_id to externalAccountId', () => {
+    it('maps external_account_id to externalAccountId for Google/Facebook accounts', () => {
+      // Google/Facebook responses set `id` to the `idn_` identification id and add `external_account_id`.
+      const data = {
+        ...base,
+        id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
+        external_account_id: 'eac_2ABXLObDmeHsnLsLgOd5panvOPJ',
+        identification_id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
+      } as ExternalAccountJSON;
+
       const externalAccount = ExternalAccount.fromJSON(data);
 
       expect(externalAccount.externalAccountId).toBe('eac_2ABXLObDmeHsnLsLgOd5panvOPJ');
-    });
-
-    it('keeps id and identificationId pointing at the identification id', () => {
-      const externalAccount = ExternalAccount.fromJSON(data);
-
+      // `id` and `identificationId` keep the `idn_` value for these providers.
       expect(externalAccount.id).toBe('idn_2ABXLLckIF5kLikvzAVRxuuN31M');
       expect(externalAccount.identificationId).toBe('idn_2ABXLLckIF5kLikvzAVRxuuN31M');
+    });
+
+    it('leaves externalAccountId undefined for other providers, where id is already the eac_ id', () => {
+      // Other providers omit `external_account_id`; `id` already holds the `eac_` value.
+      const data = {
+        ...base,
+        provider: 'oauth_github',
+        id: 'eac_2ABXLObDmeHsnLsLgOd5panvOPJ',
+        identification_id: 'idn_2ABXLLckIF5kLikvzAVRxuuN31M',
+      } as ExternalAccountJSON;
+
+      const externalAccount = ExternalAccount.fromJSON(data);
+
+      expect(externalAccount.externalAccountId).toBeUndefined();
+      expect(externalAccount.id).toBe('eac_2ABXLObDmeHsnLsLgOd5panvOPJ');
     });
   });
 });


### PR DESCRIPTION
## Description

The backend `ExternalAccount` resource maps the API's `id` field, which holds an `idn_`-prefixed identification id, and never reads `external_account_id` (the `eac_`-prefixed resource id) from the response. The `eac_` id is therefore unreachable from the SDK.

This bites anyone deleting an external account. `users.deleteUserExternalAccount()` builds its path from the `eac_` id, so passing `getUser().externalAccounts[0].id` (an `idn_` value) returns `404 external_account_not_found`. The only workaround today is a raw `fetch` to read `external_account_id` off the JSON.

The raw user response already contains both ids on each external account:

```json
{
  "id": "idn_...",
  "external_account_id": "eac_...",
  "identification_id": "idn_...",
  "provider": "oauth_google"
}
```

This PR maps `external_account_id` to a new `externalAccountId` property on `ExternalAccount`. `id` keeps its current value, so the change is additive and backwards compatible. Callers can now do:

```ts
const user = await clerk.users.getUser(userId);
await clerk.users.deleteUserExternalAccount({
  userId,
  externalAccountId: user.externalAccounts[0].externalAccountId,
});
```

Fixes #7936
Fixes #7584

## How to test

`ExternalAccount.fromJSON` is covered by a new unit test in `packages/backend/src/api/resources/__tests__/ExternalAccount.test.ts` that asserts `external_account_id` maps to `externalAccountId` while `id` and `identificationId` stay on the `idn_` value. The full `@clerk/backend` suite passes.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External account data now exposes an additional, provider resource identifier (`externalAccountId`) alongside the existing identification identifier.
* **Bug Fixes**
  * External accounts retrieved from user lookups can now be deleted reliably using the correct account identifier (avoids not-found errors).
* **Tests**
  * Added test coverage to verify identifier mapping across providers and ensure both identifiers are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->