### PR TITLE
fix(ui): locale-aware negative amount formatting

### DIFF
--- a/.changeset/sixty-hairs-sniff.md
+++ b/.changeset/sixty-hairs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Use locale and currency aware formatting for negative money amounts

--- a/packages/ui/src/components/Checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/Checkout/CheckoutForm.tsx
@@ -10,6 +10,7 @@ import { SegmentedControl } from '@/ui/elements/SegmentedControl';
 import { Select, SelectButton, SelectOptionList } from '@/ui/elements/Select';
 import { DevModeOverlay } from '@/ui/elements/DevModeNotice';
 import { Tooltip } from '@/ui/elements/Tooltip';
+import { toNegativeAmount } from '@/ui/utils/billing';
 import {
   getCheckoutSeatUnitTotal,
   getIncludedSeatsUnitTotalTier,
@@ -134,7 +135,7 @@ export const CheckoutForm = withCardStateProvider(() => {
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.proratedDiscount')} />
               <LineItems.Description
-                text={totals.discounts?.proration?.amount ? `- ${$(totals.discounts.proration.amount)}` : ''}
+                text={totals.discounts?.proration?.amount ? $(toNegativeAmount(totals.discounts.proration.amount)) : ''}
               />
             </LineItems.Group>
           )}
@@ -142,7 +143,7 @@ export const CheckoutForm = withCardStateProvider(() => {
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.creditRemainder')} />
               <LineItems.Description
-                text={totals.credits?.proration?.amount ? `- ${$(totals.credits.proration.amount)}` : ''}
+                text={totals.credits?.proration?.amount ? $(toNegativeAmount(totals.credits.proration.amount)) : ''}
               />
             </LineItems.Group>
           )}
@@ -150,7 +151,9 @@ export const CheckoutForm = withCardStateProvider(() => {
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.payerCreditRemainder')} />
               <LineItems.Description
-                text={totals.credits?.payer?.appliedAmount ? `- ${$(totals.credits.payer.appliedAmount)}` : ''}
+                text={
+                  totals.credits?.payer?.appliedAmount ? $(toNegativeAmount(totals.credits.payer.appliedAmount)) : ''
+                }
               />
             </LineItems.Group>
           )}

--- a/packages/ui/src/components/Checkout/__tests__/Checkout.test.tsx
+++ b/packages/ui/src/components/Checkout/__tests__/Checkout.test.tsx
@@ -446,8 +446,8 @@ describe('Checkout', () => {
     expect(prorationCreditRow).toBeInTheDocument();
     expect(accountCreditRow).toBeInTheDocument();
 
-    expect(prorationCreditRow).toHaveTextContent('- $5.00');
-    expect(accountCreditRow).toHaveTextContent('- $10.00');
+    expect(prorationCreditRow).toHaveTextContent('-$5.00');
+    expect(accountCreditRow).toHaveTextContent('-$10.00');
   });
 
   it('renders free trial details during confirmation stage', async () => {
@@ -1738,7 +1738,7 @@ describe('Checkout', () => {
 
       const proratedDiscountRow = getByText('Prorated discount').closest('.cl-lineItemsGroup');
       expect(proratedDiscountRow).toBeInTheDocument();
-      expect(proratedDiscountRow).toHaveTextContent('- $5.00');
+      expect(proratedDiscountRow).toHaveTextContent('-$5.00');
 
       const totalPerPeriodRow = getByText('Total per period').closest('.cl-lineItemsGroup');
       expect(totalPerPeriodRow).toBeInTheDocument();

--- a/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
+++ b/packages/ui/src/components/PaymentAttempts/PaymentAttemptPage.tsx
@@ -5,6 +5,7 @@ import { Alert } from '@/ui/elements/Alert';
 import { Header } from '@/ui/elements/Header';
 import { LineItems } from '@/ui/elements/LineItems';
 import { ProfileCard } from '@/ui/elements/ProfileCard';
+import { toNegativeAmount } from '@/ui/utils/billing';
 import { getPlanSeatLimit, getSeatsPerUnitTotal, summarizeSeatCharges } from '@/ui/utils/billingPlanSeats';
 import { formatDate } from '@/ui/utils/formatDate';
 import { truncateWithEndVisible } from '@/ui/utils/truncateTextWithEndVisible';
@@ -281,7 +282,7 @@ function PaymentAttemptBody({ paymentAttempt }: { paymentAttempt: BillingPayment
         {paymentAttempt.totals?.discounts?.proration && paymentAttempt.totals.discounts.proration.amount.amount > 0 && (
           <LineItems.Group variant='tertiary'>
             <LineItems.Title title={localizationKeys('billing.proratedDiscount')} />
-            <LineItems.Description text={`- ${$(paymentAttempt.totals.discounts.proration.amount)}`} />
+            <LineItems.Description text={$(toNegativeAmount(paymentAttempt.totals.discounts.proration.amount))} />
           </LineItems.Group>
         )}
         {subscriptionItem.credits &&
@@ -289,7 +290,7 @@ function PaymentAttemptBody({ paymentAttempt }: { paymentAttempt: BillingPayment
           subscriptionItem.credits.proration.amount.amount > 0 && (
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.prorationCredit')} />
-              <LineItems.Description text={`- ${$(subscriptionItem.credits.proration.amount)}`} />
+              <LineItems.Description text={$(toNegativeAmount(subscriptionItem.credits.proration.amount))} />
             </LineItems.Group>
           )}
         {subscriptionItem.credits &&
@@ -297,7 +298,7 @@ function PaymentAttemptBody({ paymentAttempt }: { paymentAttempt: BillingPayment
           subscriptionItem.credits.payer.appliedAmount.amount > 0 && (
             <LineItems.Group variant='tertiary'>
               <LineItems.Title title={localizationKeys('billing.accountCredit')} />
-              <LineItems.Description text={`- ${$(subscriptionItem.credits.payer.appliedAmount)}`} />
+              <LineItems.Description text={$(toNegativeAmount(subscriptionItem.credits.payer.appliedAmount))} />
             </LineItems.Group>
           )}
       </LineItems.Root>

--- a/packages/ui/src/utils/__tests__/billing.test.ts
+++ b/packages/ui/src/utils/__tests__/billing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { toNegativeAmount } from '../billing';
+
+describe('toNegativeAmount', () => {
+  it('converts positive amounts to negative', () => {
+    const amount = {
+      amount: 100,
+      amountFormatted: '1.00',
+      currency: 'usd',
+      currencySymbol: '$',
+    };
+    expect(toNegativeAmount(amount)).toStrictEqual({
+      amount: -100,
+      amountFormatted: '-1.00',
+      currency: 'usd',
+      currencySymbol: '$',
+    });
+  });
+
+  it('retains negative amounts', () => {
+    const amount = {
+      amount: -100,
+      amountFormatted: '-1.00',
+      currency: 'usd',
+      currencySymbol: '$',
+    };
+    expect(toNegativeAmount(amount)).toStrictEqual({
+      amount: -100,
+      amountFormatted: '-1.00',
+      currency: 'usd',
+      currencySymbol: '$',
+    });
+  });
+});

--- a/packages/ui/src/utils/billing.ts
+++ b/packages/ui/src/utils/billing.ts
@@ -1,0 +1,18 @@
+import type { BillingMoneyAmount } from '@clerk/shared/types/billing';
+
+/**
+ * Given a BillingMoneyAmount, convert positive values to negative. If the amount is already negative, leave it alone.
+ */
+export function toNegativeAmount(amount: BillingMoneyAmount): BillingMoneyAmount {
+  if (amount.amount < 0) {
+    return amount;
+  }
+
+  return {
+    ...amount,
+    // convert positive amounts to negative
+    amount: -amount.amount,
+    // naively converts amountFormatted
+    amountFormatted: `-${amount.amountFormatted}`,
+  };
+}


### PR DESCRIPTION
## Description

This PR introduces locale- and currency-aware formatting of negative monetary values. For example, formatting a negative value in Chilean peso would result in `$-5.000` instead of the previous implementation which would have put the `-` symbol before the currency symbol.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Negative billing amounts now display correctly with locale-aware currency formatting, including proration, credits, and payer/account credits.

* **Bug Fixes**
  * Fixed spacing in negative money values so amounts now render like `-$5.00` instead of `- $5.00`.
  * Preserved already-negative amounts while normalizing positive values shown as credits or discounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->