### PR TITLE
fix(electron): retain client token in memory

### DIFF
--- a/.changeset/tidy-otters-authenticate.md
+++ b/.changeset/tidy-otters-authenticate.md
@@ -1,0 +1,5 @@
+---
+'@clerk/electron': patch
+---
+
+Fix sign-in flows when OS-backed token persistence is unavailable by retaining the current client token for the lifetime of the Electron renderer.

--- a/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
+++ b/packages/electron/src/react/__tests__/ClerkProvider.test.tsx
@@ -347,4 +347,76 @@ describe('Electron ClerkProvider', () => {
 
     expect(tokenCache.saveToken).toHaveBeenCalledWith('__clerk_client_jwt', 'updated-client-jwt');
   });
+
+  it('reuses response tokens when the Electron token cache cannot persist them', async () => {
+    tokenCache.getToken.mockResolvedValue(null);
+    renderToStaticMarkup(<ClerkProvider publishableKey='pk_test_unavailable_persistence'>App</ClerkProvider>);
+
+    const firstRequest = {
+      headers: new Headers(),
+      url: new URL('https://api.clerk.test/v1/client/sign_ins'),
+    };
+    await beforeRequest?.(firstRequest);
+    expect(firstRequest.headers.has('Authorization')).toBe(false);
+
+    await afterResponse?.(
+      {},
+      new Response(null, {
+        headers: {
+          Authorization: 'Bearer client-jwt-from-response',
+        },
+      }),
+    );
+
+    const nextRequest = {
+      headers: new Headers(),
+      url: new URL('https://api.clerk.test/v1/client/sign_ins/attempt/prepare_verification'),
+    };
+    await beforeRequest?.(nextRequest);
+
+    expect(nextRequest.headers.get('Authorization')).toBe('Bearer client-jwt-from-response');
+    expect(tokenCache.getToken).toHaveBeenCalledTimes(1);
+
+    await afterResponse?.(
+      {},
+      new Response(null, {
+        headers: {
+          Authorization: 'Bearer rotated-client-jwt',
+        },
+      }),
+    );
+
+    const requestAfterRotation = {
+      headers: new Headers(),
+      url: new URL('https://api.clerk.test/v1/client'),
+    };
+    await beforeRequest?.(requestAfterRotation);
+
+    expect(requestAfterRotation.headers.get('Authorization')).toBe('Bearer rotated-client-jwt');
+    expect(tokenCache.getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse response tokens across publishable keys', async () => {
+    tokenCache.getToken.mockResolvedValue(null);
+    renderToStaticMarkup(<ClerkProvider publishableKey='pk_test_first_instance'>App</ClerkProvider>);
+
+    await afterResponse?.(
+      {},
+      new Response(null, {
+        headers: {
+          Authorization: 'Bearer first-instance-client-jwt',
+        },
+      }),
+    );
+
+    renderToStaticMarkup(<ClerkProvider publishableKey='pk_test_second_instance'>App</ClerkProvider>);
+    const request = {
+      headers: new Headers(),
+      url: new URL('https://api.clerk.test/v1/client'),
+    };
+    await beforeRequest?.(request);
+
+    expect(request.headers.has('Authorization')).toBe(false);
+    expect(tokenCache.getToken).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/electron/src/react/create-clerk-instance.ts
+++ b/packages/electron/src/react/create-clerk-instance.ts
@@ -27,6 +27,7 @@ export function createClerkInstance(publishableKey: string, passkeys?: PasskeySu
   }
 
   const clerk = new Clerk(publishableKey);
+  let clientJwt: string | null = null;
 
   if (passkeys) {
     attachPasskeys(clerk, passkeys);
@@ -37,7 +38,7 @@ export function createClerkInstance(publishableKey: string, passkeys?: PasskeySu
     request.url?.searchParams.append('_is_native', '1');
     request.url?.searchParams.append('_electron_sdk_version', PACKAGE_VERSION);
 
-    const token = await window.__clerk_internal_electron?.tokenCache.getToken(CLERK_CLIENT_JWT_KEY);
+    const token = clientJwt ?? (await window.__clerk_internal_electron?.tokenCache.getToken(CLERK_CLIENT_JWT_KEY));
     if (token) {
       const headers = new Headers(request.headers);
       headers.set('Authorization', `Bearer ${token}`);
@@ -52,6 +53,7 @@ export function createClerkInstance(publishableKey: string, passkeys?: PasskeySu
     }
 
     const token = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : authorization;
+    clientJwt = token;
     await window.__clerk_internal_electron?.tokenCache.saveToken(CLERK_CLIENT_JWT_KEY, token);
   });
 


### PR DESCRIPTION
## Description

**Package:** `@clerk/electron@0.0.37`

**TL;DR:** The Electron storage adapter intentionally skips persistence when OS-backed encryption is unavailable or fails. The sign-in flow then drops the client JWT between two requests, so the next request has no Authorization header and Clerk reports that the user is signed out. The documented behavior says this state should sign the user out on restart, not block the current sign-in attempt.

**Steps to reproduce:**

1. Configure an Electron app with `createClerkBridge({ storage })`, `exposeClerkBridge()`, and `<ClerkProvider>` from `@clerk/electron/react`.
2. Use a `TokenStorage` where `getItem()` returns `null` and `setItem()` resolves without writing. This matches the bundled `storage()` behavior when secure OS encryption is unavailable or encryption fails.
3. Start an email-code sign-in.
4. The first Frontend API response returns an `Authorization: Bearer <client JWT>` header. Continue to first-factor verification.

**Expected behavior:**

The client JWT from the response remains available for the rest of the current Clerk instance. Sign-in completes, although the user may be signed out after restarting the app because the token was not persisted.

**Actual behavior:**

The response hook passes the client JWT to the no-op token cache. The next request reads `null`, omits its Authorization header, and receives `401 signed_out` from the Frontend API.

This was observed in a packaged macOS app. The no-op `TokenStorage` above reproduces the package behavior without depending on that machine state.

**Why:**

1. `storage().setItem()` returns without persisting when no secure cipher is available, and also catches encryption failures without writing plaintext.
2. `createClerkInstance()` handles an Authorization response only by calling `tokenCache.saveToken()`.
3. Every following request calls `tokenCache.getToken()` again. There is no in-memory copy of the response token.
4. A permitted persistence failure therefore becomes an immediate authentication failure.

**Fix:**

Retain the latest response client JWT in memory for the lifetime of its Clerk instance and prefer it on following requests while continuing to attempt secure persistence. Token rotation replaces the in-memory value, and a different publishable key receives a different Clerk instance. Disk storage behavior is unchanged, and the fix does not enable unencrypted persistence.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://github.com/clerk/clerk-docs) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
