### PR TITLE
fix(expo): Resolve Android native modules optionally

### DIFF
--- a/.changeset/fix-android-optional-native-module.md
+++ b/.changeset/fix-android-optional-native-module.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Fix a crash on Android in Expo Go where rendering `<ClerkProvider>` failed with `Cannot find native module 'ClerkExpo'`, even for JavaScript-only flows that use no native components.

--- a/packages/expo/src/specs/NativeClerkGoogleSignIn.android.ts
+++ b/packages/expo/src/specs/NativeClerkGoogleSignIn.android.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo';
+import { requireOptionalNativeModule } from 'expo';
 
 type NativeMap = Record<string, unknown>;
 
@@ -10,4 +10,5 @@ interface Spec {
   signOut(): Promise<void>;
 }
 
-export default requireNativeModule<Spec>('ClerkGoogleSignIn');
+// Optional so getNativeModule() can surface its actionable error instead.
+export default requireOptionalNativeModule<Spec>('ClerkGoogleSignIn');

--- a/packages/expo/src/specs/NativeClerkGoogleSignIn.android.ts
+++ b/packages/expo/src/specs/NativeClerkGoogleSignIn.android.ts
@@ -10,5 +10,6 @@ interface Spec {
   signOut(): Promise<void>;
 }
 
-// Optional so getNativeModule() can surface its actionable error instead.
+// Optional so getNativeModule() surfaces its actionable error rather than
+// throwing at import time.
 export default requireOptionalNativeModule<Spec>('ClerkGoogleSignIn');

--- a/packages/expo/src/specs/NativeClerkModule.android.ts
+++ b/packages/expo/src/specs/NativeClerkModule.android.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo';
+import { requireOptionalNativeModule } from 'expo';
 
 interface Spec {
   // Exposed by Expo Modules EventEmitter for internal native client change events.
@@ -14,4 +14,5 @@ interface Spec {
   ): Promise<void>;
 }
 
-export default requireNativeModule<Spec>('ClerkExpo');
+// Optional so it resolves to null in Expo Go instead of throwing at import time.
+export default requireOptionalNativeModule<Spec>('ClerkExpo');

--- a/packages/expo/src/specs/__tests__/androidSpecs.test.ts
+++ b/packages/expo/src/specs/__tests__/androidSpecs.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import ClerkGoogleSignInSpec from '../NativeClerkGoogleSignIn.android';
+import ClerkExpoSpec from '../NativeClerkModule.android';
+
+// Simulates Expo Go on Android, where the native modules are not compiled in:
+// requireNativeModule throws, requireOptionalNativeModule resolves to null.
+vi.mock('expo', () => ({
+  requireNativeModule: (name: string) => {
+    throw new Error(`Cannot find native module '${name}'`);
+  },
+  requireOptionalNativeModule: () => null,
+}));
+
+describe('android native module specs', () => {
+  test('NativeClerkModule resolves to null instead of throwing at import time', () => {
+    expect(ClerkExpoSpec).toBeNull();
+  });
+
+  test('NativeClerkGoogleSignIn resolves to null instead of throwing at import time', () => {
+    expect(ClerkGoogleSignInSpec).toBeNull();
+  });
+});

--- a/packages/expo/src/specs/__tests__/androidSpecs.test.ts
+++ b/packages/expo/src/specs/__tests__/androidSpecs.test.ts
@@ -1,23 +1,51 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import ClerkGoogleSignInSpec from '../NativeClerkGoogleSignIn.android';
-import ClerkExpoSpec from '../NativeClerkModule.android';
-
-// Simulates Expo Go on Android, where the native modules are not compiled in:
-// requireNativeModule throws, requireOptionalNativeModule resolves to null.
-vi.mock('expo', () => ({
-  requireNativeModule: (name: string) => {
-    throw new Error(`Cannot find native module '${name}'`);
-  },
-  requireOptionalNativeModule: () => null,
+const mocks = vi.hoisted(() => ({
+  available: {} as Record<string, unknown>,
 }));
 
+// Only returns a module when one is registered under the exact name requested.
+vi.mock('expo', () => ({
+  requireNativeModule: (name: string) => {
+    const nativeModule = mocks.available[name];
+    if (!nativeModule) {
+      throw new Error(`Cannot find native module '${name}'`);
+    }
+    return nativeModule;
+  },
+  requireOptionalNativeModule: (name: string) => mocks.available[name] ?? null,
+}));
+
+// Path is a variable because TypeScript cannot resolve the platform suffix in a
+// dynamic import.
+const importSpec = async (path: string) => (await import(path)).default;
+
+const importSpecs = async () => ({
+  clerkExpo: await importSpec('../NativeClerkModule.android'),
+  googleSignIn: await importSpec('../NativeClerkGoogleSignIn.android'),
+});
+
 describe('android native module specs', () => {
-  test('NativeClerkModule resolves to null instead of throwing at import time', () => {
-    expect(ClerkExpoSpec).toBeNull();
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.available = {};
   });
 
-  test('NativeClerkGoogleSignIn resolves to null instead of throwing at import time', () => {
-    expect(ClerkGoogleSignInSpec).toBeNull();
+  test('resolve to null instead of throwing when not compiled in (Expo Go)', async () => {
+    const { clerkExpo, googleSignIn } = await importSpecs();
+
+    expect(clerkExpo).toBeNull();
+    expect(googleSignIn).toBeNull();
+  });
+
+  test('resolve the module registered under the expected name (development build)', async () => {
+    const clerkExpoModule = { configure: vi.fn() };
+    const googleSignInModule = { signIn: vi.fn() };
+    mocks.available = { ClerkExpo: clerkExpoModule, ClerkGoogleSignIn: googleSignInModule };
+
+    const { clerkExpo, googleSignIn } = await importSpecs();
+
+    expect(clerkExpo).toBe(clerkExpoModule);
+    expect(googleSignIn).toBe(googleSignInModule);
   });
 });


### PR DESCRIPTION
## Description

On Android, the native module specs used `requireNativeModule`, which throws at  import time. Since `ClerkProvider` imports that chain unconditionally, every Android app crashed at startup with `Cannot find native module 'ClerkExpo'` when the module wasn't compiled in (Expo Go), even for JavaScript-only flows.

iOS already used `requireOptionalNativeModule`. This makes Android match, letting the existing null guard degrade gracefully.

Fixes #9197

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
