### PR TITLE
fix(backend): point lockUser() JSDoc to canonical System Dashboard link

### DIFF
--- a/.changeset/lockuser-protect-rules-system-link.md
+++ b/.changeset/lockuser-protect-rules-system-link.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Update the `lockUser()` JSDoc to point at the **System** page under **Protect** > **Rules** (`/~/protect/rules/system`), matching the Clerk Dashboard's Protect navigation.

--- a/packages/backend/src/api/endpoints/UserApi.ts
+++ b/packages/backend/src/api/endpoints/UserApi.ts
@@ -785,7 +785,7 @@ export class UserAPI extends AbstractAPI {
   }
 
   /**
-   * Locks the given [`User`](https://clerk.com/docs/reference/backend/types/backend-user), which means that they are not allowed to sign in again until the lock expires or is manually unlocked. By default, lockout duration is 1 hour, but it can be configured in the application's [**Rules**](https://dashboard.clerk.com/~/protect/rules) settings. See the [guide on user locks](https://clerk.com/docs/guides/secure/user-lockout).
+   * Locks the given [`User`](https://clerk.com/docs/reference/backend/types/backend-user), which means that they are not allowed to sign in again until the lock expires or is manually unlocked. By default, lockout duration is 1 hour, but it can be configured in the application's [**System**](https://dashboard.clerk.com/~/protect/rules/system) settings under **Protect** > **Rules**. See the [guide on user locks](https://clerk.com/docs/guides/secure/user-lockout).
    * @param userId - The ID of the user to lock.
    */
   public async lockUser(userId: string) {


### PR DESCRIPTION
The Dashboard's Protect navigation moved **Rules** under a **System** / **Custom** split, so the old `/~/protect/rules` target now redirects. This updates the `lockUser()` JSDoc to point at the **System** page (`/~/protect/rules/system`) under **Protect** > **Rules**.

This is the last occurrence of the old link — the hand-authored docs are handled in clerk/clerk#3319, but the `lockUser()` reference at `clerk-docs/clerk-typedoc/backend/user-api/methods/lock-user.mdx` is generated from this JSDoc, so the fix has to land here and flow back through the Typedoc refresh.

## Context

- Docs link updates: clerk/clerk#3319
- Dashboard nav change: clerk/dashboard#10173