### PR TITLE
chore(*): deprecate the keyless substrate ahead of removal

### DIFF
--- a/.changeset/keyless-substrate-deprecated.md
+++ b/.changeset/keyless-substrate-deprecated.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+'@clerk/backend': patch
+---
+
+Mark the keyless substrate as deprecated ahead of removal in the next major: `resolveKeysWithKeylessFallback` in `@clerk/shared/keyless`, and the experimental accountless applications API in `@clerk/backend`. Both are kept functional for the claimed-keys migration path and for older published SDK versions.

--- a/packages/backend/src/api/endpoints/AccountlessApplicationsAPI.ts
+++ b/packages/backend/src/api/endpoints/AccountlessApplicationsAPI.ts
@@ -9,6 +9,9 @@ type AccountlessApplicationParams = {
   source?: string;
 };
 
+/**
+ * @deprecated Keyless mode is no longer activated by the framework SDKs. Kept for the claimed-keys migration path and older published SDK versions; remove in the next major.
+ */
 export class AccountlessApplicationAPI extends AbstractAPI {
   public async createAccountlessApplication(params?: AccountlessApplicationParams): Promise<AccountlessApplication> {
     const headerParams = params?.requestHeaders ? Object.fromEntries(params.requestHeaders.entries()) : undefined;

--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -48,6 +48,9 @@ export function createBackendApiClient(options: CreateBackendApiOptions) {
   const request = buildRequest(options);
 
   return {
+    /**
+     * @deprecated Keyless mode is no longer activated by the framework SDKs. Kept for the claimed-keys migration path and older published SDK versions; remove in the next major.
+     */
     __experimental_accountlessApplications: new AccountlessApplicationAPI(
       buildRequest({ ...options, requireSecretKey: false }),
     ),

--- a/packages/backend/src/api/resources/AccountlessApplication.ts
+++ b/packages/backend/src/api/resources/AccountlessApplication.ts
@@ -1,5 +1,8 @@
 import type { AccountlessApplicationJSON } from './JSON';
 
+/**
+ * @deprecated Keyless mode is no longer activated by the framework SDKs. Kept for the claimed-keys migration path and older published SDK versions; remove in the next major.
+ */
 export class AccountlessApplication {
   constructor(
     readonly publishableKey: string,

--- a/packages/shared/src/keyless/resolveKeysWithKeylessFallback.ts
+++ b/packages/shared/src/keyless/resolveKeysWithKeylessFallback.ts
@@ -17,6 +17,8 @@ export interface KeylessResult {
  * @param keylessService - The keyless service instance (or null if unavailable)
  * @param canUseKeyless - Whether keyless mode is enabled in the current environment
  * @returns The resolved keys (either configured or from keyless mode)
+ *
+ * @deprecated Keyless mode is no longer activated by the framework SDKs; kept for older published SDK versions. Remove in the next major.
  */
 export async function resolveKeysWithKeylessFallback(
   configuredPublishableKey: string | undefined,

--- a/packages/shared/src/keyless/service.ts
+++ b/packages/shared/src/keyless/service.ts
@@ -128,6 +128,8 @@ export interface KeylessService {
    * @param configuredPublishableKey - The publishable key from options or environment
    * @param configuredSecretKey - The secret key from options or environment
    * @returns The resolved keys (either configured or from keyless mode)
+   *
+   * @deprecated Keyless mode is no longer activated by the framework SDKs; kept for older published SDK versions. Remove in the next major.
    */
   resolveKeysWithKeylessFallback: (
     configuredPublishableKey: string | undefined,


### PR DESCRIPTION
## Description

Part 5 of the keyless→CLI stack (#9491 → #9493 → #9487 → #9488), stacked on #9487. Pre-announces the next-major removal of the keyless substrate now that no current SDK activates it:

- `@clerk/shared/keyless`: `resolveKeysWithKeylessFallback` (standalone function and the `KeylessService` method) marked `@deprecated` — zero in-repo callers after #9487.
- `@clerk/backend`: `__experimental_accountlessApplications`, `AccountlessApplicationAPI`, and the `AccountlessApplication` resource marked `@deprecated`.

Everything stays functional: the claimed-keys migration path in `@clerk/nextjs` still calls `completeOnboarding`, and older published SDK versions resolve `^`-ranged `@clerk/shared`/`@clerk/backend` and continue to work.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

