### PR TITLE
chore(localizations): Fix wording for Okta instructions in self-serve SSO

### DIFF
--- a/.changeset/young-jeans-own.md
+++ b/.changeset/young-jeans-own.md
@@ -2,4 +2,4 @@
 '@clerk/localizations': patch
 ---
 
-Fix Okta instructions wording to align with docs
+Fix Okta instructions in self-serve SSO flow such as updating the expressions on attribute statement step

--- a/.changeset/young-jeans-own.md
+++ b/.changeset/young-jeans-own.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Fix Okta instructions wording to align with docs

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -579,7 +579,7 @@ export const enUS: LocalizationResource = {
         createAppStep: {
           completeSamlIntegrationInstructions: {
             step1:
-              'From the  <bold>Feedback**</bold>, select <bold>This is an internal app that we have created.</bold>',
+              'From the <bold>Feedback**</bold>, select <bold>This is an internal app that we have created.</bold>',
             step2: 'Click <bold>Finish</bold> to complete the integration.',
             title: 'Complete the SAML integration',
           },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -578,8 +578,7 @@ export const enUS: LocalizationResource = {
         },
         createAppStep: {
           completeSamlIntegrationInstructions: {
-            step1:
-              'From the <bold>Feedback**</bold>, select <bold>This is an internal app that we have created.</bold>',
+            step1: 'From the <bold>Feedback</bold>, select <bold>This is an internal app that we have created.</bold>',
             step2: 'Click <bold>Finish</bold> to complete the integration.',
             title: 'Complete the SAML integration',
           },
@@ -628,7 +627,7 @@ export const enUS: LocalizationResource = {
           },
           metadataUrl: {
             description:
-              'In your Okta SAML application, go to the  <bold>Sign On</bold> tab and retrieve the metadata URL. Paste it below.',
+              'In your Okta SAML application, go to the <bold>Sign On</bold> tab and retrieve the metadata URL. Paste it below.',
             label: 'Metadata URL',
             placeholder: 'Paste URL here...',
           },

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -557,15 +557,15 @@ export const enUS: LocalizationResource = {
             },
             rows: {
               email: {
-                expression: 'user.email',
+                expression: 'user.profile.email',
                 name: 'mail',
               },
               firstName: {
-                expression: 'user.firstName',
+                expression: 'user.profile.firstName',
                 name: 'firstName',
               },
               lastName: {
-                expression: 'user.lastName',
+                expression: 'user.profile.lastName',
                 name: 'lastName',
               },
             },
@@ -578,7 +578,8 @@ export const enUS: LocalizationResource = {
         },
         createAppStep: {
           completeSamlIntegrationInstructions: {
-            step1: 'From the options menu, select <bold>This is an internal app that we have created.</bold>',
+            step1:
+              'From the  <bold>Feedback**</bold>, select <bold>This is an internal app that we have created.</bold>',
             step2: 'Click <bold>Finish</bold> to complete the integration.',
             title: 'Complete the SAML integration',
           },
@@ -608,7 +609,7 @@ export const enUS: LocalizationResource = {
         identityProviderMetadataStep: {
           headerSubtitle: 'Add your Okta application metadata',
           manual: {
-            description: 'In your Okta SAML application, go to the Sign On tab and retrieve these values.',
+            description: 'In your Okta SAML application, go to the <bold>Sign On</bold> tab and retrieve these values.',
             issuer: {
               label: 'Issuer',
               placeholder: 'Paste URL here...',
@@ -627,7 +628,7 @@ export const enUS: LocalizationResource = {
           },
           metadataUrl: {
             description:
-              'In your Okta SAML application, go to the Sign On tab and retrieve the metadata URL. Paste it below.',
+              'In your Okta SAML application, go to the  <bold>Sign On</bold> tab and retrieve the metadata URL. Paste it below.',
             label: 'Metadata URL',
             placeholder: 'Paste URL here...',
           },


### PR DESCRIPTION
## Description

Solves these three copy/ wording issues:

- Fixing the wording mismatch for the expressions btw docs and dashboard: `user.profile.<tag>` on docs and `user.<tag>` on dashboard 

  <img width="1419" height="219" alt="Screenshot 2026-06-25 at 9 56 46 am" src="https://github.com/user-attachments/assets/de221696-8b27-417b-b7e3-fad24b5fed30" />

- Fixed wording to `**Feedback** page` rather than `options menu` to align with docs and the OKTA UI 
- Made **Sign on** in `Sign On tab` bold since it's the name of a tab

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Localization**
  * Updated Okta SAML English setup text for the self-serve SSO flow with clearer step-by-step guidance.
  * Changed attribute mapping expressions to use `user.profile.*` while keeping attribute names the same.
  * Revised instructions to reference the internal app from the **Feedback** UI (instead of an options menu).
  * Improved formatting and wording around the **Sign On** step and the metadata URL instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->