### PR TITLE
fix(js): Render standalone APIKeys in org context when user API keys are disabled

### DIFF
--- a/.changeset/api-keys-org-context-user-disabled.md
+++ b/.changeset/api-keys-org-context-user-disabled.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix the standalone `<APIKeys />` component failing to render when an organization is active and user API keys are disabled but organization API keys are enabled. The component now correctly checks the user API keys setting only when no organization is active.

--- a/integration/tests/api-keys-component.test.ts
+++ b/integration/tests/api-keys-component.test.ts
@@ -388,6 +388,44 @@ test.describe('api keys component @machine', () => {
     await u.page.unrouteAll();
   });
 
+  test('standalone API keys component renders in org context when user API keys are disabled', async ({
+    page,
+    context,
+  }) => {
+    const u = createTestUtils({ app, page, context });
+
+    await u.po.signIn.goTo();
+    await u.po.signIn.waitForMounted();
+    await u.po.signIn.signInWithEmailAndInstantPassword({ email: fakeAdmin.email, password: fakeAdmin.password });
+    await u.po.expect.toBeSignedIn();
+
+    await u.po.organizationSwitcher.goTo();
+    await u.po.organizationSwitcher.waitForMounted();
+    await u.po.organizationSwitcher.waitForAnOrganizationToSelected();
+
+    await mockAPIKeysEnvironmentSettings(u.page, { user_api_keys_enabled: false });
+
+    let capturedSubject: string | null = null;
+    const apiKeyRequestPromise = u.page.waitForRequest(request => {
+      if (request.url().includes('api_keys')) {
+        const url = new URL(request.url());
+        capturedSubject = url.searchParams.get('subject');
+        return true;
+      }
+      return false;
+    });
+
+    await u.po.page.goToRelative('/api-keys');
+    await u.po.apiKeys.waitForMounted();
+    await expect(u.page.locator('.cl-apiKeys-root')).toBeVisible();
+
+    // Org API keys are listed, so the subject must be the organization
+    await apiKeyRequestPromise;
+    expect(capturedSubject).toBe(fakeOrganization.organization.id);
+
+    await u.page.unrouteAll();
+  });
+
   test.describe('api key list invalidation', () => {
     // Helper function to count actual API key rows (not empty state)
     const createAPIKeyCountHelper = (u: any) => async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1454,7 +1454,7 @@ export class Clerk implements ClerkInterface {
       return;
     }
 
-    if (disabledUserAPIKeysFeature(this, this.environment)) {
+    if (!this.organization && disabledUserAPIKeysFeature(this, this.environment)) {
       if (this.#instanceType === 'development') {
         throw new ClerkRuntimeError(warnings.cannotRenderAPIKeysComponentForUserWhenDisabled, {
           code: CANNOT_RENDER_API_KEYS_USER_DISABLED_ERROR_CODE,


### PR DESCRIPTION
## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
