### PR TITLE
fix(ui): Ensure tab focus ring is visible for keyboard interactions

### DIFF
--- a/.changeset/ui-tab-focus-ring.md
+++ b/.changeset/ui-tab-focus-ring.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix focus ring visibility on `Tab` elements for keyboard navigation.

--- a/packages/ui/src/elements/Tabs.tsx
+++ b/packages/ui/src/elements/Tabs.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 import React from 'react';
 
 import { Button, descriptors, Flex, useLocalizations } from '../customizables';
-import type { PropsOfComponent } from '../styledSystem';
+import { common, type PropsOfComponent } from '../styledSystem';
 import { getValidChildren } from '../utils/getValidReactChildren';
 
 type TabsContextValue = {
@@ -173,6 +173,9 @@ export const Tab = (props: TabProps) => {
           padding: `${t.space.$2x5} ${t.space.$0x25}`,
           width: 'fit-content',
           '&:hover, &:focus-visible': { backgroundColor: t.colors.$transparent, boxShadow: 'none' },
+          '&:focus-visible': {
+            ...common.focusRing(t),
+          },
         }),
         sx,
       ]}


### PR DESCRIPTION
## Description

BEFORE

https://github.com/user-attachments/assets/6c37b02f-4fe0-4798-8112-f1cd0b9fa4b4

AFTER

https://github.com/user-attachments/assets/82e63f45-2566-4051-af1e-184066707901

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus ring visibility for Tab elements during keyboard navigation.
  * Focus styles now appear more consistently when tabs receive keyboard focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->