### PR TITLE
fix(ui): keep truncateWithEndVisible code-point-safe in short-width fallback

### DIFF
--- a/.changeset/truncate-surrogate-safe.md
+++ b/.changeset/truncate-surrogate-safe.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Stop `truncateWithEndVisible` from splitting characters outside the BMP (such as CJK Extension B kanji and emoji) into a broken replacement character when truncating to a very small width. The short-width fallback now slices by code point, matching the main truncation path.

--- a/packages/ui/src/utils/__tests__/truncateTextWithEndVisible.test.ts
+++ b/packages/ui/src/utils/__tests__/truncateTextWithEndVisible.test.ts
@@ -28,6 +28,14 @@ describe('truncateWithEndVisible', () => {
     expect(truncateWithEndVisible('1234567890', 5, 3)).toBe('...890');
   });
 
+  test('should not split surrogate pairs when maxLength is too small', () => {
+    // The short-maxLength fallback must stay code-point-safe like the main path.
+    // Slicing on UTF-16 code units cuts characters outside the BMP (CJK Extension B,
+    // emoji) mid-surrogate, leaving a replacement character.
+    expect(truncateWithEndVisible('𠮷𠮷𠮷𠮷𠮷', 8, 5)).toBe('...𠮷𠮷𠮷𠮷𠮷');
+    expect(truncateWithEndVisible('🍣🍣🍣🍣🍣', 8, 5)).toBe('...🍣🍣🍣🍣🍣');
+  });
+
   test('should handle email addresses', () => {
     expect(truncateWithEndVisible('test@example.com', 10)).toBe('te...e.com');
   });

--- a/packages/ui/src/utils/truncateTextWithEndVisible.ts
+++ b/packages/ui/src/utils/truncateTextWithEndVisible.ts
@@ -20,7 +20,7 @@ export function truncateWithEndVisible(str: string, maxLength = 20, endChars = 5
   }
 
   if (maxLength <= endChars + ELLIPSIS_LENGTH) {
-    return ELLIPSIS + str.slice(-endChars);
+    return ELLIPSIS + Array.from(str).slice(-endChars).join('');
   }
 
   const chars = Array.from(str);


### PR DESCRIPTION
`truncateWithEndVisible` keeps the start and end of a string and puts an ellipsis in the middle. The main path builds the result from `Array.from(str)`, so it slices on code points and never breaks a character. The short-width fallback (taken when `maxLength <= endChars + 3`) instead returns `ELLIPSIS + str.slice(-endChars)`, which slices on UTF-16 code units.

For characters outside the BMP (CJK Extension B kanji, emoji) each character is a surrogate pair of two code units, so `str.slice(-endChars)` can cut one in half and leave a lone surrogate:

```ts
truncateWithEndVisible('𠮷𠮷𠮷𠮷𠮷', 8, 5)
// before: '...\uDFB7𠮷𠮷'  (broken leading character)
// after:  '...𠮷𠮷𠮷𠮷𠮷'
```

The fallback now slices by code point, the same way the main path already does. ASCII inputs are unaffected and the existing tests still pass. Added a test covering the fallback with astral characters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation so very short widths no longer split multi-code-point characters.
  * Fixed fallback truncation to preserve emoji and other non-BMP characters, avoiding broken replacement symbols.
  * Added test coverage to verify truncation remains correct for Unicode characters in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->