### PR TITLE
fix(localizations): Update tr-TR waitlist translations

### DIFF
--- a/.changeset/eight-gifts-enjoy.md
+++ b/.changeset/eight-gifts-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Update tr-TR waitlist translations

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -2218,7 +2218,7 @@ export const trTR: LocalizationResource = {
   },
   waitlist: {
     start: {
-      actionLink: 'Giriş Yap',
+      actionLink: 'Giriş yap',
       actionText: 'Hesabınız var mı?',
       formButton: 'Kayıt Ol',
       subtitle: 'Kaydolduktan sonra erken erişim kazanabilirsiniz.',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -881,7 +881,7 @@ export const trTR: LocalizationResource = {
   formFieldInputPlaceholder__apiKeyName: undefined,
   formFieldInputPlaceholder__backupCode: 'Yedek kodu girin',
   formFieldInputPlaceholder__confirmDeletionUserAccount: 'Hesabı sil',
-  formFieldInputPlaceholder__emailAddress: 'email@example.com',
+  formFieldInputPlaceholder__emailAddress: 'ornek@email.com',
   formFieldInputPlaceholder__emailAddress_username: 'email veya kullanıcı adı',
   formFieldInputPlaceholder__emailAddresses: 'ornek@email.com, ornek2@email.com',
   formFieldInputPlaceholder__firstName: 'Adınızı girin',
@@ -2218,8 +2218,8 @@ export const trTR: LocalizationResource = {
   },
   waitlist: {
     start: {
-      actionLink: 'Bekleme listesine katıl',
-      actionText: 'Hala bir hesabınız yok mu?',
+      actionLink: 'Giriş Yap',
+      actionText: 'Hesabınız var mı?',
       formButton: 'Kayıt Ol',
       subtitle: 'Kaydolduktan sonra erken erişim kazanabilirsiniz.',
       title: 'Bekleme Listesine Katılın',


### PR DESCRIPTION
## Description

Waitlist actions were misleading. Action links to sign in page but the action text was "Still don't have an account?", and action link was "Join Waitlist". I changed them to match the behavior.


## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: localization
