### PR TITLE
fix(js): preserve SignUpFuture reference across SSO-to-sign-up transition

### DIFF
--- a/.changeset/fix-signup-future-sso-transfer-stale-ref.md
+++ b/.changeset/fix-signup-future-sso-transfer-stale-ref.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Fix `signUp.update()` sending a PATCH request to `/client/sign_ups` instead of `/client/sign_ups/{id}` after an SSO sign-in transitions to a sign-up flow (e.g. when legal acceptance is required). The `SignUpFuture` reference held by hooks is now preserved across the transition and reflects the correct sign-up id.

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -143,7 +143,11 @@ export class Client extends BaseResource implements ClientResource {
       this.id = data.id;
       this.sessions = (data.sessions || []).map(s => new Session(s));
 
-      if (data.sign_up && this.signUp instanceof SignUp && this.signUp.id === data.sign_up.id) {
+      if (data.sign_up && this.signUp instanceof SignUp && (this.signUp.id === data.sign_up.id || !this.signUp.id)) {
+        // Update in-place when ids match OR when the existing signUp has no id yet
+        // (e.g. an SSO sign-in that transitions to a sign-up flow). Reusing the same
+        // SignUp instance preserves any SignUpFuture references held by hooks so they
+        // remain valid and reflect the correct id after the transition.
         this.signUp.__internal_updateFromJSON(data.sign_up);
       } else {
         this.signUp = new SignUp(data.sign_up);


### PR DESCRIPTION
Fixes #8338

When an SSO sign-in transitions to a sign-up flow (e.g. the account does not exist and legal acceptance is required), Client.fromJSON created a brand-new SignUp instance because the existing one had no id while the incoming server data did. The SignUpFuture held by useSignUp() hooks pointed at the stale, id-less instance. Calling signUp.update({ legalAccepted: true }) then sent PATCH /client/sign_ups (no id segment) instead of PATCH /client/sign_ups/{id}, resulting in a 405 error.

Root cause: Client.fromJSON only reuses the existing SignUp instance when this.signUp.id === data.sign_up.id. During SSO transfer the old instance has no id, so the condition was false and a new instance was created — discarding the SignUpFuture reference held by hooks.

Fix: Also update in-place when !this.signUp.id (the instance is still uninitialized). __internal_updateFromJSON populates all fields including id, so the existing SignUpFuture transparently sees the correct id after the transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where sign-up updates could fail after an SSO sign-in transitioned into a sign-up flow.
  * Preserved the active sign-up state across that transition so the correct sign-up identifier is used for subsequent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->