### PR TITLE
fix(backend): Add required provider field to CreateEnterpriseConnectionParams

### DIFF
--- a/.changeset/heavy-melons-argue.md
+++ b/.changeset/heavy-melons-argue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Add the required `provider` field to `CreateEnterpriseConnectionParams`. The Backend API has always required `provider` when creating an enterprise connection, so calls to `createEnterpriseConnection()` without it type-checked but failed at runtime. The parameter type now reflects the API contract.

--- a/.changeset/heavy-melons-argue.md
+++ b/.changeset/heavy-melons-argue.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-Add the required `provider` field to `CreateEnterpriseConnectionParams`. The Backend API has always required `provider` when creating an enterprise connection, so calls to `createEnterpriseConnection()` without it type-checked but failed at runtime. The parameter type now reflects the API contract.
+Add the required `provider` field to `CreateEnterpriseConnectionParams`. The Backend API has always required `provider` when creating an enterprise connection, so calls to `createEnterpriseConnection()` without it type-checked but failed at runtime. The field is typed to the supported provider values (`'saml_custom'`, `'saml_okta'`, `'saml_google'`, `'saml_microsoft'`, `'oidc_custom'`, `'oidc_github_enterprise'`, `'oidc_gitlab'`), so unsupported values are also caught at compile time.

--- a/integration/tests/tanstack-start/enterprise-sso.test.ts
+++ b/integration/tests/tanstack-start/enterprise-sso.test.ts
@@ -13,7 +13,6 @@ const FAKE_IDP_CERTIFICATE =
 /**
  * Helper to create and activate a SAML enterprise connection.
  * The Clerk API requires creating the connection first (inactive), then activating via update.
- * The `provider` field is required by the API but missing from the SDK types, so we cast.
  */
 async function createActiveEnterpriseConnection(
   clerk: ReturnType<typeof createTestUtils>['services']['clerk'],
@@ -28,7 +27,7 @@ async function createActiveEnterpriseConnection(
       idpSsoUrl: opts.idpSsoUrl,
       idpCertificate: FAKE_IDP_CERTIFICATE,
     },
-  } as Parameters<typeof clerk.enterpriseConnections.createEnterpriseConnection>[0]);
+  });
 
   return clerk.enterpriseConnections.updateEnterpriseConnection(conn.id, { active: true });
 }

--- a/packages/backend/src/api/__tests__/EnterpriseConnectionApi.test.ts
+++ b/packages/backend/src/api/__tests__/EnterpriseConnectionApi.test.ts
@@ -60,6 +60,7 @@ describe('EnterpriseConnectionAPI', () => {
 
             expect(body.name).toBe('Clerk');
             expect(body.domains).toEqual(['clerk.dev']);
+            expect(body.provider).toBe('saml_custom');
             expect(body.saml).toEqual({
               idp_entity_id: 'xxx',
               idp_metadata_url: 'https://oauth.devsuccess.app/metadata',
@@ -74,6 +75,7 @@ describe('EnterpriseConnectionAPI', () => {
       await apiClient.enterpriseConnections.createEnterpriseConnection({
         name: 'Clerk',
         domains: ['clerk.dev'],
+        provider: 'saml_custom',
         saml: {
           idpEntityId: 'xxx',
           idpMetadataUrl: 'https://oauth.devsuccess.app/metadata',
@@ -89,6 +91,7 @@ describe('EnterpriseConnectionAPI', () => {
           validateHeaders(async ({ request }) => {
             const body = (await request.json()) as Record<string, unknown>;
 
+            expect(body.provider).toBe('oidc_custom');
             expect(body.oidc).toEqual({
               discovery_url: 'https://oidc.example.com/.well-known/openid-configuration',
               client_id: 'client_123',
@@ -107,6 +110,7 @@ describe('EnterpriseConnectionAPI', () => {
       await apiClient.enterpriseConnections.createEnterpriseConnection({
         name: 'OIDC Connection',
         domains: ['example.com'],
+        provider: 'oidc_custom',
         oidc: {
           discoveryUrl: 'https://oidc.example.com/.well-known/openid-configuration',
           clientId: 'client_123',

--- a/packages/backend/src/api/__tests__/EnterpriseConnectionApi.test.ts
+++ b/packages/backend/src/api/__tests__/EnterpriseConnectionApi.test.ts
@@ -1,7 +1,8 @@
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { server, validateHeaders } from '../../mock-server';
+import type { CreateEnterpriseConnectionParams } from '../endpoints/EnterpriseConnectionApi';
 import { createBackendApiClient } from '../factory';
 
 describe('EnterpriseConnectionAPI', () => {
@@ -121,6 +122,12 @@ describe('EnterpriseConnectionAPI', () => {
           requiresPkce: true,
         },
       });
+    });
+
+    it('requires provider and rejects unsupported values at the type level', () => {
+      expectTypeOf<{ name: string; domains: string[] }>().not.toExtend<CreateEnterpriseConnectionParams>();
+      expectTypeOf<'saml_bogus'>().not.toExtend<CreateEnterpriseConnectionParams['provider']>();
+      expectTypeOf<'saml_okta'>().toExtend<CreateEnterpriseConnectionParams['provider']>();
     });
   });
 

--- a/packages/backend/src/api/endpoints/EnterpriseConnectionApi.ts
+++ b/packages/backend/src/api/endpoints/EnterpriseConnectionApi.ts
@@ -83,6 +83,8 @@ export type CreateEnterpriseConnectionParams = {
   active?: boolean;
   /** Whether the enterprise connection should sync user attributes between the IdP and Clerk. */
   syncUserAttributes?: boolean;
+  /** The identity provider (IdP) of the enterprise connection. For example, `'saml_custom'` or `'oidc_custom'`. */
+  provider: string;
   /** Configuration for if the enterprise connection uses OAuth (OIDC). */
   oidc?: EnterpriseConnectionOidcParams;
   /** Configuration for if the enterprise connection uses SAML. */

--- a/packages/backend/src/api/endpoints/EnterpriseConnectionApi.ts
+++ b/packages/backend/src/api/endpoints/EnterpriseConnectionApi.ts
@@ -1,4 +1,4 @@
-import type { ClerkPaginationRequest } from '@clerk/shared/types';
+import type { ClerkPaginationRequest, OrganizationEnterpriseConnectionProvider } from '@clerk/shared/types';
 
 import { joinPaths } from '../../util/path';
 import type { EnterpriseConnection } from '../resources';
@@ -84,7 +84,7 @@ export type CreateEnterpriseConnectionParams = {
   /** Whether the enterprise connection should sync user attributes between the IdP and Clerk. */
   syncUserAttributes?: boolean;
   /** The identity provider (IdP) of the enterprise connection. For example, `'saml_custom'` or `'oidc_custom'`. */
-  provider: string;
+  provider: OrganizationEnterpriseConnectionProvider;
   /** Configuration for if the enterprise connection uses OAuth (OIDC). */
   oidc?: EnterpriseConnectionOidcParams;
   /** Configuration for if the enterprise connection uses SAML. */


### PR DESCRIPTION
## Description

`CreateEnterpriseConnectionParams` was missing the `provider` field, but the Backend API requires it (`validate:"required"` on BAPI's `CreateParams`). Calls to `createEnterpriseConnection()` without it type-checked fine and then failed validation at runtime. The type now carries a required `provider`, typed as the `OrganizationEnterpriseConnectionProvider` union from `@clerk/shared/types` — the same narrow-union pattern `SamlConnectionApi` already uses — so both missing and unsupported values are caught at compile time.

Verified against the clerk_go source: `provider` is required on create, and the shared union exactly matches the server allowlist — `saml_custom`, `saml_okta`, `saml_google`, `saml_microsoft`, `oidc_custom`, `oidc_github_enterprise`, and `oidc_gitlab`.

Two side effects worth calling out:

- Making the field required is a compile-time break for TypeScript callers that omit it — but those calls were already broken at runtime, so this converts a runtime failure into a type error. Shipping as a patch for that reason.
- The tanstack-start enterprise SSO integration test was already passing `provider` behind an `as` cast to work around the missing field. The cast is now removed.

To test: `pnpm --filter @clerk/backend test:node EnterpriseConnectionApi.test.ts` — both create tests pass `provider` and assert it reaches the request body, and type-level assertions lock in that `provider` is required and rejects unsupported values.

A follow-up will align the remaining create-params gaps with the BAPI contract (`name` and `domains` are also required server-side).

Discovered while reviewing clerk/clerk#2887, where a docs code sample calling `createEnterpriseConnection` without `provider` would fail BAPI validation despite type-checking.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enterprise connection creation now requires a supported provider, preventing invalid requests and related runtime failures.
  * Added validation for supported SAML and OIDC provider values.

* **Tests**
  * Expanded coverage to verify provider values are included for SAML and OIDC connections.
  * Added type-level checks to reject unsupported provider values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->