### PR TITLE
feat(ui): Add dev-mode test credential hint to sign-in/sign-up fields

### DIFF
--- a/.changeset/dev-mode-test-credential-hint.md
+++ b/.changeset/dev-mode-test-credential-hint.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Add a development-mode hint to the sign-in and sign-up email/phone fields that nudges developers toward Clerk test credentials. Hovering or focusing the field reveals an info icon next to the label; opening it shows a tip about test identifiers and the `424242` verification code, plus a button that inserts a suggested test email or phone number. The hint only appears in development, on empty fields.

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -571,6 +571,25 @@ function SignInStartInternal(): JSX.Element {
   // @ts-expect-error `action` is not typed
   const { action, validLastAuthenticationStrategies, ...identifierFieldProps } = identifierField.props;
 
+  const identifierDevHint =
+    identifierAttribute === 'phone_number'
+      ? {
+          text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
+          action: {
+            label: 'Insert test phone number',
+            onInsert: () => identifierField.setValue('+12015550100'),
+          },
+        }
+      : identifierAttribute === 'email_address' || identifierAttribute === 'email_address_username'
+        ? {
+            text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
+            action: {
+              label: 'Insert test email',
+              onInsert: () => identifierField.setValue('your_email+clerk_test@example.com'),
+            },
+          }
+        : undefined;
+
   const lastAuthenticationStrategy = clerk.client?.lastAuthenticationStrategy;
   const isIdentifierLastAuthenticationStrategy =
     lastAuthenticationStrategy && totalEnabledAuthMethods > 1
@@ -635,6 +654,7 @@ function SignInStartInternal(): JSX.Element {
                         <DynamicField
                           actionLabel={nextIdentifier?.action}
                           onActionClicked={switchToNextIdentifier}
+                          devHint={identifierDevHint}
                           {...identifierFieldProps}
                           autoFocus={shouldAutofocus}
                           autoComplete={isWebAuthnAutofillSupported ? 'webauthn' : undefined}

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -19,6 +19,8 @@ import { Form } from '@/ui/elements/Form';
 import { Header } from '@/ui/elements/Header';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 import { SocialButtonsReversibleContainerWithDivider } from '@/ui/elements/ReversibleContainer';
+import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import { handleError } from '@/ui/utils/errorHandler';
 import { isMobileDevice } from '@/ui/utils/isMobileDevice';
 import type { FormControlState } from '@/ui/utils/useFormControl';
@@ -579,14 +581,16 @@ function SignInStartInternal(): JSX.Element {
             label: 'Insert test phone number',
             onInsert: () => identifierField.setValue('+12015550100'),
           },
+          isTestValue: isClerkTestPhoneNumber,
         }
       : identifierAttribute === 'email_address' || identifierAttribute === 'email_address_username'
         ? {
             text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
             action: {
               label: 'Insert test email',
-              onInsert: () => identifierField.setValue('your_email+clerk_test@example.com'),
+              onInsert: () => identifierField.setValue(toClerkTestEmail(identifierField.value)),
             },
+            isTestValue: (value: string) => value.includes('+clerk_test'),
           }
         : undefined;
 

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -86,6 +86,13 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 isRequired={fields.emailAddress?.required}
                 isOptional={!fields.emailAddress?.required}
                 isDisabled={fields.emailAddress?.disabled}
+                devHint={{
+                  text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
+                  action: {
+                    label: 'Insert test email',
+                    onInsert: () => formState.emailAddress.setValue('your_email+clerk_test@example.com'),
+                  },
+                }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
               />
@@ -97,6 +104,13 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 {...formState.phoneNumber.props}
                 isRequired={fields.phoneNumber?.required}
                 isOptional={!fields.phoneNumber?.required}
+                devHint={{
+                  text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
+                  action: {
+                    label: 'Insert test phone number',
+                    onInsert: () => formState.phoneNumber.setValue('+12015550100'),
+                  },
+                }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
               />

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Form } from '@/ui/elements/Form';
 import { LegalCheckbox } from '@/ui/elements/LegalConsentCheckbox';
+import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import type { FormControlState } from '@/ui/utils/useFormControl';
 
 import { Col, localizationKeys, useAppearance } from '../../customizables';
@@ -90,8 +92,9 @@ export const SignUpForm = (props: SignUpFormProps) => {
                   text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
                   action: {
                     label: 'Insert test email',
-                    onInsert: () => formState.emailAddress.setValue('your_email+clerk_test@example.com'),
+                    onInsert: () => formState.emailAddress.setValue(toClerkTestEmail(formState.emailAddress.value)),
                   },
+                  isTestValue: value => value.includes('+clerk_test'),
                 }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
@@ -110,6 +113,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                     label: 'Insert test phone number',
                     onInsert: () => formState.phoneNumber.setValue('+12015550100'),
                   },
+                  isTestValue: isClerkTestPhoneNumber,
                 }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}

--- a/packages/ui/src/elements/FieldControl.tsx
+++ b/packages/ui/src/elements/FieldControl.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef } from 'react';
 
 import type { LocalizationKey } from '../customizables';
 import {
+  Box,
   CheckboxInput,
   descriptors,
   Flex,
@@ -22,6 +23,8 @@ import type { PropsOfComponent } from '../styledSystem';
 import type { useFormControl as useFormControlUtil } from '../utils/useFormControl';
 import { OTPCodeControl, OTPResendButton, OTPRoot } from './CodeControl';
 import { useCardState } from './contexts';
+import type { FieldDevHintValue } from './FieldDevHint';
+import { FieldDevHint } from './FieldDevHint';
 import type { FormFeedbackProps } from './FormControl';
 import { FormFeedback } from './FormControl';
 import { InputGroup } from './InputGroup';
@@ -117,14 +120,16 @@ const FieldLabelIcon = (props: { icon?: React.ComponentType }) => {
   );
 };
 
-const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey | string }>) => {
+const FieldLabel = (
+  props: PropsWithChildren<{ localizationKey?: LocalizationKey | string; devHint?: FieldDevHintValue }>,
+) => {
   const { isRequired, id, label, isDisabled, hasError } = useFormField();
 
   if (!(props.localizationKey || label) && !props.children) {
     return null;
   }
 
-  return (
+  const labelElement = (
     <FormLabel
       localizationKey={props.localizationKey || label}
       elementDescriptor={descriptors.formFieldLabel}
@@ -132,13 +137,34 @@ const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey
       hasError={!!hasError}
       isDisabled={isDisabled}
       isRequired={isRequired}
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
+      sx={{ display: props.devHint ? 'inline' : 'flex', alignItems: 'center' }}
     >
       {props.children}
     </FormLabel>
+  );
+
+  if (!props.devHint) {
+    return labelElement;
+  }
+
+  // The label text and the dev hint are siblings inside an inline-block relative
+  // wrapper (makeLocalizable renders either its key text OR children, never both,
+  // so the hint cannot live inside the label). The label flows inline; the hint's
+  // absolute trigger sits at its static position trailing the text, and
+  // paddingInlineEnd reserves room so long labels wrap cleanly.
+  return (
+    <Box
+      as='span'
+      sx={{
+        position: 'relative',
+        display: 'inline-block',
+        textAlign: 'start',
+        paddingInlineEnd: '1.25em',
+      }}
+    >
+      {labelElement}
+      <FieldDevHint hint={props.devHint} />
+    </Box>
   );
 };
 

--- a/packages/ui/src/elements/FieldDevHint.tsx
+++ b/packages/ui/src/elements/FieldDevHint.tsx
@@ -37,6 +37,12 @@ type DevHintAction = {
 export type FieldDevHintValue = {
   text: string | LocalizationKey;
   action?: DevHintAction;
+  /**
+   * Returns true when the current field value is already a test credential. When provided, the
+   * hint stays visible (as a warning) while the field holds a non-test value and only hides once
+   * the value is a test credential. When omitted, the hint hides as soon as the field has any value.
+   */
+  isTestValue?: (value: string) => boolean;
 };
 
 type FieldDevHintProps = {
@@ -51,7 +57,14 @@ type FieldDevHintProps = {
 const FieldDevHintBase = (props: FieldDevHintProps) => {
   const { showDevModeNotice } = useDevMode();
   const { value } = useFormField();
-  const { text, action } = props.hint;
+  const { text, action, isTestValue } = props.hint;
+
+  const stringValue = typeof value === 'string' ? value : '';
+  const hasValue = stringValue.length > 0;
+  // Satisfied → hide. No predicate: any value satisfies. With predicate: only a test value does.
+  const satisfied = hasValue && (isTestValue ? isTestValue(stringValue) : true);
+  // A non-test value keeps the warning icon persistently visible, not just on hover/focus.
+  const persist = hasValue && !satisfied;
 
   const [open, setOpen] = React.useState(false);
 
@@ -92,8 +105,7 @@ const FieldDevHintBase = (props: FieldDevHintProps) => {
   const portalRoot = usePortalRoot();
   const effectiveRoot = portalRoot?.() ?? undefined;
 
-  // Only nudge on an empty field; once the developer has typed (or inserted) a value, hide it.
-  if (!showDevModeNotice || value) {
+  if (!showDevModeNotice || satisfied) {
     return null;
   }
 
@@ -120,8 +132,9 @@ const FieldDevHintBase = (props: FieldDevHintProps) => {
           borderRadius: t.radii.$sm,
           color: t.colors.$warning500,
           // Hidden until the field is hovered/focused (revealed by the formField
-          // container in Form.tsx) or the popover is open.
-          opacity: 0,
+          // container in Form.tsx) or the popover is open. When `persist` (a non-test
+          // value is present) it stays visible as a warning.
+          opacity: persist ? 1 : 0,
           transitionProperty: 'opacity',
           transitionDuration: t.transitionDuration.$fast,
           '&[data-open="true"]': { opacity: 1 },

--- a/packages/ui/src/elements/FieldDevHint.tsx
+++ b/packages/ui/src/elements/FieldDevHint.tsx
@@ -1,0 +1,192 @@
+import { usePortalRoot } from '@clerk/shared/react';
+import {
+  autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingPortal,
+  offset,
+  safePolygon,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import * as React from 'react';
+
+import { Box, Button, Col, Icon, type LocalizationKey, Text, useAppearance } from '../customizables';
+import { usePrefersReducedMotion } from '../hooks';
+import { useDevMode } from '../hooks/useDevMode';
+import { InformationCircle } from '../icons';
+import { useFormField } from '../primitives/hooks/useFormField';
+import { withFloatingTree } from './contexts';
+
+type DevHintAction = {
+  label: string | LocalizationKey;
+  /** Populates the field with a suggested test identifier. */
+  onInsert: () => void;
+};
+
+export type FieldDevHintValue = {
+  text: string | LocalizationKey;
+  action?: DevHintAction;
+};
+
+type FieldDevHintProps = {
+  hint: FieldDevHintValue;
+};
+
+/**
+ * Dev-only info affordance rendered next to a field label. On hover/focus of the ⓘ
+ * icon it opens a popover that nudges developers toward test credentials and can
+ * insert a suggested test identifier into the field. Renders nothing outside dev mode.
+ */
+const FieldDevHintBase = (props: FieldDevHintProps) => {
+  const { showDevModeNotice } = useDevMode();
+  const { value } = useFormField();
+  const { text, action } = props.hint;
+
+  const [open, setOpen] = React.useState(false);
+
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const { animations } = useAppearance().parsedOptions;
+  const isMotionSafe = !prefersReducedMotion && animations === true;
+
+  const nodeId = useFloatingNodeId();
+  const { refs, floatingStyles, context } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: 'top',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(6), flip({ padding: 6 }), shift({ padding: 6 })],
+  });
+
+  // safePolygon keeps the popover open while the cursor travels from the icon into
+  // the content, so the insert button stays clickable on hover.
+  const hover = useHover(context, { handleClose: safePolygon() });
+  const focus = useFocus(context);
+  // Tap-to-toggle for touch, where there is no hover and iOS does not reliably
+  // focus a button on tap (so useHover/useFocus alone would never open it).
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: 'dialog' });
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, click, dismiss, role]);
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: isMotionSafe ? 180 : 0,
+    initial: { opacity: 0, transform: 'translateY(4px)' },
+    open: { opacity: 1, transform: 'translateY(0)' },
+    close: { opacity: 0, transform: 'translateY(4px)' },
+  });
+
+  const triggerRef = useMergeRefs([refs.setReference]);
+  const floatingRef = useMergeRefs([refs.setFloating]);
+  const portalRoot = usePortalRoot();
+  const effectiveRoot = portalRoot?.() ?? undefined;
+
+  // Only nudge on an empty field; once the developer has typed (or inserted) a value, hide it.
+  if (!showDevModeNotice || value) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        variant='unstyled'
+        aria-label='Development testing tip'
+        data-dev-hint-trigger=''
+        data-open={open}
+        {...getReferenceProps()}
+        sx={t => ({
+          // Absolutely positioned at its static location (trailing the label text) so
+          // it doesn't force the label to wrap; the label reserves room via its
+          // padding-inline-end (see Form.tsx). height: 1lh centers it on the text line.
+          position: 'absolute',
+          marginInlineStart: '0.25em',
+          height: '1lh',
+          lineHeight: '1lh',
+          display: 'inline-flex',
+          alignItems: 'center',
+          padding: 0,
+          borderRadius: t.radii.$sm,
+          color: t.colors.$warning500,
+          // Hidden until the field is hovered/focused (revealed by the formField
+          // container in Form.tsx) or the popover is open.
+          opacity: 0,
+          transitionProperty: 'opacity',
+          transitionDuration: t.transitionDuration.$fast,
+          '&[data-open="true"]': { opacity: 1 },
+        })}
+      >
+        <Icon
+          icon={InformationCircle}
+          aria-hidden
+          sx={t => ({ width: t.sizes.$4, height: t.sizes.$4 })}
+        />
+      </Button>
+
+      {isMounted && (
+        <FloatingNode id={nodeId}>
+          <FloatingPortal root={effectiveRoot}>
+            {/* modal=false + initialFocus=-1: hovering with a mouse does not steal
+                focus, but keyboard users can Tab from the trigger into the content. */}
+            <FloatingFocusManager
+              context={context}
+              modal={false}
+              initialFocus={-1}
+            >
+              <Box
+                ref={floatingRef}
+                style={floatingStyles}
+                {...getFloatingProps()}
+                sx={t => ({ zIndex: t.zIndices.$tooltip })}
+              >
+                <Col
+                  style={transitionStyles}
+                  gap={2}
+                  sx={t => ({
+                    maxWidth: t.sizes.$60,
+                    padding: t.space.$3,
+                    borderRadius: t.radii.$lg,
+                    backgroundColor: t.colors.$colorBackground,
+                    borderWidth: t.borderWidths.$normal,
+                    borderStyle: t.borderStyles.$solid,
+                    borderColor: t.colors.$borderAlpha100,
+                    boxShadow: t.shadows.$menuShadow,
+                  })}
+                >
+                  <Text
+                    localizationKey={text}
+                    variant='body'
+                    colorScheme='secondary'
+                  />
+                  {action && (
+                    <Button
+                      variant='outline'
+                      localizationKey={action.label}
+                      onClick={() => {
+                        action.onInsert();
+                        setOpen(false);
+                      }}
+                    />
+                  )}
+                </Col>
+              </Box>
+            </FloatingFocusManager>
+          </FloatingPortal>
+        </FloatingNode>
+      )}
+    </>
+  );
+};
+
+export const FieldDevHint = withFloatingTree(FieldDevHintBase);

--- a/packages/ui/src/elements/Form.tsx
+++ b/packages/ui/src/elements/Form.tsx
@@ -12,6 +12,7 @@ import { LastAuthenticationStrategyBadge } from './Badge';
 import type { OTPInputProps } from './CodeControl';
 import { useCardState } from './contexts';
 import { Field } from './FieldControl';
+import type { FieldDevHintValue } from './FieldDevHint';
 
 const [FormState, useFormState] = createContextAndHook<{
   isLoading: boolean;
@@ -126,24 +127,40 @@ type CommonInputProps = CommonFieldRootProps & {
   onActionClicked?: React.MouseEventHandler;
   icon?: React.ComponentType;
   isLastAuthenticationStrategy?: boolean;
+  devHint?: FieldDevHintValue;
 };
 
 const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
-  const { isOptional, isLastAuthenticationStrategy, icon, actionLabel, children, onActionClicked, ...fieldProps } =
-    props;
+  const {
+    isOptional,
+    isLastAuthenticationStrategy,
+    icon,
+    actionLabel,
+    children,
+    onActionClicked,
+    devHint,
+    ...fieldProps
+  } = props;
   return (
     <Field.Root {...fieldProps}>
       <Col
         elementDescriptor={descriptors.formField}
         elementId={descriptors.formField.setId(fieldProps.id)}
-        sx={{ position: 'relative', flex: '1 1 auto' }}
+        sx={{
+          position: 'relative',
+          flex: '1 1 auto',
+          // Reveal the dev hint icon only while the field is hovered or focused.
+          ...(devHint && {
+            '&:hover [data-dev-hint-trigger], &:focus-within [data-dev-hint-trigger]': { opacity: 1 },
+          }),
+        }}
       >
         <Flex
           direction='col'
           sx={t => ({ gap: t.space.$2 })}
         >
           <Field.LabelRow>
-            <Field.Label />
+            <Field.Label devHint={devHint} />
             <Field.LabelIcon icon={icon} />
             {!actionLabel && isOptional && <Field.AsOptional />}
             {actionLabel && (

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -34,6 +34,16 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
     locationBasedCountryIso,
   });
 
+  // The component seeds its internal state from `value` only on mount. Sync later
+  // programmatic `value` changes (e.g. inserting a test phone number) into the
+  // internal state; guarded on inequality so it never loops with onChange.
+  useEffect(() => {
+    if (typeof value === 'string' && value && value !== numberWithCode) {
+      setNumberAndIso(value);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
   const callOnChangeProp = () => {
     // Quick and dirty way to match this component's public API
     // with every other Input component, so we can use the same helpers

--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -75,6 +75,13 @@ const { applyVariants, filterProps } = createVariants(
             [vars.border]: theme.colors.$danger500,
             [vars.alpha]: theme.colors.$dangerAlpha50,
           },
+          warning: {
+            [vars.accent]: theme.colors.$warning500,
+            [vars.accentHover]: theme.colors.$warning600,
+            [vars.accentContrast]: theme.colors.$white,
+            [vars.border]: theme.colors.$warning500,
+            [vars.alpha]: theme.colors.$warningAlpha50,
+          },
         },
         variant: {
           solid: {

--- a/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { toClerkTestEmail } from '../clerkTestEmail';
+
+describe('toClerkTestEmail', () => {
+  it('adds the +clerk_test subaddress to the local part', () => {
+    expect(toClerkTestEmail('alex@work.com')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('preserves an existing subaddress', () => {
+    expect(toClerkTestEmail('alex+newsletter@work.com')).toBe('alex+newsletter+clerk_test@work.com');
+  });
+
+  it('is a no-op when the value is already a test email', () => {
+    expect(toClerkTestEmail('alex+clerk_test@work.com')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(toClerkTestEmail('  alex@work.com  ')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('falls back to a placeholder when empty', () => {
+    expect(toClerkTestEmail('')).toBe('your_email+clerk_test@example.com');
+    expect(toClerkTestEmail('   ')).toBe('your_email+clerk_test@example.com');
+  });
+
+  it('handles a value with no domain yet', () => {
+    expect(toClerkTestEmail('alex')).toBe('alex+clerk_test@example.com');
+  });
+});

--- a/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isClerkTestPhoneNumber } from '../clerkTestPhoneNumber';
+
+describe('isClerkTestPhoneNumber', () => {
+  it('matches numbers in the 555-01XX test range', () => {
+    expect(isClerkTestPhoneNumber('+12015550100')).toBe(true);
+    expect(isClerkTestPhoneNumber('+12015550199')).toBe(true);
+  });
+
+  it('ignores formatting', () => {
+    expect(isClerkTestPhoneNumber('+1 (201) 555-0100')).toBe(true);
+  });
+
+  it('rejects numbers outside the test range', () => {
+    expect(isClerkTestPhoneNumber('+12015550200')).toBe(false);
+    expect(isClerkTestPhoneNumber('+12015551234')).toBe(false);
+  });
+
+  it('rejects empty or partial input', () => {
+    expect(isClerkTestPhoneNumber('')).toBe(false);
+    expect(isClerkTestPhoneNumber('+1201')).toBe(false);
+  });
+});

--- a/packages/ui/src/utils/clerkTestEmail.ts
+++ b/packages/ui/src/utils/clerkTestEmail.ts
@@ -1,0 +1,22 @@
+const CLERK_TEST_SUBADDRESS = '+clerk_test';
+const FALLBACK_TEST_EMAIL = 'your_email+clerk_test@example.com';
+
+/**
+ * Turns whatever the developer has typed into a Clerk test email by adding the `+clerk_test`
+ * subaddress to the local part. Falls back to a placeholder when the field is empty, and is a
+ * no-op when the value is already a test email.
+ */
+export const toClerkTestEmail = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return FALLBACK_TEST_EMAIL;
+  }
+  if (trimmed.includes(CLERK_TEST_SUBADDRESS)) {
+    return trimmed;
+  }
+  const at = trimmed.indexOf('@');
+  if (at === -1) {
+    return `${trimmed}${CLERK_TEST_SUBADDRESS}@example.com`;
+  }
+  return `${trimmed.slice(0, at)}${CLERK_TEST_SUBADDRESS}${trimmed.slice(at)}`;
+};

--- a/packages/ui/src/utils/clerkTestPhoneNumber.ts
+++ b/packages/ui/src/utils/clerkTestPhoneNumber.ts
@@ -1,0 +1,7 @@
+/**
+ * Clerk test phone numbers are fictional US numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
+ * range, i.e. the last seven digits are `555 01XX`. Ignores formatting so it works on any input.
+ */
+export const isClerkTestPhoneNumber = (value: string): boolean => {
+  return /55501\d\d$/.test(value.replace(/\D/g, ''));
+};


### PR DESCRIPTION
## Description

Adds dev mode hints for prefilling email/phone number inputs with testing values.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dev-only info hints for sign-in and sign-up email/phone fields, with an ℹ️ popover and “insert test” quick actions.
  - Introduced a new **warning** button color scheme.
- **Bug Fixes**
  - Improved phone input behavior so externally provided values update reliably after mount.
- **Developer Experience**
  - Dev hints appear only in development mode and only for empty/non-test values.
- **Tests**
  - Added unit tests for test-email conversion and test-phone detection helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->