### PR TITLE
fix(clerk-js): complete the Safari ITP touch hop in redirect

### DIFF
--- a/.changeset/smart-jars-repeat.md
+++ b/.changeset/smart-jars-repeat.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Complete the Safari ITP cookie refresh when `setActive({ redirectUrl })` navigates.
+
+Safari's ITP caps the client cookie at 7 days when it is re-issued from a fetch, so `setActive()` routes its redirect through `/v1/client/touch` to restore the full lifetime. That navigation was immediately followed by a second one to the undecorated redirect URL, which superseded it and aborted the touch request before it completed, leaving the cookie capped.
+
+This applies to flows that pass `redirectUrl` without a `navigate` callback — email link sign-in, the password reset success screen, the OAuth popup flow, and direct `setActive({ session, redirectUrl })` calls — in apps where Clerk performs a full page navigation rather than handing off to a router. Users still landed on the correct page, so the only symptom was Safari sessions ending after 7 days and returning devices being challenged as if they were new.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -349,6 +349,8 @@ describe('Clerk singleton', () => {
         const redirectUrl = new URL((sut.navigate as ReturnType<typeof vi.fn>).mock.calls[0][0]);
         expect(redirectUrl.pathname).toEqual('/v1/client/touch');
         expect(redirectUrl.searchParams.get('redirect_url')).toEqual(`${mockWindowLocation.href}/redirect-url-path`);
+        // A second navigate would supersede the touch hop and abort it before it completes.
+        expect(sut.navigate).toHaveBeenCalledTimes(1);
       });
 
       it('does not redirect the user to the /v1/client/touch endpoint if the cookie_expires_at is more than 8 days away', async () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1864,14 +1864,7 @@ export class Clerk implements ClerkInterface {
               );
             }
           } else if (redirectUrl) {
-            if (this.client.isEligibleForTouch()) {
-              const absoluteRedirectUrl = new URL(redirectUrl, window.location.href);
-              const redirectUrlWithAuth = this.buildUrlWithAuth(
-                this.client.buildTouchUrl({ redirectUrl: absoluteRedirectUrl }),
-              );
-              await this.navigate(redirectUrlWithAuth);
-            }
-            await this.navigate(redirectUrl);
+            await this.navigate(this.#decorateUrlWithTouch(redirectUrl));
           }
         });
       }


### PR DESCRIPTION
The `else if (redirectUrl)` branch navigated to `/v1/client/touch` and then immediately navigated again to the undecorated redirect URL. Where both resolve to a hard navigation, the second assignment supersedes the first and the touch request is aborted, so the client cookie is never extended past ITP's 7 day cap.

This was a regression that was accidentally introduced in https://github.com/clerk/javascript/pull/6486/changes#diff-1952d6b8ac4b5495e1dba57c32bff9ce72d43f83595c1bc8532a76cf31feb753L1314 11 months ago, when an `else` in a nested control flow was accidentally dropped. I suspect it was not reported because Safari use is less common and the sign out would have only occurred after 7 days.

Route the redirect through the shared #decorateUrlWithTouch helper instead, which returns the URL unchanged when the client is not eligible.

The existing test asserted only navigate.mock.calls[0][0], so it stayed green across the regression; it now also asserts navigate is called exactly once.

## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
