### PR TITLE
fix(ui): Balance headings and prettify body text to reduce widows

### DIFF
--- a/.changeset/text-wrap-widows.md
+++ b/.changeset/text-wrap-widows.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Headings now use `text-wrap: balance` and body text uses `text-wrap: pretty` to reduce widows and orphans when text wraps across lines. This is a progressive enhancement that falls back to normal wrapping in browsers without support.

--- a/packages/ui/src/primitives/Heading.tsx
+++ b/packages/ui/src/primitives/Heading.tsx
@@ -6,6 +6,7 @@ const { applyVariants, filterProps } = createVariants(theme => ({
     boxSizing: 'border-box',
     color: `${theme.colors.$colorForeground}`,
     margin: 0,
+    textWrap: 'balance',
   },
   variants: {
     textVariant: { ...common.textVariants(theme) },

--- a/packages/ui/src/primitives/Text.tsx
+++ b/packages/ui/src/primitives/Text.tsx
@@ -10,6 +10,7 @@ const { applyVariants, filterProps } = createVariants(theme => {
       boxSizing: 'border-box',
       margin: 0,
       fontSize: 'inherit',
+      textWrap: 'pretty',
       ...common.disabled(theme),
     },
     variants: {


### PR DESCRIPTION
## Description

Reduces text widows and orphans in Clerk UI by setting `text-wrap` centrally on the two legacy text primitives: `Heading` uses `text-wrap: balance` (evens out line lengths on short titles) and `Text` uses `text-wrap: pretty` (prevents widows on longer body copy). Applying this in the primitives' base styles covers every heading and text element without per-component edits, and it's a progressive enhancement that falls back to normal wrapping in browsers without support. This is purely cosmetic and backwards-compatible.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 📖 Refactoring / dependency upgrade / documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading wrapping for more balanced line lengths.
  * Improved body text wrapping to reduce awkward widows and orphans.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->