### PR TITLE
fix(localizations): use future tense for nl-NL and nl-BE

### DIFF
--- a/.changeset/open-teeth-hunt.md
+++ b/.changeset/open-teeth-hunt.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Use future tense for nl-NL and nl-BE translations

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -1971,7 +1971,7 @@ export const nlBE: LocalizationResource = {
     },
     emailAddressPage: {
       emailCode: {
-        formHint: 'Een mail met daarin een verificatiecode is verstuurd naar dit adres.',
+        formHint: 'Een mail met daarin een verificatiecode zal worden verstuurd naar dit adres.',
         formSubtitle: 'Voer de verificatiecode in die verstuurd is naar {{identifier}}',
         formTitle: 'Verificatiecode',
         resendButton: 'Verstuur code opnieuw',
@@ -2080,7 +2080,7 @@ export const nlBE: LocalizationResource = {
       title__update: 'Wachtwoord wijzigen',
     },
     phoneNumberPage: {
-      infoText: 'Een SMS met daarin een verificatiecode is verstuurd naar dit nummer.',
+      infoText: 'Een SMS met daarin een verificatiecode zal worden verstuurd naar dit nummer.',
       removeResource: {
         messageLine1: '{{identifier}} zal van dit account verwijderd worden.',
         messageLine2: 'Je zal niet meer kunnen inloggen met dit telefoonnummer.',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -1971,7 +1971,7 @@ export const nlNL: LocalizationResource = {
     },
     emailAddressPage: {
       emailCode: {
-        formHint: 'Een mail met daarin een verificatiecode is verstuurd naar dit adres.',
+        formHint: 'Een mail met daarin een verificatiecode zal worden verstuurd naar dit adres.',
         formSubtitle: 'Voer de verificatiecode in die verstuurd is naar {{identifier}}',
         formTitle: 'Verificatiecode',
         resendButton: 'Verstuur code opnieuw',
@@ -2080,7 +2080,7 @@ export const nlNL: LocalizationResource = {
       title__update: 'Wachtwoord wijzigen',
     },
     phoneNumberPage: {
-      infoText: 'Een SMS met daarin een verificatiecode is verstuurd naar dit nummer.',
+      infoText: 'Een SMS met daarin een verificatiecode zal worden verstuurd naar dit nummer.',
       removeResource: {
         messageLine1: '{{identifier}} zal van dit account verwijderd worden.',
         messageLine2: 'Je zal niet meer kunnen inloggen met dit telefoonnummer.',


### PR DESCRIPTION
The email and phone verification copy implied the code had already been sent. These screens send the code after the user continues, so the Dutch and Belgian strings now say it will be sent.