### PR TITLE
docs(backend,nextjs): Align JSDoc link targets with docs link rules

### DIFF
--- a/.changeset/invitation-metadata-link-target.md
+++ b/.changeset/invitation-metadata-link-target.md
@@ -1,5 +1,6 @@
 ---
 '@clerk/backend': patch
+'@clerk/nextjs': patch
 ---
 
-Remove `{{ target: '_blank' }}` from the internal Metadata docs link in the `Invitation` resource JSDoc. Only API reference links should open in a new tab.
+Align JSDoc link targets with the docs link rules: internal docs links don't open in a new tab (removed `{{ target: '_blank' }}` from the `Invitation` Metadata link), while API reference links do (added it to the `ExternalAccount` Backend API link and the `currentUser()` endpoint link).

--- a/.changeset/invitation-metadata-link-target.md
+++ b/.changeset/invitation-metadata-link-target.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Remove `{{ target: '_blank' }}` from the internal Metadata docs link in the `Invitation` resource JSDoc. Only API reference links should open in a new tab.

--- a/packages/backend/src/api/resources/ExternalAccount.ts
+++ b/packages/backend/src/api/resources/ExternalAccount.ts
@@ -32,7 +32,7 @@ export class ExternalAccount {
     readonly username: string | null,
     /** The phone number related to this specific external account. */
     readonly phoneNumber: string | null,
-    /** Metadata that can be read from the Frontend API and Backend API and can be set only from the [Backend API](https://clerk.com/docs/reference/backend-api). */
+    /** Metadata that can be read from the Frontend API and Backend API and can be set only from the [Backend API](https://clerk.com/docs/reference/backend-api){{ target: '_blank' }}. */
     readonly publicMetadata: Record<string, unknown> | null = {},
     /** A descriptive label to differentiate multiple external accounts of the same user for the same provider. */
     readonly label: string | null,

--- a/packages/backend/src/api/resources/Invitation.ts
+++ b/packages/backend/src/api/resources/Invitation.ts
@@ -16,7 +16,7 @@ export class Invitation {
     readonly id: string,
     /** The email address that the invitation was sent to. */
     readonly emailAddress: string,
-    /** [Metadata](https://clerk.com/docs/reference/types/metadata#user-public-metadata){{ target: '_blank' }} that can be read from the Frontend API and [Backend API](https://clerk.com/docs/reference/backend-api){{ target: '_blank' }} and can be set only from the Backend API. Once the user accepts the invitation and signs up, these metadata will end up in the user's public metadata. */
+    /** [Metadata](https://clerk.com/docs/reference/types/metadata#user-public-metadata) that can be read from the Frontend API and [Backend API](https://clerk.com/docs/reference/backend-api){{ target: '_blank' }} and can be set only from the Backend API. Once the user accepts the invitation and signs up, these metadata will end up in the user's public metadata. */
     readonly publicMetadata: Record<string, unknown> | null,
     /** The Unix timestamp when the `Invitation` was first created. */
     readonly createdAt: number,

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -12,7 +12,7 @@ type CurrentUserOptions = PendingSessionOptions;
  *
  * Under the hood, this helper:
  * - calls `fetch()`, so it is automatically deduped per request.
- * - uses the [`GET /v1/users/{user_id}`](https://clerk.com/docs/reference/backend-api/tag/users/GET/users/%7Buser_id%7D) endpoint.
+ * - uses the [`GET /v1/users/{user_id}`](https://clerk.com/docs/reference/backend-api/tag/users/GET/users/%7Buser_id%7D){{ target: '_blank' }} endpoint.
  * - counts towards the [Backend API request rate limit](https://clerk.com/docs/guides/how-clerk-works/system-limits).
  *
  * @param opts - Options to configure the behavior of the helper.


### PR DESCRIPTION
## Description

The docs enforce two link-target rules that now cover generated typedoc content: internal docs links don't carry an explicit `{{ target: '_blank' }}` (readers stay in the docs), and API reference links (`/docs/reference/backend-api`, `/docs/reference/frontend-api`, `/docs/reference/platform-api`) require it, since they leave the docs content for the API reference viewer. The lint found three JSDoc violations, all fixed here:

- `Invitation.publicMetadata` — internal Metadata link drops the annotation.
- `ExternalAccount.publicMetadata` — Backend API link gains it.
- `currentUser()` — Backend API endpoint link gains it.

I swept `packages/*/src` in both directions — internal links carrying the annotation and API reference links missing it — and these three are the full set.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
