### PR TITLE
chore(expo): bump clerk-ios to 1.2.8

### DIFF
--- a/.changeset/expo-bump-clerk-ios-1-2-8.md
+++ b/.changeset/expo-bump-clerk-ios-1-2-8.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-ios` SDK from `1.2.7` to `1.2.8`. See the Clerk iOS release: https://github.com/clerk/clerk-ios/releases/tag/1.2.8.

--- a/packages/expo/ios/ClerkExpo.podspec
+++ b/packages/expo/ios/ClerkExpo.podspec
@@ -18,7 +18,7 @@ else
 end
 
 clerk_ios_repo = 'https://github.com/clerk/clerk-ios.git'
-clerk_ios_version = '1.2.7'
+clerk_ios_version = '1.2.8'
 
 Pod::Spec.new do |s|
   s.name           = 'ClerkExpo'


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-ios` SDK in `@clerk/expo` from `1.2.7` to `1.2.8`.

Release: https://github.com/clerk/clerk-ios/releases/tag/1.2.8

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled iOS authentication component to a newer patch release, which may include stability and compatibility improvements for Expo apps.

* **Chores**
  * Bumped the packaged iOS dependency version to keep the SDK aligned with the latest available patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->