### PR TITLE
fix(nuxt): preserve multiple set-cookie headers

### DIFF
--- a/.changeset/calm-cookies-wait.md
+++ b/.changeset/calm-cookies-wait.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nuxt': patch
+---
+
+Preserve every cookie directive returned while authenticating server requests.

--- a/packages/nuxt/src/runtime/server/__tests__/clerkMiddleware.test.ts
+++ b/packages/nuxt/src/runtime/server/__tests__/clerkMiddleware.test.ts
@@ -113,6 +113,34 @@ describe('clerkMiddleware(params)', () => {
     expect(await response.json()).toEqual(SESSION_AUTH_RESPONSE);
   });
 
+  test('preserves multiple Set-Cookie headers returned by authenticateRequest', async () => {
+    const authHeaders = new Headers();
+    const cookies = [
+      '__clerk_handshake=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax',
+      '__session=refreshed; Path=/; HttpOnly; SameSite=Lax',
+    ];
+    cookies.forEach(cookie => authHeaders.append('set-cookie', cookie));
+    authHeaders.set('x-clerk-auth-status', 'signed-in');
+    authenticateRequestMock.mockResolvedValueOnce({
+      toAuth: () => SESSION_AUTH_RESPONSE,
+      headers: authHeaders,
+    });
+
+    const app = createApp();
+    const handler = toWebHandler(app);
+    app.use(clerkMiddleware());
+    app.use(
+      '/',
+      eventHandler(event => event.context.auth()),
+    );
+
+    const response = await handler(new Request(new URL('/', 'http://localhost')));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual(cookies);
+    expect(response.headers.get('x-clerk-auth-status')).toBe('signed-in');
+  });
+
   test('executes handler and renders route when used with a custom handler', async () => {
     const app = createApp();
     const handler = toWebHandler(app);

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -136,9 +136,15 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]) => {
     }
 
     if (requestState.headers) {
+      const setCookieHeaders = requestState.headers.getSetCookie();
       requestState.headers.forEach((value, key) => {
-        setResponseHeader(event, key, value);
+        if (key.toLowerCase() !== 'set-cookie') {
+          setResponseHeader(event, key, value);
+        }
       });
+      if (setCookieHeaders.length > 0) {
+        setResponseHeader(event, 'set-cookie', setCookieHeaders);
+      }
     }
 
     const authObjectFn = (opts?: PendingSessionOptions) => requestState.toAuth(opts);


### PR DESCRIPTION
## Description

Fixes #9573

`authenticateRequest()` can return multiple `Set-Cookie` directives while completing a handshake or refreshing a session. The Nuxt middleware previously forwarded each directive with H3's `setResponseHeader()`, so every cookie replaced the one before it and only the final directive reached the browser.

This change collects all authentication `Set-Cookie` values and forwards them to H3 as one array-valued response header. Other authentication headers keep the existing replacement behavior. The regression test demonstrates that both a handshake deletion and refreshed session cookie survive the middleware, while an ordinary auth header is still forwarded.

Run `pnpm --filter @clerk/nuxt test` to execute the regression and Nuxt type checks. The package suite passes 20 tests, and `pnpm build` passes all 24 monorepo build tasks on Node 24.15.0. A monorepo-wide `pnpm test` run completed all Nuxt tests but had two unrelated `@clerk/ui` tests time out under parallel load; both passed when rerun directly (33 passed, 2 skipped, 2 todo).

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
