### PR TITLE
fix(backend): reject machine JWTs presented as session tokens

### DIFF
--- a/.changeset/shiny-words-lay.md
+++ b/.changeset/shiny-words-lay.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Reject machine tokens (M2M and OAuth JWTs) presented in the `__session` cookie. Previously such a token could pass session verification and produce a signed-in state with the machine identity as `userId`, defeating `if (userId)` authorization checks. The cookie path now mirrors the existing header-path guard and returns a signed-out state for these tokens.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -8,6 +8,7 @@ import {
   mockJwks,
   mockJwt,
   mockJwtPayload,
+  mockM2MJwtPayload,
   signingJwks,
 } from '../../fixtures';
 import {
@@ -1277,6 +1278,32 @@ describe('tokens.authenticateRequest(options)', () => {
 
     expect(requestState).toBeSignedIn();
     expect(requestState.toAuth()).toBeSignedInToAuth();
+  });
+
+  test('cookieToken: returns signed out when an M2M JWT is presented in the __session cookie (SDK-107)', async () => {
+    // A same-instance M2M JWT carries the instance issuer, so it survives the suffixed-cookie check.
+    const { data: m2mJwt } = await signJwt({ ...mockM2MJwtPayload, iss: mockJwtPayload.iss }, signingJwks, {
+      algorithm: 'RS256',
+      header: { typ: 'JWT', kid: 'ins_2GIoQhbUpy0hX7B2cVkuTMinXoD' },
+    });
+
+    const requestState = await authenticateRequest(
+      mockRequestWithCookies(
+        {},
+        {
+          __clerk_db_jwt: 'deadbeef',
+          __client_uat: `${mockJwtPayload.iat - 10}`,
+          __session: m2mJwt!,
+        },
+      ),
+      mockOptions(),
+    );
+
+    expect(requestState).toBeSignedOut({
+      reason: AuthErrorReason.TokenTypeMismatch,
+      message: '',
+    });
+    expect(requestState.toAuth()).toBeSignedOutToAuth();
   });
 
   // todo(

--- a/packages/backend/src/tokens/__tests__/verify.test.ts
+++ b/packages/backend/src/tokens/__tests__/verify.test.ts
@@ -113,6 +113,22 @@ describe('tokens.verify(token, options)', () => {
     expect(errors).toBeDefined();
     expect(errors?.[0].message).toContain('signature');
   });
+
+  it('rejects a JWT tagged with the M2M category before key resolution (AISEC-91)', async () => {
+    // Non-machine `sub` isolates the category guard from the sub-based machine-JWT check;
+    // no jwks server is mocked, proving the guard fires before any network call.
+    const token = await createSignedM2MJwt({ ...mockM2MJwtPayload, sub: mockJwtPayload.sub });
+
+    const { data, errors } = await verifyToken(token, {
+      apiUrl: 'https://api.clerk.test',
+      secretKey: 'a-valid-key',
+      skipJwksCache: true,
+    });
+
+    expect(data).toBeUndefined();
+    expect(errors?.[0].reason).toBe('token-invalid');
+    expect(errors?.[0].message).toBe('Invalid session token category.');
+  });
 });
 
 describe('tokens.verifyMachineAuthToken(token, options)', () => {

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -631,6 +631,17 @@ export const authenticateRequest: AuthenticateRequest = (async (
       return handleSessionTokenError(decodedErrors[0], 'cookie');
     }
 
+    // Machine JWTs pass verifyToken() but must not be accepted as session tokens (mirrors header path).
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (isMachineJwt(authenticateContext.sessionTokenInCookie!)) {
+      return signedOut({
+        tokenType: TokenType.SessionToken,
+        authenticateContext,
+        reason: AuthErrorReason.TokenTypeMismatch,
+        message: '',
+      });
+    }
+
     if (decodeResult.payload.iat < authenticateContext.clientUat) {
       return handleMaybeHandshakeStatus(authenticateContext, AuthErrorReason.SessionTokenIATBeforeClientUAT, '');
     }

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -19,6 +19,7 @@ import { loadClerkJwkFromPem, loadClerkJWKFromRemote } from './keys';
 import {
   API_KEY_PREFIX,
   isJwtFormat,
+  JWT_CATEGORY_M2M_TOKEN,
   M2M_SUBJECT_PREFIX,
   M2M_TOKEN_PREFIX,
   OAUTH_ACCESS_TOKEN_TYPES,
@@ -118,6 +119,20 @@ export async function verifyToken(
 
   const { header } = decodedResult;
   const { kid } = header;
+
+  // Reject machine JWTs (e.g. M2M) tagged with a non-session category but signed by the same
+  // instance key, regardless of transport. Reciprocal of the machine verifier's `cat` check.
+  if (header.cat === JWT_CATEGORY_M2M_TOKEN) {
+    return {
+      errors: [
+        new TokenVerificationError({
+          action: TokenVerificationErrorAction.EnsureClerkJWT,
+          reason: TokenVerificationErrorReason.TokenInvalid,
+          message: 'Invalid session token category.',
+        }),
+      ],
+    };
+  }
 
   try {
     let key: JsonWebKey;


### PR DESCRIPTION
## Description

The cookie path (authenticateRequestWithTokenInCookie) lacked the isMachineJwt() guard the header path has, so a same-instance M2M JWT in the \_\_session cookie passed verifyToken() and produced a signed-in state with userId = "mch\_...".

- Guard the cookie path with isMachineJwt(), mirroring the header path
- verifyToken() now also rejects any JWT tagged with a non-session token category (cat), closing the confusion regardless of transport
- Add regression tests for both paths

Fixes SDK-107

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Machine-to-machine tokens and OAuth JWTs provided through the session cookie are now rejected instead of being treated as signed-in sessions.
  * Invalid session token categories now consistently return a signed-out authentication state.
  * Session token validation rejects unsupported token types earlier, improving authorization safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->