### PR TITLE
fix(ui): align UserButton action buttons with username text

### DIFF
--- a/.changeset/user-button-multisession-action-alignment.md
+++ b/.changeset/user-button-multisession-action-alignment.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix the `<UserButton />` popover so the "Manage account" & "Sign out" buttons line up with the username text instead of sitting slightly to the left of them.

--- a/.changeset/user-button-multisession-action-alignment.md
+++ b/.changeset/user-button-multisession-action-alignment.md
@@ -2,4 +2,4 @@
 '@clerk/ui': patch
 ---
 
-Fix the `<UserButton />` popover so the "Manage account" & "Sign out" buttons line up with the username text instead of sitting slightly to the left of them.
+Fix `<UserButton />` session actions alignment.

--- a/packages/ui/src/components/UserButton/SessionActions.tsx
+++ b/packages/ui/src/components/UserButton/SessionActions.tsx
@@ -174,7 +174,11 @@ export const MultiSessionActions = (props: MultiSessionActionsProps) => {
         >
           <Flex
             justify='between'
-            sx={t => ({ marginInlineStart: t.space.$12, padding: `0 ${t.space.$5} ${t.space.$4}`, gap: t.space.$2 })}
+            sx={t => ({
+              marginInlineStart: `calc(${t.sizes.$9} + ${t.space.$4})`,
+              padding: `0 ${t.space.$5} ${t.space.$4}`,
+              gap: t.space.$2,
+            })}
           >
             <SmallAction
               elementDescriptor={descriptors.userButtonPopoverActionButton}


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

Linear issue: https://linear.app/clerk/issue/PD-49/align-button-actions-with-username-text-in-userbutton-component

This PR fixes an alignment issue on the UserButton popover. The "Manage account" and "Sign out" action buttons are now left aligned with the username text. Before, they were slightly indented to the left.

Image of change:
<img width="396" height="268" alt="Screenshot 2026-06-29 at 11 38 31 AM" src="https://github.com/user-attachments/assets/8e0be916-3558-4b2b-a6ef-3a50e7b016fa" />

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: UI fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Adjusted spacing, margin, and padding for `<UserButton />` session action controls in the default action view to improve visual alignment with the username and make the popover buttons look more consistent.
* **Chores**
  * Added a changeset for a patch release documenting the session action alignment fix in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->