### PR TITLE
fix(ui): Fix OrganizationSwitcher avatar flash and polish popover styling

### DIFF
--- a/.changeset/avatar-sync-decode.md
+++ b/.changeset/avatar-sync-decode.md
@@ -1,5 +1,0 @@
----
-'@clerk/ui': patch
----
-
-Decode avatar images synchronously so a freshly mounted avatar (e.g. when the `<OrganizationSwitcher />` popover opens) paints on its first frame instead of briefly flashing the avatar background.

--- a/.changeset/avatar-sync-decode.md
+++ b/.changeset/avatar-sync-decode.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Decode avatar images synchronously so a freshly mounted avatar (e.g. when the `<OrganizationSwitcher />` popover opens) paints on its first frame instead of briefly flashing the avatar background.

--- a/.changeset/org-switcher-polish.md
+++ b/.changeset/org-switcher-polish.md
@@ -1,0 +1,9 @@
+---
+'@clerk/ui': patch
+---
+
+Polish the `<OrganizationSwitcher />`:
+
+- Decode avatar images synchronously so a freshly mounted avatar (e.g. when the popover opens) paints on its first frame instead of briefly flashing the avatar background.
+- Highlight the trigger while its popover is open.
+- Align the "Create organization" action's height with the other rows for a consistent list.

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -43,6 +43,10 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
           t => ({
             padding: `${t.space.$1} ${t.space.$2}`,
             position: 'relative',
+            '&[aria-expanded="true"]': {
+              backgroundColor: 'var(--alpha)',
+              color: 'var(--accentHover)',
+            },
           }),
           sx,
         ]}

--- a/packages/ui/src/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -26,7 +26,7 @@ const CreateOrganizationButton = ({
       label={localizationKeys('organizationSwitcher.action__createOrganization')}
       onClick={onCreateOrganizationClick}
       sx={t => ({
-        padding: `${t.space.$5} ${t.space.$5}`,
+        padding: `${t.space.$4} ${t.space.$5}`,
       })}
       iconSx={t => ({
         width: t.sizes.$9,
@@ -34,7 +34,7 @@ const CreateOrganizationButton = ({
       })}
       iconBoxSx={t => ({
         width: t.sizes.$9,
-        height: t.sizes.$6,
+        height: t.sizes.$9,
       })}
       spinnerSize='sm'
     />

--- a/packages/ui/src/elements/Avatar.tsx
+++ b/packages/ui/src/elements/Avatar.tsx
@@ -97,6 +97,10 @@ export const Avatar = (props: AvatarProps) => {
         title={title}
         alt={`${title}'s logo`}
         src={imageUrl || ''}
+        // Decode the (typically cached) avatar bytes before presenting so a freshly-mounted
+        // <img> paints on its first frame instead of flashing the avatar background for a tick.
+        // Safe for avatar-sized images: decode is off-thread/sub-ms and only affects already-fetched bytes.
+        decoding='sync'
         sx={{
           objectFit: 'cover',
           width: '100%',


### PR DESCRIPTION
## Description
- makes org switcher row heights consistent (was like 3px off before)
- adds sticky open style to popover trigger (standard ala vercel & notion for popovers)
- removes avatar flash on first render of org popover (more noticeable on dark mode, screenshot of the frame below)

<img width="842" height="612" alt="Screenshot 2026-07-08 at 5 14 43 PM" src="https://github.com/user-attachments/assets/c9751704-434c-4fc0-883d-d6baf5446b36" />

| Before | After |
| --- | --- |
| <img width="458" height="431" alt="Screenshot 2026-07-08 at 6 29 53 PM" src="https://github.com/user-attachments/assets/cdf1a7d1-03a4-4a9e-bc1f-f78897eb2262" /> | <img width="469" height="419" alt="Screenshot 2026-07-08 at 6 29 19 PM" src="https://github.com/user-attachments/assets/0bc43dc5-37c1-4aab-8c63-1fa68d8ddabd" /> |


Follow up PR imporving popover anims [here](https://github.com/clerk/javascript/pull/9113)


<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the organization switcher’s open state with clearer visual highlighting.
  * Made newly loaded avatars appear more smoothly on first display.
* **Bug Fixes**
  * Reduced brief background flashing when avatars mount.
  * Aligned the “Create organization” action row with the rest of the menu items for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->