### PR TITLE
fix(astro,chrome-extension): Add missing Astro and Chrome Extension exports

### DIFF
--- a/.changeset/add-chrome-extension-legacy.md
+++ b/.changeset/add-chrome-extension-legacy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/chrome-extension': patch
+---
+
+Add the `/legacy` entry point for the legacy `useSignIn()` and `useSignUp()` hooks.

--- a/.changeset/fix-astro-types-export.md
+++ b/.changeset/fix-astro-types-export.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': patch
+---
+
+Fix the `/types` entry point to export the documented Clerk types.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -59,7 +59,7 @@
       "types": "./dist/webhooks.d.ts",
       "default": "./dist/webhooks.js"
     },
-    "./types": "./dist/types/index.d.ts",
+    "./types": "./dist/types/types/index.d.ts",
     "./env": "./env.d.ts",
     "./components": "./components/index.ts",
     "./package.json": "./package.json"

--- a/packages/chrome-extension/legacy/package.json
+++ b/packages/chrome-extension/legacy/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/cjs/legacy.js",
+  "module": "../dist/esm/legacy.js",
+  "types": "../dist/types/legacy.d.ts"
+}

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -53,6 +53,16 @@
         "default": "./dist/cjs/background/index.js"
       }
     },
+    "./legacy": {
+      "import": {
+        "types": "./dist/types/legacy.d.ts",
+        "default": "./dist/esm/legacy.js"
+      },
+      "require": {
+        "types": "./dist/types/legacy.d.ts",
+        "default": "./dist/cjs/legacy.js"
+      }
+    },
     "./types": {
       "types": "./dist/types/types/index.d.ts"
     },
@@ -66,6 +76,7 @@
     "client",
     "dist",
     "internal",
+    "legacy",
     "react",
     "types"
   ],

--- a/packages/chrome-extension/src/__tests__/exports.test.ts
+++ b/packages/chrome-extension/src/__tests__/exports.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import * as publicExports from '../index';
+import * as legacyExports from '../legacy';
 
 describe('public exports', () => {
   it('should not include a breaking change', () => {
     expect(Object.keys(publicExports).sort()).toMatchSnapshot();
+  });
+});
+
+describe('legacy public exports', () => {
+  it('should not include a breaking change', () => {
+    expect(Object.keys(legacyExports).sort()).toEqual(['useSignIn', 'useSignUp']);
   });
 });

--- a/packages/chrome-extension/src/legacy.ts
+++ b/packages/chrome-extension/src/legacy.ts
@@ -1,0 +1,1 @@
+export { useSignIn, useSignUp } from '@clerk/react/legacy';

--- a/packages/chrome-extension/tsup.config.ts
+++ b/packages/chrome-extension/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(overrideOptions => {
       './src/index.ts',
       './src/background/index.ts',
       './src/client/index.ts',
+      './src/legacy.ts',
       './src/react/index.ts',
       './src/types/index.ts',
     ],


### PR DESCRIPTION
## Description

Fixes #9425 and #9426.

Corrects the `@clerk/astro/types` export so it exposes the documented Clerk types.

Adds the documented `@clerk/chrome-extension/legacy` entry point for the legacy `useSignIn()` and `useSignUp()` hooks, including ESM, CommonJS, and TypeScript declarations.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
