### PR TITLE
fix(expo): prevent initialization retry leaks

### DIFF
--- a/.changeset/tidy-expo-retries.md
+++ b/.changeset/tidy-expo-retries.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Prevent Expo apps from accumulating duplicate initialization requests while the Clerk API is unavailable or the app reloads.

--- a/packages/expo/src/provider/singleton/__tests__/createClerkInstance.test.ts
+++ b/packages/expo/src/provider/singleton/__tests__/createClerkInstance.test.ts
@@ -1,5 +1,6 @@
 import type { Clerk } from '@clerk/clerk-js';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ClerkRuntimeError } from '@clerk/shared/error';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { TokenCache } from '../../../cache/types';
 import { CLERK_CLIENT_JWT_KEY } from '../../../constants';
@@ -7,6 +8,7 @@ import { CLERK_CLIENT_JWT_KEY } from '../../../constants';
 const mocks = vi.hoisted(() => {
   return {
     constructorSpy: vi.fn(),
+    requestInitialResources: vi.fn<() => Promise<void>>(),
   };
 });
 
@@ -31,9 +33,16 @@ class MockClerk {
   }
 
   addListener = vi.fn();
+  __internal_reloadInitialResources = () => mocks.requestInitialResources();
+  __internal_getCachedResources?: () => Promise<{ client: unknown; environment: unknown }>;
   __internal_onBeforeRequest = vi.fn();
   __internal_onAfterResponse = vi.fn();
 }
+
+const createUnavailableResourceCache = () => ({
+  get: () => Promise.resolve(null),
+  set: () => Promise.resolve(),
+});
 
 const loadCreateClerkInstance = async () => {
   const mod = await import('../createClerkInstance');
@@ -44,6 +53,7 @@ describe('createClerkInstance', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mocks.requestInitialResources.mockResolvedValue(undefined);
   });
 
   test('passes proxyUrl to the native Clerk constructor', async () => {
@@ -383,5 +393,109 @@ describe('createClerkInstance', () => {
 
     expect(initialTokenCache.saveToken).not.toHaveBeenCalled();
     expect(latestTokenCache.saveToken).toHaveBeenCalledWith(CLERK_CLIENT_JWT_KEY, 'fresh-token');
+  });
+
+  describe('initial resource recovery', () => {
+    const setupUnavailableResources = async () => {
+      const createClerkInstance = await loadCreateClerkInstance();
+      const getClerkInstance = createClerkInstance(MockClerk as unknown as typeof Clerk);
+      const clerk = getClerkInstance({
+        publishableKey: 'pk_test_123',
+        __experimental_resourceCache: createUnavailableResourceCache,
+      }) as unknown as MockClerk;
+
+      return { clerk, getClerkInstance };
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test('keeps one FAPI recovery attempt active across repeated cache misses', async () => {
+      mocks.requestInitialResources.mockImplementation(() => new Promise(() => {}));
+
+      const { clerk } = await setupUnavailableResources();
+
+      const cachedResources = await Promise.all([
+        clerk.__internal_getCachedResources?.(),
+        clerk.__internal_getCachedResources?.(),
+      ]);
+
+      expect(cachedResources).toEqual([
+        { client: expect.any(Object), environment: expect.any(Object) },
+        { client: expect.any(Object), environment: expect.any(Object) },
+      ]);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not retry a failed recovery after the instance is replaced', async () => {
+      mocks.requestInitialResources.mockRejectedValue(
+        new ClerkRuntimeError('FAPI unavailable', { code: 'network_error' }),
+      );
+
+      const { clerk, getClerkInstance } = await setupUnavailableResources();
+
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+
+      getClerkInstance({ publishableKey: 'pk_test_second' });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not start another FAPI recovery while one is still pending', async () => {
+      mocks.requestInitialResources.mockImplementation(() => new Promise(() => {}));
+
+      const { clerk } = await setupUnavailableResources();
+
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+    });
+
+    test('backs off failed FAPI recovery attempts without waiting more than 30 seconds', async () => {
+      mocks.requestInitialResources.mockRejectedValue(
+        new ClerkRuntimeError('FAPI unavailable', { code: 'network_error' }),
+      );
+
+      const { clerk } = await setupUnavailableResources();
+
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+
+      const retryDelays = [2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+      for (const [index, retryDelay] of retryDelays.entries()) {
+        await vi.advanceTimersByTimeAsync(retryDelay);
+        expect(mocks.requestInitialResources).toHaveBeenCalledTimes(index + 2);
+      }
+    });
+
+    test('stops recovering after the initial resources load', async () => {
+      mocks.requestInitialResources.mockResolvedValue(undefined);
+
+      const { clerk } = await setupUnavailableResources();
+
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+
+      await clerk.__internal_getCachedResources?.();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(mocks.requestInitialResources).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/expo/src/provider/singleton/createClerkInstance.ts
+++ b/packages/expo/src/provider/singleton/createClerkInstance.ts
@@ -44,6 +44,9 @@ type ResolvedClerkRuntimeOptions = Omit<ClerkRuntimeOptions, 'publishableKey'> &
   publishableKey: string;
 };
 
+const RESOURCE_RETRY_MAX_DELAY_MS = 30_000;
+const RESOURCE_RETRY_MAX_EXPONENT = 4;
+
 function hasOwnOption<Key extends keyof BuildClerkOptions>(
   options: BuildClerkOptions | undefined,
   key: Key,
@@ -53,6 +56,7 @@ function hasOwnOption<Key extends keyof BuildClerkOptions>(
 
 let __internal_clerk: HeadlessBrowserClerk | BrowserClerk | undefined;
 let __internal_clerkOptions: ClerkRuntimeOptions | undefined;
+let __internal_cancelResourceRetries: (() => void) | undefined;
 // Token IO can change without recreating the native singleton.
 let __internal_tokenCache: TokenCache = MemoryTokenCache;
 
@@ -110,6 +114,9 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
     if (!__internal_clerk || hasConfigChanged) {
       assertValidProxyUrl(proxyUrl);
 
+      __internal_cancelResourceRetries?.();
+      __internal_cancelResourceRetries = undefined;
+
       if (hasConfigChanged) {
         void __internal_tokenCache.clearToken?.(CLERK_CLIENT_JWT_KEY);
       }
@@ -118,7 +125,8 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
       const saveToken = (key: string, token: string) => __internal_tokenCache.saveToken(key, token);
 
       __internal_clerkOptions = { publishableKey, proxyUrl, domain };
-      __internal_clerk = new ClerkClass(publishableKey, { proxyUrl, domain }) as unknown as BrowserClerk;
+      const clerk = new ClerkClass(publishableKey, { proxyUrl, domain }) as unknown as BrowserClerk;
+      __internal_clerk = clerk;
 
       if (Platform.OS === 'ios' || Platform.OS === 'android') {
         // @ts-expect-error - This is an internal API
@@ -162,17 +170,64 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
         const isClerkNetworkError = (err: unknown): boolean => isClerkRuntimeError(err) && err.code === 'network_error';
 
         if (createResourceCache) {
-          const retryInitilizeResourcesFromFAPI = async () => {
-            try {
-              await __internal_clerk?.__internal_reloadInitialResources();
-            } catch (err: unknown) {
-              // Retry after 3 seconds if the error is a network error or a 5xx error
-              if (isClerkNetworkError(err) || !is4xxError(err)) {
-                // Retry after 2 seconds if the error is a network error
-                // Retry after 10 seconds if the error is a 5xx FAPI error
-                const timeout = isClerkNetworkError(err) ? 2000 : 10000;
-                setTimeout(() => void retryInitilizeResourcesFromFAPI(), timeout);
+          let resourceRetryTimer: ReturnType<typeof setTimeout> | undefined;
+          let resourceRetryCancelled = false;
+          let resourceRetryInFlight = false;
+          let resourceRetryFailureCount = 0;
+          let initialResourcesLoaded = false;
+
+          __internal_cancelResourceRetries = () => {
+            resourceRetryCancelled = true;
+            if (resourceRetryTimer !== undefined) {
+              clearTimeout(resourceRetryTimer);
+              resourceRetryTimer = undefined;
+            }
+          };
+
+          const scheduleResourceRetry = (timeout: number) => {
+            if (
+              resourceRetryCancelled ||
+              initialResourcesLoaded ||
+              resourceRetryTimer !== undefined ||
+              resourceRetryInFlight
+            ) {
+              return;
+            }
+
+            resourceRetryTimer = setTimeout(() => {
+              resourceRetryTimer = undefined;
+              if (resourceRetryCancelled || initialResourcesLoaded) {
+                return;
               }
+              void retryInitializeResourcesFromFAPI();
+            }, timeout);
+          };
+
+          const retryInitializeResourcesFromFAPI = async () => {
+            if (resourceRetryCancelled || initialResourcesLoaded || resourceRetryInFlight) {
+              return;
+            }
+
+            resourceRetryInFlight = true;
+            let nextRetryTimeout: number | undefined;
+            try {
+              await clerk.__internal_reloadInitialResources();
+              initialResourcesLoaded = true;
+            } catch (err: unknown) {
+              if (isClerkNetworkError(err) || !is4xxError(err)) {
+                const initialRetryTimeout = isClerkNetworkError(err) ? 2000 : 10000;
+                nextRetryTimeout = Math.min(
+                  initialRetryTimeout * 2 ** resourceRetryFailureCount,
+                  RESOURCE_RETRY_MAX_DELAY_MS,
+                );
+                resourceRetryFailureCount = Math.min(resourceRetryFailureCount + 1, RESOURCE_RETRY_MAX_EXPONENT);
+              }
+            } finally {
+              resourceRetryInFlight = false;
+            }
+
+            if (nextRetryTimeout !== undefined) {
+              scheduleResourceRetry(nextRetryTimeout);
             }
           };
 
@@ -210,7 +265,7 @@ export function createClerkInstance(ClerkClass: typeof Clerk) {
             if (!environment || !client) {
               environment = DUMMY_CLERK_ENVIRONMENT_RESOURCE;
               client = DUMMY_CLERK_CLIENT_RESOURCE;
-              setTimeout(() => void retryInitilizeResourcesFromFAPI(), 3000);
+              scheduleResourceRetry(3000);
             }
             return { client, environment };
           };


### PR DESCRIPTION
## Description

When the Frontend API (FAPI) is unavailable, Expo falls back to cached resources and schedules `__internal_reloadInitialResources()`. Fast Refresh and repeated reloads can run this path several times during local development. Each cache miss could start an independent recursive retry timer, and old timers were not cancelled when the Clerk instance was replaced.

I observed hundreds of simulator TCP connections in Proxyman, eventually exhausting macOS ephemeral ports.

## Current approach

This PR:

- Allows only one pending retry timer or request per Clerk instance.
- Cancels the previous instance's retry timer when the instance is replaced.
- Stops retrying after resources load successfully.
- Uses exponential backoff capped at 30 seconds.

The retry timing is:

- The initial cache-miss retry remains 3 seconds.
- Network failures retry after 2, 4, 8, 16, and then 30 seconds.
- Other retryable failures, including 5xx responses, retry after 10, 20, and then 30 seconds.
- Retries continue indefinitely at the 30-second cap.

Healthy initialization is unchanged. During a prolonged outage, a real app may take up to 30 seconds to detect that FAPI has recovered.

## Alternative approach

Keep the same single-flight and cancellation behavior, but preserve the existing fixed retry timing:

- Network failures retry every 2 seconds.
- Other retryable failures retry every 10 seconds.
- Retries stop after resources load successfully.

### Difference

- The current approach sends fewer requests during a long outage, but recovery may be detected later.
- The alternative preserves the existing production recovery timing, but continues calling FAPI every 2 or 10 seconds while it is unavailable.
- Both approaches prevent stacked retry loops and stale instances from continuing to retry.

The lifecycle tests cover duplicate cache misses, an in-flight request, replacement after a failed attempt, successful recovery, and capped backoff.

## Checklist

- [x] `pnpm --filter @clerk/expo test`
- [x] `pnpm --filter @clerk/expo build`
- [x] No package exports changed
- [x] No documentation update is needed for this internal fix

## Type of change

- [x] 🐛 Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Expo resource initialization when the Clerk API is unavailable or cached resources are missing.
  * Prevented duplicate recovery requests during app reloads or repeated resource misses.
  * Added cancellable retries with increasing delays, capped at 30 seconds.
  * Stopped retries after successful initialization or when the active instance changes.

* **Chores**
  * Prepared a patch release for `@clerk/expo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->