### PR TITLE
chore(expo): bump clerk-ios to 1.3.2

### DIFF
--- a/.changeset/expo-bump-clerk-ios-1-3-2.md
+++ b/.changeset/expo-bump-clerk-ios-1-3-2.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-ios` SDK from `1.3.1` to `1.3.2`. See the Clerk iOS release: https://github.com/clerk/clerk-ios/releases/tag/1.3.2.

--- a/packages/expo/ios/ClerkExpo.podspec
+++ b/packages/expo/ios/ClerkExpo.podspec
@@ -18,7 +18,7 @@ else
 end
 
 clerk_ios_repo = 'https://github.com/clerk/clerk-ios.git'
-clerk_ios_version = '1.3.1'
+clerk_ios_version = '1.3.2'
 
 Pod::Spec.new do |s|
   s.name           = 'ClerkExpo'


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-ios` SDK in `@clerk/expo` from `1.3.1` to `1.3.2`.

Release: https://github.com/clerk/clerk-ios/releases/tag/1.3.2

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled iOS SDK to version 1.3.2.
  * Scheduled a patch release for the Expo package containing the SDK update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->