### PR TITLE
chore(backend): remove retired enhanced email deliverability setting

### DIFF
--- a/.changeset/tidy-pandas-retire-eed.md
+++ b/.changeset/tidy-pandas-retire-eed.md
@@ -1,0 +1,9 @@
+---
+'@clerk/backend': major
+---
+
+Remove the retired `enhancedEmailDeliverability` instance setting. The
+underlying delivery path (Clerk's legacy shared-domain sending) has been
+retired server-side, and the field is ignored by the Backend API, so it is
+removed from `InstanceApi.updateInstance` params, the `InstanceSettings`
+resource, and its JSON type.

--- a/packages/backend/src/api/endpoints/InstanceApi.ts
+++ b/packages/backend/src/api/endpoints/InstanceApi.ts
@@ -12,8 +12,6 @@ export type UpdateParams = {
   testMode?: boolean | null | undefined;
   /** Whether the instance should be using the Have I Been Pwned (HIBP) service to check passwords for breaches. */
   hibp?: boolean | null | undefined;
-  /** Whether the instance should send emails from "verifications@clerk.dev" instead of your domain. This can be helpful if you do not have a high domain reputation. */
-  enhancedEmailDeliverability?: boolean | null | undefined;
   /** The support email for the instance. */
   supportEmail?: string | null | undefined;
   /** The npm version for `@clerk/clerk-js`. */

--- a/packages/backend/src/api/resources/InstanceSettings.ts
+++ b/packages/backend/src/api/resources/InstanceSettings.ts
@@ -6,7 +6,6 @@ export class InstanceSettings {
     readonly restrictedToAllowlist?: boolean | undefined,
     readonly fromEmailAddress?: string | undefined,
     readonly progressiveSignUp?: boolean | undefined,
-    readonly enhancedEmailDeliverability?: boolean | undefined,
   ) {}
 
   static fromJSON(data: InstanceSettingsJSON): InstanceSettings {
@@ -15,7 +14,6 @@ export class InstanceSettings {
       data.restricted_to_allowlist,
       data.from_email_address,
       data.progressive_sign_up,
-      data.enhanced_email_deliverability,
     );
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -323,7 +323,6 @@ export interface InstanceSettingsJSON extends ClerkResourceJSON {
   restricted_to_allowlist: boolean;
   from_email_address: string;
   progressive_sign_up: boolean;
-  enhanced_email_deliverability: boolean;
 }
 
 export interface InvitationJSON extends ClerkResourceJSON {


### PR DESCRIPTION
## Summary

Follow-up to the Postmark send-path removal (clerk_go#21398). That PR deleted the behavior; this one deletes the field.

The setting no longer affects anything: routing, unverified-DNS suppression, template forcing, and the magic-link validator were all removed, and every remaining instance was flipped to `false` in production on 2026-08-26 (20 production + 14 development). What is left is an inert boolean on the API surface, plus dead config.

## Rollout ordering

Only one ordering constraint remains:

1. **clerk_go#21398** (behavior removal) — merged and released.
2. **dashboard#10112 before clerk_go#21613.** #21613 stops DAPI returning `enhanced_email_deliverability`, and the dashboard reads it today for the email-logs banner. The failure mode is soft — the value would just read as `undefined` and the banner would hide — but shipping the consumer first avoids a window where the dashboard reads a field the API no longer returns.
3. **clerk_go#21613.**

Everything else is independent and can land in any order: **backoffice#724** is type-only with no reader, **terraform-app-infra#3193** removes config nothing reads (the cenv constants went out with #21398), **clk#49** is documentation, and the SDK PRs land on their owners' release cadence.

**No released API contract changes.** An earlier revision of clerk_go#21613 removed the field from the base FAPI `Client` schema — which is inherited by all six API versions, so it would have dropped a `required` field from five *stable* versions that clients pin to. FAPI and BAPI now keep serializing it as `false` instead.

## Still outstanding after this

The `ENHANCED_DELIVERABILITY_POSTMARK_SERVER_TOKEN` secrets remain in four SOPS-encrypted files (production and staging, `api_common` and `pubsubworker`). They need someone with sops keys. The Postmark account itself also still needs decommissioning.

## Changes in this repo

Removes the retired `enhancedEmailDeliverability` setting from `@clerk/backend`: the `InstanceApi.updateInstance` param, the `InstanceSettings` resource, and its JSON type. The param has been a server-side no-op since the delivery path was retired, and the Backend API now ignores it entirely.

Breaking change to a public type, so a major changeset is included. Flagged as draft for the SDK owners to slot into their release cadence - no rush, the server tolerates clients that still send the field.

<!-- clk:companion-prs -->
## Companion PRs

- **backoffice**: https://github.com/clerk/backoffice/pull/724
- **clerk-sdk-go**: https://github.com/clerk/clerk-sdk-go/pull/599
- **clerk_go**: https://github.com/clerk/clerk_go/pull/21398
- **dashboard**: https://github.com/clerk/dashboard/pull/10112
- **terraform-app-infra**: https://github.com/clerk/terraform-app-infra/pull/3193
- **clerk_go:api-surface**: https://github.com/clerk/clerk_go/pull/21613
<!-- /clk:companion-prs -->

