### PR TITLE
fix(expo): forward oidcPrompt and oidcLoginHint in useSSO hooks

### DIFF
--- a/.changeset/expo-sso-oidc-prompt.md
+++ b/.changeset/expo-sso-oidc-prompt.md
@@ -1,0 +1,6 @@
+---
+'@clerk/expo': patch
+'@clerk/shared': patch
+---
+
+`useSSO()` now accepts `oidcPrompt` and `oidcLoginHint` and forwards them to the sign-in request.

--- a/packages/expo/src/hooks/__tests__/useSSO.experimental.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSSO.experimental.test.ts
@@ -202,6 +202,25 @@ describe('experimental useSSO', () => {
     expect(response.signIn).toBe(reloadedSignIn);
   });
 
+  test.each([
+    { strategy: 'oauth_google', oidcPrompt: 'select_account', oidcLoginHint: 'user@example.com' },
+    {
+      strategy: 'enterprise_sso',
+      identifier: 'user@example.com',
+      oidcPrompt: 'consent',
+      oidcLoginHint: 'user@example.com',
+    },
+  ] as const)('forwards SSO options to sign-in creation: %j', async params => {
+    const { result } = renderHook(() => useSSO());
+
+    await result.current.startSSOFlow(params);
+
+    expect(mockSignIn.create).toHaveBeenCalledWith({
+      ...params,
+      redirectUrl: 'myapp://sso-callback',
+    });
+  });
+
   test('ignores a session retained by an unrelated sign-up resource', async () => {
     mockSignUp.createdSessionId = 'sess_stale_signup';
     const { result } = renderHook(() => useSSO());

--- a/packages/expo/src/hooks/__tests__/useSSO.test.ts
+++ b/packages/expo/src/hooks/__tests__/useSSO.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     useSignIn: vi.fn(),
     useSignUp: vi.fn(),
     openAuthSessionAsync: vi.fn(),
+    loadSSODependencies: vi.fn(),
   };
 });
 
@@ -26,19 +27,18 @@ vi.mock('react-native', () => {
   };
 });
 
-vi.mock('expo-web-browser', () => {
+vi.mock('../ssoDependencies', () => {
   return {
-    openAuthSessionAsync: mocks.openAuthSessionAsync,
+    loadSSODependencies: mocks.loadSSODependencies,
   };
 });
-
-// expo-auth-session is intentionally left unmocked: it cannot be require()'d in this environment,
-// which exercises the dependency-load failure path (the bug behind #8288). Only the error-path
-// test reaches that require(); the other tests return before it, so they are unaffected.
 
 describe('useSSO', () => {
   const mockSignIn = {
     create: vi.fn(),
+    firstFactorVerification: {
+      externalVerificationRedirectURL: new URL('https://accounts.example.com/sso'),
+    },
   };
 
   const mockSignUp = {
@@ -50,6 +50,16 @@ describe('useSSO', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    mocks.loadSSODependencies.mockReturnValue({
+      AuthSession: {
+        makeRedirectUri: () => 'myapp://sso-callback',
+      },
+      WebBrowser: {
+        openAuthSessionAsync: mocks.openAuthSessionAsync,
+      },
+    });
+    mocks.openAuthSessionAsync.mockResolvedValue({ type: 'cancel' });
 
     mocks.useSignIn.mockReturnValue({
       signIn: mockSignIn,
@@ -71,6 +81,7 @@ describe('useSSO', () => {
     const { result } = renderHook(() => useSSO());
 
     expect(typeof result.current.startSSOFlow).toBe('function');
+    expect(mocks.loadSSODependencies).not.toHaveBeenCalled();
   });
 
   test('returns early without starting the flow when Clerk is not loaded', async () => {
@@ -84,16 +95,39 @@ describe('useSSO', () => {
 
     const response = await result.current.startSSOFlow({ strategy: 'oauth_google' });
 
+    expect(mocks.loadSSODependencies).not.toHaveBeenCalled();
     expect(mockSignIn.create).not.toHaveBeenCalled();
     expect(mocks.openAuthSessionAsync).not.toHaveBeenCalled();
     expect(response.createdSessionId).toBe(null);
   });
 
   test('surfaces the underlying error when an auth-session dependency fails to load', async () => {
+    const error = new Error('Unable to load expo-auth-session');
+    mocks.loadSSODependencies.mockImplementationOnce(() => {
+      throw error;
+    });
     const { result } = renderHook(() => useSSO());
 
-    await expect(result.current.startSSOFlow({ strategy: 'oauth_google' })).rejects.toThrow(
-      /required for SSO: .+\. If they are not installed/s,
-    );
+    await expect(result.current.startSSOFlow({ strategy: 'oauth_google' })).rejects.toBe(error);
+    expect(mockSignIn.create).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { strategy: 'oauth_google', oidcPrompt: 'select_account', oidcLoginHint: 'user@example.com' },
+    {
+      strategy: 'enterprise_sso',
+      identifier: 'user@example.com',
+      oidcPrompt: 'consent',
+      oidcLoginHint: 'user@example.com',
+    },
+  ] as const)('forwards SSO options to sign-in creation: %j', async params => {
+    const { result } = renderHook(() => useSSO());
+
+    await result.current.startSSOFlow(params);
+
+    expect(mockSignIn.create).toHaveBeenCalledWith({
+      ...params,
+      redirectUrl: 'myapp://sso-callback',
+    });
   });
 });

--- a/packages/expo/src/hooks/useSSO.experimental.ts
+++ b/packages/expo/src/hooks/useSSO.experimental.ts
@@ -19,6 +19,10 @@ export type StartSSOFlowParams = {
    * Defaults to an Expo AuthSession URL with the `sso-callback` path.
    */
   redirectUrl?: string;
+  /** Space-separated OIDC prompt values, such as `select_account` or `consent`. */
+  oidcPrompt?: string;
+  /** Identifier to suggest to the identity provider for sign-in. */
+  oidcLoginHint?: string;
   /**
    * Metadata to attach to the user when the SSO flow creates a new account.
    */
@@ -116,7 +120,7 @@ export function useSSO(): UseSSOReturn {
 
     const { AuthSession, WebBrowser: WebBrowserModule } = loadSSODependencies();
 
-    const { strategy, unsafeMetadata, authSessionOptions } = startSSOFlowParams ?? {};
+    const { strategy, oidcPrompt, oidcLoginHint, unsafeMetadata, authSessionOptions } = startSSOFlowParams ?? {};
 
     /**
      * Creates a redirect URL based on the application platform
@@ -133,6 +137,8 @@ export function useSSO(): UseSSOReturn {
     const { error: signInError } = await signIn.create({
       strategy,
       redirectUrl,
+      oidcPrompt,
+      oidcLoginHint,
       ...(startSSOFlowParams.strategy === 'enterprise_sso' ? { identifier: startSSOFlowParams.identifier } : {}),
     });
     if (signInError) {

--- a/packages/expo/src/hooks/useSSO.ts
+++ b/packages/expo/src/hooks/useSSO.ts
@@ -9,9 +9,12 @@ import type {
 import type * as WebBrowser from 'expo-web-browser';
 
 import { errorThrower } from '../utils/errors';
+import { loadSSODependencies } from './ssoDependencies';
 
 export type StartSSOFlowParams = {
   redirectUrl?: string;
+  oidcPrompt?: string;
+  oidcLoginHint?: string;
   unsafeMetadata?: SignUpUnsafeMetadata;
   authSessionOptions?: Pick<WebBrowser.AuthSessionOpenOptions, 'showInRecents'>;
 } & (
@@ -66,26 +69,9 @@ export function useSSO() {
       };
     }
 
-    // Load via synchronous require() instead of import(): Metro inlines require() into the main
-    // bundle, while import() emits an async chunk that fails to resolve without @expo/metro-runtime.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- type-only annotation for optional dependency
-    let AuthSession: typeof import('expo-auth-session');
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- type-only annotation for optional dependency
-    let WebBrowserModule: typeof import('expo-web-browser');
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      AuthSession = require('expo-auth-session');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      WebBrowserModule = require('expo-web-browser');
-    } catch (err) {
-      return errorThrower.throw(
-        `Unable to load expo-auth-session and expo-web-browser, which are required for SSO: ${
-          err instanceof Error ? err.message : 'Unknown error'
-        }. If they are not installed, run: npx expo install expo-auth-session expo-web-browser`,
-      );
-    }
+    const { AuthSession, WebBrowser: WebBrowserModule } = loadSSODependencies();
 
-    const { strategy, unsafeMetadata, authSessionOptions } = startSSOFlowParams ?? {};
+    const { strategy, oidcPrompt, oidcLoginHint, unsafeMetadata, authSessionOptions } = startSSOFlowParams ?? {};
 
     /**
      * Creates a redirect URL based on the application platform
@@ -102,6 +88,8 @@ export function useSSO() {
     await signIn.create({
       strategy,
       redirectUrl,
+      oidcPrompt,
+      oidcLoginHint,
       ...(startSSOFlowParams.strategy === 'enterprise_sso' ? { identifier: startSSOFlowParams.identifier } : {}),
     });
 

--- a/packages/shared/src/types/signInFuture.ts
+++ b/packages/shared/src/types/signInFuture.ts
@@ -26,6 +26,14 @@ export interface SignInFutureCreateParams {
    */
   redirectUrl?: string;
   /**
+   * The value to pass to the [OIDC `prompt` parameter](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=prompt,reauthentication%20and%20consent.) in the generated OAuth redirect URL.
+   */
+  oidcPrompt?: string;
+  /**
+   * The value to pass to the [OIDC `login_hint` parameter](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=login_hint,in%20\(if%20necessary\).) in the generated OAuth redirect URL.
+   */
+  oidcLoginHint?: string;
+  /**
    * The URL that the user will be redirected to, after successful authorization from the OAuth provider and Clerk sign-in.
    */
   actionCompleteRedirectUrl?: string;


### PR DESCRIPTION
## Description

The `useSSO` hook now accept `oidcPrompt` and `oidcLoginHint` in `startSSOFlow()` and forward them to `signIn.create()`. Both hooks were dropping them.

I did a similar fix here https://github.com/clerk/javascript/pull/9354

Fixes #9680

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
