### PR TITLE
refactor(ui): Improve password toggle alignment and hit area

### DIFF
--- a/.changeset/password-toggle-hit-area.md
+++ b/.changeset/password-toggle-hit-area.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Enlarge the show/hide password toggle button's hit area with added padding and rounded corners, making it easier to tap and giving it a clearer hover/focus target.

--- a/packages/ui/src/baseTheme.ts
+++ b/packages/ui/src/baseTheme.ts
@@ -305,6 +305,14 @@ const clerkTheme: Appearance = {
         borderWidth: 0,
         boxShadow: `0px 0px 2px 0px rgba(0, 0, 0, 0.08), 0px 1px 2px 0px rgba(25, 28, 33, 0.12), 0px 0px 0px 1px ${theme.colors.$borderAlpha100}`,
       },
+      formFieldInputShowPasswordButton: {
+        insetInlineEnd: theme.space.$0x75,
+        insetBlock: theme.space.$0x75,
+        borderRadius: `calc(${theme.radii.$md} - ${theme.space.$0x75})`,
+        '&::before': {
+          inset: `calc(${theme.space.$0x75} * -1)`,
+        },
+      },
     };
   },
 } satisfies Appearance;

--- a/packages/ui/src/elements/PasswordInput.tsx
+++ b/packages/ui/src/elements/PasswordInput.tsx
@@ -114,12 +114,10 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         onClick={() => setHidden(s => !s)}
         sx={theme => ({
           position: 'absolute',
-          insetInlineEnd: 0,
-          marginInlineEnd: theme.space.$0x75,
-          paddingInline: theme.space.$2,
-          height: `calc(100% - (${theme.space.$0x75} * 2))`,
-          color: theme.colors.$neutralAlpha400,
+          insetInlineEnd: theme.space.$0x75,
           borderRadius: theme.radii.$sm,
+          color: theme.colors.$neutralAlpha400,
+          paddingInline: theme.space.$2,
           '&::before': {
             content: '""',
             position: 'absolute',

--- a/packages/ui/src/elements/PasswordInput.tsx
+++ b/packages/ui/src/elements/PasswordInput.tsx
@@ -115,8 +115,18 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         sx={theme => ({
           position: 'absolute',
           insetInlineEnd: 0,
-          marginInlineEnd: theme.space.$1,
+          marginInlineEnd: theme.space.$0x75,
+          paddingInline: theme.space.$2,
+          height: `calc(100% - (${theme.space.$0x75} * 2))`,
           color: theme.colors.$neutralAlpha400,
+          borderRadius: theme.radii.$sm,
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: `calc(${theme.space.$0x75} * -1)`,
+            display: 'block',
+            borderRadius: theme.radii.$md,
+          },
         })}
         icon={hidden ? Eye : EyeSlash}
       />

--- a/packages/ui/src/elements/PasswordInput.tsx
+++ b/packages/ui/src/elements/PasswordInput.tsx
@@ -115,6 +115,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         sx={theme => ({
           position: 'absolute',
           insetInlineEnd: theme.space.$0x75,
+          insetBlock: theme.space.$0x75,
           borderRadius: theme.radii.$sm,
           color: theme.colors.$neutralAlpha400,
           paddingInline: theme.space.$2,

--- a/packages/ui/src/elements/PasswordInput.tsx
+++ b/packages/ui/src/elements/PasswordInput.tsx
@@ -114,15 +114,15 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         onClick={() => setHidden(s => !s)}
         sx={theme => ({
           position: 'absolute',
-          insetInlineEnd: theme.space.$0x75,
-          insetBlock: theme.space.$0x75,
-          borderRadius: theme.radii.$sm,
+          insetInlineEnd: theme.space.$1,
+          insetBlock: theme.space.$1,
+          borderRadius: `calc(${theme.radii.$md} - ${theme.space.$1})`,
           color: theme.colors.$neutralAlpha400,
           paddingInline: theme.space.$2,
           '&::before': {
             content: '""',
             position: 'absolute',
-            inset: `calc(${theme.space.$0x75} * -1)`,
+            inset: `calc(${theme.space.$1} * -1)`,
             display: 'block',
             borderRadius: theme.radii.$md,
           },

--- a/packages/ui/src/foundations/sizes.ts
+++ b/packages/ui/src/foundations/sizes.ts
@@ -95,6 +95,7 @@ type ExtractRemValues<T> = {
 const spaceUnits = Object.freeze({
   '0x25': spacingScale['0x25'].rem,
   '0x5': spacingScale['0x5'].rem,
+  '0x75': spacingScale['0x75'].rem,
   '1': spacingScale['1'].rem,
   '1x5': spacingScale['1x5'].rem,
   '2': spacingScale['2'].rem,

--- a/packages/ui/src/foundations/sizes.ts
+++ b/packages/ui/src/foundations/sizes.ts
@@ -16,6 +16,7 @@ const baseSpaceUnits = Object.freeze({
 const spacingScale = Object.freeze({
   '0x25': { rem: '0.0625rem', multiplier: 0.25 },
   '0x5': { rem: '0.125rem', multiplier: 0.5 },
+  '0x75': { rem: '0.1875rem', multiplier: 0.75 },
   '1': { rem: '0.25rem', multiplier: 1 },
   '1x5': { rem: '0.375rem', multiplier: 1.5 },
   '2': { rem: '0.5rem', multiplier: 2 },
@@ -197,4 +198,4 @@ const radii = Object.freeze({
  */
 const spaceScaleKeys = Object.keys(spacingScale) as SpacingScaleKey[];
 
-export { sizes, space, radii, spaceScaleKeys };
+export { radii, sizes, space, spaceScaleKeys };


### PR DESCRIPTION
## Description

Improves PasswordInput toggle styling.

- makes toggle right alignment match the top and bottom alignment
- reduces toggle button width
- ensure border radius matches for focus outline alignment
- increase toggle hit area with before pseudo element

| STATE | BEFORE | AFTER |
|--------|--------|--------|
| idle | <img width="1020" height="462" alt="Screenshot 2026-07-06 at 5 45 08 PM" src="https://github.com/user-attachments/assets/187333c1-7f4d-4b31-a04a-31347db0bb5e" /> | <img width="1136" height="576" alt="Screenshot 2026-07-06 at 5 47 52 PM" src="https://github.com/user-attachments/assets/0211bef6-16e2-4f5f-bf73-21c2a768bea8" /> |
| hover | <img width="986" height="389" alt="Screenshot 2026-07-06 at 5 46 33 PM" src="https://github.com/user-attachments/assets/4674922d-5225-458b-ab75-b953b7ec7220" /> | <img width="1092" height="522" alt="Screenshot 2026-07-06 at 5 48 06 PM" src="https://github.com/user-attachments/assets/e9ca0fad-de3f-430b-987d-dab55931eb6e" /> |
| focus | <img width="941" height="496" alt="Screenshot 2026-07-06 at 5 47 24 PM" src="https://github.com/user-attachments/assets/a6a5b662-ff14-4325-9d9b-47d20efbe340" /> | <img width="1152" height="499" alt="Screenshot 2026-07-06 at 5 48 29 PM" src="https://github.com/user-attachments/assets/3545a9a3-ca16-40b3-9585-ccc71b942204" /> |

## Type of change
- [x] Refactor (styling / non-breaking)

This is a styling-only, backwards-compatible change to `@clerk/ui`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a smaller fractional spacing option (`0x75`) for more precise UI layout control.

* **Bug Fixes**
  * Improved the password show/hide toggle with better visual alignment and a larger touch/click hit area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->