### PR TITLE
chore(expo): Add message about Google sign in migration in next major

### DIFF
--- a/.changeset/google-signin-package-heads-up.md
+++ b/.changeset/google-signin-package-heads-up.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Add a development warning and API docs note that native Google Sign-In will require installing `@clerk/expo-google-signin` in the next major version.

--- a/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
@@ -127,6 +127,25 @@ describe('useSignInWithGoogle', () => {
   });
 
   describe('startGoogleAuthenticationFlow', () => {
+    test('should warn once in development about the upcoming package split', () => {
+      const originalDev = globalThis.__DEV__;
+      globalThis.__DEV__ = true;
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      try {
+        renderHook(() => useSignInWithGoogle());
+        renderHook(() => useSignInWithGoogle());
+
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin. The @clerk/expo/google import path will continue to work.',
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+        globalThis.__DEV__ = originalDev;
+      }
+    });
+
     test('should return the hook with startGoogleAuthenticationFlow function', () => {
       const { result } = renderHook(() => useSignInWithGoogle());
 

--- a/packages/expo/src/hooks/useSignInWithApple.ios.ts
+++ b/packages/expo/src/hooks/useSignInWithApple.ios.ts
@@ -24,7 +24,7 @@ export type StartAppleAuthenticationFlowReturnType = {
  *
  * @example
  * ```tsx
- * import { useSignInWithApple } from '@clerk/clerk-expo';
+ * import { useSignInWithApple } from '@clerk/expo';
  * import { Button } from 'react-native';
  *
  * function AppleSignInButton() {

--- a/packages/expo/src/hooks/useSignInWithApple.ts
+++ b/packages/expo/src/hooks/useSignInWithApple.ts
@@ -21,7 +21,7 @@ export type StartAppleAuthenticationFlowReturnType = {
  *
  * @example
  * ```tsx
- * import { useSSO } from '@clerk/clerk-expo';
+ * import { useSSO } from '@clerk/expo';
  * import { Button } from 'react-native';
  *
  * function AppleSignInButton() {

--- a/packages/expo/src/hooks/useSignInWithGoogle.android.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.android.ts
@@ -17,9 +17,12 @@ export type {
  * - Built-in nonce support for replay attack protection
  * - No additional dependencies required
  *
+ * In the next major version, apps using native Google Sign-In will need to install
+ * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ *
  * @example
  * ```tsx
- * import { useSignInWithGoogle } from '@clerk/clerk-expo';
+ * import { useSignInWithGoogle } from '@clerk/expo';
  * import { Button } from 'react-native';
  *
  * function GoogleSignInButton() {

--- a/packages/expo/src/hooks/useSignInWithGoogle.ios.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.ios.ts
@@ -17,9 +17,12 @@ export type {
  * - Built-in nonce support for replay attack protection
  * - No additional dependencies required
  *
+ * In the next major version, apps using native Google Sign-In will need to install
+ * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ *
  * @example
  * ```tsx
- * import { useSignInWithGoogle } from '@clerk/clerk-expo';
+ * import { useSignInWithGoogle } from '@clerk/expo';
  * import { Button } from 'react-native';
  *
  * function GoogleSigninButton() {

--- a/packages/expo/src/hooks/useSignInWithGoogle.shared.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.shared.ts
@@ -23,6 +23,19 @@ type PlatformConfig = {
   requiresIosClientId: boolean;
 };
 
+let hasWarnedAboutGoogleSignInPackage = false;
+
+function warnAboutGoogleSignInPackageMigration() {
+  if (!__DEV__ || hasWarnedAboutGoogleSignInPackage) {
+    return;
+  }
+
+  hasWarnedAboutGoogleSignInPackage = true;
+  console.warn(
+    'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin. The @clerk/expo/google import path will continue to work.',
+  );
+}
+
 /**
  * Helper to get Google client IDs from expo-constants or process.env.
  * Dynamically imports expo-constants to keep it optional.
@@ -59,6 +72,8 @@ async function getGoogleClientIds(): Promise<{ webClientId?: string; iosClientId
  */
 export function createUseSignInWithGoogle(platformConfig: PlatformConfig) {
   return function useSignInWithGoogle() {
+    warnAboutGoogleSignInPackageMigration();
+
     const clerk = useClerk();
 
     async function startGoogleAuthenticationFlow(

--- a/packages/expo/src/hooks/useSignInWithGoogle.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.ts
@@ -21,9 +21,12 @@ export type StartGoogleAuthenticationFlowReturnType = {
  * Native Google Authentication is only available on iOS and Android.
  * For web platforms, use the OAuth-based Google Sign-In flow instead via useSSO.
  *
+ * In the next major version, apps using native Google Sign-In will need to install
+ * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ *
  * @example
  * ```tsx
- * import { useSSO } from '@clerk/clerk-expo';
+ * import { useSSO } from '@clerk/expo';
  * import { Button } from 'react-native';
  *
  * function GoogleSignInButton() {


### PR DESCRIPTION
## Description

This PR add sa development warning that native Google Sign-In will require installing `@clerk/expo-google-signin` in the next major version.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only warning for Google Sign-In to help apps prepare for the next major version.
  * Updated sign-in examples to use the current package import path.

* **Documentation**
  * Clarified Google Sign-In setup guidance, including the need for an additional package in the next major release.
  * Refreshed Apple and Google sign-in examples for consistency.

* **Tests**
  * Added coverage to ensure the development warning is shown only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->