### PR TITLE
feat(backend): add OAuth application token revocation

### DIFF
--- a/.changeset/oauth-application-revoke-token.md
+++ b/.changeset/oauth-application-revoke-token.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Add `clerkClient.oauthApplications.revokeToken()` for revoking opaque OAuth application access and refresh tokens.

--- a/packages/backend/src/api/__tests__/OAuthApplicationsApi.test.ts
+++ b/packages/backend/src/api/__tests__/OAuthApplicationsApi.test.ts
@@ -1,0 +1,51 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server, validateHeaders } from '../../mock-server';
+import { createBackendApiClient } from '../factory';
+
+describe('OAuthApplications', () => {
+  const oauthApplicationId = 'oauthapp_xxxxx';
+
+  describe('revokeToken', () => {
+    it('revokes an OAuth application token', async () => {
+      const apiClient = createBackendApiClient({
+        apiUrl: 'https://api.clerk.test',
+        secretKey: 'sk_xxxxx',
+      });
+
+      server.use(
+        http.post(
+          `https://api.clerk.test/v1/oauth_applications/${oauthApplicationId}/revoke_token`,
+          validateHeaders(async ({ request }) => {
+            expect(request.headers.get('Authorization')).toBe('Bearer sk_xxxxx');
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.token).toBe('oat_xxxxx');
+            return new HttpResponse(null, { status: 204 });
+          }),
+        ),
+      );
+
+      const response = await apiClient.oauthApplications.revokeToken({
+        oauthApplicationId,
+        token: 'oat_xxxxx',
+      });
+
+      expect(response).toBeUndefined();
+    });
+
+    it('throws error when OAuth application ID is missing', async () => {
+      const apiClient = createBackendApiClient({
+        apiUrl: 'https://api.clerk.test',
+        secretKey: 'sk_xxxxx',
+      });
+
+      await expect(
+        apiClient.oauthApplications.revokeToken({
+          oauthApplicationId: '',
+          token: 'oat_xxxxx',
+        }),
+      ).rejects.toThrow('A valid resource ID is required.');
+    });
+  });
+});

--- a/packages/backend/src/api/endpoints/OAuthApplicationsApi.ts
+++ b/packages/backend/src/api/endpoints/OAuthApplicationsApi.ts
@@ -37,6 +37,17 @@ type UpdateOAuthApplicationParams = CreateOAuthApplicationParams & {
   oauthApplicationId: string;
 };
 
+type RevokeOAuthApplicationTokenParams = {
+  /**
+   * The ID of the OAuth application for which to revoke the token.
+   */
+  oauthApplicationId: string;
+  /**
+   * The opaque OAuth access token or refresh token to revoke.
+   */
+  token: string;
+};
+
 type GetOAuthApplicationListParams = ClerkPaginationRequest<{
   /**
    * Sorts OAuth applications by name or created_at.
@@ -98,6 +109,18 @@ export class OAuthApplicationsApi extends AbstractAPI {
     return this.request<OAuthApplication>({
       method: 'POST',
       path: joinPaths(basePath, oauthApplicationId, 'rotate_secret'),
+    });
+  }
+
+  public async revokeToken(params: RevokeOAuthApplicationTokenParams) {
+    const { oauthApplicationId, ...bodyParams } = params;
+
+    this.requireId(oauthApplicationId);
+
+    return this.request<void>({
+      method: 'POST',
+      path: joinPaths(basePath, oauthApplicationId, 'revoke_token'),
+      bodyParams,
     });
   }
 }

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -184,6 +184,13 @@ export function buildRequest(options: BuildRequestOptions) {
         });
       }
 
+      if (res.status === 204) {
+        return {
+          data: undefined as T,
+          errors: null,
+        };
+      }
+
       // TODO: Parse JSON or Text response based on a response header
       const isJSONResponse =
         res?.headers && res.headers?.get(constants.Headers.ContentType) === constants.ContentTypes.Json;


### PR DESCRIPTION
## Summary

Adds SDK support for the new OAuth application token revocation endpoint and documents the backend SDK method.

Validation run:
- go test ./oauthapplication
- pnpm --filter @clerk/backend test:node src/api/__tests__/OAuthApplicationsApi.test.ts
- pnpm --filter @clerk/backend test:edge-runtime src/api/__tests__/OAuthApplicationsApi.test.ts
- pnpm --filter @clerk/backend lint
- pnpm run build:tsx in clerk-docs
- pnpm run lint in clerk-docs

## Changes in this repo

Adds clerkClient.oauthApplications.revokeToken(), handles 204 responses as void, includes focused node and edge-runtime tests, and adds a changeset for @clerk/backend.

<!-- clk:companion-prs -->
## Companion PRs

- **clerk-docs**: https://github.com/clerk/clerk-docs/pull/3484
- **clerk-sdk-go**: https://github.com/clerk/clerk-sdk-go/pull/574
<!-- /clk:companion-prs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to revoke OAuth application access and refresh tokens from the backend client.

* **Bug Fixes**
  * Improved handling of no-content responses so successful revocation calls return cleanly without errors.
  * Added validation feedback when a required OAuth application ID is missing.

* **Documentation**
  * Updated release guidance to reflect this new backend capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->