### PR TITLE
fix(ui): Improve members notification badge loading experience

### DIFF
--- a/.changeset/skeleton-members-badge-loading.md
+++ b/.changeset/skeleton-members-badge-loading.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': minor
+---
+
+Add a `Skeleton` loading placeholder with a subtle shimmer, targetable via the new `skeleton` appearance descriptor. The Organization Profile members tabs now reserve space for their notification count badges while loading, so the tabs no longer shift when the counts appear.

--- a/packages/ui/src/common/NotificationCountBadge.tsx
+++ b/packages/ui/src/common/NotificationCountBadge.tsx
@@ -1,6 +1,7 @@
 import { formatToCompactNumber } from '@/utils/intl';
 
-import { Box, Flex, localizationKeys, NotificationBadge, useLocalizations } from '../customizables';
+import { Flex, localizationKeys, NotificationBadge, useLocalizations } from '../customizables';
+import { Skeleton } from '../elements/Skeleton';
 import { usePrefersReducedMotion } from '../hooks';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { animations } from '../styledSystem';
@@ -39,17 +40,11 @@ export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
       ]}
     >
       {isLoading ? (
-        <Box
-          as='span'
-          aria-hidden
+        <Skeleton
           sx={t => ({
             height: t.space.$4,
             width: t.space.$5,
             borderRadius: t.radii.$lg,
-            backgroundColor: t.colors.$neutralAlpha100,
-            animation: prefersReducedMotion
-              ? 'none'
-              : `${animations.loadingPulse} 2s ${t.transitionTiming.$slowBezier} infinite`,
           })}
         />
       ) : (

--- a/packages/ui/src/common/NotificationCountBadge.tsx
+++ b/packages/ui/src/common/NotificationCountBadge.tsx
@@ -1,6 +1,6 @@
 import { formatToCompactNumber } from '@/utils/intl';
 
-import { Flex, localizationKeys, NotificationBadge, useLocalizations } from '../customizables';
+import { Box, Flex, localizationKeys, NotificationBadge, useLocalizations } from '../customizables';
 import { usePrefersReducedMotion } from '../hooks';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { animations } from '../styledSystem';
@@ -9,10 +9,11 @@ type NotificationCountBadgeProps = PropsOfComponent<typeof NotificationBadge> & 
   notificationCount: number;
   containerSx?: ThemableCssProp;
   shouldAnimate?: boolean;
+  isLoading?: boolean;
 };
 
 export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
-  const { notificationCount, containerSx, shouldAnimate = true, ...restProps } = props;
+  const { notificationCount, containerSx, shouldAnimate = true, isLoading = false, ...restProps } = props;
   const prefersReducedMotion = usePrefersReducedMotion();
   const { t } = useLocalizations();
   const localeKey = t(localizationKeys('locale'));
@@ -37,12 +38,28 @@ export const NotificationCountBadge = (props: NotificationCountBadgeProps) => {
         containerSx,
       ]}
     >
-      <NotificationBadge
-        sx={enterExitAnimation}
-        {...restProps}
-      >
-        {formattedNotificationCount}
-      </NotificationBadge>
+      {isLoading ? (
+        <Box
+          as='span'
+          aria-hidden
+          sx={t => ({
+            height: t.space.$4,
+            width: t.space.$5,
+            borderRadius: t.radii.$lg,
+            backgroundColor: t.colors.$neutralAlpha100,
+            animation: prefersReducedMotion
+              ? 'none'
+              : `${animations.loadingPulse} 2s ${t.transitionTiming.$slowBezier} infinite`,
+          })}
+        />
+      ) : (
+        <NotificationBadge
+          sx={enterExitAnimation}
+          {...restProps}
+        >
+          {formattedNotificationCount}
+        </NotificationBadge>
+      )}
     </Flex>
   );
 };

--- a/packages/ui/src/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/ui/src/components/OrganizationProfile/OrganizationMembers.tsx
@@ -84,37 +84,36 @@ export const OrganizationMembers = withCardStateProvider(() => {
               <TabsList sx={t => ({ gap: t.space.$2 })}>
                 {canReadMemberships && (
                   <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__members')}>
-                    {!!memberships?.count && (
-                      <NotificationCountBadge
-                        shouldAnimate={!query}
-                        notificationCount={memberships.count}
-                        colorScheme='outline'
-                      />
-                    )}
+                    <NotificationCountBadge
+                      shouldAnimate={false}
+                      isLoading={!memberships?.data || memberships.isLoading}
+                      notificationCount={memberships?.count ?? 0}
+                      colorScheme='outline'
+                    />
                   </Tab>
                 )}
                 {canManageMemberships && (
                   <Tab
                     localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__invitations')}
                   >
-                    {invitations?.data && !invitations.isLoading && (
-                      <NotificationCountBadge
-                        notificationCount={invitations.count}
-                        colorScheme='outline'
-                      />
-                    )}
+                    <NotificationCountBadge
+                      shouldAnimate={false}
+                      isLoading={!invitations?.data || invitations.isLoading}
+                      notificationCount={invitations?.count ?? 0}
+                      colorScheme='outline'
+                    />
                   </Tab>
                 )}
                 {canManageMemberships && isDomainsEnabled && (
                   <Tab
                     localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')}
                   >
-                    {membershipRequests?.data && !membershipRequests.isLoading && (
-                      <NotificationCountBadge
-                        notificationCount={membershipRequests.count}
-                        colorScheme='outline'
-                      />
-                    )}
+                    <NotificationCountBadge
+                      shouldAnimate={false}
+                      isLoading={!membershipRequests?.data || membershipRequests.isLoading}
+                      notificationCount={membershipRequests?.count ?? 0}
+                      colorScheme='outline'
+                    />
                   </Tab>
                 )}
               </TabsList>

--- a/packages/ui/src/customizables/elementDescriptors.ts
+++ b/packages/ui/src/customizables/elementDescriptors.ts
@@ -510,6 +510,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'notificationBadge',
   'buttonArrowIcon',
   'spinner',
+  'skeleton',
 
   'apiKeys',
   'apiKeysHeader',

--- a/packages/ui/src/elements/Skeleton.tsx
+++ b/packages/ui/src/elements/Skeleton.tsx
@@ -1,0 +1,59 @@
+import { Box, descriptors } from '../customizables';
+import { usePrefersReducedMotion } from '../hooks';
+import type { PropsOfComponent } from '../styledSystem';
+import { animations } from '../styledSystem';
+
+type SkeletonProps = PropsOfComponent<typeof Box> & {
+  /** When false, render children as-is instead of the loading placeholder. Defaults to true. */
+  show?: boolean;
+};
+
+/**
+ * Decorative placeholder for loading states with a subtle shimmer. Two modes:
+ *
+ * - **Block** — `<Skeleton sx={{ width, height }} />` reserves space with a plain bar.
+ * - **Content** — `<Skeleton><Button /></Skeleton>` sizes to the wrapped children (rendered
+ *   invisibly) so the placeholder matches the real content and nothing shifts on load.
+ *
+ * Pass `show={false}` to render the children normally. Targetable via the `skeleton` descriptor.
+ */
+export const Skeleton = (props: SkeletonProps) => {
+  const { show = true, sx, children, ...rest } = props;
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (!show) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Box
+      as='span'
+      aria-hidden
+      elementDescriptor={descriptors.skeleton}
+      sx={[
+        t => ({
+          position: 'relative',
+          display: children ? 'inline-block' : 'block',
+          overflow: 'hidden',
+          borderRadius: t.radii.$md,
+          backgroundColor: t.colors.$neutralAlpha100,
+          '> *': { visibility: 'hidden' },
+          '::after': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: `linear-gradient(90deg, ${t.colors.$transparent} 0%, ${t.colors.$neutralAlpha50} 50%, ${t.colors.$transparent} 100%)`,
+            backgroundSize: '200% 100%',
+            animation: prefersReducedMotion
+              ? 'none'
+              : `${animations.loadingShimmer} 1.5s ${t.transitionTiming.$slowBezier} infinite`,
+          },
+        }),
+        sx,
+      ]}
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/ui/src/internal/appearance.ts
+++ b/packages/ui/src/internal/appearance.ts
@@ -646,6 +646,7 @@ export type ElementsConfig = {
   notificationBadge: WithOptions;
   buttonArrowIcon: WithOptions;
   spinner: WithOptions;
+  skeleton: WithOptions;
 
   apiKeys: WithOptions;
   apiKeysHeader: WithOptions;

--- a/packages/ui/src/styledSystem/animations.ts
+++ b/packages/ui/src/styledSystem/animations.ts
@@ -38,8 +38,9 @@ const fadeOut = keyframes`
   100% { opacity: 0; }
 `;
 
-const loadingPulse = keyframes`
-  50% { opacity: 0.5; }
+const loadingShimmer = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 `;
 
 const inAnimation = keyframes`
@@ -147,5 +148,5 @@ export const animations = {
   inDelayAnimation,
   outAnimation,
   notificationAnimation,
-  loadingPulse,
+  loadingShimmer,
 };

--- a/packages/ui/src/styledSystem/animations.ts
+++ b/packages/ui/src/styledSystem/animations.ts
@@ -38,6 +38,10 @@ const fadeOut = keyframes`
   100% { opacity: 0; }
 `;
 
+const loadingPulse = keyframes`
+  50% { opacity: 0.5; }
+`;
+
 const inAnimation = keyframes`
   0% {
     opacity: 0;
@@ -143,4 +147,5 @@ export const animations = {
   inDelayAnimation,
   outAnimation,
   notificationAnimation,
+  loadingPulse,
 };


### PR DESCRIPTION
## Description

Introduce new `<Skeleton />` component and replace OrgProfile members tab notification badge animation.

BEFORE

https://github.com/user-attachments/assets/e9c41e64-fee4-4715-8187-aae98a25bd2e

AFTER

https://github.com/user-attachments/assets/02b2edca-259d-4df1-8507-644f0ac89eb8


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable skeleton loading placeholder with a subtle shimmer effect.
  - Added support for customizing the skeleton’s appearance through theme styling.
  - Added loading states for notification count badges.

- **Bug Fixes**
  - Organization Profile member tabs now reserve space for notification counts while loading, preventing layout shifts when counts appear.
  - Skeleton animations respect reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->