### PR TITLE
fix(backend): Reject JWT-template tokens on the acceptsToken any/array header path

### DIFF
--- a/.changeset/reject-jwt-template-accepts-token-any.md
+++ b/.changeset/reject-jwt-template-accepts-token-any.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Reject JWT-template tokens presented as session tokens in the `Authorization` header when `acceptsToken` is `'any'` or an array that includes `'session_token'`. `authenticateRequest()` now returns a signed-out state with reason `token-type-mismatch` for such a token, matching the existing `acceptsToken: 'session_token'` behavior.

--- a/packages/backend/src/tokens/__tests__/request.test.ts
+++ b/packages/backend/src/tokens/__tests__/request.test.ts
@@ -1310,8 +1310,9 @@ describe('tokens.authenticateRequest(options)', () => {
   // Regression tests for SEC-340. A JWT-template token is signed by the same instance key and
   // passes verifyToken(), but carries no `sid`, so it outlives revocation of the session that
   // minted it and must not authenticate one.
+  const templateInHeader = (jwt: string) => mockRequestWithHeaderAuth({ authorization: jwt });
   describe.each([
-    ['headerToken', (jwt: string) => mockRequestWithHeaderAuth({ authorization: jwt })],
+    ['headerToken', templateInHeader, {}],
     [
       'cookieToken',
       (jwt: string) =>
@@ -1319,8 +1320,15 @@ describe('tokens.authenticateRequest(options)', () => {
           {},
           { __clerk_db_jwt: 'deadbeef', __client_uat: `${mockJwtPayload.iat - 10}`, __session: jwt },
         ),
+      {},
     ],
-  ])('%s: JWT-template token presented as a session token (SEC-340)', (_label, buildRequest) => {
+    ['headerToken, acceptsToken: any', templateInHeader, { acceptsToken: 'any' as const }],
+    [
+      'headerToken, acceptsToken: [session_token, m2m_token]',
+      templateInHeader,
+      { acceptsToken: ['session_token', 'm2m_token'] as const },
+    ],
+  ])('%s: JWT-template token presented as a session token (SEC-340)', (_label, buildRequest, options) => {
     test('returns signed out', async () => {
       const { sid: _sid, ...payloadWithoutSid } = mockJwtPayload;
       const { data: templateJwt } = await signJwt(payloadWithoutSid, signingJwks, {
@@ -1328,7 +1336,7 @@ describe('tokens.authenticateRequest(options)', () => {
         header: { typ: 'JWT', kid: 'ins_2GIoQhbUpy0hX7B2cVkuTMinXoD', cat: JWT_CATEGORY_JWT_TEMPLATE },
       });
 
-      const requestState = await authenticateRequest(buildRequest(templateJwt!), mockOptions());
+      const requestState = await authenticateRequest(buildRequest(templateJwt!), mockOptions(options));
 
       expect(requestState).toBeSignedOut({
         reason: AuthErrorReason.TokenTypeMismatch,

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -864,7 +864,16 @@ export const authenticateRequest: AuthenticateRequest = (async (
       });
     }
 
-    // Handle as a regular session token
+    // Handle as a regular session token. Mirrors the session-only header path (SEC-340).
+    if (hasNonSessionJwtCategory(tokenInHeader)) {
+      return signedOut({
+        tokenType: TokenType.SessionToken,
+        authenticateContext,
+        reason: AuthErrorReason.TokenTypeMismatch,
+        message: '',
+      });
+    }
+
     const { data, errors } = await verifyToken(tokenInHeader, authenticateContext);
     if (errors) {
       return handleSessionTokenError(errors[0], 'header');


### PR DESCRIPTION
## Description

Follow-up to #9469 (SEC-340). That PR rejects JWT-template tokens (`cat=cl_B7d4PD222AAA`) on the session-only header and cookie paths, but `authenticateAnyRequestWithTokenInHeader` — used when `acceptsToken` is `'any'` or an array that includes `'session_token'` — still fell through `isMachineToken()` → `verifyToken()` → `signedIn`, so a template token in the `Authorization` header was accepted as a `session_token` on those routes. Same consequence as the original report: the token has no `sid` and outlives revocation of the session that minted it, and it carries no `sts`, so a pending session presents as fully signed in.

This adds the same `hasNonSessionJwtCategory` check before the session-token branch of that path, returning `signed-out` / `token-type-mismatch`, and extends the SEC-340 regression tests to cover `acceptsToken: 'any'` and `['session_token', 'm2m_token']`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

🤖 Generated with [Claude Code](https://claude.com/claude-code)