### PR TITLE
fix(ui): provide CardState to composed OrganizationProfileGeneralPanel default page

### DIFF
--- a/.changeset/org-general-panel-cardstate.md
+++ b/.changeset/org-general-panel-cardstate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix `OrganizationProfileGeneralPanel` (from `@clerk/ui/experimental`) throwing "CardState not found" when opening the leave-organization or delete-organization confirmation in its default, no-children page mode. The panel now provides the same root `CardStateProvider` that a mounted `<OrganizationProfile />` supplies.

--- a/packages/ui/src/composed/OrganizationProfile/General.tsx
+++ b/packages/ui/src/composed/OrganizationProfile/General.tsx
@@ -26,7 +26,15 @@ function GeneralComposed({ children }: PropsWithChildren): ReactNode {
 
 export function OrganizationProfileGeneralPanel({ children }: PropsWithChildren): ReactNode {
   if (!children) {
-    return <OrganizationGeneralPage />;
+    // Unlike AccountPage/SecurityPage, OrganizationGeneralPage does not self-wrap in a
+    // CardStateProvider. Mounted <OrganizationProfile /> supplies one at its root, so the
+    // leave/delete confirmation forms (useLeaveWithRevalidations -> useCardState) resolve it.
+    // The composed panel is a standalone entry point, so it must provide the same root here.
+    return (
+      <CardStateProvider>
+        <OrganizationGeneralPage />
+      </CardStateProvider>
+    );
   }
 
   // The section confirmation forms (leave/delete) call useCardState(), so children must be wrapped

--- a/packages/ui/src/composed/__tests__/OrganizationProfileSections.test.tsx
+++ b/packages/ui/src/composed/__tests__/OrganizationProfileSections.test.tsx
@@ -135,6 +135,25 @@ describe('OrganizationProfile composed sections', () => {
     });
   });
 
+  describe('General — default page mode (no children)', () => {
+    it('provides CardState so the leave-organization confirmation can open', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'TestOrg' }] });
+      });
+
+      fixtures.clerk.organization?.getDomains.mockReturnValue(Promise.resolve({ data: [], total_count: 0 }));
+
+      const { userEvent } = render(<OrganizationProfileGeneralPanel />, { wrapper });
+
+      // Before the fix, LeaveOrganizationForm's useLeaveWithRevalidations() calls useCardState()
+      // with no ancestor CardStateProvider and throws "CardState not found".
+      await userEvent.click(await screen.findByRole('button', { name: /leave organization/i }));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument());
+    });
+  });
+
   describe('General — section outside page', () => {
     it('useRequirePage throws when rendered outside a page component', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {


### PR DESCRIPTION
## Description

The composed `OrganizationProfileGeneralPanel` (exported from `@clerk/ui/experimental`) threw `CardState not found` when a consumer used it in its default, no-children page mode and then clicked **Leave organization** or **Delete organization**:

```tsx
<OrganizationProfileProvider>
  <OrganizationProfileGeneralPanel />
</OrganizationProfileProvider>
```

### Root cause

`OrganizationGeneralPage` does not self-wrap in a `CardStateProvider` (unlike `AccountPage` / `SecurityPage`, which use `withCardStateProvider`). In the mounted `<OrganizationProfile />`, the missing provider is supplied by the single root `withCardStateProvider` at the component root (`OrganizationProfile/index.tsx`). The leave/delete confirmation forms call `useCardState()` at the *form* level (`useLeaveWithRevalidations`, `ActionConfirmationPage.tsx:21`) — outside `ActionConfirmationPage`'s own self-wrap — so they rely on that root provider.

The composed panel is a standalone entry point and did not reproduce that root, so the form-level `useCardState()` had no ancestor provider and threw.

### Fix

Wrap the no-children branch of `OrganizationProfileGeneralPanel` in a `CardStateProvider`, mirroring what the mounted `<OrganizationProfile />` provides at its root (and what the composed Security panel already does). The nesting with `ActionConfirmationPage`'s own provider is identical to production behavior today and is harmless — each provider scopes its own subtree.

## Checklist

- [x] Unit test added reproducing the throw and asserting the leave-organization confirmation opens
- [x] `@clerk/ui` patch changeset
- [x] Scope limited to the one affected page; audited the other 8 composed panels (Account/Security self-wrap; billing pages either self-wrap or use no card state)

## Type of change

- [x] 🐛 Bug fix
