### PR TITLE
feat(ui): add composed UserProfile panels and section components

### DIFF
--- a/packages/ui/src/composed/UserProfile/APIKeys.tsx
+++ b/packages/ui/src/composed/UserProfile/APIKeys.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { lazy, type ReactNode } from 'react';
+
+import { APIKeysSection } from '../APIKeysSection';
+
+const APIKeysPage = lazy(() =>
+  import('../../components/UserProfile/APIKeysPage').then(m => ({
+    default: m.APIKeysPage,
+  })),
+);
+
+export const UserProfileAPIKeysPanel = (): ReactNode => <APIKeysSection page={APIKeysPage} />;

--- a/packages/ui/src/composed/UserProfile/Account.tsx
+++ b/packages/ui/src/composed/UserProfile/Account.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { CardStateProvider, useCardState } from '@/ui/elements/contexts';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
+
+import { AccountPage } from '../../components/UserProfile/AccountPage';
+import { localizationKeys } from '../../customizables';
+import { PageContext } from '../PageContext';
+
+function AccountComposed({ children }: PropsWithChildren): ReactNode {
+  const card = useCardState();
+  return (
+    <ProfileCard.Page>
+      <ProfileCard.PagePanel
+        pageId='account'
+        titleKey={localizationKeys('userProfile.start.headerTitle__account')}
+        alertContent={card.error}
+        outerSx={t => ({ gap: t.space.$8, color: t.colors.$colorForeground, isolation: 'isolate' })}
+      >
+        {children}
+      </ProfileCard.PagePanel>
+    </ProfileCard.Page>
+  );
+}
+
+export function UserProfileAccountPanel({ children }: PropsWithChildren): ReactNode {
+  if (!children) {
+    return <AccountPage />;
+  }
+
+  return (
+    <PageContext.Provider value='account'>
+      <CardStateProvider>
+        <AccountComposed>{children}</AccountComposed>
+      </CardStateProvider>
+    </PageContext.Provider>
+  );
+}

--- a/packages/ui/src/composed/UserProfile/AccountConnectedAccounts.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountConnectedAccounts.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountConnectedAccounts as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfileConnectedAccountsSection = createSection('UserProfileConnectedAccountsSection', Section);

--- a/packages/ui/src/composed/UserProfile/AccountEmails.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountEmails.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountEmails as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfileEmailSection = createSection('UserProfileEmailSection', Section);

--- a/packages/ui/src/composed/UserProfile/AccountEnterpriseAccounts.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountEnterpriseAccounts.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountEnterpriseAccounts as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfileEnterpriseAccountsSection = createSection('UserProfileEnterpriseAccountsSection', Section);

--- a/packages/ui/src/composed/UserProfile/AccountPhone.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountPhone.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountPhone as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfilePhoneSection = createSection('UserProfilePhoneSection', Section);

--- a/packages/ui/src/composed/UserProfile/AccountProfile.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountProfile.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { UserProfileSection } from '../../components/UserProfile/UserProfileSection';
+import { createSection } from '../createSection';
+
+export const UserProfileProfileSection = createSection('UserProfileProfileSection', UserProfileSection);

--- a/packages/ui/src/composed/UserProfile/AccountUsername.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountUsername.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountUsername as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfileUsernameSection = createSection('UserProfileUsernameSection', Section);

--- a/packages/ui/src/composed/UserProfile/AccountWeb3.tsx
+++ b/packages/ui/src/composed/UserProfile/AccountWeb3.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AccountWeb3 as Section } from '../../components/UserProfile/AccountSections';
+import { createSection } from '../createSection';
+
+export const UserProfileWeb3Section = createSection('UserProfileWeb3Section', Section);

--- a/packages/ui/src/composed/UserProfile/Billing.tsx
+++ b/packages/ui/src/composed/UserProfile/Billing.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { lazy, type ReactNode } from 'react';
+
+import { BillingSection } from '../BillingSection';
+
+const BillingPage = lazy(() =>
+  import('../../components/UserProfile/BillingPage').then(m => ({
+    default: m.BillingPage,
+  })),
+);
+
+const PlansPage = lazy(() =>
+  import('../../components/UserProfile/PlansPage').then(m => ({
+    default: m.PlansPage,
+  })),
+);
+
+const StatementPage = lazy(() =>
+  import('../../components/Statements').then(m => ({
+    default: m.StatementPage,
+  })),
+);
+
+const PaymentAttemptPage = lazy(() =>
+  import('../../components/PaymentAttempts').then(m => ({
+    default: m.PaymentAttemptPage,
+  })),
+);
+
+export const UserProfileBillingPanel = (): ReactNode => (
+  <BillingSection
+    billing={BillingPage}
+    plans={PlansPage}
+    statement={StatementPage}
+    paymentAttempt={PaymentAttemptPage}
+  />
+);

--- a/packages/ui/src/composed/UserProfile/Security.tsx
+++ b/packages/ui/src/composed/UserProfile/Security.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { CardStateProvider, useCardState } from '@/ui/elements/contexts';
+import { ProfileCard } from '@/ui/elements/ProfileCard';
+
+import { SecurityPage } from '../../components/UserProfile/SecurityPage';
+import { localizationKeys } from '../../customizables';
+import { PageContext } from '../PageContext';
+
+function SecurityComposed({ children }: PropsWithChildren): ReactNode {
+  const card = useCardState();
+  return (
+    <ProfileCard.Page>
+      <ProfileCard.PagePanel
+        pageId='security'
+        titleKey={localizationKeys('userProfile.start.headerTitle__security')}
+        alertContent={card.error}
+      >
+        {children}
+      </ProfileCard.PagePanel>
+    </ProfileCard.Page>
+  );
+}
+
+export function UserProfileSecurityPanel({ children }: PropsWithChildren): ReactNode {
+  if (!children) {
+    return <SecurityPage />;
+  }
+
+  return (
+    <PageContext.Provider value='security'>
+      <CardStateProvider>
+        <SecurityComposed>{children}</SecurityComposed>
+      </CardStateProvider>
+    </PageContext.Provider>
+  );
+}

--- a/packages/ui/src/composed/UserProfile/SecurityActiveDevices.tsx
+++ b/packages/ui/src/composed/UserProfile/SecurityActiveDevices.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { ActiveDevicesSection } from '../../components/UserProfile/ActiveDevicesSection';
+import { createSection } from '../createSection';
+
+export const UserProfileActiveDevicesSection = createSection('UserProfileActiveDevicesSection', ActiveDevicesSection);

--- a/packages/ui/src/composed/UserProfile/SecurityDelete.tsx
+++ b/packages/ui/src/composed/UserProfile/SecurityDelete.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { SecurityDelete as Section } from '../../components/UserProfile/SecuritySections';
+import { createSection } from '../createSection';
+
+export const UserProfileDeleteSection = createSection('UserProfileDeleteSection', Section);

--- a/packages/ui/src/composed/UserProfile/SecurityMfa.tsx
+++ b/packages/ui/src/composed/UserProfile/SecurityMfa.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { SecurityMfa as Section } from '../../components/UserProfile/SecuritySections';
+import { createSection } from '../createSection';
+
+export const UserProfileMfaSection = createSection('UserProfileMfaSection', Section);

--- a/packages/ui/src/composed/UserProfile/SecurityPasskeys.tsx
+++ b/packages/ui/src/composed/UserProfile/SecurityPasskeys.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { SecurityPasskeys as Section } from '../../components/UserProfile/SecuritySections';
+import { createSection } from '../createSection';
+
+export const UserProfilePasskeysSection = createSection('UserProfilePasskeysSection', Section);

--- a/packages/ui/src/composed/UserProfile/SecurityPassword.tsx
+++ b/packages/ui/src/composed/UserProfile/SecurityPassword.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { SecurityPassword as Section } from '../../components/UserProfile/SecuritySections';
+import { createSection } from '../createSection';
+
+export const UserProfilePasswordSection = createSection('UserProfilePasswordSection', Section);

--- a/packages/ui/src/composed/UserProfile/UserProfileProvider.tsx
+++ b/packages/ui/src/composed/UserProfile/UserProfileProvider.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useClerk, useUser } from '@clerk/shared/react';
+import type { EnvironmentResource, OAuthProvider, OAuthScope, UserProfileProps } from '@clerk/shared/types';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import type { Appearance } from '@/ui/internal/appearance';
+
+import { UserProfileContext } from '../../contexts/components/UserProfile';
+import { fallbackModuleManager, ProfileProviderShell } from '../ProfileProviderShell';
+
+type UserProfileProviderProps = PropsWithChildren<{
+  appearance?: Appearance;
+  additionalOAuthScopes?: Partial<Record<OAuthProvider, OAuthScope[]>>;
+  apiKeysProps?: UserProfileProps['apiKeysProps'];
+}>;
+
+export const UserProfileProvider = (props: UserProfileProviderProps): ReactNode => {
+  const { children, appearance, additionalOAuthScopes, apiKeysProps } = props;
+  const clerk = useClerk();
+  const { isLoaded, user } = useUser();
+
+  const environment = (clerk as any).__internal_environment as EnvironmentResource | null | undefined;
+  const moduleManager = clerk.__internal_moduleManager ?? fallbackModuleManager;
+
+  if (!isLoaded || !user || !environment) {
+    return null;
+  }
+
+  const userProfileCtxValue = {
+    componentName: 'UserProfile' as const,
+    mode: 'mounted' as const,
+    routing: 'hash' as const,
+    path: undefined,
+    additionalOAuthScopes,
+    apiKeysProps,
+    customPages: [],
+  };
+
+  return (
+    <ProfileProviderShell
+      clerk={clerk}
+      environment={environment}
+      moduleManager={moduleManager}
+      appearanceKey='userProfile'
+      flow='userProfile'
+      globalAppearance={clerk.__internal_getOption('appearance')}
+      appearance={appearance}
+    >
+      <UserProfileContext.Provider value={userProfileCtxValue}>{children}</UserProfileContext.Provider>
+    </ProfileProviderShell>
+  );
+};

--- a/packages/ui/src/composed/UserProfile/UserProfileProvider.tsx
+++ b/packages/ui/src/composed/UserProfile/UserProfileProvider.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useClerk, useUser } from '@clerk/shared/react';
-import type { EnvironmentResource, OAuthProvider, OAuthScope, UserProfileProps } from '@clerk/shared/types';
+import type { OAuthProvider, OAuthScope, UserProfileProps } from '@clerk/shared/types';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 import type { Appearance } from '@/ui/internal/appearance';
 
 import { UserProfileContext } from '../../contexts/components/UserProfile';
-import { fallbackModuleManager, ProfileProviderShell } from '../ProfileProviderShell';
+import { ProfileProviderShell, resolveComposedClerkRuntime } from '../ProfileProviderShell';
 
 type UserProfileProviderProps = PropsWithChildren<{
   appearance?: Appearance;
@@ -20,8 +20,7 @@ export const UserProfileProvider = (props: UserProfileProviderProps): ReactNode 
   const clerk = useClerk();
   const { isLoaded, user } = useUser();
 
-  const environment = (clerk as any).__internal_environment as EnvironmentResource | null | undefined;
-  const moduleManager = clerk.__internal_moduleManager ?? fallbackModuleManager;
+  const { environment, moduleManager } = resolveComposedClerkRuntime(clerk, isLoaded);
 
   if (!isLoaded || !user || !environment) {
     return null;

--- a/packages/ui/src/composed/UserProfile/index.tsx
+++ b/packages/ui/src/composed/UserProfile/index.tsx
@@ -1,0 +1,17 @@
+export { UserProfileProvider } from './UserProfileProvider';
+export { UserProfileAccountPanel } from './Account';
+export { UserProfileSecurityPanel } from './Security';
+export { UserProfileBillingPanel } from './Billing';
+export { UserProfileAPIKeysPanel } from './APIKeys';
+export { UserProfileProfileSection } from './AccountProfile';
+export { UserProfileUsernameSection } from './AccountUsername';
+export { UserProfileEmailSection } from './AccountEmails';
+export { UserProfilePhoneSection } from './AccountPhone';
+export { UserProfileConnectedAccountsSection } from './AccountConnectedAccounts';
+export { UserProfileEnterpriseAccountsSection } from './AccountEnterpriseAccounts';
+export { UserProfileWeb3Section } from './AccountWeb3';
+export { UserProfilePasswordSection } from './SecurityPassword';
+export { UserProfilePasskeysSection } from './SecurityPasskeys';
+export { UserProfileMfaSection } from './SecurityMfa';
+export { UserProfileActiveDevicesSection } from './SecurityActiveDevices';
+export { UserProfileDeleteSection } from './SecurityDelete';

--- a/packages/ui/src/composed/__tests__/UserProfile.test.tsx
+++ b/packages/ui/src/composed/__tests__/UserProfile.test.tsx
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, screen, waitFor } from '@/test/utils';
+
+import { AccountPage } from '../../components/UserProfile/AccountPage';
+import { SecurityPage } from '../../components/UserProfile/SecurityPage';
+import { clearFetchCache } from '../../hooks';
+
+const { createFixtures } = bindCreateFixtures('UserProfile');
+
+describe('Experimental UserProfile', () => {
+  beforeEach(() => {
+    clearFetchCache();
+  });
+
+  // The page components (AccountPage/SecurityPage) are thin wrappers that render
+  // the composed panels. The section-visibility matrix is asserted once at the
+  // component level in AccountSections/SecuritySections; here we only cover what
+  // the page level adds — the enterprise-SSO additional-identification guard —
+  // plus a single mount smoke per page.
+  describe('Account page', () => {
+    it('hides add buttons when enterprise SSO disables additional identifications', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          enterprise_accounts: [
+            {
+              active: true,
+              enterprise_connection: {
+                disable_additional_identifications: true,
+              },
+            } as any,
+          ],
+        });
+        f.withEnterpriseSso();
+      });
+
+      const { queryByRole } = render(<AccountPage />, { wrapper });
+      expect(queryByRole('button', { name: /add email address/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Security page', () => {
+    it('renders active devices section', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+      fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+      render(<SecurityPage />, { wrapper });
+      await waitFor(() => screen.getByText(/active devices/i));
+    });
+  });
+});

--- a/packages/ui/src/composed/__tests__/UserProfileSections.test.tsx
+++ b/packages/ui/src/composed/__tests__/UserProfileSections.test.tsx
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, screen, waitFor } from '@/test/utils';
+
+import { clearFetchCache } from '../../hooks';
+import { UserProfileAccountPanel } from '../UserProfile/Account';
+import { UserProfileConnectedAccountsSection } from '../UserProfile/AccountConnectedAccounts';
+import { UserProfileEmailSection } from '../UserProfile/AccountEmails';
+import { UserProfileEnterpriseAccountsSection } from '../UserProfile/AccountEnterpriseAccounts';
+import { UserProfilePhoneSection } from '../UserProfile/AccountPhone';
+import { UserProfileProfileSection } from '../UserProfile/AccountProfile';
+import { UserProfileUsernameSection } from '../UserProfile/AccountUsername';
+import { UserProfileWeb3Section } from '../UserProfile/AccountWeb3';
+import { UserProfileSecurityPanel } from '../UserProfile/Security';
+import { UserProfileActiveDevicesSection } from '../UserProfile/SecurityActiveDevices';
+import { UserProfileDeleteSection } from '../UserProfile/SecurityDelete';
+import { UserProfilePasswordSection } from '../UserProfile/SecurityPassword';
+
+const { createFixtures } = bindCreateFixtures('UserProfile');
+
+describe('UserProfile composed sections', () => {
+  beforeEach(() => {
+    clearFetchCache();
+  });
+
+  describe('Account — inline form flow', () => {
+    it('inline form flow: update profile opens form', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withName();
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+      });
+
+      const { getByRole, getByLabelText, userEvent } = render(<UserProfileAccountPanel />, { wrapper });
+      await userEvent.click(getByRole('button', { name: /update profile/i }));
+      await waitFor(() => getByLabelText(/first name/i));
+      expect(getByLabelText(/first name/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Account — section composition mode', () => {
+    it('renders only declared sections', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withPhoneNumber();
+        f.withUser({
+          first_name: 'Test',
+          last_name: 'User',
+          email_addresses: ['test@clerk.com'],
+          phone_numbers: ['+11111111111'],
+        });
+      });
+
+      const { queryByText } = render(
+        <UserProfileAccountPanel>
+          <UserProfileProfileSection />
+          <UserProfileEmailSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('Test User');
+      expect(screen.getAllByText(/email address/i).length).toBeGreaterThan(0);
+      expect(queryByText(/phone number/i)).not.toBeInTheDocument();
+    });
+
+    it('renders header', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileProfileSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('Profile details');
+    });
+
+    it('renders custom content between sections', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileProfileSection />
+          <div data-testid='custom-banner'>Custom content</div>
+          <UserProfileEmailSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId('custom-banner')).toBeInTheDocument();
+      screen.getByText('Custom content');
+    });
+
+    it('environment guard: disabled email renders null', async () => {
+      const { wrapper } = await createFixtures(f => {
+        // Email NOT enabled
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+      });
+
+      const { queryByText } = render(
+        <UserProfileAccountPanel>
+          <UserProfileProfileSection />
+          <UserProfileEmailSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('Test User');
+      expect(queryByText(/email address/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Account — individual sections', () => {
+    it('UserProfileProfileSection renders user name', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Jane', last_name: 'Doe' });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileProfileSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('Jane Doe');
+    });
+
+    it('UserProfileUsernameSection renders when enabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUsername();
+        f.withUser({ email_addresses: ['test@clerk.com'], username: 'jdoe' });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileUsernameSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('jdoe');
+    });
+
+    it('UserProfileUsernameSection renders null when disabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'], username: 'jdoe' });
+      });
+
+      const { container } = render(
+        <UserProfileAccountPanel>
+          <UserProfileUsernameSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      expect(container.querySelector('[class*="profileSection"]')).not.toBeInTheDocument();
+    });
+
+    it('UserProfileEmailSection renders email list', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withUser({ email_addresses: ['primary@clerk.com', 'secondary@clerk.com'] });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileEmailSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText('primary@clerk.com');
+      screen.getByText('secondary@clerk.com');
+    });
+
+    it('UserProfilePhoneSection renders phone list when enabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withPhoneNumber();
+        f.withUser({ email_addresses: ['test@clerk.com'], phone_numbers: ['+11111111111'] });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfilePhoneSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      expect(screen.getAllByText(/phone number/i).length).toBeGreaterThan(0);
+    });
+
+    it('UserProfileConnectedAccountsSection renders when social providers enabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withSocialProvider({ provider: 'google' });
+        f.withUser({
+          email_addresses: ['test@clerk.com'],
+          external_accounts: [{ provider: 'google', email_address: 'test@clerk.com' }],
+        });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileConnectedAccountsSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText(/connected accounts/i);
+    });
+
+    it('UserProfileEnterpriseAccountsSection renders null when enterprise SSO disabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+
+      const { queryByText } = render(
+        <UserProfileAccountPanel>
+          <UserProfileEnterpriseAccountsSection />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      expect(queryByText(/enterprise accounts/i)).not.toBeInTheDocument();
+    });
+
+    it('UserProfileWeb3Section renders when web3_wallet enabled', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withWeb3Wallet();
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+
+      render(
+        <UserProfileAccountPanel>
+          <UserProfileWeb3Section />
+        </UserProfileAccountPanel>,
+        { wrapper },
+      );
+
+      screen.getByText(/web3 wallets/i);
+    });
+  });
+
+  describe('Account — section outside page', () => {
+    it('useRequirePage throws when rendered outside a page component', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+
+      expect(() => render(<UserProfileEmailSection />, { wrapper })).toThrow(
+        '<UserProfileEmailSection> must be rendered inside a page component',
+      );
+    });
+  });
+
+  describe('Security — section composition mode', () => {
+    it('renders only declared sections', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withPassword();
+        f.withPasskey();
+        f.withUser({ email_addresses: ['test@clerk.com'], delete_self_enabled: true });
+      });
+      fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+      const { queryByText } = render(
+        <UserProfileSecurityPanel>
+          <UserProfilePasswordSection />
+          <UserProfileActiveDevicesSection />
+        </UserProfileSecurityPanel>,
+        { wrapper },
+      );
+
+      await waitFor(() => screen.getByText(/^password/i));
+      screen.getByText(/active devices/i);
+      expect(queryByText(/^passkeys/i)).not.toBeInTheDocument();
+      expect(queryByText(/delete account/i)).not.toBeInTheDocument();
+    });
+
+    it('UserProfileActiveDevicesSection renders without guard', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+      fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+      render(
+        <UserProfileSecurityPanel>
+          <UserProfileActiveDevicesSection />
+        </UserProfileSecurityPanel>,
+        { wrapper },
+      );
+
+      await waitFor(() => screen.getByText(/active devices/i));
+    });
+
+    it('UserProfileDeleteSection respects user flag', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.com'], delete_self_enabled: false });
+      });
+      fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
+
+      const { queryByText } = render(
+        <UserProfileSecurityPanel>
+          <UserProfileDeleteSection />
+          <UserProfileActiveDevicesSection />
+        </UserProfileSecurityPanel>,
+        { wrapper },
+      );
+
+      await waitFor(() => screen.getByText(/active devices/i));
+      expect(queryByText(/delete account/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/composed/__tests__/UserProfileSections.test.tsx
+++ b/packages/ui/src/composed/__tests__/UserProfileSections.test.tsx
@@ -250,8 +250,13 @@ describe('UserProfile composed sections', () => {
 
   describe('Account — section outside page', () => {
     it('useRequirePage throws when rendered outside a page component', async () => {
-      const { wrapper } = await createFixtures(f => {
+      const { wrapper, fixtures } = await createFixtures(f => {
         f.withUser({ email_addresses: ['test@clerk.com'] });
+      });
+      // The guard only throws for a development SDK; mark the fixture accordingly.
+      Object.defineProperty(fixtures.clerk, 'sdkMetadata', {
+        value: { environment: 'development' },
+        configurable: true,
       });
 
       expect(() => render(<UserProfileEmailSection />, { wrapper })).toThrow(

--- a/packages/ui/src/composed/__tests__/action-animation.test.tsx
+++ b/packages/ui/src/composed/__tests__/action-animation.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('@formkit/auto-animate/react');
+vi.unmock('@formkit/auto-animate');
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, screen, waitFor } from '@/test/utils';
+
+import { clearFetchCache } from '../../hooks';
+import { UserProfileAccountPanel } from '../UserProfile/Account';
+import { UserProfileEmailSection } from '../UserProfile/AccountEmails';
+import { UserProfileProfileSection } from '../UserProfile/AccountProfile';
+
+const { createFixtures } = bindCreateFixtures('UserProfile');
+
+function findAddAnimationCall(calls: any[]) {
+  return calls.find(call => {
+    const keyframes = call[0];
+    if (!Array.isArray(keyframes)) {
+      return false;
+    }
+    return keyframes.some(
+      (kf: any) => kf.opacity === 0 && typeof kf.transform === 'string' && kf.transform.includes('scale'),
+    );
+  });
+}
+
+describe('Action open animation', () => {
+  beforeEach(() => {
+    clearFetchCache();
+    vi.mocked(Element.prototype.animate).mockClear();
+  });
+
+  it('calls el.animate with add keyframes when "Add email" action opens', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withUser({
+        first_name: 'Test',
+        last_name: 'User',
+        email_addresses: ['test@clerk.com'],
+      });
+    });
+
+    const { userEvent } = render(<UserProfileAccountPanel />, { wrapper });
+    vi.mocked(Element.prototype.animate).mockClear();
+
+    await userEvent.click(screen.getByRole('button', { name: /add email address/i }));
+    await waitFor(() => expect(screen.getByLabelText(/email address/i)).toBeInTheDocument());
+
+    expect(findAddAnimationCall(vi.mocked(Element.prototype.animate).mock.calls)).toBeDefined();
+  });
+
+  it('composed sections: "Add email" triggers add animation', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withUser({
+        first_name: 'Test',
+        last_name: 'User',
+        email_addresses: ['test@clerk.com'],
+      });
+    });
+
+    const { userEvent } = render(
+      <UserProfileAccountPanel>
+        <UserProfileProfileSection />
+        <UserProfileEmailSection />
+      </UserProfileAccountPanel>,
+      { wrapper },
+    );
+
+    vi.mocked(Element.prototype.animate).mockClear();
+    await userEvent.click(screen.getByRole('button', { name: /add email address/i }));
+    await waitFor(() => expect(screen.getByLabelText(/email address/i)).toBeInTheDocument());
+
+    expect(findAddAnimationCall(vi.mocked(Element.prototype.animate).mock.calls)).toBeDefined();
+  });
+});

--- a/packages/ui/src/composed/__tests__/hotload-vs-bundle-risks.test.tsx
+++ b/packages/ui/src/composed/__tests__/hotload-vs-bundle-risks.test.tsx
@@ -1,0 +1,183 @@
+import { logger } from '@clerk/shared/logger';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render } from '@/test/utils';
+import { getStyleCache } from '@/ui/internal/styleCacheStore';
+import { createEmotionCache } from '@/ui/styledSystem/createEmotionCache';
+
+import { clearFetchCache } from '../../hooks';
+import { fallbackModuleManager, resolveComposedClerkRuntime } from '../ProfileProviderShell';
+import { UserProfileProvider } from '../UserProfile/UserProfileProvider';
+
+function patchEnvironment(clerk: any, env: any) {
+  Object.defineProperty(clerk, '__internal_environment', { value: env, configurable: true });
+}
+
+function insertRule(cache: ReturnType<typeof createEmotionCache>, name: string, styles: string) {
+  cache.insert('', { name, styles, next: undefined } as any, cache.sheet, true);
+}
+
+describe('hotload (clerk-js) vs app-bundle (composed) risks', () => {
+  const { createFixtures } = bindCreateFixtures('UserProfile');
+
+  beforeEach(() => {
+    clearFetchCache();
+  });
+
+  // RISK 1 (inherent, documented) — Two emotion runtimes, one document.
+  // The composed `styleCacheStore` WeakMap dedups cache creation only WITHIN the
+  // app bundle. The hotloaded clerk-js inlines its own @emotion (module-scoped
+  // state does not cross the bundle boundary — same reason clerk.ts exposes
+  // `__internal_moduleManager` as a getter). So when a page shows both a
+  // hotloaded AIO component (e.g. the impersonation fab, which auto-mounts) and
+  // a bundled composed profile, TWO independent `cl-internal` caches emit styles
+  // into the same <head>. This cannot be deduped from the composed side; it needs
+  // a clerk-js contract change (share its cache) or a pinned-min-version policy.
+  // The test pins the current reality so a future shared-cache fix flips it.
+  it('does not share/dedup styles between the AIO-path cache and the composed-path cache', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+    });
+    patchEnvironment(fixtures.clerk, fixtures.environment);
+
+    render(
+      <UserProfileProvider>
+        <div data-testid='child' />
+      </UserProfileProvider>,
+      { wrapper },
+    );
+
+    const composedCache = getStyleCache(fixtures.clerk);
+    // The AIO StyleCacheProvider builds its cache the same way, but the hotloaded
+    // clerk-js does it inside its own bundle, so it is never stored in this store.
+    const aioCache = createEmotionCache({});
+
+    expect(composedCache).toBeDefined();
+    if (!composedCache) {
+      return;
+    }
+
+    // Same emotion key -> both write <style data-emotion="cl-internal"> groups.
+    expect(composedCache.key).toBe('cl-internal');
+    expect(aioCache.key).toBe('cl-internal');
+    // But they are different registries: the WeakMap cannot reach across bundles.
+    expect(aioCache).not.toBe(composedCache);
+
+    // The exact same rule gets independently inserted by each cache: on a real
+    // page that is a duplicate insertion, with independent ordering.
+    insertRule(composedCache, 'dup', 'color:red;');
+    insertRule(aioCache, 'dup', 'color:red;');
+
+    expect(composedCache.inserted.dup).toBeDefined();
+    expect(aioCache.inserted.dup).toBeDefined();
+  });
+
+  // RISK 2 (fixed) — cache params must not freeze at the first composed mount.
+  // The shared cache is keyed on the clerk instance so sibling roots reuse it,
+  // but a change to nonce/cssLayerName must rebuild it (matching what the AIO
+  // StyleCacheProvider does via its useMemo deps). Otherwise whatever the first
+  // composed root saw would win forever and later styles would silently diverge
+  // from AIO's cascade (e.g. missing the configured @layer).
+  it('rebuilds the shared cache when cssLayerName changes after the first mount', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'Test', last_name: 'User' });
+    });
+    patchEnvironment(fixtures.clerk, fixtures.environment);
+
+    // First mount: appearance has no cssLayerName.
+    fixtures.clerk.__internal_getOption = () => undefined;
+
+    const first = render(
+      <UserProfileProvider>
+        <div data-testid='a' />
+      </UserProfileProvider>,
+      { wrapper },
+    );
+    first.unmount();
+
+    // App turns on a css layer AFTER the first profile mounted.
+    fixtures.clerk.__internal_getOption = (key: string) =>
+      key === 'appearance' ? { cssLayerName: 'app-layer' } : undefined;
+
+    render(
+      <UserProfileProvider>
+        <div data-testid='b' />
+      </UserProfileProvider>,
+      { wrapper },
+    );
+
+    const cache = getStyleCache(fixtures.clerk);
+    expect(cache).toBeDefined();
+    if (!cache) {
+      return;
+    }
+
+    insertRule(cache, 'layered', 'color:blue;');
+    const emitted = cache.sheet.tags.map((tag: HTMLStyleElement) => tag.textContent ?? '').join('');
+
+    expect(emitted).toContain('color:blue');
+    // The second mount asked for `@layer app-layer`; the cache must have been
+    // rebuilt with that layer instead of reusing the first-mount (unwrapped) one.
+    expect(emitted).toContain('@layer app-layer');
+  });
+});
+
+// RISK 3 (fixed) — version skew must not fail silently.
+// Composed reads `__internal_environment` / `__internal_moduleManager` off the
+// hotloaded clerk-js. When the loaded clerk-js is older than the composed code
+// bundled in the app, those are absent and the provider renders nothing. That is
+// intentional (can't render without runtime state), but it must be observable:
+// once clerk has finished loading, a missing runtime is a real misconfiguration
+// and gets a one-time dev warning instead of a blank screen with no signal.
+describe('composed runtime resolution (version skew)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warnOnce').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns once when clerk is loaded but exposes no environment (older clerk-js)', () => {
+    const clerk = { __internal_moduleManager: { import: () => Promise.resolve({}) } } as any;
+
+    const { environment, moduleManager } = resolveComposedClerkRuntime(clerk, true);
+
+    expect(environment).toBeUndefined();
+    expect(moduleManager).toBe(clerk.__internal_moduleManager);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/clerk-js/i);
+  });
+
+  it('warns and falls back to the loud module manager when the manager is absent', () => {
+    const clerk = { __internal_environment: {} } as any;
+
+    const { environment, moduleManager } = resolveComposedClerkRuntime(clerk, true);
+
+    expect(environment).toBeDefined();
+    expect(moduleManager).toBe(fallbackModuleManager);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn while clerk is still loading (transient absence is normal)', () => {
+    const clerk = {} as any;
+
+    resolveComposedClerkRuntime(clerk, false);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn once clerk is fully wired', () => {
+    const clerk = {
+      __internal_environment: {},
+      __internal_moduleManager: { import: () => Promise.resolve({}) },
+    } as any;
+
+    resolveComposedClerkRuntime(clerk, true);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Stack 5/7. Composed `UserProfile` panels and section leaf components + their tests. Depends on the extracted Sections (PR 3) and the shell (PR 4).

Not yet wired to the public entrypoint.

_Changesets live only on the release PR #9144; this PR carries none._

<!-- stack-table -->

---

### Stack

Reviewed as a stack. The 7 PRs merge bottom-up into release branch #9144, which integrates into `main` as a single unit.

| # | PR | Layer |
|---|----|-------|
| – | #9144 | release → `main` (integration) |
| 1 | #9130 | moduleManager getter across build boundary |
| 2 | #9131 | shared profile UI infra |
| 3 | #9132 | extract Section components from profile pages |
| 4 | #9133 | composed shell + providers infra |
| 5 | **#9134** 👈 | **composed UserProfile** |
| 6 | #9135 | composed OrganizationProfile |
| 7 | #9136 | expose `@clerk/ui/experimental` (public API) |