### PR TITLE
fix(ui): guard clipboard data in paste handlers

### DIFF
--- a/.changeset/calm-taxis-paste.md
+++ b/.changeset/calm-taxis-paste.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Prevent phone number and multi-email fields from crashing when they receive paste events without clipboard data.

--- a/packages/ui/src/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/ui/src/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -4,7 +4,7 @@ import { waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { bindCreateFixtures } from '@/test/create-fixtures';
-import { render } from '@/test/utils';
+import { fireEvent, render } from '@/test/utils';
 
 import { Action } from '../../../elements/Action';
 import { clearFetchCache } from '../../../hooks';
@@ -92,6 +92,28 @@ describe('InviteMembersPage', () => {
 
     await waitFor(async () => expect(await findByText('Invite new members')).toBeInTheDocument());
     getByText('Enter or paste one or more email addresses, separated by spaces or commas.');
+  });
+
+  it('ignores paste events without clipboard data', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withOrganizations();
+      f.withUser({
+        email_addresses: ['test@clerk.com'],
+        organization_memberships: [{ name: 'Org1', role: 'admin' }],
+      });
+    });
+
+    fixtures.clerk.organization?.getInvitations.mockRejectedValue(null);
+    fixtures.clerk.organization?.getRoles.mockRejectedValue(null);
+
+    const { getByTestId } = render(
+      <Action.Root>
+        <InviteMembersScreen />
+      </Action.Root>,
+      { wrapper },
+    );
+
+    expect(() => fireEvent.paste(getByTestId('tag-input'), { clipboardData: null })).not.toThrow();
   });
 
   describe('with default role', () => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -448,6 +448,18 @@ describe('SignInStart', () => {
 
       expect(screen.getByRole('textbox', { name: /phone number/i })).toHaveAttribute('type', 'tel');
     });
+
+    it('ignores paste events without clipboard data', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withPhoneNumber();
+        f.withSupportEmail();
+      });
+      render(<SignInStart />, { wrapper });
+
+      const input = screen.getByRole('textbox', { name: /phone number/i });
+
+      expect(() => fireEvent.paste(input, { clipboardData: null })).not.toThrow();
+    });
   });
 
   describe('initialValues', () => {

--- a/packages/ui/src/elements/PhoneInput/index.tsx
+++ b/packages/ui/src/elements/PhoneInput/index.tsx
@@ -48,8 +48,12 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps & { feedback
   useEffect(callOnChangeProp, [numberWithCode]);
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const inputValue = e.clipboardData?.getData('text');
+    if (inputValue === undefined) {
+      return;
+    }
+
     e.preventDefault();
-    const inputValue = e.clipboardData.getData('text');
     if (inputValue.includes('+')) {
       setNumberAndIso(inputValue);
     } else {

--- a/packages/ui/src/elements/TagInput.tsx
+++ b/packages/ui/src/elements/TagInput.tsx
@@ -102,9 +102,14 @@ export const TagInput = (props: TagInputProps) => {
   };
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const inputValue = e.clipboardData?.getData('text');
+    if (inputValue === undefined) {
+      return;
+    }
+
     e.preventDefault();
     addTag(
-      (e.clipboardData.getData('text') || '')
+      (inputValue || '')
         .split(/,| |\n|\t/)
         .filter(Boolean)
         .map(tag => tag.trim()),


### PR DESCRIPTION
## Description

Prevents `PhoneInput` and `TagInput` from assuming clipboard data is present on every paste event. Programmatically dispatched paste events can expose null clipboard data, which caused an unhandled `TypeError` in Clerk UI.

The affected handlers now ignore events without clipboard data while preserving normal paste behavior. Regression coverage exercises both the sign-in phone number field and the organization invite multi-email field.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: