### PR TITLE
chore(localizations): Improve Finnish translations

### DIFF
--- a/.changeset/gold-shrimps-win.md
+++ b/.changeset/gold-shrimps-win.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Improve Finnish translations

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -1409,8 +1409,8 @@ export const fiFI: LocalizationResource = {
         titleNewTab: 'Kirjautunut toiseen välilehteen',
       },
       verifiedTransferable: {
-        subtitle: undefined,
-        title: undefined,
+        subtitle: 'Palaa alkuperäiseen välilehteen jatkaaksesi',
+        title: 'Sähköposti vahvistettu',
       },
     },
     emailLinkMfa: {
@@ -1475,10 +1475,10 @@ export const fiFI: LocalizationResource = {
       title: 'Tarkista puhelimesi',
     },
     protectCheck: {
-      loading: undefined,
-      retryButton: undefined,
-      subtitle: undefined,
-      title: undefined,
+      loading: 'Ladataan…',
+      retryButton: 'Yritä uudelleen',
+      subtitle: 'Odota hetki, tarkistamme pyyntöäsi.',
+      title: 'Tarkistetaan pyyntöäsi',
     },
     resetPassword: {
       formButtonPrimary: 'Nollaa salasana',
@@ -1586,10 +1586,10 @@ export const fiFI: LocalizationResource = {
       title: 'Tarkista puhelimesi',
     },
     protectCheck: {
-      loading: undefined,
-      retryButton: undefined,
-      subtitle: undefined,
-      title: undefined,
+      loading: 'Ladataan…',
+      retryButton: 'Yritä uudelleen',
+      subtitle: 'Odota hetki, tarkistamme pyyntöäsi.',
+      title: 'Tarkistetaan pyyntöäsi',
     },
     restrictedAccess: {
       actionLink: 'Kirjaudu sisään',
@@ -1738,7 +1738,8 @@ export const fiFI: LocalizationResource = {
     },
   },
   unstable__errors: {
-    action_blocked: undefined,
+    action_blocked:
+      'Toimintoa ei voitu suorittaa. Yritä myöhemmin uudelleen tai ota yhteyttä tukeen, jos ongelma jatkuu.',
     already_a_member_in_organization: '{{email}} on jo tämän organisaation jäsen.',
     api_key_name_already_exists: 'API-avaimen nimi on jo olemassa.',
     api_key_usage_exceeded:
@@ -1771,7 +1772,8 @@ export const fiFI: LocalizationResource = {
     form_password_compromised__sign_in: undefined,
     form_password_incorrect: undefined,
     form_password_length_too_short: 'Salasanasi on liian lyhyt. Sen on oltava vähintään 8 merkkiä pitkä.',
-    form_password_matches_identifier: undefined,
+    form_password_matches_identifier:
+      'Salasana ei voi olla sama kuin sähköpostiosoitteesi, puhelinnumerosi tai käyttäjänimesi. Valitse tilisi turvallisuuden vuoksi toinen salasana.',
     form_password_not_strong_enough: 'Salasana ei ole riittävän vahva.',
     form_password_or_identifier_incorrect:
       'Salasana tai sähköpostiosoite on väärä. Yritä uudelleen tai käytä toista menetelmää.',
@@ -1789,8 +1791,8 @@ export const fiFI: LocalizationResource = {
     insufficient_seats_change_plan: undefined,
     insufficient_seats_contact_support: undefined,
     not_allowed_access:
-      "Sähköpostiosoite tai puhelinnumero ei ole sallittu rekisteröityäksesi. Tämä voi johtua siitä, että sähköpostiosoite sisältää '+', '=', '#' tai '.' merkkejä, käyttäät aluetta, joka on sidottu tilapäisyyden sähköpostitilaukseen, tai olet eksplisiittisesti estetty. Jos uskoo, että tämä on virhe, ota yhteyttä tukeen.",
-    oauth_access_denied: undefined,
+      "Sähköpostiosoitteella tai puhelinnumerolla ei voi rekisteröityä. Syynä voi olla, että sähköpostiosoite sisältää merkkejä '+', '=', '#' tai '.', että verkkotunnus kuuluu väliaikaiseen sähköpostipalveluun, tai että osoite on erikseen estetty. Jos tämä on mielestäsi virhe, ota yhteyttä tukeen.",
+    oauth_access_denied: 'Et myöntänyt käyttöoikeutta tiliisi.',
     organization_domain_blocked: undefined,
     organization_domain_common: undefined,
     organization_domain_exists_for_enterprise_connection: undefined,
@@ -1818,12 +1820,14 @@ export const fiFI: LocalizationResource = {
     phone_number_exists: 'Tämä puhelinnumero on jo käytössä. Kokeile toista.',
     protect_check_aborted: undefined,
     protect_check_already_resolved: undefined,
-    protect_check_execution_failed: undefined,
-    protect_check_invalid_script: undefined,
-    protect_check_invalid_sdk_url: undefined,
-    protect_check_script_load_failed: undefined,
-    protect_check_timed_out: undefined,
-    protect_check_unsupported_environment: undefined,
+    protect_check_execution_failed: 'Tarkistus ei valmistunut. Yritä uudelleen.',
+    protect_check_invalid_script: 'Tarkistusta ei voitu ladata. Ota yhteyttä tukeen, jos ongelma jatkuu.',
+    protect_check_invalid_sdk_url: 'Tarkistusta ei voitu käynnistää. Ota yhteyttä tukeen.',
+    protect_check_script_load_failed:
+      'Tarkistusta ei voitu ladata. Syynä voi olla verkkoyhteys tai sisällön suojauskäytäntö, joka estää tarkistuksen skriptin. Yritä uudelleen tai ota yhteyttä tukeen.',
+    protect_check_timed_out: 'Tarkistus ei valmistunut ajoissa. Yritä uudelleen.',
+    protect_check_unsupported_environment:
+      'Tarkistusta ei tueta tässä ympäristössä. Jatka tavallisella selaimella tai ota yhteyttä tukeen.',
     session_exists: 'Olet jo kirjautunut sisään.',
     web3_missing_identifier: 'Web3-lompakkoa ei löytynyt. Asenna sellainen jatkaaksesi.',
     web3_signature_request_rejected: 'Hylkäsit allekirjoituspyynnön. Yritä uudelleen jatkaaksesi.',


### PR DESCRIPTION
## Description

Adds the following translations for Finnish:
- signIn.emailLink.verifiedTransferable — title, subtitle
- signIn.protectCheck and signUp.protectCheck — title, subtitle, loading, retryButton
- unstable__errors — action_blocked, oauth_access_denied, form_password_matches_identifier, and the six protect_check_* errors (execution_failed, invalid_script, invalid_sdk_url, script_load_failed, timed_out, unsupported_environment)

Fixes the following translation, which was not proper language: 
- not_allowed_access

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Localization update (Finnish)
