### PR TITLE
fix(js): keep native OAuth transport callbacks inside the component router

### DIFF
--- a/.changeset/native-oauth-modal-navigation.md
+++ b/.changeset/native-oauth-modal-navigation.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Fix native OAuth transport flows (e.g. `@clerk/electron`) breaking out of modal components and failing with "Redirect url mismatch" errors.
+
+Intermediate OAuth callback steps (sign-in to sign-up transfer, continue, MFA factors, password reset) now navigate inside the component's own router instead of navigating the app window to an internal Clerk route. Transport flows also always send the registered transport callback URL as the completion redirect, so production instances no longer reject sign-in or sign-up requests when a page-derived URL was picked up as the completion redirect.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -1730,6 +1730,66 @@ describe('Clerk singleton', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    it('uses __internal_navigate for intermediate callback navigations instead of window-level navigation', async () => {
+      mockEnvironmentFetch.mockReturnValue(
+        Promise.resolve({
+          authConfig: {},
+          userSettings: mockUserSettings,
+          displayConfig: mockDisplayConfig,
+          isSingleSession: () => false,
+          isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
+          onWindowLocationHost: () => false,
+        }),
+      );
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          signedInSessions: [],
+          signIn: new SignIn({
+            status: 'needs_identifier',
+            first_factor_verification: {
+              status: 'transferable',
+              strategy: 'oauth_google',
+              external_verification_redirect_url: '',
+              error: {
+                code: 'external_account_not_found',
+                long_message: 'The External Account was not found.',
+                message: 'Invalid external account',
+              },
+            },
+            second_factor_verification: null,
+            identifier: '',
+            user_data: null,
+            created_session_id: null,
+            created_user_id: null,
+          } as any as SignInJSON),
+          signUp: new SignUp(null),
+        }),
+      );
+
+      const internalNavigate = vi.fn().mockResolvedValue(undefined);
+      const mockSignUpCreate = vi
+        .fn()
+        .mockReturnValue(Promise.resolve({ status: 'missing_requirements', missingFields: ['phone_number'] }));
+
+      const sut = new Clerk(productionPublishableKey);
+      await sut.load(mockedLoadOptions);
+      if (!sut.client) {
+        fail('we should always have a client');
+      }
+      sut.client.signUp.create = mockSignUpCreate;
+
+      await sut.handleRedirectCallback({
+        continueSignUpUrl: 'continue',
+        __internal_navigate: internalNavigate,
+      });
+
+      await waitFor(() => {
+        expect(internalNavigate).toHaveBeenCalledWith('continue');
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     it('does not initiate the transfer flow when transferable: false is passed', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -1790,6 +1790,66 @@ describe('Clerk singleton', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    it('passes raw component-relative paths to __internal_navigate on development instances', async () => {
+      mockEnvironmentFetch.mockReturnValue(
+        Promise.resolve({
+          authConfig: {},
+          userSettings: mockUserSettings,
+          displayConfig: mockDisplayConfig,
+          isSingleSession: () => false,
+          isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
+          onWindowLocationHost: () => false,
+        }),
+      );
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          signedInSessions: [],
+          signIn: new SignIn({
+            status: 'needs_identifier',
+            first_factor_verification: {
+              status: 'transferable',
+              strategy: 'oauth_google',
+              external_verification_redirect_url: '',
+              error: {
+                code: 'external_account_not_found',
+                long_message: 'The External Account was not found.',
+                message: 'Invalid external account',
+              },
+            },
+            second_factor_verification: null,
+            identifier: '',
+            user_data: null,
+            created_session_id: null,
+            created_user_id: null,
+          } as any as SignInJSON),
+          signUp: new SignUp(null),
+        }),
+      );
+
+      const internalNavigate = vi.fn().mockResolvedValue(undefined);
+      const mockSignUpCreate = vi
+        .fn()
+        .mockReturnValue(Promise.resolve({ status: 'missing_requirements', missingFields: ['phone_number'] }));
+
+      const sut = new Clerk(developmentPublishableKey);
+      await sut.load(mockedLoadOptions);
+      if (!sut.client) {
+        fail('we should always have a client');
+      }
+      sut.client.signUp.create = mockSignUpCreate;
+
+      await sut.__internal_handleResourceCallback(sut.client.signIn, {
+        continueSignUpUrl: 'continue',
+        __internal_navigate: internalNavigate,
+      });
+
+      await waitFor(() => {
+        expect(internalNavigate).toHaveBeenCalledWith('continue');
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     it('does not initiate the transfer flow when transferable: false is passed', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2389,11 +2389,14 @@ export class Clerk implements ClerkInterface {
     const signIn = 'identifier' in (signInOrUp || {}) ? (signInOrUp as SignInResource) : _signIn;
     const signUp = 'missingFields' in (signInOrUp || {}) ? (signInOrUp as SignUpResource) : _signUp;
 
-    const resolvedNavigate = customNavigate ?? params.__internal_navigate;
+    // The component router expects raw component-relative paths; buildUrlWithAuth would absolutize
+    // them on development instances and push the navigation back out to the window.
     const navigate = (to: string) =>
-      resolvedNavigate && typeof resolvedNavigate === 'function'
-        ? resolvedNavigate(this.buildUrlWithAuth(to))
-        : this.navigate(this.buildUrlWithAuth(to));
+      customNavigate && typeof customNavigate === 'function'
+        ? customNavigate(this.buildUrlWithAuth(to))
+        : params.__internal_navigate && typeof params.__internal_navigate === 'function'
+          ? params.__internal_navigate(to)
+          : this.navigate(this.buildUrlWithAuth(to));
 
     return this._handleRedirectCallback(params, {
       signUp,

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2389,9 +2389,10 @@ export class Clerk implements ClerkInterface {
     const signIn = 'identifier' in (signInOrUp || {}) ? (signInOrUp as SignInResource) : _signIn;
     const signUp = 'missingFields' in (signInOrUp || {}) ? (signInOrUp as SignUpResource) : _signUp;
 
+    const resolvedNavigate = customNavigate ?? params.__internal_navigate;
     const navigate = (to: string) =>
-      customNavigate && typeof customNavigate === 'function'
-        ? customNavigate(this.buildUrlWithAuth(to))
+      resolvedNavigate && typeof resolvedNavigate === 'function'
+        ? resolvedNavigate(this.buildUrlWithAuth(to))
         : this.navigate(this.buildUrlWithAuth(to));
 
     return this._handleRedirectCallback(params, {
@@ -2741,8 +2742,9 @@ export class Clerk implements ClerkInterface {
     }
     const { signIn, signUp } = this.client;
 
+    const resolvedNavigate = customNavigate ?? params.__internal_navigate;
     const navigate = (to: string) =>
-      customNavigate && typeof customNavigate === 'function' ? customNavigate(to) : this.navigate(to);
+      resolvedNavigate && typeof resolvedNavigate === 'function' ? resolvedNavigate(to) : this.navigate(to);
 
     return this._handleRedirectCallback(params, {
       signUp,

--- a/packages/clerk-js/src/utils/__tests__/authenticateWithTransport.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/authenticateWithTransport.test.ts
@@ -43,7 +43,7 @@ describe('_authenticateWithTransport', () => {
     expect(resource.create).not.toHaveBeenCalled();
   });
 
-  it('replaces a page-derived redirectUrlComplete with the transport URL so FAPI only ever validates the registered callback', async () => {
+  it('replaces a page-derived redirectUrlComplete with the transport URL', async () => {
     const clerk = makeClerk();
     const transport = {
       getRedirectUrl: vi.fn().mockResolvedValue('myapp://app/'),

--- a/packages/clerk-js/src/utils/__tests__/authenticateWithTransport.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/authenticateWithTransport.test.ts
@@ -34,13 +34,46 @@ describe('_authenticateWithTransport', () => {
     });
 
     expect(authenticateMethod).toHaveBeenCalledWith(
-      expect.objectContaining({ redirectUrl: 'myapp://sso-callback', redirectUrlComplete: '/done' }),
+      expect.objectContaining({ redirectUrl: 'myapp://sso-callback', redirectUrlComplete: 'myapp://sso-callback' }),
       expect.any(Function),
     );
     expect(transport.open).toHaveBeenCalledWith(new URL('https://provider.example/auth'));
     expect(resource.reload).toHaveBeenCalledWith({ rotatingTokenNonce: 'abc' });
     expect(clerk.__internal_handleResourceCallback).toHaveBeenCalledWith(resource, callbackParams);
     expect(resource.create).not.toHaveBeenCalled();
+  });
+
+  it('replaces a page-derived redirectUrlComplete with the transport URL so FAPI only ever validates the registered callback', async () => {
+    const clerk = makeClerk();
+    const transport = {
+      getRedirectUrl: vi.fn().mockResolvedValue('myapp://app/'),
+      open: vi.fn().mockResolvedValue({ callbackUrl: 'myapp://app/?rotating_token_nonce=abc' }),
+    };
+    const resource = {
+      reload: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    const authenticateMethod = vi.fn(async (_params, navigate) => {
+      navigate(new URL('https://provider.example/auth'));
+    });
+
+    await _authenticateWithTransport({
+      clerk: clerk as any,
+      transport,
+      resource,
+      authenticateMethod,
+      params: {
+        strategy: 'oauth_google',
+        redirectUrl: 'some-ui-callback',
+        redirectUrlComplete: 'myapp://app/CLERK-ROUTER/VIRTUAL/sign-up#/settings/connections',
+      } as any,
+      callbackParams: {},
+    });
+
+    expect(authenticateMethod).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUrl: 'myapp://app/', redirectUrlComplete: 'myapp://app/' }),
+      expect.any(Function),
+    );
   });
 
   it('reloads without a nonce when the callback URL has no nonce', async () => {

--- a/packages/clerk-js/src/utils/authenticateWithTransport.ts
+++ b/packages/clerk-js/src/utils/authenticateWithTransport.ts
@@ -71,10 +71,8 @@ export async function _authenticateWithTransport(opts: {
   const redirectUrl = String(await opts.transport.getRedirectUrl());
 
   let verificationUrl: URL | string | undefined;
-  // Production FAPI validates both URLs against the instance's redirect allowlist, and only the
-  // transport callback is guaranteed to be registered. Page-derived completion URLs (e.g. a modal's
-  // window.location.href) would be rejected; the app's real destination is handled client-side via
-  // `callbackParams` after the callback completes.
+  // Production FAPI validates both URLs against the redirect allowlist and only the transport
+  // callback is guaranteed registered; the app's destination is navigated client-side instead.
   await opts.authenticateMethod({ ...opts.params, redirectUrl, redirectUrlComplete: redirectUrl }, url => {
     verificationUrl = url;
   });

--- a/packages/clerk-js/src/utils/authenticateWithTransport.ts
+++ b/packages/clerk-js/src/utils/authenticateWithTransport.ts
@@ -71,7 +71,11 @@ export async function _authenticateWithTransport(opts: {
   const redirectUrl = String(await opts.transport.getRedirectUrl());
 
   let verificationUrl: URL | string | undefined;
-  await opts.authenticateMethod({ ...opts.params, redirectUrl }, url => {
+  // Production FAPI validates both URLs against the instance's redirect allowlist, and only the
+  // transport callback is guaranteed to be registered. Page-derived completion URLs (e.g. a modal's
+  // window.location.href) would be rejected; the app's real destination is handled client-side via
+  // `callbackParams` after the callback completes.
+  await opts.authenticateMethod({ ...opts.params, redirectUrl, redirectUrlComplete: redirectUrl }, url => {
     verificationUrl = url;
   });
 

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -1328,9 +1328,7 @@ export type HandleOAuthCallbackParams = TransferableOption &
     /**
      * Internal navigation hook used by Clerk UI to keep intermediate OAuth callback navigations
      * (continue, factor steps, sign-in/sign-up switches) inside the component's own router when the
-     * callback completes in-process (transport flows). Without it, these navigations fall back to
-     * window-level navigation, which breaks modal flows in native apps. Not set by the web
-     * redirect/popup paths.
+     * callback completes in-process (transport flows). Not set by the web redirect/popup paths.
      *
      * @internal
      */

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -1325,6 +1325,16 @@ export type HandleOAuthCallbackParams = TransferableOption &
       redirectUrl: string;
       decorateUrl: (url: string) => string;
     }) => Promise<unknown>;
+    /**
+     * Internal navigation hook used by Clerk UI to keep intermediate OAuth callback navigations
+     * (continue, factor steps, sign-in/sign-up switches) inside the component's own router when the
+     * callback completes in-process (transport flows). Without it, these navigations fall back to
+     * window-level navigation, which breaks modal flows in native apps. Not set by the web
+     * redirect/popup paths.
+     *
+     * @internal
+     */
+    __internal_navigate?: (to: string) => Promise<unknown>;
   };
 
 export type HandleSamlCallbackParams = HandleOAuthCallbackParams;

--- a/packages/ui/src/components/SignIn/SignInSocialButtons.tsx
+++ b/packages/ui/src/components/SignIn/SignInSocialButtons.tsx
@@ -84,6 +84,7 @@ export const SignInSocialButtons = React.memo((props: SignInSocialButtonsProps) 
             __internal_callbackParams: {
               ...buildSignInOAuthTransportCallbackParams(ctx),
               __internal_navigateOnSetActive: ctx.navigateOnSetActive,
+              __internal_navigate: navigate,
             },
           })
           .catch(err => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInSocialButtons.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInSocialButtons.test.tsx
@@ -50,6 +50,7 @@ describe('SignInSocialButtons', () => {
             secondFactorUrl: 'factor-two',
             resetPasswordUrl: 'reset-password',
             __internal_navigateOnSetActive: expect.any(Function),
+            __internal_navigate: expect.any(Function),
           }),
         }),
       );

--- a/packages/ui/src/components/SignUp/SignUpSocialButtons.tsx
+++ b/packages/ui/src/components/SignUp/SignUpSocialButtons.tsx
@@ -76,6 +76,7 @@ export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) 
             __internal_callbackParams: {
               ...buildSignUpOAuthTransportCallbackParams(ctx),
               __internal_navigateOnSetActive: ctx.navigateOnSetActive,
+              __internal_navigate: navigate,
             },
           })
           .catch(err => {

--- a/packages/ui/src/components/SignUp/__tests__/SignUpSocialButtons.test.tsx
+++ b/packages/ui/src/components/SignUp/__tests__/SignUpSocialButtons.test.tsx
@@ -66,6 +66,7 @@ describe('SignUpSocialButtons', () => {
           verifyPhoneNumberUrl: 'verify-phone-number',
           unsafeMetadata: { source: 'test' },
           __internal_navigateOnSetActive: expect.any(Function),
+          __internal_navigate: expect.any(Function),
         }),
       });
     });


### PR DESCRIPTION
## Description

This PR fixes native OAuth transport flows (e.g. `@clerk/electron`) breaking out of modal components. When a callback needed an intermediate step such as a sign-in to sign-up transfer, the continue step, or an MFA factor, clerk-js navigated the app window to an internal Clerk route like `/CLERK-ROUTER/VIRTUAL/sign-up`. In Electron apps this reloaded the renderer on a route the app does not have, and the leaked URL was later submitted as the completion redirect, which production instances reject with a "Redirect url mismatch" error ([ref](https://clerkinc.slack.com/archives/C068ZP01R7A/p1786222968731609)).

The prebuilt UI now hands its own router to the transport callback via an internal param so those steps render inside the component, and `_authenticateWithTransport` now submits the registered transport callback URL as the completion redirect while the app's real destination is navigated client-side. Both changes are internal and optional, so older UI versions keep the existing behavior.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: