### PR TITLE
fix(ui): keep truncateWithEndVisible code-point-safe in short-width fallback

### DIFF
--- a/.changeset/truncate-surrogate-safe.md
+++ b/.changeset/truncate-surrogate-safe.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Stop `truncateWithEndVisible` from splitting characters outside the BMP (such as CJK Extension B kanji and emoji) into a broken replacement character when truncating to a very small width. The short-width fallback now slices by code point, matching the main truncation path.

--- a/packages/ui/src/utils/__tests__/truncateTextWithEndVisible.test.ts
+++ b/packages/ui/src/utils/__tests__/truncateTextWithEndVisible.test.ts
@@ -28,6 +28,21 @@ describe('truncateWithEndVisible', () => {
     expect(truncateWithEndVisible('1234567890', 5, 3)).toBe('...890');
   });
 
+  test('should not split surrogate pairs when maxLength is too small', () => {
+    // The short-maxLength fallback must stay code-point-safe like the main path.
+    // Slicing on UTF-16 code units cuts characters outside the BMP (CJK Extension B,
+    // emoji) mid-surrogate, leaving a replacement character.
+    expect(truncateWithEndVisible('𠮷𠮷𠮷𠮷𠮷𠮷', 5, 5)).toBe('...𠮷𠮷𠮷𠮷𠮷');
+    expect(truncateWithEndVisible('🍣🍣🍣🍣🍣🍣', 5, 5)).toBe('...🍣🍣🍣🍣🍣');
+  });
+
+  test('should measure length by code point, not UTF-16 unit', () => {
+    // 5 astral characters are 10 UTF-16 code units but fit within maxLength 8,
+    // so the string is returned unchanged rather than truncated.
+    expect(truncateWithEndVisible('𠮷𠮷𠮷𠮷𠮷', 8, 5)).toBe('𠮷𠮷𠮷𠮷𠮷');
+    expect(truncateWithEndVisible('🍣🍣🍣🍣🍣', 8, 5)).toBe('🍣🍣🍣🍣🍣');
+  });
+
   test('should handle email addresses', () => {
     expect(truncateWithEndVisible('test@example.com', 10)).toBe('te...e.com');
   });

--- a/packages/ui/src/utils/truncateTextWithEndVisible.ts
+++ b/packages/ui/src/utils/truncateTextWithEndVisible.ts
@@ -15,12 +15,8 @@ export function truncateWithEndVisible(str: string, maxLength = 20, endChars = 5
   const ELLIPSIS = '...';
   const ELLIPSIS_LENGTH = ELLIPSIS.length;
 
-  if (!str || str.length <= maxLength) {
+  if (!str) {
     return str;
-  }
-
-  if (maxLength <= endChars + ELLIPSIS_LENGTH) {
-    return ELLIPSIS + str.slice(-endChars);
   }
 
   const chars = Array.from(str);
@@ -28,6 +24,10 @@ export function truncateWithEndVisible(str: string, maxLength = 20, endChars = 5
 
   if (totalChars <= maxLength) {
     return str;
+  }
+
+  if (maxLength <= endChars + ELLIPSIS_LENGTH) {
+    return ELLIPSIS + chars.slice(-endChars).join('');
   }
 
   const beginLength = maxLength - endChars - ELLIPSIS_LENGTH;


### PR DESCRIPTION
`truncateWithEndVisible` keeps the start and end of a string and puts an ellipsis in the middle. The main path builds the result from `Array.from(str)`, so it slices on code points and never breaks a character. The short-width fallback (taken when `maxLength <= endChars + 3`) instead returned `ELLIPSIS + str.slice(-endChars)`, which slices on UTF-16 code units.

For characters outside the BMP (CJK Extension B kanji, emoji) each character is a surrogate pair of two code units, so `str.slice(-endChars)` can cut one in half and leave a lone surrogate:

```ts
truncateWithEndVisible('𠮷𠮷𠮷𠮷𠮷', 8, 5)
// before: '...\uDFB7𠮷𠮷'  (broken leading character)
// after:  '...𠮷𠮷𠮷𠮷𠮷'
```

The fallback now slices by code point, the same way the main path already does. ASCII inputs are unaffected and the existing tests still pass. Added a test covering the fallback with astral characters.

---

Re-creates #9029 from a branch in this repo so CI runs with the necessary secrets. Authored by @greymoth-jp; original commit authorship is preserved in git history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation so very short widths no longer split emoji or other non-BMP characters into broken symbols.
  * Made character counting and fallback truncation behave consistently with Unicode code points, preserving readable output.
  * Added coverage for Unicode edge cases to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->