### PR TITLE
fix(shared): Avoid trailing period after dashboard URL in key error messages

### DIFF
--- a/.changeset/fix-dashboard-link-punctuation.md
+++ b/.changeset/fix-dashboard-link-punctuation.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Reword the missing/invalid key error messages so the Clerk Dashboard URL is no longer immediately followed by a period. Terminals and dev overlays were including the period in the link, producing a broken URL that failed to open the API Keys page.

--- a/packages/shared/src/errors/errorThrower.ts
+++ b/packages/shared/src/errors/errorThrower.ts
@@ -6,21 +6,21 @@ npx clerk@latest init
 
 \`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
-If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys.`,
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy its Publishable key from https://dashboard.clerk.com/last-active?path=api-keys in the Clerk Dashboard.`,
   MissingPublishableKeyErrorMessage: `Missing publishableKey. To set up Clerk for this project, in your terminal run:
 
 npx clerk@latest init
 
 \`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
-If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys in the Clerk Dashboard. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingSecretKeyErrorMessage: `Missing secretKey. To set up Clerk for this project, in your terminal run:
 
 npx clerk@latest init
 
 \`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
-If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys. Or copy them from https://dashboard.clerk.com/last-active?path=api-keys in the Clerk Dashboard. Deploy a production instance by running \`npx clerk@latest deploy\`, or \`npx clerk@latest env pull --instance prod\` to use an existing one.`,
   MissingClerkProvider: `{{source}} can only be used within the <ClerkProvider /> component. Learn more: https://clerk.com/docs/components/clerk-provider`,
 });
 

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -104,7 +104,7 @@ npx clerk@latest init
 
 \`npx clerk@latest init\` creates a Clerk application and writes keys to your .env file. No Clerk account or login required and the command is non-interactive.
 
-If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy them from https://dashboard.clerk.com/last-active?path=api-keys.`;
+If you have a Clerk application, run \`npx clerk@latest env pull\` to write the keys (\`--instance prod\` for production keys). Or copy them from https://dashboard.clerk.com/last-active?path=api-keys in the Clerk Dashboard.`;
 
 export function parsePublishableKey(
   key: string | undefined,


### PR DESCRIPTION
## Description

The missing/invalid key error messages ended a sentence immediately after `https://dashboard.clerk.com/last-active?path=api-keys`. Terminals and dev overlays linkify the trailing period into the URL, producing `?path=api-keys.`, which the dashboard fails to resolve — users land on /apps instead of the API Keys page. PostHog shows ~13% of error-link clicks hit the broken variant.

Rewords the four affected strings in `@clerk/shared` (`errorThrower.ts`, `keys.ts`) so the URL sits mid-sentence with a trailing word absorbing the period. No other runtime strings in the repo have a URL directly followed by sentence punctuation.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

🤖 Generated with [Claude Code](https://claude.com/claude-code)