### PR TITLE
fix(expo): preserve mounted native auth view

### DIFF
--- a/.changeset/calm-spoons-listen.md
+++ b/.changeset/calm-spoons-listen.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Keep post-authentication prompts open in the native `AuthView` when the Clerk iOS SDK configuration refreshes.

--- a/packages/expo/ios/ClerkNativeViewHost.swift
+++ b/packages/expo/ios/ClerkNativeViewHost.swift
@@ -66,7 +66,8 @@ public class ClerkNativeViewHost: ExpoView {
       object: nil,
       queue: .main
     ) { [weak self] _ in
-      self?.setNeedsHostedViewUpdate()
+      guard let self, !hostingCoordinator.hasAttachedController else { return }
+      setNeedsHostedViewUpdate()
     }
   }
 
@@ -144,6 +145,10 @@ public class ClerkUserProfileCustomPageHost: ClerkNativeViewHost {
 private final class ClerkNativeHostingCoordinator {
   private weak var containerView: UIView?
   private var hostingController: UIViewController?
+
+  var hasAttachedController: Bool {
+    hostingController != nil
+  }
 
   init(containerView: UIView) {
     self.containerView = containerView

--- a/packages/expo/ios/Tests/ClerkNativeViewHostTests.swift
+++ b/packages/expo/ios/Tests/ClerkNativeViewHostTests.swift
@@ -1,0 +1,66 @@
+import UIKit
+import XCTest
+@testable import ClerkExpo
+
+final class ClerkNativeViewHostTests: XCTestCase {
+  @MainActor
+  func testConfigureNotificationDoesNotReplaceAttachedController() {
+    let hostView = TestClerkNativeViewHost(appContext: nil)
+    let controller = UIViewController()
+    hostView.controller = controller
+    let window = mountInWindow(hostView)
+    let callsBeforeNotification = hostView.makeHostedControllerCallCount
+
+    NotificationCenter.default.post(name: .clerkNativeSDKDidConfigure, object: nil)
+
+    XCTAssertEqual(hostView.makeHostedControllerCallCount, callsBeforeNotification)
+    XCTAssertTrue(controller.view.superview === hostView)
+    unmount(hostView, from: window)
+  }
+
+  @MainActor
+  func testConfigureNotificationAttachesControllerWhenInitiallyUnavailable() {
+    let hostView = TestClerkNativeViewHost(appContext: nil)
+    let window = mountInWindow(hostView)
+    let callsBeforeConfiguration = hostView.makeHostedControllerCallCount
+    let controller = UIViewController()
+    hostView.controller = controller
+
+    NotificationCenter.default.post(name: .clerkNativeSDKDidConfigure, object: nil)
+
+    XCTAssertEqual(hostView.makeHostedControllerCallCount, callsBeforeConfiguration + 1)
+    XCTAssertTrue(controller.view.superview === hostView)
+
+    NotificationCenter.default.post(name: .clerkNativeSDKDidConfigure, object: nil)
+
+    XCTAssertEqual(hostView.makeHostedControllerCallCount, callsBeforeConfiguration + 1)
+    unmount(hostView, from: window)
+  }
+
+  @MainActor
+  private func mountInWindow(_ hostView: UIView) -> UIWindow {
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    let viewController = UIViewController()
+    window.rootViewController = viewController
+    viewController.view.addSubview(hostView)
+    window.makeKeyAndVisible()
+    return window
+  }
+
+  @MainActor
+  private func unmount(_ hostView: UIView, from window: UIWindow) {
+    hostView.removeFromSuperview()
+    window.isHidden = true
+  }
+}
+
+@MainActor
+private final class TestClerkNativeViewHost: ClerkNativeViewHost {
+  var controller: UIViewController?
+  private(set) var makeHostedControllerCallCount = 0
+
+  override func makeHostedController() -> UIViewController? {
+    makeHostedControllerCallCount += 1
+    return controller
+  }
+}


### PR DESCRIPTION
## Description

Prevents an already-mounted native iOS `AuthView` from being replaced when the Clerk SDK configuration refreshes. Replacing the hosting controller could reset the native navigation stack during post-authentication flows, causing prompts such as trusted-device enrollment to disappear before the user could respond.

Configuration notifications will still attach the native controller when it was initially unavailable. Tests cover both preserving an existing controller and attaching one after delayed configuration.

To test, render an Expo `AuthView` using `mode="signInOrUp"` and `isDismissible={false}`, then complete authentication with a user eligible for trusted-device enrollment. Confirm that the enrollment prompt remains visible after the authentication state synchronizes and can be completed normally.

Fix related to: https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01M0ZRA3A0JFDP0QG0P15SWPDD

<!-- Fixes #(issue number) -->

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
