### PR TITLE
fix(ui): clear the invitation ticket when a sign-in completes on a challenge

### DIFF
--- a/.changeset/clear-ticket-after-challenge.md
+++ b/.changeset/clear-ticket-after-challenge.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Clear the invitation ticket from the URL when a sign-in completes on a verification challenge.

--- a/packages/ui/src/components/SignIn/SignInProtectCheck.tsx
+++ b/packages/ui/src/components/SignIn/SignInProtectCheck.tsx
@@ -1,3 +1,4 @@
+import { removeClerkQueryParam } from '@clerk/shared/internal/clerk-js/queryParams';
 import { useClerk } from '@clerk/shared/react';
 import type { SignInResource } from '@clerk/shared/types';
 import { useEffect, useRef, useState } from 'react';
@@ -72,6 +73,9 @@ function SignInProtectCheckInternal(): JSX.Element | null {
         return;
       }
       if (updatedSignIn.status === 'complete' && updatedSignIn.createdSessionId) {
+        // A ticket sign-in that would have completed on the start page is completing here
+        // instead, so the ticket has to be cleared here too — otherwise it stays in the URL.
+        removeClerkQueryParam('__clerk_ticket');
         await setActive({
           session: updatedSignIn.createdSessionId,
           navigate: async ({ session, decorateUrl }) => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInProtectCheck.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInProtectCheck.test.tsx
@@ -23,6 +23,29 @@ beforeEach(() => {
 });
 
 describe('SignInProtectCheck', () => {
+  it('clears the invitation ticket when the sign-in completes on the challenge', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.startSignInWithProtectCheck();
+    });
+    const url = new URL(window.location.href);
+    url.searchParams.set('__clerk_ticket', 'tkt_abc');
+    window.history.replaceState({}, '', url.toString());
+
+    mockExecute.mockResolvedValue('proof-abc');
+    fixtures.signIn.submitProtectCheck.mockResolvedValue({
+      status: 'complete',
+      protectCheck: null,
+      createdSessionId: 'sess_1',
+    } as unknown as SignInResource);
+
+    render(<SignInProtectCheck />, { wrapper });
+
+    await waitFor(() => {
+      expect(fixtures.clerk.setActive).toHaveBeenCalled();
+    });
+    expect(new URL(window.location.href).searchParams.get('__clerk_ticket')).toBeNull();
+  });
+
   describe('enterprise SSO', () => {
     const enterpriseSSOSignIn = (supportedFirstFactors: unknown[]) =>
       ({


### PR DESCRIPTION
## Description

Stacked on #9620 — review the delta only; that one merges first.

A sign-in started from an organization invitation clears the ticket from the URL when it completes. If a verification challenge is required, the sign-in completes on the challenge instead, which did not clear it — so the ticket stayed in the address bar afterwards.

Clear it there too, matching what the start page and the sign-up flow already do.

**Effects and risks**

- `removeClerkQueryParam` is a no-op when the parameter is absent, so this only affects the ticket case.
- Only covers a sign-in that completes on the challenge itself. One that continues to another step and completes there keeps the parameter, as it does today without a challenge — unchanged here.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
