### PR TITLE
feat(electron): allow custom user agent for session activity

### DIFF
--- a/.changeset/electron-user-agent.md
+++ b/.changeset/electron-user-agent.md
@@ -2,4 +2,4 @@
 "@clerk/electron": patch
 ---
 
-Add a `userAgent` option to `createClerkBridge()` so Electron apps can customize UserProfile session activity attribution.
+Add a `userAgent` option to `createClerkBridge()` so Electron apps can customize the app name used for UserProfile session activity attribution while preserving platform details.

--- a/.changeset/electron-user-agent.md
+++ b/.changeset/electron-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@clerk/electron": patch
+---
+
+Add a `userAgent` option to `createClerkBridge()` so Electron apps can customize UserProfile session activity attribution.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -96,6 +96,16 @@ import { passkeys } from '@clerk/electron/passkeys';
 </ClerkProvider>;
 ```
 
+Pass `userAgent` to `createClerkBridge` before creating renderer windows to control what Clerk uses for UserProfile session activity attribution:
+
+```ts
+createClerkBridge({
+  storage: storage(),
+  renderer: { scheme: 'my-app', host: 'renderer' },
+  userAgent: 'Acme Desktop/1.2.3',
+});
+```
+
 ## Content Security Policy
 
 `@clerk/electron` loads Clerk's prebuilt UI from Clerk's CDN at runtime rather than bundling it, so your renderer's Content Security Policy must allow Clerk's Frontend API host. If it doesn't, the UI script fails to load and Clerk components never render.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -96,13 +96,13 @@ import { passkeys } from '@clerk/electron/passkeys';
 </ClerkProvider>;
 ```
 
-Pass `userAgent` to `createClerkBridge` before creating renderer windows to control what Clerk uses for UserProfile session activity attribution:
+Pass `userAgent` to `createClerkBridge` before creating renderer windows to set an app-specific product token, such as `Acme Co/1.0.0`. Clerk preserves Electron's platform details, such as `Macintosh` or `Windows`, while using the product token for UserProfile session activity attribution:
 
 ```ts
 createClerkBridge({
   storage: storage(),
   renderer: { scheme: 'my-app', host: 'renderer' },
-  userAgent: 'Acme Desktop/1.2.3',
+  userAgent: 'Acme Co/1.0.0',
 });
 ```
 

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -72,6 +72,14 @@ describe('createClerkBridge', () => {
     expect(app.userAgentFallback).toBe('Acme Co/1.0.0');
   });
 
+  it('falls back to the configured user-agent when the app fallback has malformed platform details', () => {
+    app.userAgentFallback = 'Mozilla/5.0 ((((';
+
+    createClerkBridge({ storage, userAgent: 'Acme Co/1.0.0' });
+
+    expect(app.userAgentFallback).toBe('Acme Co/1.0.0');
+  });
+
   it('registers the configured renderer scheme as privileged before app ready', () => {
     createClerkBridge({
       storage,

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -10,6 +10,7 @@ vi.mock('electron', () => ({
     on: vi.fn(),
     removeListener: vi.fn(),
     setAsDefaultProtocolClient: vi.fn(),
+    userAgentFallback: 'Electron default',
   },
   ipcMain: {
     handle: vi.fn(),
@@ -42,6 +43,7 @@ describe('createClerkBridge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    app.userAgentFallback = 'Electron default';
   });
 
   it('requires a storage adapter', () => {
@@ -52,6 +54,12 @@ describe('createClerkBridge', () => {
     createClerkBridge({ storage });
 
     expect(ipcMain.handle).toHaveBeenCalledTimes(3);
+  });
+
+  it('sets the app user-agent fallback when configured', () => {
+    createClerkBridge({ storage, userAgent: 'Acme Desktop/1.2.3' });
+
+    expect(app.userAgentFallback).toBe('Acme Desktop/1.2.3');
   });
 
   it('registers the configured renderer scheme as privileged before app ready', () => {

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -10,7 +10,8 @@ vi.mock('electron', () => ({
     on: vi.fn(),
     removeListener: vi.fn(),
     setAsDefaultProtocolClient: vi.fn(),
-    userAgentFallback: 'Electron default',
+    userAgentFallback:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
   },
   ipcMain: {
     handle: vi.fn(),
@@ -43,7 +44,8 @@ describe('createClerkBridge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app.userAgentFallback = 'Electron default';
+    app.userAgentFallback =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
   });
 
   it('requires a storage adapter', () => {
@@ -56,10 +58,18 @@ describe('createClerkBridge', () => {
     expect(ipcMain.handle).toHaveBeenCalledTimes(3);
   });
 
-  it('sets the app user-agent fallback when configured', () => {
-    createClerkBridge({ storage, userAgent: 'Acme Desktop/1.2.3' });
+  it('keeps the platform details when setting the app user-agent fallback', () => {
+    createClerkBridge({ storage, userAgent: 'Acme Co/1.0.0' });
 
-    expect(app.userAgentFallback).toBe('Acme Desktop/1.2.3');
+    expect(app.userAgentFallback).toBe('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/20100101 Acme Co/1.0.0');
+  });
+
+  it('falls back to the configured user-agent when the app fallback has no platform details', () => {
+    app.userAgentFallback = 'Electron default';
+
+    createClerkBridge({ storage, userAgent: 'Acme Co/1.0.0' });
+
+    expect(app.userAgentFallback).toBe('Acme Co/1.0.0');
   });
 
   it('registers the configured renderer scheme as privileged before app ready', () => {

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -19,6 +19,18 @@ function assertValidRendererOriginConfig(renderer: NonNullable<CreateClerkBridge
   }
 }
 
+function buildUserAgentFallback(defaultUserAgent: string, productToken: string): string {
+  const platformComment = defaultUserAgent.match(/\([^)]*\)/)?.[0];
+
+  if (!platformComment) {
+    return productToken;
+  }
+
+  // Clerk's session activity parser preserves the platform comment and treats the
+  // token after Gecko as the app/browser name.
+  return `Mozilla/5.0 ${platformComment} Gecko/20100101 ${productToken}`;
+}
+
 /**
  * Creates the Clerk bridge for Electron's main process.
  *
@@ -38,7 +50,7 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
   const passkeys = options.passkeys ? setupPasskeysMain() : null;
 
   if (options.userAgent) {
-    app.userAgentFallback = options.userAgent;
+    app.userAgentFallback = buildUserAgentFallback(app.userAgentFallback, options.userAgent);
   }
 
   if (options.renderer) {

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -1,4 +1,4 @@
-import { protocol } from 'electron';
+import { app, protocol } from 'electron';
 
 import type { ClerkBridge, CreateClerkBridgeOptions } from '../shared/types';
 import { setupTokenCacheIpcHandlers } from './ipc-handlers';
@@ -36,6 +36,10 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
   const cleanupTokenPersistence = setupTokenCacheIpcHandlers(options.storage);
   let cleanupOAuthTransport: (() => void) | undefined;
   const passkeys = options.passkeys ? setupPasskeysMain() : null;
+
+  if (options.userAgent) {
+    app.userAgentFallback = options.userAgent;
+  }
 
   if (options.renderer) {
     assertValidRendererOriginConfig(options.renderer);

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -20,11 +20,14 @@ function assertValidRendererOriginConfig(renderer: NonNullable<CreateClerkBridge
 }
 
 function buildUserAgentFallback(defaultUserAgent: string, productToken: string): string {
-  const platformComment = defaultUserAgent.match(/\([^)]*\)/)?.[0];
+  const platformCommentStart = defaultUserAgent.indexOf('(');
+  const platformCommentEnd = defaultUserAgent.indexOf(')', platformCommentStart + 1);
 
-  if (!platformComment) {
+  if (platformCommentStart === -1 || platformCommentEnd === -1) {
     return productToken;
   }
+
+  const platformComment = defaultUserAgent.slice(platformCommentStart, platformCommentEnd + 1);
 
   // Clerk's session activity parser preserves the platform comment and treats the
   // token after Gecko as the app/browser name.

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -22,6 +22,11 @@ export type CreateClerkBridgeOptions = {
    * the optional `@clerk/electron-passkeys` package and `exposeClerkBridge({ passkeys: true })`.
    */
   passkeys?: boolean;
+  /**
+   * Overrides Electron's user-agent fallback. Clerk uses this value for UserProfile session
+   * activity attribution when no webContents or session-level user-agent is set.
+   */
+  userAgent?: string;
 };
 
 export type ExposeClerkBridgeOptions = {

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -23,8 +23,10 @@ export type CreateClerkBridgeOptions = {
    */
   passkeys?: boolean;
   /**
-   * Overrides Electron's user-agent fallback. Clerk uses this value for UserProfile session
-   * activity attribution when no webContents or session-level user-agent is set.
+   * Product token to use in Electron's user-agent fallback. Clerk uses the resulting
+   * user-agent for UserProfile session activity attribution when no webContents or
+   * session-level user-agent is set. The Electron platform comment is preserved so
+   * device details such as macOS or Windows can still be detected.
    */
   userAgent?: string;
 };


### PR DESCRIPTION
## Summary

Adds a `userAgent` option to `createClerkBridge()` for Electron apps that want to control how the app appears in UserProfile session activity.

The option sets Electron's `app.userAgentFallback`, and the README now shows the setup alongside the existing bridge configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Electron apps can now pass a custom `userAgent` when creating the Clerk bridge to improve UserProfile session activity attribution.

* **Bug Fixes**
  * User-agent fallback now preserves platform-related information when available.
  * If platform details can’t be derived (including malformed fallbacks), the configured `userAgent` is used.

* **Documentation**
  * Updated the Electron “Getting Started” guide with the new `userAgent` configuration example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->