### PR TITLE
feat(ui): add composed profile shell, providers infra and stub router

### DIFF
--- a/packages/ui/src/composed/APIKeysSection.tsx
+++ b/packages/ui/src/composed/APIKeysSection.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Suspense, type ComponentType, type ReactNode } from 'react';
+
+import { CardStateProvider } from '../elements/contexts';
+
+export function APIKeysSection({ page: Page }: { page: ComponentType }): ReactNode {
+  return (
+    <CardStateProvider>
+      <Suspense fallback={null}>
+        <Page />
+      </Suspense>
+    </CardStateProvider>
+  );
+}

--- a/packages/ui/src/composed/BillingSection.tsx
+++ b/packages/ui/src/composed/BillingSection.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Suspense, type ComponentType, type ReactNode } from 'react';
+
+import { RouteContext } from '../router/RouteContext';
+import { useBillingRouter } from './useBillingRouter';
+
+type BillingSectionProps = {
+  billing: ComponentType;
+  plans: ComponentType;
+  statement: ComponentType;
+  paymentAttempt: ComponentType;
+};
+
+export function BillingSection({
+  billing: Billing,
+  plans: Plans,
+  statement: Statement,
+  paymentAttempt: PaymentAttempt,
+}: BillingSectionProps): ReactNode {
+  const { router, route } = useBillingRouter();
+
+  let content: ReactNode;
+  switch (route.page) {
+    case 'plans':
+      content = <Plans />;
+      break;
+    case 'statement':
+      content = <Statement />;
+      break;
+    case 'payment-attempt':
+      content = <PaymentAttempt />;
+      break;
+    default:
+      content = <Billing />;
+  }
+
+  return (
+    <RouteContext.Provider value={router}>
+      <Suspense fallback={null}>{content}</Suspense>
+    </RouteContext.Provider>
+  );
+}

--- a/packages/ui/src/composed/PageContext.tsx
+++ b/packages/ui/src/composed/PageContext.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+type PageId = 'account' | 'security' | 'general';
+
+export const PageContext = createContext<PageId | null>(null);

--- a/packages/ui/src/composed/ProfileProviderShell.tsx
+++ b/packages/ui/src/composed/ProfileProviderShell.tsx
@@ -9,6 +9,7 @@
 // `styleCacheStore` so sibling composed roots don't duplicate style insertions.
 
 import { ClerkRuntimeError } from '@clerk/shared/error';
+import { logger } from '@clerk/shared/logger';
 import type { ModuleManager } from '@clerk/shared/moduleManager';
 import type { EnvironmentResource, LoadedClerk } from '@clerk/shared/types';
 // eslint-disable-next-line no-restricted-imports
@@ -19,7 +20,7 @@ import { useMemo } from 'react';
 import { AppearanceProvider } from '@/ui/customizables/AppearanceContext';
 import { FlowMetadataProvider } from '@/ui/elements/contexts';
 import type { Appearance, Elements } from '@/ui/internal/appearance';
-import { getStyleCache, setStyleCache } from '@/ui/internal/styleCacheStore';
+import { getStyleCacheEntry, setStyleCache } from '@/ui/internal/styleCacheStore';
 import { RouteContext } from '@/ui/router/RouteContext';
 import { InternalThemeProvider } from '@/ui/styledSystem';
 import { createEmotionCache } from '@/ui/styledSystem/createEmotionCache';
@@ -46,6 +47,55 @@ export const fallbackModuleManager: ModuleManager = {
     ),
 };
 
+// `__internal_environment` is a getter on the concrete clerk-js Clerk class but
+// is absent from the shared `LoadedClerk` type (composed profiles are newer than
+// that getter on some clerk-js versions in the wild), so it is read through a
+// narrow structural type rather than the typed interface.
+type ClerkWithInternalEnvironment = {
+  __internal_environment?: EnvironmentResource | null;
+};
+
+/**
+ * Resolves the clerk-js runtime state (environment + module manager) that the
+ * composed profile shell needs. Composed UI is bundled into the consumer app but
+ * clerk-js is hotloaded separately, so an app can bundle composed components that
+ * are newer than the loaded clerk-js. `moduleManager` falls back to a loud stub;
+ * `environment` can only be absent, so once clerk has finished loading a missing
+ * runtime is a real version mismatch and gets a one-time warning instead of a
+ * silent blank render.
+ */
+export function resolveComposedClerkRuntime(
+  clerk: LoadedClerk,
+  clerkLoaded: boolean,
+): { environment: EnvironmentResource | null | undefined; moduleManager: ModuleManager } {
+  // SAFETY: __internal_environment is a real getter on the clerk-js Clerk class
+  // but not on the shared LoadedClerk interface. Narrowing to an optional field
+  // (not `any`) keeps the access typed and forces callers to handle `undefined`.
+  const environment = (clerk as LoadedClerk & ClerkWithInternalEnvironment).__internal_environment;
+  const moduleManager = clerk.__internal_moduleManager ?? fallbackModuleManager;
+
+  if (clerkLoaded && (!environment || clerk.__internal_moduleManager === undefined)) {
+    logger.warnOnce(
+      'Clerk: Composed profile components could not read the runtime state (environment/module manager) from the loaded @clerk/clerk-js, so nothing will render. This usually means the loaded clerk-js is older than the composed components bundled in your app. Upgrade @clerk/clerk-js (or your framework SDK) to a version that supports composed profiles.',
+    );
+  }
+
+  return { environment, moduleManager };
+}
+
+// `nonce` lives on IsomorphicClerkOptions, not ClerkOptions, so `__internal_getOption`'s
+// `K extends keyof ClerkOptions` constraint rejects the key even though clerk-js stores
+// and returns it at runtime.
+type ClerkWithNonceOption = { __internal_getOption(key: string): string | undefined };
+
+function readNonceOption(clerk: LoadedClerk): string | undefined {
+  // SAFETY: nonce is a runtime option clerk-js resolves through the same getter,
+  // but its key is absent from the typed ClerkOptions surface. Narrowing to a
+  // string-keyed method (not `any`) keeps the return typed. Called as a method so
+  // the getter keeps its `this` binding to the clerk instance.
+  return (clerk as unknown as ClerkWithNonceOption).__internal_getOption('nonce');
+}
+
 const composedOverrides: Elements = {
   profilePageContent: { padding: 0 },
 };
@@ -67,14 +117,17 @@ type SharedStyleCacheProviderProps = PropsWithChildren<{
 }>;
 
 // One emotion cache per clerk instance, so sibling composed roots share inserts.
+// Reuse the stored cache only when it was built from the same nonce/cssLayerName;
+// a change to either rebuilds it (mirroring the AIO StyleCacheProvider) instead of
+// pinning whatever the first-mounted sibling saw.
 function SharedStyleCacheProvider({ clerk, nonce, cssLayerName, children }: SharedStyleCacheProviderProps): ReactNode {
   const cache = useMemo(() => {
-    const existing = getStyleCache(clerk);
-    if (existing) {
-      return existing;
+    const existing = getStyleCacheEntry(clerk);
+    if (existing && existing.nonce === nonce && existing.cssLayerName === cssLayerName) {
+      return existing.cache;
     }
     const next = createEmotionCache({ nonce, cssLayerName });
-    setStyleCache(clerk, next);
+    setStyleCache(clerk, { cache: next, nonce, cssLayerName });
     return next;
   }, [clerk, nonce, cssLayerName]);
 
@@ -114,8 +167,7 @@ export function ProfileProviderShell({
   return (
     <SharedStyleCacheProvider
       clerk={clerk}
-      // nonce lives on IsomorphicClerkOptions, not ClerkOptions, so the typed K-constraint rejects it
-      nonce={(clerk as any).__internal_getOption('nonce')}
+      nonce={readNonceOption(clerk)}
       cssLayerName={normalizedGlobalAppearance?.cssLayerName}
     >
       {/* parsed appearance for cl-* styled components */}

--- a/packages/ui/src/composed/ProfileProviderShell.tsx
+++ b/packages/ui/src/composed/ProfileProviderShell.tsx
@@ -47,10 +47,6 @@ export const fallbackModuleManager: ModuleManager = {
     ),
 };
 
-// `__internal_environment` is a getter on the concrete clerk-js Clerk class but
-// is absent from the shared `LoadedClerk` type (composed profiles are newer than
-// that getter on some clerk-js versions in the wild), so it is read through a
-// narrow structural type rather than the typed interface.
 type ClerkWithInternalEnvironment = {
   __internal_environment?: EnvironmentResource | null;
 };
@@ -68,9 +64,7 @@ export function resolveComposedClerkRuntime(
   clerk: LoadedClerk,
   clerkLoaded: boolean,
 ): { environment: EnvironmentResource | null | undefined; moduleManager: ModuleManager } {
-  // SAFETY: __internal_environment is a real getter on the clerk-js Clerk class
-  // but not on the shared LoadedClerk interface. Narrowing to an optional field
-  // (not `any`) keeps the access typed and forces callers to handle `undefined`.
+  // SAFETY: __internal_environment is a real clerk-js getter absent from the shared LoadedClerk type; narrowing (not `any`) keeps it typed.
   const environment = (clerk as LoadedClerk & ClerkWithInternalEnvironment).__internal_environment;
   const moduleManager = clerk.__internal_moduleManager ?? fallbackModuleManager;
 
@@ -83,16 +77,10 @@ export function resolveComposedClerkRuntime(
   return { environment, moduleManager };
 }
 
-// `nonce` lives on IsomorphicClerkOptions, not ClerkOptions, so `__internal_getOption`'s
-// `K extends keyof ClerkOptions` constraint rejects the key even though clerk-js stores
-// and returns it at runtime.
 type ClerkWithNonceOption = { __internal_getOption(key: string): string | undefined };
 
 function readNonceOption(clerk: LoadedClerk): string | undefined {
-  // SAFETY: nonce is a runtime option clerk-js resolves through the same getter,
-  // but its key is absent from the typed ClerkOptions surface. Narrowing to a
-  // string-keyed method (not `any`) keeps the return typed. Called as a method so
-  // the getter keeps its `this` binding to the clerk instance.
+  // SAFETY: nonce is a runtime clerk-js option whose key is absent from the typed ClerkOptions; narrowing (not `any`) keeps the return typed. Called as a method to preserve `this`.
   return (clerk as unknown as ClerkWithNonceOption).__internal_getOption('nonce');
 }
 
@@ -150,8 +138,8 @@ export function ProfileProviderShell({
   // state — a consumer URL change wouldn't be a meaningful signal to clear
   // either, so observing it would only cause spurious clears.
   const router = useMemo(() => createComposedRouter(clerk.navigate), [clerk]);
-  // Match the portal path's normalization (Components.tsx:209) so a cssLayerName
-  // nested inside appearance.theme gets hoisted to top-level for @layer wrapping.
+  // Match the portal path's appearance normalization so a cssLayerName nested inside
+  // appearance.theme gets hoisted to top-level for @layer wrapping.
   const normalizedGlobalAppearance = useMemo(
     () => extractCssLayerNameFromAppearance(globalAppearance),
     [globalAppearance],

--- a/packages/ui/src/composed/ProfileProviderShell.tsx
+++ b/packages/ui/src/composed/ProfileProviderShell.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+// Composed UserProfile / OrganizationProfile mount outside the clerk-js portal
+// tree, so this shell rebuilds the providers normally split between
+// `LazyProviders` and `LazyComponentRenderer` / `LazyModalRenderer` in
+// `packages/ui/src/lazyModules/providers.tsx`. `ClerkContextProvider` is
+// intentionally omitted — the consumer's `<ClerkProvider>` supplies `clerk` via
+// `useClerk()`. The emotion cache is keyed per clerk instance in
+// `styleCacheStore` so sibling composed roots don't duplicate style insertions.
+
+import { ClerkRuntimeError } from '@clerk/shared/error';
+import type { ModuleManager } from '@clerk/shared/moduleManager';
+import type { EnvironmentResource, LoadedClerk } from '@clerk/shared/types';
+// eslint-disable-next-line no-restricted-imports
+import { CacheProvider } from '@emotion/react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import { useMemo } from 'react';
+
+import { AppearanceProvider } from '@/ui/customizables/AppearanceContext';
+import { FlowMetadataProvider } from '@/ui/elements/contexts';
+import type { Appearance, Elements } from '@/ui/internal/appearance';
+import { getStyleCache, setStyleCache } from '@/ui/internal/styleCacheStore';
+import { RouteContext } from '@/ui/router/RouteContext';
+import { InternalThemeProvider } from '@/ui/styledSystem';
+import { createEmotionCache } from '@/ui/styledSystem/createEmotionCache';
+import { extractCssLayerNameFromAppearance } from '@/ui/utils/extractCssLayerNameFromAppearance';
+
+import { EnvironmentProvider } from '../contexts/EnvironmentContext';
+import { ModuleManagerProvider } from '../contexts/ModuleManagerContext';
+import { OptionsProvider } from '../contexts/OptionsContext';
+import { AppearanceOverrides } from '../elements/AppearanceOverrides';
+import { createComposedRouter } from './stubRouter';
+
+// Used when `clerk.__internal_moduleManager` is `undefined`. In a correctly wired app clerk-js
+// exposes its ModuleManager through that getter, so reaching this means the loaded clerk-js is too
+// old to expose it (an older clerk-js also predates composed profiles entirely). Fail loudly on the
+// first dynamic import (Web3, billing, password strength) instead of silently resolving `undefined`
+// and surfacing later as an opaque access on the missing module.
+export const fallbackModuleManager: ModuleManager = {
+  import: () =>
+    Promise.reject(
+      new ClerkRuntimeError(
+        'Composed profile components could not resolve a Clerk module manager: this Clerk instance does not expose one. This usually means the loaded @clerk/clerk-js is too old to support composed profiles.',
+        { code: 'composed_module_manager_unavailable' },
+      ),
+    ),
+};
+
+const composedOverrides: Elements = {
+  profilePageContent: { padding: 0 },
+};
+
+type ProfileProviderShellProps = PropsWithChildren<{
+  clerk: LoadedClerk;
+  environment: EnvironmentResource;
+  moduleManager: ModuleManager;
+  appearanceKey: 'userProfile' | 'organizationProfile';
+  flow: 'userProfile' | 'organizationProfile';
+  globalAppearance: Appearance | undefined;
+  appearance?: Appearance;
+}>;
+
+type SharedStyleCacheProviderProps = PropsWithChildren<{
+  clerk: LoadedClerk;
+  nonce?: string;
+  cssLayerName?: string;
+}>;
+
+// One emotion cache per clerk instance, so sibling composed roots share inserts.
+function SharedStyleCacheProvider({ clerk, nonce, cssLayerName, children }: SharedStyleCacheProviderProps): ReactNode {
+  const cache = useMemo(() => {
+    const existing = getStyleCache(clerk);
+    if (existing) {
+      return existing;
+    }
+    const next = createEmotionCache({ nonce, cssLayerName });
+    setStyleCache(clerk, next);
+    return next;
+  }, [clerk, nonce, cssLayerName]);
+
+  return <CacheProvider value={cache}>{children}</CacheProvider>;
+}
+
+export function ProfileProviderShell({
+  children,
+  clerk,
+  environment,
+  moduleManager,
+  appearanceKey,
+  flow,
+  globalAppearance,
+  appearance,
+}: ProfileProviderShellProps): ReactNode {
+  // currentPath is left empty: composed has no Clerk-internal navigation. Each
+  // section owns its own CardStateProvider, so errors clear on section unmount
+  // (single-section mounting). Side-by-side sections keep independent error
+  // state — a consumer URL change wouldn't be a meaningful signal to clear
+  // either, so observing it would only cause spurious clears.
+  const router = useMemo(() => createComposedRouter(clerk.navigate), [clerk]);
+  // Match the portal path's normalization (Components.tsx:209) so a cssLayerName
+  // nested inside appearance.theme gets hoisted to top-level for @layer wrapping.
+  const normalizedGlobalAppearance = useMemo(
+    () => extractCssLayerNameFromAppearance(globalAppearance),
+    [globalAppearance],
+  );
+  const options = useMemo(
+    () => ({
+      localization: clerk.__internal_getOption('localization'),
+      supportEmail: clerk.__internal_getOption('supportEmail'),
+    }),
+    [clerk],
+  );
+
+  return (
+    <SharedStyleCacheProvider
+      clerk={clerk}
+      // nonce lives on IsomorphicClerkOptions, not ClerkOptions, so the typed K-constraint rejects it
+      nonce={(clerk as any).__internal_getOption('nonce')}
+      cssLayerName={normalizedGlobalAppearance?.cssLayerName}
+    >
+      {/* parsed appearance for cl-* styled components */}
+      <AppearanceProvider
+        appearanceKey={appearanceKey}
+        globalAppearance={normalizedGlobalAppearance}
+        appearance={appearance}
+      >
+        {/* flow= for Flow.Root/Part data-clerk-* selectors */}
+        <FlowMetadataProvider flow={flow}>
+          {/* Emotion ThemeProvider over parsed theme */}
+          <InternalThemeProvider>
+            {/* dynamic-import bridge (Web3) */}
+            <ModuleManagerProvider moduleManager={moduleManager}>
+              {/* threads localization + supportEmail from the consumer's <ClerkProvider> */}
+              <OptionsProvider value={options}>
+                {/* read by useEnvironment() across MFA/account sections */}
+                <EnvironmentProvider value={environment}>
+                  {/* router stub: navigate→clerk.navigate, matches/refresh no-op */}
+                  <RouteContext.Provider value={router}>
+                    {/* zero out profilePageContent padding when embedded */}
+                    <AppearanceOverrides elements={composedOverrides}>{children}</AppearanceOverrides>
+                  </RouteContext.Provider>
+                </EnvironmentProvider>
+              </OptionsProvider>
+            </ModuleManagerProvider>
+          </InternalThemeProvider>
+        </FlowMetadataProvider>
+      </AppearanceProvider>
+    </SharedStyleCacheProvider>
+  );
+}

--- a/packages/ui/src/composed/__tests__/stub-limitations.test.ts
+++ b/packages/ui/src/composed/__tests__/stub-limitations.test.ts
@@ -1,0 +1,131 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createComposedRouter, stubRouter } from '../stubRouter';
+import { useBillingRouter } from '../useBillingRouter';
+
+describe('createComposedRouter', () => {
+  it('navigate delegates to clerkNavigate for same-origin paths', async () => {
+    const clerkNavigate = vi.fn().mockResolvedValue(undefined);
+    const router = createComposedRouter(clerkNavigate);
+
+    await router.navigate('/dashboard');
+
+    expect(clerkNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('navigate delegates to clerkNavigate for relative paths', async () => {
+    const clerkNavigate = vi.fn().mockResolvedValue(undefined);
+    const router = createComposedRouter(clerkNavigate);
+
+    await router.navigate('../');
+
+    expect(clerkNavigate).toHaveBeenCalledWith('../');
+  });
+
+  it('navigate delegates to clerkNavigate for external URLs', async () => {
+    const clerkNavigate = vi.fn().mockResolvedValue(undefined);
+    const router = createComposedRouter(clerkNavigate);
+
+    await router.navigate('https://external.example.com/callback');
+
+    expect(clerkNavigate).toHaveBeenCalledWith('https://external.example.com/callback');
+  });
+
+  it('baseNavigate delegates to clerkNavigate with URL href', async () => {
+    const clerkNavigate = vi.fn().mockResolvedValue(undefined);
+    const router = createComposedRouter(clerkNavigate);
+
+    await router.baseNavigate(new URL('https://example.com/path'));
+
+    expect(clerkNavigate).toHaveBeenCalledWith('https://example.com/path');
+  });
+
+  it('resolve produces URLs relative to current location', () => {
+    const router = createComposedRouter(vi.fn());
+
+    const resolved = router.resolve('/some-path');
+    expect(resolved.pathname).toBe('/some-path');
+  });
+});
+
+describe('createComposedRouter — AIO-only APIs throw in dev', () => {
+  it('matches() throws', () => {
+    const router = createComposedRouter(vi.fn());
+    expect(() => router.matches('/foo')).toThrow(/not supported inside composed sections/);
+  });
+
+  it('refresh() throws', () => {
+    const router = createComposedRouter(vi.fn());
+    expect(() => router.refresh()).toThrow(/not supported inside composed sections/);
+  });
+
+  it('getMatchData() throws', () => {
+    const router = createComposedRouter(vi.fn());
+    expect(() => router.getMatchData('/foo')).toThrow(/not supported inside composed sections/);
+  });
+});
+
+describe('stubRouter fallback', () => {
+  it('is created with window.location.assign as navigator', () => {
+    // stubRouter is a pre-built instance that delegates to window.location.assign.
+    // We can't spy on window.location.assign in jsdom, but we verify it's a valid router.
+    expect(stubRouter.navigate).toBeDefined();
+    expect(stubRouter.baseNavigate).toBeDefined();
+  });
+});
+
+describe('useBillingRouter — in-memory by design', () => {
+  // Composed billing routing is purely React state — the consumer owns the
+  // page URL. Trade-off: back/forward, refresh, and deep-links do not preserve
+  // sub-route or tab state. These tests pin that decision.
+
+  let originalHash: string;
+
+  afterEach(() => {
+    window.location.hash = originalHash ?? '';
+  });
+
+  it('navigate() does not touch window.location.hash', async () => {
+    originalHash = window.location.hash;
+    const { result } = renderHook(() => useBillingRouter());
+
+    await act(async () => {
+      await result.current.router.navigate('plans');
+    });
+
+    expect(window.location.hash).toBe(originalHash);
+    expect(result.current.route.page).toBe('plans');
+  });
+
+  it('navigate() does not push a history entry', async () => {
+    const before = window.history.length;
+    const { result } = renderHook(() => useBillingRouter());
+
+    await act(async () => {
+      await result.current.router.navigate('statement/abc');
+    });
+
+    expect(window.history.length).toBe(before);
+  });
+});
+
+describe('createComposedRouter — SSR safety', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolve() does not throw when window is undefined', () => {
+    vi.stubGlobal('window', undefined);
+
+    const router = createComposedRouter(vi.fn());
+    expect(() => router.resolve('/some-path')).not.toThrow();
+    expect(router.resolve('/some-path').pathname).toBe('/some-path');
+  });
+
+  it('stubRouter.navigate is a no-op (does not throw) when window is undefined', async () => {
+    vi.stubGlobal('window', undefined);
+
+    await expect(stubRouter.navigate('/foo')).resolves.toBeUndefined();
+  });
+});

--- a/packages/ui/src/composed/createSection.tsx
+++ b/packages/ui/src/composed/createSection.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import type { ComponentType, ReactNode } from 'react';
+
+import { useRequirePage } from './useRequirePage';
+
+export function createSection(name: string, Component: ComponentType): () => ReactNode {
+  function Section(): ReactNode {
+    if (!useRequirePage(name)) return null;
+    return <Component />;
+  }
+  Section.displayName = name;
+  return Section;
+}

--- a/packages/ui/src/composed/stubRouter.ts
+++ b/packages/ui/src/composed/stubRouter.ts
@@ -1,0 +1,57 @@
+import type { RouteContextValue } from '../router/RouteContext';
+
+const SSR_BASE = 'http://localhost/';
+
+// Composed sections render outside the AIO Route/Switch tree, so the stub
+// router has no path-matching state. Calls into these APIs almost always mean
+// someone added a <Route>, navigateToFlowStart(), or refresh() inside a
+// composed section — fail loudly in dev so that's caught at the test level
+// instead of silently rendering null.
+function unsupported(api: string): never {
+  throw new Error(
+    `[@clerk/ui composed] router.${api} is not supported inside composed sections. ` +
+      `Composed sections are leaf-only — <Route>, navigateToFlowStart(), router.refresh(), ` +
+      `getMatchData() and urlStateParam are AIO-only. Move routing to the consumer.`,
+  );
+}
+
+function maybeUnsupported<T>(api: string, prodValue: T): T {
+  if (typeof __DEV__ === 'undefined' || __DEV__) {
+    unsupported(api);
+  }
+  return prodValue;
+}
+
+export function createComposedRouter(
+  clerkNavigate: (to: string) => Promise<unknown> | void,
+  currentPath: string = '',
+): RouteContextValue {
+  return {
+    basePath: '',
+    startPath: '',
+    flowStartPath: '',
+    fullPath: '',
+    indexPath: '',
+    currentPath,
+    matches: () => maybeUnsupported('matches()', false),
+    navigate: async (to: string) => {
+      await clerkNavigate(to);
+    },
+    baseNavigate: async (toURL: URL) => {
+      await clerkNavigate(toURL.href);
+    },
+    resolve: (to: string) => new URL(to, typeof window !== 'undefined' ? window.location.href : SSR_BASE),
+    refresh: () => maybeUnsupported('refresh()', undefined),
+    params: {},
+    queryString: '',
+    queryParams: {},
+    getMatchData: () => maybeUnsupported('getMatchData()', false),
+  };
+}
+
+export const stubRouter: RouteContextValue = createComposedRouter(to => {
+  if (typeof window !== 'undefined') {
+    window.location.assign(to);
+  }
+  return Promise.resolve();
+});

--- a/packages/ui/src/composed/useBillingRouter.ts
+++ b/packages/ui/src/composed/useBillingRouter.ts
@@ -1,0 +1,98 @@
+// In-memory routing for composed billing — intentionally not URL-backed. The
+// consumer owns the page URL, so we don't touch hash/history. Trade-off:
+// back/forward, refresh, and deep-links don't preserve sub-route or tab state.
+import { useMemo, useState } from 'react';
+
+import type { RouteContextValue } from '../router/RouteContext';
+import { stubRouter } from './stubRouter';
+
+type BillingRoute =
+  | { page: 'billing' }
+  | { page: 'plans' }
+  | { page: 'statement'; statementId: string }
+  | { page: 'payment-attempt'; paymentAttemptId: string };
+
+function resolveNavigation(to: string): BillingRoute {
+  let path = to;
+  while (path.startsWith('../')) {
+    path = path.slice(3);
+  }
+
+  if (!path || path === '/') {
+    return { page: 'billing' };
+  }
+
+  if (path === 'plans') {
+    return { page: 'plans' };
+  }
+
+  const statementMatch = path.match(/^statement\/(.+)$/);
+  if (statementMatch) {
+    return { page: 'statement', statementId: statementMatch[1] };
+  }
+
+  const paymentMatch = path.match(/^payment-attempt\/(.+)$/);
+  if (paymentMatch) {
+    return { page: 'payment-attempt', paymentAttemptId: paymentMatch[1] };
+  }
+
+  return { page: 'billing' };
+}
+
+function pathFromRoute(route: BillingRoute): string {
+  switch (route.page) {
+    case 'plans':
+      return 'billing/plans';
+    case 'statement':
+      return `billing/statement/${route.statementId}`;
+    case 'payment-attempt':
+      return `billing/payment-attempt/${route.paymentAttemptId}`;
+    default:
+      return 'billing';
+  }
+}
+
+function paramsFromRoute(route: BillingRoute): Record<string, string> {
+  switch (route.page) {
+    case 'statement':
+      return { statementId: route.statementId };
+    case 'payment-attempt':
+      return { paymentAttemptId: route.paymentAttemptId };
+    default:
+      return {};
+  }
+}
+
+export function useBillingRouter(): { router: RouteContextValue; route: BillingRoute } {
+  const [route, setRoute] = useState<BillingRoute>({ page: 'billing' });
+  const [queryParams, setQueryParams] = useState<Record<string, string>>({});
+
+  const router: RouteContextValue = useMemo(
+    () => ({
+      ...stubRouter,
+      currentPath: pathFromRoute(route),
+      params: paramsFromRoute(route),
+      queryParams,
+      queryString: new URLSearchParams(queryParams).toString(),
+      navigate: async (to: string, options?: { searchParams?: URLSearchParams }) => {
+        try {
+          const url = new URL(to);
+          if (url.origin !== window.location.origin) {
+            window.location.href = to;
+            return;
+          }
+        } catch {}
+        const newRoute = resolveNavigation(to);
+        setRoute(newRoute);
+        if (options?.searchParams) {
+          setQueryParams(Object.fromEntries(options.searchParams.entries()));
+        } else if (newRoute.page !== route.page) {
+          setQueryParams({});
+        }
+      },
+    }),
+    [route, queryParams],
+  );
+
+  return { router, route };
+}

--- a/packages/ui/src/composed/useBillingRouter.ts
+++ b/packages/ui/src/composed/useBillingRouter.ts
@@ -1,6 +1,8 @@
 // In-memory routing for composed billing — intentionally not URL-backed. The
 // consumer owns the page URL, so we don't touch hash/history. Trade-off:
 // back/forward, refresh, and deep-links don't preserve sub-route or tab state.
+// Composed sections are leaf-only (see stubRouter), so this is a typed in-memory
+// state machine rather than VirtualRouter/BaseRouter <Route> matching.
 import { useMemo, useState } from 'react';
 
 import type { RouteContextValue } from '../router/RouteContext';

--- a/packages/ui/src/composed/useRequirePage.ts
+++ b/packages/ui/src/composed/useRequirePage.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+
+import { PageContext } from './PageContext';
+
+export function useRequirePage(componentName: string): boolean {
+  const page = useContext(PageContext);
+  if (!page) {
+    if (typeof __DEV__ === 'undefined' || __DEV__) {
+      throw new Error(
+        `<${componentName}> must be rendered inside a page component (e.g. <UserProfileAccountPanel>, <UserProfileSecurityPanel>, <OrganizationProfileGeneralPanel>).`,
+      );
+    }
+    return false;
+  }
+  return true;
+}

--- a/packages/ui/src/composed/useRequirePage.ts
+++ b/packages/ui/src/composed/useRequirePage.ts
@@ -1,11 +1,15 @@
+import { useClerk } from '@clerk/shared/react';
 import { useContext } from 'react';
+
+import { isDevelopmentSDK } from '@/ui/utils/runtimeEnvironment';
 
 import { PageContext } from './PageContext';
 
 export function useRequirePage(componentName: string): boolean {
+  const clerk = useClerk();
   const page = useContext(PageContext);
   if (!page) {
-    if (typeof __DEV__ === 'undefined' || __DEV__) {
+    if (isDevelopmentSDK(clerk)) {
       throw new Error(
         `<${componentName}> must be rendered inside a page component (e.g. <UserProfileAccountPanel>, <UserProfileSecurityPanel>, <OrganizationProfileGeneralPanel>).`,
       );

--- a/packages/ui/src/internal/styleCacheStore.ts
+++ b/packages/ui/src/internal/styleCacheStore.ts
@@ -1,15 +1,10 @@
 // eslint-disable-next-line no-restricted-imports
 import type { EmotionCache } from '@emotion/cache';
 
-// Why: composed profile roots (UserProfile + OrganizationProfile) mount as
-// separate React roots in the consumer tree, so N can be live per clerk instance.
-// One `cl-internal` emotion cache per instance is the invariant (two live caches,
-// same key = duplicate style inserts, broken emotion dedup/ordering). AIO gets this
-// free from its single portal tree; composed reconstructs it by keying the cache
-// on the clerk instance here so sibling roots reuse one cache instead of each making
-// their own. The cache is stored with the nonce/cssLayerName it was built from so a
-// later change to either rebuilds it (matching the AIO StyleCacheProvider) instead
-// of pinning whatever the first-mounted root happened to see.
+// Sibling composed roots share one `cl-internal` emotion cache per clerk instance;
+// two live caches under the same key would duplicate style inserts. Keyed with the
+// nonce/cssLayerName it was built from so a change to either rebuilds it (matching
+// the AIO StyleCacheProvider).
 type StyleCacheEntry = {
   cache: EmotionCache;
   nonce: string | undefined;

--- a/packages/ui/src/internal/styleCacheStore.ts
+++ b/packages/ui/src/internal/styleCacheStore.ts
@@ -7,13 +7,25 @@ import type { EmotionCache } from '@emotion/cache';
 // same key = duplicate style inserts, broken emotion dedup/ordering). AIO gets this
 // free from its single portal tree; composed reconstructs it by keying the cache
 // on the clerk instance here so sibling roots reuse one cache instead of each making
-// their own.
-const store = new WeakMap<object, EmotionCache>();
+// their own. The cache is stored with the nonce/cssLayerName it was built from so a
+// later change to either rebuilds it (matching the AIO StyleCacheProvider) instead
+// of pinning whatever the first-mounted root happened to see.
+type StyleCacheEntry = {
+  cache: EmotionCache;
+  nonce: string | undefined;
+  cssLayerName: string | undefined;
+};
 
-export function getStyleCache(clerkInstance: object): EmotionCache | undefined {
+const store = new WeakMap<object, StyleCacheEntry>();
+
+export function getStyleCacheEntry(clerkInstance: object): StyleCacheEntry | undefined {
   return store.get(clerkInstance);
 }
 
-export function setStyleCache(clerkInstance: object, cache: EmotionCache): void {
-  store.set(clerkInstance, cache);
+export function getStyleCache(clerkInstance: object): EmotionCache | undefined {
+  return store.get(clerkInstance)?.cache;
+}
+
+export function setStyleCache(clerkInstance: object, entry: StyleCacheEntry): void {
+  store.set(clerkInstance, entry);
 }


### PR DESCRIPTION
Stack 4/7. New (unexported) infra for the composed profile API: `ProfileProviderShell`, `stubRouter`, `useBillingRouter`, `useRequirePage`, `PageContext`, `createSection`, plus the shared `APIKeysSection`/`BillingSection` used by both User and Org composed dirs.

Nothing is exported from the package yet.

_Changesets live only on the release PR #9144; this PR carries none._

<!-- stack-table -->

---

### Stack

Reviewed as a stack. The 7 PRs merge bottom-up into release branch #9144, which integrates into `main` as a single unit.

| # | PR | Layer |
|---|----|-------|
| – | #9144 | release → `main` (integration) |
| 1 | #9130 | moduleManager getter across build boundary |
| 2 | #9131 | shared profile UI infra |
| 3 | #9132 | extract Section components from profile pages |
| 4 | **#9133** 👈 | **composed shell + providers infra** |
| 5 | #9134 | composed UserProfile |
| 6 | #9135 | composed OrganizationProfile |
| 7 | #9136 | expose `@clerk/ui/experimental` (public API) |