### PR TITLE
feat(ui): add SSO fallback sign-in flow to `<SignIn />`

### DIFF
--- a/.changeset/sso-fallback-sign-in-flow.md
+++ b/.changeset/sso-fallback-sign-in-flow.md
@@ -1,0 +1,12 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/shared': minor
+'@clerk/ui': minor
+---
+
+Add the SSO fallback sign-in flow to `<SignIn />`, for instances that let enterprise users sign in with an email code when they cannot reach their identity provider.
+
+On such an instance the sign-in no longer redirects straight to the identity provider. It shows the SSO action — or the connection picker, when several connections serve the address — alongside a "Can't use SSO?" link leading to the standard email code step, which carries a notice that the organization requires single sign-on and that the attempt is recorded. The link is driven purely by instance configuration and looks identical for every user; the API never discloses who is actually allowed to use the fallback. Instances without the feature are unaffected.
+
+Custom flows can read the same factor from the new `ssoFallbackFirstFactors` property on the sign-in resource. The flow adds the `signIn.enterpriseSSO` and `signIn.ssoFallback` localization keys and the `ssoFallback` card action element id.

--- a/.changeset/sso-fallback-sign-in-flow.md
+++ b/.changeset/sso-fallback-sign-in-flow.md
@@ -5,8 +5,8 @@
 '@clerk/ui': minor
 ---
 
-Add the SSO fallback sign-in flow to `<SignIn />`, for instances that let enterprise users sign in with an email code when they cannot reach their identity provider.
+Add the SSO fallback sign-in flow to `<SignIn />`, for enterprise users the instance has allowlisted to sign in with an email code when they cannot reach their identity provider.
 
-On such an instance the sign-in no longer redirects straight to the identity provider. It shows the SSO action — or the connection picker, when several connections serve the address — alongside a "Can't use SSO?" link leading to the standard email code step, which carries a notice that the organization requires single sign-on and that the attempt is recorded. The link is driven purely by instance configuration and looks identical for every user; the API never discloses who is actually allowed to use the fallback. Instances without the feature are unaffected.
+For such a user the sign-in no longer redirects straight to the identity provider. It shows the SSO action — or the connection picker, when several connections serve the address — alongside a "Can't use SSO?" link leading to the standard email code step, which carries a notice that the organization requires single sign-on and that the attempt is recorded. Users without a fallback, and instances without the feature, are unaffected.
 
 Custom flows can read the same factor from the new `ssoFallbackFirstFactors` property on the sign-in resource. The flow adds the `signIn.enterpriseSSO` and `signIn.ssoFallback` localization keys and the `ssoFallback` card action element id.

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -118,6 +118,7 @@ export class SignIn extends BaseResource implements SignInResource {
   supportedIdentifiers: SignInIdentifier[] = [];
   supportedFirstFactors: SignInFirstFactor[] | null = [];
   supportedSecondFactors: SignInSecondFactor[] | null = null;
+  ssoFallbackFirstFactors: SignInFirstFactor[] | null = null;
   firstFactorVerification: VerificationResource = new Verification(null);
   secondFactorVerification: VerificationResource = new Verification(null);
   identifier: string | null = null;
@@ -639,6 +640,9 @@ export class SignIn extends BaseResource implements SignInResource {
       this.identifier = data.identifier;
       this.supportedFirstFactors = deepSnakeToCamel(data.supported_first_factors) as SignInFirstFactor[] | null;
       this.supportedSecondFactors = deepSnakeToCamel(data.supported_second_factors) as SignInSecondFactor[] | null;
+      this.ssoFallbackFirstFactors = deepSnakeToCamel(data.sso_fallback_first_factors ?? null) as
+        | SignInFirstFactor[]
+        | null;
       this.firstFactorVerification = new Verification(data.first_factor_verification);
       this.secondFactorVerification = new Verification(data.second_factor_verification);
       this.createdSessionId = data.created_session_id;
@@ -708,6 +712,7 @@ export class SignIn extends BaseResource implements SignInResource {
       supported_identifiers: this.supportedIdentifiers,
       supported_first_factors: deepCamelToSnake(this.supportedFirstFactors),
       supported_second_factors: deepCamelToSnake(this.supportedSecondFactors),
+      sso_fallback_first_factors: deepCamelToSnake(this.ssoFallbackFirstFactors) ?? undefined,
       first_factor_verification: this.firstFactorVerification.__internal_toSnapshot(),
       second_factor_verification: this.secondFactorVerification.__internal_toSnapshot(),
       identifier: this.identifier,
@@ -825,6 +830,10 @@ class SignInFuture implements SignInFutureResource {
 
   get supportedSecondFactors() {
     return this.#resource.supportedSecondFactors ?? [];
+  }
+
+  get ssoFallbackFirstFactors() {
+    return this.#resource.ssoFallbackFirstFactors ?? [];
   }
 
   get isTransferable() {

--- a/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
+++ b/packages/clerk-js/src/core/resources/__tests__/SignIn.test.ts
@@ -3291,4 +3291,48 @@ describe('SignIn', () => {
       expect(result.protectCheck).toBeNull();
     });
   });
+
+  describe('ssoFallbackFirstFactors', () => {
+    const baseJSON = {
+      id: 'signin_123',
+      object: 'sign_in',
+      status: 'needs_first_factor',
+      supported_identifiers: [],
+      identifier: 'user@corp.com',
+      user_data: {} as any,
+      supported_first_factors: [{ strategy: 'enterprise_sso' }],
+      supported_second_factors: [],
+      first_factor_verification: null,
+      second_factor_verification: null,
+      created_session_id: null,
+    } as any;
+
+    it('defaults to null when the field is absent', () => {
+      const signIn = new SignIn(baseJSON);
+
+      expect(signIn.ssoFallbackFirstFactors).toBeNull();
+      expect(signIn.__internal_future.ssoFallbackFirstFactors).toEqual([]);
+      expect(signIn.__internal_toSnapshot().sso_fallback_first_factors).toBeUndefined();
+    });
+
+    it('round-trips the field through the snapshot', () => {
+      const signIn = new SignIn({
+        ...baseJSON,
+        sso_fallback_first_factors: [
+          { strategy: 'email_code', safe_identifier: 'user@corp.com', email_address_id: 'idn_hmac' },
+        ],
+      });
+
+      expect(signIn.ssoFallbackFirstFactors).toEqual([
+        { strategy: 'email_code', safeIdentifier: 'user@corp.com', emailAddressId: 'idn_hmac' },
+      ]);
+      expect(signIn.__internal_future.ssoFallbackFirstFactors).toEqual(signIn.ssoFallbackFirstFactors);
+
+      const snapshot = signIn.__internal_toSnapshot();
+      expect(snapshot.sso_fallback_first_factors).toEqual([
+        { strategy: 'email_code', safe_identifier: 'user@corp.com', email_address_id: 'idn_hmac' },
+      ]);
+      expect(new SignIn(snapshot).ssoFallbackFirstFactors).toEqual(signIn.ssoFallbackFirstFactors);
+    });
+  });
 });

--- a/packages/localizations/src/ar-SA.ts
+++ b/packages/localizations/src/ar-SA.ts
@@ -1450,6 +1450,9 @@ export const arSA: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'رمز تحقق لإعادة تعيين كلمة المرور',
       resendButton: 'لم يصلك أي رمز؟ حاول مرة أخرى.',
@@ -1515,6 +1518,15 @@ export const arSA: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'نريد التحقق من هويتك قبل أعادة تعيين كلمة المرور',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'إنشاء حساب جديد',

--- a/packages/localizations/src/be-BY.ts
+++ b/packages/localizations/src/be-BY.ts
@@ -1458,6 +1458,9 @@ export const beBY: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Код аднаўлення пароля',
       resendButton: 'Адправіць код яшчэ раз',
@@ -1522,6 +1525,15 @@ export const beBY: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Неабходна верыфікаваць вашу асобу перад аднаўленнем пароля',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Зарэгістравацца',

--- a/packages/localizations/src/bg-BG.ts
+++ b/packages/localizations/src/bg-BG.ts
@@ -1454,6 +1454,9 @@ export const bgBG: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Код за нулиране на парола',
       resendButton: 'Не сте получили код? Изпрати отново',
@@ -1518,6 +1521,15 @@ export const bgBG: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Трябва да потвърдим вашата самоличност, преди да нулираме паролата ви.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Регистрирайте се',

--- a/packages/localizations/src/bn-IN.ts
+++ b/packages/localizations/src/bn-IN.ts
@@ -1462,6 +1462,9 @@ export const bnIN: LocalizationResource = {
       subtitle: 'আপনি যে এন্টারপ্রাইজ অ্যাকাউন্ট দিয়ে চালিয়ে যেতে চান তা নির্বাচন করুন।',
       title: 'আপনার এন্টারপ্রাইজ অ্যাকাউন্ট বেছে নিন',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'পাসওয়ার্ড রিসেট কোড',
       resendButton: 'কোনো কোড পাননি? পুনরায় পাঠান',
@@ -1528,6 +1531,15 @@ export const bnIN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'আপনার পাসওয়ার্ড রিসেট করার আগে আমাদের আপনার পরিচয় যাচাই করতে হবে।',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'সাইন আপ করুন',

--- a/packages/localizations/src/ca-ES.ts
+++ b/packages/localizations/src/ca-ES.ts
@@ -1462,6 +1462,9 @@ export const caES: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Codi de restabliment de contrasenya',
       resendButton: 'No has rebut el codi? Reenvia',
@@ -1527,6 +1530,15 @@ export const caES: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Necessitem verificar la teva identitat abans de restablir la teva contrasenya.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: "Registra't",

--- a/packages/localizations/src/cs-CZ.ts
+++ b/packages/localizations/src/cs-CZ.ts
@@ -1461,6 +1461,9 @@ export const csCZ: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kód pro resetování hesla',
       resendButton: 'Neobdrželi jste kód? Znovu poslat',
@@ -1526,6 +1529,15 @@ export const csCZ: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Před resetováním hesla musíme ověřit vaši identitu.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrovat se',

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -1452,6 +1452,9 @@ export const daDK: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Nulstil adgangskode',
       resendButton: 'Modtog du ikke en kode? Send igen',
@@ -1516,6 +1519,15 @@ export const daDK: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Vi skal bekræfte din identitet, før du nulstiller din adgangskode.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Tilmeld dig',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -1469,6 +1469,9 @@ export const deDE: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Passwort-Code zurücksetzen',
       resendButton: 'Sie haben keinen Code erhalten? Erneut senden',
@@ -1535,6 +1538,15 @@ export const deDE: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Bevor wir Ihr Passwort zurücksetzen können, müssen wir Ihre Identität überprüfen.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrieren',

--- a/packages/localizations/src/el-GR.ts
+++ b/packages/localizations/src/el-GR.ts
@@ -1462,6 +1462,9 @@ export const elGR: LocalizationResource = {
       subtitle: 'Συνδεθείτε με SSO επιχείρησης',
       title: 'Σύνδεση επιχείρησης',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Επαναφορά κωδικού πρόσβασης',
       resendButton: 'Δεν λάβατε κωδικό; Αποστολή ξανά',
@@ -1528,6 +1531,15 @@ export const elGR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Πρέπει να επαληθεύσουμε την ταυτότητά σας πριν επαναφέρουμε τον κωδικό πρόσβασής σας.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Εγγραφή',

--- a/packages/localizations/src/en-GB.ts
+++ b/packages/localizations/src/en-GB.ts
@@ -1454,6 +1454,9 @@ export const enGB: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Reset password code',
       resendButton: "Didn't receive a code? Resend",
@@ -1518,6 +1521,15 @@ export const enGB: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'We need to verify your identity before resetting your password.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Sign up',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -1485,6 +1485,9 @@ export const enUS: LocalizationResource = {
       subtitle: 'Select the enterprise account with which you wish to continue.',
       title: 'Choose your enterprise account',
     },
+    enterpriseSSO: {
+      formButtonPrimary: 'Continue with SSO',
+    },
     forgotPassword: {
       formTitle: 'Reset password code',
       resendButton: "Didn't receive a code? Resend",
@@ -1570,6 +1573,15 @@ export const enUS: LocalizationResource = {
       subtitleCombined: undefined,
       title: 'Sign in to {{applicationName}}',
       titleCombined: 'Continue to {{applicationName}}',
+    },
+    ssoFallback: {
+      actionLink: "Can't use SSO?",
+      code: {
+        resendButton: "Didn't receive a code? Resend",
+        subtitle: 'to continue to {{applicationName}}',
+        title: 'Check your email',
+      },
+      notice: 'Your organization requires single sign-on. Continuing without it is recorded.',
     },
     totpMfa: {
       formTitle: 'Verification code',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -1553,6 +1553,15 @@ export const enUS: LocalizationResource = {
     resetPasswordMfa: {
       detailsLabel: 'We need to verify your identity before resetting your password.',
     },
+    ssoFallback: {
+      actionLink: "Can't use SSO?",
+      code: {
+        resendButton: "Didn't receive a code? Resend",
+        subtitle: 'to continue to {{applicationName}}',
+        title: 'Check your email',
+      },
+      notice: 'Your organization requires single sign-on. Continuing without it is recorded.',
+    },
     start: {
       actionLink: 'Sign up',
       actionLink__join_waitlist: 'Join waitlist',
@@ -1573,15 +1582,6 @@ export const enUS: LocalizationResource = {
       subtitleCombined: undefined,
       title: 'Sign in to {{applicationName}}',
       titleCombined: 'Continue to {{applicationName}}',
-    },
-    ssoFallback: {
-      actionLink: "Can't use SSO?",
-      code: {
-        resendButton: "Didn't receive a code? Resend",
-        subtitle: 'to continue to {{applicationName}}',
-        title: 'Check your email',
-      },
-      notice: 'Your organization requires single sign-on. Continuing without it is recorded.',
     },
     totpMfa: {
       formTitle: 'Verification code',

--- a/packages/localizations/src/es-CR.ts
+++ b/packages/localizations/src/es-CR.ts
@@ -1459,6 +1459,9 @@ export const esCR: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código para restablecer contraseña',
       resendButton: '¿No recibiste un código? Reenviar',
@@ -1525,6 +1528,15 @@ export const esCR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Es necesario verificar su identidad para restablecer su contraseña.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrarse',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -1463,6 +1463,9 @@ export const esES: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código de restablecimiento de contraseña',
       resendButton: '¿No recibiste un código? Reenviar',
@@ -1527,6 +1530,15 @@ export const esES: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Necesitamos verificar tu identidad antes de restablecer tu contraseña.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Regístrese',

--- a/packages/localizations/src/es-MX.ts
+++ b/packages/localizations/src/es-MX.ts
@@ -1460,6 +1460,9 @@ export const esMX: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código para restablecer contraseña',
       resendButton: '¿No recibiste un código? Reenviar',
@@ -1526,6 +1529,15 @@ export const esMX: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Es necesario verificar su identidad para restablecer su contraseña.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrarse',

--- a/packages/localizations/src/es-UY.ts
+++ b/packages/localizations/src/es-UY.ts
@@ -1458,6 +1458,9 @@ export const esUY: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código para restablecer la contraseña',
       resendButton: '¿No recibiste un código? Reenviar',
@@ -1523,6 +1526,15 @@ export const esUY: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Necesitamos verificar tu identidad antes de restablecer tu contraseña.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrate',

--- a/packages/localizations/src/fa-IR.ts
+++ b/packages/localizations/src/fa-IR.ts
@@ -1463,6 +1463,9 @@ export const faIR: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'کد رمز عبور را بازنشانی کنید',
       resendButton: 'کدی دریافت نکردید؟ ارسال دوباره',
@@ -1528,6 +1531,15 @@ export const faIR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'قبل از تنظیم مجدد رمز عبور، باید هویت شما را تأیید کنیم.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'ثبت نام',

--- a/packages/localizations/src/fi-FI.ts
+++ b/packages/localizations/src/fi-FI.ts
@@ -1464,6 +1464,9 @@ export const fiFI: LocalizationResource = {
       subtitle: 'Valitse yritystili, jolla haluat jatkaa.',
       title: 'Valitse yritystilisi',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Nollaa salasana',
       resendButton: 'Etkö saanut koodia? Lähetä uudelleen',
@@ -1529,6 +1532,15 @@ export const fiFI: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Ennen salasanan nollaamista on varmistettava henkilöllisyytesi.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Rekisteröidy',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -1470,6 +1470,9 @@ export const frFR: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Code de réinitialisation du mot de passe',
       resendButton: "Vous n'avez pas reçu de code ? Renvoyer",
@@ -1535,6 +1538,15 @@ export const frFR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Nous devons vérifier votre identité avant de réinitialiser votre mot de passe.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: "S'inscrire",

--- a/packages/localizations/src/he-IL.ts
+++ b/packages/localizations/src/he-IL.ts
@@ -1446,6 +1446,9 @@ export const heIL: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'אפס קוד הסיסמה',
       resendButton: 'שלח קוד שוב',
@@ -1509,6 +1512,15 @@ export const heIL: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'אנחנו צריכים לאמת את זהותך לפני שנאפס את הסיסמה שלך.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'הרשמה',

--- a/packages/localizations/src/hi-IN.ts
+++ b/packages/localizations/src/hi-IN.ts
@@ -1462,6 +1462,9 @@ export const hiIN: LocalizationResource = {
       subtitle: 'वह एंटरप्राइज़ खाता चुनें जिसके साथ आप जारी रखना चाहते हैं।',
       title: 'अपना एंटरप्राइज़ खाता चुनें',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'पासवर्ड रीसेट कोड',
       resendButton: 'कोड नहीं मिला? फिर से भेजें',
@@ -1528,6 +1531,15 @@ export const hiIN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'आपका पासवर्ड रीसेट करने से पहले हमें आपकी पहचान सत्यापित करनी होगी।',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'साइन अप करें',

--- a/packages/localizations/src/hr-HR.ts
+++ b/packages/localizations/src/hr-HR.ts
@@ -1464,6 +1464,9 @@ export const hrHR: LocalizationResource = {
       subtitle: 'Odaberite poslovni račun s kojim želite nastaviti.',
       title: 'Odaberite svoj poslovni račun',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kod za resetiranje lozinke',
       resendButton: 'Niste primili kod? Pošalji ponovno',
@@ -1529,6 +1532,15 @@ export const hrHR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Moramo potvrditi vaš identitet prije resetiranja lozinke.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrirajte se',

--- a/packages/localizations/src/hu-HU.ts
+++ b/packages/localizations/src/hu-HU.ts
@@ -1466,6 +1466,9 @@ export const huHU: LocalizationResource = {
       subtitle: 'Válaszd ki a vállalati fiókot, amellyel folytatni szeretnéd.',
       title: 'Válaszd ki a vállalati fiókodat',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Jelszó visszaállító kód',
       resendButton: 'Nem kaptad meg a kódot? Újraküldés',
@@ -1531,6 +1534,15 @@ export const huHU: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Vissza kell igazolnod az identitásod, mielőtt visszaállítod a jelszavad',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Regisztráció',

--- a/packages/localizations/src/id-ID.ts
+++ b/packages/localizations/src/id-ID.ts
@@ -1457,6 +1457,9 @@ export const idID: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kode reset kata sandi',
       resendButton: 'Tidak menerima kode? Kirim ulang',
@@ -1522,6 +1525,15 @@ export const idID: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Kami perlu memverifikasi identitas Anda sebelum mereset kata sandi.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Daftar',

--- a/packages/localizations/src/is-IS.ts
+++ b/packages/localizations/src/is-IS.ts
@@ -1465,6 +1465,9 @@ export const isIS: LocalizationResource = {
       subtitle: 'Veldu fyrirtækjareikninginn sem þú vilt halda áfram með.',
       title: 'Veldu fyrirtækjareikning',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Endurstilla lykilorð kóða',
       resendButton: 'Fékkstu ekki kóða? Senda aftur',
@@ -1530,6 +1533,15 @@ export const isIS: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Við þurfum að staðfesta auðkenni þitt áður en við endurstillum lykilorðið þitt.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Skrá sig',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -1462,6 +1462,9 @@ export const itIT: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Codice di reset della password',
       resendButton: 'Non hai ricevuto un codice? Reinvia',
@@ -1526,6 +1529,15 @@ export const itIT: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Dobbiamo verificare la tua identità prima di resettare la tua password.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrati',

--- a/packages/localizations/src/ja-JP.ts
+++ b/packages/localizations/src/ja-JP.ts
@@ -1463,6 +1463,9 @@ export const jaJP: LocalizationResource = {
       subtitle: '続行するエンタープライズアカウントを選択してください。',
       title: 'エンタープライズアカウントを選択',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'パスワードリセットコード',
       resendButton: 'コードを再送信',
@@ -1528,6 +1531,15 @@ export const jaJP: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'パスワードをリセットする前に、身元を確認する必要があります。',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'サインアップ',

--- a/packages/localizations/src/kk-KZ.ts
+++ b/packages/localizations/src/kk-KZ.ts
@@ -1445,6 +1445,9 @@ export const kkKZ: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Құпия сөзді қалпына келтіру коды',
       resendButton: 'Код алмадыңыз ба? Қайта жіберу',
@@ -1510,6 +1513,15 @@ export const kkKZ: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Құпия сөзді өзгерту үшін тұлғаңызды растау қажет.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Тіркелу',

--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -1450,6 +1450,9 @@ export const koKR: LocalizationResource = {
       subtitle: '계속할 기업 계정을 선택해 주세요.',
       title: '기업 계정 선택',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: '비밀번호 재설정 코드',
       resendButton: '코드 재전송',
@@ -1513,6 +1516,15 @@ export const koKR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: '비밀번호를 재설정하기 전에 신원을 확인해야 해요.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: '회원가입',

--- a/packages/localizations/src/mn-MN.ts
+++ b/packages/localizations/src/mn-MN.ts
@@ -1455,6 +1455,9 @@ export const mnMN: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Нууц үг шинэчлэх код',
       resendButton: 'Код хүлээж аваагүй юу? Дахин илгээх',
@@ -1520,6 +1523,15 @@ export const mnMN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Нууц үгээ шинэчлэхээс өмнө бид таны хувийн мэдээллийг баталгаажуулах шаардлагатай.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Бүртгүүлэх',

--- a/packages/localizations/src/ms-MY.ts
+++ b/packages/localizations/src/ms-MY.ts
@@ -1467,6 +1467,9 @@ export const msMY: LocalizationResource = {
       subtitle: 'Pilih akaun perusahaan yang anda ingin teruskan.',
       title: 'Pilih akaun perusahaan anda',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kod tetapan semula kata laluan',
       resendButton: 'Tidak menerima kod? Hantar semula',
@@ -1532,6 +1535,15 @@ export const msMY: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Kami perlu mengesahkan identiti anda sebelum menetapkan semula kata laluan anda.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Daftar',

--- a/packages/localizations/src/nb-NO.ts
+++ b/packages/localizations/src/nb-NO.ts
@@ -1465,6 +1465,9 @@ export const nbNO: LocalizationResource = {
       subtitle: 'Velg bedriftskontoen du ønsker å fortsette med.',
       title: 'Velg bedriftskonto',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Tilbakestill passord-kode',
       resendButton: 'Send kode på nytt',
@@ -1531,6 +1534,15 @@ export const nbNO: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Vi må bekrefte identiteten din før vi tilbakestiller passordet ditt.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Opprett konto',

--- a/packages/localizations/src/nl-BE.ts
+++ b/packages/localizations/src/nl-BE.ts
@@ -1455,6 +1455,9 @@ export const nlBE: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Wachtwoord resetcode',
       resendButton: 'Niet ontvangen? Verstuur opnieuw',
@@ -1519,6 +1522,15 @@ export const nlBE: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Voor veiligheidsredenen is het vereist om je wachtwoord te resetten.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registreren',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -1455,6 +1455,9 @@ export const nlNL: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Wachtwoord resetcode',
       resendButton: 'Niet ontvangen? Verstuur opnieuw',
@@ -1519,6 +1522,15 @@ export const nlNL: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Voor veiligheidsredenen is het vereist om je wachtwoord te resetten.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registreren',

--- a/packages/localizations/src/pl-PL.ts
+++ b/packages/localizations/src/pl-PL.ts
@@ -1455,6 +1455,9 @@ export const plPL: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kod werfikacyjny resetowania hasła',
       resendButton: 'Nie otrzymałeś kodu? Wyślij ponownie',
@@ -1520,6 +1523,15 @@ export const plPL: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Przed zresetowaniem hasła musimy zweryfikować tożsamość użytkownika.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Zarejestruj się',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -1464,6 +1464,9 @@ export const ptBR: LocalizationResource = {
       subtitle: 'Selecione a conta corporativa com a qual deseja continuar.',
       title: 'Escolha sua conta corporativa',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código de redefinição de senha',
       resendButton: 'Não recebeu um código? Reenviar',
@@ -1529,6 +1532,15 @@ export const ptBR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Precisamos verificar sua identidade antes de redefinir sua senha.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registre-se',

--- a/packages/localizations/src/pt-PT.ts
+++ b/packages/localizations/src/pt-PT.ts
@@ -1465,6 +1465,9 @@ export const ptPT: LocalizationResource = {
       subtitle: 'Selecione a conta empresarial com a qual pretende continuar.',
       title: 'Escolha a sua conta empresarial',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Código de redefinição de palavra-passe',
       resendButton: 'Não recebeu um código? Reenviar',
@@ -1529,6 +1532,15 @@ export const ptPT: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Precisamos verificar a sua identidade antes de redefinir a palavra-passe.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registar-se',

--- a/packages/localizations/src/ro-RO.ts
+++ b/packages/localizations/src/ro-RO.ts
@@ -1466,6 +1466,9 @@ export const roRO: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Cod pentru resetarea parolei',
       resendButton: 'Nu ai primit un cod? Retrimite',
@@ -1531,6 +1534,15 @@ export const roRO: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Trebuie să îți verificăm identitatea înainte de a reseta parola.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Înregistrează-te',

--- a/packages/localizations/src/ru-RU.ts
+++ b/packages/localizations/src/ru-RU.ts
@@ -1462,6 +1462,9 @@ export const ruRU: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Код восстановления пароля',
       resendButton: 'Отправить код еще раз',
@@ -1527,6 +1530,15 @@ export const ruRU: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Необходимо верифицировать вашу личность перед восстановлением пароля',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Зарегистрироваться',

--- a/packages/localizations/src/sk-SK.ts
+++ b/packages/localizations/src/sk-SK.ts
@@ -1455,6 +1455,9 @@ export const skSK: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Overovací kód pre obnovenie hesla',
       resendButton: 'Znovu poslať kód',
@@ -1520,6 +1523,15 @@ export const skSK: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Pred obnovením hesla je potrebné overiť vašu totožnosť.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registrovať sa',

--- a/packages/localizations/src/sr-RS.ts
+++ b/packages/localizations/src/sr-RS.ts
@@ -1452,6 +1452,9 @@ export const srRS: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Kod za resetovanje lozinke',
       resendButton: 'Nisi primio kod? Pošalji ponovo',
@@ -1517,6 +1520,15 @@ export const srRS: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Potrebno je da potvrdimo tvoj identitet pre resetovanja lozinke.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Registruj se',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -1455,6 +1455,9 @@ export const svSE: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Återställ lösenordskod',
       resendButton: 'Fick du inte en kod? Skicka igen',
@@ -1520,6 +1523,15 @@ export const svSE: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Vi behöver verifiera din identitet innan vi återställer ditt lösenord.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Skapa konto',

--- a/packages/localizations/src/ta-IN.ts
+++ b/packages/localizations/src/ta-IN.ts
@@ -1468,6 +1468,9 @@ export const taIN: LocalizationResource = {
       subtitle: 'நீங்கள் தொடர விரும்பும் நிறுவன கணக்கைத் தேர்ந்தெடுக்கவும்.',
       title: 'உங்கள் நிறுவன கணக்கைத் தேர்வு செய்யவும்',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'கடவுச்சொல் மீட்டமைப்பு குறியீடு',
       resendButton: 'குறியீடு கிடைக்கவில்லையா? மீண்டும் அனுப்பு',
@@ -1533,6 +1536,15 @@ export const taIN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'உங்கள் கடவுச்சொல்லை மீட்டமைப்பதற்கு முன் உங்கள் அடையாளத்தை சரிபார்க்க வேண்டும்.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'பதிவு செய்',

--- a/packages/localizations/src/te-IN.ts
+++ b/packages/localizations/src/te-IN.ts
@@ -1465,6 +1465,9 @@ export const teIN: LocalizationResource = {
       subtitle: 'మీరు కొనసాగించాలనుకుంటున్న ఎంటర్‌ప్రైజ్ ఖాతాను ఎంచుకోండి.',
       title: 'మీ ఎంటర్‌ప్రైజ్ ఖాతాను ఎంచుకోండి',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'పాస్‌వర్డ్ రీసెట్ కోడ్',
       resendButton: 'కోడ్ అందలేదా? మళ్ళీ పంపండి',
@@ -1531,6 +1534,15 @@ export const teIN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'మీ పాస్‌వర్డ్‌ను రీసెట్ చేయడానికి ముందు మీ గుర్తింపును మేము ధృవీకరించాలి.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'సైన్ అప్ చేయండి',

--- a/packages/localizations/src/th-TH.ts
+++ b/packages/localizations/src/th-TH.ts
@@ -1454,6 +1454,9 @@ export const thTH: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'รหัสรีเซ็ตรหัสผ่าน',
       resendButton: 'ไม่ได้รับรหัส? ส่งใหม่',
@@ -1518,6 +1521,15 @@ export const thTH: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'เราต้องยืนยันตัวตนของคุณก่อนรีเซ็ตรหัสผ่าน',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'สมัครสมาชิก',

--- a/packages/localizations/src/tr-TR.ts
+++ b/packages/localizations/src/tr-TR.ts
@@ -1454,6 +1454,9 @@ export const trTR: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Şifre sıfırlama kodu',
       resendButton: 'Tekrar gönder',
@@ -1519,6 +1522,15 @@ export const trTR: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Şifrenizi sıfırlamadan önce kimliğinizi doğrulamamız gerekiyor.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Kayıt ol',

--- a/packages/localizations/src/uk-UA.ts
+++ b/packages/localizations/src/uk-UA.ts
@@ -1452,6 +1452,9 @@ export const ukUA: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Код відновлення пароля',
       resendButton: 'Надіслати код ще раз',
@@ -1516,6 +1519,15 @@ export const ukUA: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Необхідно верифікувати вашу особу перед відновленням пароля',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Зареєструватися',

--- a/packages/localizations/src/vi-VN.ts
+++ b/packages/localizations/src/vi-VN.ts
@@ -1462,6 +1462,9 @@ export const viVN: LocalizationResource = {
       subtitle: 'Chọn tài khoản doanh nghiệp bạn muốn dùng để tiếp tục.',
       title: 'Chọn tài khoản doanh nghiệp của bạn',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: 'Mã xác minh mật khẩu',
       resendButton: 'Không nhận được mã? Gửi lại',
@@ -1527,6 +1530,15 @@ export const viVN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: 'Chúng tôi cần xác minh danh tính của bạn trước khi đặt lại mật khẩu.',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: 'Đăng ký',

--- a/packages/localizations/src/zh-CN.ts
+++ b/packages/localizations/src/zh-CN.ts
@@ -1442,6 +1442,9 @@ export const zhCN: LocalizationResource = {
       subtitle: undefined,
       title: undefined,
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: '重置密码代码',
       resendButton: '重新发送代码',
@@ -1505,6 +1508,15 @@ export const zhCN: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: '我们需要验证您的身份才能重置您的密码。',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: '注册',

--- a/packages/localizations/src/zh-TW.ts
+++ b/packages/localizations/src/zh-TW.ts
@@ -1445,6 +1445,9 @@ export const zhTW: LocalizationResource = {
       subtitle: '請選擇您想要繼續使用的企業帳戶。',
       title: '選擇一個企業帳戶',
     },
+    enterpriseSSO: {
+      formButtonPrimary: undefined,
+    },
     forgotPassword: {
       formTitle: '重設密碼代碼',
       resendButton: '重新傳送代碼',
@@ -1508,6 +1511,15 @@ export const zhTW: LocalizationResource = {
     },
     resetPasswordMfa: {
       detailsLabel: '我們需要驗證您的身份才能重設您的密碼。',
+    },
+    ssoFallback: {
+      actionLink: undefined,
+      code: {
+        resendButton: undefined,
+        subtitle: undefined,
+        title: undefined,
+      },
+      notice: undefined,
     },
     start: {
       actionLink: '註冊',

--- a/packages/react/src/stateProxy.ts
+++ b/packages/react/src/stateProxy.ts
@@ -153,6 +153,9 @@ export class StateProxy implements State {
         get supportedFirstFactors() {
           return gateProperty(target, 'supportedFirstFactors', []);
         },
+        get ssoFallbackFirstFactors() {
+          return gateProperty(target, 'ssoFallbackFirstFactors', []);
+        },
         get supportedSecondFactors() {
           return gateProperty(target, 'supportedSecondFactors', []);
         },

--- a/packages/shared/src/types/elementIds.ts
+++ b/packages/shared/src/types/elementIds.ts
@@ -95,7 +95,8 @@ export type CardActionId =
   | 'signIn'
   | 'usePasskey'
   | 'waitlist'
-  | 'signOut';
+  | 'signOut'
+  | 'ssoFallback';
 
 export type MenuId = 'invitation' | 'member' | ProfileSectionId;
 export type SelectId = 'countryCode' | 'role' | 'paymentMethod' | 'apiKeyExpiration';

--- a/packages/shared/src/types/localization.ts
+++ b/packages/shared/src/types/localization.ts
@@ -619,6 +619,18 @@ export type __internal_LocalizationResource = {
       title: LocalizationValue;
       subtitle: LocalizationValue;
     };
+    enterpriseSSO: {
+      formButtonPrimary: LocalizationValue;
+    };
+    ssoFallback: {
+      actionLink: LocalizationValue;
+      notice: LocalizationValue;
+      code: {
+        title: LocalizationValue;
+        subtitle: LocalizationValue;
+        resendButton: LocalizationValue;
+      };
+    };
     web3Solana: {
       title: LocalizationValue;
       subtitle: LocalizationValue;

--- a/packages/shared/src/types/signIn.ts
+++ b/packages/shared/src/types/signIn.ts
@@ -51,6 +51,16 @@ export interface SignInResource extends ClerkResource {
   supportedIdentifiers: SignInIdentifier[];
   supportedFirstFactors: SignInFirstFactor[] | null;
   supportedSecondFactors: SignInSecondFactor[] | null;
+  /**
+   * Factors an enterprise-routed user can fall back to when they cannot reach their
+   * identity provider. Kept out of `supportedFirstFactors` so consumers that assert
+   * that list is purely enterprise keep working.
+   *
+   * Its presence says the instance allows a fallback, never that this particular
+   * user may use one — the API does not disclose that, and the UI must not branch
+   * on it.
+   */
+  ssoFallbackFirstFactors: SignInFirstFactor[] | null;
   clientTrustState?: ClientTrustState;
   firstFactorVerification: VerificationResource;
   secondFactorVerification: VerificationResource;
@@ -130,6 +140,11 @@ export interface SignInJSON extends ClerkResourceJSON {
   user_data: UserDataJSON;
   supported_first_factors: SignInFirstFactorJSON[];
   supported_second_factors: SignInSecondFactorJSON[];
+  /**
+   * Present only when the instance has opted into SSO fallback and the sign-in is
+   * still owed its first factor. Absent everywhere else.
+   */
+  sso_fallback_first_factors?: SignInFirstFactorJSON[];
   first_factor_verification: VerificationJSON | null;
   second_factor_verification: VerificationJSON | null;
   created_session_id: string | null;

--- a/packages/shared/src/types/signIn.ts
+++ b/packages/shared/src/types/signIn.ts
@@ -51,15 +51,6 @@ export interface SignInResource extends ClerkResource {
   supportedIdentifiers: SignInIdentifier[];
   supportedFirstFactors: SignInFirstFactor[] | null;
   supportedSecondFactors: SignInSecondFactor[] | null;
-  /**
-   * Factors an enterprise-routed user can fall back to when they cannot reach their
-   * identity provider. Kept out of `supportedFirstFactors` so consumers that assert
-   * that list is purely enterprise keep working.
-   *
-   * The API returns this only for users the instance has allowlisted for a fallback,
-   * so its presence is itself the eligibility signal. Anything rendered from it is
-   * visible to whoever supplied the identifier.
-   */
   ssoFallbackFirstFactors: SignInFirstFactor[] | null;
   clientTrustState?: ClientTrustState;
   firstFactorVerification: VerificationResource;
@@ -140,10 +131,6 @@ export interface SignInJSON extends ClerkResourceJSON {
   user_data: UserDataJSON;
   supported_first_factors: SignInFirstFactorJSON[];
   supported_second_factors: SignInSecondFactorJSON[];
-  /**
-   * Present only when the instance has opted into SSO fallback and the sign-in is
-   * still owed its first factor. Absent everywhere else.
-   */
   sso_fallback_first_factors?: SignInFirstFactorJSON[];
   first_factor_verification: VerificationJSON | null;
   second_factor_verification: VerificationJSON | null;

--- a/packages/shared/src/types/signIn.ts
+++ b/packages/shared/src/types/signIn.ts
@@ -56,9 +56,9 @@ export interface SignInResource extends ClerkResource {
    * identity provider. Kept out of `supportedFirstFactors` so consumers that assert
    * that list is purely enterprise keep working.
    *
-   * Its presence says the instance allows a fallback, never that this particular
-   * user may use one — the API does not disclose that, and the UI must not branch
-   * on it.
+   * The API returns this only for users the instance has allowlisted for a fallback,
+   * so its presence is itself the eligibility signal. Anything rendered from it is
+   * visible to whoever supplied the identifier.
    */
   ssoFallbackFirstFactors: SignInFirstFactor[] | null;
   clientTrustState?: ClientTrustState;

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -339,7 +339,7 @@ export interface SignInFutureResource {
   readonly supportedSecondFactors: SignInSecondFactor[];
 
   /**
-   * Factors an enterprise-routed user can fall back to when they cannot reach their identity provider. Empty unless the instance allows a fallback; its contents never indicate whether this particular user is permitted to use one.
+   * Factors an enterprise-routed user can fall back to when they cannot reach their identity provider. Empty unless the instance has allowlisted this user for a fallback, so a non-empty list is itself the eligibility signal.
    */
   readonly ssoFallbackFirstFactors: SignInFirstFactor[];
 

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -339,6 +339,11 @@ export interface SignInFutureResource {
   readonly supportedSecondFactors: SignInSecondFactor[];
 
   /**
+   * Factors an enterprise-routed user can fall back to when they cannot reach their identity provider. Empty unless the instance allows a fallback; its contents never indicate whether this particular user is permitted to use one.
+   */
+  readonly ssoFallbackFirstFactors: SignInFirstFactor[];
+
+  /**
    * The current status of the sign-in.
    * <ul>
    * <li>`'complete'` - The sign-in process has been completed successfully.</li>

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -339,7 +339,7 @@ export interface SignInFutureResource {
   readonly supportedSecondFactors: SignInSecondFactor[];
 
   /**
-   * Factors an enterprise-routed user can fall back to when they cannot reach their identity provider. Empty unless the instance has allowlisted this user for a fallback, so a non-empty list is itself the eligibility signal.
+   * Factors an enterprise SSO user can fall back to when they cannot reach their identity provider. Empty unless the instance has allowlisted this user for a fallback.
    */
   readonly ssoFallbackFirstFactors: SignInFirstFactor[];
 

--- a/packages/ui/bundlewatch.config.json
+++ b/packages/ui/bundlewatch.config.json
@@ -6,7 +6,7 @@
     { "path": "./dist/framework*.js", "maxSize": "44KB" },
     { "path": "./dist/vendors*.js", "maxSize": "73KB" },
     { "path": "./dist/ui-common*.js", "maxSize": "134KB" },
-    { "path": "./dist/signin*.js", "maxSize": "17.5KB" },
+    { "path": "./dist/signin*.js", "maxSize": "19KB" },
     { "path": "./dist/signup*.js", "maxSize": "13KB" },
     { "path": "./dist/userprofile*.js", "maxSize": "16KB" },
     { "path": "./dist/organizationprofile*.js", "maxSize": "13KB" },

--- a/packages/ui/src/common/ChooseEnterpriseConnectionCard.tsx
+++ b/packages/ui/src/common/ChooseEnterpriseConnectionCard.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from 'react';
 import { useState } from 'react';
 
 import type { LocalizationKey } from '@/ui/customizables';
@@ -22,7 +23,8 @@ export const ChooseEnterpriseConnectionCard = ({
   subtitle,
   onClick,
   enterpriseConnections,
-}: ChooseEnterpriseConnectionCardProps) => {
+  children,
+}: PropsWithChildren<ChooseEnterpriseConnectionCardProps>) => {
   const card = useCardState();
 
   return (
@@ -47,6 +49,8 @@ export const ChooseEnterpriseConnectionCard = ({
             />
           ))}
         </Grid>
+
+        {children}
       </Card.Content>
 
       <Card.Footer />

--- a/packages/ui/src/components/SignIn/SignInFactorOne.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOne.tsx
@@ -13,7 +13,7 @@ import { localizationKeys } from '../../localization';
 import { useRouter } from '../../router';
 import type { AlternativeMethodsMode } from './AlternativeMethods';
 import { AlternativeMethods } from './AlternativeMethods';
-import { hasMultipleEnterpriseConnections, SIGN_IN_RESET_PASSWORD_INTENT_PARAM } from './shared';
+import { getSSOFallbackFactor, hasMultipleEnterpriseConnections, SIGN_IN_RESET_PASSWORD_INTENT_PARAM } from './shared';
 import { SignInFactorOneAlternativePhoneCodeCard } from './SignInFactorOneAlternativePhoneCodeCard';
 import { SignInFactorOneEmailCodeCard } from './SignInFactorOneEmailCodeCard';
 import { SignInFactorOneEmailLinkCard } from './SignInFactorOneEmailLinkCard';
@@ -23,6 +23,7 @@ import { SignInFactorOnePasskey } from './SignInFactorOnePasskey';
 import type { PasswordErrorCode } from './SignInFactorOnePasswordCard';
 import { SignInFactorOnePasswordCard } from './SignInFactorOnePasswordCard';
 import { SignInFactorOnePhoneCodeCard } from './SignInFactorOnePhoneCodeCard';
+import { SignInFactorOneSSOFallback } from './SignInFactorOneSSOFallback';
 import { useResetPasswordFactor } from './useResetPasswordFactor';
 import { determineStartingSignInFactor, factorHasLocalStrategy } from './utils';
 
@@ -109,6 +110,10 @@ function SignInFactorOneInternal(): JSX.Element {
     supportedFirstFactors,
   });
 
+  // Frozen on mount: a later response may drop the field, which would otherwise unmount the
+  // fallback screens mid-flow.
+  const ssoFallbackFactor = React.useRef(getSSOFallbackFactor(signIn)).current;
+
   const resetPasswordFactor = useResetPasswordFactor();
   const resetPasswordIntent = router.queryParams[SIGN_IN_RESET_PASSWORD_INTENT_PARAM] === 'true';
 
@@ -161,6 +166,15 @@ function SignInFactorOneInternal(): JSX.Element {
       prevCurrentFactor: prev.currentFactor,
     }));
   };
+
+  /**
+   * An enterprise-routed sign-in on an instance that allows a fallback owns its own screens,
+   * including the enterprise connection choice, so that the fallback stays reachable from them.
+   * @experimental
+   */
+  if (ssoFallbackFactor) {
+    return <SignInFactorOneSSOFallback fallbackFactor={ssoFallbackFactor} />;
+  }
 
   /**
    * Prompt to choose between a list of enterprise connections as supported first factors

--- a/packages/ui/src/components/SignIn/SignInFactorOne.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOne.tsx
@@ -167,11 +167,6 @@ function SignInFactorOneInternal(): JSX.Element {
     }));
   };
 
-  /**
-   * An enterprise-routed sign-in on an instance that allows a fallback owns its own screens,
-   * including the enterprise connection choice, so that the fallback stays reachable from them.
-   * @experimental
-   */
   if (ssoFallbackFactor) {
     return <SignInFactorOneSSOFallback fallbackFactor={ssoFallbackFactor} />;
   }

--- a/packages/ui/src/components/SignIn/SignInFactorOne.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOne.tsx
@@ -110,7 +110,7 @@ function SignInFactorOneInternal(): JSX.Element {
     supportedFirstFactors,
   });
 
-  // Frozen on mount: a later response may drop the field, which would otherwise unmount the
+  // Frozen on mount: client-piggybacking may drop the field, which would otherwise unmount the
   // fallback screens mid-flow.
   const ssoFallbackFactor = React.useRef(getSSOFallbackFactor(signIn)).current;
 

--- a/packages/ui/src/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -29,6 +29,7 @@ export type SignInFactorOneCodeCard = Pick<
 export type SignInFactorOneCodeFormProps = SignInFactorOneCodeCard & {
   cardTitle: LocalizationKey;
   cardSubtitle: LocalizationKey;
+  cardNotice?: LocalizationKey;
   inputLabel: LocalizationKey;
   resendButton: LocalizationKey;
   identityPreviewEditButtonAriaLabel: LocalizationKey;
@@ -169,6 +170,7 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
     <VerificationCodeCard
       cardTitle={props.cardTitle}
       cardSubtitle={props.cardSubtitle}
+      cardNotice={props.cardNotice}
       inputLabel={props.inputLabel}
       resendButton={props.resendButton}
       onCodeEntryFinishedAction={action}

--- a/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
@@ -20,11 +20,10 @@ type SignInFactorOneSSOFallbackProps = {
 };
 
 /**
- * Enterprise-routed sign-in with an instance-level fallback available.
+ * Enterprise-routed sign-in for a user the instance has allowlisted for a fallback.
  *
  * Replaces the automatic redirect to the identity provider with a screen the user can act on,
- * since the fallback is only reachable from one. Every screen here renders identically for
- * allowlisted and non-allowlisted users — the API never discloses which is which.
+ * since the fallback is only reachable from one.
  * @experimental
  */
 export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProps) => {

--- a/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
@@ -9,7 +9,6 @@ import { handleError } from '@/ui/utils/errorHandler';
 
 import { useCoreSignIn, useSignInContext } from '../../contexts';
 import { Button, Col, descriptors, Flow, localizationKeys } from '../../customizables';
-import { maskEmailAddress } from '../../utils/formatSafeIdentifier';
 import { hasMultipleEnterpriseConnections } from './shared';
 import { SignInFactorOneCodeForm } from './SignInFactorOneCodeForm';
 
@@ -33,12 +32,6 @@ export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProp
   const signIn = useCoreSignIn();
   const [step, setStep] = React.useState<Step>('sso');
   const [isRedirecting, setIsRedirecting] = React.useState(false);
-
-  // `safe_identifier` is the address the user typed, unmasked; the design shows it obfuscated.
-  const maskedFallbackFactor = React.useMemo(
-    () => ({ ...fallbackFactor, safeIdentifier: maskEmailAddress(fallbackFactor.safeIdentifier) as string }),
-    [fallbackFactor],
-  );
 
   const goToStep = (next: Step) => {
     card.setError(undefined);
@@ -78,7 +71,7 @@ export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProp
     return (
       <Flow.Part part='ssoFallback'>
         <SignInFactorOneCodeForm
-          factor={maskedFallbackFactor}
+          factor={fallbackFactor}
           factorAlreadyPrepared={false}
           onFactorPrepare={() => {}}
           cardTitle={localizationKeys('signIn.ssoFallback.code.title')}

--- a/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
@@ -1,0 +1,144 @@
+import type { EmailCodeFactor } from '@clerk/shared/types';
+import React from 'react';
+
+import { ChooseEnterpriseConnectionCard } from '@/ui/common/ChooseEnterpriseConnectionCard';
+import { Card } from '@/ui/elements/Card';
+import { useCardState } from '@/ui/elements/contexts';
+import { Header } from '@/ui/elements/Header';
+import { handleError } from '@/ui/utils/errorHandler';
+
+import { useCoreSignIn, useSignInContext } from '../../contexts';
+import { Button, Col, descriptors, Flow, localizationKeys } from '../../customizables';
+import { maskEmailAddress } from '../../utils/formatSafeIdentifier';
+import { hasMultipleEnterpriseConnections } from './shared';
+import { SignInFactorOneCodeForm } from './SignInFactorOneCodeForm';
+
+type Step = 'sso' | 'code';
+
+type SignInFactorOneSSOFallbackProps = {
+  fallbackFactor: EmailCodeFactor;
+};
+
+/**
+ * Enterprise-routed sign-in with an instance-level fallback available.
+ *
+ * Replaces the automatic redirect to the identity provider with a screen the user can act on,
+ * since the fallback is only reachable from one. Every screen here renders identically for
+ * allowlisted and non-allowlisted users — the API never discloses which is which.
+ * @experimental
+ */
+export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProps) => {
+  const { fallbackFactor } = props;
+  const card = useCardState();
+  const ctx = useSignInContext();
+  const signIn = useCoreSignIn();
+  const [step, setStep] = React.useState<Step>('sso');
+  const [isRedirecting, setIsRedirecting] = React.useState(false);
+
+  // `safe_identifier` is the address the user typed, unmasked; the design shows it obfuscated.
+  const maskedFallbackFactor = React.useMemo(
+    () => ({ ...fallbackFactor, safeIdentifier: maskEmailAddress(fallbackFactor.safeIdentifier) as string }),
+    [fallbackFactor],
+  );
+
+  const goToStep = (next: Step) => {
+    card.setError(undefined);
+    setStep(next);
+  };
+
+  const authenticateWithEnterpriseSSO = async (enterpriseConnectionId?: string) => {
+    await signIn.authenticateWithRedirect({
+      strategy: 'enterprise_sso',
+      redirectUrl: ctx.ssoCallbackUrl,
+      redirectUrlComplete: ctx.afterSignInUrl || '/',
+      oidcPrompt: ctx.oidcPrompt,
+      continueSignIn: true,
+      ...(enterpriseConnectionId && { enterpriseConnectionId }),
+    });
+  };
+
+  const handleContinueWithSSO = () => {
+    setIsRedirecting(true);
+    authenticateWithEnterpriseSSO().catch(err => {
+      setIsRedirecting(false);
+      handleError(err, [], card.setError);
+    });
+  };
+
+  if (step === 'code') {
+    return (
+      <Flow.Part part='ssoFallback'>
+        <SignInFactorOneCodeForm
+          factor={maskedFallbackFactor}
+          factorAlreadyPrepared={false}
+          onFactorPrepare={() => {}}
+          cardTitle={localizationKeys('signIn.ssoFallback.code.title')}
+          cardSubtitle={localizationKeys('signIn.ssoFallback.code.subtitle')}
+          cardNotice={localizationKeys('signIn.ssoFallback.notice')}
+          inputLabel={localizationKeys('signIn.emailCode.formTitle')}
+          resendButton={localizationKeys('signIn.ssoFallback.code.resendButton')}
+          identityPreviewEditButtonAriaLabel={localizationKeys('identityPreviewEditButton__emailAddress')}
+          onShowAlternativeMethodsClicked={() => goToStep('sso')}
+        />
+      </Flow.Part>
+    );
+  }
+
+  const fallbackAction = (
+    <Card.Action elementId='ssoFallback'>
+      <Card.ActionLink
+        localizationKey={localizationKeys('signIn.ssoFallback.actionLink')}
+        onClick={() => goToStep('code')}
+      />
+    </Card.Action>
+  );
+
+  if (hasMultipleEnterpriseConnections(signIn.supportedFirstFactors)) {
+    const enterpriseConnections = signIn.supportedFirstFactors.map(factor => ({
+      id: factor.enterpriseConnectionId,
+      name: factor.enterpriseConnectionName,
+    }));
+
+    return (
+      <Flow.Part part='ssoFallback'>
+        <ChooseEnterpriseConnectionCard
+          title={localizationKeys('signIn.enterpriseConnections.title')}
+          subtitle={localizationKeys('signIn.enterpriseConnections.subtitle')}
+          onClick={authenticateWithEnterpriseSSO}
+          enterpriseConnections={enterpriseConnections}
+        >
+          {fallbackAction}
+        </ChooseEnterpriseConnectionCard>
+      </Flow.Part>
+    );
+  }
+
+  return (
+    <Flow.Part part='ssoFallback'>
+      <Card.Root>
+        <Card.Content>
+          <Header.Root showLogo>
+            <Header.Title localizationKey={localizationKeys('signIn.start.title')} />
+            <Header.Subtitle localizationKey={localizationKeys('signIn.start.subtitle')} />
+          </Header.Root>
+          <Card.Alert>{card.error}</Card.Alert>
+          <Col
+            elementDescriptor={descriptors.main}
+            gap={4}
+          >
+            <Button
+              elementDescriptor={descriptors.formButtonPrimary}
+              block
+              hasArrow
+              isLoading={isRedirecting}
+              localizationKey={localizationKeys('signIn.enterpriseSSO.formButtonPrimary')}
+              onClick={handleContinueWithSSO}
+            />
+            {fallbackAction}
+          </Col>
+        </Card.Content>
+        <Card.Footer />
+      </Card.Root>
+    </Flow.Part>
+  );
+};

--- a/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
+++ b/packages/ui/src/components/SignIn/SignInFactorOneSSOFallback.tsx
@@ -56,13 +56,23 @@ export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProp
     });
   };
 
+  const handleSSOError = (err: Error) => handleError(err, [], card.setError);
+
   const handleContinueWithSSO = () => {
     setIsRedirecting(true);
     authenticateWithEnterpriseSSO().catch(err => {
       setIsRedirecting(false);
-      handleError(err, [], card.setError);
+      handleSSOError(err);
     });
   };
+
+  // The connection button only resets its own loading state on rejection, so surface the error
+  // here and rethrow to keep that reset.
+  const handleSelectEnterpriseConnection = (enterpriseConnectionId: string) =>
+    authenticateWithEnterpriseSSO(enterpriseConnectionId).catch(err => {
+      handleSSOError(err);
+      throw err;
+    });
 
   if (step === 'code') {
     return (
@@ -103,7 +113,7 @@ export const SignInFactorOneSSOFallback = (props: SignInFactorOneSSOFallbackProp
         <ChooseEnterpriseConnectionCard
           title={localizationKeys('signIn.enterpriseConnections.title')}
           subtitle={localizationKeys('signIn.enterpriseConnections.subtitle')}
-          onClick={authenticateWithEnterpriseSSO}
+          onClick={handleSelectEnterpriseConnection}
           enterpriseConnections={enterpriseConnections}
         >
           {fallbackAction}

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -242,12 +242,7 @@ function SignInStartInternal(): JSX.Element {
         }
         switch (res.status) {
           case 'needs_first_factor': {
-            if (
-              !hasOnlyEnterpriseSSOFirstFactors(res) ||
-              hasMultipleEnterpriseConnections(res.supportedFirstFactors) ||
-              // The fallback is only reachable from a screen, so stop short of the automatic redirect.
-              !!getSSOFallbackFactor(res)
-            ) {
+            if (!canRedirectToEnterpriseSSO(res)) {
               return navigate('factor-one');
             }
 
@@ -424,12 +419,7 @@ function SignInStartInternal(): JSX.Element {
           }
           break;
         case 'needs_first_factor': {
-          if (
-            !hasOnlyEnterpriseSSOFirstFactors(res) ||
-            hasMultipleEnterpriseConnections(res.supportedFirstFactors) ||
-            // The fallback is only reachable from a screen, so stop short of the automatic redirect.
-            !!getSSOFallbackFactor(res)
-          ) {
+          if (!canRedirectToEnterpriseSSO(res)) {
             if (options?.resetPasswordIntent) {
               return navigate('factor-one', {
                 searchParams: new URLSearchParams({ [SIGN_IN_RESET_PASSWORD_INTENT_PARAM]: 'true' }),
@@ -737,6 +727,17 @@ const hasOnlyEnterpriseSSOFirstFactors = (signIn: SignInResource): boolean => {
 
   return signIn.supportedFirstFactors.every(ff => ff.strategy === 'enterprise_sso');
 };
+
+/**
+ * Whether the sign-in can go straight to the identity provider without showing a card first.
+ *
+ * A connection choice and an SSO fallback are both only reachable from one, so either sends the
+ * user to `factor-one` instead.
+ */
+const canRedirectToEnterpriseSSO = (signIn: SignInResource): boolean =>
+  hasOnlyEnterpriseSSOFirstFactors(signIn) &&
+  !hasMultipleEnterpriseConnections(signIn.supportedFirstFactors) &&
+  !getSSOFallbackFactor(signIn);
 
 const InstantPasswordRow = ({
   field,

--- a/packages/ui/src/components/SignIn/SignInStart.tsx
+++ b/packages/ui/src/components/SignIn/SignInStart.tsx
@@ -41,6 +41,7 @@ import { useRouter } from '../../router';
 import { handleCombinedFlowTransfer } from './handleCombinedFlowTransfer';
 import { navigateOnSignInProtectGate } from './handleProtectCheck';
 import {
+  getSSOFallbackFactor,
   hasMultipleEnterpriseConnections,
   SIGN_IN_RESET_PASSWORD_INTENT_PARAM,
   useHandleAuthenticateWithPasskey,
@@ -241,7 +242,12 @@ function SignInStartInternal(): JSX.Element {
         }
         switch (res.status) {
           case 'needs_first_factor': {
-            if (!hasOnlyEnterpriseSSOFirstFactors(res) || hasMultipleEnterpriseConnections(res.supportedFirstFactors)) {
+            if (
+              !hasOnlyEnterpriseSSOFirstFactors(res) ||
+              hasMultipleEnterpriseConnections(res.supportedFirstFactors) ||
+              // The fallback is only reachable from a screen, so stop short of the automatic redirect.
+              !!getSSOFallbackFactor(res)
+            ) {
               return navigate('factor-one');
             }
 
@@ -418,7 +424,12 @@ function SignInStartInternal(): JSX.Element {
           }
           break;
         case 'needs_first_factor': {
-          if (!hasOnlyEnterpriseSSOFirstFactors(res) || hasMultipleEnterpriseConnections(res.supportedFirstFactors)) {
+          if (
+            !hasOnlyEnterpriseSSOFirstFactors(res) ||
+            hasMultipleEnterpriseConnections(res.supportedFirstFactors) ||
+            // The fallback is only reachable from a screen, so stop short of the automatic redirect.
+            !!getSSOFallbackFactor(res)
+          ) {
             if (options?.resetPasswordIntent) {
               return navigate('factor-one', {
                 searchParams: new URLSearchParams({ [SIGN_IN_RESET_PASSWORD_INTENT_PARAM]: 'true' }),

--- a/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
@@ -22,7 +22,7 @@ describe('SignInFactorOne SSO fallback', () => {
     screen.getByText("Can't use SSO?");
   });
 
-  it('does not render the fallback when the instance does not offer one', async () => {
+  it('does not render the fallback when the user is not allowlisted for one', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress();
       f.withEnterpriseSso();

--- a/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
@@ -1,0 +1,123 @@
+import type { SignInResource } from '@clerk/shared/types';
+import { describe, expect, it } from 'vitest';
+
+import { bindCreateFixtures } from '@/test/create-fixtures';
+import { render, screen } from '@/test/utils';
+
+import { SignInFactorOne } from '../SignInFactorOne';
+
+const { createFixtures } = bindCreateFixtures('SignIn');
+
+describe('SignInFactorOne SSO fallback', () => {
+  it('offers the fallback next to the SSO action for a single connection', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
+    });
+
+    render(<SignInFactorOne />, { wrapper });
+
+    await screen.findByText('Continue with SSO');
+    screen.getByText("Can't use SSO?");
+  });
+
+  it('does not render the fallback when the instance does not offer one', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO();
+    });
+
+    render(<SignInFactorOne />, { wrapper });
+
+    expect(screen.queryByText("Can't use SSO?")).not.toBeInTheDocument();
+  });
+
+  it('offers a single fallback action alongside multiple connections', async () => {
+    const { wrapper } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({
+        supportSSOFallback: true,
+        enterpriseConnections: [
+          { id: 'conn_okta', name: 'Okta' },
+          { id: 'conn_msft', name: 'Microsoft' },
+        ],
+      });
+    });
+
+    render(<SignInFactorOne />, { wrapper });
+
+    await screen.findByText('Okta');
+    screen.getByText('Microsoft');
+    expect(screen.getAllByText("Can't use SSO?")).toHaveLength(1);
+  });
+
+  it('redirects to the identity provider when the SSO action is used', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
+    });
+
+    const { userEvent } = render(<SignInFactorOne />, { wrapper });
+
+    await userEvent.click(await screen.findByText('Continue with SSO'));
+
+    expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'enterprise_sso', continueSignIn: true }),
+    );
+  });
+
+  it('prepares the email code with the handle and warns on the code screen', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
+    });
+    fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+    const { userEvent } = render(<SignInFactorOne />, { wrapper });
+
+    await userEvent.click(await screen.findByText("Can't use SSO?"));
+
+    await screen.findByText('Check your email');
+    screen.getByText(/Your organization requires single sign-on/i);
+    expect(fixtures.signIn.prepareFirstFactor).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'email_code', emailAddressId: 'idn_hmac' }),
+    );
+  });
+
+  it('masks the email address on the code screen', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({ identifier: 'hello@clerk.com', supportSSOFallback: true });
+    });
+    fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+    const { userEvent } = render(<SignInFactorOne />, { wrapper });
+
+    await userEvent.click(await screen.findByText("Can't use SSO?"));
+
+    await screen.findByText('h***@clerk.com');
+    expect(screen.queryByText('hello@clerk.com')).not.toBeInTheDocument();
+  });
+
+  it('returns to the SSO screen from the code screen', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withEmailAddress();
+      f.withEnterpriseSso();
+      f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
+    });
+    fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
+
+    const { userEvent } = render(<SignInFactorOne />, { wrapper });
+
+    await userEvent.click(await screen.findByText("Can't use SSO?"));
+    await userEvent.click(await screen.findByText('Use another method'));
+
+    await screen.findByText('Continue with SSO');
+  });
+});

--- a/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInFactorOneSSOFallback.test.tsx
@@ -12,7 +12,6 @@ describe('SignInFactorOne SSO fallback', () => {
   it('offers the fallback next to the SSO action for a single connection', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
     });
 
@@ -25,7 +24,6 @@ describe('SignInFactorOne SSO fallback', () => {
   it('does not render the fallback when the user is not allowlisted for one', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO();
     });
 
@@ -37,7 +35,6 @@ describe('SignInFactorOne SSO fallback', () => {
   it('offers a single fallback action alongside multiple connections', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO({
         supportSSOFallback: true,
         enterpriseConnections: [
@@ -57,7 +54,6 @@ describe('SignInFactorOne SSO fallback', () => {
   it('redirects to the identity provider when the SSO action is used', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
     });
 
@@ -73,7 +69,6 @@ describe('SignInFactorOne SSO fallback', () => {
   it('prepares the email code with the handle and warns on the code screen', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
     });
     fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
@@ -89,26 +84,9 @@ describe('SignInFactorOne SSO fallback', () => {
     );
   });
 
-  it('masks the email address on the code screen', async () => {
-    const { wrapper, fixtures } = await createFixtures(f => {
-      f.withEmailAddress();
-      f.withEnterpriseSso();
-      f.startSignInWithEnterpriseSSO({ identifier: 'hello@clerk.com', supportSSOFallback: true });
-    });
-    fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
-
-    const { userEvent } = render(<SignInFactorOne />, { wrapper });
-
-    await userEvent.click(await screen.findByText("Can't use SSO?"));
-
-    await screen.findByText('h***@clerk.com');
-    expect(screen.queryByText('hello@clerk.com')).not.toBeInTheDocument();
-  });
-
   it('returns to the SSO screen from the code screen', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress();
-      f.withEnterpriseSso();
       f.startSignInWithEnterpriseSSO({ supportSSOFallback: true });
     });
     fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -1003,6 +1003,38 @@ describe('SignInStart', () => {
         expect.not.stringContaining('__clerk_ticket'),
       );
     });
+
+    it('stops short of the redirect when the instance offers an SSO fallback', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      fixtures.signIn.create.mockResolvedValueOnce({
+        status: 'needs_first_factor',
+        supportedFirstFactors: [{ strategy: 'enterprise_sso' }],
+        ssoFallbackFirstFactors: [
+          { strategy: 'email_code', safeIdentifier: 'hello@clerk.com', emailAddressId: 'idn_hmac' },
+        ],
+      } as unknown as SignInResource);
+
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { href: 'http://localhost/sign-in?__clerk_ticket=test_ticket' },
+      });
+      Object.defineProperty(window, 'history', {
+        writable: true,
+        value: { replaceState: vi.fn() },
+      });
+
+      render(
+        <CardStateProvider>
+          <SignInStart />
+        </CardStateProvider>,
+        { wrapper },
+      );
+
+      await waitFor(() => expect(fixtures.router.navigate).toHaveBeenCalledWith('factor-one'));
+      expect(fixtures.signIn.authenticateWithRedirect).not.toHaveBeenCalled();
+    });
   });
 
   describe('Captcha', () => {

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -450,6 +450,26 @@ describe('SignInStart', () => {
         continueSignIn: true,
       });
     });
+
+    it('stops short of the redirect when the instance offers an SSO fallback', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      fixtures.signIn.create.mockReturnValueOnce(
+        Promise.resolve({
+          status: 'needs_first_factor',
+          supportedFirstFactors: [{ strategy: 'enterprise_sso' }],
+          ssoFallbackFirstFactors: [
+            { strategy: 'email_code', safeIdentifier: 'hello@clerk.com', emailAddressId: 'idn_hmac' },
+          ],
+        } as unknown as SignInResource),
+      );
+      const { userEvent } = render(<SignInStart />, { wrapper });
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
+      await userEvent.click(screen.getByText('Continue'));
+      expect(fixtures.signIn.authenticateWithRedirect).not.toHaveBeenCalled();
+      expect(fixtures.router.navigate).toHaveBeenCalledWith('factor-one');
+    });
   });
 
   describe('Identifier switching', () => {

--- a/packages/ui/src/components/SignIn/shared.ts
+++ b/packages/ui/src/components/SignIn/shared.ts
@@ -2,7 +2,7 @@ import { isClerkRuntimeError, isUserLockedError } from '@clerk/shared/error';
 import { clerkInvalidFAPIResponse } from '@clerk/shared/internal/clerk-js/errors';
 import { __internal_WebAuthnAbortService } from '@clerk/shared/internal/clerk-js/passkeys';
 import { useClerk } from '@clerk/shared/react';
-import type { EnterpriseSSOFactor, SignInFirstFactor, SignInResource } from '@clerk/shared/types';
+import type { EmailCodeFactor, EnterpriseSSOFactor, SignInFirstFactor, SignInResource } from '@clerk/shared/types';
 import { useCallback, useEffect } from 'react';
 
 import { useCardState } from '@/ui/elements/contexts';
@@ -108,4 +108,20 @@ function hasMultipleEnterpriseConnections(
   );
 }
 
-export { hasMultipleEnterpriseConnections, useHandleAuthenticateWithPasskey };
+/**
+ * Returns the email code factor an enterprise-routed sign-in may fall back to, or `null`.
+ *
+ * The list is populated purely from instance configuration: it says the instance allows a
+ * fallback, never that this particular user is allowed one. Branching on anything more would
+ * turn the UI into an enumeration oracle for the allowlist.
+ * @experimental
+ */
+function getSSOFallbackFactor(signIn: SignInResource): EmailCodeFactor | null {
+  if (!signIn.supportedFirstFactors?.some(factor => factor.strategy === 'enterprise_sso')) {
+    return null;
+  }
+
+  return (signIn.ssoFallbackFirstFactors?.find(factor => factor.strategy === 'email_code') as EmailCodeFactor) ?? null;
+}
+
+export { getSSOFallbackFactor, hasMultipleEnterpriseConnections, useHandleAuthenticateWithPasskey };

--- a/packages/ui/src/components/SignIn/shared.ts
+++ b/packages/ui/src/components/SignIn/shared.ts
@@ -110,9 +110,6 @@ function hasMultipleEnterpriseConnections(
 
 /**
  * Returns the email code factor a sign-in may fall back to, or `null`.
- *
- * The API populates the list only for allowlisted users, so a factor here means this user is
- * eligible and anything rendered from it discloses that to whoever supplied the identifier.
  * @experimental
  */
 function getSSOFallbackFactor(signIn: SignInResource): EmailCodeFactor | null {

--- a/packages/ui/src/components/SignIn/shared.ts
+++ b/packages/ui/src/components/SignIn/shared.ts
@@ -109,7 +109,7 @@ function hasMultipleEnterpriseConnections(
 }
 
 /**
- * Returns the email code factor an enterprise-routed sign-in may fall back to, or `null`.
+ * Returns the email code factor a sign-in may fall back to, or `null`.
  *
  * The API populates the list only for allowlisted users, so a factor here means this user is
  * eligible and anything rendered from it discloses that to whoever supplied the identifier.

--- a/packages/ui/src/components/SignIn/shared.ts
+++ b/packages/ui/src/components/SignIn/shared.ts
@@ -111,9 +111,8 @@ function hasMultipleEnterpriseConnections(
 /**
  * Returns the email code factor an enterprise-routed sign-in may fall back to, or `null`.
  *
- * The list is populated purely from instance configuration: it says the instance allows a
- * fallback, never that this particular user is allowed one. Branching on anything more would
- * turn the UI into an enumeration oracle for the allowlist.
+ * The API populates the list only for allowlisted users, so a factor here means this user is
+ * eligible and anything rendered from it discloses that to whoever supplied the identifier.
  * @experimental
  */
 function getSSOFallbackFactor(signIn: SignInResource): EmailCodeFactor | null {

--- a/packages/ui/src/elements/contexts/index.tsx
+++ b/packages/ui/src/elements/contexts/index.tsx
@@ -133,6 +133,7 @@ export type FlowMetadata = {
     | 'chooseOrganization'
     | 'chooseWallet'
     | 'enterpriseConnections'
+    | 'ssoFallback'
     | 'organizationCreationDisabled'
     | 'methodSelectionMFA'
     | 'provideEmail'

--- a/packages/ui/src/test/fixture-helpers.ts
+++ b/packages/ui/src/test/fixture-helpers.ts
@@ -116,6 +116,12 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
     supportResetPassword?: boolean;
   };
 
+  type SignInWithEnterpriseSSOParams = {
+    identifier?: string;
+    enterpriseConnections?: Array<{ id: string; name: string }>;
+    supportSSOFallback?: boolean;
+  };
+
   type SignInFactorTwoParams = {
     identifier?: string;
     supportPhoneCode?: boolean;
@@ -154,6 +160,28 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
             ]
           : []),
       ],
+      user_data: { ...(createUserFixture() as any) },
+    } as SignInJSON;
+  };
+
+  const startSignInWithEnterpriseSSO = (params?: SignInWithEnterpriseSSOParams) => {
+    const { identifier = 'hello@clerk.com', enterpriseConnections, supportSSOFallback } = params || {};
+    baseClient.sign_in = {
+      status: 'needs_first_factor',
+      identifier,
+      supported_identifiers: ['email_address'],
+      supported_first_factors: enterpriseConnections?.length
+        ? enterpriseConnections.map(({ id, name }) => ({
+            strategy: 'enterprise_sso',
+            enterprise_connection_id: id,
+            enterprise_connection_name: name,
+          }))
+        : [{ strategy: 'enterprise_sso' }],
+      ...(supportSSOFallback && {
+        sso_fallback_first_factors: [
+          { strategy: 'email_code', safe_identifier: identifier, email_address_id: 'idn_hmac' },
+        ],
+      }),
       user_data: { ...(createUserFixture() as any) },
     } as SignInJSON;
   };
@@ -287,6 +315,7 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
 
   return {
     startSignInWithEmailAddress,
+    startSignInWithEnterpriseSSO,
     startSignInWithPhoneNumber,
     startSignInFactorTwo,
     startSignInClientTrust,

--- a/packages/ui/src/utils/__tests__/formatSafeIdentifier.test.ts
+++ b/packages/ui/src/utils/__tests__/formatSafeIdentifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSafeIdentifier, maskEmailAddress } from '../formatSafeIdentifier';
+import { formatSafeIdentifier } from '../formatSafeIdentifier';
 
 describe('formatSafeIdentifier', () => {
   const cases = [
@@ -15,20 +15,5 @@ describe('formatSafeIdentifier', () => {
 
   it.each(cases)('formats the safe identifier', (str, expected) => {
     expect(formatSafeIdentifier(str)).toBe(expected);
-  });
-});
-
-describe('maskEmailAddress', () => {
-  const cases = [
-    ['hello@example.com', 'h***@example.com'],
-    ['h***@example.com', 'h***@example.com'],
-    ['a@example.com', 'a***@example.com'],
-    ['username', 'username'],
-    ['@example.com', '@example.com'],
-    ['', ''],
-  ];
-
-  it.each(cases)('masks the local part of %s', (str, expected) => {
-    expect(maskEmailAddress(str)).toBe(expected);
   });
 });

--- a/packages/ui/src/utils/__tests__/formatSafeIdentifier.test.ts
+++ b/packages/ui/src/utils/__tests__/formatSafeIdentifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSafeIdentifier } from '../formatSafeIdentifier';
+import { formatSafeIdentifier, maskEmailAddress } from '../formatSafeIdentifier';
 
 describe('formatSafeIdentifier', () => {
   const cases = [
@@ -15,5 +15,20 @@ describe('formatSafeIdentifier', () => {
 
   it.each(cases)('formats the safe identifier', (str, expected) => {
     expect(formatSafeIdentifier(str)).toBe(expected);
+  });
+});
+
+describe('maskEmailAddress', () => {
+  const cases = [
+    ['hello@example.com', 'h***@example.com'],
+    ['h***@example.com', 'h***@example.com'],
+    ['a@example.com', 'a***@example.com'],
+    ['username', 'username'],
+    ['@example.com', '@example.com'],
+    ['', ''],
+  ];
+
+  it.each(cases)('masks the local part of %s', (str, expected) => {
+    expect(maskEmailAddress(str)).toBe(expected);
   });
 });

--- a/packages/ui/src/utils/formatSafeIdentifier.ts
+++ b/packages/ui/src/utils/formatSafeIdentifier.ts
@@ -13,18 +13,3 @@ export const formatSafeIdentifier = (str: string | undefined | null) => {
   }
   return stringToFormattedPhoneString(str);
 };
-
-/**
- * Masks the local part of an email address, e.g. `user@corp.com` -> `u***@corp.com`.
- * Needed where the server hands back the address the user typed rather than an obfuscated one.
- */
-export const maskEmailAddress = (str: string | undefined | null) => {
-  if (!str || isMaskedIdentifier(str)) {
-    return str;
-  }
-  const at = str.lastIndexOf('@');
-  if (at <= 0) {
-    return str;
-  }
-  return `${str.slice(0, 1)}***${str.slice(at)}`;
-};

--- a/packages/ui/src/utils/formatSafeIdentifier.ts
+++ b/packages/ui/src/utils/formatSafeIdentifier.ts
@@ -13,3 +13,18 @@ export const formatSafeIdentifier = (str: string | undefined | null) => {
   }
   return stringToFormattedPhoneString(str);
 };
+
+/**
+ * Masks the local part of an email address, e.g. `user@corp.com` -> `u***@corp.com`.
+ * Needed where the server hands back the address the user typed rather than an obfuscated one.
+ */
+export const maskEmailAddress = (str: string | undefined | null) => {
+  if (!str || isMaskedIdentifier(str)) {
+    return str;
+  }
+  const at = str.lastIndexOf('@');
+  if (at <= 0) {
+    return str;
+  }
+  return `${str.slice(0, 1)}***${str.slice(at)}`;
+};


### PR DESCRIPTION
## Description

Enterprise-routed sign-ins for users the instance has allowlisted for an SSO fallback no longer redirect straight to the identity provider. `<SignIn />` stops at a screen offering SSO — or the existing connection picker, when several connections serve the address — alongside a "Can't use SSO?" link that leads to the standard email code step, which carries a notice that the organization requires single sign-on and that the attempt is recorded.

The link renders whenever `sso_fallback_first_factors` is present, which the API returns only for allowlisted users. Users without a fallback, and instances without the feature, are unaffected.

Also adds `ssoFallbackFirstFactors` to the sign-in resource for custom flows.

Fixes ORGS-1825.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: