### PR TITLE
fix(localizations): Fix email attribute expression for Okta in self-serve SSO

### DIFF
--- a/.changeset/modern-planets-attack.md
+++ b/.changeset/modern-planets-attack.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Fix Okta expression label for email attribute on the self-serve SSO flow

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -557,7 +557,7 @@ export const enUS: LocalizationResource = {
             },
             rows: {
               email: {
-                expression: 'user.mail',
+                expression: 'user.email',
                 name: 'mail',
               },
               firstName: {


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Okta SAML email attribute mapping in self-serve SSO, so the email field now uses the proper expression.
  - Updated the related label to better reflect the email attribute in the Okta flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->