### PR TITLE
feat(shared): point missing and invalid key errors at the Clerk CLI

### DIFF
--- a/.changeset/cli-error-copy.md
+++ b/.changeset/cli-error-copy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Update missing and invalid key error messages to recommend the Clerk CLI: `npx clerk@latest init` (non-interactive, no Clerk account required) to create an application, `npx clerk@latest env pull` to fetch the keys of an existing one, and `npx clerk@latest deploy` / `npx clerk@latest env pull --instance prod` for production. This covers both the `errorThrower` messages and the errors thrown by `parsePublishableKey(key, { fatal: true })`, which previously surfaced server-side as a bare `Publishable key not valid.` The Dashboard link is kept for manual key copying.

--- a/packages/backend/src/__tests__/createRedirect.test.ts
+++ b/packages/backend/src/__tests__/createRedirect.test.ts
@@ -28,7 +28,7 @@ describe('redirect(redirectAdapter)', () => {
       } as any);
 
       expect(() => redirectToSignIn({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
       );
     });
   });
@@ -258,7 +258,7 @@ describe('redirect(redirectAdapter)', () => {
       });
 
       expect(() => redirectToSignUp({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
       );
     });
 

--- a/packages/backend/src/__tests__/createRedirect.test.ts
+++ b/packages/backend/src/__tests__/createRedirect.test.ts
@@ -28,7 +28,7 @@ describe('redirect(redirectAdapter)', () => {
       } as any);
 
       expect(() => redirectToSignIn({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
       );
     });
   });
@@ -258,7 +258,7 @@ describe('redirect(redirectAdapter)', () => {
       });
 
       expect(() => redirectToSignUp({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
       );
     });
 

--- a/packages/shared/src/__tests__/error.spec.ts
+++ b/packages/shared/src/__tests__/error.spec.ts
@@ -16,13 +16,13 @@ describe('ErrorThrower', () => {
 
   it('throws the correct error message and interpolates pkg and known parameters', () => {
     expect(() => errorThrower.throwInvalidPublishableKeyError({ key: 'whatever' })).toThrow(
-      '@clerk/test-package: The publishableKey passed to Clerk is invalid. You can get your Publishable key at https://dashboard.clerk.com/last-active?path=api-keys. (key=whatever)',
+      '@clerk/test-package: The publishableKey passed to Clerk is invalid (key=whatever, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, run:\n\n  npx clerk@latest init',
     );
   });
 
   it('throws the correct error message and interpolates pkg if no parameters are provided', () => {
     expect(() => errorThrower.throwMissingPublishableKeyError()).toThrow(
-      '@clerk/test-package: Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.',
+      '@clerk/test-package: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/error.spec.ts
+++ b/packages/shared/src/__tests__/error.spec.ts
@@ -16,13 +16,13 @@ describe('ErrorThrower', () => {
 
   it('throws the correct error message and interpolates pkg and known parameters', () => {
     expect(() => errorThrower.throwInvalidPublishableKeyError({ key: 'whatever' })).toThrow(
-      '@clerk/test-package: The publishableKey passed to Clerk is invalid (key=whatever, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, run:\n\n  npx clerk@latest init',
+      '@clerk/test-package: The publishableKey passed to Clerk is invalid (key=whatever, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, in your terminal run:\n\n  npx clerk@latest init',
     );
   });
 
   it('throws the correct error message and interpolates pkg if no parameters are provided', () => {
     expect(() => errorThrower.throwMissingPublishableKeyError()).toThrow(
-      '@clerk/test-package: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
+      '@clerk/test-package: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/keys.spec.ts
+++ b/packages/shared/src/__tests__/keys.spec.ts
@@ -81,7 +81,7 @@ describe('parsePublishableKey(key)', () => {
 
   it('throws an error if the publishable key is missing, when fatal: true', () => {
     expect(() => parsePublishableKey(undefined, { fatal: true })).toThrowError(
-      'Publishable key is missing. To create a Clerk application with valid keys, run:\n\n  npx clerk@latest init',
+      'Publishable key is missing. To create a Clerk application with valid keys, in your terminal run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/keys.spec.ts
+++ b/packages/shared/src/__tests__/keys.spec.ts
@@ -60,7 +60,7 @@ describe('parsePublishableKey(key)', () => {
   it('throws an error for keys with extra characters after $ when fatal: true', () => {
     expect(() =>
       parsePublishableKey('pk_live_ZmFrZS1jbGVyay1tYWxmb3JtZWQuY2xlcmsuYWNjb3VudHMuZGV2JGV4dHJh', { fatal: true }),
-    ).toThrowError('Publishable key not valid.');
+    ).toThrowError('Publishable key not valid');
   });
 
   it('returns null for keys with multiple $ characters', () => {
@@ -72,18 +72,16 @@ describe('parsePublishableKey(key)', () => {
   });
 
   it('throws an error if the key cannot be decoded when fatal: true', () => {
-    expect(() => parsePublishableKey('pk_live_invalid!@#$', { fatal: true })).toThrowError(
-      'Publishable key not valid.',
-    );
+    expect(() => parsePublishableKey('pk_live_invalid!@#$', { fatal: true })).toThrowError('Publishable key not valid');
   });
 
   it('throws an error if the key is not a valid publishable key, when fatal: true', () => {
-    expect(() => parsePublishableKey('fake_pk', { fatal: true })).toThrowError('Publishable key not valid.');
+    expect(() => parsePublishableKey('fake_pk', { fatal: true })).toThrowError('Publishable key not valid');
   });
 
   it('throws an error if the publishable key is missing, when fatal: true', () => {
     expect(() => parsePublishableKey(undefined, { fatal: true })).toThrowError(
-      'Publishable key is missing. Ensure that your publishable key is correctly configured. Double-check your environment configuration for your keys, or access them here: https://dashboard.clerk.com/last-active?path=api-keys',
+      'Publishable key is missing. To create a Clerk application with valid keys, run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
+++ b/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
@@ -46,7 +46,7 @@ describe('loadClerkJsScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkJsScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
     );
   });
 
@@ -310,7 +310,7 @@ describe('loadClerkUIScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkUIScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
+++ b/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
@@ -46,7 +46,7 @@ describe('loadClerkJsScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkJsScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
     );
   });
 
@@ -310,7 +310,7 @@ describe('loadClerkUIScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkUIScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. To set up Clerk for this project, run:\n\n  npx clerk@latest init',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/errors/errorThrower.ts
+++ b/packages/shared/src/errors/errorThrower.ts
@@ -1,20 +1,26 @@
 const DefaultMessages = Object.freeze({
   InvalidProxyUrlErrorMessage: `The proxyUrl passed to Clerk is invalid. The expected value for proxyUrl is an absolute URL or a relative path with a leading '/'. (key={{url}})`,
-  InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid (key={{key}}, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, run:
+  InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid (key={{key}}, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, in your terminal run:
 
   npx clerk@latest init
 
-The command is non-interactive and requires no Clerk account or login. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys to your env file (\`--instance prod\` for production keys), or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys.`,
-  MissingPublishableKeyErrorMessage: `Missing publishableKey. To set up Clerk for this project, run:
+It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys.`,
+  MissingPublishableKeyErrorMessage: `Missing publishableKey. To set up Clerk for this project, in your terminal run:
 
   npx clerk@latest init
 
-The command is non-interactive and requires no Clerk account or login: it creates a Clerk application and writes the required keys to your env file. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys, or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploying to production? Run \`npx clerk@latest deploy\` to provision a production instance, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
-  MissingSecretKeyErrorMessage: `Missing secretKey. To set up Clerk for this project, run:
+It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
+  MissingSecretKeyErrorMessage: `Missing secretKey. To set up Clerk for this project, in your terminal run:
 
   npx clerk@latest init
 
-The command is non-interactive and requires no Clerk account or login: it creates a Clerk application and writes the required keys to your env file. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys, or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploying to production? Run \`npx clerk@latest deploy\` to provision a production instance, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
+It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingClerkProvider: `{{source}} can only be used within the <ClerkProvider /> component. Learn more: https://clerk.com/docs/components/clerk-provider`,
 });
 

--- a/packages/shared/src/errors/errorThrower.ts
+++ b/packages/shared/src/errors/errorThrower.ts
@@ -1,8 +1,20 @@
 const DefaultMessages = Object.freeze({
   InvalidProxyUrlErrorMessage: `The proxyUrl passed to Clerk is invalid. The expected value for proxyUrl is an absolute URL or a relative path with a leading '/'. (key={{url}})`,
-  InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid. You can get your Publishable key at https://dashboard.clerk.com/last-active?path=api-keys. (key={{key}})`,
-  MissingPublishableKeyErrorMessage: `Missing publishableKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.`,
-  MissingSecretKeyErrorMessage: `Missing secretKey. You can get your key at https://dashboard.clerk.com/last-active?path=api-keys.`,
+  InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid (key={{key}}, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, run:
+
+  npx clerk@latest init
+
+The command is non-interactive and requires no Clerk account or login. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys to your env file (\`--instance prod\` for production keys), or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys.`,
+  MissingPublishableKeyErrorMessage: `Missing publishableKey. To set up Clerk for this project, run:
+
+  npx clerk@latest init
+
+The command is non-interactive and requires no Clerk account or login: it creates a Clerk application and writes the required keys to your env file. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys, or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploying to production? Run \`npx clerk@latest deploy\` to provision a production instance, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
+  MissingSecretKeyErrorMessage: `Missing secretKey. To set up Clerk for this project, run:
+
+  npx clerk@latest init
+
+The command is non-interactive and requires no Clerk account or login: it creates a Clerk application and writes the required keys to your env file. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys, or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploying to production? Run \`npx clerk@latest deploy\` to provision a production instance, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingClerkProvider: `{{source}} can only be used within the <ClerkProvider /> component. Learn more: https://clerk.com/docs/components/clerk-provider`,
 });
 

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -98,11 +98,13 @@ function isValidDecodedPublishableKey(decoded: string): boolean {
   return withoutTrailing.includes('.');
 }
 
-const fatalKeyGuidance = `To create a Clerk application with valid keys, run:
+const fatalKeyGuidance = `To create a Clerk application with valid keys, in your terminal run:
 
   npx clerk@latest init
 
-The command is non-interactive and requires no Clerk account or login. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys to your env file (\`--instance prod\` for production keys), or copy them from https://dashboard.clerk.com/last-active?path=api-keys.`;
+It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy them from https://dashboard.clerk.com/last-active?path=api-keys.`;
 
 export function parsePublishableKey(
   key: string | undefined,

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -98,6 +98,12 @@ function isValidDecodedPublishableKey(decoded: string): boolean {
   return withoutTrailing.includes('.');
 }
 
+const fatalKeyGuidance = `To create a Clerk application with valid keys, run:
+
+  npx clerk@latest init
+
+The command is non-interactive and requires no Clerk account or login. If you already have a Clerk application, run \`npx clerk@latest env pull\` to write its keys to your env file (\`--instance prod\` for production keys), or copy them from https://dashboard.clerk.com/last-active?path=api-keys.`;
+
 export function parsePublishableKey(
   key: string | undefined,
   options: ParsePublishableKeyOptions & { fatal: true },
@@ -127,12 +133,10 @@ export function parsePublishableKey(
 
   if (!key || !isPublishableKey(key)) {
     if (options.fatal && !key) {
-      throw new Error(
-        'Publishable key is missing. Ensure that your publishable key is correctly configured. Double-check your environment configuration for your keys, or access them here: https://dashboard.clerk.com/last-active?path=api-keys',
-      );
+      throw new Error(`Publishable key is missing. ${fatalKeyGuidance}`);
     }
     if (options.fatal && !isPublishableKey(key)) {
-      throw new Error('Publishable key not valid.');
+      throw new Error(`Publishable key not valid (expected format: pk_test_... or pk_live_...). ${fatalKeyGuidance}`);
     }
     return null;
   }
@@ -144,14 +148,14 @@ export function parsePublishableKey(
     decodedFrontendApi = isomorphicAtob(key.split('_')[2]);
   } catch {
     if (options.fatal) {
-      throw new Error('Publishable key not valid: Failed to decode key.');
+      throw new Error(`Publishable key not valid: Failed to decode key. ${fatalKeyGuidance}`);
     }
     return null;
   }
 
   if (!isValidDecodedPublishableKey(decodedFrontendApi)) {
     if (options.fatal) {
-      throw new Error('Publishable key not valid: Decoded key has invalid format.');
+      throw new Error(`Publishable key not valid: Decoded key has invalid format. ${fatalKeyGuidance}`);
     }
     return null;
   }


### PR DESCRIPTION
## Description

Pure copy change, no behavior:

- `@clerk/shared` `errorThrower`: the default missing `publishableKey`/`secretKey` and invalid `publishableKey` messages now recommend the Clerk CLI: `npx clerk@latest init` (noted as non-interactive, no Clerk account or login required) to create an application, `npx clerk@latest env pull` to fetch the keys of an existing one, and `npx clerk@latest deploy` / `npx clerk@latest env pull --instance prod` for production. Every SDK instantiating the shared `errorThrower` inherits the copy.
- `parsePublishableKey(key, { fatal: true })`: the missing/invalid throws now carry the same CLI guidance. This is the error the server actually hits — `authenticateRequest` fatally parses the key on every request, so a fabricated or missing key previously surfaced in dev server logs as a bare `Publishable key not valid.` with no remediation. Fixes it for every server SDK at once.

The same message is shown in every environment — there is no dev/prod branching. The Dashboard link is kept for manual key copying.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🌟 New feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
