### PR TITLE
fix(e2e): Stop relying on startVerification to reset fva in reverification tests

### DIFF
--- a/integration/tests/reverification.test.ts
+++ b/integration/tests/reverification.test.ts
@@ -231,21 +231,24 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // FAPI no longer resets fva when a verification starts (USER-5572), so wait
-        // for the signed-in factor to age past the action's afterMinutes threshold.
+        // Starting a verification no longer resets fva server-side, so wait for the
+        // signed-in factor to age past the action's afterMinutes threshold.
         await u.po.expect.toBeSignedIn();
-        await page.waitForFunction(
-          async () => {
-            const token = await window.Clerk.session?.getToken({ skipCache: true });
-            if (!token) {
-              return false;
-            }
-            const { fva } = JSON.parse(atob(token.split('.')[1]));
-            return Array.isArray(fva) && fva[0] >= 1;
-          },
-          null,
-          { polling: 5_000, timeout: 120_000 },
-        );
+        await expect
+          .poll(
+            () =>
+              page.evaluate(async () => {
+                const token = await window.Clerk.session?.getToken({ skipCache: true });
+                if (!token) {
+                  return -1;
+                }
+                const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+                const { fva } = JSON.parse(atob(payload));
+                return Array.isArray(fva) ? fva[0] : -1;
+              }),
+            { intervals: [5_000], timeout: 120_000 },
+          )
+          .toBeGreaterThanOrEqual(1);
         await u.page.goToRelative(`/requires-re-verification`);
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(
@@ -272,21 +275,24 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // FAPI no longer resets fva when a verification starts (USER-5572), so wait
-        // for the signed-in factor to age past the action's afterMinutes threshold.
+        // Starting a verification no longer resets fva server-side, so wait for the
+        // signed-in factor to age past the action's afterMinutes threshold.
         await u.po.expect.toBeSignedIn();
-        await page.waitForFunction(
-          async () => {
-            const token = await window.Clerk.session?.getToken({ skipCache: true });
-            if (!token) {
-              return false;
-            }
-            const { fva } = JSON.parse(atob(token.split('.')[1]));
-            return Array.isArray(fva) && fva[0] >= 1;
-          },
-          null,
-          { polling: 5_000, timeout: 120_000 },
-        );
+        await expect
+          .poll(
+            () =>
+              page.evaluate(async () => {
+                const token = await window.Clerk.session?.getToken({ skipCache: true });
+                if (!token) {
+                  return -1;
+                }
+                const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+                const { fva } = JSON.parse(atob(payload));
+                return Array.isArray(fva) ? fva[0] : -1;
+              }),
+            { intervals: [5_000], timeout: 120_000 },
+          )
+          .toBeGreaterThanOrEqual(1);
 
         await u.page.goToRelative(`/action-with-use-reverification`);
         await u.po.expect.toBeSignedIn();

--- a/integration/tests/reverification.test.ts
+++ b/integration/tests/reverification.test.ts
@@ -231,8 +231,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // Starting a verification no longer resets fva server-side, so wait for the
-        // signed-in factor to age past the action's afterMinutes threshold.
+        // startVerification no longer resets fva server-side, so age the signed-in factor past afterMinutes
         await u.po.expect.toBeSignedIn();
         await expect
           .poll(
@@ -243,8 +242,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
                   return -1;
                 }
                 const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
-                const { fva } = JSON.parse(atob(payload));
-                return Array.isArray(fva) ? fva[0] : -1;
+                return JSON.parse(atob(payload)).fva?.[0] ?? -1;
               }),
             { intervals: [5_000], timeout: 120_000 },
           )
@@ -275,8 +273,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // Starting a verification no longer resets fva server-side, so wait for the
-        // signed-in factor to age past the action's afterMinutes threshold.
+        // startVerification no longer resets fva server-side, so age the signed-in factor past afterMinutes
         await u.po.expect.toBeSignedIn();
         await expect
           .poll(
@@ -287,8 +284,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
                   return -1;
                 }
                 const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
-                const { fva } = JSON.parse(atob(payload));
-                return Array.isArray(fva) ? fva[0] : -1;
+                return JSON.parse(atob(payload)).fva?.[0] ?? -1;
               }),
             { intervals: [5_000], timeout: 120_000 },
           )

--- a/integration/tests/reverification.test.ts
+++ b/integration/tests/reverification.test.ts
@@ -231,13 +231,21 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // Hack to reset fva
+        // FAPI no longer resets fva when a verification starts (USER-5572), so wait
+        // for the signed-in factor to age past the action's afterMinutes threshold.
         await u.po.expect.toBeSignedIn();
-        await page.evaluate(async () => {
-          return window.Clerk.session.startVerification({
-            level: 'first_factor',
-          });
-        });
+        await page.waitForFunction(
+          async () => {
+            const token = await window.Clerk.session?.getToken({ skipCache: true });
+            if (!token) {
+              return false;
+            }
+            const { fva } = JSON.parse(atob(token.split('.')[1]));
+            return Array.isArray(fva) && fva[0] >= 1;
+          },
+          null,
+          { polling: 5_000, timeout: 120_000 },
+        );
         await u.page.goToRelative(`/requires-re-verification`);
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(
@@ -248,6 +256,7 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
       });
 
       test(`reverification recovery from ${capitalize(type)}`, async ({ page, context }) => {
+        test.setTimeout(270_000);
         const u = createTestUtils({ app, page, context });
 
         await u.po.signIn.goTo();
@@ -263,13 +272,21 @@ testAgainstRunningApps({ withEnv: [appConfigs.envs.withReverification] })(
         await u.page.getByRole('button', { name: /LogUserId/i }).click();
         await expect(u.page.getByText(/\{\s*"userId"\s*:\s*"user_[^"]+"\s*\}/i)).toBeVisible();
 
-        // Hack to reset fva
+        // FAPI no longer resets fva when a verification starts (USER-5572), so wait
+        // for the signed-in factor to age past the action's afterMinutes threshold.
         await u.po.expect.toBeSignedIn();
-        await page.evaluate(async () => {
-          return window.Clerk.session.startVerification({
-            level: 'first_factor',
-          });
-        });
+        await page.waitForFunction(
+          async () => {
+            const token = await window.Clerk.session?.getToken({ skipCache: true });
+            if (!token) {
+              return false;
+            }
+            const { fva } = JSON.parse(atob(token.split('.')[1]));
+            return Array.isArray(fva) && fva[0] >= 1;
+          },
+          null,
+          { polling: 5_000, timeout: 120_000 },
+        );
 
         await u.page.goToRelative(`/action-with-use-reverification`);
         await u.po.expect.toBeSignedIn();


### PR DESCRIPTION
## Description

Starting a session verification no longer resets the session's `fva` (recent server-side hardening), so the `// Hack to reset fva` in the Action reverification tests stopped working and both tests fail deterministically.

This PR replaces the hack with polling a fresh token until `fva` ages past the action's `afterMinutes: 1` threshold.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
