### PR TITLE
fix(ui): merge container styles into Mosaic Icon via xstyle

### DIFF
--- a/.changeset/mosaic-icon-xstyle.md
+++ b/.changeset/mosaic-icon-xstyle.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/ui': patch
 ---
-
-Fix the Mosaic `Banner` and `Field.Error` icons so their line-height-based sizing reliably overrides the icon's default size, and expose the banner icon as `.cl-banner-icon`.

--- a/.changeset/mosaic-icon-xstyle.md
+++ b/.changeset/mosaic-icon-xstyle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/ui': patch
+---
+
+Fix the Mosaic `Banner` and `Field.Error` icons so their line-height-based sizing reliably overrides the icon's default size, and expose the banner icon as `.cl-banner-icon`.

--- a/packages/ui/src/mosaic/components/banner/banner.test.tsx
+++ b/packages/ui/src/mosaic/components/banner/banner.test.tsx
@@ -49,6 +49,7 @@ describe('Mosaic Banner', () => {
     );
     const icon = container.querySelector('.cl-banner-root > .cl-icon');
     expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('cl-banner-icon');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
 
     rerender(

--- a/packages/ui/src/mosaic/components/banner/banner.tsx
+++ b/packages/ui/src/mosaic/components/banner/banner.tsx
@@ -48,7 +48,8 @@ const Root = React.forwardRef<HTMLDivElement, BannerRootProps>(function MosaicBa
           <Icon
             name={ICONS[color]}
             aria-hidden='true'
-            {...stylex.props(styles.icon)}
+            xstyle={styles.icon}
+            {...themeProps('banner-icon')}
           />
           <div {...mergeStyleProps(themeProps('banner-content'), stylex.props(reset.base, styles.content))}>
             {children}

--- a/packages/ui/src/mosaic/components/field/field.tsx
+++ b/packages/ui/src/mosaic/components/field/field.tsx
@@ -150,7 +150,7 @@ const FieldError = React.forwardRef<HTMLParagraphElement, FieldErrorProps>(funct
             name='alert-circle'
             size='sm'
             aria-hidden='true'
-            {...stylex.props(styles.errorIcon)}
+            xstyle={styles.errorIcon}
           />
           <span>{children}</span>
         </>

--- a/packages/ui/src/mosaic/components/icon/icon.test.tsx
+++ b/packages/ui/src/mosaic/components/icon/icon.test.tsx
@@ -1,10 +1,17 @@
+import * as stylex from '@stylexjs/stylex';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import type { MosaicIconOverrides } from '../../icons/overrides';
 import { MosaicProvider } from '../../MosaicProvider';
+import { space } from '../../tokens.stylex';
 import { Icon } from './icon';
+
+const containerStyles = stylex.create({
+  lineBox: { height: '1lh' },
+  mdHeight: { height: space['4'] },
+});
 
 const wrap = (ui: React.ReactElement, icons?: MosaicIconOverrides) =>
   render(<MosaicProvider icons={icons}>{ui}</MosaicProvider>);
@@ -59,6 +66,18 @@ describe('Mosaic Icon', () => {
     expect(svg).toHaveAttribute('data-size', 'lg');
     expect(svg).toHaveClass('cl-icon', 'my-icon');
     expect(svg).toHaveStyle({ marginTop: '8px' });
+  });
+
+  it('lets a container xstyle override the size atoms instead of stacking a second class', () => {
+    const { container } = wrap(
+      <Icon
+        name='chevron-right'
+        xstyle={containerStyles.lineBox}
+      />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass(stylex.props(containerStyles.lineBox).className ?? '');
+    expect(svg).not.toHaveClass(stylex.props(containerStyles.mdHeight).className ?? '');
   });
 
   it('emits no placement attribute when the icon is not placed', () => {

--- a/packages/ui/src/mosaic/components/icon/icon.tsx
+++ b/packages/ui/src/mosaic/components/icon/icon.tsx
@@ -13,6 +13,8 @@ export interface IconProps extends React.ComponentPropsWithRef<'svg'> {
   name: IconName;
   size?: 'sm' | 'md' | 'lg';
   placement?: 'inline-start' | 'inline-end';
+  /** StyleX atoms from the container; merged last so they win over the icon's own size atoms. */
+  xstyle?: stylex.StyleXStyles;
 }
 
 /**
@@ -26,7 +28,7 @@ export interface IconProps extends React.ComponentPropsWithRef<'svg'> {
  * follow the writing mode rather than naming a physical edge.
  */
 export const Icon = React.forwardRef<SVGSVGElement, IconProps>(function MosaicIcon(
-  { name, size = 'md', placement, className, style, ...rest },
+  { name, size = 'md', placement, xstyle, className, style, ...rest },
   ref,
 ) {
   const override = useMosaicIcons()[name];
@@ -34,7 +36,7 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(function MosaicIc
   // child by what it is: `:has([data-icon='inline-end'])` can't match some other placed descendant.
   const props = mergeStyleProps(
     themeProps('icon', { size, icon: placement }),
-    stylex.props(reset.base, styles.base, sizes[size], iconScope),
+    stylex.props(reset.base, styles.base, sizes[size], iconScope, xstyle),
     className,
     style,
   );

--- a/packages/ui/src/mosaic/user-profile/user-profile-api-keys-panel.view.tsx
+++ b/packages/ui/src/mosaic/user-profile/user-profile-api-keys-panel.view.tsx
@@ -77,7 +77,7 @@ export function UserProfileApiKeysPanelView({
             aria-hidden
             name='search'
             size='sm'
-            {...stylex.props(styles.searchIcon)}
+            xstyle={styles.searchIcon}
           />
           <Input
             aria-label='Search API keys'

--- a/packages/ui/src/mosaic/user-profile/user-profile-provider-icon.tsx
+++ b/packages/ui/src/mosaic/user-profile/user-profile-provider-icon.tsx
@@ -21,7 +21,7 @@ export function UserProfileProviderIcon(props: UserProfileProviderIconProps) {
           <Icon
             aria-hidden
             name={props.name}
-            {...stylex.props(styles.providerIcon)}
+            xstyle={styles.providerIcon}
           />
         )}
       </IconFrame>

--- a/packages/ui/src/mosaic/user-profile/user-profile-security-icon.tsx
+++ b/packages/ui/src/mosaic/user-profile/user-profile-security-icon.tsx
@@ -27,7 +27,7 @@ export function UserProfileSecurityIcon({ name }: { name: UserProfileSecurityIco
         aria-hidden
         name={icons[name]}
         size='lg'
-        {...stylex.props(styles.icon)}
+        xstyle={styles.icon}
       />
     </Section.Media>
   );


### PR DESCRIPTION
## Description

Containers that sized a Mosaic `Icon` (the `Banner` and `Field.Error` icons at `1lh`, and the user-profile security, provider, and search icons) spread their own `stylex.props(...)` output onto the icon. StyleX only resolves conflicting properties within a single `stylex.props` call, so the container's `height` and the icon's own `sizes[size]` atom ended up as two equal-priority classes and stylesheet order decided which won. In practice the icon's size atom won and the `1lh` height was dropped.

`Icon` now accepts an `xstyle` prop that is merged last in its own `stylex.props` call, so the container's atoms deterministically override the icon's defaults. All call sites that previously spread resolved atoms onto an `Icon` use `xstyle` instead. The banner icon also gets the `cl-banner-icon` slot class.

| BEFORE | AFTER |
|--------|--------|
| <img width="361" height="120" alt="Screenshot 2026-09-09 at 3 44 42 PM" src="https://github.com/user-attachments/assets/4352f5be-f43b-41d9-be86-45e373db03bd" /> | <img width="379" height="126" alt="Screenshot 2026-09-09 at 3 45 10 PM" src="https://github.com/user-attachments/assets/7352f5c7-06a4-4b8e-80c0-fde1d9b5b814" /> | 

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: