### PR TITLE
fix(ui): close only the open Select on Escape inside a Drawer

### DIFF
--- a/.changeset/drawer-select-escape.md
+++ b/.changeset/drawer-select-escape.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix pressing `Escape` while a `Select` is open inside a `Drawer` (for example the payment method picker in Checkout) dismissing the entire Drawer. `Escape` now closes only the open `Select` and leaves the Drawer open. The `Select` now wires up its floating interaction props so it handles `Escape` itself, and the `Drawer` roots a floating tree so nested floating elements are recognized as its children.

--- a/packages/ui/src/elements/Drawer.tsx
+++ b/packages/ui/src/elements/Drawer.tsx
@@ -2,10 +2,14 @@ import { usePortalRoot, useSafeLayoutEffect } from '@clerk/shared/react/index';
 import type { UseDismissProps, UseFloatingOptions, UseRoleProps } from '@floating-ui/react';
 import {
   FloatingFocusManager,
+  FloatingNode,
   FloatingPortal,
+  FloatingTree,
   useClick,
   useDismiss,
   useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
   useInteractions,
   useMergeRefs,
   useRole,
@@ -78,7 +82,22 @@ interface RootProps {
   dismissProps?: UseDismissProps;
 }
 
-function Root({
+function Root(props: RootProps) {
+  // The Drawer must be the root of a FloatingTree so that nested floating
+  // elements (e.g. a Select) register as its children. Without this, pressing
+  // Escape to close a nested popover also dismisses the Drawer.
+  const parentNodeId = useFloatingParentNodeId();
+  if (parentNodeId == null) {
+    return (
+      <FloatingTree>
+        <RootContent {...props} />
+      </FloatingTree>
+    );
+  }
+  return <RootContent {...props} />;
+}
+
+function RootContent({
   children,
   open,
   onOpenChange,
@@ -90,10 +109,12 @@ function Root({
   const direction = useDirection();
   const portalRoot = usePortalRoot();
   const effectivePortalRoot = portalProps?.root ?? portalRoot?.() ?? undefined;
+  const nodeId = useFloatingNodeId();
 
   const { refs, context } = useFloating({
     open,
     onOpenChange,
+    nodeId,
     transform: false,
     strategy,
     placement: direction === 'ltr' ? 'right' : 'left',
@@ -107,25 +128,27 @@ function Root({
   ]);
 
   return (
-    <DrawerContext.Provider
-      value={{
-        isOpen: open,
-        setIsOpen: onOpenChange,
-        strategy,
-        portalProps: { ...portalProps, root: effectivePortalRoot },
-        refs,
-        context,
-        getFloatingProps,
-        direction,
-      }}
-    >
-      <FloatingPortal
-        {...portalProps}
-        root={effectivePortalRoot}
+    <FloatingNode id={nodeId}>
+      <DrawerContext.Provider
+        value={{
+          isOpen: open,
+          setIsOpen: onOpenChange,
+          strategy,
+          portalProps: { ...portalProps, root: effectivePortalRoot },
+          refs,
+          context,
+          getFloatingProps,
+          direction,
+        }}
       >
-        {children}
-      </FloatingPortal>
-    </DrawerContext.Provider>
+        <FloatingPortal
+          {...portalProps}
+          root={effectivePortalRoot}
+        >
+          {children}
+        </FloatingPortal>
+      </DrawerContext.Provider>
+    </FloatingNode>
   );
 }
 

--- a/packages/ui/src/elements/Select.tsx
+++ b/packages/ui/src/elements/Select.tsx
@@ -289,7 +289,7 @@ export const SelectOptionList = (props: SelectOptionListProps) => {
   } = useSelectState();
   const { filteredItems: options, searchInputProps } = searchInputCtx;
   const [focusedIndex, setFocusedIndex] = useState(0);
-  const { isOpen, floating, styles, nodeId, context } = popoverCtx;
+  const { isOpen, floating, styles, nodeId, context, getFloatingProps } = popoverCtx;
   const containerRef = React.useRef<HTMLDivElement>(null);
   const effectiveListboxId = id ?? generatedListboxId;
   const effectiveAriaLabelledBy = ariaLabelledBy ?? (ariaLabel ? undefined : triggerId);
@@ -361,7 +361,7 @@ export const SelectOptionList = (props: SelectOptionListProps) => {
         elementDescriptor={descriptors.selectOptionsContainer}
         elementId={descriptors.selectOptionsContainer.setId(elementId)}
         ref={floating}
-        onKeyDown={onKeyDown}
+        {...getFloatingProps({ onKeyDown })}
         direction='col'
         justify='start'
         sx={[

--- a/packages/ui/src/elements/__tests__/Drawer.test.tsx
+++ b/packages/ui/src/elements/__tests__/Drawer.test.tsx
@@ -1,0 +1,66 @@
+import { ClerkInstanceContext } from '@clerk/shared/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EnvironmentProvider } from '../../contexts';
+import { AppearanceProvider } from '../../customizables';
+import { InternalThemeProvider } from '../../styledSystem';
+import { Drawer } from '../Drawer';
+import { Select, SelectButton, SelectOptionList } from '../Select';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const TestProviders = ({ children }: PropsWithChildren) => (
+  <ClerkInstanceContext.Provider value={{ value: { client: {}, user: {} } as any }}>
+    <EnvironmentProvider value={{ displayConfig: { applicationName: 'TestApp' } } as any}>
+      <AppearanceProvider>
+        <InternalThemeProvider>{children}</InternalThemeProvider>
+      </AppearanceProvider>
+    </EnvironmentProvider>
+  </ClerkInstanceContext.Provider>
+);
+
+describe('Drawer', () => {
+  it('does not close the Drawer when Escape dismisses an open nested Select', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onOpenChange = vi.fn();
+
+    render(
+      <Drawer.Root
+        open
+        onOpenChange={onOpenChange}
+      >
+        <Drawer.Content>
+          <Select
+            options={options}
+            value={null}
+            onChange={vi.fn()}
+            portal
+          >
+            <SelectButton />
+            <SelectOptionList />
+          </Select>
+        </Drawer.Content>
+      </Drawer.Root>,
+      { wrapper: TestProviders },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Select an option' }));
+    const listbox = await screen.findByRole('listbox');
+
+    // A real browser moves focus into the open Select; jsdom does not, so focus
+    // it explicitly before dispatching Escape from within it.
+    listbox.focus();
+    fireEvent.keyDown(listbox, { key: 'Escape', code: 'Escape' });
+
+    // Escape closes the nested Select but must not bubble up to dismiss the
+    // Drawer itself.
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/elements/__tests__/Drawer.test.tsx
+++ b/packages/ui/src/elements/__tests__/Drawer.test.tsx
@@ -62,5 +62,11 @@ describe('Drawer', () => {
     // Drawer itself.
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     expect(onOpenChange).not.toHaveBeenCalled();
+
+    // With the Select closed, a second Escape now dismisses the Drawer.
+    // floating-ui invokes onOpenChange(open, event, reason), so assert on the open arg.
+    fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' });
+    expect(onOpenChange).toHaveBeenCalled();
+    expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

Pressing `Escape` while a `Select` was open inside a `Drawer` (for example the payment method picker in Checkout) dismissed the entire Drawer instead of just the Select. Two issues were at play: the `Select` never applied floating-ui's `getFloatingProps()` to its floating element, so its `Escape` handler only lived as a native document listener that the Drawer's synthetic `stopPropagation()` prevented from firing; and `Drawer.Root` was not a `FloatingTree` node, so nested floating elements were not recognized as its children. The `Select` now wires up its interaction props (handling `Escape` itself and stopping propagation) and the `Drawer` roots a floating tree, so `Escape` now closes only the open `Select` and a second `Escape` closes the Drawer. To test: open the Checkout drawer, open the payment method `Select`, press `Escape`, and confirm only the Select closes.

BEFORE

https://github.com/user-attachments/assets/4f5d8b6e-c005-4d49-9256-040b2bc0652c

AFTER

https://github.com/user-attachments/assets/04893617-8a2d-45aa-956f-b8627b22d5ee


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pressing **Escape** while a Select menu is open inside a Drawer now closes only the Select menu.
  - Pressing **Escape** again dismisses the Drawer as expected.
  - Improved keyboard interaction for nested floating components and drawers.

- **Tests**
  - Added coverage verifying Select and Drawer dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->