### PR TITLE
docs(backend): note M2MToken timestamps are in milliseconds

### DIFF
--- a/.changeset/m2m-token-timestamp-units.md
+++ b/.changeset/m2m-token-timestamp-units.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Clarify in the `M2MToken` JSDoc that the `expiration`, `createdAt`, and `updatedAt` timestamps are Unix timestamps in milliseconds (not seconds).

--- a/.changeset/m2m-token-timestamp-units.md
+++ b/.changeset/m2m-token-timestamp-units.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-Clarify in the `M2MToken` JSDoc that the `expiration`, `createdAt`, and `updatedAt` timestamps are Unix timestamps in milliseconds (not seconds).
+Clarify in the `M2MToken`, `APIKey`, and `IdPOAuthAccessToken` JSDoc that the timestamp properties (`expiration`, `lastUsedAt`, `createdAt`, and `updatedAt`) are Unix timestamps in milliseconds (not seconds).

--- a/packages/backend/src/api/resources/APIKey.ts
+++ b/packages/backend/src/api/resources/APIKey.ts
@@ -23,17 +23,17 @@ export class APIKey {
     readonly revocationReason: string | null,
     /** Whether the API key has expired. */
     readonly expired: boolean,
-    /** The Unix timestamp when the API key expires. `null` if the API key never expires. */
+    /** The Unix timestamp (in milliseconds) when the API key expires. `null` if the API key never expires. */
     readonly expiration: number | null,
     /** The user ID for the user creating the API key. */
     readonly createdBy: string | null,
     /** A description for the API key. */
     readonly description: string | null,
-    /** The Unix timestamp when the API key was last used to authenticate a request. */
+    /** The Unix timestamp (in milliseconds) when the API key was last used to authenticate a request. */
     readonly lastUsedAt: number | null,
-    /** The Unix timestamp when the API key was created. */
+    /** The Unix timestamp (in milliseconds) when the API key was created. */
     readonly createdAt: number,
-    /** The Unix timestamp when the API key was last updated. */
+    /** The Unix timestamp (in milliseconds) when the API key was last updated. */
     readonly updatedAt: number,
     /** The API key secret. */
     readonly secret?: string,

--- a/packages/backend/src/api/resources/IdPOAuthAccessToken.ts
+++ b/packages/backend/src/api/resources/IdPOAuthAccessToken.ts
@@ -19,8 +19,11 @@ export class IdPOAuthAccessToken {
     readonly revoked: boolean,
     readonly revocationReason: string | null,
     readonly expired: boolean,
+    /** The Unix timestamp (in milliseconds) when the access token expires. */
     readonly expiration: number | null,
+    /** The Unix timestamp (in milliseconds) when the access token was created. */
     readonly createdAt: number,
+    /** The Unix timestamp (in milliseconds) when the access token was last updated. */
     readonly updatedAt: number,
   ) {}
 

--- a/packages/backend/src/api/resources/M2MToken.ts
+++ b/packages/backend/src/api/resources/M2MToken.ts
@@ -55,11 +55,11 @@ export class M2MToken {
     readonly revocationReason: string | null,
     /** Whether the M2M token has expired. */
     readonly expired: boolean,
-    /** The Unix timestamp when the M2M token expires. */
+    /** The Unix timestamp (in milliseconds) when the M2M token expires. */
     readonly expiration: number | null,
-    /** The Unix timestamp when the M2M token was created. */
+    /** The Unix timestamp (in milliseconds) when the M2M token was created. */
     readonly createdAt: number,
-    /** The Unix timestamp when the M2M token was last updated. */
+    /** The Unix timestamp (in milliseconds) when the M2M token was last updated. */
     readonly updatedAt: number,
     /** The token string. */
     readonly token?: string,


### PR DESCRIPTION
## Description

Clarify in the `M2MToken` JSDoc that `expiration`, `createdAt`, and `updatedAt` are Unix timestamps in milliseconds (not seconds). The constructor already converts JWT `exp`/`iat` claims via `* 1000`, so the values are milliseconds; only the doc comments were ambiguous.

- [Linear ticket](https://linear.app/clerk/issue/DOCS-11355/fix-documentation-on-m2m-token-timestamps-in-clerk) 
- [Sibling PR on `clerk-docs`](https://github.com/clerk/javascript/pull/9122)

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified that machine-to-machine token and related OAuth/API key timestamp fields (`expiration`, `createdAt`, `lastUsedAt`, `updatedAt`) are Unix timestamps expressed in milliseconds.
  * Updated the existing release notes to reflect this documentation clarification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->