### PR TITLE
fix(clerk-js): keep SignIn identity after resetSignIn

### DIFF
--- a/.changeset/fresh-signins-reset.md
+++ b/.changeset/fresh-signins-reset.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fix `useSignIn()` returning a stale resource after resetting sign-in and starting a new SSO flow.

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -163,7 +163,7 @@ export class Client extends BaseResource implements ClientResource {
         this.signUp = new SignUp(data.sign_up);
       }
 
-      if (data.sign_in && this.signIn instanceof SignIn && this.signIn.id === data.sign_in.id) {
+      if (data.sign_in && this.signIn instanceof SignIn && (this.signIn.id === data.sign_in.id || !this.signIn.id)) {
         this.signIn.__internal_updateFromJSON(data.sign_in);
       } else {
         this.signIn = new SignIn(data.sign_in);

--- a/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/Client.test.ts
@@ -226,6 +226,44 @@ describe('Client Singleton', () => {
     expect(client.signIn.id).toBe('test_sign_in_id_v2');
   });
 
+  it('preserves sign in identity after resetSignIn when fromJSON receives a new attempt', () => {
+    const user = createUser({ first_name: 'John', last_name: 'Doe', id: 'user_1' });
+    const initialClientJSON: ClientJSON = {
+      object: 'client',
+      id: 'test_id',
+      status: 'active',
+      last_active_session_id: null,
+      sign_in: createSignIn({ id: 'test_sign_in_id', status: 'needs_first_factor' }, user),
+      sign_up: null,
+      sessions: [],
+      created_at: Date.now() - 1000,
+      updated_at: Date.now(),
+    } as any;
+
+    // @ts-expect-error We cannot mess with the singleton when tests are running in parallel
+    const client = new Client(initialClientJSON);
+    client.resetSignIn();
+    const resetSignIn = client.signIn;
+
+    client.fromJSON({
+      ...initialClientJSON,
+      sign_in: createSignIn(
+        {
+          id: 'test_sign_in_id_v2',
+          status: 'needs_second_factor',
+          identifier: 'updated@example.com',
+        },
+        user,
+      ),
+      updated_at: Date.now() + 1000,
+    });
+
+    expect(client.signIn).toBe(resetSignIn);
+    expect(client.signIn.id).toBe('test_sign_in_id_v2');
+    expect(client.signIn.identifier).toBe('updated@example.com');
+    expect(client.signIn.status).toBe('needs_second_factor');
+  });
+
   it('has the same initial properties', () => {
     const clientJSON = {
       object: 'client',


### PR DESCRIPTION
## Description

Problem: After `signIn.reset()` or `client.resetSignIn()`, a later SSO attempt in the same handler can leave Future `useSignIn()` consumers reading a stale resource.

Root cause: `resetSignIn()` installs a fresh empty `SignIn`, while `Client.fromJSON()` previously updated an existing `SignIn` only when its ID matched the incoming attempt. The empty reset resource therefore failed the ID check and was replaced, breaking the retained reference.

Solution: Reuse and update the current `SignIn` when its ID matches the incoming attempt or when its current ID is empty. Differing non-empty attempts continue to replace the resource.

Tests: Added `Client.test.ts` coverage that resets sign-in, applies a new attempt through `fromJSON()`, and verifies both object identity and refreshed attempt data. The full `clerk-js` suite passes with 1,058 tests, and the package build passes.

Fixes #9006

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: