### PR TITLE
chore(expo): bump clerk-android to 1.0.38

### DIFF
--- a/.changeset/expo-bump-clerk-android-1-0-38.md
+++ b/.changeset/expo-bump-clerk-android-1-0-38.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-android` SDK (`clerk-android-api` and `clerk-android-ui`) from `1.0.37` to `1.0.38`. See the Clerk Android release: https://github.com/clerk/clerk-android/releases/tag/v1.0.38.

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -20,8 +20,8 @@ def clerkExpoVersion = clerkExpoPackageJson.version.toString()
 // See: https://docs.gradle.org/current/userguide/version_catalogs.html for app-level version catalogs
 ext {
   kotlinxCoroutinesVersion = "1.7.3"
-  clerkAndroidApiVersion = "1.0.37"
-  clerkAndroidUiVersion = "1.0.37"
+  clerkAndroidApiVersion = "1.0.38"
+  clerkAndroidUiVersion = "1.0.38"
   composeVersion = "1.7.0"
   activityComposeVersion = "1.9.0"
   lifecycleVersion = "2.8.0"


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-android` SDK in `@clerk/expo` from `1.0.37` to `1.0.38`.

Release: https://github.com/clerk/clerk-android/releases/tag/v1.0.38

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation
