### PR TITLE
fix(electron): retain client token when persistence fails

### DIFF
--- a/.changeset/bright-dogs-remember.md
+++ b/.changeset/bright-dogs-remember.md
@@ -1,0 +1,5 @@
+---
+'@clerk/electron': patch
+---
+
+Keep the current client token available for the lifetime of the Electron app when secure persistence is unavailable or fails.

--- a/.changeset/bright-dogs-remember.md
+++ b/.changeset/bright-dogs-remember.md
@@ -3,3 +3,5 @@
 ---
 
 Keep the current client token available for the lifetime of the Electron app when secure persistence is unavailable or fails.
+
+Fixed a race where an older in-flight token write could replace a newer token when multiple requests completed at the same time.

--- a/packages/electron/src/storage/__tests__/index.test.ts
+++ b/packages/electron/src/storage/__tests__/index.test.ts
@@ -34,6 +34,16 @@ vi.mock('electron-store', () => ({
 const ss = safeStorage as unknown as Record<string, unknown>;
 const asyncSafeStorage = safeStorage as typeof safeStorage & AsyncSafeStorage;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
 /** Installs the synchronous `safeStorage` API. */
 function installSync({ available = true }: { available?: boolean } = {}) {
   ss.isEncryptionAvailable = vi.fn(() => available);
@@ -160,6 +170,24 @@ describe('getItem', () => {
       expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
     });
 
+    it('does not re-save a rotated token after it is removed', async () => {
+      installSync();
+      installAsync();
+      const encryption = deferred<Buffer>();
+      storeGet.mockReturnValue(`enc:${Buffer.from('old-cipher').toString('base64')}`);
+      vi.mocked(asyncSafeStorage.decryptStringAsync).mockResolvedValue({ result: 'jwt', shouldReEncrypt: true });
+      vi.mocked(asyncSafeStorage.encryptStringAsync).mockReturnValue(encryption.promise);
+      const adapter = storage();
+
+      const read = adapter.getItem('token-key');
+      await vi.waitFor(() => expect(asyncSafeStorage.encryptStringAsync).toHaveBeenCalledWith('jwt'));
+      await adapter.removeItem('token-key');
+      encryption.resolve(Buffer.from('re-encrypted'));
+
+      await expect(read).resolves.toBe('jwt');
+      expect(storeSet).not.toHaveBeenCalled();
+    });
+
     it('returns null without deleting the entry when decryption rejects', async () => {
       installSync();
       installAsync();
@@ -214,6 +242,45 @@ describe('setItem', () => {
 
     expect(asyncSafeStorage.encryptStringAsync).toHaveBeenCalledWith('jwt');
     expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+  });
+
+  it('does not persist a pending write after the token is removed', async () => {
+    installSync();
+    installAsync();
+    const encryption = deferred<Buffer>();
+    vi.mocked(asyncSafeStorage.encryptStringAsync).mockReturnValue(encryption.promise);
+    const adapter = storage();
+
+    const write = adapter.setItem('token-key', 'jwt');
+    await vi.waitFor(() => expect(asyncSafeStorage.encryptStringAsync).toHaveBeenCalledWith('jwt'));
+    await adapter.removeItem('token-key');
+    encryption.resolve(Buffer.from('enc(jwt)'));
+    await write;
+
+    expect(storeSet).not.toHaveBeenCalled();
+    await expect(adapter.getItem('token-key')).resolves.toBeNull();
+  });
+
+  it('does not let an older failed write replace a newer token', async () => {
+    installSync();
+    installAsync();
+    const olderEncryption = deferred<Buffer>();
+    vi.mocked(asyncSafeStorage.encryptStringAsync).mockImplementation(value => {
+      return value === 'old-jwt' ? olderEncryption.promise : Promise.resolve(Buffer.from(`enc(${value})`));
+    });
+    storeGet.mockReturnValue(`enc:${Buffer.from('new-cipher').toString('base64')}`);
+    vi.mocked(asyncSafeStorage.decryptStringAsync).mockResolvedValue({ result: 'new-jwt', shouldReEncrypt: false });
+    const adapter = storage();
+
+    const olderWrite = adapter.setItem('token-key', 'old-jwt');
+    await vi.waitFor(() => expect(asyncSafeStorage.encryptStringAsync).toHaveBeenCalledWith('old-jwt'));
+    await adapter.setItem('token-key', 'new-jwt');
+    olderEncryption.reject(new Error('encrypt failed'));
+    await olderWrite;
+
+    await expect(adapter.getItem('token-key')).resolves.toBe('new-jwt');
+    expect(storeSet).toHaveBeenCalledOnce();
+    expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(new-jwt)').toString('base64')}`);
   });
 
   it('falls back to the sync API (never calling the async crypto) when async encryption is unavailable', async () => {

--- a/packages/electron/src/storage/__tests__/index.test.ts
+++ b/packages/electron/src/storage/__tests__/index.test.ts
@@ -194,6 +194,18 @@ describe('setItem', () => {
     expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
   });
 
+  it('continues reading persisted storage after a successful write', async () => {
+    installSync();
+    storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+    vi.mocked(safeStorage.decryptString).mockReturnValue('persisted-jwt');
+    const adapter = storage();
+
+    await adapter.setItem('token-key', 'jwt');
+
+    await expect(adapter.getItem('token-key')).resolves.toBe('persisted-jwt');
+    expect(storeGet).toHaveBeenCalledWith('token-key');
+  });
+
   it('encrypts tokens before storing them (async backend)', async () => {
     installSync();
     installAsync();
@@ -218,10 +230,13 @@ describe('setItem', () => {
   it('does not persist when no encryption is available and no fallback is configured', async () => {
     installSync({ available: false });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const adapter = storage();
 
-    await storage().setItem('token-key', 'jwt');
+    await adapter.setItem('token-key', 'jwt');
 
     expect(storeSet).not.toHaveBeenCalled();
+    await expect(adapter.getItem('token-key')).resolves.toBe('jwt');
+    expect(storeGet).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledOnce();
 
     warn.mockRestore();
@@ -234,6 +249,23 @@ describe('setItem', () => {
     await storage({ unencryptedFallback: true }).setItem('token-key', 'jwt');
 
     expect(storeSet).toHaveBeenCalledWith('token-key', 'raw:jwt');
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('retains tokens in memory when unencrypted persistence fails', async () => {
+    installSync({ available: false });
+    storeSet.mockImplementationOnce(() => {
+      throw new Error('write failed');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const adapter = storage({ unencryptedFallback: true });
+
+    await adapter.setItem('token-key', 'jwt');
+
+    await expect(adapter.getItem('token-key')).resolves.toBe('jwt');
+    expect(storeGet).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledOnce();
 
     warn.mockRestore();
@@ -262,9 +294,12 @@ describe('setItem', () => {
 
     // Even with the fallback enabled, a *failed encrypt* (vs. unavailable encryption) must not be
     // persisted in the clear.
-    await storage({ unencryptedFallback: true }).setItem('token-key', 'jwt');
+    const adapter = storage({ unencryptedFallback: true });
+    await adapter.setItem('token-key', 'jwt');
 
     expect(storeSet).not.toHaveBeenCalled();
+    await expect(adapter.getItem('token-key')).resolves.toBe('jwt');
+    expect(storeGet).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledOnce();
 
     warn.mockRestore();
@@ -281,9 +316,14 @@ describe('setItem', () => {
 
     await adapter.setItem('token-key', 'jwt');
     expect(storeSet).not.toHaveBeenCalled(); // not persisted while unavailable
+    await expect(adapter.getItem('token-key')).resolves.toBe('jwt');
 
     await adapter.setItem('token-key', 'jwt');
     expect(storeSet).toHaveBeenCalledWith('token-key', `enc:${Buffer.from('enc(jwt)').toString('base64')}`);
+
+    storeGet.mockReturnValue(`enc:${Buffer.from('cipher').toString('base64')}`);
+    vi.mocked(safeStorage.decryptString).mockReturnValue('persisted-jwt');
+    await expect(adapter.getItem('token-key')).resolves.toBe('persisted-jwt');
 
     warn.mockRestore();
   });
@@ -308,5 +348,21 @@ describe('removeItem', () => {
     await storage().removeItem('token-key');
 
     expect(storeDelete).toHaveBeenCalledWith('token-key');
+  });
+
+  it('removes tokens retained after persistence is unavailable', async () => {
+    installSync({ available: false });
+    storeGet.mockReturnValue(undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const adapter = storage();
+
+    await adapter.setItem('token-key', 'jwt');
+    await adapter.removeItem('token-key');
+
+    await expect(adapter.getItem('token-key')).resolves.toBeNull();
+    expect(storeDelete).toHaveBeenCalledWith('token-key');
+    expect(storeGet).toHaveBeenCalledWith('token-key');
+
+    warn.mockRestore();
   });
 });

--- a/packages/electron/src/storage/index.ts
+++ b/packages/electron/src/storage/index.ts
@@ -128,6 +128,14 @@ export function storage(options: StorageOptions = {}): TokenStorage {
     ...(options.path ? { cwd: options.path } : {}),
   });
   const memoryFallback = new Map<string, string>();
+  const mutationVersions = new Map<string, number>();
+
+  const beginMutation = (key: string) => {
+    const version = (mutationVersions.get(key) ?? 0) + 1;
+    mutationVersions.set(key, version);
+    return version;
+  };
+  const isCurrentMutation = (key: string, version: number) => (mutationVersions.get(key) ?? 0) === version;
 
   let cachedCipher: Cipher | null = null;
   let resolving: Promise<Cipher | null> | null = null;
@@ -172,6 +180,7 @@ export function storage(options: StorageOptions = {}): TokenStorage {
       }
 
       if (stored.startsWith(ENCRYPTED_PREFIX)) {
+        const mutationVersion = mutationVersions.get(key) ?? 0;
         const cipher = await getCipher();
 
         // No usable OS encryption, preserve entry.
@@ -187,7 +196,10 @@ export function storage(options: StorageOptions = {}): TokenStorage {
           if (shouldReEncrypt) {
             // OS key has rotated, persist with new value
             try {
-              store.set(key, ENCRYPTED_PREFIX + (await cipher.encrypt(value)));
+              const encrypted = await cipher.encrypt(value);
+              if (isCurrentMutation(key, mutationVersion)) {
+                store.set(key, ENCRYPTED_PREFIX + encrypted);
+              }
             } catch {
               // keep the existing payload; it still decrypts for now
             }
@@ -205,7 +217,12 @@ export function storage(options: StorageOptions = {}): TokenStorage {
       return null;
     },
     async setItem(key, value) {
+      const mutationVersion = beginMutation(key);
       const cipher = await getCipher();
+
+      if (!isCurrentMutation(key, mutationVersion)) {
+        return;
+      }
 
       if (!cipher) {
         if (options.unencryptedFallback) {
@@ -229,14 +246,22 @@ export function storage(options: StorageOptions = {}): TokenStorage {
       }
 
       try {
-        store.set(key, ENCRYPTED_PREFIX + (await cipher.encrypt(value)));
+        const encrypted = await cipher.encrypt(value);
+        if (!isCurrentMutation(key, mutationVersion)) {
+          return;
+        }
+        store.set(key, ENCRYPTED_PREFIX + encrypted);
         memoryFallback.delete(key);
       } catch {
+        if (!isCurrentMutation(key, mutationVersion)) {
+          return;
+        }
         memoryFallback.set(key, value);
         warnOnce('Clerk: failed to securely persist a token; it will only be available until the app exits.');
       }
     },
     removeItem(key) {
+      beginMutation(key);
       memoryFallback.delete(key);
       store.delete(key);
     },

--- a/packages/electron/src/storage/index.ts
+++ b/packages/electron/src/storage/index.ts
@@ -128,6 +128,7 @@ export function storage(options: StorageOptions = {}): TokenStorage {
     ...(options.path ? { cwd: options.path } : {}),
   });
   const memoryFallback = new Map<string, string>();
+  // IPC requests can resolve out of order, so only the latest mutation may update storage.
   const mutationVersions = new Map<string, number>();
 
   const beginMutation = (key: string) => {

--- a/packages/electron/src/storage/index.ts
+++ b/packages/electron/src/storage/index.ts
@@ -127,6 +127,7 @@ export function storage(options: StorageOptions = {}): TokenStorage {
     name: options.name ?? 'clerk-tokens',
     ...(options.path ? { cwd: options.path } : {}),
   });
+  const memoryFallback = new Map<string, string>();
 
   let cachedCipher: Cipher | null = null;
   let resolving: Promise<Cipher | null> | null = null;
@@ -155,6 +156,11 @@ export function storage(options: StorageOptions = {}): TokenStorage {
 
   return {
     async getItem(key) {
+      const fallback = memoryFallback.get(key);
+      if (fallback !== undefined) {
+        return fallback;
+      }
+
       const stored = store.get(key);
 
       if (!stored) {
@@ -203,11 +209,18 @@ export function storage(options: StorageOptions = {}): TokenStorage {
 
       if (!cipher) {
         if (options.unencryptedFallback) {
-          warnOnce(
-            'Clerk: OS encryption is unavailable; falling back to unencrypted storage. Session tokens are being stored unencrypted on local disk.',
-          );
-          store.set(key, RAW_PREFIX + value);
+          try {
+            store.set(key, RAW_PREFIX + value);
+            memoryFallback.delete(key);
+            warnOnce(
+              'Clerk: OS encryption is unavailable; falling back to unencrypted storage. Tokens are being stored unencrypted on local disk.',
+            );
+          } catch {
+            memoryFallback.set(key, value);
+            warnOnce('Clerk: failed to persist a token; it will only be available until the app exits.');
+          }
         } else {
+          memoryFallback.set(key, value);
           warnOnce(
             'Clerk: OS encryption is unavailable and unencryptedFallback is not enabled, so tokens are not being persisted. The user will be signed out on the next launch. Pass `storage({ unencryptedFallback: true })` to persist unencrypted (less secure).',
           );
@@ -217,12 +230,14 @@ export function storage(options: StorageOptions = {}): TokenStorage {
 
       try {
         store.set(key, ENCRYPTED_PREFIX + (await cipher.encrypt(value)));
+        memoryFallback.delete(key);
       } catch {
-        // Encryption is available but encryption failed
-        warnOnce('Clerk: failed to encrypt the session token; it was not persisted.');
+        memoryFallback.set(key, value);
+        warnOnce('Clerk: failed to securely persist a token; it will only be available until the app exits.');
       }
     },
     removeItem(key) {
+      memoryFallback.delete(key);
       store.delete(key);
     },
   };


### PR DESCRIPTION
## Description

Keep the latest client token available when Electron cannot persist it securely, allowing the current authentication flow to continue without writing plaintext tokens to disk.

Successful writes continue using persisted storage as the source of truth. The in-memory fallback is removed when persistence recovers or the token is cleared.

Fixes the same issue as https://github.com/clerk/javascript/pull/9584 but handles it in the main process to avoid multiple renderer window collisions & IPC races

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
