### PR TITLE
fix(ui): Avoid domain and billing loading shifts

### DIFF
--- a/.changeset/avoid-domain-loading-shift.md
+++ b/.changeset/avoid-domain-loading-shift.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Prevent layout shift in the organization domain list by keeping row height consistent between loading and loaded states.

--- a/.changeset/avoid-domain-loading-shift.md
+++ b/.changeset/avoid-domain-loading-shift.md
@@ -1,5 +1,0 @@
----
-'@clerk/ui': patch
----
-
-Prevent layout shift in the organization domain list by keeping row height consistent between loading and loaded states.

--- a/.changeset/fix-loading-shift.md
+++ b/.changeset/fix-loading-shift.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Reduce layout shift while loading the organization and billing UI. The domain list, billing subscription section, and payment methods now reserve their loaded height while data is fetched, and the subscription section shows a loading indicator instead of rendering nothing.

--- a/packages/ui/src/components/OrganizationProfile/DomainList.tsx
+++ b/packages/ui/src/components/OrganizationProfile/DomainList.tsx
@@ -158,7 +158,7 @@ export const DomainList = withProtect(
             sx={[
               t => ({
                 width: '100%',
-                height: t.space.$10,
+                height: t.space.$8,
                 position: 'relative',
               }),
             ]}

--- a/packages/ui/src/components/PaymentMethods/PaymentMethods.tsx
+++ b/packages/ui/src/components/PaymentMethods/PaymentMethods.tsx
@@ -11,7 +11,7 @@ import { handleError } from '@/ui/utils/errorHandler';
 import { RemoveResourceForm } from '../../common';
 import { DevOnly } from '../../common/DevOnly';
 import { usePaymentMethods, useSubscriberTypeContext, useSubscriberTypeLocalizationRoot } from '../../contexts';
-import { localizationKeys } from '../../customizables';
+import { Box, localizationKeys } from '../../customizables';
 import { Action } from '../../elements/Action';
 import { useActionContext } from '../../elements/Action/ActionRoot';
 import * as AddPaymentMethod from './AddPaymentMethod';
@@ -142,7 +142,9 @@ export const PaymentMethods = withCardStateProvider(() => {
           disableAnimation
         >
           {isLoading ? (
-            <FullHeightLoader />
+            <Box sx={t => ({ height: t.space.$16 })}>
+              <FullHeightLoader />
+            </Box>
           ) : (
             <>
               {sortedPaymentMethods.map(paymentMethod => (

--- a/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
+++ b/packages/ui/src/components/Subscriptions/SubscriptionsList.tsx
@@ -2,6 +2,7 @@ import type { BillingSubscriptionItemResource, BillingSubscriptionResource } fro
 import { Fragment, useMemo } from 'react';
 
 import { useProtect } from '@/ui/common/Gate';
+import { FullHeightLoader } from '@/ui/elements/FullHeightLoader';
 import { ProfileSection } from '@/ui/elements/Section';
 import { common } from '@/ui/styledSystem';
 import { getSeatLimitAndIncludedSeatsLocalizationKey } from '@/ui/utils/billingPlanSeats';
@@ -16,6 +17,7 @@ import {
 } from '../../contexts';
 import type { LocalizationKey } from '../../customizables';
 import {
+  Box,
   Col,
   Flex,
   Icon,
@@ -47,7 +49,7 @@ export function SubscriptionsList({
 }) {
   const localizationRoot = useSubscriberTypeLocalizationRoot();
   const subscriberType = useSubscriberTypeContext();
-  const { subscriptionItems, data: subscription } = useSubscription();
+  const { subscriptionItems, data: subscription, isLoading } = useSubscription();
   const canManageBilling =
     useProtect(has => has({ permission: 'org:sys_billing:manage' })) || subscriberType === 'user';
   const { navigate } = useRouter();
@@ -92,94 +94,103 @@ export function SubscriptionsList({
         paddingTop: t.space.$1,
       })}
     >
-      {subscriptionItems.length > 0 && (
-        <Table
-          sx={t => ({
-            overflow: 'hidden',
-            'tr > td': {
-              paddingTop: t.space.$3,
-              paddingBottom: t.space.$3,
-              paddingInlineStart: t.space.$3,
-              paddingInlineEnd: t.space.$3,
-            },
-          })}
-          tableHeadVisuallyHidden
-        >
-          <Thead>
-            <Tr>
-              <Th
-                localizationKey={localizationKeys(
-                  `${localizationRoot}.billingPage.subscriptionsListSection.tableHeader__plan`,
-                )}
-              />
-              <Th
-                localizationKey={localizationKeys(
-                  `${localizationRoot}.billingPage.subscriptionsListSection.tableHeader__startDate`,
-                )}
-              />
-            </Tr>
-          </Thead>
-          <Tbody>
-            {sortedSubscriptionItems.map(subscriptionItem => (
-              <SubscriptionItemRow
-                key={subscriptionItem.id}
-                subscriptionItem={subscriptionItem}
-                length={sortedSubscriptionItems.length}
-              />
-            ))}
-            {subscription?.nextPayment ? (
-              <SubscriptionOverviewRow
-                nextPayment={subscription.nextPayment}
-                localizationRoot={localizationRoot}
+      {isLoading && subscriptionItems.length === 0 ? (
+        // Reserve the loaded height (42px card + gap + button) to avoid shifting content on load
+        <Box sx={t => ({ height: `calc(${t.space.$1} * 10.5 + ${t.space.$2} + ${t.space.$8})` })}>
+          <FullHeightLoader />
+        </Box>
+      ) : (
+        <>
+          {subscriptionItems.length > 0 && (
+            <Table
+              sx={t => ({
+                overflow: 'hidden',
+                'tr > td': {
+                  paddingTop: t.space.$3,
+                  paddingBottom: t.space.$3,
+                  paddingInlineStart: t.space.$3,
+                  paddingInlineEnd: t.space.$3,
+                },
+              })}
+              tableHeadVisuallyHidden
+            >
+              <Thead>
+                <Tr>
+                  <Th
+                    localizationKey={localizationKeys(
+                      `${localizationRoot}.billingPage.subscriptionsListSection.tableHeader__plan`,
+                    )}
+                  />
+                  <Th
+                    localizationKey={localizationKeys(
+                      `${localizationRoot}.billingPage.subscriptionsListSection.tableHeader__startDate`,
+                    )}
+                  />
+                </Tr>
+              </Thead>
+              <Tbody>
+                {sortedSubscriptionItems.map(subscriptionItem => (
+                  <SubscriptionItemRow
+                    key={subscriptionItem.id}
+                    subscriptionItem={subscriptionItem}
+                    length={sortedSubscriptionItems.length}
+                  />
+                ))}
+                {subscription?.nextPayment ? (
+                  <SubscriptionOverviewRow
+                    nextPayment={subscription.nextPayment}
+                    localizationRoot={localizationRoot}
+                  />
+                ) : null}
+              </Tbody>
+            </Table>
+          )}
+
+          <ProfileSection.ButtonGroup id='subscriptionsList'>
+            {billingPlansExist ? (
+              <ProfileSection.ArrowButton
+                id='subscriptionsList'
+                textLocalizationKey={subscriptionItems.length > 0 ? switchPlansLabel : newSubscriptionLabel}
+                sx={[
+                  t => ({
+                    justifyContent: 'start',
+                    height: t.sizes.$8,
+                    width: isManageButtonVisible ? 'unset' : undefined,
+                  }),
+                ]}
+                leftIcon={subscriptionItems.length > 0 ? ArrowUpDown : Plus}
+                rightIcon={null}
+                leftIconSx={t => ({
+                  width: t.sizes.$4,
+                  height: t.sizes.$4,
+                })}
+                onClick={() => void navigate('plans')}
               />
             ) : null}
-          </Tbody>
-        </Table>
+
+            {isManageButtonVisible ? (
+              <ProfileSection.ArrowButton
+                id='subscriptionsList'
+                textLocalizationKey={manageSubscriptionLabel}
+                sx={[
+                  t => ({
+                    justifyContent: 'start',
+                    height: t.sizes.$8,
+                    width: 'unset',
+                  }),
+                ]}
+                rightIcon={null}
+                leftIcon={Cog}
+                leftIconSx={t => ({
+                  width: t.sizes.$4,
+                  height: t.sizes.$4,
+                })}
+                onClick={event => openSubscriptionDetails(event)}
+              />
+            ) : null}
+          </ProfileSection.ButtonGroup>
+        </>
       )}
-
-      <ProfileSection.ButtonGroup id='subscriptionsList'>
-        {billingPlansExist ? (
-          <ProfileSection.ArrowButton
-            id='subscriptionsList'
-            textLocalizationKey={subscriptionItems.length > 0 ? switchPlansLabel : newSubscriptionLabel}
-            sx={[
-              t => ({
-                justifyContent: 'start',
-                height: t.sizes.$8,
-                width: isManageButtonVisible ? 'unset' : undefined,
-              }),
-            ]}
-            leftIcon={subscriptionItems.length > 0 ? ArrowUpDown : Plus}
-            rightIcon={null}
-            leftIconSx={t => ({
-              width: t.sizes.$4,
-              height: t.sizes.$4,
-            })}
-            onClick={() => void navigate('plans')}
-          />
-        ) : null}
-
-        {isManageButtonVisible ? (
-          <ProfileSection.ArrowButton
-            id='subscriptionsList'
-            textLocalizationKey={manageSubscriptionLabel}
-            sx={[
-              t => ({
-                justifyContent: 'start',
-                height: t.sizes.$8,
-                width: 'unset',
-              }),
-            ]}
-            rightIcon={null}
-            leftIcon={Cog}
-            leftIconSx={t => ({
-              width: t.sizes.$4,
-              height: t.sizes.$4,
-            })}
-            onClick={event => openSubscriptionDetails(event)}
-          />
-        ) : null}
-      </ProfileSection.ButtonGroup>
     </ProfileSection.Root>
   );
 }


### PR DESCRIPTION
## Description

Reduce layout shift while the organization and billing UI load. Each section now reserves its loaded height while data is fetched, so surrounding content no longer jumps when it resolves.

- **Domains**: the loading placeholder matches a single domain row height.
- **Subscription**: reserves the loaded card + button height and shows a loading indicator. Previously it rendered nothing while loading, so the "Switch plans" button painted with the wrong label and then shifted into place.
- **Payment methods**: the loader reserves the row + add-button height instead of collapsing to the spinner size.

Domains BEFORE

https://github.com/user-attachments/assets/d8685aa8-331e-4ef9-85f9-6162beac9885

Domains AFTER

https://github.com/user-attachments/assets/8c5b8039-b84a-40d2-9480-be8a273ef89d

Billing BEFORE

https://github.com/user-attachments/assets/25129b47-32b5-425e-9da9-0da8a78fb57d

Billing AFTER

https://github.com/user-attachments/assets/f0106ff0-7260-4650-809f-442fcab3a8ac

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced layout shifting while organization and billing information loads.
  - Added consistent reserved space and loading indicators for subscription details and payment methods.
  - Improved the domain list loading state to provide a smoother visual transition.
  - Subscription actions and content now appear more predictably as data becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->