### PR TITLE
fix(testing): Add Cypress v15 to peerDependencies

### DIFF
--- a/.changeset/wise-cycles-relate.md
+++ b/.changeset/wise-cycles-relate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/testing': minor
+---
+
+Increase peer dependency range for Cypress to include v15

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@playwright/test": "^1",
-    "cypress": "^13 || ^14"
+    "cypress": "^13 || ^14 || ^15"
   },
   "peerDependenciesMeta": {
     "@playwright/test": {


### PR DESCRIPTION
## Description

This PR adds Cypress v15 to the `peerDependencies` for `@clerk/testing`. One of our customers reports that it appears to be compatible. This should prevent issues where the testing package might possibly bring in the wrong version of Cypress.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Cypress compatibility to include version 15.
  * Updated the release note entry to reflect the dependency range change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->