### PR TITLE
fix(ui): Scope table row hover radius to the last row

### DIFF
--- a/.changeset/table-hover-radius.md
+++ b/.changeset/table-hover-radius.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix table row hover styling so the rounded bottom corners are only applied to the last row, matching the table's border radius. Previously any hovered row showed a stray corner radius.

--- a/packages/ui/src/primitives/Table.tsx
+++ b/packages/ui/src/primitives/Table.tsx
@@ -47,10 +47,10 @@ const { applyVariants, filterProps } = createVariants(theme => {
         borderInlineEndWidth: '0px',
         borderColor: theme.colors.$borderAlpha150,
       },
-      'tr:hover td:first-of-type': {
+      'tr:last-of-type:hover td:first-of-type': {
         borderEndStartRadius: theme.radii.$lg,
       },
-      'tr:hover td:last-of-type': {
+      'tr:last-of-type:hover td:last-of-type': {
         borderEndEndRadius: theme.radii.$lg,
       },
       'tr > th:first-of-type': {


### PR DESCRIPTION
## Description

Fixes a table row hover styling bug where any hovered row displayed a stray rounded bottom corner. The `tr:hover` selectors that applied `$lg` bottom-corner radius are now scoped to `tr:last-of-type:hover`, so the rounded corners only appear on the last row where they tuck into the table's own border radius. Interior rows now hover with square corners.

| BEFORE | AFTER |
|--------|--------|
| <img width="383" height="261" alt="Screenshot 2026-07-15 at 11 30 22 AM" src="https://github.com/user-attachments/assets/8a724ddc-d772-4a45-9dc9-c6ae97d34c3c" /> | <img width="357" height="252" alt="Screenshot 2026-07-15 at 11 29 41 AM" src="https://github.com/user-attachments/assets/7b370a07-c339-4432-a67e-5c8802927ff4" /> | 

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table row hover styling so rounded bottom corners appear only on the last row, eliminating stray corner rounding on other rows.

* **Documentation**
  * Added a release note documenting the table hover styling correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->