### PR TITLE
docs(nextjs): add @deprecated tag to removed control-component stubs

### DIFF
--- a/.changeset/deprecated-tag-removed-control-components.md
+++ b/.changeset/deprecated-tag-removed-control-components.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Add `@deprecated` tags to the removed `<SignedIn>`, `<SignedOut>`, and `<Protect>` control-component stubs so editors and lint rules flag them at authoring time (with the `<Show>` migration guidance) instead of only failing when rendered.

--- a/packages/nextjs/src/removedControlComponents.ts
+++ b/packages/nextjs/src/removedControlComponents.ts
@@ -30,6 +30,8 @@ function throwRemovedControlComponentError(
  * - Core 3 changelog: https://clerk.com/changelog/2026-03-03-core-3
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
+ *
+ * @deprecated Removed in Clerk Core 3. Rendering `<SignedIn>` throws an error. Use `<Show when="signed-in">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function SignedIn(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError(
@@ -58,6 +60,8 @@ export function SignedIn(_props: RemovedControlComponentProps): never {
  * - Core 3 changelog: https://clerk.com/changelog/2026-03-03-core-3
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
+ *
+ * @deprecated Removed in Clerk Core 3. Rendering `<SignedOut>` throws an error. Use `<Show when="signed-out">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function SignedOut(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError(
@@ -90,6 +94,8 @@ export function SignedOut(_props: RemovedControlComponentProps): never {
  * - Core 3 changelog: https://clerk.com/changelog/2026-03-03-core-3
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
+ *
+ * @deprecated Removed in Clerk Core 3. Rendering `<Protect>` throws an error. Use `<Show when={...}>` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function Protect(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError('Protect', 'https://clerk.com/err/protect-is-not-available-in-clerk-nextjs');

--- a/packages/nextjs/src/removedControlComponents.ts
+++ b/packages/nextjs/src/removedControlComponents.ts
@@ -31,7 +31,7 @@ function throwRemovedControlComponentError(
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
  *
- * @deprecated Removed in Clerk Core 3. Rendering `<SignedIn>` throws an error. Use `<Show when="signed-in">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
+ * @deprecated Removed in Clerk Core 3 (`@clerk/nextjs@7.0.0`). Rendering `<SignedIn>` throws an error. Use `<Show when="signed-in">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function SignedIn(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError(
@@ -61,7 +61,7 @@ export function SignedIn(_props: RemovedControlComponentProps): never {
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
  *
- * @deprecated Removed in Clerk Core 3. Rendering `<SignedOut>` throws an error. Use `<Show when="signed-out">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
+ * @deprecated Removed in Clerk Core 3 (`@clerk/nextjs@7.0.0`). Rendering `<SignedOut>` throws an error. Use `<Show when="signed-out">` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function SignedOut(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError(
@@ -95,7 +95,7 @@ export function SignedOut(_props: RemovedControlComponentProps): never {
  * - Core 3 upgrade guide: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
  * - `<Show>` component docs: https://clerk.com/docs/reference/components/control/show
  *
- * @deprecated Removed in Clerk Core 3. Rendering `<Protect>` throws an error. Use `<Show when={...}>` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
+ * @deprecated Removed in Clerk Core 3 (`@clerk/nextjs@7.0.0`). Rendering `<Protect>` throws an error. Use `<Show when={...}>` instead — see https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3.
  */
 export function Protect(_props: RemovedControlComponentProps): never {
   return throwRemovedControlComponentError('Protect', 'https://clerk.com/err/protect-is-not-available-in-clerk-nextjs');


### PR DESCRIPTION
## Description

`SignedIn`, `SignedOut`, and `Protect` still exist in `@clerk/nextjs` as throwing stubs (re-added in #9273), but their error only fires at render time. This adds a `@deprecated` line to each stub's JSDoc so the removal surfaces at authoring time instead — IDE strikethrough, TS diagnostics, and eslint deprecation rules all fire on import. Each tag carries the `<Show>` replacement and links the Core 3 upgrade guide, since agents keep grepping the bundled type definitions for exactly this migration.

Resolves [DOCS-12094](https://linear.app/clerk/issue/DOCS-12094/add-deprecated-tag-to-the-removed-control-component-stubs-in).

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
