### PR TITLE
fix(ui): Update org switcher avatar alignment and radii

### DIFF
--- a/.changeset/org-switcher-trigger-avatar-radius.md
+++ b/.changeset/org-switcher-trigger-avatar-radius.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Reduce the organization avatar's border radius in the `OrganizationSwitcher` trigger so it stays proportional at the smaller trigger size.

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -41,7 +41,7 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
         focusRing={false}
         sx={[
           t => ({
-            padding: `${t.space.$1} ${t.space.$2}`,
+            padding: `${t.space.$1} ${t.space.$2} ${t.space.$1} ${t.space.$1}`,
             position: 'relative',
             '&[aria-expanded="true"]': {
               backgroundColor: 'var(--alpha)',
@@ -62,6 +62,7 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
             gap={3}
             size='xs'
             organization={organization}
+            avatarSx={t => ({ borderRadius: t.radii.$sm })}
             sx={{ maxWidth: '30ch' }}
           />
         )}


### PR DESCRIPTION
## Description

- Reduce left padding to be consistent with block padding
- Fix avatar radii sizing

| BEFORE | AFTER |
|--------|--------|
| <img width="1160" height="332" alt="Screenshot 2026-07-13 at 3 29 42 PM" src="https://github.com/user-attachments/assets/2a1b6086-5b6a-4c2e-8edc-87de3ea71cfb" /> | <img width="1350" height="445" alt="Screenshot 2026-07-13 at 3 29 20 PM" src="https://github.com/user-attachments/assets/0a5e3ca9-52b0-4a0e-b2de-ba3924947f1a" /> | 

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved organization switcher trigger spacing for better small-size alignment.
  * Updated organization avatar styling to use a smaller, more proportional border radius in the switcher trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->