### PR TITLE
chore(expo): Mention config plugin in Google Sign-In migration notice

### DIFF
--- a/.changeset/fresh-masks-warn-google-plugin.md
+++ b/.changeset/fresh-masks-warn-google-plugin.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Clarify the native Google Sign-In migration warning to mention the required Expo config plugin.

--- a/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSignInWithGoogle.test.ts
@@ -138,7 +138,7 @@ describe('useSignInWithGoogle', () => {
 
         expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin. The @clerk/expo/google import path will continue to work.',
+          'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin and adding its Expo config plugin. The @clerk/expo/google import path will continue to work.',
         );
       } finally {
         consoleWarnSpy.mockRestore();

--- a/packages/expo/src/hooks/useSignInWithGoogle.android.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.android.ts
@@ -18,7 +18,7 @@ export type {
  * - No additional dependencies required
  *
  * In the next major version, apps using native Google Sign-In will need to install
- * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ * `@clerk/expo-google-signin` alongside `@clerk/expo` and add its Expo config plugin.
  *
  * @example
  * ```tsx

--- a/packages/expo/src/hooks/useSignInWithGoogle.ios.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.ios.ts
@@ -18,7 +18,7 @@ export type {
  * - No additional dependencies required
  *
  * In the next major version, apps using native Google Sign-In will need to install
- * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ * `@clerk/expo-google-signin` alongside `@clerk/expo` and add its Expo config plugin.
  *
  * @example
  * ```tsx

--- a/packages/expo/src/hooks/useSignInWithGoogle.shared.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.shared.ts
@@ -33,7 +33,7 @@ function warnAboutGoogleSignInPackageMigration() {
 
   hasWarnedAboutGoogleSignInPackage = true;
   console.warn(
-    'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin. The @clerk/expo/google import path will continue to work.',
+    'Clerk: In the next major version, native Google Sign-In will require installing @clerk/expo-google-signin and adding its Expo config plugin. The @clerk/expo/google import path will continue to work.',
   );
 }
 

--- a/packages/expo/src/hooks/useSignInWithGoogle.ts
+++ b/packages/expo/src/hooks/useSignInWithGoogle.ts
@@ -22,7 +22,7 @@ export type StartGoogleAuthenticationFlowReturnType = {
  * For web platforms, use the OAuth-based Google Sign-In flow instead via useSSO.
  *
  * In the next major version, apps using native Google Sign-In will need to install
- * `@clerk/expo-google-signin` alongside `@clerk/expo`.
+ * `@clerk/expo-google-signin` alongside `@clerk/expo` and add its Expo config plugin.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified Google Sign-In migration guidance across app warnings and docs.
  * Added a reminder to install the required Expo config plugin when using native Google Sign-In.
  * Kept the existing import path note, so current setups continue to work during the transition.

* **Chores**
  * Updated the release note entry to mark the change as a patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->