### PR TITLE
fix(expo): Support secondary button theme colors in native UI

### DIFF
--- a/.changeset/sso-secondary-button-colors.md
+++ b/.changeset/sso-secondary-button-colors.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Allow Expo native theme JSON to configure secondary button background and foreground colors for native SSO buttons.

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
@@ -484,7 +484,9 @@ class ClerkExpoModule : Module() {
             border = json.optStringColor("border"),
             ring = json.optStringColor("ring"),
             muted = json.optStringColor("muted"),
-            shadow = json.optStringColor("shadow")
+            shadow = json.optStringColor("shadow"),
+            secondaryButtonBackground = json.optStringColor("secondaryButtonBackground"),
+            secondaryButtonForeground = json.optStringColor("secondaryButtonForeground")
         )
     }
 

--- a/packages/expo/app.plugin.js
+++ b/packages/expo/app.plugin.js
@@ -225,7 +225,8 @@ const withClerkAppleSignIn = config => {
  * Accepts a `theme` prop pointing to a JSON file with optional keys:
  *   - colors: { primary, background, input, danger, success, warning,
  *               foreground, mutedForeground, primaryForeground, inputForeground,
- *               neutral, border, ring, muted, shadow }  (hex color strings)
+ *               neutral, border, ring, muted, shadow, secondaryButtonBackground,
+ *               secondaryButtonForeground }  (hex color strings)
  *   - darkColors: same keys as colors (for dark mode)
  *   - design: { fontFamily: string, borderRadius: number }
  *
@@ -248,6 +249,8 @@ const VALID_COLOR_KEYS = [
   'ring',
   'muted',
   'shadow',
+  'secondaryButtonBackground',
+  'secondaryButtonForeground',
 ];
 
 const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;

--- a/packages/expo/ios/ClerkNativeBridge.swift
+++ b/packages/expo/ios/ClerkNativeBridge.swift
@@ -380,6 +380,8 @@ final class ClerkNativeBridge {
       neutral: dict["neutral"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultNeutralColor,
       ring: dict["ring"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultRingColor,
       muted: dict["muted"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultMutedColor,
+      secondaryButtonBackground: dict["secondaryButtonBackground"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultSecondaryButtonBackgroundColor,
+      secondaryButtonForeground: dict["secondaryButtonForeground"].flatMap { colorFromHex($0) },
       shadow: dict["shadow"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultShadowColor,
       border: dict["border"].flatMap { colorFromHex($0) } ?? ClerkTheme.Colors.defaultBorderColor
     )

--- a/packages/expo/src/__tests__/appPlugin.theme.test.js
+++ b/packages/expo/src/__tests__/appPlugin.theme.test.js
@@ -88,6 +88,25 @@ describe('validateThemeJson', () => {
     expect(() => validateThemeJson({ colors: { shadow: '#00000080' } })).not.toThrow();
   });
 
+  test('accepts secondary button color keys without warnings', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() =>
+      validateThemeJson({
+        colors: {
+          secondaryButtonBackground: '#FFFFFF',
+          secondaryButtonForeground: '#111111',
+        },
+        darkColors: {
+          secondaryButtonBackground: '#111111',
+          secondaryButtonForeground: '#FFFFFF',
+        },
+      }),
+    ).not.toThrow();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   // --- unknown keys ---
 
   test('warns on unknown color keys but does not throw', () => {


### PR DESCRIPTION
## Description

This PR forwards `secondaryButtonBackground` and `secondaryButtonForeground` from Expo theme JSON to native iOS and Android Clerk themes.

<img width="647" height="591" alt="Screenshot 2026-06-25 at 9 35 08 AM" src="https://github.com/user-attachments/assets/6a4178b8-b59e-4e65-9f5a-af89beb61621" />

<img width="644" height="582" alt="Screenshot 2026-06-25 at 9 34 28 AM" src="https://github.com/user-attachments/assets/078ba24f-0b2b-40b5-9544-eb4cf1fc380f" />


## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expo native theme settings now support secondary button background and foreground colors for native SSO buttons on both iOS and Android.
  * Theme validation now recognizes these additional color options without flagging them as unknown.

* **Tests**
  * Added coverage to ensure themes using the new secondary button colors are accepted without warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->