### PR TITLE
fix(ui): render a message for password errors the UI does not map

### DIFF
--- a/.changeset/great-pots-tickle.md
+++ b/.changeset/great-pots-tickle.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Display a proper message when a password is rejected for matching one of the account's identifiers. Previously this error rendered as the incomplete sentence "Your password must contain ." on sign-up, reset password, and the user profile password form. The new message is available under the `unstable__errors.form_password_matches_identifier` localization key, and any password error the UI does not recognize now falls back to the message returned by the API instead of an empty sentence.

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -1746,6 +1746,7 @@ export const arSA: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'كلمة المرور ليست قوية',
     form_password_or_identifier_incorrect:
       'كلمة المرور أو عنوان البريد الإلكتروني غير صحيح. حاول مرة أخرى أو استخدم طريقة أخرى.',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -1757,6 +1757,7 @@ export const beBY: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Невірны пароль.',
     form_password_length_too_short: 'Пароль занадта кароткі.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Ваш пароль недастаткова надзейны.',
     form_password_or_identifier_incorrect:
       'Пароль або адрас электроннай пошты няправільны. Паспрабуйце яшчэ раз або выкарыстоўвайце іншы метад.',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -1750,6 +1750,7 @@ export const bgBG: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Невалидна парола. Моля, опитайте отново.',
     form_password_length_too_short: 'Паролата е твърде кратка. Моля, въведете поне 8 символа.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough:
       'Паролата трябва да съдържа поне една главна буква, една цифра и един специален символ.',
     form_password_or_identifier_incorrect:

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -1769,6 +1769,7 @@ export const bnIN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'আপনি যে পাসওয়ার্ড লিখেছেন তা ভুল। দয়া করে আবার চেষ্টা করুন।',
     form_password_length_too_short: 'আপনার পাসওয়ার্ড খুব ছোট। এটি কমপক্ষে ৮ অক্ষর দীর্ঘ হতে হবে।',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'আপনার পাসওয়ার্ড যথেষ্ট শক্তিশালী নয়।',
     form_password_or_identifier_incorrect:
       'পাসওয়ার্ড বা ইমেইল ঠিকানা ভুল। আবার চেষ্টা করুন বা অন্য পদ্ধতি ব্যবহার করুন।',

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -1760,6 +1760,7 @@ export const caES: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'La contrasenya introduïda és incorrecta.',
     form_password_length_too_short: 'La teva contrasenya ha de tenir almenys 8 caràcters.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'La teva contrasenya no és prou forta.',
     form_password_or_identifier_incorrect:
       "La contrasenya o l'identificador és incorrecte. Torna-ho a intentar o utilitza un altre mètode.",

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -1762,6 +1762,7 @@ export const csCZ: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Heslo je nesprávné.',
     form_password_length_too_short: 'Heslo je příliš krátké.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Vaše heslo není dostatečně silné.',
     form_password_or_identifier_incorrect:
       'Heslo nebo e-mailová adresa je nesprávná. Zkuste to znovu nebo použijte jinou metodu.',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -1747,6 +1747,7 @@ export const daDK: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Adgangskoden er forkert.',
     form_password_length_too_short: 'Adgangskoden er for kort.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Adgangskoden er ikke stærk nok.',
     form_password_or_identifier_incorrect:
       'Adgangskoden eller e-mailadressen er forkert. Prøv igen eller brug en anden metode.',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -1770,6 +1770,7 @@ export const deDE: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Das eingegebene Passwort ist falsch.',
     form_password_length_too_short: 'Das Passwort ist zu kurz. Es muss mindestens 8 Zeichen lang sein.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Passwort nicht stark genug.',
     form_password_or_identifier_incorrect:
       'Passwort oder E-Mail-Adresse ist falsch. Versuchen Sie es erneut oder verwenden Sie eine andere Methode.',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -1765,6 +1765,7 @@ export const elGR: LocalizationResource = {
     form_password_incorrect: 'Ο κωδικός πρόσβασης δεν είναι σωστός.',
     form_password_length_too_short:
       'Ο κωδικός πρόσβασής σας πρέπει να αποτελείται από τουλάχιστον {{length}} χαρακτήρες.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Ο κωδικός πρόσβασής σας δεν είναι αρκετά ισχυρός.',
     form_password_or_identifier_incorrect:
       'Ο κωδικός πρόσβασης ή η διεύθυνση email είναι λανθασμένη. Δοκιμάστε ξανά ή χρησιμοποιήστε άλλη μέθοδο.',

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -1751,6 +1751,7 @@ export const enGB: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'The password you entered is incorrect. Please try again.',
     form_password_length_too_short: 'Your password is too short. It must be at least 8 characters long.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_or_identifier_incorrect: 'Password or email address is incorrect. Try again, or use another method.',
     form_password_pwned:

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -1787,6 +1787,8 @@ export const enUS: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Your password is too short. It must be at least 8 characters long.',
+    form_password_matches_identifier:
+      'Password cannot match your email address, phone number or username. For account safety, please use a different password.',
     form_password_not_strong_enough: 'Your password is not strong enough.',
     form_password_or_identifier_incorrect: undefined,
     form_password_pwned:

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -1759,6 +1759,7 @@ export const esCR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Contraseña incorrecta.',
     form_password_length_too_short: 'La contraseña es muy corta.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'La contraseña no es suficientemente segura.',
     form_password_or_identifier_incorrect:
       'La contraseña o la dirección de correo electrónico es incorrecta. Inténtalo de nuevo o usa otro método.',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -1761,6 +1761,7 @@ export const esES: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Contraseña incorrecta.',
     form_password_length_too_short: 'La contraseña es demasiado corta.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Tu contraseña no es lo suficientemente fuerte.',
     form_password_or_identifier_incorrect:
       'La contraseña o la dirección de correo electrónico es incorrecta. Inténtalo de nuevo o usa otro método.',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -1760,6 +1760,7 @@ export const esMX: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Contraseña incorrecta.',
     form_password_length_too_short: 'La contraseña es muy corta.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'La contraseña no es suficientemente segura.',
     form_password_or_identifier_incorrect:
       'La contraseña o la dirección de correo electrónico es incorrecta. Inténtalo de nuevo o usa otro método.',

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -1759,6 +1759,7 @@ export const esUY: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'La contraseña ingresada es incorrecta. Por favor, intentá de nuevo.',
     form_password_length_too_short: 'Tu contraseña es demasiado corta. Debe tener al menos 8 caracteres.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Tu contraseña no es lo suficientemente fuerte.',
     form_password_or_identifier_incorrect:
       'La contraseña o la dirección de correo electrónico es incorrecta. Intentá de nuevo o usá otro método.',

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -1761,6 +1761,7 @@ export const faIR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'رمز عبور نادرست است.',
     form_password_length_too_short: 'رمز عبور شما خیلی کوتاه است. باید حداقل ۸ کاراکتر داشته باشد.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'رمز عبور شما به اندازه کافی قوی نیست.',
     form_password_or_identifier_incorrect:
       'رمز عبور یا آدرس ایمیل نادرست است. دوباره تلاش کنید یا از روش دیگری استفاده کنید.',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -1771,6 +1771,7 @@ export const fiFI: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Salasanasi on liian lyhyt. Sen on oltava vähintään 8 merkkiä pitkä.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Salasana ei ole riittävän vahva.',
     form_password_or_identifier_incorrect:
       'Salasana tai sähköpostiosoite on väärä. Yritä uudelleen tai käytä toista menetelmää.',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -1769,6 +1769,7 @@ export const frFR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Mot de passe incorrect',
     form_password_length_too_short: 'Votre mot de passe est trop court.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: "Votre mot de passe n'est pas assez fort.",
     form_password_or_identifier_incorrect:
       "Le mot de passe ou l'adresse e-mail est incorrect. Réessayez ou utilisez une autre méthode.",

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -1738,6 +1738,7 @@ export const heIL: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'הסיסמה שלך אינה מספיק חזקה.',
     form_password_or_identifier_incorrect: 'הסיסמה או כתובת האימייל שגויים. נסה שוב או השתמש בשיטה אחרת.',
     form_password_pwned: 'הסיסמה הזו נמצאה כחלק מהפרטים שנחשפו בהפרת נתונים ולא ניתן להשתמש בה, נסה סיסמה אחרת במקום.',

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -1768,6 +1768,7 @@ export const hiIN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'आपके द्वारा दर्ज किया गया पासवर्ड गलत है। कृपया पुनः प्रयास करें।',
     form_password_length_too_short: 'आपका पासवर्ड बहुत छोटा है। इसमें कम से कम 8 अक्षर होने चाहिए।',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'आपका पासवर्ड पर्याप्त मजबूत नहीं है।',
     form_password_or_identifier_incorrect:
       'पासवर्ड या ईमेल पता गलत है। कृपया पुनः प्रयास करें या किसी अन्य विधि का उपयोग करें।',

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -1774,6 +1774,7 @@ export const hrHR: LocalizationResource = {
       'Ova lozinka je pronađena kao dio curenja podataka i ne može se koristiti. Molimo resetirajte svoju lozinku.',
     form_password_incorrect: 'Netočna lozinka. Pokušajte ponovno.',
     form_password_length_too_short: 'Vaša lozinka je prekratka. Mora sadržavati najmanje 8 znakova.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Vaša lozinka nije dovoljno jaka.',
     form_password_or_identifier_incorrect:
       'Lozinka ili e-mail adresa nisu točne. Pokušajte ponovno ili koristite drugu metodu.',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -1774,6 +1774,7 @@ export const huHU: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'A jelszavad túl rövid. Legalább 8 karakter hosszúnak kell lennie.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'A jelszó nem elég erős',
     form_password_or_identifier_incorrect:
       'A jelszó vagy az e-mail cím helytelen. Próbáld újra vagy használj másik módszert.',

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -1757,6 +1757,7 @@ export const idID: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Kata sandi Anda tidak cukup kuat.',
     form_password_or_identifier_incorrect: 'Kata sandi atau alamat email salah. Coba lagi atau gunakan metode lain.',
     form_password_pwned:

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -1773,6 +1773,7 @@ export const isIS: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Lykilorðið þitt er of stutt. Það verður að vera að minnsta kosti 8 stafir.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Lykilorðið þitt er ekki nógu sterkt.',
     form_password_or_identifier_incorrect: 'Lykilorðið eða netfangið er rangt. Reyndu aftur eða notaðu aðra aðferð.',
     form_password_pwned:

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -1759,6 +1759,7 @@ export const itIT: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Password errata.',
     form_password_length_too_short: 'La password deve avere almeno 8 caratteri.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'La tua password non è abbastanza forte.',
     form_password_or_identifier_incorrect: "La password o l'indirizzo email è errato. Riprova o usa un altro metodo.",
     form_password_pwned: 'Questa password è stata trovata in una violazione dei dati. Scegli una password diversa.',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -1769,6 +1769,7 @@ export const jaJP: LocalizationResource = {
       'このパスワードは侵害された可能性があります。アカウントを保護するため、別のサインイン方法を使用してください。サインイン後にパスワードのリセットが必要になります。',
     form_password_incorrect: '入力されたパスワードが正しくありません。もう一度お試しください。',
     form_password_length_too_short: 'パスワードが短すぎます。8文字以上である必要があります。',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'パスワードの強度が不十分です。',
     form_password_or_identifier_incorrect:
       'パスワードまたはメールアドレスが正しくありません。もう一度お試しいただくか、別の方法をご利用ください。',

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -1740,6 +1740,7 @@ export const kkKZ: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Құпия сөз қате.',
     form_password_length_too_short: 'Құпия сөз тым қысқа. Кемінде 8 таңба болуы керек.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Құпия сөз әлсіз.',
     form_password_or_identifier_incorrect:
       'Құпия сөз немесе электрондық пошта мекенжайы дұрыс емес. Қайталап көріңіз немесе басқа әдісті пайдаланыңыз.',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -1745,6 +1745,7 @@ export const koKR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: '비밀번호가 너무 짧아요. 최소 8자 이상이어야 해요.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: '비밀번호가 충분히 안전하지 않아요.',
     form_password_or_identifier_incorrect:
       '비밀번호 또는 이메일 주소가 올바르지 않아요. 다시 시도하거나 다른 방법을 사용해 보세요.',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -1751,6 +1751,7 @@ export const mnMN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Нууц үг буруу байна.',
     form_password_length_too_short: 'Нууц үгийн урт хэт богино байна.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Таны нууц үг хангалттай хүчтэй биш байна.',
     form_password_or_identifier_incorrect:
       'Нууц үг эсвэл имэйл хаяг буруу байна. Дахин оролдох эсвэл өөр арга ашиглана уу.',

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -1776,6 +1776,7 @@ export const msMY: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Kata laluan yang anda masukkan tidak betul. Sila cuba lagi.',
     form_password_length_too_short: 'Kata laluan anda terlalu pendek. Ia mesti sekurang-kurangnya 8 aksara panjang.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Kata laluan anda tidak cukup kuat.',
     form_password_or_identifier_incorrect:
       'Kata laluan atau alamat e-mel tidak betul. Cuba lagi atau gunakan kaedah lain.',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -1772,6 +1772,7 @@ export const nbNO: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Passordet ditt er for kort. Det må være minst 8 tegn langt.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Passordet ditt er ikke sterkt nok.',
     form_password_or_identifier_incorrect:
       'Passordet eller e-postadressen er feil. Prøv igjen eller bruk en annen metode.',

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -1751,6 +1751,7 @@ export const nlBE: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Het wachtwoord is incorrect.',
     form_password_length_too_short: 'Het wachtwoord is te kort.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Je wachtwoord is niet sterk genoeg.',
     form_password_or_identifier_incorrect:
       'Het wachtwoord of het e-mailadres is onjuist. Probeer het opnieuw of gebruik een andere methode.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -1751,6 +1751,7 @@ export const nlNL: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Het wachtwoord is incorrect.',
     form_password_length_too_short: 'Het wachtwoord is te kort.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Je wachtwoord is niet sterk genoeg.',
     form_password_or_identifier_incorrect:
       'Het wachtwoord of het e-mailadres is onjuist. Probeer het opnieuw of gebruik een andere methode.',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -1755,6 +1755,7 @@ export const plPL: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Wprowadzone hasło jest nieprawidłowe. Spróbuj ponownie.',
     form_password_length_too_short: 'Twoje hasło jest zbyt krótkie. Musi mieć co najmniej 8 znaków.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Twoje hasło nie jest wystarczająco silne',
     form_password_or_identifier_incorrect:
       'Hasło lub adres e-mail jest nieprawidłowy. Spróbuj ponownie lub użyj innej metody.',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -1765,6 +1765,7 @@ export const ptBR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Senha incorreta.',
     form_password_length_too_short: 'Sua senha é muito curta. Por favor, tente novamente.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Sua senha não é forte o suficiente.',
     form_password_or_identifier_incorrect:
       'A senha ou o endereço de e-mail está incorreto. Tente novamente ou use outro método.',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -1771,6 +1771,7 @@ export const ptPT: LocalizationResource = {
       'Esta palavra-passe foi comprometida numa violação de dados. Escolha outra para continuar.',
     form_password_incorrect: 'Palavra-passe incorreta.',
     form_password_length_too_short: 'A palavra-passe é muito curta.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'A sua palavra-passe não é forte o suficiente.',
     form_password_or_identifier_incorrect:
       'A palavra-passe ou o endereço de e-mail está incorreto. Tente novamente ou utilize outro método.',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -1766,6 +1766,7 @@ export const roRO: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Parola este prea scurtă. Trebuie să aibă cel puțin 8 caractere.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Parola ta nu este suficient de puternică.',
     form_password_or_identifier_incorrect:
       'Parola sau adresa de e-mail este incorectă. Încearcă din nou sau folosește o altă metodă.',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -1764,6 +1764,7 @@ export const ruRU: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Ваш пароль недостаточно надежный.',
     form_password_or_identifier_incorrect:
       'Пароль или адрес электронной почты неверен. Попробуйте снова или используйте другой метод.',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -1756,6 +1756,7 @@ export const skSK: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Heslo je nesprávne. Skontrolujte a skúste to znova.',
     form_password_length_too_short: 'Heslo musí mať aspoň 8 znakov.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Vaše heslo nie je dostatočne silné.',
     form_password_or_identifier_incorrect:
       'Heslo alebo e-mailová adresa je nesprávna. Skúste to znova alebo použite inú metódu.',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -1748,6 +1748,7 @@ export const srRS: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Lozinka je netačna.',
     form_password_length_too_short: 'Lozinka je prekratka.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Tvoja lozinka nije dovoljno jaka.',
     form_password_or_identifier_incorrect:
       'Лозинка или адреса е-поште је нетачна. Покушај поново или користи други метод.',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -1753,6 +1753,7 @@ export const svSE: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Lösenordet är felaktigt.',
     form_password_length_too_short: 'Lösenordet är för kort.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Ditt lösenord är inte tillräckligt starkt.',
     form_password_or_identifier_incorrect:
       'Lösenordet eller e-postadressen är felaktig. Försök igen eller använd en annan metod.',

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -1776,6 +1776,7 @@ export const taIN: LocalizationResource = {
     form_password_incorrect: 'நீங்கள் உள்ளிட்ட கடவுச்சொல் தவறானது. மீண்டும் முயற்சிக்கவும்.',
     form_password_length_too_short:
       'உங்கள் கடவுச்சொல் மிகவும் குறுகியது. இது குறைந்தது 8 எழுத்துகள் நீளமாக இருக்க வேண்டும்.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'உங்கள் கடவுச்சொல் போதுமான வலிமை இல்லை.',
     form_password_or_identifier_incorrect:
       'கடவுச்சொல் அல்லது மின்னஞ்சல் முகவரி தவறானது. மீண்டும் முயற்சிக்கவும் அல்லது வேறு முறையைப் பயன்படுத்தவும்.',

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -1773,6 +1773,7 @@ export const teIN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'మీరు నమోదు చేసిన పాస్‌వర్డ్ తప్పు. దయచేసి మళ్ళీ ప్రయత్నించండి.',
     form_password_length_too_short: 'మీ పాస్‌వర్డ్ చాలా చిన్నది. ఇది కనీసం 8 అక్షరాల పొడవు ఉండాలి.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'మీ పాస్‌వర్డ్ సరిపడా బలంగా లేదు.',
     form_password_or_identifier_incorrect:
       'పాస్‌వర్డ్ లేదా ఇమెయిల్ చిరునామా తప్పు. దయచేసి మళ్ళీ ప్రయత్నించండి లేదా మరొక పద్ధతిని ఉపయోగించండి.',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -1748,6 +1748,7 @@ export const thTH: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'รหัสผ่านของคุณสั้นเกินไป ต้องมีความยาวอย่างน้อย 8 ตัวอักษร',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'รหัสผ่านของคุณไม่แข็งแกร่งพอ',
     form_password_or_identifier_incorrect: 'รหัสผ่านหรือที่อยู่อีเมลไม่ถูกต้อง ลองอีกครั้งหรือใช้วิธีอื่น',
     form_password_pwned:

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -1752,6 +1752,7 @@ export const trTR: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: 'Şifre yanlış.',
     form_password_length_too_short: 'Şifre çok kısa.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Şifreniz yeterince güçlü değil.',
     form_password_or_identifier_incorrect:
       'Şifre veya e-posta adresi yanlış. Tekrar deneyin veya başka bir yöntem kullanın.',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -1748,6 +1748,7 @@ export const ukUA: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Ваш пароль недостатньо надійний.',
     form_password_or_identifier_incorrect:
       'Пароль або адреса електронної пошти невірні. Спробуйте ще раз або використайте інший метод.',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -1767,6 +1767,7 @@ export const viVN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Mật khẩu của bạn quá ngắn. Nó phải có ít nhất 8 ký tự.',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: 'Mật khẩu của bạn không đủ mạnh.',
     form_password_or_identifier_incorrect:
       'Mật khẩu hoặc địa chỉ email không đúng. Vui lòng thử lại hoặc sử dụng phương thức khác.',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -1733,6 +1733,7 @@ export const zhCN: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: undefined,
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: '您的密码强度不够。',
     form_password_or_identifier_incorrect: '密码或电子邮件地址不正确。请重试或使用其他方法。',
     form_password_pwned: '这个密码在数据泄露中被发现，不能使用，请换一个密码试试。',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -1737,6 +1737,7 @@ export const zhTW: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: '您的密碼太短。長度必須至少為 8 個字元。',
+    form_password_matches_identifier: undefined,
     form_password_not_strong_enough: '您的密碼強度不足。',
     form_password_or_identifier_incorrect: '密碼或電子郵件地址不正確。請重試或使用其他方法。',
     form_password_pwned: '此密碼已在已知的資料外洩事件中出現，請改用其他密碼。',

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -2158,6 +2158,7 @@ type UnstableErrors = WithParamName<{
   form_password_pwned: LocalizationValue;
   form_password_pwned__sign_in: LocalizationValue;
   form_new_password_matches_current: LocalizationValue;
+  form_password_matches_identifier: LocalizationValue;
   /** @deprecated Use `form_password_compromised__sign_in` instead */
   form_password_untrusted__sign_in: LocalizationValue;
   form_password_compromised__sign_in: LocalizationValue;

--- a/packages/ui/src/utils/__tests__/passwordUtils.test.tsx
+++ b/packages/ui/src/utils/__tests__/passwordUtils.test.tsx
@@ -161,6 +161,65 @@ describe('createPasswordError() constructs error that password', () => {
     );
   });
 
+  it('matches one of the account identifiers', async () => {
+    const { wrapper: Wrapper } = await createFixtures();
+
+    const wrapperBefore = ({ children }) => (
+      <Wrapper>
+        <OptionsProvider value={{ localization: {} }}>{children}</OptionsProvider>
+      </Wrapper>
+    );
+
+    const { result } = renderHook(() => useLocalizations(), { wrapper: wrapperBefore });
+
+    const res = createPasswordError(
+      [{ code: 'form_password_matches_identifier', message: 'server message' }],
+      createLocalizationConfig(result.current.t),
+    );
+    expect(res).toBe(
+      'Password cannot match your email address, phone number or username. For account safety, please use a different password.',
+    );
+  });
+
+  it('falls back to the server message for a code with no complexity mapping', async () => {
+    const { wrapper: Wrapper } = await createFixtures();
+
+    const wrapperBefore = ({ children }) => (
+      <Wrapper>
+        <OptionsProvider value={{ localization: {} }}>{children}</OptionsProvider>
+      </Wrapper>
+    );
+
+    const { result } = renderHook(() => useLocalizations(), { wrapper: wrapperBefore });
+
+    const res = createPasswordError(
+      [{ code: 'form_password_some_future_rule', message: 'Server explains the rule.' }],
+      createLocalizationConfig(result.current.t),
+    );
+    expect(res).toBe('Server explains the rule.');
+  });
+
+  it('ignores unmapped codes that accompany a mapped one', async () => {
+    const { wrapper: Wrapper } = await createFixtures();
+
+    const wrapperBefore = ({ children }) => (
+      <Wrapper>
+        <OptionsProvider value={{ localization: {} }}>{children}</OptionsProvider>
+      </Wrapper>
+    );
+
+    const { result } = renderHook(() => useLocalizations(), { wrapper: wrapperBefore });
+
+    const res = createPasswordError(
+      [
+        { code: 'form_password_no_uppercase', message: '' },
+        { code: 'form_password_some_future_rule', message: 'Server explains the rule.' },
+      ],
+      createLocalizationConfig(result.current.t),
+    );
+    expect(res).toBe('Your password must contain an uppercase letter.');
+  });
+
   //
   // zxcvbn
   //

--- a/packages/ui/src/utils/__tests__/passwordUtils.test.tsx
+++ b/packages/ui/src/utils/__tests__/passwordUtils.test.tsx
@@ -181,7 +181,7 @@ describe('createPasswordError() constructs error that password', () => {
     );
   });
 
-  it('falls back to the server message for a code with no complexity mapping', async () => {
+  it('returns the error itself for a code with no complexity mapping, so translateError handles it', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -192,11 +192,12 @@ describe('createPasswordError() constructs error that password', () => {
 
     const { result } = renderHook(() => useLocalizations(), { wrapper: wrapperBefore });
 
-    const res = createPasswordError(
-      [{ code: 'form_password_some_future_rule', message: 'Server explains the rule.' }],
-      createLocalizationConfig(result.current.t),
-    );
-    expect(res).toBe('Server explains the rule.');
+    const error = { code: 'form_password_some_future_rule', message: 'Server explains the rule.' };
+    const res = createPasswordError([error], createLocalizationConfig(result.current.t));
+
+    expect(res).toBe(error);
+    // setError() pipes the result through translateError, which falls back to the API message
+    expect(result.current.translateError(res)).toBe('Server explains the rule.');
   });
 
   it('ignores unmapped codes that accompany a mapped one', async () => {

--- a/packages/ui/src/utils/passwordUtils.ts
+++ b/packages/ui/src/utils/passwordUtils.ts
@@ -30,7 +30,10 @@ type LocalizationConfigProps = {
   passwordSettings: Pick<PasswordSettingsData, 'max_length' | 'min_length'>;
 };
 
-export const createPasswordError = (errors: ClerkAPIError[], localizationConfig: LocalizationConfigProps) => {
+export const createPasswordError = (
+  errors: ClerkAPIError[],
+  localizationConfig: LocalizationConfigProps,
+): ClerkAPIError | string | undefined => {
   if (!localizationConfig) {
     return errors[0].longMessage;
   }
@@ -60,11 +63,14 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
   const minLenErrors = errors.filter(e => e.code === 'form_password_length_too_short');
 
   const complexityErrors = mapComplexityErrors(passwordSettings);
-  const knownErrors = (minLenErrors.length ? minLenErrors : errors).filter(e => e.code in complexityErrors);
+  const knownErrors = (minLenErrors.length ? minLenErrors : errors).filter(e =>
+    Object.hasOwn(complexityErrors, e.code),
+  );
 
-  // an unmapped code would otherwise render the prefix with an empty list, eg "Your password must contain ."
+  // returning the error lets translateError localize by code before falling back to the API message;
+  // building the sentence here would render the prefix with an empty list, eg "Your password must contain ."
   if (!knownErrors.length) {
-    return errors?.[0]?.longMessage || errors?.[0]?.message || '';
+    return errors?.[0];
   }
 
   const message = knownErrors.map((s: any) => {

--- a/packages/ui/src/utils/passwordUtils.ts
+++ b/packages/ui/src/utils/passwordUtils.ts
@@ -40,7 +40,8 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
   if (
     errors?.[0]?.code === 'form_password_size_in_bytes_exceeded' ||
     errors?.[0]?.code === 'form_password_pwned' ||
-    errors?.[0]?.code === 'form_new_password_matches_current'
+    errors?.[0]?.code === 'form_new_password_matches_current' ||
+    errors?.[0]?.code === 'form_password_matches_identifier'
   ) {
     return `${t(localizationKeys(`unstable__errors.${errors?.[0]?.code}` as any)) || errors?.[0]?.message}`;
   }
@@ -58,8 +59,16 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
   // show min length error first by itself
   const minLenErrors = errors.filter(e => e.code === 'form_password_length_too_short');
 
-  const message = (minLenErrors.length ? minLenErrors : errors).map((s: any) => {
-    const localizedKey = (mapComplexityErrors(passwordSettings) as any)[s.code];
+  const complexityErrors = mapComplexityErrors(passwordSettings);
+  const knownErrors = (minLenErrors.length ? minLenErrors : errors).filter(e => e.code in complexityErrors);
+
+  // an unmapped code would otherwise render the prefix with an empty list, eg "Your password must contain ."
+  if (!knownErrors.length) {
+    return errors?.[0]?.longMessage || errors?.[0]?.message || '';
+  }
+
+  const message = knownErrors.map((s: any) => {
+    const localizedKey = (complexityErrors as any)[s.code];
 
     if (Array.isArray(localizedKey)) {
       const [lk, attr, val] = localizedKey;


### PR DESCRIPTION
We pushed a new password error from the backend with the intention that it would be passed through to our SDKs. However, password fields have special behavior that override the generic error builder and do not fallback to the apierror from the backend.

Two layers to the fix:

1. Specific: handle `form_password_matches_identifier`, and add the `unstable__errors.form_password_matches_identifier` key with an en-US string mirroring the server copy.
2. General: filter to codes present in `mapComplexityErrors` and, when none remain, fall back to `longMessage || message`. This restores the passthrough for any future unrecognized code, and stops an unmapped code arriving alongside a mapped one from contributing a blank list item.

<img width="812" height="706" alt="CleanShot 2026-08-14 at 11 08 20@2x" src="https://github.com/user-attachments/assets/d9641cc7-8bad-49d0-951a-f45c3f17f49c" />


## Description

<!--
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
