### PR TITLE
fix(backend): Do not throw URIError when a cookie has a malformed percent-escape

### DIFF
--- a/.changeset/kind-rooms-report.md
+++ b/.changeset/kind-rooms-report.md
@@ -1,0 +1,9 @@
+---
+'@clerk/backend': patch
+---
+
+Fix `URIError: URI malformed` being thrown while parsing the `Cookie` header.
+
+`ClerkRequest` decodes percent-escapes across the whole header rather than per value, so an invalid sequence in any cookie — including ones Clerk neither set nor reads, such as those written by analytics or third-party scripts — reached `decodeURIComponent` and threw. The decode runs from the constructor, so the error escaped `createClerkRequest` and failed the request before any auth logic ran. Because the offending value stays in the browser until it expires, every subsequent request from that client failed too.
+
+Escape sequences that cannot be decoded are now left as their raw text, and the rest of the header parses as before.

--- a/packages/backend/src/tokens/__tests__/clerkRequest.test.ts
+++ b/packages/backend/src/tokens/__tests__/clerkRequest.test.ts
@@ -97,6 +97,30 @@ describe('createClerkRequest', () => {
       expect(req.cookies.get('baz')).toBe('qux');
     });
 
+    // `%E2` is an incomplete UTF-8 lead byte, so `decodeURIComponent` throws on it.
+    // The decode runs over the whole header, so a cookie Clerk never set and never
+    // reads can fail the request before any auth logic runs (issue #9333).
+    it('does not throw when another cookie has a malformed percent-escape', () => {
+      const req = new Request('http://localhost:3000', {
+        headers: new Headers({ cookie: '__session=abc; analytics_id=%E2%9' }),
+      });
+      expect(() => createClerkRequest(req)).not.toThrow();
+      expect(createClerkRequest(req).cookies.get('__session')).toBe('abc');
+    });
+
+    // A value that cannot be decoded is kept as-is, so callers still see whatever
+    // the client sent rather than an empty or dropped cookie.
+    it.each([
+      ['truncated sequence', '%E2%9'],
+      ['lone continuation byte', '%98'],
+      ['overlong encoding', '%C0%80'],
+    ])('leaves a cookie with a %s undecoded', (_label, value) => {
+      const req = createClerkRequest(
+        new Request('http://localhost:3000', { headers: new Headers({ cookie: `analytics_id=${value}` }) }),
+      );
+      expect(req.cookies.get('analytics_id')).toBe(value);
+    });
+
     it('should parse and return cookies even if no cookie header exists', () => {
       const req = createClerkRequest(new Request('http://localhost:3000', { headers: new Headers() }));
       expect(req.cookies.get('foo')).toBeUndefined();

--- a/packages/backend/src/tokens/clerkRequest.ts
+++ b/packages/backend/src/tokens/clerkRequest.ts
@@ -99,7 +99,22 @@ class ClerkRequest extends Request {
   }
 
   private decodeCookieValue(str: string) {
-    return str ? str.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent) : str;
+    if (!str) {
+      return str;
+    }
+
+    // The decode runs over the whole header rather than per value, so an escape
+    // in any cookie - including ones Clerk neither set nor reads - reaches
+    // `decodeURIComponent`, which throws on invalid UTF-8 (truncated, lone, or
+    // overlong sequences). This is called from the constructor, so that would
+    // fail the request before any auth logic runs. Leave such runs raw instead.
+    return str.replace(/(%[0-9A-Z]{2})+/g, match => {
+      try {
+        return decodeURIComponent(match);
+      } catch {
+        return match;
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #9333.

`ClerkRequest` decodes percent-escapes across the whole `Cookie` header rather than per value, so an invalid sequence in any cookie — including ones Clerk neither set nor reads, such as those written by analytics or third-party scripts — reached `decodeURIComponent` and threw `URIError: URI malformed`. The decode runs from the constructor, so the error escaped `createClerkRequest` and failed the request before any auth logic ran. Because the offending value stays in the browser until it expires, every subsequent request from that client failed too; on `@clerk/nextjs` this surfaces as a 500 from `clerkMiddleware()` that the application has no way to catch.

Escape runs that cannot be decoded are now left as their raw text, and the rest of the header parses as before.

Whole-header decoding is deliberately preserved, so the existing behaviour where an escaped `;` splits one value into separate cookies (`foo=%20bar%3B%20baz%3Dqux` → `foo=bar`, `baz=qux`) is unchanged and its test still passes.

Covered by tests for the three shapes reported in the issue: truncated sequence (`%E2%9`), lone continuation byte (`%98`), and overlong encoding (`%C0%80`). Each throws on `main` and passes here.

The lowercase-hex asymmetry also noted in #9333 (`%c3%a9` is left raw while `%C3%A9` decodes) is intentionally left alone. Fixing it would change parsed cookie values for existing users rather than just stop a crash, so it seems better suited to its own change.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
