### PR TITLE
fix(backend): decode cookie values after parsing

### DIFF
--- a/.changeset/tidy-cookies-smile.md
+++ b/.changeset/tidy-cookies-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Decode request cookie values only after parsing cookie boundaries, preserving malformed percent encodings and preventing encoded delimiters from being treated as separate cookies.

--- a/packages/backend/src/tokens/__tests__/clerkRequest.test.ts
+++ b/packages/backend/src/tokens/__tests__/clerkRequest.test.ts
@@ -89,12 +89,36 @@ describe('createClerkRequest', () => {
       expect(req.cookies.get('foo')).toBe('bar');
     });
 
-    it('should parse and return cookies with special characters', () => {
+    it('should decode values after parsing cookie pairs', () => {
       const req = createClerkRequest(
-        new Request('http://localhost:3000', { headers: new Headers({ cookie: 'foo=%20bar%3B%20baz%3Dqux' }) }),
+        new Request('http://localhost:3000', {
+          headers: new Headers({ cookie: 'foo=%20bar%3B%20baz%3Dqux; after=parsed' }),
+        }),
       );
-      expect(req.cookies.get('foo')).toBe('bar');
-      expect(req.cookies.get('baz')).toBe('qux');
+
+      expect(req.cookies.get('foo')).toBe(' bar; baz=qux');
+      expect(req.cookies.get('baz')).toBeUndefined();
+      expect(req.cookies.get('after')).toBe('parsed');
+    });
+
+    it.each(['%E2%9', '%98', '%C0%80'])('should preserve a malformed encoded cookie value: %s', value => {
+      const req = createClerkRequest(
+        new Request('http://localhost:3000', {
+          headers: new Headers({ cookie: `__session=abc; analytics_id=${value}; after=parsed` }),
+        }),
+      );
+
+      expect(req.cookies.get('__session')).toBe('abc');
+      expect(req.cookies.get('analytics_id')).toBe(value);
+      expect(req.cookies.get('after')).toBe('parsed');
+    });
+
+    it('should decode lowercase percent escapes', () => {
+      const req = createClerkRequest(
+        new Request('http://localhost:3000', { headers: new Headers({ cookie: 'foo=%c3%a9' }) }),
+      );
+
+      expect(req.cookies.get('foo')).toBe('é');
     });
 
     it('should parse and return cookies even if no cookie header exists', () => {

--- a/packages/backend/src/tokens/clerkRequest.ts
+++ b/packages/backend/src/tokens/clerkRequest.ts
@@ -94,12 +94,8 @@ class ClerkRequest extends Request {
   }
 
   private parseCookies(req: Request) {
-    const cookiesRecord = parse(this.decodeCookieValue(req.headers.get('cookie') || ''));
+    const cookiesRecord = parse(req.headers.get('cookie') || '');
     return new Map(Object.entries(cookiesRecord));
-  }
-
-  private decodeCookieValue(str: string) {
-    return str ? str.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent) : str;
   }
 }
 


### PR DESCRIPTION
## Summary

- parse cookie boundaries before percent-decoding values
- preserve malformed percent-encoded values instead of throwing
- add regression coverage for malformed and lowercase encodings
- include an `@clerk/backend` patch changeset

## Why

`ClerkRequest` decoded the complete `Cookie` header before parsing it. A malformed escape could throw during request construction, while encoded `;` and `=` characters could be reinterpreted as cookie boundaries. The `cookie` dependency already decodes each isolated value safely and returns the raw value when decoding fails.

Fixes #9333.