### PR TITLE
fix(clerk-js,ui): show the challenge raised while handing off to an enterprise connection

### DIFF
--- a/.changeset/enterprise-sso-hand-off-challenge.md
+++ b/.changeset/enterprise-sso-hand-off-challenge.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/ui': patch
+---
+
+Fix enterprise SSO sign-ins erroring instead of showing a verification challenge raised while handing off to the identity provider.

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -388,6 +388,12 @@ export class SignIn extends BaseResource implements SignInResource {
 
     const redirectUrl = SignIn.clerk.buildUrlWithAuth(params.redirectUrl);
 
+    // A pending `protect_check` leaves the hand-off unprepared: the server returns before it
+    // builds a verification, so there is no external URL to navigate to. Stop rather than
+    // reporting the response as invalid — the caller runs the challenge and calls back in with
+    // `continueSignIn`, at which point the hand-off is prepared for real.
+    const isChallengePending = () => !!this.protectCheck || this.status === 'needs_protect_check';
+
     if (!this.id || !continueSignIn) {
       await this.create({
         strategy,
@@ -395,6 +401,10 @@ export class SignIn extends BaseResource implements SignInResource {
         redirectUrl,
         actionCompleteRedirectUrl,
       });
+
+      if (isChallengePending()) {
+        return;
+      }
     }
 
     if (strategy === 'enterprise_sso') {
@@ -405,6 +415,10 @@ export class SignIn extends BaseResource implements SignInResource {
         oidcPrompt,
         enterpriseConnectionId,
       });
+
+      if (isChallengePending()) {
+        return;
+      }
     }
 
     const { status, externalVerificationRedirectURL } = this.firstFactorVerification;

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -388,10 +388,8 @@ export class SignIn extends BaseResource implements SignInResource {
 
     const redirectUrl = SignIn.clerk.buildUrlWithAuth(params.redirectUrl);
 
-    // A pending `protect_check` leaves the hand-off unprepared: the server returns before it
-    // builds a verification, so there is no external URL to navigate to. Stop rather than
-    // reporting the response as invalid — the caller runs the challenge and calls back in with
-    // `continueSignIn`, at which point the hand-off is prepared for real.
+    // Defer external navigation while a challenge is pending: the caller resolves it and calls
+    // back in with `continueSignIn`.
     const isChallengePending = () => !!this.protectCheck || this.status === 'needs_protect_check';
 
     if (!this.id || !continueSignIn) {

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -311,6 +311,104 @@ describe('SignIn', () => {
     });
   });
 
+  describe('authenticateWithRedirect with a pending challenge', () => {
+    const originalFetch = BaseResource._fetch;
+
+    afterEach(() => {
+      BaseResource._fetch = originalFetch;
+      vi.clearAllMocks();
+      SignIn.clerk = {} as any;
+    });
+
+    const gatedResponse = {
+      client: null,
+      response: {
+        id: 'signin_123',
+        status: 'needs_protect_check',
+        first_factor_verification: null,
+        protect_check: {
+          status: 'pending',
+          token: 'challenge-token-abc',
+          sdk_url: 'https://sdk.example.com/challenge.js',
+        },
+      },
+    };
+
+    const setupClerk = () => {
+      const windowNavigate = vi.fn();
+      SignIn.clerk = {
+        buildUrlWithAuth: vi.fn(u => u),
+        __internal_windowNavigate: windowNavigate,
+        __internal_environment: { displayConfig: { captchaOauthBypass: [] } },
+      } as any;
+      return windowNavigate;
+    };
+
+    it('stops after create instead of preparing a hand-off it cannot follow', async () => {
+      const windowNavigate = setupClerk();
+      const mockFetch = vi.fn().mockResolvedValue(gatedResponse);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn();
+      await expect(
+        signIn.authenticateWithRedirect({
+          strategy: 'enterprise_sso',
+          redirectUrl: '/sso-callback',
+          redirectUrlComplete: '/',
+        }),
+      ).resolves.toBeUndefined();
+
+      // Only the create call — the prepare is not attempted while the challenge is pending.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(windowNavigate).not.toHaveBeenCalled();
+      expect(signIn.protectCheck?.status).toBe('pending');
+    });
+
+    it('stops when preparing the enterprise SSO hand-off returns a challenge', async () => {
+      const windowNavigate = setupClerk();
+      const mockFetch = vi.fn().mockResolvedValue(gatedResponse);
+      BaseResource._fetch = mockFetch;
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      await expect(
+        signIn.authenticateWithRedirect({
+          strategy: 'enterprise_sso',
+          redirectUrl: '/sso-callback',
+          redirectUrlComplete: '/',
+          continueSignIn: true,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(windowNavigate).not.toHaveBeenCalled();
+      expect(signIn.protectCheck?.status).toBe('pending');
+    });
+
+    it('follows the hand-off once no challenge is pending', async () => {
+      const windowNavigate = setupClerk();
+      BaseResource._fetch = vi.fn().mockResolvedValue({
+        client: null,
+        response: {
+          id: 'signin_123',
+          status: 'needs_first_factor',
+          first_factor_verification: {
+            status: 'unverified',
+            external_verification_redirect_url: 'https://idp.example/auth',
+          },
+        },
+      });
+
+      const signIn = new SignIn({ id: 'signin_123' } as any);
+      await signIn.authenticateWithRedirect({
+        strategy: 'enterprise_sso',
+        redirectUrl: '/sso-callback',
+        redirectUrlComplete: '/',
+        continueSignIn: true,
+      });
+
+      expect(windowNavigate).toHaveBeenCalledWith(new URL('https://idp.example/auth'));
+    });
+  });
+
   describe('signIn.create', () => {
     afterEach(() => {
       vi.clearAllMocks();

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -454,13 +454,17 @@ function SignInStartInternal(): JSX.Element {
     const redirectUrl = ctx.ssoCallbackUrl;
     const redirectUrlComplete = ctx.afterSignInUrl || '/';
 
-    return signIn.authenticateWithRedirect({
+    await signIn.authenticateWithRedirect({
       strategy: 'enterprise_sso',
       redirectUrl,
       redirectUrlComplete,
       oidcPrompt: ctx.oidcPrompt,
       continueSignIn: true,
     });
+
+    // Preparing the hand-off can itself raise a challenge, in which case no redirect was issued
+    // and the sign-in is sitting on the gate instead.
+    navigateOnSignInProtectGate(signIn, navigate, 'protect-check');
   };
 
   const attemptToRecoverFromSignInError = async (e: any) => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -450,6 +450,28 @@ describe('SignInStart', () => {
         continueSignIn: true,
       });
     });
+
+    it('routes to the challenge when preparing the hand-off raises one', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      fixtures.signIn.create.mockReturnValueOnce(
+        Promise.resolve({
+          status: 'needs_first_factor',
+          supportedFirstFactors: [{ strategy: 'enterprise_sso' }],
+        } as unknown as SignInResource),
+      );
+      // No redirect is issued: the sign-in comes back sitting on the challenge instead.
+      fixtures.signIn.authenticateWithRedirect.mockImplementationOnce(() => {
+        (fixtures.signIn as any).protectCheck = { status: 'pending', token: 'challenge-token-abc' };
+        return Promise.resolve();
+      });
+      const { userEvent } = render(<SignInStart />, { wrapper });
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
+      await userEvent.click(screen.getByText('Continue'));
+      expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalled();
+      expect(fixtures.router.navigate).toHaveBeenCalledWith('protect-check');
+    });
   });
 
   describe('Identifier switching', () => {


### PR DESCRIPTION
## Description

A sign-in that uses an enterprise connection can be asked for a verification challenge at the point it hands off to the identity provider. When that happens the server returns before it has prepared the hand-off, so there is no external URL to follow.

`SignIn.authenticateWithRedirect` treated that response as invalid and threw, and the sign-in dead-ended on an error the user cannot act on.

It now returns instead, and the caller routes to the challenge. Once resolved, the hand-off is retried with `continueSignIn` and prepared for real. If the challenge arrives on `create`, the prepare is skipped rather than issued and discarded.

**Effects and risks**

- The early return applies to every strategy that goes through this method, not only enterprise connections. For OAuth the response today carries both a pending challenge and a redirect URL, so this stops at the challenge where it previously redirected and picked it up on the callback. Both routes end at the same place; this is the shorter one.
- `authenticateWithEnterpriseSSO` now awaits rather than returning its promise, so the loading state it holds is released by the navigation instead of by the redirect.
- No change when nothing is pending: the redirect is followed exactly as before.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
