### PR TITLE
fix(backend): Return TokenVerificationError from decodeJwt for undecodable tokens

### DIFF
--- a/.changeset/decodejwt-malformed-token.md
+++ b/.changeset/decodejwt-malformed-token.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Return a `TokenVerificationError` from `decodeJwt` and `verifyToken` for tokens whose header, payload, or signature cannot be decoded.

--- a/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
+++ b/packages/backend/src/jwt/__tests__/verifyJwt.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TokenVerificationError } from '../../errors';
 import {
   createJwt,
   mockJwks,
@@ -84,6 +85,18 @@ describe('decodeJwt(jwt)', () => {
   it('throws an error if number is given as jwt', () => {
     const { errors: [error] = [] } = decodeJwt('42');
     expect(error).toMatchObject(invalidTokenError);
+  });
+
+  it('returns an error if the token segments are not valid base64url', () => {
+    const { errors: [error] = [] } = decodeJwt('aaa.bbb.ccc');
+    expect(error).toBeInstanceOf(TokenVerificationError);
+    expect(error).toMatchObject({ reason: 'token-invalid' });
+  });
+
+  it('returns an error if the token segments do not decode to JSON', () => {
+    const { errors: [error] = [] } = decodeJwt('YWJj.YWJj.YWJj');
+    expect(error).toBeInstanceOf(TokenVerificationError);
+    expect(error).toMatchObject({ reason: 'token-invalid' });
   });
 });
 

--- a/packages/backend/src/jwt/verifyJwt.ts
+++ b/packages/backend/src/jwt/verifyJwt.ts
@@ -79,10 +79,21 @@ export function decodeJwt(token: string): JwtReturnType<Jwt, TokenVerificationEr
   // encode - and _.
 
   // More info at https://stackoverflow.com/questions/54062583/how-to-verify-a-signed-jwt-with-subtlecrypto-of-the-web-crypto-API
-  const header = JSON.parse(decoder.decode(base64url.parse(rawHeader, { loose: true })));
-  const payload = JSON.parse(decoder.decode(base64url.parse(rawPayload, { loose: true })));
-
-  const signature = base64url.parse(rawSignature, { loose: true });
+  let header, payload, signature;
+  try {
+    header = JSON.parse(decoder.decode(base64url.parse(rawHeader, { loose: true })));
+    payload = JSON.parse(decoder.decode(base64url.parse(rawPayload, { loose: true })));
+    signature = base64url.parse(rawSignature, { loose: true });
+  } catch {
+    return {
+      errors: [
+        new TokenVerificationError({
+          reason: TokenVerificationErrorReason.TokenInvalid,
+          message: `Invalid JWT form. The header, payload, or signature could not be decoded.`,
+        }),
+      ],
+    };
+  }
 
   const data = {
     header,


### PR DESCRIPTION
## Description

 `decodeJwt` checks that a token has three dot-separated segments, but the `base64url.parse` and `JSON.parse` calls after that check were unguarded. A token like `aaa.bbb.ccc` threw a raw `SyntaxError` instead of the documented `TokenVerificationError`, and `verifyToken` rejected with the same `SyntaxError`.

The segment parsing is now wrapped so undecodable headers, payloads, or signatures produce a `TokenVerificationError` with reason `token-invalid`, matching the behavior for every other malformed token shape.

Fixes https://github.com/clerk/javascript/issues/9263

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
