### PR TITLE
fix(ui): suppress passkey autofill RP ID errors

### DIFF
--- a/.changeset/quiet-firefox-passkeys.md
+++ b/.changeset/quiet-firefox-passkeys.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Prevent passkey autofill from displaying an RP ID or domain error when a browser rejects a background credential request.

--- a/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/ui/src/components/SignIn/__tests__/SignInStart.test.tsx
@@ -1,4 +1,4 @@
-import { ClerkAPIResponseError } from '@clerk/shared/error';
+import { ClerkAPIResponseError, ClerkWebAuthnError } from '@clerk/shared/error';
 import { CAPTCHA_ELEMENT_ID } from '@clerk/shared/internal/clerk-js/constants';
 import { OAUTH_PROVIDERS } from '@clerk/shared/oauth';
 import type { SignInResource } from '@clerk/shared/types';
@@ -152,6 +152,32 @@ describe('SignInStart', () => {
             flow: 'autofill',
           });
         });
+      });
+
+      it('does not display related-origin errors from passkey autofill', async () => {
+        const { wrapper, fixtures } = await createFixtures(f => {
+          f.withEmailAddress();
+          f.withPasskey();
+          f.withPasskeySettings({
+            allow_autofill: true,
+            show_sign_in_button: true,
+          });
+        });
+
+        fixtures.signIn.authenticateWithPasskey.mockRejectedValue(
+          new ClerkWebAuthnError('The operation is insecure.', {
+            code: 'passkey_invalid_rpID_or_domain',
+          }),
+        );
+        render(<SignInStart />, { wrapper });
+
+        await waitFor(() => {
+          expect(fixtures.signIn.authenticateWithPasskey).toHaveBeenCalledWith({
+            flow: 'autofill',
+          });
+        });
+        expect(screen.queryByText(/operation is insecure/i)).not.toBeInTheDocument();
+        screen.getByText('Use passkey instead');
       });
 
       it('skips autofill when the host reports no autofill support', async () => {

--- a/packages/ui/src/components/SignIn/shared.ts
+++ b/packages/ui/src/components/SignIn/shared.ts
@@ -70,8 +70,11 @@ function useHandleAuthenticateWithPasskey(
         if (err.code === 'passkey_operation_aborted') {
           return;
         }
-        // In case of autofill, if retrieval of credentials is cancelled by the user avoid showing errors as it results to pour UX.
-        if (flow === 'autofill' && err.code === 'passkey_retrieval_cancelled') {
+        // Autofill runs in the background, so browser rejections must not surface as form errors.
+        if (
+          flow === 'autofill' &&
+          (err.code === 'passkey_retrieval_cancelled' || err.code === 'passkey_invalid_rpID_or_domain')
+        ) {
           return;
         }
       }


### PR DESCRIPTION
## Description

Suppress `passkey_invalid_rpID_or_domain` during background passkey autofill. Firefox rejects conditional requests that require Related Origin Requests even when the authentication-host configuration is valid, which currently surfaces a form error on page load.

The explicit passkey action remains unchanged, which will work fine with RoR requests. 

fixes: CORE-3589

Mozilla workaround that causes this error: https://bugzilla.mozilla.org/show_bug.cgi?id=2043449

## Checklist

- [ ] `pnpm test` runs as expected.
- [ ] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about/getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
