### PR TITLE
fix(shared): Declare package as side-effect-free for tree-shaking

### DIFF
--- a/.changeset/shared-sideeffects-false.md
+++ b/.changeset/shared-sideeffects-false.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Declare `@clerk/shared` as side-effect-free (`"sideEffects": false`) so bundlers can tree-shake unused exports from the package.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "author": "Clerk",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
## Description

`@clerk/nextjs` declares `"sideEffects": false`, but `@clerk/shared`, which it stands on, omits the field. Bundlers therefore have to assume every module in `@clerk/shared` may have side effects and cannot drop unused exports reached through it. This is the `@clerk/shared` part of #9475.

This adds `"sideEffects": false` to `@clerk/shared`. Its published source has no import-time side effects: there are no CSS or bare side-effect imports, and the only `globalThis` write (in `createClerkDevCache`) runs lazily when the function is called rather than on import. The declaration matches `@clerk/nextjs` and the other framework packages that already set it.

Scope note: this covers the `@clerk/shared` half of #9475 only. `@clerk/react` is intentionally left out, because its entry (`src/index.ts`) has genuine import-time side effects: the `window.global` shim in `polyfills.ts`, and top-level `setErrorThrowerOptions` / `setClerkJSLoadingErrorPackageName` calls. It would need the array form rather than a blanket `false`, and which built chunks that array has to cover depends on the merged `tsdown` output described in the issue. Happy to follow up on `@clerk/react` separately.

Part of #9475

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
