### PR TITLE
fix(expo-google-signin): resolve presenting view controller from the key window on iOS

### DIFF
--- a/.changeset/ios-google-signin-presenting-window.md
+++ b/.changeset/ios-google-signin-presenting-window.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo-google-signin': patch
+---
+
+Fix iOS Google sign-in failing with `GOOGLE_SIGN_IN_ERROR` in apps with more than one window or scene. The presenting view controller is now resolved from the key window of the foreground-active scene instead of an arbitrary window, so overlays such as splash screens or windows created by other modules no longer break the sign-in flow.

--- a/packages/expo-google-signin/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo-google-signin/ios/ClerkGoogleSignInModule.swift
@@ -148,7 +148,7 @@ public class ClerkGoogleSignInModule: Module {
       ?? scenes.first { $0.activationState == .foregroundInactive }
       ?? scenes.first
 
-    guard let window = scene?.windows.first(where: { $0.isKeyWindow })
+    guard let window = scene?.windows.first(where: { $0.isKeyWindow && !$0.isHidden && $0.rootViewController != nil })
             ?? scene?.windows.first(where: { !$0.isHidden && $0.rootViewController != nil }),
           let rootVC = window.rootViewController else {
       return nil

--- a/packages/expo-google-signin/ios/ClerkGoogleSignInModule.swift
+++ b/packages/expo-google-signin/ios/ClerkGoogleSignInModule.swift
@@ -143,14 +143,19 @@ public class ClerkGoogleSignInModule: Module {
   }
 
   private func getPresentingViewController() -> UIViewController? {
-    guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-          let window = scene.windows.first,
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    let scene = scenes.first { $0.activationState == .foregroundActive }
+      ?? scenes.first { $0.activationState == .foregroundInactive }
+      ?? scenes.first
+
+    guard let window = scene?.windows.first(where: { $0.isKeyWindow })
+            ?? scene?.windows.first(where: { !$0.isHidden && $0.rootViewController != nil }),
           let rootVC = window.rootViewController else {
       return nil
     }
 
     var topVC = rootVC
-    while let presentedVC = topVC.presentedViewController {
+    while let presentedVC = topVC.presentedViewController, !presentedVC.isBeingDismissed {
       topVC = presentedVC
     }
     return topVC


### PR DESCRIPTION
## Description

iOS native Google sign-in fails in apps that have more than one window or scene when sign-in is invoked.

This does not reproduce in a vanilla dev build, since single-window apps resolve `.first` correctly. I replicated it by adding a decoy window in the fixture app's `AppDelegate` (`windowLevel` below `.normal`, no root view controller, unhidden shortly after launch). With that in place, sign-in rejects instantly with no auth sheet. With this fix and the same decoy, the Google consent sheet presents normally.


https://github.com/user-attachments/assets/20581962-685e-4508-8fef-b749d287c639


Fixes #9504

Resolves MOBILE-627

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: