### PR TITLE
[WIP] feat(ui): Origin-aware open/close animations for popover menus and selects

### DIFF
--- a/.changeset/popover-enter-exit-animations.md
+++ b/.changeset/popover-enter-exit-animations.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+The `<OrganizationSwitcher />` and `<UserButton />` popovers now open instantly and fade out on close, replacing the previous slide-and-scale entrance animation. Motion is disabled when `appearance.animations` is `false` or the user prefers reduced motion.

--- a/.changeset/popover-enter-exit-animations.md
+++ b/.changeset/popover-enter-exit-animations.md
@@ -2,4 +2,4 @@
 '@clerk/ui': patch
 ---
 
-The `<OrganizationSwitcher />` and `<UserButton />` popovers now open instantly and fade out on close, replacing the previous slide-and-scale entrance animation. Motion is disabled when `appearance.animations` is `false` or the user prefers reduced motion.
+The `<OrganizationSwitcher />` and `<UserButton />` popovers now open and close with an origin-aware scale-and-fade animation that grows from the edge nearest the trigger. Motion is disabled when `appearance.animations` is `false` or the user prefers reduced motion.

--- a/.changeset/popover-enter-exit-animations.md
+++ b/.changeset/popover-enter-exit-animations.md
@@ -2,4 +2,4 @@
 '@clerk/ui': patch
 ---
 
-The `<OrganizationSwitcher />` and `<UserButton />` popovers now open and close with an origin-aware scale-and-fade animation that grows from the edge nearest the trigger. Motion is disabled when `appearance.animations` is `false` or the user prefers reduced motion.
+Popover-based surfaces now open and close with an origin-aware scale-and-fade that grows from the edge nearest the trigger, replacing the previous entrance-only slide animation. This covers the `<OrganizationSwitcher />` / `<UserButton />` menus, the overflow (⋯) menus, and selects — menus keep a quick-in / soft-out feel while selects use a quicker exit. Motion is disabled when `appearance.animations` is `false` or the user prefers reduced motion.

--- a/integration/tests/custom-pages.test.ts
+++ b/integration/tests/custom-pages.test.ts
@@ -405,14 +405,19 @@ testAgainstRunningApps({ withPattern: ['react.vite.withEmailCodes'] })(
         const notificationsButton = buttons[2];
         const languageButton = buttons[3];
 
+        // Clicking an action closes the popover, which now plays an exit animation and stays
+        // mounted until it finishes — wait for it to fully close before re-opening, otherwise
+        // the re-open races the still-visible exiting popover.
         // Test chat toggle
         await chatButton.click();
+        await u.po.userButton.waitForPopoverClosed();
         await u.po.userButton.toggleTrigger();
         await u.po.userButton.waitForPopover();
         await expect(chatButton).toHaveText('🌐Chat is ON');
         await expect(languageButton).toHaveText('🌍Language: EN');
 
         await notificationsButton.click();
+        await u.po.userButton.waitForPopoverClosed();
         await u.po.userButton.toggleTrigger();
         await u.po.userButton.waitForPopover();
         await expect(notificationsButton).toHaveText('🌐Notifications 🔔 ON');
@@ -460,14 +465,19 @@ testAgainstRunningApps({ withPattern: ['react.vite.withEmailCodes'] })(
         const languageButton = buttons[3];
         const manageAccountButton = buttons[4];
 
+        // Clicking an action closes the popover, which now plays an exit animation and stays
+        // mounted until it finishes — wait for it to fully close before re-opening, otherwise
+        // the re-open races the still-visible exiting popover.
         // Test chat toggle
         await chatButton.click();
+        await u.po.userButton.waitForPopoverClosed();
         await u.po.userButton.toggleTrigger();
         await u.po.userButton.waitForPopover();
         await expect(chatButton).toHaveText('🌐Chat is ON');
         await expect(languageButton).toHaveText('🌍Language: EN');
 
         await notificationsButton.click();
+        await u.po.userButton.waitForPopoverClosed();
         await u.po.userButton.toggleTrigger();
         await u.po.userButton.waitForPopover();
         await expect(notificationsButton).toHaveText('🌐Notifications 🔔 ON');
@@ -507,6 +517,10 @@ testAgainstRunningApps({ withPattern: ['react.vite.withEmailCodes'] })(
         const toggleButton = pagesContainer.locator('button', { hasText: 'Toggle menu items' });
         await expect(toggleButton.locator('span')).toHaveText('🔔');
         await toggleButton.click();
+
+        // The action closes the popover with an exit animation that keeps it mounted until it
+        // finishes; wait for the full close so the re-open doesn't race the exiting popover.
+        await u.po.userButton.waitForPopoverClosed();
 
         // Re-open menu to see updated items
         await u.po.userButton.toggleTrigger();

--- a/packages/testing/src/playwright/unstable/page-objects/apiKeys.ts
+++ b/packages/testing/src/playwright/unstable/page-objects/apiKeys.ts
@@ -61,7 +61,10 @@ export const createAPIKeysComponentPageObject = (testArgs: { page: EnhancedPage 
       return page.getByLabel(/Type "Revoke" to confirm/i).fill(value);
     },
     clickConfirmRevokeButton: () => {
-      return page.getByText(/Revoke key/i).click();
+      // Target the modal's submit button by its descriptor class rather than by text: the menu
+      // action that opens this modal is also labelled "Revoke key", and it now lingers through an
+      // exit animation, so a text locator transiently matches both (strict-mode violation).
+      return page.locator('.cl-apiKeysRevokeModal .cl-apiKeysRevokeModalSubmitButton').click();
     },
   };
   return self;

--- a/packages/ui/bundlewatch.config.json
+++ b/packages/ui/bundlewatch.config.json
@@ -5,7 +5,7 @@
     { "path": "./dist/ui.shared.browser.js", "maxSize": "40KB" },
     { "path": "./dist/framework*.js", "maxSize": "44KB" },
     { "path": "./dist/vendors*.js", "maxSize": "73KB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "130KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "132KB" },
     { "path": "./dist/signin*.js", "maxSize": "17KB" },
     { "path": "./dist/signup*.js", "maxSize": "13KB" },
     { "path": "./dist/userprofile*.js", "maxSize": "16KB" },

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -137,7 +137,6 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
           ref={ref}
           role='dialog'
           aria-label={`${currentOrg?.name} is active`}
-          shouldEntryAnimate={false}
           {...rest}
         >
           <PopoverCard.Content elementDescriptor={descriptors.organizationSwitcherPopoverMain}>

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -23,7 +23,6 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
     const { close: unsafeClose, ...rest } = props;
     const close = () => unsafeClose?.(false);
     const card = useCardState();
-    const { __experimental_asStandalone } = useOrganizationSwitcherContext();
     const { openOrganizationProfile, openCreateOrganization } = useClerk();
     const getContainer = usePortalRoot();
     const { organization: currentOrg } = useOrganization();
@@ -138,7 +137,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
           ref={ref}
           role='dialog'
           aria-label={`${currentOrg?.name} is active`}
-          shouldEntryAnimate={!__experimental_asStandalone}
+          shouldEntryAnimate={false}
           {...rest}
         >
           <PopoverCard.Content elementDescriptor={descriptors.organizationSwitcherPopoverMain}>

--- a/packages/ui/src/components/OrganizationSwitcher/index.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/index.tsx
@@ -42,7 +42,7 @@ const OrganizationSwitcherWithFloatingTree = withFloatingTree<{ children: ReactE
       <Popover
         nodeId={nodeId}
         context={context}
-        isOpen={isOpen}
+        animateExit
         order={['content']}
         initialFocus={popoverRef}
       >

--- a/packages/ui/src/components/UserButton/UserButtonPopover.tsx
+++ b/packages/ui/src/components/UserButton/UserButtonPopover.tsx
@@ -19,7 +19,6 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
   const close = () => unsafeClose?.(false);
   const { session } = useSession() as { session: SignedInSessionResource };
   const userButtonContext = useUserButtonContext();
-  const { __experimental_asStandalone } = userButtonContext;
   const { authConfig } = useEnvironment();
   const { user } = useUser();
   const { t } = useLocalizations();
@@ -40,7 +39,7 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
         ref={ref}
         role='dialog'
         aria-label={t(localizationKeys('userButton.label__userButtonPopover'))}
-        shouldEntryAnimate={!__experimental_asStandalone}
+        shouldEntryAnimate={false}
         {...rest}
       >
         <PopoverCard.Content elementDescriptor={descriptors.userButtonPopoverMain}>

--- a/packages/ui/src/components/UserButton/UserButtonPopover.tsx
+++ b/packages/ui/src/components/UserButton/UserButtonPopover.tsx
@@ -39,7 +39,6 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
         ref={ref}
         role='dialog'
         aria-label={t(localizationKeys('userButton.label__userButtonPopover'))}
-        shouldEntryAnimate={false}
         {...rest}
       >
         <PopoverCard.Content elementDescriptor={descriptors.userButtonPopoverMain}>

--- a/packages/ui/src/components/UserButton/index.tsx
+++ b/packages/ui/src/components/UserButton/index.tsx
@@ -41,7 +41,7 @@ const UserButtonWithFloatingTree = withFloatingTree<{ children: ReactElement }>(
       <Popover
         nodeId={nodeId}
         context={context}
-        isOpen={isOpen}
+        animateExit
         order={['content']}
         initialFocus={popoverRef}
       >

--- a/packages/ui/src/elements/Menu.tsx
+++ b/packages/ui/src/elements/Menu.tsx
@@ -18,7 +18,6 @@ import { Col, descriptors, SimpleButton } from '../customizables';
 import type { UsePopoverReturn } from '../hooks';
 import { usePopover } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
-import { animations } from '../styledSystem';
 import { colors } from '../utils/colors';
 import { withFloatingTree } from './contexts';
 import { Popover } from './Popover';
@@ -124,20 +123,24 @@ type MenuListProps = PropsOfComponent<typeof Col> & {
 export const MenuList = (props: MenuListProps) => {
   const { sx, asPortal, ...rest } = props;
   const { popoverCtx, elementId, getFloatingProps, elementsRef } = useMenuState();
-  const { floating, styles, isOpen, context, nodeId } = popoverCtx;
+  const { floating, styles, context, nodeId } = popoverCtx;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mergedRef = useMergeRefs([containerRef, floating]);
 
+  // `FloatingList` only provides list-navigation context (no DOM), so it wraps the `Popover`
+  // rather than nesting inside it — that keeps the `Col` as the `Popover`'s direct child, which is
+  // the element the `animateExit` transition (origin-aware scale + fade) is applied to.
   return (
-    <Popover
-      context={context}
-      nodeId={nodeId}
-      isOpen={isOpen}
-      portal={asPortal}
-      order={['content']}
-      modal={false}
-    >
-      <FloatingList elementsRef={elementsRef}>
+    <FloatingList elementsRef={elementsRef}>
+      <Popover
+        context={context}
+        nodeId={nodeId}
+        animateExit
+        initialScale={0.88}
+        portal={asPortal}
+        order={['content']}
+        modal={false}
+      >
         <Col
           elementDescriptor={descriptors.menuList}
           elementId={descriptors.menuList.setId(elementId)}
@@ -153,8 +156,6 @@ export const MenuList = (props: MenuListProps) => {
               padding: t.space.$0x5,
               overflow: 'hidden',
               top: `calc(100% + ${t.space.$2})`,
-              animation: `${animations.dropdownSlideInScaleAndFade} ${t.transitionDuration.$slower} ${t.transitionTiming.$slowBezier}`,
-              transformOrigin: 'top center',
               zIndex: t.zIndices.$dropdown,
               gap: t.space.$0x5,
             }),
@@ -164,8 +165,8 @@ export const MenuList = (props: MenuListProps) => {
           {...getFloatingProps()}
           {...rest}
         />
-      </FloatingList>
-    </Popover>
+      </Popover>
+    </FloatingList>
   );
 };
 

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -145,6 +145,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           </Text>
         </SelectButton>
         <SelectOptionList
+          initialScale={0.96}
           sx={{ padding: '0 0' }}
           containerSx={theme => ({
             gap: 0,

--- a/packages/ui/src/elements/Popover.tsx
+++ b/packages/ui/src/elements/Popover.tsx
@@ -155,6 +155,7 @@ export const Popover = (props: PopoverProps) => {
         <FloatingFocusManager
           context={context}
           initialFocus={initialFocus}
+          outsideElementsInert={outsideElementsInert}
           order={order}
           modal={modal}
         >

--- a/packages/ui/src/elements/Popover.tsx
+++ b/packages/ui/src/elements/Popover.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { useAppearance } from '../customizables';
 import { transitionDurationValues, transitionTiming } from '../foundations/transitions';
-import { usePrefersReducedMotion } from '../hooks';
+import { useDirection, usePrefersReducedMotion } from '../hooks';
 
 type PopoverProps = PropsWithChildren<{
   context: FloatingContext<ReferenceType>;
@@ -20,6 +20,19 @@ type PopoverProps = PropsWithChildren<{
    * @default false
    */
   animateExit?: boolean;
+  /**
+   * When `animateExit` is set, exits quickly (`$faster`, matching the entrance) instead of the
+   * default soft exit (`$slower`). The entrance is always `$faster`.
+   * @default false
+   */
+  exitFast?: boolean;
+  /**
+   * The scale the popover animates from on enter (and collapses to on exit) when `animateExit`
+   * is set. Scale is proportional, so compact surfaces travel fewer pixels — lower this
+   * (e.g. `0.92`) to give small popovers like menus a more pronounced motion.
+   * @default 0.96
+   */
+  initialScale?: number;
   /**
    * Determines whether outside elements are inert when modal is enabled. This enables pointer modality without a backdrop.
    * @default false
@@ -41,6 +54,27 @@ type PopoverProps = PropsWithChildren<{
   root?: HTMLElement | React.MutableRefObject<HTMLElement | null>;
 }>;
 
+/**
+ * Maps a resolved Floating UI placement to a `transform-origin` so the popover grows from the
+ * point nearest its trigger. The primary axis anchors to the edge opposite the `side`; when the
+ * placement is aligned to a corner (`-start` / `-end`) the cross axis hugs that corner, otherwise
+ * it stays centered. Horizontal alignment is mirrored under RTL to match Floating UI's
+ * direction-aware resolved position.
+ */
+const getTransformOrigin = (placement: string, direction: 'ltr' | 'rtl'): string => {
+  const [side, alignment] = placement.split('-');
+  if (side === 'top' || side === 'bottom') {
+    const y = side === 'top' ? 'bottom' : 'top';
+    const start = direction === 'rtl' ? 'right' : 'left';
+    const end = direction === 'rtl' ? 'left' : 'right';
+    const x = alignment === 'start' ? start : alignment === 'end' ? end : 'center';
+    return `${x} ${y}`;
+  }
+  const x = side === 'left' ? 'right' : 'left';
+  const y = alignment === 'start' ? 'top' : alignment === 'end' ? 'bottom' : 'center';
+  return `${x} ${y}`;
+};
+
 export const Popover = (props: PopoverProps) => {
   const {
     context,
@@ -51,6 +85,8 @@ export const Popover = (props: PopoverProps) => {
     nodeId,
     isOpen,
     animateExit = false,
+    exitFast = false,
+    initialScale = 0.96,
     portal = true,
     root,
     children,
@@ -60,31 +96,28 @@ export const Popover = (props: PopoverProps) => {
   const effectiveRoot = root ?? portalRoot?.() ?? undefined;
 
   const prefersReducedMotion = usePrefersReducedMotion();
+  const direction = useDirection();
   const { animations: layoutAnimations } = useAppearance().parsedOptions;
   const isMotionSafe = !prefersReducedMotion && layoutAnimations === true;
   const animate = animateExit && isMotionSafe;
+  const closeDuration = exitFast ? transitionDurationValues.faster : transitionDurationValues.slower;
 
   // Animate in on mount and out on close with an origin-aware scale + fade. Keeping the element
   // mounted through the close transition (via `isMounted`) is what makes the exit animation
   // possible. `transformOrigin` is derived from the resolved placement so the popover grows from
-  // the edge nearest its trigger (Floating UI's placement-aware transitions).
+  // the point nearest its trigger — the aligned corner when present, otherwise the edge center.
   const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
     duration: {
-      open: animate ? transitionDurationValues.fast : 0,
-      close: animate ? transitionDurationValues.slower : 0,
+      open: animate ? transitionDurationValues.faster : 0,
+      close: animate ? closeDuration : 0,
     },
-    common: ({ side }) => ({
-      transformOrigin: {
-        top: 'bottom',
-        bottom: 'top',
-        left: 'right',
-        right: 'left',
-      }[side],
+    common: ({ placement }) => ({
+      transformOrigin: getTransformOrigin(placement, direction),
       transitionTimingFunction: transitionTiming.swiftOut,
     }),
-    initial: { opacity: animate ? 0 : 1, transform: animate ? 'scale(0.96)' : 'scale(1)' },
+    initial: { opacity: animate ? 0 : 1, transform: animate ? `scale(${initialScale})` : 'scale(1)' },
     open: { opacity: 1, transform: 'scale(1)' },
-    close: { opacity: animate ? 0 : 1, transform: animate ? 'scale(0.96)' : 'scale(1)' },
+    close: { opacity: animate ? 0 : 1, transform: animate ? `scale(${initialScale})` : 'scale(1)' },
   });
 
   // Non-animating consumers keep the original synchronous `isOpen` unmount.

--- a/packages/ui/src/elements/Popover.tsx
+++ b/packages/ui/src/elements/Popover.tsx
@@ -1,14 +1,23 @@
 import { usePortalRoot } from '@clerk/shared/react';
 import type { FloatingContext, ReferenceType } from '@floating-ui/react';
-import { FloatingFocusManager, FloatingNode, FloatingPortal } from '@floating-ui/react';
+import { FloatingFocusManager, FloatingNode, FloatingPortal, useTransitionStyles } from '@floating-ui/react';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
+
+import { useAppearance } from '../customizables';
+import { usePrefersReducedMotion } from '../hooks';
 
 type PopoverProps = PropsWithChildren<{
   context: FloatingContext<ReferenceType>;
   nodeId?: string;
   isOpen?: boolean;
   initialFocus?: number | React.MutableRefObject<HTMLElement | null>;
+  /**
+   * When `true`, the popover appears instantly but stays mounted through a short fade-out on close,
+   * instead of unmounting immediately. Opt-in so other consumers keep their current instant behavior.
+   * @default false
+   */
+  animateExit?: boolean;
   /**
    * Determines whether outside elements are inert when modal is enabled. This enables pointer modality without a backdrop.
    * @default false
@@ -39,6 +48,7 @@ export const Popover = (props: PopoverProps) => {
     modal = true,
     nodeId,
     isOpen,
+    animateExit = false,
     portal = true,
     root,
     children,
@@ -47,11 +57,34 @@ export const Popover = (props: PopoverProps) => {
   const portalRoot = usePortalRoot();
   const effectiveRoot = root ?? portalRoot?.() ?? undefined;
 
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const { animations: layoutAnimations } = useAppearance().parsedOptions;
+  const isMotionSafe = !prefersReducedMotion && layoutAnimations === true;
+
+  // Appear instantly for snappiness, fade out on close. Keeping the element mounted
+  // through the close transition (via `isMounted`) is what makes the exit animation possible.
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    // `close` matches the theme's `$slow` (200ms) transition duration.
+    duration: { open: 0, close: animateExit && isMotionSafe ? 200 : 0 },
+    initial: { opacity: 1 },
+    open: { opacity: 1 },
+    close: { opacity: animateExit ? 0 : 1 },
+  });
+
+  // Non-animating consumers keep the original synchronous `isOpen` unmount.
+  const shouldRender = animateExit ? isMounted : isOpen;
+  const content =
+    animateExit && React.isValidElement<{ style?: React.CSSProperties }>(children)
+      ? React.cloneElement(children, {
+          style: { ...children.props.style, ...transitionStyles },
+        })
+      : children;
+
   if (portal) {
     return (
       <FloatingNode id={nodeId}>
         <FloatingPortal root={effectiveRoot}>
-          {isOpen && (
+          {shouldRender && (
             <FloatingFocusManager
               context={context}
               initialFocus={initialFocus}
@@ -59,7 +92,7 @@ export const Popover = (props: PopoverProps) => {
               order={order}
               modal={modal}
             >
-              <>{children}</>
+              <>{content}</>
             </FloatingFocusManager>
           )}
         </FloatingPortal>
@@ -69,14 +102,14 @@ export const Popover = (props: PopoverProps) => {
 
   return (
     <FloatingNode id={nodeId}>
-      {isOpen && (
+      {shouldRender && (
         <FloatingFocusManager
           context={context}
           initialFocus={initialFocus}
           order={order}
           modal={modal}
         >
-          <>{children}</>
+          <>{content}</>
         </FloatingFocusManager>
       )}
     </FloatingNode>

--- a/packages/ui/src/elements/Popover.tsx
+++ b/packages/ui/src/elements/Popover.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from 'react';
 import React from 'react';
 
 import { useAppearance } from '../customizables';
+import { transitionDurationValues, transitionTiming } from '../foundations/transitions';
 import { usePrefersReducedMotion } from '../hooks';
 
 type PopoverProps = PropsWithChildren<{
@@ -13,8 +14,9 @@ type PopoverProps = PropsWithChildren<{
   isOpen?: boolean;
   initialFocus?: number | React.MutableRefObject<HTMLElement | null>;
   /**
-   * When `true`, the popover appears instantly but stays mounted through a short fade-out on close,
-   * instead of unmounting immediately. Opt-in so other consumers keep their current instant behavior.
+   * When `true`, the popover animates in on mount with an origin-aware scale + fade and stays
+   * mounted through a matching fade-out on close, instead of appearing/unmounting instantly.
+   * Opt-in so other consumers keep their current instant behavior.
    * @default false
    */
   animateExit?: boolean;
@@ -60,15 +62,29 @@ export const Popover = (props: PopoverProps) => {
   const prefersReducedMotion = usePrefersReducedMotion();
   const { animations: layoutAnimations } = useAppearance().parsedOptions;
   const isMotionSafe = !prefersReducedMotion && layoutAnimations === true;
+  const animate = animateExit && isMotionSafe;
 
-  // Appear instantly for snappiness, fade out on close. Keeping the element mounted
-  // through the close transition (via `isMounted`) is what makes the exit animation possible.
+  // Animate in on mount and out on close with an origin-aware scale + fade. Keeping the element
+  // mounted through the close transition (via `isMounted`) is what makes the exit animation
+  // possible. `transformOrigin` is derived from the resolved placement so the popover grows from
+  // the edge nearest its trigger (Floating UI's placement-aware transitions).
   const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
-    // `close` matches the theme's `$slow` (200ms) transition duration.
-    duration: { open: 0, close: animateExit && isMotionSafe ? 200 : 0 },
-    initial: { opacity: 1 },
-    open: { opacity: 1 },
-    close: { opacity: animateExit ? 0 : 1 },
+    duration: {
+      open: animate ? transitionDurationValues.fast : 0,
+      close: animate ? transitionDurationValues.slower : 0,
+    },
+    common: ({ side }) => ({
+      transformOrigin: {
+        top: 'bottom',
+        bottom: 'top',
+        left: 'right',
+        right: 'left',
+      }[side],
+      transitionTimingFunction: transitionTiming.swiftOut,
+    }),
+    initial: { opacity: animate ? 0 : 1, transform: animate ? 'scale(0.96)' : 'scale(1)' },
+    open: { opacity: 1, transform: 'scale(1)' },
+    close: { opacity: animate ? 0 : 1, transform: animate ? 'scale(0.96)' : 'scale(1)' },
   });
 
   // Non-animating consumers keep the original synchronous `isOpen` unmount.

--- a/packages/ui/src/elements/PopoverCard.tsx
+++ b/packages/ui/src/elements/PopoverCard.tsx
@@ -3,24 +3,13 @@ import React from 'react';
 import { useEnvironment } from '../contexts';
 import { Col, descriptors, Flex, Flow, useAppearance } from '../customizables';
 import type { ElementDescriptor } from '../customizables/elementDescriptors';
-import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
-import { animations, common } from '../styledSystem';
+import type { PropsOfComponent } from '../styledSystem';
+import { common } from '../styledSystem';
 import { colors } from '../utils/colors';
 import { Card } from './Card';
 
-const PopoverCardRoot = React.forwardRef<
-  HTMLDivElement,
-  PropsOfComponent<typeof Card.Content> & {
-    shouldEntryAnimate?: boolean;
-  }
->((props, ref) => {
-  const { elementDescriptor, shouldEntryAnimate = true, ...rest } = props;
-
-  const withAnimation: ThemableCssProp = t => ({
-    animation: shouldEntryAnimate
-      ? `${animations.dropdownSlideInScaleAndFade} ${t.transitionDuration.$fast}`
-      : undefined,
-  });
+const PopoverCardRoot = React.forwardRef<HTMLDivElement, PropsOfComponent<typeof Card.Content>>((props, ref) => {
+  const { elementDescriptor, ...rest } = props;
 
   return (
     <Flow.Part part='popover'>
@@ -30,16 +19,13 @@ const PopoverCardRoot = React.forwardRef<
         ref={ref}
         // Popover cards always render as raised — flush is scoped to simple card components
         elevation='raised'
-        sx={[
-          t => ({
-            width: t.sizes.$94,
-            maxWidth: `calc(100vw - ${t.sizes.$8})`,
-            zIndex: t.zIndices.$modal,
-            borderRadius: t.radii.$xl,
-            outline: 'none',
-          }),
-          withAnimation,
-        ]}
+        sx={t => ({
+          width: t.sizes.$94,
+          maxWidth: `calc(100vw - ${t.sizes.$8})`,
+          zIndex: t.zIndices.$modal,
+          borderRadius: t.radii.$xl,
+          outline: 'none',
+        })}
       >
         {props.children}
       </Card.Root>

--- a/packages/ui/src/elements/Select.tsx
+++ b/packages/ui/src/elements/Select.tsx
@@ -7,7 +7,7 @@ import { Button, descriptors, Flex, Icon, Input, Text } from '../customizables';
 import { usePopover, useSearchInput } from '../hooks';
 import { ChevronDown } from '../icons';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
-import { animations, common } from '../styledSystem';
+import { common } from '../styledSystem';
 import { colors } from '../utils/colors';
 import { withFloatingTree } from './contexts';
 import type { InputWithIcon } from './InputWithIcon';
@@ -257,6 +257,11 @@ type SelectOptionListProps = PropsOfComponent<typeof Flex> & {
   containerSx?: ThemableCssProp;
   footer?: React.ReactNode;
   onReachEnd?: () => void;
+  /**
+   * Scale the dropdown animates from on open. Defaults to the compact select value; raise it
+   * (e.g. `0.96`) for wider dropdowns like the phone country-code picker.
+   */
+  initialScale?: number;
 };
 
 export const SelectOptionList = (props: SelectOptionListProps) => {
@@ -265,6 +270,7 @@ export const SelectOptionList = (props: SelectOptionListProps) => {
     sx,
     footer,
     onReachEnd,
+    initialScale = 0.92,
     id,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
@@ -353,7 +359,9 @@ export const SelectOptionList = (props: SelectOptionListProps) => {
     <Popover
       nodeId={nodeId}
       context={context}
-      isOpen={isOpen}
+      animateExit
+      exitFast
+      initialScale={initialScale}
       portal={portal || false}
       order={['content']}
     >
@@ -369,8 +377,6 @@ export const SelectOptionList = (props: SelectOptionListProps) => {
             backgroundColor: colors.makeSolid(theme.colors.$colorBackground),
             borderRadius: theme.radii.$lg,
             overflow: 'hidden',
-            animation: `${animations.dropdownSlideInScaleAndFade} ${theme.transitionDuration.$slower} ${theme.transitionTiming.$slowBezier}`,
-            transformOrigin: 'top center',
             boxShadow: theme.shadows.$menuShadow,
             zIndex: theme.zIndices.$dropdown,
           }),

--- a/packages/ui/src/elements/__tests__/Menu.test.tsx
+++ b/packages/ui/src/elements/__tests__/Menu.test.tsx
@@ -85,7 +85,9 @@ describe('Menu', () => {
       expect(getByRole('menu')).toBeInTheDocument();
 
       await userEvent.click(getByRole('button', { name: 'Open menu' }));
-      expect(queryByRole('menu')).not.toBeInTheDocument();
+      // The popover stays mounted through its exit transition, so the menu unmounts on
+      // animation-end rather than synchronously with the close.
+      await waitFor(() => expect(queryByRole('menu')).not.toBeInTheDocument());
     });
 
     it('fires the menu item onClick and closes the menu on selection', async () => {
@@ -100,7 +102,7 @@ describe('Menu', () => {
       await userEvent.click(getByRole('menuitem', { name: 'Remove' }));
 
       expect(onClick).toHaveBeenCalledTimes(1);
-      expect(queryByRole('menu')).not.toBeInTheDocument();
+      await waitFor(() => expect(queryByRole('menu')).not.toBeInTheDocument());
     });
 
     it('keeps the menu open after selection when closeAfterClick is false', async () => {
@@ -277,7 +279,7 @@ describe('Menu', () => {
       await userEvent.keyboard('{Enter}');
 
       expect(onClick).toHaveBeenCalledTimes(1);
-      expect(queryByRole('menu')).not.toBeInTheDocument();
+      await waitFor(() => expect(queryByRole('menu')).not.toBeInTheDocument());
     });
 
     it('does not trap focus — Tab exits the menu', async () => {
@@ -305,7 +307,7 @@ describe('Menu', () => {
 
       await userEvent.keyboard('{Escape}');
 
-      expect(queryByRole('menu')).not.toBeInTheDocument();
+      await waitFor(() => expect(queryByRole('menu')).not.toBeInTheDocument());
       expect(trigger).toHaveFocus();
     });
 

--- a/packages/ui/src/foundations/transitions.ts
+++ b/packages/ui/src/foundations/transitions.ts
@@ -27,6 +27,7 @@ const transitionTiming = Object.freeze({
   easeOut: 'ease-out',
   bezier: 'cubic-bezier(0.32, 0.72, 0, 1)',
   slowBezier: 'cubic-bezier(0.16, 1, 0.3, 1)',
+  swiftOut: 'cubic-bezier(0.175, 0.885, 0.32, 1.1)',
 } as const);
 
 export { transitionDuration, transitionTiming, transitionProperty, transitionDurationValues };

--- a/packages/ui/src/foundations/transitions.ts
+++ b/packages/ui/src/foundations/transitions.ts
@@ -3,6 +3,7 @@ const transitionDurationValues = Object.freeze({
   slower: 280,
   slow: 200,
   fast: 120,
+  faster: 90,
   focusRing: 200,
   controls: 100,
   textField: 450,


### PR DESCRIPTION
**TODO**
- [ ] Some origins are off. needs refinement.

## Description
Improves snappyness and adds origin awareness of org switcher, user button, menus & select popover anims. 

| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/7c236e2e-ad89-48e6-80c8-0eca8ef3b11e | https://github.com/user-attachments/assets/cfaa57ef-e3bd-4a84-9803-2b8b4a8b2cf6 |





<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popover-based surfaces (organization switching, user actions, overflow menus, and selects) now open/close with origin-aware scale-and-fade transitions (entrance plus exit), with softer exits for non-select menus and faster exits for selects.
  * Select dropdowns (including the Phone Input country picker) now support `initialScale` (with component-specific defaults) and improved exit timing via `exitFast`.
  * Added new transition timing options: `faster` duration and `swiftOut` easing.
* **Bug Fixes**
  * Motion effects are disabled when reduced motion is enabled or when appearance animations are turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->