### PR TITLE
Superseded by #9326

### DIFF
--- a/.changeset/core-3558-remove-password.md
+++ b/.changeset/core-3558-remove-password.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add `clerkClient.users.removePassword(userId, params?)` to remove a user's password through the Backend API. Existing sessions remain active by default; pass `{ signOutOfOtherSessions: true }` to revoke them.

--- a/packages/backend/src/api/__tests__/UserApi.test.ts
+++ b/packages/backend/src/api/__tests__/UserApi.test.ts
@@ -176,4 +176,37 @@ describe('UserAPI', () => {
       expect(response.publicMetadata).toEqual({ replaced: true });
     });
   });
+
+  describe('removePassword', () => {
+    it('calls POST /users/{id}/remove_password without a request body by default', async () => {
+      const postHandler = vi.fn(async ({ request }: { request: Request }) => {
+        expect(await request.text()).toBe('');
+        return HttpResponse.json(mockUserResponse);
+      });
+
+      server.use(http.post('https://api.clerk.test/v1/users/user_123/remove_password', validateHeaders(postHandler)));
+
+      const response = await apiClient.users.removePassword('user_123');
+
+      expect(postHandler).toHaveBeenCalledTimes(1);
+      expect(response.id).toBe('user_123');
+    });
+
+    it('passes signOutOfOtherSessions in the request body', async () => {
+      const postHandler = vi.fn(async ({ request }: { request: Request }) => {
+        expect(await request.json()).toEqual({ sign_out_of_other_sessions: true });
+        return HttpResponse.json(mockUserResponse);
+      });
+
+      server.use(http.post('https://api.clerk.test/v1/users/user_123/remove_password', validateHeaders(postHandler)));
+
+      await apiClient.users.removePassword('user_123', { signOutOfOtherSessions: true });
+
+      expect(postHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('requires a user ID', async () => {
+      await expect(apiClient.users.removePassword('')).rejects.toThrow('A valid resource ID is required.');
+    });
+  });
 });

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -366,6 +366,12 @@ export type VerifyPasswordParams = {
   password: string;
 };
 
+/** @inline */
+export type RemovePasswordParams = {
+  /** When set to `true`, all of the user's active sessions are revoked after their password is removed. Defaults to `false`. */
+  signOutOfOtherSessions?: boolean;
+};
+
 /** @generateWithEmptyComment */
 export type VerifyTOTPParams = {
   /** The ID of the user to verify the TOTP for. */
@@ -694,6 +700,39 @@ export class UserAPI extends AbstractAPI {
       method: 'GET',
       path: joinPaths(basePath, userId, 'organization_invitations'),
       queryParams,
+    });
+  }
+
+  /**
+   * Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+   *
+   * By default, existing sessions remain active. Set `signOutOfOtherSessions` to `true` to revoke sessions active when the request is processed.
+   * @param userId - The ID of the user whose password to remove.
+   * @param params - Options for the request.
+   * @returns The updated [`User`](https://clerk.com/docs/reference/backend/types/backend-user).
+   * @example
+   * ### Keep existing sessions active
+   *
+   * ```ts
+   * const user = await clerkClient.users.removePassword('user_123');
+   * ```
+   *
+   * @example
+   * ### Revoke existing sessions
+   *
+   * ```ts
+   * const user = await clerkClient.users.removePassword('user_123', {
+   *   signOutOfOtherSessions: true,
+   * });
+   * ```
+   */
+  public async removePassword(userId: string, params: RemovePasswordParams = {}) {
+    this.requireId(userId);
+
+    return this.request<User>({
+      method: 'POST',
+      path: joinPaths(basePath, userId, 'remove_password'),
+      bodyParams: params,
     });
   }
 


### PR DESCRIPTION
Superseded by [#9326](https://github.com/clerk/javascript/pull/9326) after the source branch was renamed.