### PR TITLE
fix(backend): guard deleteOrganization against empty organization ID

### DIFF
--- a/.changeset/delete-organization-require-id.md
+++ b/.changeset/delete-organization-require-id.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+`organizations.deleteOrganization()` now validates that an organization ID was provided. Calling it with an empty ID throws `A valid resource ID is required.` locally instead of issuing a `DELETE` request to the organizations collection endpoint, matching the other ID-based methods on the API.

--- a/packages/backend/src/api/__tests__/OrganizationApi.test.ts
+++ b/packages/backend/src/api/__tests__/OrganizationApi.test.ts
@@ -185,6 +185,12 @@ describe('OrganizationAPI', () => {
     });
   });
 
+  describe('deleteOrganization', () => {
+    it('throws an error when the organization ID is missing', async () => {
+      await expect(apiClient.organizations.deleteOrganization('')).rejects.toThrow('A valid resource ID is required.');
+    });
+  });
+
   describe('createOrganizationInvitationBulk', () => {
     const mockInvitation = {
       object: 'organization_invitation',

--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -361,6 +361,8 @@ export class OrganizationAPI extends AbstractAPI {
   }
 
   public async deleteOrganization(organizationId: string) {
+    this.requireId(organizationId);
+
     return this.request<Organization>({
       method: 'DELETE',
       path: joinPaths(basePath, organizationId),


### PR DESCRIPTION
`OrganizationAPI.deleteOrganization()` was the lone ID-based method on that client without a `requireId()` guard. Since `joinPaths()` filters out falsy segments, `deleteOrganization('')` quietly built `/organizations` and fired a `DELETE` at the collection route instead of throwing locally. This adds the guard so an empty ID fails fast with `A valid resource ID is required.`, matching every sibling method.

Pre-existing on `main` (spotted by CodeRabbit on #8853); pulling it out as its own one-liner rather than folding a behavior change into that docs-only PR. The added test confirms the empty-ID call now rejects locally (it fails without the guard).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization deletion now validates that an organization ID is provided before sending the request.
  * If an empty ID is used, the app now returns a clear error message instead of attempting the action.
  
* **Tests**
  * Added coverage for the new validation behavior to ensure the error is shown as expected.
  
* **Chores**
  * Updated the release notes entry to document the behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->