### PR TITLE
chore(expo): bump clerk-android to 1.1.5

### DIFF
--- a/.changeset/expo-bump-clerk-android-1-1-5.md
+++ b/.changeset/expo-bump-clerk-android-1-1-5.md
@@ -1,0 +1,5 @@
+---
+'@clerk/expo': patch
+---
+
+Bump the bundled `clerk-android` SDK (`clerk-android-api` and `clerk-android-ui`) from `1.1.4` to `1.1.5`. See the Clerk Android release: https://github.com/clerk/clerk-android/releases/tag/v1.1.5.

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -20,8 +20,8 @@ def clerkExpoVersion = clerkExpoPackageJson.version.toString()
 // See: https://docs.gradle.org/current/userguide/version_catalogs.html for app-level version catalogs
 ext {
   kotlinxCoroutinesVersion = "1.7.3"
-  clerkAndroidApiVersion = "1.1.4"
-  clerkAndroidUiVersion = "1.1.4"
+  clerkAndroidApiVersion = "1.1.5"
+  clerkAndroidUiVersion = "1.1.5"
   okhttpVersion = "5.4.0"
   okhttpUrlConnectionVersion = "5.0.0-alpha.16"
   composeVersion = "1.7.0"


### PR DESCRIPTION
## Description

Bumps the bundled `clerk-android` SDK in `@clerk/expo` from `1.1.4` to `1.1.5`.

Release: https://github.com/clerk/clerk-android/releases/tag/v1.1.5

## Checklist

- JavaScript repo CI will run on the PR.
- Not applicable: JSDoc comments or documentation updates.

## Type of change

Refactoring / dependency upgrade / documentation
