### PR TITLE
fix(ui): Display non-validation Stripe errors within Checkout component

### DIFF
--- a/.changeset/brave-mammals-burn.md
+++ b/.changeset/brave-mammals-burn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix the payment method form getting stuck in a loading state after a failed card setup. Non-validation errors such as 3DS authentication failures are now displayed.

--- a/packages/ui/src/components/PaymentMethods/AddPaymentMethod.tsx
+++ b/packages/ui/src/components/PaymentMethods/AddPaymentMethod.tsx
@@ -206,7 +206,14 @@ const AddPaymentMethodForm = ({ children }: PropsWithChildren) => {
 
     const { data, error } = await submitPaymentElement();
     if (error) {
-      return; // just return, since stripe will handle the error
+      card.setIdle();
+      // Validation errors are already rendered inline by Stripe's PaymentElement.
+      // Non-validation errors (e.g. 3DS authentication failure) are not surfaced by
+      // Stripe's UI, so we display them ourselves.
+      if (error.error.type !== 'validation_error') {
+        card.setError(error.error.message);
+      }
+      return;
     }
     try {
       await onSuccess(data);


### PR DESCRIPTION
We currently defer to Stripe to handle any errors when submitting the payment method form, but this assumes any error will be validation in nature, allowing for other errors like 3DS authorization errors to go unhandled. This change fixes that by handling any non-validation error.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a payment method form issue where failed card setup could leave the UI stuck in a loading state.
  * Improved error handling so non-validation payment errors are shown clearly instead of getting hidden.
  * Validation-related card errors continue to display inline as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->