### PR TITLE
fix(ui): allow legal links to wrap naturally within text

### DIFF
--- a/.changeset/wrap-links-inside-text.md
+++ b/.changeset/wrap-links-inside-text.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Allow the "Terms of Service" and "Privacy Policy" links in the sign-up legal consent label to wrap naturally across lines. They were previously styled `display: inline-flex`, which forced each link to wrap as a single unbreakable unit, leaving a gap at the end of the preceding line.

--- a/packages/ui/src/elements/LegalConsentCheckbox.tsx
+++ b/packages/ui/src/elements/LegalConsentCheckbox.tsx
@@ -55,6 +55,7 @@ const LegalCheckboxLabel = (props: { termsUrl?: string; privacyPolicyUrl?: strin
           text={t(localizationKey)}
           isExternal
           sx={t => ({
+            display: 'inline',
             textDecoration: 'underline',
             textUnderlineOffset: t.space.$1,
           })}


### PR DESCRIPTION
## Description

On the sign-up "Legal consent" screen, the "I agree to the Terms of Service and Privacy Policy" label is wrapped awkwardly, because the two legal links are rendered as `display: inline-flex`, making each one an atomic inline box the browser cannot break inside. As a result, `Privacy Policy` always wrapped to its own line, leaving a large gap at the end of the preceding line.

This PR styles the links in the legal-consent label as `display: inline`, letting the text break at the last fitting word so the line fills the available width before wrapping. The change is scoped to the consent label's links via its existing `sx`, so no other component is affected.

To test the change:
- Run `pnpm dev:sandbox`
- Go to `http://localhost:4000/sign-up`
- You can see that the `Private Policy` link now wraps around by the space.

| Before | After |
| --- | --- |
| <img width="402" height="208" alt="Screenshot 2026-08-08 at 09 49 31" src="https://github.com/user-attachments/assets/08349874-680d-4422-951e-a06f831a9880" /> | <img width="405" height="206" alt="Screenshot 2026-08-08 at 09 48 51" src="https://github.com/user-attachments/assets/bbc68a6e-dfb7-4a57-b7ab-c7f3401a28c2" /> |

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
