### PR TITLE
feat(ui): Prototype inline test-credential button in field

### DIFF
--- a/.changeset/dev-mode-test-credential-hint.md
+++ b/.changeset/dev-mode-test-credential-hint.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Add a development-mode hint to the sign-in and sign-up email/phone fields that nudges developers toward Clerk test credentials. Hovering or focusing the field reveals an info icon next to the label; opening it shows a tip about test identifiers and the `424242` verification code, plus a button that inserts a suggested test email or phone number. The hint only appears in development, on empty fields.

--- a/.changeset/dev-mode-test-credential-hint.md
+++ b/.changeset/dev-mode-test-credential-hint.md
@@ -2,4 +2,4 @@
 '@clerk/ui': patch
 ---
 
-Add a development-mode hint to the sign-in and sign-up email/phone fields that nudges developers toward Clerk test credentials. Hovering or focusing the field reveals an info icon next to the label; opening it shows a tip about test identifiers and the `424242` verification code, plus a button that inserts a suggested test email or phone number. The hint only appears in development, on empty fields.
+Add a development-mode hint to the sign-in and sign-up email/phone fields that nudges developers toward Clerk test credentials. Focusing the field reveals an inline "Use test email" or "Use test number" button inside the input; clicking it inserts a suggested test identifier (verify it on the next screen with the code `424242`). The hint only appears in development and stays visible until the field holds a valid test credential.

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -571,6 +571,25 @@ function SignInStartInternal(): JSX.Element {
   // @ts-expect-error `action` is not typed
   const { action, validLastAuthenticationStrategies, ...identifierFieldProps } = identifierField.props;
 
+  const identifierDevHint =
+    identifierAttribute === 'phone_number'
+      ? {
+          text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
+          action: {
+            label: 'Insert test phone number',
+            onInsert: () => identifierField.setValue('+12015550100'),
+          },
+        }
+      : identifierAttribute === 'email_address' || identifierAttribute === 'email_address_username'
+        ? {
+            text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
+            action: {
+              label: 'Insert test email',
+              onInsert: () => identifierField.setValue('your_email+clerk_test@example.com'),
+            },
+          }
+        : undefined;
+
   const lastAuthenticationStrategy = clerk.client?.lastAuthenticationStrategy;
   const isIdentifierLastAuthenticationStrategy =
     lastAuthenticationStrategy && totalEnabledAuthMethods > 1
@@ -635,6 +654,7 @@ function SignInStartInternal(): JSX.Element {
                         <DynamicField
                           actionLabel={nextIdentifier?.action}
                           onActionClicked={switchToNextIdentifier}
+                          devHint={identifierDevHint}
                           {...identifierFieldProps}
                           autoFocus={shouldAutofocus}
                           autoComplete={isWebAuthnAutofillSupported ? 'webauthn' : undefined}

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -19,6 +19,8 @@ import { Form } from '@/ui/elements/Form';
 import { Header } from '@/ui/elements/Header';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 import { SocialButtonsReversibleContainerWithDivider } from '@/ui/elements/ReversibleContainer';
+import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import { handleError } from '@/ui/utils/errorHandler';
 import { isMobileDevice } from '@/ui/utils/isMobileDevice';
 import type { FormControlState } from '@/ui/utils/useFormControl';
@@ -579,14 +581,16 @@ function SignInStartInternal(): JSX.Element {
             label: 'Insert test phone number',
             onInsert: () => identifierField.setValue('+12015550100'),
           },
+          isTestValue: isClerkTestPhoneNumber,
         }
       : identifierAttribute === 'email_address' || identifierAttribute === 'email_address_username'
         ? {
             text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
             action: {
               label: 'Insert test email',
-              onInsert: () => identifierField.setValue('your_email+clerk_test@example.com'),
+              onInsert: () => identifierField.setValue(toClerkTestEmail(identifierField.value)),
             },
+            isTestValue: (value: string) => value.includes('+clerk_test'),
           }
         : undefined;
 

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -578,7 +578,7 @@ function SignInStartInternal(): JSX.Element {
       ? {
           text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
           action: {
-            label: 'Insert test phone number',
+            label: 'Use test number',
             onInsert: () => identifierField.setValue('+12015550100'),
           },
           isTestValue: isClerkTestPhoneNumber,
@@ -587,7 +587,7 @@ function SignInStartInternal(): JSX.Element {
         ? {
             text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
             action: {
-              label: 'Insert test email',
+              label: 'Use test email',
               onInsert: () => identifierField.setValue(toClerkTestEmail(identifierField.value)),
             },
             isTestValue: (value: string) => value.includes('+clerk_test'),

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -19,7 +19,7 @@ import { Form } from '@/ui/elements/Form';
 import { Header } from '@/ui/elements/Header';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 import { SocialButtonsReversibleContainerWithDivider } from '@/ui/elements/ReversibleContainer';
-import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestEmail, toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
 import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import { handleError } from '@/ui/utils/errorHandler';
 import { isMobileDevice } from '@/ui/utils/isMobileDevice';
@@ -590,7 +590,7 @@ function SignInStartInternal(): JSX.Element {
               label: 'Use test email',
               onInsert: () => identifierField.setValue(toClerkTestEmail(identifierField.value)),
             },
-            isTestValue: (value: string) => value.includes('+clerk_test'),
+            isTestValue: isClerkTestEmail,
           }
         : undefined;
 

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -86,6 +86,13 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 isRequired={fields.emailAddress?.required}
                 isOptional={!fields.emailAddress?.required}
                 isDisabled={fields.emailAddress?.disabled}
+                devHint={{
+                  text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
+                  action: {
+                    label: 'Insert test email',
+                    onInsert: () => formState.emailAddress.setValue('your_email+clerk_test@example.com'),
+                  },
+                }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
               />
@@ -97,6 +104,13 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 {...formState.phoneNumber.props}
                 isRequired={fields.phoneNumber?.required}
                 isOptional={!fields.phoneNumber?.required}
+                devHint={{
+                  text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
+                  action: {
+                    label: 'Insert test phone number',
+                    onInsert: () => formState.phoneNumber.setValue('+12015550100'),
+                  },
+                }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
               />

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Form } from '@/ui/elements/Form';
 import { LegalCheckbox } from '@/ui/elements/LegalConsentCheckbox';
+import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import type { FormControlState } from '@/ui/utils/useFormControl';
 
 import { Col, localizationKeys, useAppearance } from '../../customizables';
@@ -90,8 +92,9 @@ export const SignUpForm = (props: SignUpFormProps) => {
                   text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
                   action: {
                     label: 'Insert test email',
-                    onInsert: () => formState.emailAddress.setValue('your_email+clerk_test@example.com'),
+                    onInsert: () => formState.emailAddress.setValue(toClerkTestEmail(formState.emailAddress.value)),
                   },
+                  isTestValue: value => value.includes('+clerk_test'),
                 }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
@@ -110,6 +113,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                     label: 'Insert test phone number',
                     onInsert: () => formState.phoneNumber.setValue('+12015550100'),
                   },
+                  isTestValue: isClerkTestPhoneNumber,
                 }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_email') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Form } from '@/ui/elements/Form';
 import { LegalCheckbox } from '@/ui/elements/LegalConsentCheckbox';
-import { toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
+import { isClerkTestEmail, toClerkTestEmail } from '@/ui/utils/clerkTestEmail';
 import { isClerkTestPhoneNumber } from '@/ui/utils/clerkTestPhoneNumber';
 import type { FormControlState } from '@/ui/utils/useFormControl';
 
@@ -94,7 +94,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                     label: 'Use test email',
                     onInsert: () => formState.emailAddress.setValue(toClerkTestEmail(formState.emailAddress.value)),
                   },
-                  isTestValue: value => value.includes('+clerk_test'),
+                  isTestValue: isClerkTestEmail,
                 }}
                 actionLabel={canToggleEmailPhone ? localizationKeys('signUp.start.actionLink__use_phone') : undefined}
                 onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}

--- a/packages/ui/src/components/SignUp/SignUpForm.tsx
+++ b/packages/ui/src/components/SignUp/SignUpForm.tsx
@@ -91,7 +91,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 devHint={{
                   text: 'Testing? Use a test email so you skip a real inbox. Verify it on the next screen with the code 424242.',
                   action: {
-                    label: 'Insert test email',
+                    label: 'Use test email',
                     onInsert: () => formState.emailAddress.setValue(toClerkTestEmail(formState.emailAddress.value)),
                   },
                   isTestValue: value => value.includes('+clerk_test'),
@@ -110,7 +110,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
                 devHint={{
                   text: 'Testing? Use a test phone number so you skip a real SMS. Verify it on the next screen with the code 424242.',
                   action: {
-                    label: 'Insert test phone number',
+                    label: 'Use test number',
                     onInsert: () => formState.phoneNumber.setValue('+12015550100'),
                   },
                   isTestValue: isClerkTestPhoneNumber,

--- a/packages/ui/src/elements/FieldControl.tsx
+++ b/packages/ui/src/elements/FieldControl.tsx
@@ -4,7 +4,6 @@ import React, { forwardRef } from 'react';
 
 import type { LocalizationKey } from '../customizables';
 import {
-  Box,
   CheckboxInput,
   descriptors,
   Flex,
@@ -23,8 +22,6 @@ import type { PropsOfComponent } from '../styledSystem';
 import type { useFormControl as useFormControlUtil } from '../utils/useFormControl';
 import { OTPCodeControl, OTPResendButton, OTPRoot } from './CodeControl';
 import { useCardState } from './contexts';
-import type { FieldDevHintValue } from './FieldDevHint';
-import { FieldDevHint } from './FieldDevHint';
 import type { FormFeedbackProps } from './FormControl';
 import { FormFeedback } from './FormControl';
 import { InputGroup } from './InputGroup';
@@ -120,16 +117,14 @@ const FieldLabelIcon = (props: { icon?: React.ComponentType }) => {
   );
 };
 
-const FieldLabel = (
-  props: PropsWithChildren<{ localizationKey?: LocalizationKey | string; devHint?: FieldDevHintValue }>,
-) => {
+const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey | string }>) => {
   const { isRequired, id, label, isDisabled, hasError } = useFormField();
 
   if (!(props.localizationKey || label) && !props.children) {
     return null;
   }
 
-  const labelElement = (
+  return (
     <FormLabel
       localizationKey={props.localizationKey || label}
       elementDescriptor={descriptors.formFieldLabel}
@@ -137,34 +132,10 @@ const FieldLabel = (
       hasError={!!hasError}
       isDisabled={isDisabled}
       isRequired={isRequired}
-      sx={{ display: props.devHint ? 'inline' : 'flex', alignItems: 'center' }}
+      sx={{ display: 'flex', alignItems: 'center' }}
     >
       {props.children}
     </FormLabel>
-  );
-
-  if (!props.devHint) {
-    return labelElement;
-  }
-
-  // The label text and the dev hint are siblings inside an inline-block relative
-  // wrapper (makeLocalizable renders either its key text OR children, never both,
-  // so the hint cannot live inside the label). The label flows inline; the hint's
-  // absolute trigger sits at its static position trailing the text, and
-  // paddingInlineEnd reserves room so long labels wrap cleanly.
-  return (
-    <Box
-      as='span'
-      sx={{
-        position: 'relative',
-        display: 'inline-block',
-        textAlign: 'start',
-        paddingInlineEnd: '1.25em',
-      }}
-    >
-      {labelElement}
-      <FieldDevHint hint={props.devHint} />
-    </Box>
   );
 };
 

--- a/packages/ui/src/elements/FieldControl.tsx
+++ b/packages/ui/src/elements/FieldControl.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef } from 'react';
 
 import type { LocalizationKey } from '../customizables';
 import {
+  Box,
   CheckboxInput,
   descriptors,
   Flex,
@@ -22,6 +23,8 @@ import type { PropsOfComponent } from '../styledSystem';
 import type { useFormControl as useFormControlUtil } from '../utils/useFormControl';
 import { OTPCodeControl, OTPResendButton, OTPRoot } from './CodeControl';
 import { useCardState } from './contexts';
+import type { FieldDevHintValue } from './FieldDevHint';
+import { FieldDevHint } from './FieldDevHint';
 import type { FormFeedbackProps } from './FormControl';
 import { FormFeedback } from './FormControl';
 import { InputGroup } from './InputGroup';
@@ -117,14 +120,16 @@ const FieldLabelIcon = (props: { icon?: React.ComponentType }) => {
   );
 };
 
-const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey | string }>) => {
+const FieldLabel = (
+  props: PropsWithChildren<{ localizationKey?: LocalizationKey | string; devHint?: FieldDevHintValue }>,
+) => {
   const { isRequired, id, label, isDisabled, hasError } = useFormField();
 
   if (!(props.localizationKey || label) && !props.children) {
     return null;
   }
 
-  return (
+  const labelElement = (
     <FormLabel
       localizationKey={props.localizationKey || label}
       elementDescriptor={descriptors.formFieldLabel}
@@ -132,13 +137,34 @@ const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey
       hasError={!!hasError}
       isDisabled={isDisabled}
       isRequired={isRequired}
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
+      sx={{ display: props.devHint ? 'inline' : 'flex', alignItems: 'center' }}
     >
       {props.children}
     </FormLabel>
+  );
+
+  if (!props.devHint) {
+    return labelElement;
+  }
+
+  // The label text and the dev hint are siblings inside an inline-block relative
+  // wrapper (makeLocalizable renders either its key text OR children, never both,
+  // so the hint cannot live inside the label). The label flows inline; the hint's
+  // absolute trigger sits at its static position trailing the text, and
+  // paddingInlineEnd reserves room so long labels wrap cleanly.
+  return (
+    <Box
+      as='span'
+      sx={{
+        position: 'relative',
+        display: 'inline-block',
+        textAlign: 'start',
+        paddingInlineEnd: '1.25em',
+      }}
+    >
+      {labelElement}
+      <FieldDevHint hint={props.devHint} />
+    </Box>
   );
 };
 

--- a/packages/ui/src/elements/FieldDevHint.tsx
+++ b/packages/ui/src/elements/FieldDevHint.tsx
@@ -37,6 +37,12 @@ type DevHintAction = {
 export type FieldDevHintValue = {
   text: string | LocalizationKey;
   action?: DevHintAction;
+  /**
+   * Returns true when the current field value is already a test credential. When provided, the
+   * hint stays visible (as a warning) while the field holds a non-test value and only hides once
+   * the value is a test credential. When omitted, the hint hides as soon as the field has any value.
+   */
+  isTestValue?: (value: string) => boolean;
 };
 
 type FieldDevHintProps = {
@@ -51,7 +57,14 @@ type FieldDevHintProps = {
 const FieldDevHintBase = (props: FieldDevHintProps) => {
   const { showDevModeNotice } = useDevMode();
   const { value } = useFormField();
-  const { text, action } = props.hint;
+  const { text, action, isTestValue } = props.hint;
+
+  const stringValue = typeof value === 'string' ? value : '';
+  const hasValue = stringValue.length > 0;
+  // Satisfied → hide. No predicate: any value satisfies. With predicate: only a test value does.
+  const satisfied = hasValue && (isTestValue ? isTestValue(stringValue) : true);
+  // A non-test value keeps the warning icon persistently visible, not just on hover/focus.
+  const persist = hasValue && !satisfied;
 
   const [open, setOpen] = React.useState(false);
 
@@ -92,8 +105,7 @@ const FieldDevHintBase = (props: FieldDevHintProps) => {
   const portalRoot = usePortalRoot();
   const effectiveRoot = portalRoot?.() ?? undefined;
 
-  // Only nudge on an empty field; once the developer has typed (or inserted) a value, hide it.
-  if (!showDevModeNotice || value) {
+  if (!showDevModeNotice || satisfied) {
     return null;
   }
 
@@ -120,8 +132,9 @@ const FieldDevHintBase = (props: FieldDevHintProps) => {
           borderRadius: t.radii.$sm,
           color: t.colors.$warning500,
           // Hidden until the field is hovered/focused (revealed by the formField
-          // container in Form.tsx) or the popover is open.
-          opacity: 0,
+          // container in Form.tsx) or the popover is open. When `persist` (a non-test
+          // value is present) it stays visible as a warning.
+          opacity: persist ? 1 : 0,
           transitionProperty: 'opacity',
           transitionDuration: t.transitionDuration.$fast,
           '&[data-open="true"]': { opacity: 1 },

--- a/packages/ui/src/elements/FieldDevHint.tsx
+++ b/packages/ui/src/elements/FieldDevHint.tsx
@@ -1,0 +1,192 @@
+import { usePortalRoot } from '@clerk/shared/react';
+import {
+  autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingPortal,
+  offset,
+  safePolygon,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import * as React from 'react';
+
+import { Box, Button, Col, Icon, type LocalizationKey, Text, useAppearance } from '../customizables';
+import { usePrefersReducedMotion } from '../hooks';
+import { useDevMode } from '../hooks/useDevMode';
+import { InformationCircle } from '../icons';
+import { useFormField } from '../primitives/hooks/useFormField';
+import { withFloatingTree } from './contexts';
+
+type DevHintAction = {
+  label: string | LocalizationKey;
+  /** Populates the field with a suggested test identifier. */
+  onInsert: () => void;
+};
+
+export type FieldDevHintValue = {
+  text: string | LocalizationKey;
+  action?: DevHintAction;
+};
+
+type FieldDevHintProps = {
+  hint: FieldDevHintValue;
+};
+
+/**
+ * Dev-only info affordance rendered next to a field label. On hover/focus of the ⓘ
+ * icon it opens a popover that nudges developers toward test credentials and can
+ * insert a suggested test identifier into the field. Renders nothing outside dev mode.
+ */
+const FieldDevHintBase = (props: FieldDevHintProps) => {
+  const { showDevModeNotice } = useDevMode();
+  const { value } = useFormField();
+  const { text, action } = props.hint;
+
+  const [open, setOpen] = React.useState(false);
+
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const { animations } = useAppearance().parsedOptions;
+  const isMotionSafe = !prefersReducedMotion && animations === true;
+
+  const nodeId = useFloatingNodeId();
+  const { refs, floatingStyles, context } = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+    placement: 'top',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(6), flip({ padding: 6 }), shift({ padding: 6 })],
+  });
+
+  // safePolygon keeps the popover open while the cursor travels from the icon into
+  // the content, so the insert button stays clickable on hover.
+  const hover = useHover(context, { handleClose: safePolygon() });
+  const focus = useFocus(context);
+  // Tap-to-toggle for touch, where there is no hover and iOS does not reliably
+  // focus a button on tap (so useHover/useFocus alone would never open it).
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: 'dialog' });
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, click, dismiss, role]);
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: isMotionSafe ? 180 : 0,
+    initial: { opacity: 0, transform: 'translateY(4px)' },
+    open: { opacity: 1, transform: 'translateY(0)' },
+    close: { opacity: 0, transform: 'translateY(4px)' },
+  });
+
+  const triggerRef = useMergeRefs([refs.setReference]);
+  const floatingRef = useMergeRefs([refs.setFloating]);
+  const portalRoot = usePortalRoot();
+  const effectiveRoot = portalRoot?.() ?? undefined;
+
+  // Only nudge on an empty field; once the developer has typed (or inserted) a value, hide it.
+  if (!showDevModeNotice || value) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        variant='unstyled'
+        aria-label='Development testing tip'
+        data-dev-hint-trigger=''
+        data-open={open}
+        {...getReferenceProps()}
+        sx={t => ({
+          // Absolutely positioned at its static location (trailing the label text) so
+          // it doesn't force the label to wrap; the label reserves room via its
+          // padding-inline-end (see Form.tsx). height: 1lh centers it on the text line.
+          position: 'absolute',
+          marginInlineStart: '0.25em',
+          height: '1lh',
+          lineHeight: '1lh',
+          display: 'inline-flex',
+          alignItems: 'center',
+          padding: 0,
+          borderRadius: t.radii.$sm,
+          color: t.colors.$warning500,
+          // Hidden until the field is hovered/focused (revealed by the formField
+          // container in Form.tsx) or the popover is open.
+          opacity: 0,
+          transitionProperty: 'opacity',
+          transitionDuration: t.transitionDuration.$fast,
+          '&[data-open="true"]': { opacity: 1 },
+        })}
+      >
+        <Icon
+          icon={InformationCircle}
+          aria-hidden
+          sx={t => ({ width: t.sizes.$4, height: t.sizes.$4 })}
+        />
+      </Button>
+
+      {isMounted && (
+        <FloatingNode id={nodeId}>
+          <FloatingPortal root={effectiveRoot}>
+            {/* modal=false + initialFocus=-1: hovering with a mouse does not steal
+                focus, but keyboard users can Tab from the trigger into the content. */}
+            <FloatingFocusManager
+              context={context}
+              modal={false}
+              initialFocus={-1}
+            >
+              <Box
+                ref={floatingRef}
+                style={floatingStyles}
+                {...getFloatingProps()}
+                sx={t => ({ zIndex: t.zIndices.$tooltip })}
+              >
+                <Col
+                  style={transitionStyles}
+                  gap={2}
+                  sx={t => ({
+                    maxWidth: t.sizes.$60,
+                    padding: t.space.$3,
+                    borderRadius: t.radii.$lg,
+                    backgroundColor: t.colors.$colorBackground,
+                    borderWidth: t.borderWidths.$normal,
+                    borderStyle: t.borderStyles.$solid,
+                    borderColor: t.colors.$borderAlpha100,
+                    boxShadow: t.shadows.$menuShadow,
+                  })}
+                >
+                  <Text
+                    localizationKey={text}
+                    variant='body'
+                    colorScheme='secondary'
+                  />
+                  {action && (
+                    <Button
+                      variant='outline'
+                      localizationKey={action.label}
+                      onClick={() => {
+                        action.onInsert();
+                        setOpen(false);
+                      }}
+                    />
+                  )}
+                </Col>
+              </Box>
+            </FloatingFocusManager>
+          </FloatingPortal>
+        </FloatingNode>
+      )}
+    </>
+  );
+};
+
+export const FieldDevHint = withFloatingTree(FieldDevHintBase);

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Box, Button } from '../customizables';
 import { useDevMode } from '../hooks/useDevMode';
 import { useFormField } from '../primitives/hooks/useFormField';
+import { common } from '../styledSystem';
 import type { FieldDevHintValue } from './FieldDevHint';
 
 type FieldDevInsertButtonProps = React.PropsWithChildren<{ hint: FieldDevHintValue }>;
@@ -53,7 +54,8 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
         position: 'relative',
         ...(visible &&
           buttonWidth > 0 && {
-            '& input': { paddingInlineEnd: `calc(${buttonWidth}px + ${t.space.$3})` },
+            // Reserve room for the button (its width) plus its trailing inset and a small gap.
+            '& input': { paddingInlineEnd: `calc(${buttonWidth}px + ${t.space.$2})` },
           }),
       })}
     >
@@ -62,24 +64,22 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
         <Button
           ref={buttonRef}
           variant='outline'
-          size='xs'
           textVariant='buttonSmall'
           localizationKey={typeof label === 'string' ? undefined : label}
           // Prevent the mousedown from blurring the input, so it stays focused through the click.
           onMouseDown={e => e.preventDefault()}
           onClick={() => action?.onInsert()}
           sx={t => ({
-            position: 'absolute',
+            // Reuse the canonical trailing-button geometry (symmetric $1 inset, radius
+            // concentric with the input's), then layer on the text-button chrome.
+            ...common.inputTrailingButton(t),
+            paddingBlock: 0,
+            color: t.colors.$neutralAlpha600,
+            backgroundColor: t.colors.$colorBackground,
+            whiteSpace: 'nowrap',
             // Above the phone input's container, which sets position:relative; z-index:1
             // and would otherwise paint over the button and swallow the click.
             zIndex: 2,
-            top: '50%',
-            insetInlineEnd: t.space.$1,
-            transform: 'translateY(-50%)',
-            backgroundColor: t.colors.$colorBackground,
-            whiteSpace: 'nowrap',
-            paddingInline: t.space.$1x5,
-            borderRadius: t.space.$0x75
           })}
         >
           {typeof label === 'string' ? label : undefined}

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+
+import { Box, Button } from '../customizables';
+import { useDevMode } from '../hooks/useDevMode';
+import { useFormField } from '../primitives/hooks/useFormField';
+import type { FieldDevHintValue } from './FieldDevHint';
+
+type FieldDevInsertButtonProps = React.PropsWithChildren<{ hint: FieldDevHintValue }>;
+
+/**
+ * Dev-only alternative to the label popover: renders the field's input with a small
+ * "insert test credential" button overlaid inside it, right-aligned. The button only
+ * appears while the field is focused and empty, and reserves matching padding on the
+ * input so text/placeholder never runs beneath it. Renders nothing outside dev mode.
+ */
+export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
+  const { showDevModeNotice } = useDevMode();
+  const { value } = useFormField();
+  const { action, isTestValue } = props.hint;
+
+  const stringValue = typeof value === 'string' ? value : '';
+  const hasValue = stringValue.length > 0;
+  // With a predicate, keep offering the button until the value is a real test credential
+  // (so it stays visible while the developer types a non-test address). Without one, fall
+  // back to hiding as soon as the field has any value.
+  const isTestCredential = isTestValue ? isTestValue(stringValue) : hasValue;
+
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [buttonWidth, setButtonWidth] = React.useState(0);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const visible = !!action && showDevModeNotice && isFocused && !isTestCredential;
+
+  React.useLayoutEffect(() => {
+    if (visible && buttonRef.current) {
+      setButtonWidth(buttonRef.current.offsetWidth);
+    }
+  }, [visible, action?.label]);
+
+  const label = action?.label;
+
+  return (
+    <Box
+      onFocus={() => setIsFocused(true)}
+      // Keep focused while focus moves within the field (e.g. onto the button itself),
+      // so the button does not unmount out from under a click.
+      onBlur={e => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setIsFocused(false);
+        }
+      }}
+      sx={t => ({
+        position: 'relative',
+        ...(visible &&
+          buttonWidth > 0 && {
+            '& input': { paddingInlineEnd: `calc(${buttonWidth}px + ${t.space.$3})` },
+          }),
+      })}
+    >
+      {props.children}
+      {visible && (
+        <Button
+          ref={buttonRef}
+          variant='outline'
+          size='xs'
+          textVariant='buttonSmall'
+          localizationKey={typeof label === 'string' ? undefined : label}
+          // Prevent the mousedown from blurring the input, so it stays focused through the click.
+          onMouseDown={e => e.preventDefault()}
+          onClick={() => action?.onInsert()}
+          sx={t => ({
+            position: 'absolute',
+            // Above the phone input's container, which sets position:relative; z-index:1
+            // and would otherwise paint over the button and swallow the click.
+            zIndex: 2,
+            top: '50%',
+            insetInlineEnd: t.space.$0x75,
+            transform: 'translateY(-50%)',
+            backgroundColor: t.colors.$colorBackground,
+            whiteSpace: 'nowrap',
+          })}
+        >
+          {typeof label === 'string' ? label : undefined}
+        </Button>
+      )}
+    </Box>
+  );
+};

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -9,10 +9,13 @@ import type { FieldDevHintValue } from './FieldDevHint';
 type FieldDevInsertButtonProps = React.PropsWithChildren<{ hint: FieldDevHintValue }>;
 
 /**
- * Dev-only alternative to the label popover: renders the field's input with a small
- * "insert test credential" button overlaid inside it, right-aligned. The button only
- * appears while the field is focused and empty, and reserves matching padding on the
- * input so text/placeholder never runs beneath it. Renders nothing outside dev mode.
+ * Dev-only affordance: renders the field's input with a small "use test credential"
+ * button overlaid inside it, right-aligned. The button is shown while the input is
+ * focused and its value is not yet a valid test credential (per `hint.isTestValue`),
+ * so it stays available while a developer types a non-test address and hides once the
+ * value is a test credential. When no predicate is given it hides as soon as the field
+ * has any value. It reserves matching padding on the input so text/placeholder never
+ * runs beneath it. Renders nothing outside dev mode.
  */
 export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
   const { showDevModeNotice } = useDevMode();

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -74,10 +74,12 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
             // and would otherwise paint over the button and swallow the click.
             zIndex: 2,
             top: '50%',
-            insetInlineEnd: t.space.$0x75,
+            insetInlineEnd: t.space.$1,
             transform: 'translateY(-50%)',
             backgroundColor: t.colors.$colorBackground,
             whiteSpace: 'nowrap',
+            paddingInline: t.space.$1x5,
+            borderRadius: t.space.$0x75
           })}
         >
           {typeof label === 'string' ? label : undefined}

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -1,3 +1,4 @@
+import { isVirtualClick } from '@floating-ui/react/utils';
 import * as React from 'react';
 
 import { Box, Button } from '../customizables';
@@ -71,13 +72,17 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
           variant='outline'
           textVariant='buttonSmall'
           localizationKey={typeof label === 'string' ? undefined : label}
-          // Prevent the mousedown from blurring the input, so it stays focused through the click.
+          // Prevent the mousedown from blurring the input, so it stays focused through a pointer click.
           onMouseDown={e => e.preventDefault()}
-          onClick={() => {
+          onClick={e => {
             action?.onInsert();
-            // Restore focus to the input before the button unmounts. onMouseDown covers pointer
-            // clicks, but keyboard activation (Enter/Space) would otherwise drop focus out of the field.
-            boxRef.current?.querySelector('input')?.focus();
+            // The button unmounts once a test credential is inserted. Pointer clicks keep focus on the
+            // input via onMouseDown above; only keyboard/AT activation (a virtual click) would drop focus
+            // out of the field, so restore it in that case. `isVirtualClick` also avoids re-opening the
+            // on-screen keyboard on touch. Mirrors InputWithIcon's clear button.
+            if (isVirtualClick(e.nativeEvent)) {
+              boxRef.current?.querySelector('input')?.focus({ preventScroll: true });
+            }
           }}
           sx={t => ({
             // Reuse the canonical trailing-button geometry (symmetric $1 inset, radius

--- a/packages/ui/src/elements/FieldDevInsertButton.tsx
+++ b/packages/ui/src/elements/FieldDevInsertButton.tsx
@@ -31,6 +31,7 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
 
   const [isFocused, setIsFocused] = React.useState(false);
   const [buttonWidth, setButtonWidth] = React.useState(0);
+  const boxRef = React.useRef<HTMLDivElement>(null);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
 
   const visible = !!action && showDevModeNotice && isFocused && !isTestCredential;
@@ -45,6 +46,7 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
 
   return (
     <Box
+      ref={boxRef}
       onFocus={() => setIsFocused(true)}
       // Keep focused while focus moves within the field (e.g. onto the button itself),
       // so the button does not unmount out from under a click.
@@ -71,7 +73,12 @@ export const FieldDevInsertButton = (props: FieldDevInsertButtonProps) => {
           localizationKey={typeof label === 'string' ? undefined : label}
           // Prevent the mousedown from blurring the input, so it stays focused through the click.
           onMouseDown={e => e.preventDefault()}
-          onClick={() => action?.onInsert()}
+          onClick={() => {
+            action?.onInsert();
+            // Restore focus to the input before the button unmounts. onMouseDown covers pointer
+            // clicks, but keyboard activation (Enter/Space) would otherwise drop focus out of the field.
+            boxRef.current?.querySelector('input')?.focus();
+          }}
           sx={t => ({
             // Reuse the canonical trailing-button geometry (symmetric $1 inset, radius
             // concentric with the input's), then layer on the text-button chrome.

--- a/packages/ui/src/elements/Form.tsx
+++ b/packages/ui/src/elements/Form.tsx
@@ -12,6 +12,7 @@ import { LastAuthenticationStrategyBadge } from './Badge';
 import type { OTPInputProps } from './CodeControl';
 import { useCardState } from './contexts';
 import { Field } from './FieldControl';
+import type { FieldDevHintValue } from './FieldDevHint';
 
 const [FormState, useFormState] = createContextAndHook<{
   isLoading: boolean;
@@ -126,24 +127,40 @@ type CommonInputProps = CommonFieldRootProps & {
   onActionClicked?: React.MouseEventHandler;
   icon?: React.ComponentType;
   isLastAuthenticationStrategy?: boolean;
+  devHint?: FieldDevHintValue;
 };
 
 const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
-  const { isOptional, isLastAuthenticationStrategy, icon, actionLabel, children, onActionClicked, ...fieldProps } =
-    props;
+  const {
+    isOptional,
+    isLastAuthenticationStrategy,
+    icon,
+    actionLabel,
+    children,
+    onActionClicked,
+    devHint,
+    ...fieldProps
+  } = props;
   return (
     <Field.Root {...fieldProps}>
       <Col
         elementDescriptor={descriptors.formField}
         elementId={descriptors.formField.setId(fieldProps.id)}
-        sx={{ position: 'relative', flex: '1 1 auto' }}
+        sx={{
+          position: 'relative',
+          flex: '1 1 auto',
+          // Reveal the dev hint icon only while the field is hovered or focused.
+          ...(devHint && {
+            '&:hover [data-dev-hint-trigger], &:focus-within [data-dev-hint-trigger]': { opacity: 1 },
+          }),
+        }}
       >
         <Flex
           direction='col'
           sx={t => ({ gap: t.space.$2 })}
         >
           <Field.LabelRow>
-            <Field.Label />
+            <Field.Label devHint={devHint} />
             <Field.LabelIcon icon={icon} />
             {!actionLabel && isOptional && <Field.AsOptional />}
             {actionLabel && (

--- a/packages/ui/src/elements/Form.tsx
+++ b/packages/ui/src/elements/Form.tsx
@@ -13,6 +13,7 @@ import type { OTPInputProps } from './CodeControl';
 import { useCardState } from './contexts';
 import { Field } from './FieldControl';
 import type { FieldDevHintValue } from './FieldDevHint';
+import { FieldDevInsertButton } from './FieldDevInsertButton';
 
 const [FormState, useFormState] = createContextAndHook<{
   isLoading: boolean;
@@ -149,10 +150,6 @@ const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
         sx={{
           position: 'relative',
           flex: '1 1 auto',
-          // Reveal the dev hint icon only while the field is hovered or focused.
-          ...(devHint && {
-            '&:hover [data-dev-hint-trigger], &:focus-within [data-dev-hint-trigger]': { opacity: 1 },
-          }),
         }}
       >
         <Flex
@@ -160,7 +157,7 @@ const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
           sx={t => ({ gap: t.space.$2 })}
         >
           <Field.LabelRow>
-            <Field.Label devHint={devHint} />
+            <Field.Label />
             <Field.LabelIcon icon={icon} />
             {!actionLabel && isOptional && <Field.AsOptional />}
             {actionLabel && (
@@ -175,7 +172,7 @@ const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
             <Field.Action />
           </Field.LabelRow>
 
-          {children}
+          {devHint ? <FieldDevInsertButton hint={devHint}>{children}</FieldDevInsertButton> : children}
         </Flex>
 
         <Field.Feedback />

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -35,10 +35,11 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
   });
 
   // The component seeds its internal state from `value` only on mount. Sync later
-  // programmatic `value` changes (e.g. inserting a test phone number) into the
-  // internal state; guarded on inequality so it never loops with onChange.
+  // programmatic `value` changes (e.g. inserting a test phone number, or a parent
+  // clearing the field) into the internal state; guarded on inequality so it never
+  // loops with onChange.
   useEffect(() => {
-    if (typeof value === 'string' && value && value !== numberWithCode) {
+    if (typeof value === 'string' && value !== numberWithCode) {
       setNumberAndIso(value);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -34,6 +34,16 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
     locationBasedCountryIso,
   });
 
+  // The component seeds its internal state from `value` only on mount. Sync later
+  // programmatic `value` changes (e.g. inserting a test phone number) into the
+  // internal state; guarded on inequality so it never loops with onChange.
+  useEffect(() => {
+    if (typeof value === 'string' && value && value !== numberWithCode) {
+      setNumberAndIso(value);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
   const callOnChangeProp = () => {
     // Quick and dirty way to match this component's public API
     // with every other Input component, so we can use the same helpers

--- a/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
+++ b/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
@@ -1,0 +1,103 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { useFormControl } from '@/ui/utils/useFormControl';
+
+import { withCardStateProvider } from '../contexts';
+import type { FieldDevHintValue } from '../FieldDevHint';
+import { Form } from '../Form';
+
+let showDevModeNotice = true;
+vi.mock('../../hooks/useDevMode', () => ({
+  useDevMode: () => ({ showDevModeNotice }),
+}));
+
+const { createFixtures } = bindCreateFixtures('SignIn');
+
+const onInsert = vi.fn();
+const hint: FieldDevHintValue = {
+  text: 'Testing tip',
+  action: { label: 'Use test email', onInsert },
+  isTestValue: value => value.includes('+clerk_test'),
+};
+
+const createField = (initialValue: string) =>
+  withCardStateProvider(() => {
+    const field = useFormControl('emailAddress', initialValue, {
+      type: 'email',
+      label: 'Email address',
+      placeholder: 'Enter your email address',
+    });
+
+    // @ts-ignore -- the mock field props satisfy the runtime contract
+    return (
+      <Form.PlainInput
+        {...field.props}
+        devHint={hint}
+      />
+    );
+  });
+
+const button = () => ({ name: /use test email/i });
+
+describe('FieldDevInsertButton', () => {
+  beforeEach(() => {
+    showDevModeNotice = true;
+    onInsert.mockClear();
+  });
+
+  it('does not render outside dev mode', async () => {
+    showDevModeNotice = false;
+    const { wrapper } = await createFixtures();
+    const Field = createField('');
+
+    const { getByLabelText, queryByRole } = render(<Field />, { wrapper });
+    await userEvent.click(getByLabelText(/email address/i));
+
+    expect(queryByRole('button', button())).not.toBeInTheDocument();
+  });
+
+  it('is hidden until the field is focused', async () => {
+    const { wrapper } = await createFixtures();
+    const Field = createField('');
+
+    const { getByLabelText, queryByRole, getByRole } = render(<Field />, { wrapper });
+    expect(queryByRole('button', button())).not.toBeInTheDocument();
+
+    await userEvent.click(getByLabelText(/email address/i));
+    expect(getByRole('button', button())).toBeInTheDocument();
+  });
+
+  it('stays visible while the focused value is not a test credential', async () => {
+    const { wrapper } = await createFixtures();
+    const Field = createField('alex@work.com');
+
+    const { getByLabelText, getByRole } = render(<Field />, { wrapper });
+    await userEvent.click(getByLabelText(/email address/i));
+
+    expect(getByRole('button', button())).toBeInTheDocument();
+  });
+
+  it('is hidden once the value is a test credential', async () => {
+    const { wrapper } = await createFixtures();
+    const Field = createField('alex+clerk_test@work.com');
+
+    const { getByLabelText, queryByRole } = render(<Field />, { wrapper });
+    await userEvent.click(getByLabelText(/email address/i));
+
+    expect(queryByRole('button', button())).not.toBeInTheDocument();
+  });
+
+  it('invokes onInsert when clicked', async () => {
+    const { wrapper } = await createFixtures();
+    const Field = createField('');
+
+    const { getByLabelText, getByRole } = render(<Field />, { wrapper });
+    await userEvent.click(getByLabelText(/email address/i));
+    await userEvent.click(getByRole('button', button()));
+
+    expect(onInsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
+++ b/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -110,7 +110,7 @@ describe('FieldDevInsertButton', () => {
     expect(queryByRole('button', button())).not.toBeInTheDocument();
   });
 
-  it('restores focus to the input after keyboard activation', async () => {
+  it('restores focus to the input when activated via a virtual (keyboard/AT) click', async () => {
     const { wrapper } = await createFixtures();
     const Field = createField('');
 
@@ -118,10 +118,12 @@ describe('FieldDevInsertButton', () => {
     const input = getByLabelText(/email address/i);
 
     await userEvent.click(input);
-    // Move focus to the button and activate it with the keyboard.
-    await userEvent.tab();
-    expect(getByRole('button', button())).toHaveFocus();
-    await userEvent.keyboard('{Enter}');
+    const insertButton = getByRole('button', button());
+    insertButton.focus();
+    expect(insertButton).toHaveFocus();
+
+    // Keyboard/AT activation surfaces as a click with detail 0 (a virtual click).
+    fireEvent.click(insertButton, { detail: 0 });
 
     expect(input).toHaveFocus();
   });

--- a/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
+++ b/packages/ui/src/elements/__tests__/FieldDevInsertButton.test.tsx
@@ -17,11 +17,6 @@ vi.mock('../../hooks/useDevMode', () => ({
 const { createFixtures } = bindCreateFixtures('SignIn');
 
 const onInsert = vi.fn();
-const hint: FieldDevHintValue = {
-  text: 'Testing tip',
-  action: { label: 'Use test email', onInsert },
-  isTestValue: value => value.includes('+clerk_test'),
-};
 
 const createField = (initialValue: string) =>
   withCardStateProvider(() => {
@@ -30,6 +25,19 @@ const createField = (initialValue: string) =>
       label: 'Email address',
       placeholder: 'Enter your email address',
     });
+
+    const hint: FieldDevHintValue = {
+      text: 'Testing tip',
+      action: {
+        label: 'Use test email',
+        // Mirror the real flow: inserting sets the field to a test credential (which hides the button).
+        onInsert: () => {
+          onInsert();
+          field.setValue('alex+clerk_test@work.com');
+        },
+      },
+      isTestValue: value => value.includes('+clerk_test'),
+    };
 
     // @ts-ignore -- the mock field props satisfy the runtime contract
     return (
@@ -90,14 +98,31 @@ describe('FieldDevInsertButton', () => {
     expect(queryByRole('button', button())).not.toBeInTheDocument();
   });
 
-  it('invokes onInsert when clicked', async () => {
+  it('invokes onInsert when clicked and then hides', async () => {
     const { wrapper } = await createFixtures();
     const Field = createField('');
 
-    const { getByLabelText, getByRole } = render(<Field />, { wrapper });
+    const { getByLabelText, getByRole, queryByRole } = render(<Field />, { wrapper });
     await userEvent.click(getByLabelText(/email address/i));
     await userEvent.click(getByRole('button', button()));
 
     expect(onInsert).toHaveBeenCalledTimes(1);
+    expect(queryByRole('button', button())).not.toBeInTheDocument();
+  });
+
+  it('restores focus to the input after keyboard activation', async () => {
+    const { wrapper } = await createFixtures();
+    const Field = createField('');
+
+    const { getByLabelText, getByRole } = render(<Field />, { wrapper });
+    const input = getByLabelText(/email address/i);
+
+    await userEvent.click(input);
+    // Move focus to the button and activate it with the keyboard.
+    await userEvent.tab();
+    expect(getByRole('button', button())).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -75,6 +75,13 @@ const { applyVariants, filterProps } = createVariants(
             [vars.border]: theme.colors.$danger500,
             [vars.alpha]: theme.colors.$dangerAlpha50,
           },
+          warning: {
+            [vars.accent]: theme.colors.$warning500,
+            [vars.accentHover]: theme.colors.$warning600,
+            [vars.accentContrast]: theme.colors.$white,
+            [vars.border]: theme.colors.$warning500,
+            [vars.alpha]: theme.colors.$warningAlpha50,
+          },
         },
         variant: {
           solid: {

--- a/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { toClerkTestEmail } from '../clerkTestEmail';
+import { isClerkTestEmail, toClerkTestEmail } from '../clerkTestEmail';
+
+describe('isClerkTestEmail', () => {
+  it('matches the clerk_test subaddress as a complete segment', () => {
+    expect(isClerkTestEmail('alex+clerk_test@work.com')).toBe(true);
+    expect(isClerkTestEmail('alex+newsletter+clerk_test@work.com')).toBe(true);
+    expect(isClerkTestEmail('alex+clerk_test+foo@work.com')).toBe(true);
+  });
+
+  it('does not match a near-substring segment', () => {
+    expect(isClerkTestEmail('alex+clerk_test2@work.com')).toBe(false);
+    expect(isClerkTestEmail('alex+clerk_testing@work.com')).toBe(false);
+    expect(isClerkTestEmail('alex@work.com')).toBe(false);
+  });
+});
 
 describe('toClerkTestEmail', () => {
   it('adds the +clerk_test subaddress to the local part', () => {

--- a/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestEmail.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { toClerkTestEmail } from '../clerkTestEmail';
+
+describe('toClerkTestEmail', () => {
+  it('adds the +clerk_test subaddress to the local part', () => {
+    expect(toClerkTestEmail('alex@work.com')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('preserves an existing subaddress', () => {
+    expect(toClerkTestEmail('alex+newsletter@work.com')).toBe('alex+newsletter+clerk_test@work.com');
+  });
+
+  it('is a no-op when the value is already a test email', () => {
+    expect(toClerkTestEmail('alex+clerk_test@work.com')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(toClerkTestEmail('  alex@work.com  ')).toBe('alex+clerk_test@work.com');
+  });
+
+  it('falls back to a placeholder when empty', () => {
+    expect(toClerkTestEmail('')).toBe('your_email+clerk_test@example.com');
+    expect(toClerkTestEmail('   ')).toBe('your_email+clerk_test@example.com');
+  });
+
+  it('handles a value with no domain yet', () => {
+    expect(toClerkTestEmail('alex')).toBe('alex+clerk_test@example.com');
+  });
+});

--- a/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isClerkTestPhoneNumber } from '../clerkTestPhoneNumber';
+
+describe('isClerkTestPhoneNumber', () => {
+  it('matches numbers in the 555-01XX test range', () => {
+    expect(isClerkTestPhoneNumber('+12015550100')).toBe(true);
+    expect(isClerkTestPhoneNumber('+12015550199')).toBe(true);
+  });
+
+  it('ignores formatting', () => {
+    expect(isClerkTestPhoneNumber('+1 (201) 555-0100')).toBe(true);
+  });
+
+  it('rejects numbers outside the test range', () => {
+    expect(isClerkTestPhoneNumber('+12015550200')).toBe(false);
+    expect(isClerkTestPhoneNumber('+12015551234')).toBe(false);
+  });
+
+  it('rejects empty or partial input', () => {
+    expect(isClerkTestPhoneNumber('')).toBe(false);
+    expect(isClerkTestPhoneNumber('+1201')).toBe(false);
+  });
+});

--- a/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
@@ -24,5 +24,7 @@ describe('isClerkTestPhoneNumber', () => {
   it('rejects empty or partial input', () => {
     expect(isClerkTestPhoneNumber('')).toBe(false);
     expect(isClerkTestPhoneNumber('+1201')).toBe(false);
+    // Suffix only, missing the area code.
+    expect(isClerkTestPhoneNumber('5550100')).toBe(false);
   });
 });

--- a/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
+++ b/packages/ui/src/utils/__tests__/clerkTestPhoneNumber.test.ts
@@ -17,6 +17,10 @@ describe('isClerkTestPhoneNumber', () => {
     expect(isClerkTestPhoneNumber('+12015551234')).toBe(false);
   });
 
+  it('rejects non-US numbers that happen to end in 555-01XX', () => {
+    expect(isClerkTestPhoneNumber('+442015550100')).toBe(false);
+  });
+
   it('rejects empty or partial input', () => {
     expect(isClerkTestPhoneNumber('')).toBe(false);
     expect(isClerkTestPhoneNumber('+1201')).toBe(false);

--- a/packages/ui/src/utils/clerkTestEmail.ts
+++ b/packages/ui/src/utils/clerkTestEmail.ts
@@ -2,6 +2,15 @@ const CLERK_TEST_SUBADDRESS = '+clerk_test';
 const FALLBACK_TEST_EMAIL = 'your_email+clerk_test@example.com';
 
 /**
+ * Returns true when the value already carries the `clerk_test` subaddress as a complete
+ * `+`-delimited segment of the local part (e.g. `a+clerk_test@x.com` or `a+foo+clerk_test@x.com`),
+ * not merely as a substring (so `a+clerk_test2@x.com` does not match).
+ */
+export const isClerkTestEmail = (value: string): boolean => {
+  return /\+clerk_test(\+|@|$)/.test(value.trim());
+};
+
+/**
  * Turns whatever the developer has typed into a Clerk test email by adding the `+clerk_test`
  * subaddress to the local part. Falls back to a placeholder when the field is empty, and is a
  * no-op when the value is already a test email.
@@ -11,7 +20,7 @@ export const toClerkTestEmail = (value: string): string => {
   if (!trimmed) {
     return FALLBACK_TEST_EMAIL;
   }
-  if (trimmed.includes(CLERK_TEST_SUBADDRESS)) {
+  if (isClerkTestEmail(trimmed)) {
     return trimmed;
   }
   const at = trimmed.indexOf('@');

--- a/packages/ui/src/utils/clerkTestEmail.ts
+++ b/packages/ui/src/utils/clerkTestEmail.ts
@@ -1,0 +1,22 @@
+const CLERK_TEST_SUBADDRESS = '+clerk_test';
+const FALLBACK_TEST_EMAIL = 'your_email+clerk_test@example.com';
+
+/**
+ * Turns whatever the developer has typed into a Clerk test email by adding the `+clerk_test`
+ * subaddress to the local part. Falls back to a placeholder when the field is empty, and is a
+ * no-op when the value is already a test email.
+ */
+export const toClerkTestEmail = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return FALLBACK_TEST_EMAIL;
+  }
+  if (trimmed.includes(CLERK_TEST_SUBADDRESS)) {
+    return trimmed;
+  }
+  const at = trimmed.indexOf('@');
+  if (at === -1) {
+    return `${trimmed}${CLERK_TEST_SUBADDRESS}@example.com`;
+  }
+  return `${trimmed.slice(0, at)}${CLERK_TEST_SUBADDRESS}${trimmed.slice(at)}`;
+};

--- a/packages/ui/src/utils/clerkTestPhoneNumber.ts
+++ b/packages/ui/src/utils/clerkTestPhoneNumber.ts
@@ -1,0 +1,7 @@
+/**
+ * Clerk test phone numbers are fictional US numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
+ * range, i.e. the last seven digits are `555 01XX`. Ignores formatting so it works on any input.
+ */
+export const isClerkTestPhoneNumber = (value: string): boolean => {
+  return /55501\d\d$/.test(value.replace(/\D/g, ''));
+};

--- a/packages/ui/src/utils/clerkTestPhoneNumber.ts
+++ b/packages/ui/src/utils/clerkTestPhoneNumber.ts
@@ -1,8 +1,9 @@
 /**
- * Clerk test phone numbers are fictional US (`+1`) numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
- * range, i.e. the last seven digits are `555 01XX`. Requires the `+1` country code so non-US numbers
- * that happen to end in `555 01XX` are not treated as test numbers. Ignores formatting.
+ * Clerk test phone numbers are fictional US numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
+ * range: a full 10-digit number (3-digit area code + `555 01XX`), optionally prefixed with the
+ * `1` country code. Requiring the complete shape rejects partial values (e.g. `5550100`) and
+ * non-US numbers that merely end in `555 01XX`. Ignores formatting.
  */
 export const isClerkTestPhoneNumber = (value: string): boolean => {
-  return /^1\d*55501\d\d$/.test(value.replace(/\D/g, ''));
+  return /^1?\d{3}55501\d\d$/.test(value.replace(/\D/g, ''));
 };

--- a/packages/ui/src/utils/clerkTestPhoneNumber.ts
+++ b/packages/ui/src/utils/clerkTestPhoneNumber.ts
@@ -1,7 +1,8 @@
 /**
- * Clerk test phone numbers are fictional US numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
- * range, i.e. the last seven digits are `555 01XX`. Ignores formatting so it works on any input.
+ * Clerk test phone numbers are fictional US (`+1`) numbers in the `(XXX) 555-0100`–`(XXX) 555-0199`
+ * range, i.e. the last seven digits are `555 01XX`. Requires the `+1` country code so non-US numbers
+ * that happen to end in `555 01XX` are not treated as test numbers. Ignores formatting.
  */
 export const isClerkTestPhoneNumber = (value: string): boolean => {
-  return /55501\d\d$/.test(value.replace(/\D/g, ''));
+  return /^1\d*55501\d\d$/.test(value.replace(/\D/g, ''));
 };


### PR DESCRIPTION
## Description

Prototype of an alternative treatment for the dev-mode test-credential affordance. Instead of an ⓘ popover on the field label, this renders a small **"Use test email" / "Use test number"** button overlaid inside the input, right-aligned.

Behavior:
- Only visible while the field is **focused** and the value is **not yet a valid test credential** (uses the same `isTestValue` predicate: `+clerk_test` for email, test-range detection for phone).
- Reserves matching padding on the input so text/placeholder never runs beneath the button.
- Clicking inserts the test credential (transforming a typed email by adding `+clerk_test`, or filling a test phone number) and keeps the input focused.
- Dev-mode gated via `useDevMode().showDevModeNotice` — disabling the dev-mode banner also hides it.

This is a preview branch to compare against the popover approach in #9162.

## Notes for reviewers

- Prototype only. The popover component (`FieldDevHint.tsx`) is still present but unused on this branch; the shared `FieldDevHintValue` type is reused.
- Hint strings are not localized yet (prototype scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development-only “use test credential” hints to sign-in and sign-up email/phone fields, with one-click insertion of suggested Clerk test values.
  * Introduced a dev-only field hint popover and an inline overlay insert button.
  * Added a new **warning** color scheme option for buttons.
* **Bug Fixes**
  * Phone inputs now stay synchronized when the external value changes.
* **Style**
  * Updated field label alignment styling.
* **Tests**
  * Added test coverage for Clerk test email/phone detection and the dev insert button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->