### PR TITLE
docs(shared,ui): address the review comments from #9449

### DIFF
--- a/.changeset/signup-enterprise-sso-redirect-urls.md
+++ b/.changeset/signup-enterprise-sso-redirect-urls.md
@@ -3,8 +3,4 @@
 '@clerk/ui': patch
 ---
 
-Fix sign-ups that continue into an enterprise SSO connection failing with `invalid_redirect_url` ("Redirect url invalid") instead of redirecting to the identity provider.
-
-A sign-up does not always know it requires `enterprise_sso` when the form is first submitted — the requirement appears once the identity behind the sign-up is resolved, which can happen several steps later. Whichever step was active at that point performed the hand-off to the identity provider, and most of them did so without the redirect URLs it requires, so the request was rejected and the sign-up dead-ended with no way to continue. Retrying reproduced it every time. Flows that reached SSO directly from the first sign-up form were unaffected, which is why this only showed up on some sign-ups.
-
-The redirect URLs are now derived from the sign-up context wherever the flow continues, so the hand-off works from every step: the continue form, email-link and code verification, and the verification step that precedes them.
+Fix an issue where sign-ups that used an enterprise SSO connection did not correctly forward redirect URLs.

--- a/packages/shared/src/internal/clerk-js/completeSignUpFlow.ts
+++ b/packages/shared/src/internal/clerk-js/completeSignUpFlow.ts
@@ -32,7 +32,6 @@ export const completeSignUpFlow = ({
     return handleComplete && handleComplete();
   } else if (signUp.status === 'missing_requirements') {
     if (signUp.missingFields.some(mf => mf === 'enterprise_sso')) {
-      // FAPI rejects an empty redirect url, which reaches the user as a dead end rather than the caller as a bug.
       if (!redirectUrl || !redirectUrlComplete) {
         throw new Error(
           'completeSignUpFlow: `redirectUrl` and `redirectUrlComplete` are required to continue a sign-up that is missing `enterprise_sso`.',

--- a/packages/ui/src/common/EmailLinkVerify.tsx
+++ b/packages/ui/src/common/EmailLinkVerify.tsx
@@ -14,7 +14,6 @@ import { EmailLinkStatusCard } from './EmailLinkStatusCard';
 export type EmailLinkVerifyProps = {
   redirectUrlComplete?: string;
   redirectUrl?: string;
-  /** SSO callback url, required only when the verified sign-up still has to hand off to an enterprise connection. */
   ssoCallbackUrl?: string;
   verifyEmailPath?: string;
   verifyPhonePath?: string;

--- a/packages/ui/src/components/SignUp/useCompleteSignUpFlow.ts
+++ b/packages/ui/src/components/SignUp/useCompleteSignUpFlow.ts
@@ -15,13 +15,6 @@ type CompleteSignUpFlowParams = {
   handleComplete?: () => Promise<void>;
 };
 
-/**
- * Binds the sign-up context to `completeSignUpFlow` so callers only pass the routing paths.
- *
- * `redirectUrl`, `redirectUrlComplete` and `oidcPrompt` are needed by the `enterprise_sso` branch
- * but are derived identically at every call site, so binding them here is what keeps a caller from
- * silently omitting them.
- */
 export const useCompleteSignUpFlow = () => {
   const { navigate } = useRouter();
   const { setActive } = useClerk();


### PR DESCRIPTION
Follow-up to [#9449](https://github.com/clerk/javascript/pull/9449), which merged before @dstaley's review suggestions were applied. This applies them, exactly as scoped:

- `.changeset/signup-enterprise-sso-redirect-urls.md` — replaced with the one-line summary he suggested (the changeset had not been released yet, so the shorter text is what will ship).
- `packages/shared/src/internal/clerk-js/completeSignUpFlow.ts` — dropped the comment above the redirect-url guard.
- `packages/ui/src/common/EmailLinkVerify.tsx` — dropped the `ssoCallbackUrl` prop comment.
- `packages/ui/src/components/SignUp/useCompleteSignUpFlow.ts` — dropped the hook's doc block.

Comment-only; no behaviour change, and no test or type surface moves with it.