### PR TITLE
fix(clerk-js): Backport forgot password from sign-in start

### DIFF
--- a/.changeset/sign-in-start-forgot-password-core-2.md
+++ b/.changeset/sign-in-start-forgot-password-core-2.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add a "Forgot password?" action on the sign-in start page when the password field is shown. This improves the account recovery UX when strict user enumeration protection is enabled.

--- a/packages/clerk-js/src/test/mock-helpers.ts
+++ b/packages/clerk-js/src/test/mock-helpers.ts
@@ -105,7 +105,10 @@ export const mockClerkMethods = (clerk: LoadedClerk): DeepVitestMocked<LoadedCle
   return clerkAny as DeepVitestMocked<LoadedClerk>;
 };
 
-export const mockRouteContextValue = ({ queryString = '' }: Partial<DeepVitestMocked<RouteContextValue>>) => {
+export const mockRouteContextValue = ({
+  queryString = '',
+  queryParams,
+}: Partial<DeepVitestMocked<RouteContextValue>>) => {
   return {
     basePath: '',
     startPath: '',
@@ -114,7 +117,7 @@ export const mockRouteContextValue = ({ queryString = '' }: Partial<DeepVitestMo
     indexPath: '',
     currentPath: '',
     queryString,
-    queryParams: {},
+    queryParams: queryParams ?? {},
     getMatchData: vi.fn(),
     matches: vi.fn(),
     baseNavigate: vi.fn(),

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -13,7 +13,7 @@ import { localizationKeys } from '../../localization';
 import { useRouter } from '../../router';
 import type { AlternativeMethodsMode } from './AlternativeMethods';
 import { AlternativeMethods } from './AlternativeMethods';
-import { hasMultipleEnterpriseConnections } from './shared';
+import { hasMultipleEnterpriseConnections, SIGN_IN_RESET_PASSWORD_INTENT_PARAM } from './shared';
 import { SignInFactorOneAlternativePhoneCodeCard } from './SignInFactorOneAlternativePhoneCodeCard';
 import { SignInFactorOneEmailCodeCard } from './SignInFactorOneEmailCodeCard';
 import { SignInFactorOneEmailLinkCard } from './SignInFactorOneEmailLinkCard';
@@ -62,6 +62,18 @@ function determineAlternativeMethodsMode(
   return 'forgot';
 }
 
+function removeSignInResetPasswordIntentParam(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  if (url.searchParams.has(SIGN_IN_RESET_PASSWORD_INTENT_PARAM)) {
+    url.searchParams.delete(SIGN_IN_RESET_PASSWORD_INTENT_PARAM);
+    window.history.replaceState(window.history.state, '', url);
+  }
+}
+
 function SignInFactorOneInternal(): JSX.Element {
   const { __internal_setActiveInProgress } = useClerk();
   const signIn = useCoreSignIn();
@@ -97,13 +109,17 @@ function SignInFactorOneInternal(): JSX.Element {
     supportedFirstFactors,
   });
 
-  const [showAllStrategies, setShowAllStrategies] = React.useState<boolean>(
-    () => !currentFactor || !factorHasLocalStrategy(currentFactor),
-  );
-
   const resetPasswordFactor = useResetPasswordFactor();
+  const resetPasswordIntent = router.queryParams[SIGN_IN_RESET_PASSWORD_INTENT_PARAM] === 'true';
 
-  const [showForgotPasswordStrategies, setShowForgotPasswordStrategies] = React.useState(false);
+  const [showAllStrategies, setShowAllStrategies] = React.useState<boolean>(() => {
+    const defaultShow = !currentFactor || !factorHasLocalStrategy(currentFactor);
+    return defaultShow || (resetPasswordIntent && !resetPasswordFactor);
+  });
+
+  const [showForgotPasswordStrategies, setShowForgotPasswordStrategies] = React.useState(
+    () => resetPasswordIntent && !!resetPasswordFactor,
+  );
 
   const [passwordErrorCode, setPasswordErrorCode] = React.useState<PasswordErrorCode | null>(null);
 
@@ -158,10 +174,17 @@ function SignInFactorOneInternal(): JSX.Element {
     const canGoBack = factorHasLocalStrategy(currentFactor);
 
     const toggle = showAllStrategies ? toggleAllStrategies : toggleForgotPasswordStrategies;
-    const backHandler = () => {
+    const leaveAlternativeMethods = () => {
+      // This search param only exists if the user clicked "Forgot password?" on the
+      // start page, it's a way to go directly to the password reset screen.
+      // If it does exist, we want to remove it on exit so refresh works correctly after.
+      removeSignInResetPasswordIntentParam();
+      toggle?.();
+    };
+    const backHandler: React.MouseEventHandler<Element> = () => {
       card.setError(undefined);
       setPasswordErrorCode(null);
-      toggle?.();
+      leaveAlternativeMethods();
     };
 
     const mode = determineAlternativeMethodsMode(showForgotPasswordStrategies, passwordErrorCode);
@@ -172,7 +195,7 @@ function SignInFactorOneInternal(): JSX.Element {
         onBackLinkClick={canGoBack ? backHandler : undefined}
         onFactorSelected={f => {
           selectFactor(f);
-          toggle?.();
+          leaveAlternativeMethods();
         }}
         currentFactor={currentFactor}
       />

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOne.tsx
@@ -6,6 +6,7 @@ import { useCardState, withCardStateProvider } from '@/ui/elements/contexts';
 import { ErrorCard } from '@/ui/elements/ErrorCard';
 import { LoadingCard } from '@/ui/elements/LoadingCard';
 
+import { hasUrlInFragment } from '../../../utils';
 import { withRedirectToAfterSignIn, withRedirectToSignInTask } from '../../common';
 import { useCoreSignIn, useEnvironment } from '../../contexts';
 import { useAlternativeStrategies } from '../../hooks/useAlternativeStrategies';
@@ -62,16 +63,33 @@ function determineAlternativeMethodsMode(
   return 'forgot';
 }
 
-function removeSignInResetPasswordIntentParam(): void {
+function removeSignInResetPasswordIntentParam(): boolean {
   if (typeof window === 'undefined') {
-    return;
+    return false;
   }
 
   const url = new URL(window.location.href);
+  let removed = false;
+
   if (url.searchParams.has(SIGN_IN_RESET_PASSWORD_INTENT_PARAM)) {
     url.searchParams.delete(SIGN_IN_RESET_PASSWORD_INTENT_PARAM);
+    removed = true;
+  }
+
+  if (hasUrlInFragment(url)) {
+    const fragmentUrl = new URL(url.hash.substring(1), url.origin);
+    if (fragmentUrl.searchParams.has(SIGN_IN_RESET_PASSWORD_INTENT_PARAM)) {
+      fragmentUrl.searchParams.delete(SIGN_IN_RESET_PASSWORD_INTENT_PARAM);
+      url.hash = `#${fragmentUrl.pathname}${fragmentUrl.search}${fragmentUrl.hash}`;
+      removed = true;
+    }
+  }
+
+  if (removed) {
     window.history.replaceState(window.history.state, '', url);
   }
+
+  return removed;
 }
 
 function SignInFactorOneInternal(): JSX.Element {
@@ -178,7 +196,9 @@ function SignInFactorOneInternal(): JSX.Element {
       // This search param only exists if the user clicked "Forgot password?" on the
       // start page, it's a way to go directly to the password reset screen.
       // If it does exist, we want to remove it on exit so refresh works correctly after.
-      removeSignInResetPasswordIntentParam();
+      if (removeSignInResetPasswordIntentParam()) {
+        router.refresh();
+      }
       toggle?.();
     };
     const backHandler: React.MouseEventHandler<Element> = () => {

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -40,7 +40,11 @@ import { useSupportEmail } from '../../hooks/useSupportEmail';
 import { useTotalEnabledAuthMethods } from '../../hooks/useTotalEnabledAuthMethods';
 import { useRouter } from '../../router';
 import { handleCombinedFlowTransfer } from './handleCombinedFlowTransfer';
-import { hasMultipleEnterpriseConnections, useHandleAuthenticateWithPasskey } from './shared';
+import {
+  hasMultipleEnterpriseConnections,
+  SIGN_IN_RESET_PASSWORD_INTENT_PARAM,
+  useHandleAuthenticateWithPasskey,
+} from './shared';
 import { SignInAlternativePhoneCodePhoneNumberCard } from './SignInAlternativePhoneCodePhoneNumberCard';
 import { SignInSocialButtons } from './SignInSocialButtons';
 import {
@@ -352,7 +356,10 @@ function SignInStartInternal(): JSX.Element {
     });
   };
 
-  const signInWithFields = async (...fields: Array<FormControlState<string>>) => {
+  const signInWithFields = async (
+    fields: Array<FormControlState<string>>,
+    options?: { resetPasswordIntent?: boolean },
+  ) => {
     // If the user has already selected an alternative phone code provider, we use that.
     const preferredAlternativePhoneChannel =
       alternativePhoneCodeProvider?.channel ||
@@ -390,6 +397,11 @@ function SignInStartInternal(): JSX.Element {
           break;
         case 'needs_first_factor': {
           if (!hasOnlyEnterpriseSSOFirstFactors(res) || hasMultipleEnterpriseConnections(res.supportedFirstFactors)) {
+            if (options?.resetPasswordIntent) {
+              return navigate('factor-one', {
+                searchParams: new URLSearchParams({ [SIGN_IN_RESET_PASSWORD_INTENT_PARAM]: 'true' }),
+              });
+            }
             return navigate('factor-one');
           }
 
@@ -450,7 +462,7 @@ function SignInStartInternal(): JSX.Element {
     );
 
     if (instantPasswordError) {
-      await signInWithFields(identifierField);
+      await signInWithFields([identifierField]);
     } else if (sessionAlreadyExistsError) {
       await clerk.setActive({
         session: clerk.client.lastActiveSessionId,
@@ -517,7 +529,18 @@ function SignInStartInternal(): JSX.Element {
 
   const handleFirstPartySubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    return signInWithFields(identifierField, instantPasswordField);
+    return signInWithFields([identifierField, instantPasswordField]);
+  };
+
+  const handleForgotPasswordClick: React.MouseEventHandler = e => {
+    e.preventDefault();
+    // Surface the same native required-field validation as the Continue button
+    // when the identifier is missing
+    const form = e.currentTarget.closest('form');
+    if (form && !form.reportValidity()) {
+      return;
+    }
+    void signInWithFields([identifierField], { resetPasswordIntent: true });
   };
 
   const DynamicField = useMemo(() => {
@@ -610,7 +633,10 @@ function SignInStartInternal(): JSX.Element {
                           isLastAuthenticationStrategy={isIdentifierLastAuthenticationStrategy}
                         />
                       </Form.ControlRow>
-                      <InstantPasswordRow field={passwordBasedInstance ? instantPasswordField : undefined} />
+                      <InstantPasswordRow
+                        field={passwordBasedInstance ? instantPasswordField : undefined}
+                        onForgotPasswordClick={handleForgotPasswordClick}
+                      />
                     </Col>
                     <Col center>
                       <Form.SubmitButton hasArrow />
@@ -676,7 +702,13 @@ const hasOnlyEnterpriseSSOFirstFactors = (signIn: SignInResource): boolean => {
   return signIn.supportedFirstFactors.every(ff => ff.strategy === 'enterprise_sso');
 };
 
-const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> }) => {
+const InstantPasswordRow = ({
+  field,
+  onForgotPasswordClick,
+}: {
+  field?: FormControlState<'password'>;
+  onForgotPasswordClick?: React.MouseEventHandler;
+}) => {
   const [autofilled, setAutofilled] = useState(false);
   const ref = useRef<HTMLInputElement>(null);
   const show = !!(autofilled || field?.value);
@@ -719,6 +751,8 @@ const InstantPasswordRow = ({ field }: { field?: FormControlState<'password'> })
     >
       <Form.PasswordInput
         {...field.props}
+        actionLabel={show ? localizationKeys('formFieldAction__forgotPassword') : undefined}
+        onActionClicked={show ? onForgotPasswordClick : undefined}
         ref={ref}
         tabIndex={show ? undefined : -1}
       />

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { bindCreateFixtures } from '@/test/create-fixtures';
 import { act, mockWebAuthn, render, screen } from '@/test/utils';
 
+import { SIGN_IN_RESET_PASSWORD_INTENT_PARAM } from '../shared';
 import { SignInFactorOne } from '../SignInFactorOne';
 
 const { createFixtures } = bindCreateFixtures('SignIn');
@@ -139,6 +140,46 @@ describe('SignInFactorOne', () => {
         expect(screen.queryByText('Or, sign in with another method')).not.toBeInTheDocument();
         await screen.findByText(`Email code to ${email}`);
         expect(screen.queryByText('Sign in with your password')).not.toBeInTheDocument();
+      });
+
+      describe('reset password intent from start page', () => {
+        const { createFixtures: createFixturesWithResetIntent } = bindCreateFixtures('SignIn', {
+          router: { queryParams: { [SIGN_IN_RESET_PASSWORD_INTENT_PARAM]: 'true' } },
+        });
+
+        it('opens the forgot password screen when a reset factor exists', async () => {
+          const { wrapper } = await createFixturesWithResetIntent(f => {
+            f.withEmailAddress();
+            f.withPassword();
+            f.withPreferredSignInStrategy({ strategy: 'password' });
+            f.startSignInWithEmailAddress({
+              supportEmailCode: true,
+              supportPassword: true,
+              supportResetPassword: true,
+            });
+          });
+          render(<SignInFactorOne />, { wrapper });
+          await screen.findByText('Forgot Password?');
+          await screen.findByText('Reset your password');
+        });
+
+        it('opens use another method when no reset factor exists', async () => {
+          const email = 'test@clerk.com';
+          const { wrapper } = await createFixturesWithResetIntent(f => {
+            f.withEmailAddress();
+            f.withPassword();
+            f.withPreferredSignInStrategy({ strategy: 'password' });
+            f.startSignInWithEmailAddress({
+              supportEmailCode: true,
+              supportPassword: true,
+              supportResetPassword: false,
+              identifier: email,
+            });
+          });
+          render(<SignInFactorOne />, { wrapper });
+          await screen.findByText('Use another method');
+          await screen.findByText(`Email code to ${email}`);
+        });
       });
 
       it('should render the Forgot Password alternative methods component when clicking on "Forgot password" (email)', async () => {

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -180,6 +180,44 @@ describe('SignInFactorOne', () => {
           await screen.findByText('Use another method');
           await screen.findByText(`Email code to ${email}`);
         });
+
+        it.each([
+          {
+            name: 'path router',
+            initialUrl: `/sign-in/factor-one?${SIGN_IN_RESET_PASSWORD_INTENT_PARAM}=true&preserved=value`,
+            expectedUrl: '/sign-in/factor-one?preserved=value',
+          },
+          {
+            name: 'hash router',
+            initialUrl: `/sign-in#/factor-one?${SIGN_IN_RESET_PASSWORD_INTENT_PARAM}=true&preserved=value`,
+            expectedUrl: '/sign-in#/factor-one?preserved=value',
+          },
+        ])('removes the reset intent when leaving under the $name', async ({ initialUrl, expectedUrl }) => {
+          const originalUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+          window.history.replaceState(window.history.state, '', initialUrl);
+
+          try {
+            const { wrapper, fixtures } = await createFixturesWithResetIntent(f => {
+              f.withEmailAddress();
+              f.withPassword();
+              f.withPreferredSignInStrategy({ strategy: 'password' });
+              f.startSignInWithEmailAddress({
+                supportEmailCode: true,
+                supportPassword: true,
+                supportResetPassword: true,
+              });
+            });
+            const { userEvent } = render(<SignInFactorOne />, { wrapper });
+            await screen.findByText('Reset your password');
+
+            await userEvent.click(screen.getByText('Back'));
+
+            expect(`${window.location.pathname}${window.location.search}${window.location.hash}`).toBe(expectedUrl);
+            expect(fixtures.router.refresh).toHaveBeenCalled();
+          } finally {
+            window.history.replaceState(window.history.state, '', originalUrl);
+          }
+        });
       });
 
       it('should render the Forgot Password alternative methods component when clicking on "Forgot password" (email)', async () => {

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -10,6 +10,7 @@ import { CardStateProvider } from '@/ui/elements/contexts';
 
 import { OptionsProvider } from '../../../contexts';
 import { AppearanceProvider } from '../../../customizables';
+import { SIGN_IN_RESET_PASSWORD_INTENT_PARAM } from '../shared';
 import { SignInStart } from '../SignInStart';
 
 const { createFixtures } = bindCreateFixtures('SignIn');
@@ -500,6 +501,47 @@ describe('SignInStart', () => {
       props.setProps({ initialValues: { username: 'foo' } });
       render(<SignInStart />, { wrapper });
       screen.getByDisplayValue(/foo/i);
+    });
+  });
+
+  describe('Forgot password on instant password field', () => {
+    it('navigates to factor-one with reset intent when clicking Forgot password', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withPassword({ required: true });
+      });
+      fixtures.signIn.create.mockReturnValueOnce(Promise.resolve({ status: 'needs_first_factor' } as SignInResource));
+      const { userEvent, container } = render(<SignInStart />, { wrapper });
+
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
+      const instantPasswordField = container.querySelector('#password-field') as Element;
+      fireEvent.change(instantPasswordField, { target: { value: 'some-password' } });
+
+      await userEvent.click(screen.getByText(/Forgot password/i));
+
+      await waitFor(() => {
+        expect(fixtures.signIn.create).toHaveBeenCalledWith({
+          identifier: 'hello@clerk.com',
+        });
+        expect(fixtures.router.navigate).toHaveBeenCalledWith('factor-one', {
+          searchParams: new URLSearchParams({ [SIGN_IN_RESET_PASSWORD_INTENT_PARAM]: 'true' }),
+        });
+      });
+    });
+
+    it('does not call create when identifier is empty', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withPassword({ required: true });
+      });
+      const { userEvent, container } = render(<SignInStart />, { wrapper });
+
+      const instantPasswordField = container.querySelector('#password-field') as Element;
+      fireEvent.change(instantPasswordField, { target: { value: 'some-password' } });
+
+      await userEvent.click(screen.getByText(/Forgot password/i));
+
+      expect(fixtures.signIn.create).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/clerk-js/src/ui/components/SignIn/shared.ts
+++ b/packages/clerk-js/src/ui/components/SignIn/shared.ts
@@ -11,6 +11,9 @@ import { __internal_WebAuthnAbortService } from '../../../utils/passkeys';
 import { useCoreSignIn, useSignInContext } from '../../contexts';
 import { useSupportEmail } from '../../hooks/useSupportEmail';
 
+/** Search param set when navigating from the start page "Forgot password?" action. */
+export const SIGN_IN_RESET_PASSWORD_INTENT_PARAM = '__clerk_reset_password';
+
 function useHandleAuthenticateWithPasskey(onSecondFactor: () => Promise<unknown>) {
   const card = useCardState();
   // @ts-expect-error -- private method for the time being


### PR DESCRIPTION
Backports #8733 to `release/core-2`.

When strict user enumeration protection is enabled and a password manager fills the hidden instant-password field, an incorrect password keeps the user on `SignInStart`. Core 2 has no password-recovery action in that state, so users have to discover that clearing the password and continuing with only the identifier reveals the recovery flow.

## What changed

- Show a **Forgot password?** action whenever the instant-password field is visible.
- Create an identifier-only sign-in and navigate to factor one with a temporary reset-password intent.
- Open the reset-password alternatives directly, falling back to **Use another method** when no reset factor exists.
- Clear the temporary intent when leaving the alternatives screen.
- Add regression coverage for the reset-factor, no-reset-factor, and empty-identifier paths.

## Core 2 adaptation

- Ports the reviewed `packages/ui` fix into Core 2's bundled ClerkJS UI.
- Applies the changeset to `@clerk/clerk-js`.
- Deliberately leaves unrelated post-Core-2 sign-in behavior out of the backport.

Original fix: https://github.com/clerk/javascript/pull/8733
