### PR TITLE
fix(electron): handle Linux OAuth deep links

### DIFF
--- a/.changeset/calm-taxis-return.md
+++ b/.changeset/calm-taxis-return.md
@@ -2,4 +2,4 @@
 '@clerk/electron': patch
 ---
 
-Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux, including callbacks received in startup arguments.
+Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux.

--- a/.changeset/calm-taxis-return.md
+++ b/.changeset/calm-taxis-return.md
@@ -2,4 +2,5 @@
 '@clerk/electron': patch
 ---
 
-Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux.
+Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux. Applications
+that already manage Electron's process-wide single-instance lock can disable Clerk's lock management.

--- a/.changeset/calm-taxis-return.md
+++ b/.changeset/calm-taxis-return.md
@@ -2,5 +2,13 @@
 '@clerk/electron': patch
 ---
 
-Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux. Applications
-that already manage Electron's process-wide single-instance lock can disable Clerk's lock management.
+Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux, and bring the
+signing-in window to the front when the callback arrives.
+
+Delivering those callbacks requires Electron's single-instance lock, so `createClerkBridge` now
+acquires it on Windows and Linux whenever `renderer` is configured, and quits secondary processes
+after forwarding their arguments. Applications that previously ran side-by-side instances on those
+platforms will become single-instance. macOS is unaffected. Two new escape hatches: the returned
+bridge exposes `isPrimaryInstance` so the application can stop its own bootstrap in a secondary
+process, and `manageSingleInstanceLock: false` leaves the lock to applications that manage it
+themselves.

--- a/.changeset/calm-taxis-return.md
+++ b/.changeset/calm-taxis-return.md
@@ -1,0 +1,5 @@
+---
+'@clerk/electron': patch
+---
+
+Forward OAuth deep-link callbacks to the primary Electron process on Windows and Linux, including callbacks received in startup arguments.

--- a/integration/templates/electron-vite/main.mjs
+++ b/integration/templates/electron-vite/main.mjs
@@ -63,10 +63,12 @@ function registerClerkAppProtocol() {
   });
 }
 
-app.whenReady().then(async () => {
-  registerClerkAppProtocol();
-  await createWindow();
-});
+if (clerk.isPrimaryInstance) {
+  app.whenReady().then(async () => {
+    registerClerkAppProtocol();
+    await createWindow();
+  });
+}
 
 app.on('window-all-closed', () => {
   app.quit();

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -47,7 +47,7 @@ import { storage } from '@clerk/electron/storage';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-createClerkBridge({
+const clerk = createClerkBridge({
   storage: storage(),
   renderer: {
     scheme: 'my-app',
@@ -56,28 +56,34 @@ createClerkBridge({
   passkeys: true,
 });
 
-app.whenReady().then(() => {
-  protocol.handle('my-app', request => {
-    const url = new URL(request.url);
-    const file = url.pathname === '/' ? 'index.html' : url.pathname;
+if (clerk.isPrimaryInstance) {
+  app.whenReady().then(() => {
+    protocol.handle('my-app', request => {
+      const url = new URL(request.url);
+      const file = url.pathname === '/' ? 'index.html' : url.pathname;
 
-    return net.fetch(pathToFileURL(join(__dirname, '../renderer', file)).toString());
+      return net.fetch(pathToFileURL(join(__dirname, '../renderer', file)).toString());
+    });
+
+    const win = new BrowserWindow({
+      webPreferences: {
+        preload: join(__dirname, '../preload/index.js'),
+      },
+    });
+
+    win.loadURL('my-app://renderer/');
   });
-
-  const win = new BrowserWindow({
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-    },
-  });
-
-  win.loadURL('my-app://renderer/');
-});
+}
 ```
 
-When a renderer scheme is configured, `createClerkBridge` acquires Electron's single-instance lock by
-default so OAuth deep links opened on Windows or Linux are forwarded to the primary process. Call it
-before `app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments.
-The lock is released by `cleanup()` unless it was already owned by the application.
+On Windows and Linux, a deep link starts a second copy of the app, so the callback only reaches the
+running process through Electron's single-instance lock. When a renderer scheme is configured,
+`createClerkBridge` acquires that lock by default and quits secondary processes once their
+command-line arguments have been forwarded. Call it before `app.whenReady()`, and stop your own
+bootstrap when `isPrimaryInstance` is `false` — `app.quit()` is asynchronous, so `whenReady` can
+still fire in a process that is on its way out. The lock is released by `cleanup()` unless it was
+already owned by the application. macOS is unaffected: deep links arrive through `open-url`, so no
+lock is taken and `isPrimaryInstance` is always `true`.
 
 If the application manages the lock, acquire it before creating the bridge and disable Clerk's lock
 management:

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -74,10 +74,27 @@ app.whenReady().then(() => {
 });
 ```
 
-When a renderer scheme is configured, `createClerkBridge` acquires Electron's single-instance lock so
-OAuth deep links opened on Windows or Linux are forwarded to the primary process. Call it before
-`app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments. The
-lock is released by `cleanup()` unless it was already owned by the application.
+When a renderer scheme is configured, `createClerkBridge` acquires Electron's single-instance lock by
+default so OAuth deep links opened on Windows or Linux are forwarded to the primary process. Call it
+before `app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments.
+The lock is released by `cleanup()` unless it was already owned by the application.
+
+If the application manages the lock, acquire it before creating the bridge and disable Clerk's lock
+management:
+
+```ts
+const gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+  app.quit();
+} else {
+  createClerkBridge({
+    storage: storage(),
+    renderer: { scheme: 'my-app', host: 'renderer' },
+    manageSingleInstanceLock: false,
+  });
+}
+```
 
 Linux packages must also register the renderer scheme in their `.desktop` entry so the browser can
 launch the app:

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -74,6 +74,11 @@ app.whenReady().then(() => {
 });
 ```
 
+When a renderer scheme is configured, `createClerkBridge` acquires Electron's single-instance lock so
+OAuth deep links opened on Windows or Linux are forwarded to the primary process. Call it before
+`app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments, and a
+matching callback from a cold-start launch is retained until the OAuth transport is ready.
+
 In `my-app://renderer/sign-in`, `my-app` is the scheme, `renderer` is the host, `my-app://renderer` is the origin, and `/sign-in` is the path. If your renderer uses path-based routing, serve every route from the same origin and fall back to your renderer entrypoint as needed.
 
 ```ts

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -76,8 +76,16 @@ app.whenReady().then(() => {
 
 When a renderer scheme is configured, `createClerkBridge` acquires Electron's single-instance lock so
 OAuth deep links opened on Windows or Linux are forwarded to the primary process. Call it before
-`app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments, and a
-matching callback from a cold-start launch is retained until the OAuth transport is ready.
+`app.whenReady()`. Secondary processes are quit after forwarding their command-line arguments. The
+lock is released by `cleanup()` unless it was already owned by the application.
+
+Linux packages must also register the renderer scheme in their `.desktop` entry so the browser can
+launch the app:
+
+```ini
+Exec=/path/to/my-app %U
+MimeType=x-scheme-handler/my-app;
+```
 
 In `my-app://renderer/sign-in`, `my-app` is the scheme, `renderer` is the host, `my-app://renderer` is the origin, and `/sign-in` is the path. If your renderer uses path-based routing, serve every route from the same origin and fall back to your renderer entrypoint as needed.
 

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -491,6 +491,30 @@ describe('createClerkBridge', () => {
     expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
   });
 
+  it('runs the remaining teardowns when one throws during cleanup', () => {
+    const clerk = createClerkBridge({
+      storage,
+      passkeys: true,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    // Teardowns drain in reverse, so this aborts the OAuth transport cleanup first.
+    vi.mocked(ipcMain.removeHandler).mockImplementationOnce(() => {
+      throw new Error('Handler was already removed');
+    });
+
+    expect(() => clerk.cleanup()).toThrow('Handler was already removed');
+
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(PASSKEY_CHANNELS.create);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.getToken);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.saveToken);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.clearToken);
+    expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
   it('derives the OAuth callback URL from the renderer origin', () => {
     createClerkBridge({
       storage,

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -1,5 +1,5 @@
-import { app, ipcMain, protocol, shell } from 'electron';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { app, BrowserWindow, ipcMain, protocol, shell } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAUTH_TRANSPORT_CHANNELS, PASSKEY_CHANNELS } from '../../shared/ipc';
 import type { TokenStorage } from '../../shared/types';
@@ -16,6 +16,9 @@ vi.mock('electron', () => ({
     setAsDefaultProtocolClient: vi.fn(),
     userAgentFallback:
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  },
+  BrowserWindow: {
+    fromWebContents: vi.fn(),
   },
   ipcMain: {
     handle: vi.fn(),
@@ -38,6 +41,13 @@ vi.mock('@clerk/electron-passkeys', () => ({
   },
 }));
 
+const createRendererWindow = () => ({
+  isDestroyed: vi.fn(() => false),
+  isMinimized: vi.fn(() => false),
+  restore: vi.fn(),
+  focus: vi.fn(),
+});
+
 const mainFrame = {};
 const windowSender = { mainFrame, getType: () => 'window' };
 const mainFrameEvent = { sender: windowSender, senderFrame: mainFrame } as unknown as Electron.IpcMainInvokeEvent;
@@ -55,8 +65,14 @@ describe('createClerkBridge', () => {
     vi.clearAllMocks();
     vi.mocked(app.hasSingleInstanceLock).mockReturnValue(false);
     vi.mocked(app.requestSingleInstanceLock).mockReturnValue(true);
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(null);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     app.userAgentFallback =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('requires a storage adapter', () => {
@@ -296,6 +312,8 @@ describe('createClerkBridge', () => {
   });
 
   it('does not manage the single-instance lock when disabled', () => {
+    vi.mocked(app.hasSingleInstanceLock).mockReturnValue(true);
+
     const clerk = createClerkBridge({
       storage,
       renderer: {
@@ -306,10 +324,24 @@ describe('createClerkBridge', () => {
     });
     clerk.cleanup();
 
-    expect(app.hasSingleInstanceLock).not.toHaveBeenCalled();
     expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
     expect(app.releaseSingleInstanceLock).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
     expect(ipcMain.handle).toHaveBeenCalledWith(OAUTH_TRANSPORT_CHANNELS.open, expect.any(Function));
+  });
+
+  it('warns when lock management is disabled and the application holds no lock', () => {
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+      manageSingleInstanceLock: false,
+    });
+
+    expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('manageSingleInstanceLock is false'));
   });
 
   it('releases the single-instance lock acquired by the bridge during cleanup', () => {
@@ -321,7 +353,43 @@ describe('createClerkBridge', () => {
       },
     });
     clerk.cleanup();
+    clerk.cleanup();
 
+    expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
+  it('releases the single-instance lock when initialization throws', () => {
+    vi.mocked(protocol.registerSchemesAsPrivileged).mockImplementationOnce(() => {
+      throw new Error('Scheme was already registered');
+    });
+
+    expect(() =>
+      createClerkBridge({
+        storage,
+        renderer: {
+          host: 'renderer',
+          scheme: 'my-app',
+        },
+      }),
+    ).toThrow('Scheme was already registered');
+
+    expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
+  it('releases the single-instance lock when cleanup throws', () => {
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    vi.mocked(ipcMain.removeHandler).mockImplementationOnce(() => {
+      throw new Error('Handler was already removed');
+    });
+
+    expect(() => clerk.cleanup()).toThrow('Handler was already removed');
     expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
   });
 
@@ -437,5 +505,64 @@ describe('createClerkBridge', () => {
     ]);
 
     await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
+  });
+
+  it('restores and focuses the initiating window when the callback resolves', async () => {
+    const rendererWindow = createRendererWindow();
+    rendererWindow.isMinimized.mockReturnValue(true);
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(rendererWindow as unknown as Electron.BrowserWindow);
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    const openHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+      return channel === OAUTH_TRANSPORT_CHANNELS.open;
+    })?.[1];
+    const openPromise = openHandler?.(mainFrameEvent, 'https://accounts.example.com/oauth');
+    const secondInstanceListener = vi.mocked(app.on).mock.calls.find(([event]) => event === 'second-instance')?.[1] as (
+      event: Electron.Event,
+      argv: string[],
+    ) => void;
+
+    secondInstanceListener({} as Electron.Event, ['/opt/MyApp/my-app', 'my-app://renderer/?code=123']);
+
+    await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
+    expect(rendererWindow.restore).toHaveBeenCalledOnce();
+    expect(rendererWindow.focus).toHaveBeenCalledOnce();
+  });
+
+  it('does not focus a window that was destroyed during the flow', async () => {
+    const rendererWindow = createRendererWindow();
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(rendererWindow as unknown as Electron.BrowserWindow);
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    const openHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+      return channel === OAUTH_TRANSPORT_CHANNELS.open;
+    })?.[1];
+    const openPromise = openHandler?.(mainFrameEvent, 'https://accounts.example.com/oauth');
+    const secondInstanceListener = vi.mocked(app.on).mock.calls.find(([event]) => event === 'second-instance')?.[1] as (
+      event: Electron.Event,
+      argv: string[],
+    ) => void;
+
+    rendererWindow.isDestroyed.mockReturnValue(true);
+    secondInstanceListener({} as Electron.Event, ['/opt/MyApp/my-app', 'my-app://renderer/?code=123']);
+
+    await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
+    expect(rendererWindow.focus).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -295,6 +295,23 @@ describe('createClerkBridge', () => {
     expect(app.releaseSingleInstanceLock).not.toHaveBeenCalled();
   });
 
+  it('does not manage the single-instance lock when disabled', () => {
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+      manageSingleInstanceLock: false,
+    });
+    clerk.cleanup();
+
+    expect(app.hasSingleInstanceLock).not.toHaveBeenCalled();
+    expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(app.releaseSingleInstanceLock).not.toHaveBeenCalled();
+    expect(ipcMain.handle).toHaveBeenCalledWith(OAUTH_TRANSPORT_CHANNELS.open, expect.any(Function));
+  });
+
   it('releases the single-instance lock acquired by the bridge during cleanup', () => {
     const clerk = createClerkBridge({
       storage,

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, protocol, shell } from 'electron';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAUTH_TRANSPORT_CHANNELS, PASSKEY_CHANNELS } from '../../shared/ipc';
 import type { TokenStorage } from '../../shared/types';
@@ -8,7 +8,9 @@ import { createClerkBridge } from '../create-clerk-bridge';
 vi.mock('electron', () => ({
   app: {
     on: vi.fn(),
+    quit: vi.fn(),
     removeListener: vi.fn(),
+    requestSingleInstanceLock: vi.fn(() => true),
     setAsDefaultProtocolClient: vi.fn(),
     userAgentFallback:
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -40,6 +42,7 @@ const mainFrameEvent = { sender: windowSender, senderFrame: mainFrame } as unkno
 const subframeEvent = { sender: windowSender, senderFrame: {} } as unknown as Electron.IpcMainInvokeEvent;
 
 describe('createClerkBridge', () => {
+  const originalArgv = process.argv;
   const missingStorage = {} as Parameters<typeof createClerkBridge>[0];
   const storage: TokenStorage = {
     getItem: vi.fn(),
@@ -49,8 +52,14 @@ describe('createClerkBridge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.argv = originalArgv;
+    vi.mocked(app.requestSingleInstanceLock).mockReturnValue(true);
     app.userAgentFallback =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
   });
 
   it('requires a storage adapter', () => {
@@ -251,9 +260,26 @@ describe('createClerkBridge', () => {
       },
     });
 
+    expect(app.requestSingleInstanceLock).toHaveBeenCalledOnce();
     expect(ipcMain.handle).toHaveBeenCalledWith(OAUTH_TRANSPORT_CHANNELS.getRedirectUrl, expect.any(Function));
     expect(ipcMain.handle).toHaveBeenCalledWith(OAUTH_TRANSPORT_CHANNELS.open, expect.any(Function));
     expect(app.setAsDefaultProtocolClient).toHaveBeenCalledWith('my-app');
+  });
+
+  it('quits a secondary instance before registering IPC handlers', () => {
+    vi.mocked(app.requestSingleInstanceLock).mockReturnValue(false);
+
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    expect(app.quit).toHaveBeenCalledOnce();
+    expect(ipcMain.handle).not.toHaveBeenCalled();
+    expect(app.setAsDefaultProtocolClient).not.toHaveBeenCalled();
   });
 
   it('derives the OAuth callback URL from the renderer origin', () => {
@@ -340,5 +366,54 @@ describe('createClerkBridge', () => {
 
     await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
     expect(shell.openExternal).toHaveBeenCalledWith('https://accounts.example.com/oauth');
+  });
+
+  it('resolves OAuth through a matching second-instance argument', async () => {
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    const openHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+      return channel === OAUTH_TRANSPORT_CHANNELS.open;
+    })?.[1];
+    const openPromise = openHandler?.(mainFrameEvent, 'https://accounts.example.com/oauth');
+    const secondInstanceListener = vi.mocked(app.on).mock.calls.find(([event]) => event === 'second-instance')?.[1] as (
+      event: Electron.Event,
+      argv: string[],
+    ) => void;
+
+    secondInstanceListener({} as Electron.Event, [
+      '/opt/MyApp/my-app',
+      '--enable-features=UseOzonePlatform',
+      'my-app://renderer/?code=123',
+    ]);
+
+    await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
+  });
+
+  it('resolves OAuth from a matching cold-start argument without reopening the browser', async () => {
+    process.argv = ['/opt/MyApp/my-app', 'my-app://renderer/?code=123'];
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    const openHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+      return channel === OAUTH_TRANSPORT_CHANNELS.open;
+    })?.[1];
+
+    await expect(openHandler?.(mainFrameEvent, 'https://accounts.example.com/oauth')).resolves.toEqual({
+      callbackUrl: 'my-app://renderer/?code=123',
+    });
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, protocol, shell } from 'electron';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAUTH_TRANSPORT_CHANNELS, PASSKEY_CHANNELS } from '../../shared/ipc';
 import type { TokenStorage } from '../../shared/types';
@@ -7,8 +7,10 @@ import { createClerkBridge } from '../create-clerk-bridge';
 
 vi.mock('electron', () => ({
   app: {
+    hasSingleInstanceLock: vi.fn(() => false),
     on: vi.fn(),
     quit: vi.fn(),
+    releaseSingleInstanceLock: vi.fn(),
     removeListener: vi.fn(),
     requestSingleInstanceLock: vi.fn(() => true),
     setAsDefaultProtocolClient: vi.fn(),
@@ -42,7 +44,6 @@ const mainFrameEvent = { sender: windowSender, senderFrame: mainFrame } as unkno
 const subframeEvent = { sender: windowSender, senderFrame: {} } as unknown as Electron.IpcMainInvokeEvent;
 
 describe('createClerkBridge', () => {
-  const originalArgv = process.argv;
   const missingStorage = {} as Parameters<typeof createClerkBridge>[0];
   const storage: TokenStorage = {
     getItem: vi.fn(),
@@ -52,14 +53,10 @@ describe('createClerkBridge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.argv = originalArgv;
+    vi.mocked(app.hasSingleInstanceLock).mockReturnValue(false);
     vi.mocked(app.requestSingleInstanceLock).mockReturnValue(true);
     app.userAgentFallback =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
-  });
-
-  afterEach(() => {
-    process.argv = originalArgv;
   });
 
   it('requires a storage adapter', () => {
@@ -282,6 +279,35 @@ describe('createClerkBridge', () => {
     expect(app.setAsDefaultProtocolClient).not.toHaveBeenCalled();
   });
 
+  it('reuses a single-instance lock acquired by the application', () => {
+    vi.mocked(app.hasSingleInstanceLock).mockReturnValue(true);
+
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+    clerk.cleanup();
+
+    expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(app.releaseSingleInstanceLock).not.toHaveBeenCalled();
+  });
+
+  it('releases the single-instance lock acquired by the bridge during cleanup', () => {
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+    clerk.cleanup();
+
+    expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
   it('derives the OAuth callback URL from the renderer origin', () => {
     createClerkBridge({
       storage,
@@ -394,26 +420,5 @@ describe('createClerkBridge', () => {
     ]);
 
     await expect(openPromise).resolves.toEqual({ callbackUrl: 'my-app://renderer/?code=123' });
-  });
-
-  it('resolves OAuth from a matching cold-start argument without reopening the browser', async () => {
-    process.argv = ['/opt/MyApp/my-app', 'my-app://renderer/?code=123'];
-    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
-    createClerkBridge({
-      storage,
-      renderer: {
-        host: 'renderer',
-        scheme: 'my-app',
-      },
-    });
-
-    const openHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
-      return channel === OAUTH_TRANSPORT_CHANNELS.open;
-    })?.[1];
-
-    await expect(openHandler?.(mainFrameEvent, 'https://accounts.example.com/oauth')).resolves.toEqual({
-      callbackUrl: 'my-app://renderer/?code=123',
-    });
-    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
+++ b/packages/electron/src/main/__tests__/create-clerk-bridge.test.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, protocol, shell } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { OAUTH_TRANSPORT_CHANNELS, PASSKEY_CHANNELS } from '../../shared/ipc';
+import { OAUTH_TRANSPORT_CHANNELS, PASSKEY_CHANNELS, TOKEN_CACHE_CHANNELS } from '../../shared/ipc';
 import type { TokenStorage } from '../../shared/types';
 import { createClerkBridge } from '../create-clerk-bridge';
 
@@ -41,6 +41,11 @@ vi.mock('@clerk/electron-passkeys', () => ({
   },
 }));
 
+const originalPlatform = process.platform;
+const setPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+};
+
 const createRendererWindow = () => ({
   isDestroyed: vi.fn(() => false),
   isMinimized: vi.fn(() => false),
@@ -63,6 +68,8 @@ describe('createClerkBridge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // The single-instance lock is only used where `second-instance` delivers the callback.
+    setPlatform('linux');
     vi.mocked(app.hasSingleInstanceLock).mockReturnValue(false);
     vi.mocked(app.requestSingleInstanceLock).mockReturnValue(true);
     vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(null);
@@ -72,6 +79,7 @@ describe('createClerkBridge', () => {
   });
 
   afterEach(() => {
+    setPlatform(originalPlatform);
     vi.restoreAllMocks();
   });
 
@@ -282,7 +290,7 @@ describe('createClerkBridge', () => {
   it('quits a secondary instance before registering IPC handlers', () => {
     vi.mocked(app.requestSingleInstanceLock).mockReturnValue(false);
 
-    createClerkBridge({
+    const clerk = createClerkBridge({
       storage,
       renderer: {
         host: 'renderer',
@@ -290,9 +298,56 @@ describe('createClerkBridge', () => {
       },
     });
 
+    expect(clerk.isPrimaryInstance).toBe(false);
     expect(app.quit).toHaveBeenCalledOnce();
     expect(ipcMain.handle).not.toHaveBeenCalled();
     expect(app.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+  });
+
+  it('reports the primary instance when the bridge finishes setup', () => {
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+
+    expect(clerk.isPrimaryInstance).toBe(true);
+  });
+
+  it('does not touch the single-instance lock on macOS', () => {
+    setPlatform('darwin');
+
+    const clerk = createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+    });
+    clerk.cleanup();
+
+    expect(clerk.isPrimaryInstance).toBe(true);
+    expect(app.hasSingleInstanceLock).not.toHaveBeenCalled();
+    expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(app.releaseSingleInstanceLock).not.toHaveBeenCalled();
+    expect(ipcMain.handle).toHaveBeenCalledWith(OAUTH_TRANSPORT_CHANNELS.open, expect.any(Function));
+  });
+
+  it('does not warn about disabled lock management on macOS', () => {
+    setPlatform('darwin');
+
+    createClerkBridge({
+      storage,
+      renderer: {
+        host: 'renderer',
+        scheme: 'my-app',
+      },
+      manageSingleInstanceLock: false,
+    });
+
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('reuses a single-instance lock acquired by the application', () => {
@@ -361,6 +416,49 @@ describe('createClerkBridge', () => {
   it('releases the single-instance lock when initialization throws', () => {
     vi.mocked(protocol.registerSchemesAsPrivileged).mockImplementationOnce(() => {
       throw new Error('Scheme was already registered');
+    });
+
+    expect(() =>
+      createClerkBridge({
+        storage,
+        renderer: {
+          host: 'renderer',
+          scheme: 'my-app',
+        },
+      }),
+    ).toThrow('Scheme was already registered');
+
+    expect(app.releaseSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
+  it('tears down handlers registered before initialization throws', () => {
+    vi.mocked(protocol.registerSchemesAsPrivileged).mockImplementationOnce(() => {
+      throw new Error('Scheme was already registered');
+    });
+
+    expect(() =>
+      createClerkBridge({
+        storage,
+        passkeys: true,
+        renderer: {
+          host: 'renderer',
+          scheme: 'my-app',
+        },
+      }),
+    ).toThrow('Scheme was already registered');
+
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.getToken);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.saveToken);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(TOKEN_CACHE_CHANNELS.clearToken);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(PASSKEY_CHANNELS.create);
+  });
+
+  it('surfaces the initialization error when a teardown also throws', () => {
+    vi.mocked(protocol.registerSchemesAsPrivileged).mockImplementationOnce(() => {
+      throw new Error('Scheme was already registered');
+    });
+    vi.mocked(ipcMain.removeHandler).mockImplementationOnce(() => {
+      throw new Error('Handler was already removed');
     });
 
     expect(() =>

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -52,7 +52,9 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
 
   if (options.renderer) {
     assertValidRendererOriginConfig(options.renderer);
+  }
 
+  if (options.renderer && options.manageSingleInstanceLock !== false) {
     if (!app.hasSingleInstanceLock()) {
       if (!app.requestSingleInstanceLock()) {
         app.quit();

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -48,6 +48,15 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
     );
   }
 
+  if (options.renderer) {
+    assertValidRendererOriginConfig(options.renderer);
+
+    if (!app.requestSingleInstanceLock()) {
+      app.quit();
+      return { cleanup() {} };
+    }
+  }
+
   const cleanupTokenPersistence = setupTokenCacheIpcHandlers(options.storage);
   let cleanupOAuthTransport: (() => void) | undefined;
   const passkeys = options.passkeys ? setupPasskeysMain() : null;
@@ -57,8 +66,6 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
   }
 
   if (options.renderer) {
-    assertValidRendererOriginConfig(options.renderer);
-
     protocol.registerSchemesAsPrivileged([
       {
         scheme: options.renderer.scheme,

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -80,8 +80,18 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
 
   const teardowns: Array<() => void> = [];
   const runTeardowns = (): void => {
+    const errors: unknown[] = [];
+
     while (teardowns.length > 0) {
-      teardowns.pop()?.();
+      try {
+        teardowns.pop()?.();
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+
+    if (errors.length > 0) {
+      throw errors[0];
     }
   };
 

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -53,14 +53,16 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
   if (options.renderer) {
     assertValidRendererOriginConfig(options.renderer);
 
-    if (!app.hasSingleInstanceLock()) {
+    // macOS routes deep links to the running instance through `open-url`, so the lock is only needed
+    // where `second-instance` is the delivery path.
+    if (process.platform !== 'darwin' && !app.hasSingleInstanceLock()) {
       if (options.manageSingleInstanceLock === false) {
         console.warn(
           "Clerk: manageSingleInstanceLock is false but the application does not hold Electron's single-instance lock. OAuth deep-link callbacks cannot be delivered on Windows or Linux until it is acquired.",
         );
       } else if (!app.requestSingleInstanceLock()) {
         app.quit();
-        return { cleanup() {} };
+        return { cleanup() {}, isPrimaryInstance: false };
       } else {
         ownsSingleInstanceLock = true;
       }
@@ -76,10 +78,20 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
     app.releaseSingleInstanceLock();
   };
 
+  const teardowns: Array<() => void> = [];
+  const runTeardowns = (): void => {
+    while (teardowns.length > 0) {
+      teardowns.pop()?.();
+    }
+  };
+
   try {
-    const cleanupTokenPersistence = setupTokenCacheIpcHandlers(options.storage);
-    let cleanupOAuthTransport: (() => void) | undefined;
-    const passkeys = options.passkeys ? setupPasskeysMain() : null;
+    teardowns.push(setupTokenCacheIpcHandlers(options.storage));
+
+    if (options.passkeys) {
+      const passkeys = setupPasskeysMain();
+      teardowns.push(() => passkeys.cleanup());
+    }
 
     if (options.userAgent) {
       app.userAgentFallback = buildUserAgentFallback(app.userAgentFallback, options.userAgent);
@@ -100,23 +112,30 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
         },
       ]);
 
-      cleanupOAuthTransport = setupOAuthTransportIpcHandlers({
-        renderer: options.renderer,
-      });
+      teardowns.push(
+        setupOAuthTransportIpcHandlers({
+          renderer: options.renderer,
+        }),
+      );
     }
 
     return {
+      isPrimaryInstance: true,
       cleanup() {
         try {
-          cleanupTokenPersistence();
-          cleanupOAuthTransport?.();
-          passkeys?.cleanup();
+          runTeardowns();
         } finally {
           releaseSingleInstanceLock();
         }
       },
     };
   } catch (err) {
+    try {
+      runTeardowns();
+    } catch {
+      // The initialization error is the one worth surfacing.
+    }
+
     releaseSingleInstanceLock();
     throw err;
   }

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -48,12 +48,18 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
     );
   }
 
+  let ownsSingleInstanceLock = false;
+
   if (options.renderer) {
     assertValidRendererOriginConfig(options.renderer);
 
-    if (!app.requestSingleInstanceLock()) {
-      app.quit();
-      return { cleanup() {} };
+    if (!app.hasSingleInstanceLock()) {
+      if (!app.requestSingleInstanceLock()) {
+        app.quit();
+        return { cleanup() {} };
+      }
+
+      ownsSingleInstanceLock = true;
     }
   }
 
@@ -90,6 +96,10 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
       cleanupTokenPersistence();
       cleanupOAuthTransport?.();
       passkeys?.cleanup();
+
+      if (ownsSingleInstanceLock) {
+        app.releaseSingleInstanceLock();
+      }
     },
   };
 }

--- a/packages/electron/src/main/create-clerk-bridge.ts
+++ b/packages/electron/src/main/create-clerk-bridge.ts
@@ -52,56 +52,72 @@ export function createClerkBridge(options: CreateClerkBridgeOptions): ClerkBridg
 
   if (options.renderer) {
     assertValidRendererOriginConfig(options.renderer);
-  }
 
-  if (options.renderer && options.manageSingleInstanceLock !== false) {
     if (!app.hasSingleInstanceLock()) {
-      if (!app.requestSingleInstanceLock()) {
+      if (options.manageSingleInstanceLock === false) {
+        console.warn(
+          "Clerk: manageSingleInstanceLock is false but the application does not hold Electron's single-instance lock. OAuth deep-link callbacks cannot be delivered on Windows or Linux until it is acquired.",
+        );
+      } else if (!app.requestSingleInstanceLock()) {
         app.quit();
         return { cleanup() {} };
+      } else {
+        ownsSingleInstanceLock = true;
       }
-
-      ownsSingleInstanceLock = true;
     }
   }
 
-  const cleanupTokenPersistence = setupTokenCacheIpcHandlers(options.storage);
-  let cleanupOAuthTransport: (() => void) | undefined;
-  const passkeys = options.passkeys ? setupPasskeysMain() : null;
+  const releaseSingleInstanceLock = (): void => {
+    if (!ownsSingleInstanceLock) {
+      return;
+    }
 
-  if (options.userAgent) {
-    app.userAgentFallback = buildUserAgentFallback(app.userAgentFallback, options.userAgent);
-  }
-
-  if (options.renderer) {
-    protocol.registerSchemesAsPrivileged([
-      {
-        scheme: options.renderer.scheme,
-        privileges: {
-          standard: true,
-          secure: true,
-          supportFetchAPI: true,
-          corsEnabled: true,
-          stream: true,
-          ...options.renderer.privileges,
-        },
-      },
-    ]);
-
-    cleanupOAuthTransport = setupOAuthTransportIpcHandlers({
-      renderer: options.renderer,
-    });
-  }
-
-  return {
-    cleanup() {
-      cleanupTokenPersistence();
-      cleanupOAuthTransport?.();
-      passkeys?.cleanup();
-
-      if (ownsSingleInstanceLock) {
-        app.releaseSingleInstanceLock();
-      }
-    },
+    ownsSingleInstanceLock = false;
+    app.releaseSingleInstanceLock();
   };
+
+  try {
+    const cleanupTokenPersistence = setupTokenCacheIpcHandlers(options.storage);
+    let cleanupOAuthTransport: (() => void) | undefined;
+    const passkeys = options.passkeys ? setupPasskeysMain() : null;
+
+    if (options.userAgent) {
+      app.userAgentFallback = buildUserAgentFallback(app.userAgentFallback, options.userAgent);
+    }
+
+    if (options.renderer) {
+      protocol.registerSchemesAsPrivileged([
+        {
+          scheme: options.renderer.scheme,
+          privileges: {
+            standard: true,
+            secure: true,
+            supportFetchAPI: true,
+            corsEnabled: true,
+            stream: true,
+            ...options.renderer.privileges,
+          },
+        },
+      ]);
+
+      cleanupOAuthTransport = setupOAuthTransportIpcHandlers({
+        renderer: options.renderer,
+      });
+    }
+
+    return {
+      cleanup() {
+        try {
+          cleanupTokenPersistence();
+          cleanupOAuthTransport?.();
+          passkeys?.cleanup();
+        } finally {
+          releaseSingleInstanceLock();
+        }
+      },
+    };
+  } catch (err) {
+    releaseSingleInstanceLock();
+    throw err;
+  }
 }

--- a/packages/electron/src/main/oauth-transport.ts
+++ b/packages/electron/src/main/oauth-transport.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
 
 import { OAUTH_TRANSPORT_CHANNELS } from '../shared/ipc';
 import type { RendererSchemeOptions } from '../shared/types';
@@ -10,6 +10,7 @@ type PendingOAuthFlow = {
   resolve: (value: { callbackUrl: string }) => void;
   reject: (reason: Error) => void;
   timeout: NodeJS.Timeout;
+  window: Electron.BrowserWindow | null;
 };
 
 type OAuthTransportOptions = {
@@ -37,6 +38,19 @@ function isMatchingCallbackUrl(url: string, redirectUrl: string): boolean {
 
 function findMatchingCallbackUrl(argv: string[], redirectUrl: string): string | undefined {
   return argv.find(url => isMatchingCallbackUrl(url, redirectUrl));
+}
+
+// Windows and Linux deliver the callback to a background process; macOS activates the app itself.
+function focusWindow(window: Electron.BrowserWindow | null): void {
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+
+  if (window.isMinimized()) {
+    window.restore();
+  }
+
+  window.focus();
 }
 
 function assertExternalOAuthUrl(url: string): void {
@@ -72,6 +86,7 @@ export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): 
 
     const pending = pendingOAuthFlow;
     disposePendingOAuthFlow();
+    focusWindow(pending.window);
     pending.resolve({ callbackUrl: url });
   };
 
@@ -114,13 +129,15 @@ export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): 
 
     assertExternalOAuthUrl(url);
 
+    const window = BrowserWindow.fromWebContents(event.sender);
+
     const callbackPromise = new Promise<{ callbackUrl: string }>((resolve, reject) => {
       const timeout = setTimeout(() => {
         disposePendingOAuthFlow();
         reject(new Error('Clerk: OAuth callback timed out.'));
       }, CALLBACK_TIMEOUT_MS);
 
-      pendingOAuthFlow = { resolve, reject, timeout };
+      pendingOAuthFlow = { resolve, reject, timeout, window };
     });
 
     try {

--- a/packages/electron/src/main/oauth-transport.ts
+++ b/packages/electron/src/main/oauth-transport.ts
@@ -49,7 +49,6 @@ function assertExternalOAuthUrl(url: string): void {
 
 export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): () => void {
   const redirectUrl = buildRedirectUrl(options);
-  let initialCallbackUrl = findMatchingCallbackUrl(process.argv, redirectUrl);
   let pendingOAuthFlow: PendingOAuthFlow | null = null;
 
   const disposePendingOAuthFlow = (reason?: Error): void => {
@@ -123,13 +122,6 @@ export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): 
 
       pendingOAuthFlow = { resolve, reject, timeout };
     });
-
-    if (initialCallbackUrl) {
-      const callbackUrl = initialCallbackUrl;
-      initialCallbackUrl = undefined;
-      handleCallbackUrl(callbackUrl);
-      return callbackPromise;
-    }
 
     try {
       await shell.openExternal(url);

--- a/packages/electron/src/main/oauth-transport.ts
+++ b/packages/electron/src/main/oauth-transport.ts
@@ -35,6 +35,10 @@ function isMatchingCallbackUrl(url: string, redirectUrl: string): boolean {
   }
 }
 
+function findMatchingCallbackUrl(argv: string[], redirectUrl: string): string | undefined {
+  return argv.find(url => isMatchingCallbackUrl(url, redirectUrl));
+}
+
 function assertExternalOAuthUrl(url: string): void {
   const parsedUrl = new URL(url);
 
@@ -45,6 +49,7 @@ function assertExternalOAuthUrl(url: string): void {
 
 export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): () => void {
   const redirectUrl = buildRedirectUrl(options);
+  let initialCallbackUrl = findMatchingCallbackUrl(process.argv, redirectUrl);
   let pendingOAuthFlow: PendingOAuthFlow | null = null;
 
   const disposePendingOAuthFlow = (reason?: Error): void => {
@@ -81,7 +86,7 @@ export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): 
   };
 
   const secondInstanceListener = (_event: Electron.Event, argv: string[]): void => {
-    const callbackUrl = argv.find(url => isMatchingCallbackUrl(url, redirectUrl));
+    const callbackUrl = findMatchingCallbackUrl(argv, redirectUrl);
 
     if (callbackUrl) {
       handleCallbackUrl(callbackUrl);
@@ -118,6 +123,13 @@ export function setupOAuthTransportIpcHandlers(options: OAuthTransportOptions): 
 
       pendingOAuthFlow = { resolve, reject, timeout };
     });
+
+    if (initialCallbackUrl) {
+      const callbackUrl = initialCallbackUrl;
+      initialCallbackUrl = undefined;
+      handleCallbackUrl(callbackUrl);
+      return callbackPromise;
+    }
 
     try {
       await shell.openExternal(url);

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -19,7 +19,8 @@ export type CreateClerkBridgeOptions = {
   renderer?: RendererSchemeOptions;
   /**
    * Whether Clerk should acquire and release Electron's process-wide single-instance lock for OAuth
-   * deep links. Set this to `false` when the application manages the lock itself.
+   * deep links. Set this to `false` when the application manages the lock itself. Ignored on macOS,
+   * where deep links reach the running instance through `open-url`.
    *
    * @default true
    */
@@ -50,6 +51,13 @@ export type ClerkBridge = {
    * Removes IPC handlers and listeners registered by `createClerkBridge`.
    */
   cleanup: () => void;
+  /**
+   * Whether this process is the one the application should keep booting. `false` only when Clerk
+   * detected a secondary instance, forwarded its deep-link arguments to the primary, and called
+   * `app.quit()`. Because `app.quit()` is asynchronous, skip window creation and the rest of the
+   * bootstrap when this is `false`.
+   */
+  isPrimaryInstance: boolean;
 };
 
 export type RendererSchemeOptions = CustomScheme & {

--- a/packages/electron/src/shared/types.ts
+++ b/packages/electron/src/shared/types.ts
@@ -18,6 +18,13 @@ export type CreateClerkBridgeOptions = {
    */
   renderer?: RendererSchemeOptions;
   /**
+   * Whether Clerk should acquire and release Electron's process-wide single-instance lock for OAuth
+   * deep links. Set this to `false` when the application manages the lock itself.
+   *
+   * @default true
+   */
+  manageSingleInstanceLock?: boolean;
+  /**
    * Registers the IPC handlers for native passkey ceremonies. Native support also requires
    * the optional `@clerk/electron-passkeys` package and `exposeClerkBridge({ passkeys: true })`.
    */


### PR DESCRIPTION
## Description

Acquire Electron’s single-instance lock for OAuth deep links and forward secondary-instance callbacks to the primary process. Hosts that manage the process-wide lock can opt out with `manageSingleInstanceLock: false`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: