### PR TITLE
fix(shared): classify local production keys as live

### DIFF
--- a/.changeset/honest-plants-smile.md
+++ b/.changeset/honest-plants-smile.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Fix publishable-key generation for production instances in local Clerk environments.

--- a/packages/shared/src/__tests__/keys.spec.ts
+++ b/packages/shared/src/__tests__/keys.spec.ts
@@ -19,6 +19,8 @@ describe('buildPublishableKey(frontendApi)', () => {
     ['foo-bar-13.clerk.accounts.dev', 'pk_test_Zm9vLWJhci0xMy5jbGVyay5hY2NvdW50cy5kZXYk'],
     ['clerk.boring.sawfly-91.lcl.dev', 'pk_test_Y2xlcmsuYm9yaW5nLnNhd2ZseS05MS5sY2wuZGV2JA'],
     ['clerk.boring.sawfly-91.lclclerk.com', 'pk_test_Y2xlcmsuYm9yaW5nLnNhd2ZseS05MS5sY2xjbGVyay5jb20k'],
+    ['clerk.prod.lclclerk.com', 'pk_live_Y2xlcmsucHJvZC5sY2xjbGVyay5jb20k'],
+    ['clerk.example.prod.lclclerk.com', 'pk_live_Y2xlcmsuZXhhbXBsZS5wcm9kLmxjbGNsZXJrLmNvbSQ'],
   ];
 
   test.each(cases)(

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -36,9 +36,11 @@ const PUBLISHABLE_FRONTEND_API_DEV_REGEX = /^(([a-z]+)-){2}([0-9]{1,2})\.clerk\.
  * @returns An unpadded base64-encoded publishable key with appropriate prefix (pk_live_ or pk_test_).
  */
 export function buildPublishableKey(frontendApi: string): string {
-  const isDevKey =
-    PUBLISHABLE_FRONTEND_API_DEV_REGEX.test(frontendApi) ||
-    (frontendApi.startsWith('clerk.') && LEGACY_DEV_INSTANCE_SUFFIXES.some(s => frontendApi.endsWith(s)));
+  const isLegacyDevKey =
+    frontendApi.startsWith('clerk.') &&
+    LEGACY_DEV_INSTANCE_SUFFIXES.some(s => frontendApi.endsWith(s)) &&
+    !frontendApi.endsWith('.prod.lclclerk.com');
+  const isDevKey = PUBLISHABLE_FRONTEND_API_DEV_REGEX.test(frontendApi) || isLegacyDevKey;
   const keyPrefix = isDevKey ? PUBLISHABLE_KEY_TEST_PREFIX : PUBLISHABLE_KEY_LIVE_PREFIX;
   return `${keyPrefix}${isomorphicBtoa(`${frontendApi}$`).replace(/=+$/, '')}`;
 }


### PR DESCRIPTION
## Description

Local production Frontend API hosts under `.prod.lclclerk.com` currently get a `pk_test_` key because publishable-key generation treats every `.lclclerk.com` host as development. This makes ClerkJS load a production system instance as development and require a dev browser. This change excludes local production hosts from the legacy development rule while keeping existing development host behavior.

Run `pnpm --filter @clerk/shared test -- src/__tests__/keys.spec.ts` to verify the production and development host cases.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
