### PR TITLE
docs(backend): Use root-relative link for passwordHasher contact support reference

### DIFF
--- a/.changeset/backend-relative-support-link.md
+++ b/.changeset/backend-relative-support-link.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Use a root-relative link (`/contact/support`) for the `passwordHasher` "contact support" reference so the generated API reference renders it as an internal same-tab link instead of an external one.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -224,7 +224,7 @@ export type UserPasswordHashingParams = {
    *   </ul>
    *  </ul>
    *
-   * If you need support for any particular hashing algorithm, [contact support](https://clerk.com/contact/support).
+   * If you need support for any particular hashing algorithm, [contact support](/contact/support).
    */
   passwordHasher: PasswordHasher;
 };


### PR DESCRIPTION
## Description

The `passwordHasher` param JSDoc in `packages/backend/src/api/endpoints/UserApi.ts` used an absolute `https://clerk.com/contact/support` link. The docs renderer ([`MDXLink.tsx`](https://github.com/clerk/clerk/blob/main/src/components/mdx/MDXLink.tsx)) treats absolute `http(s)://` links as external — opening a new tab with an external-link icon — whereas root-relative links are internal same-tab.

The Typedoc `replace-text` plugin only relativizes `https://clerk.com/docs` links, so this was the one non-`/docs` clerk.com link in the backend source and it leaked through as external. Switching it to `/contact/support` matches the convention already used for the `/docs/...` links authored directly in this same file.

`UserPasswordHashingParams` is shared by both `CreateUserParams` and `UpdateUserParams`, so this single change corrects all three generated files in clerk/clerk (`create-user-params.mdx`, `user-api/methods/create-user.mdx`, `user-api/methods/update-user.mdx`) on the next Typedoc sync.

This is the upstream counterpart to the support-link normalization done in clerk/clerk #3101, and a continuation of #9340.

### Testing

Regenerated the backend Typedoc locally and confirmed the generated output now emits `[contact support](/contact/support)` with no remaining absolute `clerk.com/contact` link.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: