### PR TITLE
chore(expo): bump clerk-ios to 1.5.0

### DIFF
--- a/.changeset/expo-bump-clerk-ios-1-5-0.md
+++ b/.changeset/expo-bump-clerk-ios-1-5-0.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-ios` SDK from `1.4.1` to `1.5.0`. See the Clerk iOS release: https://github.com/clerk/clerk-ios/releases/tag/1.5.0.

--- a/packages/expo/ios/ClerkExpo.podspec
+++ b/packages/expo/ios/ClerkExpo.podspec
@@ -18,7 +18,7 @@ else
 end
 
 clerk_ios_repo = 'https://github.com/clerk/clerk-ios.git'
-clerk_ios_version = '1.4.1'
+clerk_ios_version = '1.5.0'
 
 Pod::Spec.new do |s|
   s.name           = 'ClerkExpo'


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-ios` SDK in `@clerk/expo` from `1.4.1` to `1.5.0`.

Release: https://github.com/clerk/clerk-ios/releases/tag/1.5.0

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation
