### PR TITLE
chore(shared): Deprecate createPathMatcher

### DIFF
--- a/.changeset/shared-deprecate-path-matcher.md
+++ b/.changeset/shared-deprecate-path-matcher.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Deprecate `createPathMatcher()` and its pattern types (`PathMatcherParam`, `PathPattern`, `WithPathSegmentWildcard`). Pattern-based path matching is being phased out along with the framework-level `createRouteMatcher()` helpers and will be removed in the next major version. Use your framework's native routing primitives to decide which paths to protect instead.

--- a/packages/shared/src/pathMatcher.ts
+++ b/packages/shared/src/pathMatcher.ts
@@ -16,11 +16,19 @@ type StripTrailingSlash<T extends string> = T extends '/'
 /**
  * Suggests the `:path*` subtree form (e.g. `/dashboard/:path*`), which matches on
  * path-segment boundaries. `/` is special-cased to `/:path*` to avoid a malformed `//:path*`.
+ *
+ * @deprecated Will be removed in the next major version together with {@link createPathMatcher}.
  */
 export type WithPathSegmentWildcard<T = string> = T extends '/'
   ? '/:path*'
   : `${StripTrailingSlash<T & string>}/:path*`;
+/**
+ * @deprecated Will be removed in the next major version together with {@link createPathMatcher}.
+ */
 export type PathPattern = Autocomplete<WithPathSegmentWildcard>;
+/**
+ * @deprecated Will be removed in the next major version together with {@link createPathMatcher}.
+ */
 export type PathMatcherParam = Array<RegExp | PathPattern> | RegExp | PathPattern;
 
 export class MalformedURLError extends Error {
@@ -70,6 +78,10 @@ export const normalizePath = (pathname: string): string => {
  *
  * @param patterns - A string, RegExp, or array of patterns to match against
  * @returns A function that takes a pathname and returns true if it matches any of the patterns
+ *
+ * @deprecated This function will be removed in the next major version. Pattern-based path matching
+ * can diverge from how frameworks route requests; use your framework's native routing primitives
+ * to decide which paths to protect instead.
  */
 export const createPathMatcher = (patterns: PathMatcherParam) => {
   const routePatterns = [patterns || ''].flat().filter(Boolean);


### PR DESCRIPTION
With `createRouteMatcher` now deprecated in Next.js (#8994), Astro (#8981), and Nuxt (#9092), this marks the underlying `createPathMatcher()` and its pattern types in `@clerk/shared` as `@deprecated` so they can be removed in the next major.

JSDoc only, no runtime warning on purpose: `@clerk/shared` resolves via `^` ranges under framework SDK versions already published, and those call `createPathMatcher` inside their own `createRouteMatcher`. A runtime warning would show up in apps that never import it directly, and double-warn users who already get the wrapper's warning. The malformed-URL helpers in the same module (`isMalformedURLError` and friends) stay as-is since the live `clerkMiddleware` implementations depend on them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated path-pattern matching helpers and related pattern types.
  * Added clearer guidance that these APIs will be removed in the next major release.
  * Recommended using the framework’s built-in routing primitives for access and protection decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->