### PR TITLE
fix(ui): Improve phone input and menu option styling

### DIFF
--- a/.changeset/phone-input-menu-styling.md
+++ b/.changeset/phone-input-menu-styling.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Improve phone input country selector and menu item styling, refining hover and focus states, spacing, and scroll padding.

--- a/packages/ui/src/elements/Menu.tsx
+++ b/packages/ui/src/elements/Menu.tsx
@@ -206,6 +206,11 @@ export const MenuItem = (props: MenuItemProps) => {
           borderRadius: theme.radii.$sm,
           padding: `${theme.space.$1} ${theme.space.$3}`,
           whiteSpace: 'nowrap',
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: `calc(${theme.space.$0x25} * -1) calc(${theme.space.$1} * -1)`,
+          },
         }),
         sx,
       ]}

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -93,10 +93,10 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           <CountryCodeListItem
             sx={theme => ({
               '&:hover': {
-                backgroundColor: theme.colors.$neutralAlpha100,
+                backgroundColor: theme.colors.$neutralAlpha50,
               },
               '&[data-focused="true"]': {
-                backgroundColor: theme.colors.$neutralAlpha150,
+                backgroundColor: theme.colors.$neutralAlpha50,
               },
             })}
             isSelected={isSelected}
@@ -145,10 +145,11 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
           </Text>
         </SelectButton>
         <SelectOptionList
-          sx={{ padding: '0 0' }}
+          sx={{ padding: 0 }}
           containerSx={theme => ({
-            gap: 0,
-            padding: `${theme.space.$0x5} 0`,
+            gap: theme.space.$0x5,
+            padding: theme.space.$1,
+            scrollPaddingBlock: theme.space.$1,
           })}
         />
       </Select>
@@ -220,10 +221,17 @@ const CountryCodeListItem = memo((props: CountryCodeListItemProps) => {
       center
       sx={[
         theme => ({
+          position: 'relative',
           width: '100%',
           gap: theme.space.$2,
           padding: `${theme.space.$1x5} ${theme.space.$4}`,
           color: theme.colors.$colorForeground,
+          borderRadius: theme.radii.$sm,
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: `calc(${theme.space.$0x25} * -1) calc(${theme.space.$1} * -1)`,
+          },
         }),
         sx,
       ]}

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -147,8 +147,10 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
         <SelectOptionList
           sx={{ padding: 0 }}
           containerSx={theme => ({
+            overflowX: 'clip',
             gap: theme.space.$0x5,
-            padding: theme.space.$1,
+            paddingBlock: theme.space.$1,
+            paddingInline: theme.space.$0x5,
             scrollPaddingBlock: theme.space.$1,
           })}
         />


### PR DESCRIPTION
## Description

- Removes dead spots between menu items
- Updates phone input option styling to match menu items for consistency

PhoneInput BEFORE:

https://github.com/user-attachments/assets/81c3a289-5325-4092-8439-5de276c49e8c

PhoneInput AFTER:

https://github.com/user-attachments/assets/fb8430e4-0609-4190-af59-096430fc9687

| BEFORE | AFTER |
|--------|--------|
| <img width="536" height="409" alt="Screenshot 2026-07-14 at 12 42 06 PM" src="https://github.com/user-attachments/assets/edd5517f-d4ac-4b30-a6e1-fa7657244adc" /> | <img width="524" height="427" alt="Screenshot 2026-07-14 at 12 41 31 PM" src="https://github.com/user-attachments/assets/4d70754a-075c-4bb8-88f4-4e8912d0de1c" /> | 

MenuOption BEFORE:

https://github.com/user-attachments/assets/df6bd0cc-3194-49bf-92b5-3eaf96c7e727

MenuOption AFTER:

https://github.com/user-attachments/assets/6faa20ee-16a3-4e05-978b-30ea6b9d4729


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Summary

* **Style**
  * Improved menu item interactive-area visuals for more consistent states via an enhanced overlay effect.
  * Refined the phone input country selector dropdown layout, including updated spacing, scroll padding, and option list padding.
  * Standardized hover and selected background colors for country-code options.
  * Improved option visuals with updated positioning, borders, and rounded corners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->