### PR TITLE
fix(js): complete offline sign-out

### DIFF
--- a/.changeset/calm-otters-sign.md
+++ b/.changeset/calm-otters-sign.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Complete local sign-out while offline when cached resources surface a network error.

--- a/packages/clerk-js/src/core/__tests__/clerk.test.ts
+++ b/packages/clerk-js/src/core/__tests__/clerk.test.ts
@@ -1,4 +1,4 @@
-import { ClerkOfflineError, EmailLinkErrorCodeStatus } from '@clerk/shared/error';
+import { ClerkOfflineError, ClerkRuntimeError, EmailLinkErrorCodeStatus } from '@clerk/shared/error';
 import { ERROR_CODES } from '@clerk/shared/internal/clerk-js/constants';
 import type {
   ActiveSessionResource,
@@ -1289,6 +1289,53 @@ describe('Clerk singleton', () => {
         });
       },
     );
+
+    it('completes local sign-out when removing sessions fails with an offline network error', async () => {
+      mockClientRemoveSessions.mockRejectedValue(
+        new ClerkRuntimeError('Network request failed.', { code: 'network_error' }),
+      );
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          ...clientTouchDefaults,
+          signedInSessions: [mockSession1],
+          sessions: [mockSession1],
+          destroy: mockClientDestroy,
+          removeSessions: mockClientRemoveSessions,
+        }),
+      );
+
+      const sut = new Clerk(productionPublishableKey);
+      sut.navigate = vi.fn();
+      await sut.load();
+
+      await expect(sut.signOut()).resolves.toBeUndefined();
+
+      expect(sut.session).toBeNull();
+      expect(sut.navigate).toHaveBeenCalledWith('/');
+    });
+
+    it('rethrows non-network errors when removing sessions during sign-out', async () => {
+      const error = new ClerkRuntimeError('Request failed.', { code: 'unexpected_error' });
+      mockClientRemoveSessions.mockRejectedValue(error);
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          ...clientTouchDefaults,
+          signedInSessions: [mockSession1],
+          sessions: [mockSession1],
+          destroy: mockClientDestroy,
+          removeSessions: mockClientRemoveSessions,
+        }),
+      );
+
+      const sut = new Clerk(productionPublishableKey);
+      sut.navigate = vi.fn();
+      await sut.load();
+
+      await expect(sut.signOut()).rejects.toBe(error);
+
+      expect(sut.session).toBeUndefined();
+      expect(sut.navigate).not.toHaveBeenCalled();
+    });
 
     it('only removes the session that corresponds to the passed sessionId if it is not the current', async () => {
       mockClientFetch.mockReturnValue(

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -789,10 +789,16 @@ export class Clerk implements ClerkInterface {
     if (!opts.sessionId || this.client.signedInSessions.length === 1) {
       this.#setTransitiveState();
 
-      if (this.#options.experimental?.persistClient ?? true) {
-        await this.client.removeSessions();
-      } else {
-        await this.client.destroy();
+      try {
+        if (this.#options.experimental?.persistClient ?? true) {
+          await this.client.removeSessions();
+        } else {
+          await this.client.destroy();
+        }
+      } catch (err) {
+        if (!isClerkRuntimeError(err) || err.code !== 'network_error') {
+          throw err;
+        }
       }
 
       await executeSignOut();


### PR DESCRIPTION
## Description

Complete local sign-out when persisted session removal fails with an offline network error. Other client teardown errors continue to be thrown.

[MOBILE-530](https://linear.app/clerk/issue/MOBILE-530/offline-signout-leaves-clerk-stuck-isloadedfalse-when-clerkexpo)

## Checklist

- [ ] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) JSDoc comments have been added or updated for any package exports
- [ ] (If applicable) Documentation has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: