### PR TITLE
feat(backend): support organization-scoped sign-in tokens

### DIFF
--- a/.changeset/tidy-tokens-activate.md
+++ b/.changeset/tidy-tokens-activate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add an optional `orgId` parameter to `createSignInToken()` for activating an Organization when the token is redeemed.

--- a/packages/backend/src/api/__tests__/SignInTokenApi.test.ts
+++ b/packages/backend/src/api/__tests__/SignInTokenApi.test.ts
@@ -1,0 +1,46 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server, validateHeaders } from '../../mock-server';
+import { createBackendApiClient } from '../factory';
+
+describe('SignInTokenAPI', () => {
+  const apiClient = createBackendApiClient({
+    apiUrl: 'https://api.clerk.test',
+    secretKey: 'deadbeef',
+  });
+
+  it('sends the organization ID as org_id', async () => {
+    server.use(
+      http.post(
+        'https://api.clerk.test/v1/sign_in_tokens',
+        validateHeaders(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual({
+            user_id: 'user_123',
+            org_id: 'org_123',
+            expires_in_seconds: 3600,
+          });
+
+          return HttpResponse.json({
+            id: 'sign_in_token_123',
+            user_id: 'user_123',
+            token: 'token_123',
+            status: 'pending',
+            url: 'https://accounts.example.com/tickets/token_123',
+            created_at: 1,
+            updated_at: 1,
+          });
+        }),
+      ),
+    );
+
+    const response = await apiClient.signInTokens.createSignInToken({
+      userId: 'user_123',
+      orgId: 'org_123',
+      expiresInSeconds: 3600,
+    });
+
+    expect(response.id).toBe('sign_in_token_123');
+  });
+});

--- a/packages/backend/src/api/endpoints/SignInTokenApi.ts
+++ b/packages/backend/src/api/endpoints/SignInTokenApi.ts
@@ -6,6 +6,8 @@ import { AbstractAPI } from './AbstractApi';
 export type CreateSignInTokensParams = {
   /** The ID of the user to create the sign-in token for. */
   userId: string;
+  /** The ID of the organization to activate when the user signs in. Organizations must be enabled for the instance, and the user must be a member of the organization. */
+  orgId?: string;
   /** The number of seconds until the sign-in token expires. By default, the duration is `2592000` (30 days). */
   expiresInSeconds: number;
 };


### PR DESCRIPTION
## Summary

- add an optional `orgId` field to `CreateSignInTokensParams`
- serialize the value as `org_id` in the Backend API request
- add Node and edge-runtime coverage for the request body
- add a minor changeset for `@clerk/backend`

## Context

Supports the organization-scoped sign-in token API introduced in [clerk/clerk_go#20464](https://github.com/clerk/clerk_go/pull/20464).

Related SDK and docs work:

- [clerk/clerk-sdk-go#580](https://github.com/clerk/clerk-sdk-go/pull/580)
- [clerk/clerk#2977](https://github.com/clerk/clerk/pull/2977)

## Manual verification

The organization-scoped sign-in token flow was exercised against the local backend branch.

![Organization-scoped sign-in token created with orgId](https://gist.githubusercontent.com/swolfand/0cfac817e878d8dcfccc115561c0938d/raw/b3b11abcf33018045fc2584d02db044eda5d3f14/sign-in-token-org-id-demo.png)

## Validation

- `pnpm turbo build --filter=@clerk/backend`
- `pnpm turbo test --filter=@clerk/backend`
- `pnpm --filter @clerk/backend lint`
- `pnpm --filter @clerk/backend format:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in tokens can now optionally activate a specified organization when redeemed, provided the organization is enabled and the user is a member.
* **Documentation**
  * Added guidance for using the optional organization parameter when creating sign-in tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->