### PR TITLE
fix(ui): add accessible name to API Keys search input

### DIFF
--- a/.changeset/dirty-rockets-read.md
+++ b/.changeset/dirty-rockets-read.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Add an accessible name to the API Keys search input so screen readers announce it correctly.

--- a/packages/ui/src/components/APIKeys/APIKeys.tsx
+++ b/packages/ui/src/components/APIKeys/APIKeys.tsx
@@ -163,6 +163,7 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
           <Box elementDescriptor={descriptors.apiKeysSearchBox}>
             <InputWithIcon
               placeholder={t(localizationKeys('apiKeys.action__search'))}
+              aria-label={t(localizationKeys('apiKeys.action__search'))}
               leftIcon={
                 <Icon
                   icon={MagnifyingGlass}

--- a/packages/ui/src/components/APIKeys/APIKeys.tsx
+++ b/packages/ui/src/components/APIKeys/APIKeys.tsx
@@ -162,6 +162,7 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
         >
           <Box elementDescriptor={descriptors.apiKeysSearchBox}>
             <InputWithIcon
+              name='apiKeysSearch'
               placeholder={t(localizationKeys('apiKeys.action__search'))}
               aria-label={t(localizationKeys('apiKeys.action__search'))}
               leftIcon={
@@ -172,6 +173,7 @@ export const APIKeysPage = ({ subject, perPage, revokeModalRoot }: APIKeysPagePr
               }
               value={searchValue}
               type='search'
+              autoComplete='off'
               autoCapitalize='none'
               spellCheck={false}
               onChange={e => setSearchValue(e.target.value)}

--- a/packages/ui/src/components/APIKeys/__tests__/APIKeys.spec.tsx
+++ b/packages/ui/src/components/APIKeys/__tests__/APIKeys.spec.tsx
@@ -79,4 +79,16 @@ describe('APIKeys', () => {
       expect(getByText(/No API keys found/i)).toBeVisible();
     });
   });
+
+  it('exposes an accessible label on the search input', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withUser({ email_addresses: ['test@clerk.com'] });
+    });
+
+    const { getByRole } = render(<APIKeys />, { wrapper });
+
+    await waitFor(() => {
+      expect(getByRole('searchbox', { name: /search keys/i })).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Description
- Adds label to `user-profile -> api-keys` search
- suppresses chrome specific warning by adding a name attr
- turns off autocomplete. didn't feel needed/intentional for this instance. happy to turn it back on if wanted.
<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for the API Keys search field by adding a screen-reader-friendly label, ensuring it’s announced correctly.
  * Disabled browser autocomplete for the API Keys search input.
* **Tests**
  * Added coverage to verify the search input is rendered with the expected accessible name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->