### PR TITLE
chore(expo): Add deprecation notice to clerk-expo

### DIFF
--- a/.changeset/three-files-fetch.md
+++ b/.changeset/three-files-fetch.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-expo": minor
+---
+
+eprecate `@clerk/clerk-expo` in favor of `@clerk/expo` and add a runtime warning linking to the migration guide.

--- a/.changeset/three-files-fetch.md
+++ b/.changeset/three-files-fetch.md
@@ -2,4 +2,4 @@
 "@clerk/clerk-expo": minor
 ---
 
-eprecate `@clerk/clerk-expo` in favor of `@clerk/expo` and add a runtime warning linking to the migration guide.
+Deprecate `@clerk/clerk-expo` in favor of `@clerk/expo` and add a runtime warning linking to the migration guide.

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -25,6 +25,9 @@
 
 </div>
 
+> [!WARNING]
+> `@clerk/clerk-expo` is deprecated. Migrate to `@clerk/expo` by following the [Core 3 upgrade guide](https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3).
+
 ## Getting Started
 
 [Clerk](https://clerk.com/?utm_source=github&utm_medium=clerk_expo) is the easiest way to add authentication and user management to your Expo application. Add sign up, sign in, and profile management to your application in minutes.

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -1,4 +1,13 @@
 import { setErrorThrowerOptions } from '@clerk/clerk-react/internal';
+import { logger } from '@clerk/shared/logger';
+
+logger.warnOnce(`
+Clerk - DEPRECATION WARNING: @clerk/clerk-expo is deprecated.
+
+Please migrate to @clerk/expo.
+
+Migration guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
+`);
 
 export {
   isClerkAPIResponseError,


### PR DESCRIPTION
## Description

Deprecates the legacy `@clerk/clerk-expo` package in favor of `@clerk/expo`.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
