### PR TITLE
fix(js): Coalesce concurrent first/second factor preparations

### DIFF
--- a/.changeset/calm-codes-share.md
+++ b/.changeset/calm-codes-share.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Prevent overlapping sign-in factor preparations from triggering duplicate verification sends.
+Prevent overlapping sign-in factor preparations and sign-up verification preparations from triggering duplicate verification sends.

--- a/.changeset/calm-codes-share.md
+++ b/.changeset/calm-codes-share.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-js": patch
 ---
 
-Prevent overlapping sign-in factor preparations and sign-up verification preparations from triggering duplicate verification sends.
+Prevent overlapping verification preparations from triggering duplicate verification sends during sign-in, sign-up, and when verifying an email address, phone number, or web3 wallet from the user profile.

--- a/.changeset/calm-codes-share.md
+++ b/.changeset/calm-codes-share.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Prevent overlapping sign-in factor preparations from triggering duplicate verification sends.

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -29,6 +29,8 @@ export type BaseMutateParams = {
   path?: string;
 };
 
+const COALESCED_POST_TTL_MS = 15_000;
+
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
   if (!payloadErrors) {
     return;
@@ -243,8 +245,14 @@ export abstract class BaseResource {
       return pending;
     }
 
+    // The TTL guards against a stalled request (no client-side fetch timeout) pinning the entry and
+    // silently swallowing retries such as "resend code" until page reload.
+    const expireTimer = setTimeout(() => this.#pendingCoalescedPosts.delete(key), COALESCED_POST_TTL_MS);
     const post = this._baseMutate<J>({ ...params, method: 'POST' }).finally(() => {
-      this.#pendingCoalescedPosts.delete(key);
+      clearTimeout(expireTimer);
+      if (this.#pendingCoalescedPosts.get(key) === post) {
+        this.#pendingCoalescedPosts.delete(key);
+      }
     });
     this.#pendingCoalescedPosts.set(key, post);
     return post;

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -58,11 +58,6 @@ export abstract class BaseResource {
   id?: string;
   pathRoot = '';
 
-  /**
-   * POST actions listed here are coalesced: while a request for an action with an identical body is
-   * in flight on this resource, subsequent identical calls return the pending promise instead of
-   * issuing a duplicate request.
-   */
   protected coalescedPostActions: readonly string[] = [];
   #pendingCoalescedPosts = new Map<string, Promise<this>>();
 

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -33,6 +33,12 @@ export type BaseMutateParams = {
 
 const COALESCED_POST_TTL_MS = 30_000;
 
+type PendingCoalescedPost<T> = {
+  promise: Promise<T>;
+  controller: AbortController;
+  expiresAt: number;
+};
+
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
   if (!payloadErrors) {
     return;
@@ -62,7 +68,7 @@ export abstract class BaseResource {
   id?: string;
   pathRoot = '';
 
-  #pendingCoalescedPosts?: Map<string, { promise: Promise<this>; controller: AbortController; expiresAt: number }>;
+  #pendingCoalescedPosts?: Map<string, PendingCoalescedPost<this>>;
 
   static get fapiClient(): FapiClient {
     return BaseResource.clerk.getFapiClient();

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -252,7 +252,6 @@ export abstract class BaseResource {
     if (pending && Date.now() < pending.expiresAt) {
       return pending.promise;
     }
-    pending?.controller.abort();
 
     const controller = new AbortController();
     const promise = this._baseMutate<J>({ ...params, method: 'POST', signal: controller.signal }).finally(() => {

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -27,9 +27,10 @@ export type BaseMutateParams = {
   body?: any;
   method?: HTTPMethod;
   path?: string;
+  signal?: AbortSignal;
 };
 
-const COALESCED_POST_TTL_MS = 15_000;
+const COALESCED_POST_TTL_MS = 30_000;
 const COALESCED_POST_ACTIONS: readonly string[] = [];
 
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
@@ -226,9 +227,9 @@ export abstract class BaseResource {
   }
 
   protected async _baseMutate<J extends ClerkResourceJSON | null>(params: BaseMutateParams): Promise<this> {
-    const { action, body, method, path } = params;
+    const { action, body, method, path, signal } = params;
     // TODO @userland-errors:
-    const json = await BaseResource._fetch<J>({ method, path: path || this.path(action), body });
+    const json = await BaseResource._fetch<J>({ method, path: path || this.path(action), body, signal });
     return this.fromJSON((json?.response || json) as J);
   }
 
@@ -249,10 +250,12 @@ export abstract class BaseResource {
       return pending;
     }
 
-    // The TTL guards against a stalled request (no client-side fetch timeout) pinning the entry and
-    // silently swallowing retries such as "resend code" until page reload.
-    const expireTimer = setTimeout(() => this.#pendingCoalescedPosts.delete(key), COALESCED_POST_TTL_MS);
-    const post = this._baseMutate<J>({ ...params, method: 'POST' }).finally(() => {
+    const controller = new AbortController();
+    const expireTimer = setTimeout(() => {
+      this.#pendingCoalescedPosts.delete(key);
+      controller.abort();
+    }, COALESCED_POST_TTL_MS);
+    const post = this._baseMutate<J>({ ...params, method: 'POST', signal: controller.signal }).finally(() => {
       clearTimeout(expireTimer);
       if (this.#pendingCoalescedPosts.get(key) === post) {
         this.#pendingCoalescedPosts.delete(key);

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -30,6 +30,7 @@ export type BaseMutateParams = {
 };
 
 const COALESCED_POST_TTL_MS = 15_000;
+const COALESCED_POST_ACTIONS: readonly string[] = [];
 
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
   if (!payloadErrors) {
@@ -60,8 +61,11 @@ export abstract class BaseResource {
   id?: string;
   pathRoot = '';
 
-  protected coalescedPostActions: readonly string[] = [];
   #pendingCoalescedPosts = new Map<string, Promise<this>>();
+
+  protected get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
 
   static get fapiClient(): FapiClient {
     return BaseResource.clerk.getFapiClient();

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -62,7 +62,7 @@ export abstract class BaseResource {
   id?: string;
   pathRoot = '';
 
-  #pendingCoalescedPosts = new Map<string, Promise<this>>();
+  #pendingCoalescedPosts?: Map<string, { promise: Promise<this>; controller: AbortController; expiresAt: number }>;
 
   protected get coalescedPostActions(): readonly string[] {
     return COALESCED_POST_ACTIONS;
@@ -245,24 +245,21 @@ export abstract class BaseResource {
     }
 
     const key = this.#coalescedPostKey(params);
-    const pending = this.#pendingCoalescedPosts.get(key);
-    if (pending) {
-      return pending;
+    const posts = (this.#pendingCoalescedPosts ??= new Map());
+    const pending = posts.get(key);
+    if (pending && Date.now() < pending.expiresAt) {
+      return pending.promise;
     }
+    pending?.controller.abort();
 
     const controller = new AbortController();
-    const expireTimer = setTimeout(() => {
-      this.#pendingCoalescedPosts.delete(key);
-      controller.abort();
-    }, COALESCED_POST_TTL_MS);
-    const post = this._baseMutate<J>({ ...params, method: 'POST', signal: controller.signal }).finally(() => {
-      clearTimeout(expireTimer);
-      if (this.#pendingCoalescedPosts.get(key) === post) {
-        this.#pendingCoalescedPosts.delete(key);
+    const promise = this._baseMutate<J>({ ...params, method: 'POST', signal: controller.signal }).finally(() => {
+      if (posts.get(key)?.promise === promise) {
+        posts.delete(key);
       }
     });
-    this.#pendingCoalescedPosts.set(key, post);
-    return post;
+    posts.set(key, { promise, controller, expiresAt: Date.now() + COALESCED_POST_TTL_MS });
+    return promise;
   }
 
   #coalescedPostKey(params: BaseMutateParams): string {

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -25,13 +25,13 @@ export type BaseFetchOptions = ClerkResourceReloadParams & {
 export type BaseMutateParams = {
   action?: string;
   body?: any;
+  coalesce?: boolean;
   method?: HTTPMethod;
   path?: string;
   signal?: AbortSignal;
 };
 
 const COALESCED_POST_TTL_MS = 30_000;
-const COALESCED_POST_ACTIONS: readonly string[] = [];
 
 function assertProductionKeysOnDev(statusCode: number, payloadErrors?: ClerkAPIErrorJSON[]) {
   if (!payloadErrors) {
@@ -63,10 +63,6 @@ export abstract class BaseResource {
   pathRoot = '';
 
   #pendingCoalescedPosts?: Map<string, { promise: Promise<this>; controller: AbortController; expiresAt: number }>;
-
-  protected get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
 
   static get fapiClient(): FapiClient {
     return BaseResource.clerk.getFapiClient();
@@ -240,7 +236,7 @@ export abstract class BaseResource {
   }
 
   protected async _basePost<J extends ClerkResourceJSON | null>(params: BaseMutateParams = {}): Promise<this> {
-    if (!params.action || !this.coalescedPostActions.includes(params.action)) {
+    if (!params.coalesce) {
       return this._baseMutate<J>({ ...params, method: 'POST' });
     }
 

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -58,6 +58,14 @@ export abstract class BaseResource {
   id?: string;
   pathRoot = '';
 
+  /**
+   * POST actions listed here are coalesced: while a request for an action with an identical body is
+   * in flight on this resource, subsequent identical calls return the pending promise instead of
+   * issuing a duplicate request.
+   */
+  protected coalescedPostActions: readonly string[] = [];
+  #pendingCoalescedPosts = new Map<string, Promise<this>>();
+
   static get fapiClient(): FapiClient {
     return BaseResource.clerk.getFapiClient();
   }
@@ -230,7 +238,28 @@ export abstract class BaseResource {
   }
 
   protected async _basePost<J extends ClerkResourceJSON | null>(params: BaseMutateParams = {}): Promise<this> {
-    return this._baseMutate<J>({ ...params, method: 'POST' });
+    if (!params.action || !this.coalescedPostActions.includes(params.action)) {
+      return this._baseMutate<J>({ ...params, method: 'POST' });
+    }
+
+    const key = this.#coalescedPostKey(params);
+    const pending = this.#pendingCoalescedPosts.get(key);
+    if (pending) {
+      return pending;
+    }
+
+    const post = this._baseMutate<J>({ ...params, method: 'POST' }).finally(() => {
+      this.#pendingCoalescedPosts.delete(key);
+    });
+    this.#pendingCoalescedPosts.set(key, post);
+    return post;
+  }
+
+  #coalescedPostKey(params: BaseMutateParams): string {
+    const body = Object.entries(params.body ?? {})
+      .filter(([, value]) => value !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : 1));
+    return JSON.stringify([this.id, params.path, params.action, body]);
   }
 
   protected async _basePostBypass<J extends ClerkResourceJSON>(params: BaseMutateParams = {}): Promise<this> {

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -15,13 +15,7 @@ import type {
 
 import { BaseResource, IdentificationLink, Verification } from './internal';
 
-const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
-
 export class EmailAddress extends BaseResource implements EmailAddressResource {
-  protected override get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
-
   id!: string;
   emailAddress = '';
   matchesSsoConnection = false;
@@ -44,6 +38,7 @@ export class EmailAddress extends BaseResource implements EmailAddressResource {
   prepareVerification = (params: PrepareEmailAddressVerificationParams): Promise<this> => {
     return this._basePost<EmailAddressJSON>({
       action: 'prepare_verification',
+      coalesce: true,
       body: { ...params },
     });
   };

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -15,7 +15,13 @@ import type {
 
 import { BaseResource, IdentificationLink, Verification } from './internal';
 
+const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
+
 export class EmailAddress extends BaseResource implements EmailAddressResource {
+  protected override get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
+
   id!: string;
   emailAddress = '';
   matchesSsoConnection = false;

--- a/packages/clerk-js/src/core/resources/PhoneNumber.ts
+++ b/packages/clerk-js/src/core/resources/PhoneNumber.ts
@@ -10,13 +10,7 @@ import type {
 
 import { BaseResource, IdentificationLink, Verification } from './internal';
 
-const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
-
 export class PhoneNumber extends BaseResource implements PhoneNumberResource {
-  protected override get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
-
   id!: string;
   phoneNumber = '';
   reservedForSecondFactor = false;
@@ -40,6 +34,7 @@ export class PhoneNumber extends BaseResource implements PhoneNumberResource {
   prepareVerification = (): Promise<PhoneNumberResource> => {
     return this._basePost<PhoneNumberJSON>({
       action: 'prepare_verification',
+      coalesce: true,
       body: { strategy: 'phone_code' },
     });
   };

--- a/packages/clerk-js/src/core/resources/PhoneNumber.ts
+++ b/packages/clerk-js/src/core/resources/PhoneNumber.ts
@@ -10,7 +10,13 @@ import type {
 
 import { BaseResource, IdentificationLink, Verification } from './internal';
 
+const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
+
 export class PhoneNumber extends BaseResource implements PhoneNumberResource {
+  protected override get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
+
   id!: string;
   phoneNumber = '';
   reservedForSecondFactor = false;

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -98,7 +98,17 @@ import {
   clerkVerifyWeb3WalletCalledBeforeCreate,
 } from '../errors';
 import { eventBus } from '../events';
-import { BaseResource, UserData, Verification } from './internal';
+import { type BaseMutateParams, BaseResource, UserData, Verification } from './internal';
+
+const isFactorPreparationAction = (action?: string): action is 'prepare_first_factor' | 'prepare_second_factor' =>
+  action === 'prepare_first_factor' || action === 'prepare_second_factor';
+
+const factorPreparationKey = (params: BaseMutateParams): string => {
+  const body = Object.entries(params.body ?? {})
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return JSON.stringify([params.path, params.action, body]);
+};
 
 export class SignIn extends BaseResource implements SignInResource {
   pathRoot = '/client/sign_ins';
@@ -115,6 +125,25 @@ export class SignIn extends BaseResource implements SignInResource {
   userData: UserData = new UserData(null);
   clientTrustState?: ClientTrustState;
   protectCheck: ProtectCheckResource | null = null;
+  #pendingFactorPreparations = new Map<string, Promise<this>>();
+
+  protected override _basePost(params: BaseMutateParams = {}): Promise<this> {
+    if (!isFactorPreparationAction(params.action)) {
+      return super._basePost(params);
+    }
+
+    const key = factorPreparationKey(params);
+    const pending = this.#pendingFactorPreparations.get(key);
+    if (pending) {
+      return pending;
+    }
+
+    const preparation = super._basePost(params).finally(() => {
+      this.#pendingFactorPreparations.delete(key);
+    });
+    this.#pendingFactorPreparations.set(key, preparation);
+    return preparation;
+  }
 
   /**
    * The current status of the sign-in process.

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -100,8 +100,6 @@ import {
 import { eventBus } from '../events';
 import { BaseResource, UserData, Verification } from './internal';
 
-const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_first_factor', 'prepare_second_factor'];
-
 export class SignIn extends BaseResource implements SignInResource {
   pathRoot = '/client/sign_ins';
 
@@ -117,9 +115,6 @@ export class SignIn extends BaseResource implements SignInResource {
   userData: UserData = new UserData(null);
   clientTrustState?: ClientTrustState;
   protectCheck: ProtectCheckResource | null = null;
-  protected override get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
 
   /**
    * The current status of the sign-in process.
@@ -270,6 +265,7 @@ export class SignIn extends BaseResource implements SignInResource {
     return this._basePost({
       body: { ...config, strategy: params.strategy },
       action: 'prepare_first_factor',
+      coalesce: true,
     });
   };
 
@@ -361,6 +357,7 @@ export class SignIn extends BaseResource implements SignInResource {
     return this._basePost({
       body: params,
       action: 'prepare_second_factor',
+      coalesce: true,
     });
   };
 
@@ -888,6 +885,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { emailAddressId, strategy: 'reset_password_email_code' },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
     });
   }
@@ -931,6 +929,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { phoneNumberId, strategy: 'reset_password_phone_code' },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
     });
   }
@@ -1088,6 +1087,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { emailAddressId: emailCodeFactor.emailAddressId, strategy: 'email_code' },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
     });
   }
@@ -1140,6 +1140,7 @@ class SignInFuture implements SignInFutureResource {
           strategy: 'email_link',
         },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
     });
   }
@@ -1192,6 +1193,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { phoneNumberId: phoneCodeFactor.phoneNumberId, strategy: 'phone_code', channel },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
     });
   }
@@ -1257,6 +1259,7 @@ class SignInFuture implements SignInFutureResource {
             strategy: 'enterprise_sso',
           },
           action: 'prepare_first_factor',
+          coalesce: true,
         });
       }
 
@@ -1324,6 +1327,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { web3WalletId: web3FirstFactor.web3WalletId, strategy },
         action: 'prepare_first_factor',
+        coalesce: true,
       });
 
       const { message } = this.firstFactorVerification;
@@ -1395,6 +1399,7 @@ class SignInFuture implements SignInFutureResource {
         await this.#resource.__internal_basePost({
           body: { strategy: 'passkey' },
           action: 'prepare_first_factor',
+          coalesce: true,
         });
       }
 
@@ -1447,6 +1452,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { phoneNumberId, strategy: 'phone_code' },
         action: 'prepare_second_factor',
+        coalesce: true,
       });
     });
   }
@@ -1473,6 +1479,7 @@ class SignInFuture implements SignInFutureResource {
       await this.#resource.__internal_basePost({
         body: { emailAddressId, strategy: 'email_code' },
         action: 'prepare_second_factor',
+        coalesce: true,
       });
     });
   }

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -216,10 +216,6 @@ export class SignIn extends BaseResource implements SignInResource {
     });
   };
 
-  /**
-   * @remarks If an identical preparation for this sign-in is already in flight, its pending request is reused and no
-   * additional verification is sent.
-   */
   prepareFirstFactor = (params: PrepareFirstFactorParams): Promise<SignInResource> => {
     debugLogger.debug('SignIn.prepareFirstFactor', { id: this.id, strategy: params.strategy });
     let config;
@@ -356,10 +352,6 @@ export class SignIn extends BaseResource implements SignInResource {
     return { startEmailLinkFlow, cancelEmailLinkFlow: stop };
   };
 
-  /**
-   * @remarks If an identical preparation for this sign-in is already in flight, its pending request is reused and no
-   * additional verification is sent.
-   */
   prepareSecondFactor = (params: PrepareSecondFactorParams): Promise<SignInResource> => {
     debugLogger.debug('SignIn.prepareSecondFactor', { id: this.id, strategy: params.strategy });
     return this._basePost({

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -98,17 +98,7 @@ import {
   clerkVerifyWeb3WalletCalledBeforeCreate,
 } from '../errors';
 import { eventBus } from '../events';
-import { type BaseMutateParams, BaseResource, UserData, Verification } from './internal';
-
-const isFactorPreparationAction = (action?: string): action is 'prepare_first_factor' | 'prepare_second_factor' =>
-  action === 'prepare_first_factor' || action === 'prepare_second_factor';
-
-const factorPreparationKey = (params: BaseMutateParams): string => {
-  const body = Object.entries(params.body ?? {})
-    .filter(([, value]) => value !== undefined)
-    .sort(([left], [right]) => left.localeCompare(right));
-  return JSON.stringify([params.path, params.action, body]);
-};
+import { BaseResource, UserData, Verification } from './internal';
 
 export class SignIn extends BaseResource implements SignInResource {
   pathRoot = '/client/sign_ins';
@@ -125,25 +115,7 @@ export class SignIn extends BaseResource implements SignInResource {
   userData: UserData = new UserData(null);
   clientTrustState?: ClientTrustState;
   protectCheck: ProtectCheckResource | null = null;
-  #pendingFactorPreparations = new Map<string, Promise<this>>();
-
-  protected override _basePost(params: BaseMutateParams = {}): Promise<this> {
-    if (!isFactorPreparationAction(params.action)) {
-      return super._basePost(params);
-    }
-
-    const key = factorPreparationKey(params);
-    const pending = this.#pendingFactorPreparations.get(key);
-    if (pending) {
-      return pending;
-    }
-
-    const preparation = super._basePost(params).finally(() => {
-      this.#pendingFactorPreparations.delete(key);
-    });
-    this.#pendingFactorPreparations.set(key, preparation);
-    return preparation;
-  }
+  protected override coalescedPostActions: readonly string[] = ['prepare_first_factor', 'prepare_second_factor'];
 
   /**
    * The current status of the sign-in process.
@@ -244,6 +216,10 @@ export class SignIn extends BaseResource implements SignInResource {
     });
   };
 
+  /**
+   * @remarks If an identical preparation for this sign-in is already in flight, its pending request is reused and no
+   * additional verification is sent.
+   */
   prepareFirstFactor = (params: PrepareFirstFactorParams): Promise<SignInResource> => {
     debugLogger.debug('SignIn.prepareFirstFactor', { id: this.id, strategy: params.strategy });
     let config;
@@ -380,6 +356,10 @@ export class SignIn extends BaseResource implements SignInResource {
     return { startEmailLinkFlow, cancelEmailLinkFlow: stop };
   };
 
+  /**
+   * @remarks If an identical preparation for this sign-in is already in flight, its pending request is reused and no
+   * additional verification is sent.
+   */
   prepareSecondFactor = (params: PrepareSecondFactorParams): Promise<SignInResource> => {
     debugLogger.debug('SignIn.prepareSecondFactor', { id: this.id, strategy: params.strategy });
     return this._basePost({

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -100,6 +100,8 @@ import {
 import { eventBus } from '../events';
 import { BaseResource, UserData, Verification } from './internal';
 
+const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_first_factor', 'prepare_second_factor'];
+
 export class SignIn extends BaseResource implements SignInResource {
   pathRoot = '/client/sign_ins';
 
@@ -115,7 +117,9 @@ export class SignIn extends BaseResource implements SignInResource {
   userData: UserData = new UserData(null);
   clientTrustState?: ClientTrustState;
   protectCheck: ProtectCheckResource | null = null;
-  protected override coalescedPostActions: readonly string[] = ['prepare_first_factor', 'prepare_second_factor'];
+  protected override get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
 
   /**
    * The current status of the sign-in process.

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -79,6 +79,8 @@ declare global {
 export class SignUp extends BaseResource implements SignUpResource {
   pathRoot = '/client/sign_ups';
 
+  protected override coalescedPostActions: readonly string[] = ['prepare_verification'];
+
   id: string | undefined;
   private _status: SignUpStatus | null = null;
   requiredFields: SignUpField[] = [];
@@ -183,6 +185,10 @@ export class SignUp extends BaseResource implements SignUpResource {
     });
   };
 
+  /**
+   * @remarks If an identical preparation for this sign-up is already in flight, its pending request is reused and no
+   * additional verification is sent.
+   */
   prepareVerification = (params: PrepareVerificationParams): Promise<this> => {
     debugLogger.debug('SignUp.prepareVerification', { id: this.id, strategy: params.strategy });
     return this._basePost({

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -185,10 +185,6 @@ export class SignUp extends BaseResource implements SignUpResource {
     });
   };
 
-  /**
-   * @remarks If an identical preparation for this sign-up is already in flight, its pending request is reused and no
-   * additional verification is sent.
-   */
   prepareVerification = (params: PrepareVerificationParams): Promise<this> => {
     debugLogger.debug('SignUp.prepareVerification', { id: this.id, strategy: params.strategy });
     return this._basePost({

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -76,10 +76,14 @@ declare global {
   }
 }
 
+const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
+
 export class SignUp extends BaseResource implements SignUpResource {
   pathRoot = '/client/sign_ups';
 
-  protected override coalescedPostActions: readonly string[] = ['prepare_verification'];
+  protected override get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
 
   id: string | undefined;
   private _status: SignUpStatus | null = null;

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -76,14 +76,8 @@ declare global {
   }
 }
 
-const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
-
 export class SignUp extends BaseResource implements SignUpResource {
   pathRoot = '/client/sign_ups';
-
-  protected override get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
 
   id: string | undefined;
   private _status: SignUpStatus | null = null;
@@ -194,6 +188,7 @@ export class SignUp extends BaseResource implements SignUpResource {
     return this._basePost({
       body: params,
       action: 'prepare_verification',
+      coalesce: true,
     });
   };
 
@@ -979,6 +974,7 @@ class SignUpFuture implements SignUpFutureResource {
       await this.#resource.__internal_basePost({
         body: { strategy: 'email_code' },
         action: 'prepare_verification',
+        coalesce: true,
       });
     });
   }
@@ -999,6 +995,7 @@ class SignUpFuture implements SignUpFutureResource {
       await this.#resource.__internal_basePost({
         body: { strategy: 'phone_code', channel },
         action: 'prepare_verification',
+        coalesce: true,
       });
     });
   }
@@ -1026,6 +1023,7 @@ class SignUpFuture implements SignUpFutureResource {
       await this.#resource.__internal_basePost({
         body: { strategy: 'email_link', redirectUrl: absoluteVerificationUrl },
         action: 'prepare_verification',
+        coalesce: true,
       });
     });
   }
@@ -1169,6 +1167,7 @@ class SignUpFuture implements SignUpFutureResource {
       await this.#resource.__internal_basePost({
         body: { strategy },
         action: 'prepare_verification',
+        coalesce: true,
       });
 
       const { message } = this.#resource.verifications.web3Wallet;

--- a/packages/clerk-js/src/core/resources/Web3Wallet.ts
+++ b/packages/clerk-js/src/core/resources/Web3Wallet.ts
@@ -9,13 +9,7 @@ import type {
 
 import { BaseResource, Verification } from './internal';
 
-const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
-
 export class Web3Wallet extends BaseResource implements Web3WalletResource {
-  protected override get coalescedPostActions(): readonly string[] {
-    return COALESCED_POST_ACTIONS;
-  }
-
   id!: string;
   web3Wallet = '';
   verification!: VerificationResource;
@@ -36,6 +30,7 @@ export class Web3Wallet extends BaseResource implements Web3WalletResource {
   prepareVerification = (params: PrepareWeb3WalletVerificationParams): Promise<this> => {
     return this._basePost<Web3WalletJSON>({
       action: 'prepare_verification',
+      coalesce: true,
       body: { ...params },
     });
   };

--- a/packages/clerk-js/src/core/resources/Web3Wallet.ts
+++ b/packages/clerk-js/src/core/resources/Web3Wallet.ts
@@ -9,7 +9,13 @@ import type {
 
 import { BaseResource, Verification } from './internal';
 
+const COALESCED_POST_ACTIONS: readonly string[] = ['prepare_verification'];
+
 export class Web3Wallet extends BaseResource implements Web3WalletResource {
+  protected override get coalescedPostActions(): readonly string[] {
+    return COALESCED_POST_ACTIONS;
+  }
+
   id!: string;
   web3Wallet = '';
   verification!: VerificationResource;

--- a/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
@@ -1,5 +1,5 @@
-import { createDeferredPromise } from '@clerk/shared/utils';
 import type { EmailAddressJSON } from '@clerk/shared/types';
+import { createDeferredPromise } from '@clerk/shared/utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { BaseResource, EmailAddress } from '../internal';

--- a/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
@@ -30,6 +30,23 @@ describe('EmailAddress', () => {
       await Promise.all([first, second]);
     });
 
+    it('does not coalesce preparations with different strategies or params', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        response: { id: 'email_123' },
+      });
+      BaseResource._fetch = mockFetch;
+
+      const emailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+
+      await Promise.all([
+        emailAddress.prepareVerification({ strategy: 'email_code' }),
+        emailAddress.prepareVerification({ strategy: 'email_link', redirectUrl: '/verify-one' }),
+        emailAddress.prepareVerification({ strategy: 'email_link', redirectUrl: '/verify-two' }),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
     it('starts a new preparation after the previous request succeeds', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         response: { id: 'email_123' },
@@ -44,6 +61,63 @@ describe('EmailAddress', () => {
       await emailAddress.prepareVerification(params);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts a new preparation after the previous request fails', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('prepare failed'))
+        .mockResolvedValueOnce({
+          response: { id: 'email_123' },
+        });
+      BaseResource._fetch = mockFetch;
+
+      const emailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const params = { strategy: 'email_code' as const };
+
+      await expect(emailAddress.prepareVerification(params)).rejects.toThrow('prepare failed');
+      await emailAddress.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not coalesce preparations across EmailAddress instances', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const firstEmailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const secondEmailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const params = { strategy: 'email_code' as const };
+
+      const first = firstEmailAddress.prepareVerification(params);
+      const second = secondEmailAddress.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        response: { id: 'email_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('does not coalesce concurrent verification attempts', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const emailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const params = { code: '123456' };
+
+      const first = emailAddress.attemptVerification(params);
+      const second = emailAddress.attemptVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        response: { id: 'email_123' },
+      });
+      await Promise.all([first, second]);
     });
   });
 });

--- a/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/EmailAddress.test.ts
@@ -1,0 +1,49 @@
+import { createDeferredPromise } from '@clerk/shared/utils';
+import type { EmailAddressJSON } from '@clerk/shared/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BaseResource, EmailAddress } from '../internal';
+
+describe('EmailAddress', () => {
+  describe('prepareVerification', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('coalesces concurrent identical preparations', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      // @ts-ignore
+      BaseResource._fetch = mockFetch;
+
+      const emailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const params = { strategy: 'email_code' as const };
+
+      const first = emailAddress.prepareVerification(params);
+      const second = emailAddress.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        response: { id: 'email_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('starts a new preparation after the previous request succeeds', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        response: { id: 'email_123' },
+      });
+      // @ts-ignore
+      BaseResource._fetch = mockFetch;
+
+      const emailAddress = new EmailAddress({ id: 'email_123' } as EmailAddressJSON, '/me/email_addresses');
+      const params = { strategy: 'email_code' as const };
+
+      await emailAddress.prepareVerification(params);
+      await emailAddress.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -5,7 +5,6 @@ import { eventBus } from '../../events';
 import { signInErrorSignal, signInResourceSignal } from '../../signals';
 import { BaseResource } from '../internal';
 import { SignIn } from '../SignIn';
-import { SignUp } from '../SignUp';
 
 // Mock the authenticateWithPopup module
 vi.mock('../../../utils/authenticateWithPopup', async () => {
@@ -224,26 +223,6 @@ describe('SignIn', () => {
       deferred.resolve({
         client: null,
         response: { id: 'signin_456' },
-      });
-      await Promise.all([first, second]);
-    });
-
-    it('coalesces concurrent sign-up verification preparations', async () => {
-      const deferred = createDeferredPromise<any>();
-      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
-      BaseResource._fetch = mockFetch;
-
-      const signUp = new SignUp({ id: 'signup_123' } as any);
-      const params = { strategy: 'email_code' as const };
-
-      const first = signUp.prepareVerification(params);
-      const second = signUp.prepareVerification(params);
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      deferred.resolve({
-        client: null,
-        response: { id: 'signup_123' },
       });
       await Promise.all([first, second]);
     });

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -5,6 +5,7 @@ import { eventBus } from '../../events';
 import { signInErrorSignal, signInResourceSignal } from '../../signals';
 import { BaseResource } from '../internal';
 import { SignIn } from '../SignIn';
+import { SignUp } from '../SignUp';
 
 // Mock the authenticateWithPopup module
 vi.mock('../../../utils/authenticateWithPopup', async () => {
@@ -180,6 +181,47 @@ describe('SignIn', () => {
       deferred.resolve({
         client: null,
         response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('does not coalesce preparations across different sign-in attempts', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+      const first = signIn.prepareFirstFactor(params);
+      signIn.id = 'signin_456';
+      const second = signIn.prepareFirstFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_456' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('coalesces concurrent sign-up verification preparations', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const };
+
+      const first = signUp.prepareVerification(params);
+      const second = signUp.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signup_123' },
       });
       await Promise.all([first, second]);
     });

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -184,25 +184,45 @@ describe('SignIn', () => {
       await Promise.all([first, second]);
     });
 
-    it('allows a new preparation after a pending request stalls past the coalescing TTL', () => {
+    it('allows a new preparation after the TTL without aborting the pending request', async () => {
       vi.useFakeTimers();
       try {
-        const mockFetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        const firstDeferred = createDeferredPromise<any>();
+        const secondDeferred = createDeferredPromise<any>();
+        const mockFetch = vi
+          .fn()
+          .mockReturnValueOnce(firstDeferred.promise)
+          .mockReturnValueOnce(secondDeferred.promise);
         BaseResource._fetch = mockFetch;
 
         const signIn = new SignIn({ id: 'signin_123' } as any);
         const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
 
-        void signIn.prepareFirstFactor(params);
-        void signIn.prepareFirstFactor(params);
+        const first = signIn.prepareFirstFactor(params);
+        const duplicate = signIn.prepareFirstFactor(params);
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         vi.advanceTimersByTime(30_000);
 
-        void signIn.prepareFirstFactor(params);
+        const replacement = signIn.prepareFirstFactor(params);
         expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(mockFetch.mock.calls[0][0].signal.aborted).toBe(true);
+        expect(mockFetch.mock.calls[0][0].signal.aborted).toBe(false);
         expect(mockFetch.mock.calls[1][0].signal.aborted).toBe(false);
+
+        firstDeferred.resolve({
+          client: null,
+          response: { id: 'signin_123' },
+        });
+        await Promise.all([first, duplicate]);
+
+        const replacementDuplicate = signIn.prepareFirstFactor(params);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        secondDeferred.resolve({
+          client: null,
+          response: { id: 'signin_123' },
+        });
+        await Promise.all([replacement, replacementDuplicate]);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@clerk/shared/utils';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { eventBus } from '../../events';
@@ -34,6 +35,174 @@ describe('SignIn', () => {
     const signIn = new SignIn();
     const snapshot = JSON.stringify(signIn);
     expect(snapshot).toBeDefined();
+  });
+
+  describe('prepareSecondFactor', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('coalesces concurrent identical preparations', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+      const first = signIn.prepareSecondFactor(params);
+      const second = signIn.prepareSecondFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('does not coalesce preparations for different factors', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+
+      await Promise.all([
+        signIn.prepareSecondFactor({ strategy: 'email_code', emailAddressId: 'email_123' }),
+        signIn.prepareSecondFactor({ strategy: 'email_code', emailAddressId: 'email_456' }),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts a new preparation after the previous request succeeds', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+      await signIn.prepareSecondFactor(params);
+      await signIn.prepareSecondFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts a new preparation after the previous request fails', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('prepare failed'))
+        .mockResolvedValueOnce({
+          client: null,
+          response: { id: 'signin_123' },
+        });
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+      await expect(signIn.prepareSecondFactor(params)).rejects.toThrow('prepare failed');
+      await signIn.prepareSecondFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('factor preparation across APIs', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('coalesces concurrent first-factor preparations', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+      const first = signIn.prepareFirstFactor(params);
+      const second = signIn.prepareFirstFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('coalesces concurrent first-factor preparations from the future API', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      signIn.supportedFirstFactors = [
+        { strategy: 'email_code', emailAddressId: 'email_123', safeIdentifier: 't***@example.com' },
+      ];
+
+      const first = signIn.__internal_future.emailCode.sendCode({ emailAddressId: 'email_123' });
+      const second = signIn.__internal_future.emailCode.sendCode({ emailAddressId: 'email_123' });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('coalesces concurrent second-factor preparations from the future API', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      signIn.supportedSecondFactors = [
+        { strategy: 'email_code', emailAddressId: 'email_123', safeIdentifier: 't***@example.com' },
+      ];
+
+      const first = signIn.__internal_future.mfa.sendEmailCode();
+      const second = signIn.__internal_future.mfa.sendEmailCode();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('does not coalesce concurrent factor attempts', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      const params = { strategy: 'email_code' as const, code: '123456' };
+
+      const first = signIn.attemptFirstFactor(params);
+      const second = signIn.attemptFirstFactor(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signin_123' },
+      });
+      await Promise.all([first, second]);
+    });
   });
 
   describe('authenticateWithRedirect with an OAuth transport', () => {

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -198,10 +198,10 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         vi.advanceTimersByTime(30_000);
-        expect(mockFetch.mock.calls[0][0].signal.aborted).toBe(true);
 
         void signIn.prepareFirstFactor(params);
         expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch.mock.calls[0][0].signal.aborted).toBe(true);
         expect(mockFetch.mock.calls[1][0].signal.aborted).toBe(false);
       } finally {
         vi.useRealTimers();

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -185,6 +185,28 @@ describe('SignIn', () => {
       await Promise.all([first, second]);
     });
 
+    it('allows a new preparation after a pending request stalls past the coalescing TTL', () => {
+      vi.useFakeTimers();
+      try {
+        const mockFetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        BaseResource._fetch = mockFetch;
+
+        const signIn = new SignIn({ id: 'signin_123' } as any);
+        const params = { strategy: 'email_code' as const, emailAddressId: 'email_123' };
+
+        void signIn.prepareFirstFactor(params);
+        void signIn.prepareFirstFactor(params);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(15_000);
+
+        void signIn.prepareFirstFactor(params);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('does not coalesce preparations across different sign-in attempts', async () => {
       const deferred = createDeferredPromise<any>();
       const mockFetch = vi.fn().mockReturnValue(deferred.promise);

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -197,10 +197,12 @@ describe('SignIn', () => {
         void signIn.prepareFirstFactor(params);
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        vi.advanceTimersByTime(15_000);
+        vi.advanceTimersByTime(30_000);
+        expect(mockFetch.mock.calls[0][0].signal.aborted).toBe(true);
 
         void signIn.prepareFirstFactor(params);
         expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch.mock.calls[1][0].signal.aborted).toBe(false);
       } finally {
         vi.useRealTimers();
       }
@@ -503,6 +505,7 @@ describe('SignIn', () => {
         expect(BaseResource._fetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/test_id/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_address_1',
             strategy: 'email_code',
@@ -517,6 +520,7 @@ describe('SignIn', () => {
         expect(BaseResource._fetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/test_id/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_address_1',
             strategy: 'email_code',
@@ -531,6 +535,7 @@ describe('SignIn', () => {
         expect(BaseResource._fetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/test_id/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_address_1',
             strategy: 'email_code',
@@ -545,6 +550,7 @@ describe('SignIn', () => {
         expect(BaseResource._fetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/test_id/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_address_0',
             strategy: 'email_code',
@@ -917,6 +923,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_123',
             strategy: 'email_code',
@@ -951,6 +958,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_456',
             strategy: 'email_code',
@@ -1023,6 +1031,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_123',
             redirectUrl: 'https://example.com/verify',
@@ -1057,6 +1066,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_123',
             redirectUrl: 'https://other.com/verify',
@@ -1094,6 +1104,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_456',
             redirectUrl: 'https://example.com/verify',
@@ -1242,6 +1253,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_123',
             strategy: 'phone_code',
@@ -1273,6 +1285,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_123',
             strategy: 'phone_code',
@@ -1308,6 +1321,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenLastCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_456',
             strategy: 'phone_code',
@@ -1374,6 +1388,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_123',
             strategy: 'reset_password_email_code',
@@ -1439,6 +1454,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_123',
             strategy: 'reset_password_phone_code',
@@ -1468,6 +1484,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_123',
             strategy: 'reset_password_phone_code',
@@ -1598,6 +1615,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_second_factor',
+          signal: expect.any(AbortSignal),
           body: {
             phoneNumberId: 'phone_123',
             strategy: 'phone_code',
@@ -1640,6 +1658,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_second_factor',
+          signal: expect.any(AbortSignal),
           body: {
             emailAddressId: 'email_123',
             strategy: 'email_code',
@@ -1716,6 +1735,7 @@ describe('SignIn', () => {
           expect.objectContaining({
             method: 'POST',
             path: '/client/sign_ins/signin_123/prepare_first_factor',
+            signal: expect.any(AbortSignal),
             body: { strategy: 'passkey' },
           }),
         );
@@ -2023,6 +2043,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             web3WalletId: 'wallet_123',
             strategy: 'web3_metamask_signature',
@@ -2355,6 +2376,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_123/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             strategy: 'enterprise_sso',
             redirectUrl: 'https://example.com/sso-callback',
@@ -2410,6 +2432,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(2, {
           method: 'POST',
           path: '/client/sign_ins/signin_ticket/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: {
             strategy: 'enterprise_sso',
             redirectUrl: 'https://example.com/sso-callback',
@@ -2516,6 +2539,7 @@ describe('SignIn', () => {
         expect(mockFetch).toHaveBeenNthCalledWith(1, {
           method: 'POST',
           path: '/client/sign_ins/signin_enterprise/prepare_first_factor',
+          signal: expect.any(AbortSignal),
           body: expect.objectContaining({
             strategy: 'enterprise_sso',
           }),

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -623,6 +623,7 @@ describe('SignUp', () => {
           expect.objectContaining({
             method: 'POST',
             path: '/client/sign_ups/signup_123/prepare_verification',
+            signal: expect.any(AbortSignal),
             body: expect.objectContaining({
               strategy: 'phone_code',
             }),
@@ -652,6 +653,7 @@ describe('SignUp', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ups/signup_123/prepare_verification',
+          signal: expect.any(AbortSignal),
           body: {
             strategy: 'email_link',
             redirectUrl: 'https://example.com/verify',
@@ -674,6 +676,7 @@ describe('SignUp', () => {
         expect(mockFetch).toHaveBeenCalledWith({
           method: 'POST',
           path: '/client/sign_ups/signup_123/prepare_verification',
+          signal: expect.any(AbortSignal),
           body: {
             strategy: 'email_link',
             redirectUrl: 'https://other.com/verify',

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@clerk/shared/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { eventBus } from '../../events';
@@ -35,6 +36,32 @@ describe('SignUp', () => {
     const signUp = new SignUp();
     const snapshot = JSON.stringify(signUp);
     expect(snapshot).toBeDefined();
+  });
+
+  describe('prepareVerification', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('coalesces concurrent identical preparations', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const };
+
+      const first = signUp.prepareVerification(params);
+      const second = signUp.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signup_123' },
+      });
+      await Promise.all([first, second]);
+    });
   });
 
   describe('authenticateWithRedirect with an OAuth transport', () => {

--- a/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignUp.test.ts
@@ -62,6 +62,118 @@ describe('SignUp', () => {
       });
       await Promise.all([first, second]);
     });
+
+    it('does not coalesce preparations for different verifications', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signup_123' },
+      });
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+
+      await Promise.all([
+        signUp.prepareVerification({ strategy: 'email_code' }),
+        signUp.prepareVerification({ strategy: 'phone_code' }),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts a new preparation after the previous request succeeds', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: { id: 'signup_123' },
+      });
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const };
+
+      await signUp.prepareVerification(params);
+      await signUp.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts a new preparation after the previous request fails', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('prepare failed'))
+        .mockResolvedValueOnce({
+          client: null,
+          response: { id: 'signup_123' },
+        });
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const };
+
+      await expect(signUp.prepareVerification(params)).rejects.toThrow('prepare failed');
+      await signUp.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not coalesce preparations across different sign-up attempts', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const };
+
+      const first = signUp.prepareVerification(params);
+      signUp.id = 'signup_456';
+      const second = signUp.prepareVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signup_456' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('coalesces concurrent preparations from the future API', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+
+      const first = signUp.__internal_future.sendEmailCode();
+      const second = signUp.__internal_future.sendEmailCode();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signup_123' },
+      });
+      await Promise.all([first, second]);
+    });
+
+    it('does not coalesce concurrent verification attempts', async () => {
+      const deferred = createDeferredPromise<any>();
+      const mockFetch = vi.fn().mockReturnValue(deferred.promise);
+      BaseResource._fetch = mockFetch;
+
+      const signUp = new SignUp({ id: 'signup_123' } as any);
+      const params = { strategy: 'email_code' as const, code: '123456' };
+
+      const first = signUp.attemptVerification(params);
+      const second = signUp.attemptVerification(params);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      deferred.resolve({
+        client: null,
+        response: { id: 'signup_123' },
+      });
+      await Promise.all([first, second]);
+    });
   });
 
   describe('authenticateWithRedirect with an OAuth transport', () => {

--- a/packages/clerk-js/src/core/resources/__tests__/Web3Wallet.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Web3Wallet.test.ts
@@ -1,4 +1,5 @@
 import type { Web3WalletJSON } from '@clerk/shared/types';
+import { createDeferredPromise } from '@clerk/shared/utils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BaseResource, Web3Wallet } from '../internal';
@@ -33,14 +34,18 @@ describe('Web3 wallet', () => {
       web3_wallet: '0x0000000000000000000000000000000000000000',
     } as Web3WalletJSON;
 
+    const deferred = createDeferredPromise<any>();
+    const mockFetch = vi.fn().mockReturnValue(deferred.promise);
     // @ts-ignore
-    BaseResource._fetch = vi.fn().mockReturnValue(Promise.resolve({ response: web3WalletJSON }));
+    BaseResource._fetch = mockFetch;
 
     const web3Wallet = new Web3Wallet(web3WalletJSON, '/me/web3_wallets');
-    await web3Wallet.prepareVerification({ strategy: 'web3_metamask_signature' });
+    const params = { strategy: 'web3_metamask_signature' as const };
+    const first = web3Wallet.prepareVerification(params);
+    const second = web3Wallet.prepareVerification(params);
 
-    // @ts-ignore
-    expect(BaseResource._fetch).toHaveBeenCalledWith({
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith({
       method: 'POST',
       path: `/me/web3_wallets/${web3WalletJSON.id}/prepare_verification`,
       body: {
@@ -48,6 +53,9 @@ describe('Web3 wallet', () => {
       },
       signal: expect.any(AbortSignal),
     });
+
+    deferred.resolve({ response: web3WalletJSON });
+    await Promise.all([first, second]);
   });
 
   it('attemptVerification', async () => {

--- a/packages/clerk-js/src/core/resources/__tests__/Web3Wallet.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Web3Wallet.test.ts
@@ -46,6 +46,7 @@ describe('Web3 wallet', () => {
       body: {
         strategy: 'web3_metamask_signature',
       },
+      signal: expect.any(AbortSignal),
     });
   });
 


### PR DESCRIPTION
## Summary

- Coalesce identical concurrent first- and second-factor preparation requests during sign-in, sign-up, and user-profile verification
- Keep requests for different factors and authentication attempts independent

## Why

Concurrent consumers could prepare the same verification factor more than once, sending duplicate one-time codes and invalidating the code the user received first.

## Testing

- Added Vitest coverage for identical and distinct preparations, retries, future APIs, cross-attempt isolation, sign-up and profile verification, and stalled-request expiry
- Verified the Clerk JS test suite, declaration build, and lint checks
