### PR TITLE
feat(expo): send host SDK headers from Android

### DIFF
--- a/.changeset/expo-android-host-sdk.md
+++ b/.changeset/expo-android-host-sdk.md
@@ -1,0 +1,5 @@
+---
+"@clerk/expo": patch
+---
+
+Send Expo host SDK headers from the Android native bridge.

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
   id 'com.android.library'
   id 'org.jetbrains.kotlin.android'
@@ -10,6 +12,9 @@ applyKotlinExpoModulesCorePlugin()
 
 group = 'com.clerk.expo'
 version = '1.0.0'
+
+def clerkExpoPackageJson = new JsonSlurper().parse(new File(projectDir, "../package.json"))
+def clerkExpoVersion = clerkExpoPackageJson.version.toString()
 
 // Dependency versions - centralized for easier updates
 // See: https://docs.gradle.org/current/userguide/version_catalogs.html for app-level version catalogs
@@ -38,6 +43,7 @@ android {
     targetSdk safeExtGet("targetSdkVersion", 36)
     versionCode 1
     versionName "1.0.0"
+    buildConfigField "String", "CLERK_EXPO_VERSION", "\"${clerkExpoVersion}\""
   }
 
   buildTypes {
@@ -60,6 +66,7 @@ android {
   }
 
   buildFeatures {
+    buildConfig = true
     compose = true
   }
 

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkExpoModule.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.clerk.api.Clerk
+import com.clerk.api.ClerkConfigurationOptions
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.firstMessage
 import com.clerk.api.network.serialization.ClerkResult
@@ -25,6 +26,9 @@ import org.json.JSONObject
 
 private const val TAG = "ClerkExpoModule"
 private const val NATIVE_CLIENT_CHANGED_EVENT = "clerkNativeClientChanged"
+private const val HOST_SDK_HEADER = "x-clerk-host-sdk"
+private const val HOST_SDK_VERSION_HEADER = "x-clerk-host-sdk-version"
+private const val HOST_SDK = "expo"
 
 private fun debugLog(tag: String, message: String) {
     if (BuildConfig.DEBUG) {
@@ -107,6 +111,18 @@ class ClerkExpoModule : Module() {
 
     private val reactContext: Context?
         get() = appContext.reactContext
+
+    private fun clerkConfigurationOptions(): ClerkConfigurationOptions {
+        val hostSdkVersion = BuildConfig.CLERK_EXPO_VERSION.trim()
+        val customHeaders = buildMap {
+            put(HOST_SDK_HEADER, HOST_SDK)
+            if (hostSdkVersion.isNotEmpty()) {
+                put(HOST_SDK_VERSION_HEADER, hostSdkVersion)
+            }
+        }
+
+        return ClerkConfigurationOptions().withCustomHeaders(customHeaders)
+    }
 
     private fun startClientStateObserver() {
         if (clientStateObserverJob != null) {
@@ -209,7 +225,7 @@ class ClerkExpoModule : Module() {
                             .apply()
                     }
 
-                    Clerk.initialize(context, pubKey)
+                    Clerk.initialize(context, pubKey, clerkConfigurationOptions())
                     startClientStateObserver()
                     // clerk-android registers ActivityLifecycleCallbacks during
                     // initialize(), but in React Native MainActivity has already passed
@@ -261,7 +277,7 @@ class ClerkExpoModule : Module() {
 
                 val activePublishableKey = configuredPublishableKey ?: Clerk.publishableKey
                 if (activePublishableKey != null && activePublishableKey != pubKey) {
-                    Clerk.switchConfiguration(context, pubKey)
+                    Clerk.switchConfiguration(context, pubKey, clerkConfigurationOptions())
                     startClientStateObserver()
                     appContext.currentActivity?.let { Clerk.attachActivity(it) }
                     loadThemeFromAssets(context)


### PR DESCRIPTION
## Description

Adds the Expo host SDK headers to the Android native bridge by passing `ClerkConfigurationOptions` custom headers into Clerk Android initialization and reconfiguration. The Android Gradle module now exposes the `@clerk/expo` package version through `BuildConfig`, so native requests include `x-clerk-host-sdk-version` alongside `x-clerk-host-sdk: expo`.

## Type of change

- [x] New feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expo on Android now includes host SDK headers when initializing or reconfiguring the native SDK.
  * When available, the Expo SDK version is also included in the headers to improve identification.
* **Chores**
  * Updated the Android build configuration to expose the app’s Expo package version to the native layer for header generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->