### PR TITLE
fix(electron,shared,ui): keep Clerk navigation inside the Electron renderer

### DIFF
--- a/.changeset/electron-virtual-router-navigation.md
+++ b/.changeset/electron-virtual-router-navigation.md
@@ -1,0 +1,9 @@
+---
+'@clerk/electron': patch
+'@clerk/shared': patch
+'@clerk/ui': patch
+---
+
+Keep Clerk's navigation inside the renderer. `ClerkProvider` now always supplies `routerPush`/`routerReplace`, so Clerk routes through your application's router when you provide one, and never navigates the window to an internal `/CLERK-ROUTER/VIRTUAL/...` path — which no custom protocol handler can serve, and which reloaded the renderer and dropped the user out of sign-in.
+
+Applications that worked around this by passing no-op router functions, or by filtering `CLERK-ROUTER/VIRTUAL` out themselves, can remove those workarounds.

--- a/integration/templates/electron-vite/src/main.tsx
+++ b/integration/templates/electron-vite/src/main.tsx
@@ -12,8 +12,6 @@ function App() {
     <ClerkProvider
       publishableKey={PUBLISHABLE_KEY}
       __internal_clerkUIUrl={CLERK_UI_URL}
-      routerPush={() => {}}
-      routerReplace={() => {}}
     >
       <main data-testid='electron-app'>
         <Show when='signed-out'>

--- a/integration/tests/electron/basic.test.ts
+++ b/integration/tests/electron/basic.test.ts
@@ -10,6 +10,7 @@ type ElectronWindow = Window & {
     tokenCache?: Partial<Record<'clearToken' | 'getToken' | 'saveToken', unknown>>;
     oauthTransport?: Partial<Record<'getRedirectUrl' | 'open', unknown>>;
   };
+  __hardNavigations?: string[];
 };
 
 test.describe('electron basic auth @electron', () => {
@@ -73,5 +74,25 @@ test.describe('electron basic auth @electron', () => {
 
   test('keeps the signed-out state after relaunch', async ({ electronPage }) => {
     await expect(electronPage.locator('.cl-signIn-root')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('never hard navigates the renderer during sign-in', async ({ electronPage }) => {
+    const { signIn } = createPageObjects({ page: electronPage, useTestingToken: false });
+
+    await electronPage.evaluate(() => {
+      (window as ElectronWindow).__hardNavigations = [];
+      addEventListener('clerk:beforeunload', () => {
+        (window as ElectronWindow).__hardNavigations?.push(location.href);
+      });
+    });
+
+    await signIn.waitForMounted();
+    await signIn.setIdentifier(fakeUser.email!);
+    await signIn.continue();
+    await signIn.setPassword(fakeUser.password);
+    await signIn.continue();
+
+    await expect(electronPage.locator('[data-testid="user-id"]')).toHaveText(/^user_/, { timeout: 30_000 });
+    await expect(electronPage.evaluate(() => (window as ElectronWindow).__hardNavigations)).resolves.toEqual([]);
   });
 });

--- a/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
+++ b/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
@@ -99,6 +99,77 @@ describe('Electron ClerkProvider', () => {
     });
   });
 
+  describe('router handlers', () => {
+    const renderWithRouter = (props: Record<string, unknown> = {}) => {
+      renderToStaticMarkup(
+        <ClerkProvider
+          publishableKey='pk_test_provider'
+          {...props}
+        >
+          <span>App</span>
+        </ClerkProvider>,
+      );
+
+      return {
+        routerPush: capturedProviderProps?.routerPush as (to: string, metadata?: unknown) => void,
+        routerReplace: capturedProviderProps?.routerReplace as (to: string, metadata?: unknown) => void,
+      };
+    };
+
+    it('always supplies both handlers so clerk-js never falls back to a window navigation', () => {
+      const { routerPush, routerReplace } = renderWithRouter();
+
+      expect(routerPush).toBeTypeOf('function');
+      expect(routerReplace).toBeTypeOf('function');
+    });
+
+    it('absorbs virtual router paths instead of forwarding them to the application router', () => {
+      const push = vi.fn();
+      const replace = vi.fn();
+      const windowNavigate = vi.fn();
+      const { routerPush, routerReplace } = renderWithRouter({ routerPush: push, routerReplace: replace });
+
+      routerPush('/CLERK-ROUTER/VIRTUAL/sign-up#/continue', { windowNavigate });
+      routerReplace('/CLERK-ROUTER/VIRTUAL/sign-in#/factor-two', { windowNavigate });
+
+      expect(push).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+      expect(windowNavigate).not.toHaveBeenCalled();
+    });
+
+    it('absorbs virtual router paths even without an application router', () => {
+      const windowNavigate = vi.fn();
+      const { routerPush } = renderWithRouter();
+
+      routerPush('/CLERK-ROUTER/VIRTUAL/sign-up#/continue', { windowNavigate });
+
+      expect(windowNavigate).not.toHaveBeenCalled();
+    });
+
+    it('forwards real destinations to the application router', () => {
+      const push = vi.fn();
+      const replace = vi.fn();
+      const windowNavigate = vi.fn();
+      const { routerPush, routerReplace } = renderWithRouter({ routerPush: push, routerReplace: replace });
+
+      routerPush('/settings/connections', { windowNavigate });
+      routerReplace('/dashboard', { windowNavigate });
+
+      expect(push).toHaveBeenCalledWith('/settings/connections', { windowNavigate });
+      expect(replace).toHaveBeenCalledWith('/dashboard', { windowNavigate });
+      expect(windowNavigate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the host navigation for real destinations when no application router is provided', () => {
+      const windowNavigate = vi.fn();
+      const { routerPush } = renderWithRouter();
+
+      routerPush('/settings/connections', { windowNavigate });
+
+      expect(windowNavigate).toHaveBeenCalledWith('/settings/connections');
+    });
+  });
+
   it('defaults allowedRedirectProtocols to the renderer custom scheme', () => {
     stubWindowProtocol('clerk:');
 

--- a/packages/electron/src/react/index.tsx
+++ b/packages/electron/src/react/index.tsx
@@ -1,5 +1,6 @@
 import type { ClerkProviderProps as ReactClerkProviderProps } from '@clerk/react';
 import { InternalClerkProvider as ReactClerkProvider } from '@clerk/react/internal';
+import { isVirtualRouterPath } from '@clerk/shared/internal/clerk-js/url';
 import { ALLOWED_PROTOCOLS } from '@clerk/shared/internal/clerk-js/windowNavigate';
 import { loadClerkUIScript } from '@clerk/shared/loadClerkJsScript';
 import type { ClerkUIConstructor } from '@clerk/shared/ui';
@@ -79,6 +80,30 @@ function createOAuthTransport(): ClerkOAuthTransport | undefined {
   };
 }
 
+type ClerkRouterFn = NonNullable<ReactClerkProviderProps['routerPush']>;
+
+/** Always supplied, so clerk-js never reaches `window.location` and reloads the renderer. */
+function createRouterHandlers(
+  routerPush: ClerkRouterFn | undefined,
+  routerReplace: ClerkRouterFn | undefined,
+): { routerPush: ClerkRouterFn; routerReplace: ClerkRouterFn } {
+  const wrap =
+    (delegate: ClerkRouterFn | undefined): ClerkRouterFn =>
+    (to, metadata) => {
+      if (isVirtualRouterPath(to)) {
+        return;
+      }
+
+      if (delegate) {
+        return delegate(to, metadata);
+      }
+
+      metadata?.windowNavigate(to);
+    };
+
+  return { routerPush: wrap(routerPush), routerReplace: wrap(routerReplace) };
+}
+
 /**
  * Infer the custom renderer scheme registered with `createClerkBridge({ renderer })`.
  * Built-in Clerk protocols and local file renderers are not inferred.
@@ -98,15 +123,19 @@ export function ClerkProvider({
   publishableKey,
   passkeys,
   allowedRedirectProtocols,
+  routerPush,
+  routerReplace,
   ...props
 }: ClerkProviderProps): JSX.Element {
   const clerk = createClerkInstance(publishableKey, passkeys);
   const oauthTransport = createOAuthTransport();
   const clerkUI = loadClerkUI(publishableKey, props);
+  const routerHandlers = createRouterHandlers(routerPush, routerReplace);
 
   return (
     <ReactClerkProvider
       {...props}
+      {...routerHandlers}
       Clerk={clerk}
       __internal_oauthTransport={oauthTransport}
       allowedRedirectProtocols={allowedRedirectProtocols ?? defaultAllowedRedirectProtocols()}

--- a/packages/shared/src/internal/clerk-js/url.ts
+++ b/packages/shared/src/internal/clerk-js/url.ts
@@ -398,6 +398,13 @@ export const pathFromFullPath = (fullPath: string) => {
   return fullPath.replace(/CLERK-ROUTER\/(.*?)\//, '');
 };
 
+export const VIRTUAL_ROUTER_BASE_PATH = 'CLERK-ROUTER/VIRTUAL';
+
+/**
+ * Whether `to` addresses the in-memory component router rather than a real application route.
+ */
+export const isVirtualRouterPath = (to: string): boolean => to.includes(VIRTUAL_ROUTER_BASE_PATH);
+
 const frontendApiRedirectPathsWithUserInput: string[] = [
   '/oauth/authorize', // OAuth2 identify provider flow
 ];

--- a/packages/ui/src/router/VirtualRouter.tsx
+++ b/packages/ui/src/router/VirtualRouter.tsx
@@ -1,9 +1,11 @@
+import { VIRTUAL_ROUTER_BASE_PATH } from '@clerk/shared/internal/clerk-js/url';
 import { useClerk } from '@clerk/shared/react';
 import React, { useEffect } from 'react';
 
 import { useClerkModalStateParams } from '../hooks';
 import { BaseRouter } from './BaseRouter';
-export const VIRTUAL_ROUTER_BASE_PATH = 'CLERK-ROUTER/VIRTUAL';
+
+export { VIRTUAL_ROUTER_BASE_PATH };
 
 interface VirtualRouterProps {
   startPath: string;


### PR DESCRIPTION
## Description

When an Electron app supplied no `routerPush`/`routerReplace`, clerk-js fell back to a
`window.location` navigation. Additional sign-in/up steps target the internal component router
(`/CLERK-ROUTER/VIRTUAL/...`), and a renderer served from a custom scheme would often result in navigation reloading the whole renderer, unmounting Clerk and breaking the auth flow.

This PR makes `ClerkProvider` always supply a `routerPush`/`routerReplace`:

- internal virtual routers are now absorbed.
- Real destinations go to the application's router when one is provided, otherwise fall back to
  host navigation, preserving current behavior for apps that supply no router.

`isVirtualRouterPath` moves to `@clerk/shared` so `@clerk/electron` and `@clerk/ui` share one
definition; `@clerk/ui` re-exports `VIRTUAL_ROUTER_BASE_PATH` unchanged.

The `electron-vite` integration template passed no-op router functions to work around this, which
also swallowed real destinations. Those are removed, and the suite now asserts that no
`clerk:beforeunload` fires during sign-in, as that event is dispatched immediately before clerk-js
assigns `window.location`.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
