### PR TITLE
chore(ui,shared,localizations): Handle expired status for organization domain

### DIFF
--- a/.changeset/ripe-ways-greet.md
+++ b/.changeset/ripe-ways-greet.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/ui': minor
+---
+
+Handle expired organization domains on self-serve SSO flow, allowing to trigger a new verification

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -649,8 +649,12 @@ export const enUS: LocalizationResource = {
     },
     organizationDomainsStep: {
       domainCard: {
+        badge__expired: 'Expired',
         badge__unverified: 'Unverified',
         badge__verified: 'Verified',
+        expiredAtLabel:
+          "Domain verification expired on {{ date | shortDate('en-US') }}. Verify again to generate a new DNS record.",
+        expiredLabel: 'Domain verification expired. Verify again to generate a new DNS record.',
         removeButtonTooltip__lastVerifiedDomain: 'At least one verified domain is required to set up SSO.',
         removeButtonTooltip__lastVerifiedDomainActive: 'At least one verified domain is required to keep SSO enabled.',
         txtRecord: {
@@ -660,6 +664,7 @@ export const enUS: LocalizationResource = {
           valueLabel: 'Value',
         },
         verifiedAtLabel: "Verified on {{ date | shortDate('en-US') }}",
+        verifyAgainButton: 'Verify again',
       },
       domainSuggestion: {
         formButtonPrimary__add: 'Add {{domain}}',

--- a/packages/shared/src/react/hooks/useOrganizationDomains.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationDomains.tsx
@@ -137,10 +137,7 @@ function useOrganizationDomains(params: UseOrganizationDomainsParams = {}): UseO
   const unverifiedOwnershipDomainIds = useMemo(
     () =>
       (response?.data ?? [])
-        .filter(
-          (domain: OrganizationDomainResource) =>
-            domain.ownershipVerification && domain.ownershipVerification.status !== 'verified',
-        )
+        .filter((domain: OrganizationDomainResource) => domain.ownershipVerification?.status === 'unverified')
         .map((domain: OrganizationDomainResource) => domain.id),
     [response?.data],
   );

--- a/packages/shared/src/types/json.ts
+++ b/packages/shared/src/types/json.ts
@@ -20,6 +20,7 @@ import type { EmailAddressIdentifier, UsernameIdentifier } from './identifiers';
 import type { ActClaim } from './jwtv2';
 import type { OAuthProvider } from './oauth';
 import type {
+  OrganizationDomainOwnershipVerificationStatus,
   OrganizationDomainOwnershipVerificationStrategy,
   OrganizationDomainVerificationStatus,
   OrganizationEnrollmentMode,
@@ -436,7 +437,7 @@ export interface OrganizationDomainVerificationJSON {
 }
 
 export interface OrganizationDomainOwnershipVerificationJSON {
-  status: OrganizationDomainVerificationStatus;
+  status: OrganizationDomainOwnershipVerificationStatus;
   strategy: OrganizationDomainOwnershipVerificationStrategy;
   attempts: number | null;
   expire_at: number | null;

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -1390,7 +1390,11 @@ export type __internal_LocalizationResource = {
       domainCard: {
         badge__verified: LocalizationValue;
         badge__unverified: LocalizationValue;
+        badge__expired: LocalizationValue;
         verifiedAtLabel: LocalizationValue<'date'>;
+        expiredAtLabel: LocalizationValue<'date'>;
+        expiredLabel: LocalizationValue;
+        verifyAgainButton: LocalizationValue;
         removeButtonTooltip__lastVerifiedDomain: LocalizationValue;
         removeButtonTooltip__lastVerifiedDomainActive: LocalizationValue;
         txtRecord: {

--- a/packages/shared/src/types/organizationDomain.ts
+++ b/packages/shared/src/types/organizationDomain.ts
@@ -34,30 +34,51 @@ type OrganizationDomainVerificationStrategy = 'email_code';
 /**
  * The current status of an Organization domain verification.
  *
+ * <ul>
+ *  <li>`unverified`: Verification has not been completed yet. An attempt may be pending.</li>
+ *  <li>`verified`: Verification has been completed.</li>
+ *  <li>`failed`: Too many verification attempts were made without success.</li>
+ *  <li>`expired`: The pending verification attempt expired before it could be completed.</li>
+ * </ul>
+ *
  * @inline
  */
-export type OrganizationDomainVerificationStatus = 'unverified' | 'verified';
+export type OrganizationDomainVerificationStatus = 'unverified' | 'verified' | 'failed' | 'expired';
+
+/**
+ * The current status of an Organization domain ownership verification.
+ *
+ * <ul>
+ *  <li>`unverified`: Ownership has not been established yet. A TXT challenge is pending.</li>
+ *  <li>`verified`: Ownership has been verified.</li>
+ *  <li>`expired`: The pending ownership verification attempt expired before ownership could be confirmed. A new TXT challenge must be issued (via `prepareOwnershipVerification()`) to retry.</li>
+ * </ul>
+ *
+ * @inline
+ */
+export type OrganizationDomainOwnershipVerificationStatus = 'unverified' | 'verified' | 'expired';
 
 /**
  * The strategy used to verify ownership of an Organization's domain.
  * @inline
  */
-export type OrganizationDomainOwnershipVerificationStrategy = 'txt' | 'legacy' | 'manual_override';
+export type OrganizationDomainOwnershipVerificationStrategy = 'txt' | 'legacy' | 'manual_override' | 'parent_domain';
 
 /**
  * Holds the ownership verification details of an Organization's [Verified Domain](https://clerk.com/docs/guides/organizations/add-members/verified-domains). Ownership proves control of the underlying DNS domain, typically by publishing a TXT record, and is required before the domain can be used for enterprise SSO.
  */
 export interface OrganizationDomainOwnershipVerification {
   /**
-   * The current status of the domain ownership verification.
+   * The current status of the domain ownership verification. A status of `expired` means the pending TXT challenge expired before ownership could be confirmed and a new challenge must be issued.
    */
-  status: OrganizationDomainVerificationStatus;
+  status: OrganizationDomainOwnershipVerificationStatus;
   /**
    * The strategy used to verify ownership of the domain.
    * <ul>
    *  <li>`txt`: Ownership is proven by publishing a DNS TXT record (see `txtRecordName` and `txtRecordValue` on `OrganizationDomainOwnershipVerification`).</li>
    *  <li>`legacy`: Ownership was implicitly granted to domains that predate the TXT verification flow, so no per-attempt proof exists.</li>
    *  <li>`manual_override`: Ownership was granted manually by a Clerk admin via the Backend API or Dashboard, bypassing the DNS challenge.</li>
+   *  <li>`parent_domain`: Ownership was inherited from a parent domain that has already been verified, so no per-attempt proof exists.</li>
    * </ul>
    */
   strategy: OrganizationDomainOwnershipVerificationStrategy;
@@ -66,7 +87,7 @@ export interface OrganizationDomainOwnershipVerification {
    */
   attempts: number | null;
   /**
-   * The date and time when the current ownership verification attempt expires, or `null` when there is no pending attempt.
+   * The date and time when the current ownership verification attempt expires, or `null` when there is no pending attempt. When `status` is `expired`, this is the date and time at which the attempt expired.
    */
   expiresAt: Date | null;
   /**

--- a/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
@@ -81,7 +81,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
     }
   };
 
-  const handleVerifyAgain = async (domain: OrganizationDomainResource) => {
+  const handlePrepareOwnershipVerification = async (domain: OrganizationDomainResource) => {
     card.setError(undefined);
 
     try {
@@ -169,7 +169,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
                       key={domain.id}
                       domain={domain}
                       onRemove={() => setDomainToRemove(domain)}
-                      onVerifyAgain={() => handleVerifyAgain(domain)}
+                      onPrepareOwnershipVerification={() => handlePrepareOwnershipVerification(domain)}
                       isRemoveDisabled={isRemoveDisabled}
                       removeDisabledTooltip={lastVerifiedDomainTooltip}
                     />
@@ -365,13 +365,13 @@ const DomainSuggestion = ({ onSubmit }: { onSubmit: (domain: string) => Promise<
 const DomainCard = ({
   domain,
   onRemove,
-  onVerifyAgain,
+  onPrepareOwnershipVerification,
   isRemoveDisabled = false,
   removeDisabledTooltip,
 }: {
   domain: OrganizationDomainResource;
   onRemove: () => void;
-  onVerifyAgain: () => Promise<void>;
+  onPrepareOwnershipVerification: () => Promise<void>;
   isRemoveDisabled?: boolean;
   removeDisabledTooltip?: ReturnType<typeof localizationKeys>;
 }): JSX.Element | null => {
@@ -382,7 +382,7 @@ const DomainCard = ({
   const ownershipVerification = domain.ownershipVerification;
   const isVerified = ownershipVerification?.status === 'verified';
   const isExpired = ownershipVerification?.status === 'expired';
-  const cardId = isVerified ? 'verified' : isExpired ? 'expired' : 'unverified';
+  const cardId = ownershipVerification?.status ?? 'unverified';
 
   const removeButton = (
     <Button
@@ -472,7 +472,7 @@ const DomainCard = ({
             <ExpiredNotice
               key='expired'
               expiresAt={ownershipVerification?.expiresAt ?? null}
-              onVerifyAgain={onVerifyAgain}
+              onPrepareOwnershipVerification={onPrepareOwnershipVerification}
             />
           ) : ownershipVerification?.verifiedAt ? (
             <Text
@@ -498,16 +498,16 @@ const DomainCard = ({
 
 const ExpiredNotice = ({
   expiresAt,
-  onVerifyAgain,
+  onPrepareOwnershipVerification,
 }: {
   expiresAt: Date | null;
-  onVerifyAgain: () => Promise<void>;
+  onPrepareOwnershipVerification: () => Promise<void>;
 }): JSX.Element => {
   const [isVerifying, setIsVerifying] = useState(false);
 
   const handleVerifyAgain = () => {
     setIsVerifying(true);
-    void onVerifyAgain().finally(() => setIsVerifying(false));
+    void onPrepareOwnershipVerification().finally(() => setIsVerifying(false));
   };
 
   return (
@@ -523,7 +523,6 @@ const ExpiredNotice = ({
             ? localizationKeys('configureSSO.organizationDomainsStep.domainCard.expiredAtLabel', { date: expiresAt })
             : localizationKeys('configureSSO.organizationDomainsStep.domainCard.expiredLabel')
         }
-        sx={t => ({ fontSize: t.fontSizes.$sm })}
       />
 
       <Button
@@ -532,12 +531,12 @@ const ExpiredNotice = ({
         size='xs'
         isLoading={isVerifying}
         onClick={handleVerifyAgain}
-        sx={{ alignSelf: 'flex-start' }}
+        sx={t => ({ alignSelf: 'flex-start', gap: t.space.$1x5 })}
       >
         <Icon
           icon={RotateLeftRight}
           size='sm'
-          sx={t => ({ marginInlineEnd: t.space.$1 })}
+          colorScheme='neutral'
         />
         <Text
           as='span'

--- a/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
+++ b/packages/ui/src/components/ConfigureSSO/steps/OrganizationDomainsStep.tsx
@@ -25,7 +25,7 @@ import { useCardState } from '@/elements/contexts';
 import { Field } from '@/elements/FieldControl';
 import { Form } from '@/elements/Form';
 import { Tooltip } from '@/elements/Tooltip';
-import { Checkmark, Clipboard, Close } from '@/icons';
+import { Checkmark, Clipboard, Close, RotateLeftRight } from '@/icons';
 import { common } from '@/styledSystem';
 import { useFormControl } from '@/ui/utils/useFormControl';
 import { getFieldError, getGlobalError } from '@/utils/errorHandler';
@@ -43,7 +43,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
     organizationDomains,
     organizationEnterpriseConnection,
     contentRef,
-    organizationDomainMutations: { createDomain, revalidate },
+    organizationDomainMutations: { createDomain, revalidate, prepareOwnershipVerification },
     enterpriseConnectionMutations: { updateConnection },
   } = useConfigureSSO();
   const { goPrev, goNext, isFirstStep, isLastStep } = useWizard();
@@ -75,6 +75,17 @@ export const OrganizationDomainsStep = (): JSX.Element => {
 
     try {
       await createDomain(domain);
+    } catch (err: any) {
+      const apiError = getFieldError(err) ?? getGlobalError(err);
+      card.setError(apiError);
+    }
+  };
+
+  const handleVerifyAgain = async (domain: OrganizationDomainResource) => {
+    card.setError(undefined);
+
+    try {
+      await prepareOwnershipVerification([domain]);
     } catch (err: any) {
       const apiError = getFieldError(err) ?? getGlobalError(err);
       card.setError(apiError);
@@ -158,6 +169,7 @@ export const OrganizationDomainsStep = (): JSX.Element => {
                       key={domain.id}
                       domain={domain}
                       onRemove={() => setDomainToRemove(domain)}
+                      onVerifyAgain={() => handleVerifyAgain(domain)}
                       isRemoveDisabled={isRemoveDisabled}
                       removeDisabledTooltip={lastVerifiedDomainTooltip}
                     />
@@ -353,11 +365,13 @@ const DomainSuggestion = ({ onSubmit }: { onSubmit: (domain: string) => Promise<
 const DomainCard = ({
   domain,
   onRemove,
+  onVerifyAgain,
   isRemoveDisabled = false,
   removeDisabledTooltip,
 }: {
   domain: OrganizationDomainResource;
   onRemove: () => void;
+  onVerifyAgain: () => Promise<void>;
   isRemoveDisabled?: boolean;
   removeDisabledTooltip?: ReturnType<typeof localizationKeys>;
 }): JSX.Element | null => {
@@ -367,7 +381,8 @@ const DomainCard = ({
 
   const ownershipVerification = domain.ownershipVerification;
   const isVerified = ownershipVerification?.status === 'verified';
-  const cardId = isVerified ? 'verified' : 'unverified';
+  const isExpired = ownershipVerification?.status === 'expired';
+  const cardId = isVerified ? 'verified' : isExpired ? 'expired' : 'unverified';
 
   const removeButton = (
     <Button
@@ -426,11 +441,13 @@ const DomainCard = ({
             localizationKey={
               isVerified
                 ? localizationKeys('configureSSO.organizationDomainsStep.domainCard.badge__verified')
-                : localizationKeys('configureSSO.organizationDomainsStep.domainCard.badge__unverified')
+                : isExpired
+                  ? localizationKeys('configureSSO.organizationDomainsStep.domainCard.badge__expired')
+                  : localizationKeys('configureSSO.organizationDomainsStep.domainCard.badge__unverified')
             }
           />
 
-          {!isVerified && (
+          {!isVerified && !isExpired && (
             <Spinner
               size='xs'
               colorScheme='neutral'
@@ -451,7 +468,13 @@ const DomainCard = ({
 
       <Box sx={{ overflow: 'hidden' }}>
         <Animated>
-          {ownershipVerification?.verifiedAt ? (
+          {isExpired ? (
+            <ExpiredNotice
+              key='expired'
+              expiresAt={ownershipVerification?.expiresAt ?? null}
+              onVerifyAgain={onVerifyAgain}
+            />
+          ) : ownershipVerification?.verifiedAt ? (
             <Text
               key='verified'
               as='p'
@@ -469,6 +492,58 @@ const DomainCard = ({
           )}
         </Animated>
       </Box>
+    </Col>
+  );
+};
+
+const ExpiredNotice = ({
+  expiresAt,
+  onVerifyAgain,
+}: {
+  expiresAt: Date | null;
+  onVerifyAgain: () => Promise<void>;
+}): JSX.Element => {
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const handleVerifyAgain = () => {
+    setIsVerifying(true);
+    void onVerifyAgain().finally(() => setIsVerifying(false));
+  };
+
+  return (
+    <Col
+      elementDescriptor={descriptors.configureSSOVerifyDomainCardExpired}
+      sx={t => ({ gap: t.space.$3, paddingInline: t.space.$4, paddingBottom: t.space.$4 })}
+    >
+      <Text
+        as='p'
+        colorScheme='secondary'
+        localizationKey={
+          expiresAt
+            ? localizationKeys('configureSSO.organizationDomainsStep.domainCard.expiredAtLabel', { date: expiresAt })
+            : localizationKeys('configureSSO.organizationDomainsStep.domainCard.expiredLabel')
+        }
+        sx={t => ({ fontSize: t.fontSizes.$sm })}
+      />
+
+      <Button
+        variant='bordered'
+        colorScheme='secondary'
+        size='xs'
+        isLoading={isVerifying}
+        onClick={handleVerifyAgain}
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        <Icon
+          icon={RotateLeftRight}
+          size='sm'
+          sx={t => ({ marginInlineEnd: t.space.$1 })}
+        />
+        <Text
+          as='span'
+          localizationKey={localizationKeys('configureSSO.organizationDomainsStep.domainCard.verifyAgainButton')}
+        />
+      </Button>
     </Col>
   );
 };

--- a/packages/ui/src/customizables/elementDescriptors.ts
+++ b/packages/ui/src/customizables/elementDescriptors.ts
@@ -586,6 +586,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'configureSSOVerifyDomainCardRemoveButton',
   'configureSSOVerifyDomainCardTxtRecord',
   'configureSSOVerifyDomainCardTxtRecordValue',
+  'configureSSOVerifyDomainCardExpired',
   'configureSSOEmailVerificationForm',
   'configureSSOEmailVerificationIcon',
   'configureSSOEmailVerificationTitle',

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -717,11 +717,12 @@ export type ElementsConfig = {
   configureSSOVerifyDomainErrorSubtitle: WithOptions;
   configureSSOVerifyDomainList: WithOptions;
   configureSSOVerifyDomainSuggestion: WithOptions;
-  configureSSOVerifyDomainCard: WithOptions<'verified' | 'unverified'>;
-  configureSSOVerifyDomainCardBadge: WithOptions<'verified' | 'unverified'>;
+  configureSSOVerifyDomainCard: WithOptions<'verified' | 'unverified' | 'expired'>;
+  configureSSOVerifyDomainCardBadge: WithOptions<'verified' | 'unverified' | 'expired'>;
   configureSSOVerifyDomainCardRemoveButton: WithOptions;
   configureSSOVerifyDomainCardTxtRecord: WithOptions;
   configureSSOVerifyDomainCardTxtRecordValue: WithOptions;
+  configureSSOVerifyDomainCardExpired: WithOptions;
   configureSSOEmailVerificationForm: WithOptions<string>;
   configureSSOEmailVerificationIcon: WithOptions<string>;
   configureSSOEmailVerificationTitle: WithOptions<string>;


### PR DESCRIPTION
## Description

This PR handles the expired state of an organization domain, allowing to trigger another verification with fresh TXT records.

<img width="994" height="774" alt="CleanShot 2026-06-25 at 13 58 06" src="https://github.com/user-attachments/assets/05ceee4e-8d1e-4d9f-b3b1-ac2afedf588c" />

<img width="800" height="632" alt="CleanShot 2026-06-25 at 13 59 52" src="https://github.com/user-attachments/assets/9c2d4319-c50c-438b-b7bf-8a6ab57ec5b7" />

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expired organization domain verification states in the SSO setup flow.
  * Users can now trigger verification again for expired domains.
  * New messaging and badge states were added to reflect expired, verified, and re-verification statuses.

* **Bug Fixes**
  * Improved domain status handling so only truly unverified ownership checks are polled.
  * Aligned verification status data to better match the domain state shown in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->