### PR TITLE
fix(js): preserve SignInFuture reference after resetSignIn

### DIFF
--- a/.changeset/fix-signin-future-stale-ref-after-reset.md
+++ b/.changeset/fix-signin-future-stale-ref-after-reset.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix `useSignIn()` returning a stale `SignInFuture` after `resetSignIn()`. When the next sign-in attempt starts, the existing instance is now updated in-place rather than replaced, preserving the reference held by active hooks.

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -149,7 +149,7 @@ export class Client extends BaseResource implements ClientResource {
         this.signUp = new SignUp(data.sign_up);
       }
 
-      if (data.sign_in && this.signIn instanceof SignIn && this.signIn.id === data.sign_in.id) {
+      if (data.sign_in && this.signIn instanceof SignIn && (this.signIn.id === data.sign_in.id || !this.signIn.id)) {
         this.signIn.__internal_updateFromJSON(data.sign_in);
       } else {
         this.signIn = new SignIn(data.sign_in);

--- a/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
@@ -193,6 +193,41 @@ describe('Client Singleton', () => {
     expect(client.signIn.status).toBe('needs_second_factor');
   });
 
+  it('preserves sign in identity when fromJSON receives a new sign_in after reset', () => {
+    const user = createUser({ first_name: 'John', last_name: 'Doe', id: 'user_1' });
+    const session = createSession({ id: 'session_1' }, user);
+    const initialClientJSON: ClientJSON = {
+      object: 'client',
+      id: 'test_id',
+      status: 'active',
+      last_active_session_id: 'test_session_id',
+      sign_in: createSignIn({ id: 'test_sign_in_id', status: 'needs_first_factor' }, user),
+      sign_up: createSignUp({ id: 'test_sign_up_id', status: 'missing_requirements' }),
+      sessions: [session],
+      created_at: Date.now() - 1000,
+      updated_at: Date.now(),
+    } as any;
+
+    // @ts-expect-error We cannot mess with the singleton when tests are running in parallel
+    const client = new Client(initialClientJSON);
+
+    client.resetSignIn();
+    const signInAfterReset = client.signIn;
+    expect(signInAfterReset.id).toBeUndefined();
+
+    client.fromJSON({
+      ...initialClientJSON,
+      sign_in: createSignIn({ id: 'test_sign_in_id_v2', status: 'needs_first_factor', identifier: 'test@example.com' }, user),
+      updated_at: Date.now() + 1000,
+    });
+
+    // The same SignIn instance from after the reset is reused (preserving its SignInFuture
+    // reference so useSignIn() hooks stay valid across the reset → new attempt transition).
+    expect(client.signIn).toBe(signInAfterReset);
+    expect(client.signIn.id).toBe('test_sign_in_id_v2');
+    expect(client.signIn.identifier).toBe('test@example.com');
+  });
+
   it('replaces sign up and sign in identity when fromJSON receives new ids', () => {
     const user = createUser({ first_name: 'John', last_name: 'Doe', id: 'user_1' });
     const session = createSession({ id: 'session_1' }, user);


### PR DESCRIPTION
After resetSignIn(), the next call to fromJSON with fresh sign-in data was creating a brand-new SignIn instance because the id comparison this.signIn.id === data.sign_in.id) failed — the current sign-in had no id after the reset. This caused useSignIn() hooks to hold a stale __internal_future reference pointing at the discarded instance.

Fix: add || !this.signIn.id to the condition so an empty-id SignIn is updated in-place instead of replaced, preserving the __internal_future reference across the reset → new attempt transition. Same pattern as the existing SignUp fix.

Closes #9006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sign-in state so a reset no longer leaves sign-in hooks with a stale reference.
  - Subsequent sign-in attempts now update the existing sign-in state instead of swapping it out, keeping the active flow in sync.
- **Tests**
  - Added coverage to verify sign-in state updates correctly after a reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->