### PR TITLE
fix(*): resolve appearance against the Ui appearance type instead of Ui

### DIFF
--- a/.changeset/tame-donuts-shake.md
+++ b/.changeset/tame-donuts-shake.md
@@ -1,0 +1,6 @@
+---
+'@clerk/astro': patch
+'@clerk/vue': patch
+---
+
+Fix the `appearance` option rejecting valid properties such as `theme`, `variables`, and `elements` with a "does not exist in type `Appearance<Ui>`" TypeScript error. This also affects `@clerk/nuxt`, which derives its module options from `@clerk/vue`.

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -9,10 +9,10 @@ import type {
   Without,
 } from '@clerk/shared/types';
 import type { ClerkUIConstructor } from '@clerk/shared/ui';
-import type { Appearance, Ui } from '@clerk/ui/internal';
+import type { Appearance, ExtractAppearanceType, Ui } from '@clerk/ui/internal';
 
 type AstroClerkUpdateOptions<TUi extends Ui = Ui> = Pick<ClerkOptions, 'localization'> & {
-  appearance?: Appearance<TUi>;
+  appearance?: ExtractAppearanceType<TUi, Appearance>;
 };
 
 type AstroClerkIntegrationParams<TUi extends Ui = Ui> = Without<
@@ -29,7 +29,7 @@ type AstroClerkIntegrationParams<TUi extends Ui = Ui> = Without<
   | 'appearance'
 > &
   MultiDomainAndOrProxyPrimitives & {
-    appearance?: Appearance<TUi>;
+    appearance?: ExtractAppearanceType<TUi, Appearance>;
     /**
      * Controls prefetching of the `@clerk/ui` script.
      * - `false` - Skip prefetching the UI (for custom UIs using Control Components)

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -13,7 +13,7 @@ import type {
   Without,
 } from '@clerk/shared/types';
 import type { ClerkUIConstructor } from '@clerk/shared/ui';
-import type { Appearance, Ui } from '@clerk/ui/internal';
+import type { Appearance, ExtractAppearanceType, Ui } from '@clerk/ui/internal';
 import type { Plugin } from 'vue';
 import { computed, ref, shallowRef, triggerRef } from 'vue';
 
@@ -30,7 +30,7 @@ export type PluginOptions<TUi extends Ui = Ui> = Without<
 > &
   MultiDomainAndOrProxy & {
     initialState?: InitialState;
-    appearance?: Appearance<TUi>;
+    appearance?: ExtractAppearanceType<TUi, Appearance>;
     /**
      * An object to use the bundled Clerk UI instead of loading from CDN.
      * Import `ui` from `@clerk/ui` and pass it here to bundle the UI with your application.

--- a/packages/vue/src/utils/updateClerkOptions.ts
+++ b/packages/vue/src/utils/updateClerkOptions.ts
@@ -1,8 +1,8 @@
 import type { ClerkOptions } from '@clerk/shared/types';
-import type { Appearance, Ui } from '@clerk/ui/internal';
+import type { Appearance, ExtractAppearanceType, Ui } from '@clerk/ui/internal';
 
 type ClerkUpdateOptions<TUi extends Ui = Ui> = Pick<ClerkOptions, 'localization'> & {
-  appearance?: Appearance<TUi>;
+  appearance?: ExtractAppearanceType<TUi, Appearance>;
 };
 
 /**


### PR DESCRIPTION
`Appearance<T>` is generic over the theme type, but `@clerk/vue` and `@clerk/astro` passed the `Ui` type into it. That resolved to `Ui & GlobalAppearanceOptions & { signIn?: Ui, ... }`, which has none of `theme`, `variables`, `elements` or `options`, so every appearance object was rejected. `@clerk/nuxt` inherits this via `PluginOptions`.

Use `ExtractAppearanceType<TUi, Appearance>`, as `@clerk/react` already does.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
