### PR TITLE
feat(shared): polish missing/invalid key error copy

### DIFF
--- a/.changeset/keyless-error-copy-tweaks.md
+++ b/.changeset/keyless-error-copy-tweaks.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Polish the missing/invalid key error copy: drop the two-space indent before the `npx clerk@latest init` command (it rendered as a stray space in browser error overlays), start the follow-up sentence with the command name instead of "It" so the sentence stands on its own, and reword "Requires no Clerk account or login" to "No Clerk account or login required".

--- a/packages/backend/src/__tests__/createRedirect.test.ts
+++ b/packages/backend/src/__tests__/createRedirect.test.ts
@@ -28,7 +28,7 @@ describe('redirect(redirectAdapter)', () => {
       } as any);
 
       expect(() => redirectToSignIn({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\nnpx clerk@latest init',
       );
     });
   });
@@ -258,7 +258,7 @@ describe('redirect(redirectAdapter)', () => {
       });
 
       expect(() => redirectToSignUp({ returnBackUrl })).toThrowError(
-        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
+        '@clerk/backend: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\nnpx clerk@latest init',
       );
     });
 

--- a/packages/shared/src/__tests__/error.spec.ts
+++ b/packages/shared/src/__tests__/error.spec.ts
@@ -16,13 +16,13 @@ describe('ErrorThrower', () => {
 
   it('throws the correct error message and interpolates pkg and known parameters', () => {
     expect(() => errorThrower.throwInvalidPublishableKeyError({ key: 'whatever' })).toThrow(
-      '@clerk/test-package: The publishableKey passed to Clerk is invalid (key=whatever, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, in your terminal run:\n\n  npx clerk@latest init',
+      '@clerk/test-package: The publishableKey passed to Clerk is invalid (key=whatever, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, in your terminal run:\n\nnpx clerk@latest init',
     );
   });
 
   it('throws the correct error message and interpolates pkg if no parameters are provided', () => {
     expect(() => errorThrower.throwMissingPublishableKeyError()).toThrow(
-      '@clerk/test-package: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
+      '@clerk/test-package: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\nnpx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/keys.spec.ts
+++ b/packages/shared/src/__tests__/keys.spec.ts
@@ -81,7 +81,7 @@ describe('parsePublishableKey(key)', () => {
 
   it('throws an error if the publishable key is missing, when fatal: true', () => {
     expect(() => parsePublishableKey(undefined, { fatal: true })).toThrowError(
-      'Publishable key is missing. To create a Clerk application with valid keys, in your terminal run:\n\n  npx clerk@latest init',
+      'Publishable key is missing. To create a Clerk application with valid keys, in your terminal run:\n\nnpx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
+++ b/packages/shared/src/__tests__/loadClerkJsScript.spec.ts
@@ -46,7 +46,7 @@ describe('loadClerkJsScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkJsScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\nnpx clerk@latest init',
     );
   });
 
@@ -310,7 +310,7 @@ describe('loadClerkUIScript(options)', () => {
 
   test('throws error when publishableKey is missing', async () => {
     await expect(loadClerkUIScript({} as any)).rejects.toThrow(
-      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\n  npx clerk@latest init',
+      '@clerk/react: Missing publishableKey. To set up Clerk for this project, in your terminal run:\n\nnpx clerk@latest init',
     );
   });
 

--- a/packages/shared/src/errors/errorThrower.ts
+++ b/packages/shared/src/errors/errorThrower.ts
@@ -2,23 +2,23 @@ const DefaultMessages = Object.freeze({
   InvalidProxyUrlErrorMessage: `The proxyUrl passed to Clerk is invalid. The expected value for proxyUrl is an absolute URL or a relative path with a leading '/'. (key={{url}})`,
   InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid (key={{key}}, expected format: pk_test_... or pk_live_...). To create a Clerk application with valid keys, in your terminal run:
 
-  npx clerk@latest init
+npx clerk@latest init
 
-It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+\`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
 If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys.`,
   MissingPublishableKeyErrorMessage: `Missing publishableKey. To set up Clerk for this project, in your terminal run:
 
-  npx clerk@latest init
+npx clerk@latest init
 
-It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+\`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
 If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingSecretKeyErrorMessage: `Missing secretKey. To set up Clerk for this project, in your terminal run:
 
-  npx clerk@latest init
+npx clerk@latest init
 
-It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+\`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
 If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingClerkProvider: `{{source}} can only be used within the <ClerkProvider /> component. Learn more: https://clerk.com/docs/components/clerk-provider`,

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -100,9 +100,9 @@ function isValidDecodedPublishableKey(decoded: string): boolean {
 
 const fatalKeyGuidance = `To create a Clerk application with valid keys, in your terminal run:
 
-  npx clerk@latest init
+npx clerk@latest init
 
-It creates a Clerk application and writes keys to your .env file. Requires no Clerk account or login and the command is non-interactive.
+\`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
 If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy them from https://dashboard.clerk.com/last-active?path=api-keys.`;
 


### PR DESCRIPTION
## Description

Copy-only follow-up to #9491. Three tweaks to the missing/invalid key error messages (all 4 variants: missing publishable key, missing secret key, invalid publishable key, and the fatal key-parse guidance):

- **Remove the two-space indent** before the `npx clerk@latest init` command. The indent is a terminal code-block convention, but in the Next.js dev error overlay — where most new users hit this message — it renders as a stray leading space.
- **Start the follow-up sentence with the command name**: "`npx clerk@latest init` creates a Clerk application..." instead of "It creates...", so the sentence stands on its own.
- **Reword** "Requires no Clerk account or login..." to "No Clerk account or login required...".

No behavior changes. Test assertions in `shared`, `backend`, and `nextjs` updated to match.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) JSDoc comments have been added or updated for any package exports
- [ ] (If applicable) Documentation has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)