### PR TITLE
fix(nextjs): remove stray double space in clerkMiddleware detection error

### DIFF
--- a/.changeset/tidy-cameras-jump.md
+++ b/.changeset/tidy-cameras-jump.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Fix a stray double space in the `auth()` "Clerk can't detect usage of clerkMiddleware()" error, so the first bullet renders as `- clerkMiddleware() is used in your Next.js middleware file.`

--- a/.changeset/tidy-cameras-jump.md
+++ b/.changeset/tidy-cameras-jump.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Fix a stray double space in the `auth()` "Clerk can't detect usage of clerkMiddleware()" error, so the first bullet renders as `- clerkMiddleware() is used in your Next.js middleware file.`
+Fix a stray double space in the `getAuth()` "Clerk can't detect usage of clerkMiddleware()" error, so the first bullet renders as `- clerkMiddleware() is used in your Next.js middleware or proxy file.`

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -24,7 +24,7 @@ export const getAuthAuthHeaderMissing = () => authAuthHeaderMissing('getAuth', u
 
 export const authAuthHeaderMissing = (helperName = 'auth', prefixSteps?: string[], fileReference = 'middleware') => {
   return `Clerk: ${helperName}() was called but Clerk can't detect usage of clerkMiddleware(). Please ensure the following:
-- ${prefixSteps ? [...prefixSteps, ''].join('\n- ') : ' '}clerkMiddleware() is used in your Next.js ${fileReference} file.
+- ${prefixSteps ? [...prefixSteps, ''].join('\n- ') : ''}clerkMiddleware() is used in your Next.js ${fileReference} file.
 - Your ${fileReference} matcher is configured to match this route or page.
 - If you are using the src directory, make sure the ${fileReference} file is inside of it.
 


### PR DESCRIPTION
## Description

The `getAuth()` "Clerk can't detect usage of `clerkMiddleware()`" error emitted a stray double space before its first bullet, so users saw `-  clerkMiddleware() is used in your Next.js middleware or proxy file.` (two spaces after the dash).

In `authAuthHeaderMissing`, the first bullet's `prefixSteps` ternary fell back to `' '` (a single space) when `prefixSteps` was `undefined` — which is the `getAuth()` path. It's the only caller that passes `undefined`; `auth()` always passes an array (even an empty one, which is truthy), so it never hit this branch. Combined with the literal `- ` already at the start of the line, the fallback produced a double space. This changes it to `''` so that path renders `- clerkMiddleware() is used...` with a single space, matching the [docs page for this error](https://github.com/clerk/clerk-docs/blob/main/docs/reference/nextjs/errors/auth-was-called.mdx). The `prefixSteps`-provided branch (App Router src-directory hint) is unchanged.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
