### PR TITLE
test(ui): add stale protect-check route regression

### DIFF
--- a/packages/ui/src/components/SignUp/__tests__/SignUpProtectCheck.test.tsx
+++ b/packages/ui/src/components/SignUp/__tests__/SignUpProtectCheck.test.tsx
@@ -75,6 +75,21 @@ describe('SignUpProtectCheck', () => {
     expect(queryByText(/verifying your request/i)).not.toBeInTheDocument();
   });
 
+  it('routes stale standalone protect-check visits through SignUp routes back to the flow start', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.startSignUpWithEmailAddress();
+    });
+    fixtures.router.currentPath = '/sign-up/protect-check';
+    fixtures.router.fullPath = '/sign-up';
+    fixtures.router.indexPath = '/sign-up';
+    fixtures.router.matches.mockImplementation((path?: string) => path === 'protect-check');
+
+    render(<SignUp />, { wrapper });
+
+    await waitFor(() => expect(fixtures.router.navigate).toHaveBeenCalledWith('/sign-up'));
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
   it('runs the SDK challenge with the URL and resource and submits the proof token', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.startSignUpWithProtectCheck({ sdkUrl: 'https://protect.example.com/v1.js' });


### PR DESCRIPTION
Adds a failing route-level regression test for stale standalone SignUp protect-check visits after #9082. The existing stale-route test renders SignUpProtectCheck directly, but the real SignUp route wraps it in Route path="protect-check", where navigateToFlowStart currently no-ops because router.indexPath equals router.currentPath. This PR intentionally contains only the failing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the sign-up protect-check coverage to follow the full sign-up flow through the app route.
  * Added assertions that the “verifying your request” screen is not shown during redirect and that the user returns to the sign-up page.
  * Confirmed the protect-check action is not triggered for stale standalone visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->