### PR TITLE
fix(shared): allow satellite redirect URLs with non-default ports

### DIFF
--- a/.changeset/fix-allowed-redirect-origins-port.md
+++ b/.changeset/fix-allowed-redirect-origins-port.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix satellite domain redirect validation incorrectly rejecting URLs with non-default ports. Redirect URLs like `https://app.example.net:5173` (common in local development with Vite or similar dev servers) are now correctly matched against `allowedRedirectOrigins` patterns such as `https://*.example.net`.

--- a/packages/shared/src/internal/clerk-js/__tests__/url.test.ts
+++ b/packages/shared/src/internal/clerk-js/__tests__/url.test.ts
@@ -579,6 +579,14 @@ describe('isAllowedRedirect', () => {
     ['https:evil.com', [/https:\/\/www\.clerk\.com/], false],
     ['//evil.com', [/https:\/\/www\.clerk\.com/], false],
     ['..//evil.com', ['https://www.clerk.com'], false],
+    // non-default ports — satellite apps in local dev (e.g. Vite on :5173)
+    ['https://www.clerk.com:3000', ['https://www.clerk.com'], true],
+    ['https://www.clerk.com:3000/path?q=1', ['https://www.clerk.com'], true],
+    ['https://app.example.net:5173', ['https://*.example.net'], true],
+    ['https://app.example.net:5176', ['https://*.example.net'], true],
+    // non-default port must not bypass domain validation
+    ['https://evil.com:5173', ['https://*.clerk.com'], false],
+    ['https://evil.clerk.com.evil.com:5173', ['https://*.clerk.com'], false],
   ];
 
   const warnMock = vi.spyOn(logger, 'warnOnce');

--- a/packages/shared/src/internal/clerk-js/__tests__/url.test.ts
+++ b/packages/shared/src/internal/clerk-js/__tests__/url.test.ts
@@ -580,10 +580,13 @@ describe('isAllowedRedirect', () => {
     ['//evil.com', [/https:\/\/www\.clerk\.com/], false],
     ['..//evil.com', ['https://www.clerk.com'], false],
     // non-default ports — satellite apps in local dev (e.g. Vite on :5173)
-    ['https://www.clerk.com:3000', ['https://www.clerk.com'], true],
-    ['https://www.clerk.com:3000/path?q=1', ['https://www.clerk.com'], true],
+    // wildcard glob entries accept any port on the matching host
     ['https://app.example.net:5173', ['https://*.example.net'], true],
     ['https://app.example.net:5176', ['https://*.example.net'], true],
+    ['https://www.clerk.com:3000', ['https://*.clerk.com'], true],
+    // exact string entries remain port-sensitive (port is part of the origin)
+    ['https://www.clerk.com:3000', ['https://www.clerk.com'], false],
+    ['https://www.clerk.com:3000/path?q=1', ['https://www.clerk.com'], false],
     // non-default port must not bypass domain validation
     ['https://evil.com:5173', ['https://*.clerk.com'], false],
     ['https://evil.clerk.com.evil.com:5173', ['https://*.clerk.com'], false],

--- a/packages/shared/src/internal/clerk-js/url.ts
+++ b/packages/shared/src/internal/clerk-js/url.ts
@@ -436,12 +436,24 @@ export const isAllowedRedirect =
 
     const isSameOrigin = currentOrigin === url.origin;
 
+    const patterns = allowedRedirectOrigins.map(origin =>
+      typeof origin === 'string' ? globs.toRegexp(trimTrailingSlash(origin)) : origin,
+    );
+
+    // When the redirect URL includes a non-default port (common in local dev, e.g. :5173),
+    // url.origin includes the port (https://app.example.net:5173) while allowedRedirectOrigins
+    // patterns are typically port-less (https://*.example.net). Test both forms so that satellite
+    // apps running on custom ports are not incorrectly rejected.
+    const portlessOrigin = url.port !== '' ? `${url.protocol}//${url.hostname}` : null;
+
     const isAllowed =
       !isProblematicUrl(url) &&
       (isSameOrigin ||
-        allowedRedirectOrigins
-          .map(origin => (typeof origin === 'string' ? globs.toRegexp(trimTrailingSlash(origin)) : origin))
-          .some(origin => origin.test(trimTrailingSlash(url.origin))));
+        patterns.some(
+          pattern =>
+            pattern.test(trimTrailingSlash(url.origin)) ||
+            (portlessOrigin !== null && pattern.test(portlessOrigin)),
+        ));
 
     if (!isAllowed) {
       logger.warnOnce(

--- a/packages/shared/src/internal/clerk-js/url.ts
+++ b/packages/shared/src/internal/clerk-js/url.ts
@@ -436,24 +436,22 @@ export const isAllowedRedirect =
 
     const isSameOrigin = currentOrigin === url.origin;
 
-    const patterns = allowedRedirectOrigins.map(origin =>
-      typeof origin === 'string' ? globs.toRegexp(trimTrailingSlash(origin)) : origin,
-    );
-
     // When the redirect URL includes a non-default port (common in local dev, e.g. :5173),
-    // url.origin includes the port (https://app.example.net:5173) while allowedRedirectOrigins
-    // patterns are typically port-less (https://*.example.net). Test both forms so that satellite
-    // apps running on custom ports are not incorrectly rejected.
+    // url.origin includes the port (https://app.example.net:5173) while glob entries like
+    // https://*.example.net have none. For wildcard/glob entries only, also test the
+    // port-stripped origin so satellite apps on custom ports are not rejected.
+    // Exact string entries (no wildcard) remain port-sensitive to preserve the security boundary.
     const portlessOrigin = url.port !== '' ? `${url.protocol}//${url.hostname}` : null;
 
     const isAllowed =
       !isProblematicUrl(url) &&
       (isSameOrigin ||
-        patterns.some(
-          pattern =>
-            pattern.test(trimTrailingSlash(url.origin)) ||
-            (portlessOrigin !== null && pattern.test(portlessOrigin)),
-        ));
+        allowedRedirectOrigins.some(origin => {
+          const pattern = typeof origin === 'string' ? globs.toRegexp(trimTrailingSlash(origin)) : origin;
+          if (pattern.test(trimTrailingSlash(url.origin))) return true;
+          const isGlobEntry = typeof origin === 'string' && origin.includes('*');
+          return isGlobEntry && portlessOrigin !== null && pattern.test(portlessOrigin);
+        }));
 
     if (!isAllowed) {
       logger.warnOnce(

--- a/packages/shared/src/internal/clerk-js/url.ts
+++ b/packages/shared/src/internal/clerk-js/url.ts
@@ -424,7 +424,11 @@ export function requiresUserInput(redirectUrl: string): boolean {
 }
 
 export const isAllowedRedirect =
-  (allowedRedirectOrigins: Array<string | RegExp> | undefined, currentOrigin: string) => (_url: URL | string) => {
+  (
+    allowedRedirectOrigins: Array<string | RegExp> | undefined,
+    currentOrigin: string,
+  ): ((_url: URL | string) => boolean) =>
+  (_url: URL | string): boolean => {
     let url = _url;
     if (typeof url === 'string') {
       url = relativeToAbsoluteUrl(url, currentOrigin);


### PR DESCRIPTION
Fixes #8263

In local development, satellite apps often run on non-default ports (e.g. Vite on :5173, :5174). When isAllowedRedirect() evaluates the redirect URL, it compares url.origin — which includes the port suffix https://app.example.net:5173) — against patterns like https://*.example.net generated by createAllowedRedirectOrigins. The glob-to-regexp conversion anchors the pattern at the domain end, so the trailing :5173 breaks the match, causing the Account Portal to silently fall back to the home URL instead of honoring the redirect_url.

Fix: when url.port is non-empty, also test the port-stripped origin protocol + hostname) against each pattern. Domain validation is preserved — the fix only relaxes the port suffix comparison, not the domain check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirect/origin validation so redirect URLs with non-default ports (e.g., `https://app.example.net:5173`) are no longer incorrectly rejected when they match the allowed origin patterns.
  * Improved allowlist matching to remain correct for wildcard host rules and maintain strict handling for exact host entries.
  * Added test coverage for allowed and disallowed port-based redirect cases to prevent domain validation bypass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->