### PR TITLE
docs(backend): Correct Dashboard labels in instance restrictions

### DIFF
--- a/.changeset/fix-disposable-email-toggle-label.md
+++ b/.changeset/fix-disposable-email-toggle-label.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Correct the Dashboard toggle name referenced in the `blockDisposableEmailDomains` documentation. The bolded label read "Block sign-ups that use disposable email domains", but the toggle in the Clerk Dashboard is "Block sign-ups that use disposable email addresses". The property name is unchanged.

--- a/.changeset/fix-disposable-email-toggle-label.md
+++ b/.changeset/fix-disposable-email-toggle-label.md
@@ -2,4 +2,4 @@
 '@clerk/backend': patch
 ---
 
-Correct the Dashboard toggle name referenced in the `blockDisposableEmailDomains` documentation. The bolded label read "Block sign-ups that use disposable email domains", but the toggle in the Clerk Dashboard is "Block sign-ups that use disposable email addresses". The property name is unchanged.
+Correct two Dashboard labels referenced in the instance restrictions documentation. `blockDisposableEmailDomains` bolded "Block sign-ups that use disposable email domains", but the toggle in the Clerk Dashboard is "Block sign-ups that use disposable email addresses". `ignoreDotsForGmailAddresses` bolded "Ignore dots for Gmail addresses" as a Dashboard toggle, but no such control exists — the wording now matches the equivalent comment on `UpdateRestrictionsParams`. Property names are unchanged.

--- a/packages/backend/src/api/endpoints/InstanceApi.ts
+++ b/packages/backend/src/api/endpoints/InstanceApi.ts
@@ -36,7 +36,7 @@ export type UpdateRestrictionsParams = {
   blocklist?: boolean | null | undefined;
   /** Whether the instance should have [**Block email subaddresses**](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses) enabled. */
   blockEmailSubaddresses?: boolean | null | undefined;
-  /** Whether the instance should have [**Block sign-ups that use disposable email domains**](https://clerk.com/docs/guides/secure/restricting-access#block-sign-ups-that-use-disposable-email-addresses) enabled. */
+  /** Whether the instance should have [**Block sign-ups that use disposable email addresses**](https://clerk.com/docs/guides/secure/restricting-access#block-sign-ups-that-use-disposable-email-addresses) enabled. */
   blockDisposableEmailDomains?: boolean | null | undefined;
   /** Whether the instance should [ignore dots for Gmail addresses](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses). */
   ignoreDotsForGmailAddresses?: boolean | null | undefined;

--- a/packages/backend/src/api/resources/InstanceRestrictions.ts
+++ b/packages/backend/src/api/resources/InstanceRestrictions.ts
@@ -9,7 +9,7 @@ export class InstanceRestrictions {
     readonly blocklist: boolean,
     /** Whether the instance has [**Block email subaddresses**](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses) enabled. */
     readonly blockEmailSubaddresses: boolean,
-    /** Whether the instance has [**Block sign-ups that use disposable email domains**](https://clerk.com/docs/guides/secure/restricting-access#block-sign-ups-that-use-disposable-email-addresses) enabled. */
+    /** Whether the instance has [**Block sign-ups that use disposable email addresses**](https://clerk.com/docs/guides/secure/restricting-access#block-sign-ups-that-use-disposable-email-addresses) enabled. */
     readonly blockDisposableEmailDomains: boolean,
     /** Whether the instance has [**Ignore dots for Gmail addresses**](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses) enabled. */
     readonly ignoreDotsForGmailAddresses: boolean,

--- a/packages/backend/src/api/resources/InstanceRestrictions.ts
+++ b/packages/backend/src/api/resources/InstanceRestrictions.ts
@@ -11,7 +11,7 @@ export class InstanceRestrictions {
     readonly blockEmailSubaddresses: boolean,
     /** Whether the instance has [**Block sign-ups that use disposable email addresses**](https://clerk.com/docs/guides/secure/restricting-access#block-sign-ups-that-use-disposable-email-addresses) enabled. */
     readonly blockDisposableEmailDomains: boolean,
-    /** Whether the instance has [**Ignore dots for Gmail addresses**](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses) enabled. */
+    /** Whether the instance is set to [ignore dots for Gmail addresses](https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses). */
     readonly ignoreDotsForGmailAddresses: boolean,
   ) {}
 


### PR DESCRIPTION
## Description

Two TSDoc comments on the instance restrictions types bold Dashboard labels that don't match the Dashboard. Bold in these comments means "this is the name you'll see in the Dashboard," so a wrong one sends people looking for a control that isn't there.

`blockDisposableEmailDomains` reads **Block sign-ups that use disposable email domains**. The actual toggle is **Block sign-ups that use disposable email addresses**. Corrected in both places it appears.

`ignoreDotsForGmailAddresses` reads **Ignore dots for Gmail addresses**, but there's no such toggle. The Restrictions page renders four controls — restricted mode, allowlist/blocklist on sign-ins, block email subaddresses, and block disposable email addresses — and the setting appears only in the generated DAPI spec. The backend strips Gmail dots unconditionally in `Canonical()`. So there's nothing to name, and the bold comes off. `UpdateRestrictionsParams` already described the same field unbolded and lowercase, so the two now agree.

Property names are unchanged. `blockDisposableEmailDomains` is right — the check really is domain-based, matching the address's domain against a disposable-domain list. Only the human-facing labels were wrong.

Found while reviewing [clerk/clerk#3034](https://github.com/clerk/clerk/pull/3034), which touches the docs page these comments link to. The linked anchors are unchanged and still resolve.

Worth flagging for whoever picks this up: "addresses" (Dashboard, docs, pricing table) versus "domains" (these properties, the BAPI field) is a naming split that runs wider than these lines. This fixes what's provably wrong against the Dashboard and leaves the split alone.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
