### PR TITLE
fix(expo-google-signin): preserve provider failures

### DIFF
--- a/.changeset/preserve-google-sign-in-errors.md
+++ b/.changeset/preserve-google-sign-in-errors.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo-google-signin': patch
+---
+
+Fix Android Google Sign-In provider failures being reported as user cancellation.

--- a/packages/expo-google-signin/android/build.gradle
+++ b/packages/expo-google-signin/android/build.gradle
@@ -36,4 +36,5 @@ dependencies {
   implementation "androidx.credentials:credentials-play-services-auth:1.3.0"
   implementation "com.google.android.libraries.identity.googleid:googleid:1.1.1"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+  testImplementation "junit:junit:4.13.2"
 }

--- a/packages/expo-google-signin/android/src/main/java/expo/modules/clerk/googlesignin/ClerkGoogleSignInModule.kt
+++ b/packages/expo-google-signin/android/src/main/java/expo/modules/clerk/googlesignin/ClerkGoogleSignInModule.kt
@@ -98,7 +98,7 @@ class ClerkGoogleSignInModule : Module() {
 
         handleSignInResult(result, promise)
       } catch (e: GetCredentialCancellationException) {
-        promise.reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow", e)
+        rejectCredentialCancellation(promise, e)
       } catch (e: NoCredentialException) {
         promise.reject("NO_SAVED_CREDENTIAL_FOUND", "No saved credential found", e)
       } catch (e: GetCredentialException) {
@@ -145,7 +145,7 @@ class ClerkGoogleSignInModule : Module() {
 
         handleSignInResult(result, promise)
       } catch (e: GetCredentialCancellationException) {
-        promise.reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow", e)
+        rejectCredentialCancellation(promise, e)
       } catch (e: NoCredentialException) {
         promise.reject("NO_SAVED_CREDENTIAL_FOUND", "No saved credential found", e)
       } catch (e: GetCredentialException) {
@@ -191,7 +191,7 @@ class ClerkGoogleSignInModule : Module() {
 
         handleSignInResult(result, promise)
       } catch (e: GetCredentialCancellationException) {
-        promise.reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow", e)
+        rejectCredentialCancellation(promise, e)
       } catch (e: GetCredentialException) {
         promise.reject("GOOGLE_SIGN_IN_ERROR", e.message ?: "Unknown error", e)
       } catch (e: Exception) {
@@ -214,6 +214,17 @@ class ClerkGoogleSignInModule : Module() {
   }
 
   // MARK: - Helpers
+
+  private fun rejectCredentialCancellation(promise: Promise, exception: GetCredentialCancellationException) {
+    val message = exception.message ?: "Google Sign-In failed"
+
+    if (isExplicitUserCancellation(message)) {
+      promise.reject("SIGN_IN_CANCELLED", "User cancelled the sign-in flow", exception)
+      return
+    }
+
+    promise.reject("GOOGLE_SIGN_IN_ERROR", message, exception)
+  }
 
   private fun handleSignInResult(result: GetCredentialResponse, promise: Promise) {
     when (val credential = result.credential) {
@@ -255,3 +266,9 @@ class ClerkGoogleSignInModule : Module() {
     }
   }
 }
+
+private val explicitUserCancellationPattern =
+  Regex("^(?:\\[\\d+]\\s*)?cancel(?:l)?ed by user\\.?$", RegexOption.IGNORE_CASE)
+
+internal fun isExplicitUserCancellation(message: String): Boolean =
+  explicitUserCancellationPattern.matches(message.trim())

--- a/packages/expo-google-signin/android/src/test/java/expo/modules/clerk/googlesignin/ClerkGoogleSignInModuleTest.kt
+++ b/packages/expo-google-signin/android/src/test/java/expo/modules/clerk/googlesignin/ClerkGoogleSignInModuleTest.kt
@@ -1,0 +1,21 @@
+package expo.modules.clerk.googlesignin
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClerkGoogleSignInModuleTest {
+  @Test
+  fun identifiesExplicitUserCancellation() {
+    assertTrue(isExplicitUserCancellation("[16] Cancelled by user."))
+    assertTrue(isExplicitUserCancellation("Canceled by user"))
+    assertTrue(isExplicitUserCancellation("  cancelled by user  "))
+  }
+
+  @Test
+  fun preservesProviderFailures() {
+    assertFalse(isExplicitUserCancellation("[16] Account reauth failed."))
+    assertFalse(isExplicitUserCancellation("Developer console is not set up correctly."))
+    assertFalse(isExplicitUserCancellation("Request was not cancelled by user"))
+  }
+}


### PR DESCRIPTION
## Description

Fixes #9461.

Android Credential Manager providers can return non-user failures through GetCredentialCancellationException. The native module currently reports every instance as SIGN_IN_CANCELLED, causing @clerk/expo to treat those failures as an ordinary chooser dismissal and return no session or error.

This change keeps explicit Cancelled by user and Canceled by user responses as SIGN_IN_CANCELLED and reports other messages as GOOGLE_SIGN_IN_ERROR. The same classification is used by signIn, createAccount, and presentExplicitSignIn.

The standalone reproduction at https://github.com/eliotgevers/clerk-expo-google-signin-error-repro demonstrates the provider-failure and user-dismissal control cases.

## Checklist

- [ ] pnpm test runs as expected.
- [x] pnpm build runs as expected.
- [ ] (If applicable) JSDoc comments have been added or updated for any package exports
- [ ] (If applicable) Documentation has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: