### PR TITLE
chore(astro): Update dependency nanoid to v5.1.16 [SECURITY]

### DIFF
--- a/.changeset/heavy-moons-refuse.md
+++ b/.changeset/heavy-moons-refuse.md
@@ -1,0 +1,5 @@
+---
+'@clerk/astro': patch
+---
+
+Update `nanoid` to 5.1.16 to resolve [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv), which every fresh install of `@clerk/astro` surfaced as a high-severity `npm audit` warning.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@clerk/backend": "workspace:^",
     "@clerk/shared": "workspace:^",
-    "nanoid": "5.1.6",
+    "nanoid": "5.1.16",
     "nanostores": "1.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,8 +364,8 @@ importers:
         specifier: workspace:^
         version: link:../shared
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: 5.1.16
+        version: 5.1.16
       nanostores:
         specifier: 1.0.1
         version: 1.0.1
@@ -11794,8 +11794,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -28259,7 +28259,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   nanostores@1.0.1: {}
 


### PR DESCRIPTION
## Description

Bumps `@clerk/astro`'s pinned `nanoid` from 5.1.6 to 5.1.16, which resolves [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) (high: non-secure generators can loop indefinitely with a negative size). Practical exposure is low, but the pin means every fresh install of `@clerk/astro` — including each new Astro quickstart — starts with a high-severity `npm audit` warning.

Found while bumping [clerk/clerk-astro-quickstart#20](https://github.com/clerk/clerk-astro-quickstart/pull/20) to `@clerk/astro@4` for [DOCS-11934](https://linear.app/clerk/issue/DOCS-11934/unpin-astro-quickstarts-when-clerkastro-ships-astro-7-support).

Test: `pnpm --filter @clerk/astro... build` passes on the bump; the only runtime change is nanoid's patch delta.

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
