### PR TITLE
chore(repo): Include electron-passkeys in canary/snapshot releases

### DIFF
--- a/.changeset/electron-passkeys-corrected-native-packages.md
+++ b/.changeset/electron-passkeys-corrected-native-packages.md
@@ -1,0 +1,5 @@
+---
+'@clerk/electron-passkeys': patch
+---
+
+Publish corrected native platform packages for Electron passkeys.

--- a/scripts/canary.mjs
+++ b/scripts/canary.mjs
@@ -2,18 +2,10 @@
 
 import { $, echo } from 'zx';
 
-import {
-  constants,
-  getChangesetIgnoredPackages,
-  getPackageNames,
-  isElectronPasskeysPackage,
-  pinWorkspaceDeps,
-} from './common.mjs';
+import { constants, getChangesetIgnoredPackages, getPackageNames, pinWorkspaceDeps } from './common.mjs';
 
 const ignoredPackages = await getChangesetIgnoredPackages();
-const packageNames = (await getPackageNames()).filter(
-  name => !ignoredPackages.has(name) && !isElectronPasskeysPackage(name),
-);
+const packageNames = (await getPackageNames()).filter(name => !ignoredPackages.has(name));
 const packageEntries = packageNames.map(name => `'${name}': patch`).join('\n');
 
 const snapshot = `---

--- a/scripts/common.mjs
+++ b/scripts/common.mjs
@@ -34,10 +34,6 @@ export async function getPackageNames() {
   return packageNames.sort();
 }
 
-export function isElectronPasskeysPackage(name) {
-  return name === '@clerk/electron-passkeys' || name.startsWith('@clerk/electron-passkeys-');
-}
-
 /**
  * Converts `workspace:^` to `workspace:*` for all @clerk/* dependencies.
  * This ensures that snapshot/canary releases use exact versions instead of

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -2,18 +2,10 @@
 
 import { $, argv, echo } from 'zx';
 
-import {
-  constants,
-  getChangesetIgnoredPackages,
-  getPackageNames,
-  isElectronPasskeysPackage,
-  pinWorkspaceDeps,
-} from './common.mjs';
+import { constants, getChangesetIgnoredPackages, getPackageNames, pinWorkspaceDeps } from './common.mjs';
 
 const ignoredPackages = await getChangesetIgnoredPackages();
-const packageNames = (await getPackageNames()).filter(
-  name => !ignoredPackages.has(name) && !isElectronPasskeysPackage(name),
-);
+const packageNames = (await getPackageNames()).filter(name => !ignoredPackages.has(name));
 const packageEntries = packageNames.map(name => `'${name}': patch`).join('\n');
 
 const snapshot = `---


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected which native Electron passkeys packages are included in the next patch release, ensuring the appropriate platform-specific package is published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->