### PR TITLE
fix(clerk-js): backport fail-fast slow-origin load for Core 2

### DIFF
--- a/.changeset/clerkjs-fail-fast-slow-origin.md
+++ b/.changeset/clerkjs-fail-fast-slow-origin.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+---
+
+Fail fast when the Clerk Frontend API (FAPI) is slow or unreachable during load. The client request and the load-recovery token mint are now bounded by a timeout, and the timed-out client request is aborted instead of being left in flight. A cold `Clerk.load()` renders identity from a freshly minted session token (falling back to the session cookie if the mint fails) in seconds instead of hanging while retries run. After a degraded load, the client is re-fetched in the background without a time limit, so a slow-but-healthy origin recovers full client data (user profile, other sessions) without a reload. Also fixes hooks like `useUser()` keeping the cookie-derived stub user after full user data arrives. Adds a `timeLimit` utility to `@clerk/shared/utils` that optionally aborts an `AbortController` on timeout.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -7,6 +7,7 @@ import type {
   SignUpJSON,
   TokenResource,
 } from '@clerk/shared/types';
+import { createDeferredPromise } from '@clerk/shared/utils';
 import { waitFor } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
 
@@ -24,6 +25,9 @@ const mockEnvironmentFetch = vi.fn(() => Promise.resolve({}));
 
 vi.mock('../resources/Client');
 vi.mock('../resources/Environment');
+
+const { mockCreateClientFromJwt } = vi.hoisted(() => ({ mockCreateClientFromJwt: vi.fn() }));
+vi.mock('../jwt-client', () => ({ createClientFromJwt: mockCreateClientFromJwt }));
 
 vi.mock('../auth/devBrowser', () => ({
   createDevBrowser: (): DevBrowser => ({
@@ -737,6 +741,176 @@ describe('Clerk singleton', () => {
         });
       },
     );
+
+    describe('when the client fetch fails or hangs at load', () => {
+      let startPollSpy: ReturnType<typeof vi.spyOn>;
+      let stopPollSpy: ReturnType<typeof vi.spyOn>;
+      let callLog: string[];
+
+      const sessionClient = (session: any) => ({
+        signedInSessions: [session],
+        lastActiveSessionId: session.id,
+      });
+      const makeSession = (overrides: Record<string, unknown> = {}) => ({
+        id: 'sess_1',
+        status: 'active',
+        user: {},
+        getToken: vi.fn(() => Promise.resolve('fresh-token')),
+        clearCache: vi.fn(),
+        ...overrides,
+      });
+
+      // `load()` awaits native crypto (cookie suffix) before scheduling the timeout, so a single
+      // advance can run before the timer exists; advance the budget repeatedly until load settles.
+      const pumpUntilSettled = async (promise: Promise<unknown>) => {
+        let settled = false;
+        const tracked = promise.then(
+          v => ((settled = true), v),
+          e => ((settled = true), Promise.reject(e)),
+        );
+        for (let i = 0; i < 20 && !settled; i++) {
+          await vi.advanceTimersByTimeAsync(5000);
+        }
+        await tracked;
+      };
+
+      beforeEach(async () => {
+        callLog = [];
+        // Import at runtime (not top-level) so this module does not reorder the
+        // static graph and break the auto-mocked Environment/Client resources.
+        const { AuthCookieService } = await import('../auth/AuthCookieService');
+        startPollSpy = vi
+          .spyOn(AuthCookieService.prototype, 'startPollingForToken')
+          .mockImplementation(() => void callLog.push('startPoll'));
+        stopPollSpy = vi
+          .spyOn(AuthCookieService.prototype, 'stopPollingForToken')
+          .mockImplementation(() => void callLog.push('stopPoll'));
+        mockClientFetch.mockClear();
+        mockCreateClientFromJwt.mockReturnValue({ signedInSessions: [], lastActiveSessionId: null });
+      });
+
+      afterEach(() => {
+        startPollSpy.mockRestore();
+        stopPollSpy.mockRestore();
+        mockCreateClientFromJwt.mockReset();
+        vi.useRealTimers();
+      });
+
+      it('fails fast and marks Clerk degraded when the client fetch hangs', async () => {
+        vi.useFakeTimers();
+        // Only the primary fetch hangs; the background retry must resolve so it can't stall the test.
+        mockClientFetch
+          .mockReturnValueOnce(new Promise(() => {}))
+          .mockResolvedValue({ signedInSessions: [], lastActiveSessionId: null });
+
+        const sut = new Clerk(productionPublishableKey);
+        await pumpUntilSettled(sut.load());
+
+        expect(sut.status).toBe('degraded');
+        expect(stopPollSpy).toHaveBeenCalled();
+        expect(startPollSpy).toHaveBeenCalled();
+        expect(mockClientFetch.mock.calls[0]?.[0]?.abortSignal?.aborted).toBe(true);
+      });
+
+      it('builds the degraded identity from the minted token and falls back to the cookie only if the mint fails', async () => {
+        const stubSession = makeSession();
+        const freshSession = { id: 'sess_1', status: 'active', user: { id: 'user_fresh' } };
+        const freshClient = { signedInSessions: [freshSession], lastActiveSessionId: 'sess_1' };
+        mockClientFetch.mockRejectedValue(new Error('client fetch failed'));
+        mockCreateClientFromJwt.mockReturnValueOnce(sessionClient(stubSession)).mockReturnValueOnce(freshClient);
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+
+        expect(mockCreateClientFromJwt).toHaveBeenCalledTimes(2);
+        expect(mockCreateClientFromJwt).toHaveBeenNthCalledWith(2, 'fresh-token');
+        expect(sut.client).toBe(freshClient);
+        expect(sut.session).toBe(freshSession);
+        expect(sut.status).toBe('degraded');
+      });
+
+      it('clears the token cache and mints without skipCache when the client fetch fails with a session present', async () => {
+        const getToken = vi.fn(() => {
+          callLog.push('getToken');
+          return Promise.resolve('fresh-token');
+        });
+        const clearCache = vi.fn(() => void callLog.push('clearCache'));
+        const session = makeSession({ getToken, clearCache });
+        mockClientFetch.mockRejectedValue(new Error('client fetch failed'));
+        mockCreateClientFromJwt.mockReturnValue(sessionClient(session));
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+
+        expect(getToken).toHaveBeenCalledWith();
+        expect(getToken).not.toHaveBeenCalledWith({ skipCache: true });
+        expect(callLog).toEqual(['startPoll', 'stopPoll', 'clearCache', 'getToken', 'startPoll']);
+        expect(sut.status).toBe('degraded');
+      });
+
+      it('re-clears the token cache before restarting the poller when the recovery mint hangs', async () => {
+        vi.useFakeTimers();
+        const getToken = vi.fn(() => {
+          callLog.push('getToken');
+          return new Promise<string>(() => {});
+        });
+        const clearCache = vi.fn(() => void callLog.push('clearCache'));
+        const session = makeSession({ getToken, clearCache });
+        mockClientFetch.mockRejectedValue(new Error('client fetch failed'));
+        mockCreateClientFromJwt.mockReturnValue(sessionClient(session));
+
+        const sut = new Clerk(productionPublishableKey);
+        await pumpUntilSettled(sut.load());
+
+        expect(callLog).toEqual(['startPoll', 'stopPoll', 'clearCache', 'getToken', 'clearCache', 'startPoll']);
+        expect(sut.status).toBe('degraded');
+      });
+
+      it('renders the empty client without minting when there is no session cookie', async () => {
+        mockClientFetch.mockRejectedValue(new Error('client fetch failed'));
+
+        const sut = new Clerk(productionPublishableKey);
+        await sut.load();
+
+        expect(sut.session).toBeNull();
+        expect(callLog).toEqual(['startPoll', 'stopPoll', 'startPoll']);
+        expect(sut.status).toBe('degraded');
+      });
+
+      it('rethrows a 4xx client error without entering the mint path', async () => {
+        const err = Object.assign(new Error('bad request'), { status: 400 });
+        mockClientFetch.mockRejectedValue(err);
+
+        const sut = new Clerk(productionPublishableKey);
+        await expect(sut.load()).rejects.toBe(err);
+
+        expect(mockCreateClientFromJwt).not.toHaveBeenCalled();
+      });
+
+      it('re-fetches /client in the background after a degraded load and applies the late response', async () => {
+        vi.useFakeTimers();
+        const stubSession = makeSession();
+        const realSession = { id: 'sess_1', status: 'active', user: { id: 'user_real' } };
+        const realClient = { id: 'client_real', signedInSessions: [realSession], lastActiveSessionId: 'sess_1' };
+        const refetch = createDeferredPromise();
+        mockClientFetch.mockRejectedValueOnce(new Error('client fetch failed')).mockReturnValueOnce(refetch.promise);
+        mockCreateClientFromJwt.mockReturnValue(sessionClient(stubSession));
+
+        const sut = new Clerk(productionPublishableKey);
+        await pumpUntilSettled(sut.load());
+
+        expect(sut.status).toBe('degraded');
+        expect(mockClientFetch).toHaveBeenCalledTimes(2);
+
+        // The background retry is not bounded by INITIALIZATION_TIMEOUT_MS.
+        await vi.advanceTimersByTimeAsync(60_000);
+        refetch.resolve(realClient);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(sut.client).toBe(realClient);
+        expect(sut.session).toBe(realSession);
+      });
+    });
   });
 
   describe('updateSessionCookie monotonic backstop', () => {

--- a/packages/clerk-js/src/core/__tests__/jwt-client.test.ts
+++ b/packages/clerk-js/src/core/__tests__/jwt-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockJwt } from '@/test/core-fixtures';
+
+import { createClientFromJwt } from '../jwt-client';
+
+describe('createClientFromJwt', () => {
+  it('creates a client with a session and user derived from the JWT claims', () => {
+    const client = createClientFromJwt(mockJwt);
+
+    expect(client.lastActiveSessionId).toBe('sess_2GbDB4enNdCa5vS1zpC3Xzg9tK9');
+    expect(client.signedInSessions[0]?.id).toBe('sess_2GbDB4enNdCa5vS1zpC3Xzg9tK9');
+    expect(client.signedInSessions[0]?.user?.id).toBe('user_2GIpXOEpVyJw51rkZn9Kmnc6Sxr');
+  });
+
+  it('stamps the stub user with an ancient updatedAt so the real user always replaces it in memoized listeners', () => {
+    const client = createClientFromJwt(mockJwt);
+
+    expect(client.signedInSessions[0]?.user?.updatedAt?.getTime()).toBe(1);
+  });
+
+  it('returns an empty client when the JWT is missing', () => {
+    const client = createClientFromJwt(undefined);
+
+    expect(client.signedInSessions).toEqual([]);
+    expect(client.lastActiveSessionId).toBeNull();
+  });
+});

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -100,7 +100,7 @@ import type {
   Web3Provider,
 } from '@clerk/shared/types';
 import { addClerkPrefix, isAbsoluteUrl, stripScheme } from '@clerk/shared/url';
-import { allSettled, handleValueOrFn, noop } from '@clerk/shared/utils';
+import { allSettled, handleValueOrFn, noop, timeLimit } from '@clerk/shared/utils';
 import type { QueryClient } from '@tanstack/query-core';
 
 import { debugLogger, initDebugLogger } from '@/utils/debug';
@@ -191,6 +191,8 @@ const CANNOT_RENDER_SINGLE_SESSION_ENABLED_ERROR_CODE = 'cannot_render_single_se
 const CANNOT_RENDER_API_KEYS_DISABLED_ERROR_CODE = 'cannot_render_api_keys_disabled';
 const CANNOT_RENDER_API_KEYS_USER_DISABLED_ERROR_CODE = 'cannot_render_api_keys_user_disabled';
 const CANNOT_RENDER_API_KEYS_ORG_DISABLED_ERROR_CODE = 'cannot_render_api_keys_org_disabled';
+// 7s clears the measured /client edge p99.9 (~2s) with margin, so it only trips on a stuck origin
+const INITIALIZATION_TIMEOUT_MS = 7_000;
 const defaultOptions: ClerkOptions = {
   polling: true,
   standardBrowser: true,
@@ -2844,8 +2846,13 @@ export class Clerk implements ClerkInterface {
           });
 
         const initClient = async () => {
-          return Client.getOrCreateInstance()
-            .fetch()
+          // Abort the /client request on timeout so clerkjs loading does not hang
+          const clientFetchController = new AbortController();
+          return timeLimit(
+            Client.getOrCreateInstance().fetch({ abortSignal: clientFetchController.signal }),
+            INITIALIZATION_TIMEOUT_MS,
+            clientFetchController,
+          )
             .then(res => this.updateClient(res))
             .catch(async e => {
               /**
@@ -2858,27 +2865,32 @@ export class Clerk implements ClerkInterface {
 
               ++initializationDegradedCounter;
 
-              const jwtInCookie = this.#authService?.getSessionCookie();
-              const localClient = createClientFromJwt(jwtInCookie);
-
-              this.updateClient(localClient);
-
               /**
                * In most scenarios we want the poller to stop while we are fetching a fresh token during an outage.
                * We want to avoid having the below `getToken()` retrying at the same time as the poller.
                */
               this.#authService?.stopPollingForToken();
 
-              // Attempt to grab a fresh token
-              await this.session
-                ?.getToken({ skipCache: true })
-                // If the token fetch fails, let Clerk be marked as loaded and leave it up to the poller.
-                .catch(() => null)
-                .finally(() => {
-                  this.#authService?.startPollingForToken();
-                });
+              try {
+                const session = this.#defaultSession(createClientFromJwt(this.#authService?.getSessionCookie()));
+                // Prefer minting a fresh token as its claims are fresher than the cookie's
+                session?.clearCache();
+                const jwt = session
+                  ? await timeLimit(session.getToken(), INITIALIZATION_TIMEOUT_MS).catch(() => {
+                      session.clearCache();
+                      return this.#authService?.getSessionCookie();
+                    })
+                  : this.#authService?.getSessionCookie();
+                this.updateClient(createClientFromJwt(jwt));
+              } finally {
+                this.#authService?.startPollingForToken();
+              }
 
-              // Allows for Clerk to be marked as loaded with the client and session created from the JWT.
+              void Client.getOrCreateInstance()
+                .fetch()
+                .then(res => this.updateClient(res))
+                .catch(noop);
+
               return null;
             });
         };

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -260,8 +260,9 @@ export function createFapiClient(options: FapiClientOptions): FapiClient {
           initialDelay: 700,
           maxDelayBetweenRetries: 5000,
           shouldRetry: (_: unknown, iterations: number) => {
-            // We want to retry only GET requests, as other methods are not idempotent.
-            return overwrittenRequestMethod === 'GET' && iterations < maxTries;
+            // We want to retry only GET requests, as other methods are not idempotent,
+            // and stop as soon as the caller aborted the request.
+            return overwrittenRequestMethod === 'GET' && iterations < maxTries && !fetchOpts.signal?.aborted;
           },
           onBeforeRetry: (iteration: number): void => {
             // Add the retry attempt to the query string params.

--- a/packages/clerk-js/src/core/jwt-client.ts
+++ b/packages/clerk-js/src/core/jwt-client.ts
@@ -71,6 +71,10 @@ export function createClientFromJwt(jwt: string | undefined | null): Client {
         user: {
           object: 'user',
           id: userId,
+          // Epoch 1, not 0: unixEpochToDate treats 0 as "now", and a "now" timestamp makes
+          // memoizeListenerCallback consider this stub newer than the real user fetched later,
+          // so listeners would keep rendering the stub after the full client arrives.
+          updated_at: 1,
           organization_memberships:
             orgId && orgSlug && orgRole
               ? [

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -19,6 +19,7 @@ import { Client } from './internal';
 export type BaseFetchOptions = ClerkResourceReloadParams & {
   forceUpdateClient?: boolean;
   fetchMaxTries?: number;
+  abortSignal?: AbortSignal;
 };
 
 export type BaseMutateParams = {
@@ -210,6 +211,7 @@ export abstract class BaseResource {
         method: 'GET',
         path: this.path(),
         rotatingTokenNonce: opts.rotatingTokenNonce,
+        signal: opts.abortSignal,
       },
       opts,
     );

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -72,8 +72,8 @@ export class Client extends BaseResource implements ClientResource {
     return this._basePut();
   }
 
-  fetch({ fetchMaxTries }: { fetchMaxTries?: number } = {}): Promise<this> {
-    return this._baseGet({ fetchMaxTries });
+  fetch({ fetchMaxTries, abortSignal }: { fetchMaxTries?: number; abortSignal?: AbortSignal } = {}): Promise<this> {
+    return this._baseGet({ fetchMaxTries, abortSignal });
   }
 
   async destroy(): Promise<void> {

--- a/packages/shared/src/utils/__tests__/timeLimit.test.ts
+++ b/packages/shared/src/utils/__tests__/timeLimit.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { timeLimit } from '../timeLimit';
+
+describe('timeLimit', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('resolves with the value when the promise settles before ms', async () => {
+    await expect(timeLimit(Promise.resolve('token'), 10_000)).resolves.toBe('token');
+  });
+
+  it('resolves cleanly when the value is a non-promise (e.g. undefined)', async () => {
+    await expect(timeLimit(undefined, 10_000)).resolves.toBeUndefined();
+  });
+
+  it('rejects with a plain Error (no status) when ms elapses first', async () => {
+    vi.useFakeTimers();
+    const neverSettles = new Promise<string>(() => {});
+    const result = timeLimit(neverSettles, 50).catch(error => error);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    const error = await result;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: unknown }).status).toBeUndefined();
+  });
+
+  it('clears the timeout when the value settles first, leaving no pending timer', async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    await timeLimit(Promise.resolve('fast'), 10_000);
+
+    expect(clearSpy).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+  });
+
+  it('aborts the provided controller with no reason when ms elapses first', async () => {
+    vi.useFakeTimers();
+    const abort = vi.fn();
+    const neverSettles = new Promise<string>(() => {});
+    const result = timeLimit(neverSettles, 50, { abort }).catch(error => error);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await result;
+    // Abort carries no reason so the internal timeout error is never exposed via signal.reason.
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledWith();
+  });
+
+  it('does not abort when the value settles before ms', async () => {
+    const abort = vi.fn();
+
+    await timeLimit(Promise.resolve('fast'), 10_000, { abort });
+
+    expect(abort).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,3 +6,4 @@ export { noop } from './noop';
 export * from './runtimeEnvironment';
 export { handleValueOrFn } from './handleValueOrFn';
 export { fastDeepMergeAndReplace, fastDeepMergeAndKeep } from './fastDeepMerge';
+export { timeLimit } from './timeLimit';

--- a/packages/shared/src/utils/timeLimit.ts
+++ b/packages/shared/src/utils/timeLimit.ts
@@ -1,0 +1,22 @@
+export function timeLimit<T>(
+  value: T | PromiseLike<T>,
+  ms: number,
+  abortController?: Pick<AbortController, 'abort'>,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      const error = new Error(`Timed out after ${ms}ms`);
+      abortController?.abort();
+      reject(error);
+    }, ms);
+
+    // Let a Node process exit while the timeout is still pending; browsers return a number with no unref.
+    (timeoutId as { unref?: () => void }).unref?.();
+  });
+
+  return Promise.race([Promise.resolve(value), timeoutPromise]).finally(() => {
+    clearTimeout(timeoutId);
+  });
+}


### PR DESCRIPTION
Backports the fail-fast slow-origin load fix from [#9065](https://github.com/clerk/javascript/pull/9065) to the `release/core-2` line.

When Clerk's Frontend API is slow or unreachable during load, a cold `Clerk.load()` could hang for a long time. The `/client` request had no timeout, and on a 5xx or network error the recovery path burned the full retry budget before Clerk was marked loaded, so during an origin outage the app sat unresponsive instead of degrading and rendering.

What changed
The `/client` fetch and the load-recovery token mint are now bounded by a 7s timeout, and the timed-out `/client` request is aborted instead of being left in flight (via a new optional `abortSignal` threaded through `Client.fetch` down to the native fetch signal). On a slow or failed `/client`, recovery renders identity from the `__session` cookie, clears the session's token cache so the mint bypasses the cache, and keeps the cookie identity if the mint times out. After a degraded load, the client is re-fetched in the background without a time limit so a slow-but-healthy origin recovers full client data without a reload. Also adds a `timeLimit` utility to `@clerk/shared/utils`.

As-is backport
This matches main's current behavior, including the known gaps documented on [#9065](https://github.com/clerk/javascript/pull/9065): the `/environment` request is not yet bounded, and the recovery mint stops waiting but isn't cancellable. Those are intentionally carried over so core-2 tracks main, and will be backported once they're addressed there.

Adapted to core-2
`release/core-2` diverged from main about 7 months ago, so this is an adaptation rather than a cherry-pick. Core-2 already had `createClientFromJwt` and the `tokenFreshness` guard (backported in [#9090](https://github.com/clerk/javascript/pull/9090)), so only the `initClient` recovery body in `load()` was swapped; the `abortSignal` plumbing and the `timeLimit` util are net-new. No `#clientUpdateGeneration` guard exists on core-2 and none was added.

Verification
On the core-2 branch: `timeLimit` 6/6, `clerk.test.ts` 109/109 (including 7 new degraded-load tests), `jwt-client.test.ts` 3/3, `fapiClient.test.ts` 26 passing, and the clerk-js declarations typecheck is clean.
