### PR TITLE
feat(expo): add Android bottom sheet presentation

### DIFF
--- a/.changeset/soft-diamonds-slide.md
+++ b/.changeset/soft-diamonds-slide.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': minor
+---
+
+Add an Android `presentation` option to `AuthView`, including a native Material bottom sheet mode.

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
@@ -2,9 +2,19 @@ package expo.modules.clerk
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
@@ -30,6 +40,7 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
   var isDismissible: Boolean = true
   var logoMaxHeight: Float? = null
   var mode: String? = null
+  var presentation: String = "inline"
 
   private val onAuthEvent by EventDispatcher()
 
@@ -61,9 +72,37 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
   }
 
   @Composable
+  @OptIn(ExperimentalMaterial3Api::class)
   override fun Content() {
-    debugLog(TAG, "setupView - mode: $mode, isDismissible: $isDismissible, activity: $activity")
+    debugLog(
+      TAG,
+      "setupView - mode: $mode, presentation: $presentation, isDismissible: $isDismissible, activity: $activity",
+    )
 
+    if (presentation != "bottomSheet") {
+      ClerkAuthView()
+      return
+    }
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    ModalBottomSheet(
+      onDismissRequest = ::sendDismissEvent,
+      sheetState = sheetState,
+      containerColor = clerkBackgroundColor(),
+    ) {
+      BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val authHeight =
+          if (sheetState.currentValue == SheetValue.Expanded) maxHeight else maxHeight / 2
+
+        Box(modifier = Modifier.fillMaxWidth().height(authHeight)) {
+          ClerkAuthView()
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun ClerkAuthView() {
     AuthView(
       modifier = Modifier.fillMaxSize(),
       clerkTheme = authTheme(),
@@ -74,6 +113,17 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
         sendDismissEvent()
       },
     )
+  }
+
+  @Composable
+  private fun clerkBackgroundColor(): Color {
+    val isDarkMode = isSystemInDarkTheme()
+    val customTheme = Clerk.customTheme
+    val modeColors = if (isDarkMode) customTheme?.darkColors else customTheme?.lightColors
+
+    return modeColors?.background
+      ?: customTheme?.colors?.background
+      ?: if (isDarkMode) Color(0xFF131316) else Color.White
   }
 
   private fun authTheme(): ClerkTheme? {
@@ -117,6 +167,10 @@ class ClerkAuthViewModule : Module() {
 
       Prop("logoMaxHeight") { view: ClerkAuthNativeView, logoMaxHeight: Float? ->
         view.logoMaxHeight = logoMaxHeight
+      }
+
+      Prop("presentation") { view: ClerkAuthNativeView, presentation: String? ->
+        view.presentation = presentation ?: "inline"
       }
 
       OnViewDidUpdateProps { view: ClerkAuthNativeView ->

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
@@ -2,19 +2,30 @@ package expo.modules.clerk
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
@@ -89,30 +100,74 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
       onDismissRequest = ::sendDismissEvent,
       sheetState = sheetState,
       containerColor = clerkBackgroundColor(),
+      dragHandle = { SheetDragHandle() },
     ) {
       BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-        val authHeight =
-          if (sheetState.currentValue == SheetValue.Expanded) maxHeight else maxHeight / 2
+        val density = LocalDensity.current
+        val sheetOffsetPx =
+          runCatching { sheetState.requireOffset() }
+            .getOrDefault(with(density) { maxHeight.toPx() })
+        val sheetOffset = with(density) { sheetOffsetPx.toDp() }
+        val authHeight = (maxHeight - sheetOffset).coerceAtLeast(0.dp)
 
-        Box(modifier = Modifier.fillMaxWidth().height(authHeight)) {
-          ClerkAuthView()
+        if (sheetState.currentValue != SheetValue.Hidden) {
+          Box(modifier = Modifier.fillMaxWidth().height(authHeight)) {
+            ClerkAuthView(showDismissAction = false)
+          }
         }
       }
     }
   }
 
   @Composable
-  private fun ClerkAuthView() {
+  private fun ClerkAuthView(showDismissAction: Boolean = isDismissible) {
     AuthView(
       modifier = Modifier.fillMaxSize(),
       clerkTheme = authTheme(),
       mode = authMode(mode),
-      isDismissible = isDismissible,
+      isDismissible = showDismissAction,
       onDismiss = ::sendDismissEvent,
       onAuthComplete = {
         sendDismissEvent()
       },
     )
+  }
+
+  @Composable
+  @OptIn(ExperimentalMaterial3Api::class)
+  private fun SheetDragHandle() {
+    Box(modifier = Modifier.fillMaxWidth().height(48.dp)) {
+      BottomSheetDefaults.DragHandle(modifier = Modifier.align(Alignment.Center))
+      if (isDismissible) {
+        IconButton(
+          onClick = ::sendDismissEvent,
+          modifier =
+            Modifier.align(Alignment.CenterEnd)
+              .padding(end = 12.dp)
+              .semantics { contentDescription = "Close" },
+        ) {
+          val color = clerkForegroundColor()
+          Canvas(modifier = Modifier.size(24.dp)) {
+            val inset = 4.dp.toPx()
+            val strokeWidth = 2.dp.toPx()
+            drawLine(
+              color = color,
+              start = Offset(inset, inset),
+              end = Offset(size.width - inset, size.height - inset),
+              strokeWidth = strokeWidth,
+              cap = StrokeCap.Round,
+            )
+            drawLine(
+              color = color,
+              start = Offset(size.width - inset, inset),
+              end = Offset(inset, size.height - inset),
+              strokeWidth = strokeWidth,
+              cap = StrokeCap.Round,
+            )
+          }
+        }
+      }
+    }
   }
 
   @Composable
@@ -124,6 +179,17 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
     return modeColors?.background
       ?: customTheme?.colors?.background
       ?: if (isDarkMode) Color(0xFF131316) else Color.White
+  }
+
+  @Composable
+  private fun clerkForegroundColor(): Color {
+    val isDarkMode = isSystemInDarkTheme()
+    val customTheme = Clerk.customTheme
+    val modeColors = if (isDarkMode) customTheme?.darkColors else customTheme?.lightColors
+
+    return modeColors?.foreground
+      ?: customTheme?.colors?.foreground
+      ?: if (isDarkMode) Color.White else Color.Black
   }
 
   private fun authTheme(): ClerkTheme? {

--- a/packages/expo/src/native/AuthView.tsx
+++ b/packages/expo/src/native/AuthView.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useCallback } from 'react';
 import type { NativeSyntheticEvent } from 'react-native';
-import { Text, View } from 'react-native';
+import { Platform, Text, View } from 'react-native';
 
 import NativeClerkAuthView from '../specs/NativeClerkAuthView';
 import { isNativeSupported } from '../utils/native-module';
@@ -39,6 +39,7 @@ type AuthNativeEvent = NativeSyntheticEvent<Readonly<{ type: string }>>;
  */
 export function AuthView({
   mode = 'signInOrUp',
+  presentation = 'inline',
   isDismissible = true,
   logoMaxHeight,
   onDismiss,
@@ -68,6 +69,7 @@ export function AuthView({
     <NativeClerkAuthView
       style={{ flex: 1 }}
       mode={mode}
+      {...(Platform.OS === 'android' ? { presentation } : {})}
       isDismissible={isDismissible}
       logoMaxHeight={logoMaxHeight}
       onAuthEvent={handleAuthEvent}

--- a/packages/expo/src/native/AuthView.types.ts
+++ b/packages/expo/src/native/AuthView.types.ts
@@ -7,6 +7,9 @@
  */
 export type AuthViewMode = 'signIn' | 'signUp' | 'signInOrUp';
 
+/** Android presentation used by the native authentication view. */
+export type AuthViewPresentation = 'inline' | 'bottomSheet';
+
 /**
  * Props for the AuthView component.
  *
@@ -25,6 +28,17 @@ export interface AuthViewProps {
    * @default 'signInOrUp'
    */
   mode?: AuthViewMode;
+
+  /**
+   * Android presentation for the native authentication view.
+   *
+   * `'inline'` preserves the standard behavior and fills the parent container.
+   * `'bottomSheet'` presents the same Clerk flow in a Material bottom sheet.
+   * This option is ignored on iOS, where the parent controls presentation.
+   *
+   * @default 'inline'
+   */
+  presentation?: AuthViewPresentation;
 
   /**
    * Whether the authentication view can be dismissed by the user.

--- a/packages/expo/src/native/__tests__/AuthView.test.tsx
+++ b/packages/expo/src/native/__tests__/AuthView.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../../utils/native-module', () => {
 
 vi.mock('react-native', () => {
   return {
+    Platform: { OS: 'android' },
     Text: ({ children }: { children?: React.ReactNode }) => React.createElement('span', null, children),
     View: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
   };
@@ -38,6 +39,18 @@ describe('AuthView', () => {
     render(<AuthView logoMaxHeight={64} />);
 
     expect(mocks.NativeClerkAuthView.mock.calls[0]?.[0]).toMatchObject({ logoMaxHeight: 64 });
+  });
+
+  test('uses inline presentation by default', () => {
+    render(<AuthView />);
+
+    expect(mocks.NativeClerkAuthView.mock.calls[0]?.[0]).toMatchObject({ presentation: 'inline' });
+  });
+
+  test('passes bottom sheet presentation to the native auth view', () => {
+    render(<AuthView presentation='bottomSheet' />);
+
+    expect(mocks.NativeClerkAuthView.mock.calls[0]?.[0]).toMatchObject({ presentation: 'bottomSheet' });
   });
 
   test('calls onDismiss when the native auth view emits dismissed', () => {

--- a/packages/expo/src/native/index.ts
+++ b/packages/expo/src/native/index.ts
@@ -29,7 +29,7 @@
  */
 
 export { AuthView } from './AuthView';
-export type { AuthViewProps, AuthViewMode } from './AuthView.types';
+export type { AuthViewProps, AuthViewMode, AuthViewPresentation } from './AuthView.types';
 export { UserButton } from './UserButton';
 export { UserProfileView } from './UserProfileView';
 export type { UserProfileViewProps } from './UserProfileView';

--- a/packages/expo/src/specs/NativeClerkAuthView.android.ts
+++ b/packages/expo/src/specs/NativeClerkAuthView.android.ts
@@ -7,6 +7,7 @@ interface NativeProps extends ViewProps {
   mode?: string;
   isDismissible?: boolean;
   logoMaxHeight?: number;
+  presentation?: string;
   onAuthEvent?: (event: NativeSyntheticEvent<AuthEvent>) => void;
 }
 

--- a/packages/expo/src/specs/NativeClerkAuthView.ts
+++ b/packages/expo/src/specs/NativeClerkAuthView.ts
@@ -8,6 +8,7 @@ interface NativeProps extends ViewProps {
   mode?: string;
   isDismissible?: boolean;
   logoMaxHeight?: number;
+  presentation?: string;
   onAuthEvent?: (event: NativeSyntheticEvent<AuthEvent>) => void;
 }
 


### PR DESCRIPTION
## Description

Adds an opt-in Android presentation mode to the Expo native `AuthView`:

```tsx
<AuthView presentation="bottomSheet" />
```

`AuthView` continues to render inline by default, so existing full-screen and embedded usages are unchanged. When `bottomSheet` is selected on Android, the Expo native host presents Clerk's existing Compose auth flow in a Material 3 bottom sheet, uses the Clerk theme background, keeps Clerk branding visible in the partially expanded state, and supports expansion and dismissal.

Previously, the Expo bridge always mounted the Android auth view as full-parent content. React Native callers could place that content inside a modal, but could not opt into a native Material bottom-sheet presentation without modifying the bridge locally.

Validation:
- `pnpm turbo build --filter=@clerk/expo`
- `pnpm turbo test --filter=@clerk/expo` (107 tests)
- `pnpm --filter @clerk/expo lint` (no errors; existing warnings only)
- `pnpm --filter @clerk/expo format:check`
- Android release and debug builds in an Expo SDK 57 consumer app
- Manual verification on an Android emulator and Pixel 9 Pro

<img height="700" alt="Screenshot_1784739740" src="https://github.com/user-attachments/assets/9b8b979d-29a2-4fd8-b25e-bd6431f9069c" />
<img height="700" alt="Screenshot_1784741876" src="https://github.com/user-attachments/assets/6f3c626a-748c-42af-8c29-043cea6605ce" />



