### PR TITLE
docs(*): rename "Client Trust" to "Device Trust"

### DIFF
--- a/.changeset/rename-client-trust-to-device-trust.md
+++ b/.changeset/rename-client-trust-to-device-trust.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/upgrade': patch
+---
+
+Rename "Client Trust" to "Device Trust" in documentation strings and links. This is a naming change only — the `needs_client_trust` sign-in status, the `clientTrustState` property, and every other API value keep their existing names, so no integration changes are required.

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -342,7 +342,7 @@ export interface SignInFutureResource {
    * The current status of the sign-in.
    * <ul>
    * <li>`'complete'` - The sign-in process has been completed successfully.</li>
-   * <li>`'needs_client_trust'` - The user is signing in from a new device and must complete a [second factor verification](!second-factor-verification) to establish [Client Trust](https://clerk.com/docs/guides/secure/client-trust). See the [Client Trust custom flow guide](https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust) for more information.</li>
+   * <li>`'needs_client_trust'` - The user is signing in from a new device and must complete a [second factor verification](!second-factor-verification) to establish [Device Trust](https://clerk.com/docs/guides/secure/device-trust). See the [Device Trust custom flow guide](https://clerk.com/docs/guides/development/custom-flows/authentication/device-trust) for more information.</li>
    * <li>`'needs_identifier'` - The user's identifier (e.g., email address, phone number, username) hasn't been provided.</li>
    * <li>`'needs_first_factor'` - One of the following [first factor verification](!first-factor-verification) strategies is missing: `'email_link'`, `'email_code'`, `passkey`, `password`, `'phone_code'`, `'web3_base_signature'`, `'web3_metamask_signature'`, `'web3_coinbase_wallet_signature'`, `'web3_okx_wallet_signature'`, `'web3_solana_signature'`, [`OAuthStrategy`](https://clerk.com/docs/reference/types/sso#o-auth-strategy), or `'enterprise_sso'`.</li>
    * <li>`'needs_second_factor'` - One of the following [second factor verification](!second-factor-verification) strategies is missing: `'phone_code'`, `'totp'`, `'backup_code'`, `'email_code'`, or `'email_link'`.</li>

--- a/packages/upgrade/src/versions/core-3/changes/needs-client-trust-sign-in-status-added.md
+++ b/packages/upgrade/src/versions/core-3/changes/needs-client-trust-sign-in-status-added.md
@@ -1,16 +1,16 @@
 ---
-title: 'Sign-in Client Trust status handling'
+title: 'Sign-in Device Trust status handling'
 category: 'breaking'
 ---
 
 We've added a new Sign-in status of `needs_client_trust` which, given the conditions listed, will need to be handled in your application.
 
-[Clerk Documentation: Client Trust](https://clerk.com/docs/guides/secure/client-trust)
+[Clerk Documentation: Device Trust](https://clerk.com/docs/guides/secure/device-trust)
 
 Prerequisites:
 
-- [Passwords and Client Trust](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=password) are enabled.
-- You've opted-in to the Client Trust `needs_client_trust` [Update](https://dashboard.clerk.com/~/updates).
+- [Passwords and Device Trust](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=password) are enabled.
+- You've opted-in to the Device Trust `needs_client_trust` [Update](https://dashboard.clerk.com/~/updates).
 - Sign-in with [Email](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) and/or [Phone](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=phone) identifiers are enabled.
 - If [Email](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) or [SMS](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=phone) sign-in verification aren't enabled.
 


### PR DESCRIPTION
Part of [PROT-875](https://linear.app/clerk/issue/PROT-875/fully-rename-client-trust-to-device-trust).

> [!NOTE]
> **Merge order changed after review: merge this AFTER clerk/clerk#3051.** Landing it first would deadlock — once this releases, the typedoc sync regenerates `properties.mdx` with links to `device-trust`, and that sync PR fails against a clerk/clerk main that does not have the page yet. #3051 now carries the matching generated file itself, so once it lands, the sync here becomes a no-op.

## What

Renames the customer-facing feature name "Client Trust" → "Device Trust" in the two developer-facing text surfaces this repo owns:

- `SignInFutureResource.status` JSDoc in `@clerk/shared`
- The `@clerk/upgrade` core-3 change guide

## Consumers need no code changes

This is a naming change only. Every API value keeps its existing name:

- `'needs_client_trust'` — the status string apps compare against — **unchanged**
- `clientTrustState` — **unchanged**

No type signatures, exports, or runtime behavior are touched. Apps that switch on `signIn.status === 'needs_client_trust'` keep working untouched. Per Kyle in [the naming thread](https://clerkinc.slack.com/archives/C081A8SDN9F/p1784045836197369): _"we don't have to change APIs but the way we discuss clients externally should flip to devices."_

The two docs pages add a note explaining why the API value and the feature name now differ.

## Why a changeset for a comment change

The changeset is `patch`/`patch` and exists to trigger a release, not to signal API impact.

The clerk-docs typedoc sync is **release-gated** — per clerk-docs `contributing/CONTRIBUTING.md`, the sync PR opens once a javascript PR "has been merged **and a release is published**." The generated `clerk-typedoc/shared/sign-in-future-resource/properties.mdx` still links to the old docs URLs, and clerk-docs' `build:tsx` fails on those two links until it is regenerated.

Heads up that `updateInternalDependents: "always"` means this cascades patch bumps to the 21 packages depending on `@clerk/shared`. All are no-op upgrades for consumers.

## Merge order (revised)

1. `clerk/clerk`#3051 — the docs rename. Self-contained and green; creates the pages and the redirects.
2. `clerk/dashboard`#9839 — the dashboard UI labels. Must wait for #3051 to **deploy**, or its docs links 404.
3. **This PR** — keeps the JSDoc source of truth aligned. Its eventual typedoc sync is then a no-op.

## One thing not to misread

`needs-client-trust-sign-in-status-added.md` has `category: 'breaking'` in its frontmatter. That is **pre-existing** and describes the core-3 change it documents — adding the `needs_client_trust` status was breaking at the time. It is not a label on this rename, and I did not touch it.

## Verification

- `prettier --check` on all three files — clean
- `eslint` on `signInFuture.ts` — 0 errors (24 pre-existing `@extractMethods` warnings at lines 469+, unrelated to the line 337 change)
- lint-staged pre-commit hook — passed
