### PR TITLE
fix(ui): make icon social buttons match text button height

### DIFF
--- a/.changeset/social-icon-button-height.md
+++ b/.changeset/social-icon-button-height.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix icon-only social buttons rendering taller than the ones with text. They now size to the same height as the text (block) buttons across all appearance spacing and font-size settings, keeping every social button in a row consistent.

--- a/packages/ui/src/elements/SocialButtons.tsx
+++ b/packages/ui/src/elements/SocialButtons.tsx
@@ -249,13 +249,19 @@ const SocialButtonIcon = forwardRef((props: SocialButtonProps, ref: Ref<HTMLButt
       variant='outline'
       colorScheme='neutral'
       hoverAsFocus
-      sx={t => ({
-        minHeight: t.sizes.$8,
-        width: '100%',
-      })}
+      sx={{ width: '100%' }}
       {...rest}
     >
-      {icon}
+      {/* Reserve one line of button text so the icon button matches the height of the
+          block button (and its siblings) across any theme spacing/font size, instead of
+          pinning to a static minHeight that stops tracking the text-based controls. */}
+      <Flex
+        as='span'
+        center
+        sx={{ minHeight: '1lh' }}
+      >
+        {icon}
+      </Flex>
     </Button>
   );
 });


### PR DESCRIPTION
## Description

Fixes icon only social button height to be consistent with other control elements. It had a min height that made it roughly 2px taller than the other elements. Removed in favor of a wrapping element the uses `lh` unit to ensure consistent sizing.

| BEFORE | AFTER |
|--------|--------|
| <img width="514" height="335" alt="Screenshot 2026-07-01 at 7 46 32 AM" src="https://github.com/user-attachments/assets/1899ac6b-9706-4da4-93bf-2f054d560561" /> | <img width="518" height="332" alt="Screenshot 2026-07-01 at 7 45 41 AM" src="https://github.com/user-attachments/assets/de775a15-a59a-4695-87a2-37b81079309c" /> |
| [Preview](https://clerk-js-sandbox.clerkstage.dev/sign-in) | [Preview](https://clerk-js-sandbox-git-social-button-height-mismatch.clerkstage.dev/sign-in) |

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: