### PR TITLE
fix(ui): Ensure spinner box-sizing prevents shift

### DIFF
--- a/.changeset/spinner-box-sizing.md
+++ b/.changeset/spinner-box-sizing.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Set `box-sizing: border-box` on the spinner so its border no longer changes the rendered size and causes a layout shift.

--- a/packages/ui/src/primitives/Spinner.tsx
+++ b/packages/ui/src/primitives/Spinner.tsx
@@ -6,6 +6,7 @@ const { size, thickness, speed } = createCssVariables('speed', 'size', 'thicknes
 const { applyVariants, filterProps } = createVariants(theme => {
   return {
     base: {
+      boxSizing: 'border-box',
       display: 'inline-block',
       borderRadius: '99999px',
       borderTop: `${thickness} solid currentColor`,


### PR DESCRIPTION
## Description

Set `box-sizing: border-box` on the spinner so its border no longer changes the rendered size and causes a layout shift.

BEFORE


https://github.com/user-attachments/assets/8b443930-46cb-47cc-9898-8d4349a7c102


AFTER


https://github.com/user-attachments/assets/8679acbd-d0f5-4a95-af3e-041765b29c73


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spinner borders from changing its size, reducing unexpected layout shifts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->