### PR TITLE
fix(clerk-js): Backport using JWT `iat` for token cache timing

### DIFF
--- a/.changeset/token-cache-iat-core2.md
+++ b/.changeset/token-cache-iat-core2.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix token cache stale-while-revalidate timing to use the JWT issued-at time, keeping refresh thresholds accurate when tokens are cached after issuance.

--- a/packages/clerk-js/src/core/__tests__/tokenCache.test.ts
+++ b/packages/clerk-js/src/core/__tests__/tokenCache.test.ts
@@ -410,7 +410,7 @@ describe('SessionTokenCache', () => {
 
     it('removes token when it expires within the leeway threshold', async () => {
       const nowSeconds = Math.floor(Date.now() / 1000);
-      const iat = nowSeconds;
+      const iat = nowSeconds - 13;
       const exp = iat + 20;
       const soonJwt = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify({ iat, exp }))}.signature`;
 
@@ -419,7 +419,7 @@ describe('SessionTokenCache', () => {
         jwt: { claims: { exp, iat } },
       } as any);
 
-      SessionTokenCache.set({ createdAt: nowSeconds - 13, tokenId: 'soon_expired_token', tokenResolver });
+      SessionTokenCache.set({ createdAt: nowSeconds, tokenId: 'soon_expired_token', tokenResolver });
 
       await tokenResolver;
 

--- a/packages/clerk-js/src/core/resources/__tests__/Session.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Session.test.ts
@@ -21,9 +21,9 @@ describe('Session', () => {
   beforeEach(() => {
     // Mock Date.now() to make the test tokens appear valid
     // mockJwt has iat: 1666648250, exp: 1666648310
-    // Set current time to 1666648260 (10 seconds after iat, 50 seconds before exp)
+    // Set current time to iat so token appears freshly issued (60 seconds before exp)
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(1666648260 * 1000));
+    vi.setSystemTime(new Date(1666648250 * 1000));
   });
 
   afterEach(() => {

--- a/packages/clerk-js/src/core/tokenCache.ts
+++ b/packages/clerk-js/src/core/tokenCache.ts
@@ -339,6 +339,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
         const issuedAt = claims.iat;
         const expiresIn: Seconds = expiresAt - issuedAt;
 
+        value.createdAt = issuedAt;
         value.expiresIn = expiresIn;
 
         const timeoutId = setTimeout(deleteKey, expiresIn * 1000);


### PR DESCRIPTION
## Description

Backports using JWT `iat` for token cache timing from clerk/javascript@d5075a71dd3432075ca791a38ed57774abcee687 in https://github.com/clerk/javascript/pull/7317 to the Core 2 release line.

`SessionTokenCache` used cache insertion time as the start of a token’s lifetime, even though the lifetime itself comes from `exp - iat`. Tokens added to the cache after issuance could therefore stay in the fresh/stale windows too long and be returned after expiry.

Record the JWT iat as the cache start time once the token resolves, so stale-while-revalidate and expiry thresholds follow the token’s actual lifetime.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
