### PR TITLE
fix(expo): show the Android AuthView form when opened right after launch

### DIFF
--- a/.changeset/expo-android-authview-first-mount.md
+++ b/.changeset/expo-android-authview-first-mount.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Fix the Android `<AuthView>` rendering no sign-in form when it is opened within a couple of seconds of `isLoaded` turning true. The native view now recreates itself once the Clerk Android SDK finishes loading instead of staying empty until it is dismissed and reopened.

--- a/.github/workflows/expo-native-build.yml
+++ b/.github/workflows/expo-native-build.yml
@@ -187,6 +187,15 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Gradle cache
+        if: matrix.platform == 'android' && steps.native-build-cache.outputs.cache-hit != 'true'
+        uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6.3.0
+        with:
+          # This workflow never runs on main, so the default (write from main
+          # only) would never seed the cache.
+          cache-read-only: false
+          add-job-summary: on-failure
+
       - name: Prebuild Android fixture
         if: matrix.platform == 'android' && steps.native-build-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.FIXTURE_DIR }}
@@ -295,6 +304,11 @@ jobs:
           xcrun simctl spawn "$SIM_UDID" defaults write com.apple.keyboard.AutoCapitalization -bool NO || true
           xcrun simctl spawn "$SIM_UDID" defaults write com.apple.keyboard.AutoCorrection -bool NO || true
           xcrun simctl spawn "$SIM_UDID" defaults write com.apple.keyboard.Prediction -bool NO || true
+          # The one-time keyboard tutorial sheets carry their own Continue
+          # button, which can hijack taps on the AuthView's Continue.
+          for key in DidShowContinuousPathIntroduction DidShowGestureKeyboardIntroduction KeyboardDidShowProductivityTutorial UIKeyboardDidShowInternationalInfoIntroduction; do
+            xcrun simctl spawn "$SIM_UDID" defaults write com.apple.keyboard.preferences "$key" -bool YES || true
+          done
           xcrun simctl install "$SIM_UDID" ios/build/Build/Products/Release-iphonesimulator/ClerkExpoNativeBuildFixture.app
           # Stream the app's console output into the debug artifact so a hang has
           # actionable evidence (keychain/network errors) instead of just screenshots.

--- a/integration/tests/expo-native/flows/subflows/sign-in-email-password.yaml
+++ b/integration/tests/expo-native/flows/subflows/sign-in-email-password.yaml
@@ -90,6 +90,13 @@ appId: com.clerk.exponativebuildfixture
           index: 0
       - waitForAnimationToEnd:
           timeout: 5000
+      # The screen stays stable while the sign-in request is in flight, so the
+      # animation wait alone can return before the next screen exists. Wait for
+      # either outcome so the conditional below sees the real screen.
+      - extendedWaitUntil:
+          visible: 'Check your email|signed in'
+          timeout: 15000
+          optional: true
 # Some instances ask for the email code after the password instead.
 - runFlow:
     when:

--- a/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/clerk/ClerkAuthViewModule.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.api.Clerk
 import com.clerk.api.FrameworkIntegrationApi
 import com.clerk.api.ui.ClerkDesign
@@ -100,6 +103,16 @@ class ClerkAuthNativeView(context: Context, appContext: AppContext) : ClerkCompo
 
   @Composable
   private fun AuthContent() {
+    // An AuthView composed before Clerk has loaded the environment renders no
+    // form and never recovers, so recreate it once loaded.
+    val isInitialized by Clerk.isInitialized.collectAsStateWithLifecycle()
+    key(isInitialized) {
+      AuthContentBody()
+    }
+  }
+
+  @Composable
+  private fun AuthContentBody() {
     AuthView(
       modifier = Modifier.fillMaxSize(),
       clerkTheme = authTheme(),


### PR DESCRIPTION
## Description

On Android, opening `<AuthView>` right after the app starts can show an empty sheet with no sign-in form, and it stays empty until you close and reopen it. The native Android SDK starts loading after the JS SDK does, so the view can appear while the native side is still loading, and it never updates once that finishes. Waiting for `isLoaded` doesn't avoid this. The view now rebuilds itself when the native SDK is ready.

Other fixes/improvements to native E2E CI:

- Cache Gradle in the Android jobs
- Stop the iOS simulator's one-time keyboard tutorial from appearing. Its own "Continue" button can steal taps meant for the sign-in form
- After submitting the password in the sign-in flow, wait for the next screen to actually appear before checking which one it is

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
