### PR TITLE
fix(expo): Skip explicit Kotlin plugin when AGP registers the kotlin extension

### DIFF
--- a/.changeset/agp9-built-in-kotlin.md
+++ b/.changeset/agp9-built-in-kotlin.md
@@ -1,0 +1,6 @@
+---
+'@clerk/expo-google-signin': patch
+'@clerk/expo-passkeys': patch
+---
+
+Fix Android builds failing on Android Gradle Plugin 9 with `Cannot add extension with name 'kotlin'`.

--- a/packages/expo-google-signin/android/build.gradle
+++ b/packages/expo-google-signin/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9+ registers the `kotlin` extension itself, and applying kotlin-android on top of that fails configuration.
+if (project.extensions.findByName('kotlin') == null) {
+  apply plugin: 'kotlin-android'
+}
+
 apply plugin: 'maven-publish'
 
 group = 'expo.modules.clerk.googlesignin'

--- a/packages/expo-passkeys/android/build.gradle
+++ b/packages/expo-passkeys/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9+ registers the `kotlin` extension itself, and applying kotlin-android on top of that fails configuration.
+if (project.extensions.findByName('kotlin') == null) {
+  apply plugin: 'kotlin-android'
+}
+
 apply plugin: 'maven-publish'
 
 group = 'expo.modules.clerkexpopasskeys'


### PR DESCRIPTION
## Description

Builds on top of #9660 to run full CI.

Android Gradle Plugin 9 ships built-in Kotlin support and enables it by default, so AGP registers the `kotlin` extension itself. `@clerk/expo-google-signin` and `@clerk/expo-passkeys` both apply `kotlin-android` unconditionally, so the two collide and configuration fails before anything compiles.

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
