### PR TITLE
docs(shared): correct the hidePersonal docs on OrganizationSwitcherProps and OrganizationListProps

### DIFF
--- a/.changeset/organization-switcher-hide-personal-doc.md
+++ b/.changeset/organization-switcher-hide-personal-doc.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Correct the `hidePersonal` documentation on `OrganizationSwitcherProps`: setting it to `true` hides the personal account entry, and it defaults to `false`.

--- a/.changeset/organization-switcher-hide-personal-doc.md
+++ b/.changeset/organization-switcher-hide-personal-doc.md
@@ -2,4 +2,4 @@
 '@clerk/shared': patch
 ---
 
-Correct the `hidePersonal` documentation on `OrganizationSwitcherProps`: setting it to `true` hides the personal account entry, and it defaults to `false`.
+Correct the `hidePersonal` documentation on `OrganizationSwitcherProps` and `OrganizationListProps`: setting it to `true` hides the personal account entry, and it defaults to `false`.

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -2340,10 +2340,10 @@ export type OrganizationSwitcherProps = CreateOrganizationMode &
     /**
      * By default, users can switch between Organization and their personal account.
      * This option controls whether OrganizationSwitcher will include the user's personal account
-     * in the Organization list. Setting this to `false` will hide the personal account entry,
+     * in the Organization list. Setting this to `true` will hide the personal account entry,
      * and users will only be able to switch between Organizations.
      *
-     * @default true
+     * @default false
      */
     hidePersonal?: boolean;
     /**

--- a/packages/shared/src/types/clerk.ts
+++ b/packages/shared/src/types/clerk.ts
@@ -2427,10 +2427,10 @@ export type OrganizationListProps = {
   /**
    * By default, users can switch between Organization and their personal account.
    * This option controls whether OrganizationList will include the user's personal account
-   * in the Organization list. Setting this to `false` will hide the personal account entry,
+   * in the Organization list. Setting this to `true` will hide the personal account entry,
    * and users will only be able to switch between Organizations.
    *
-   * @default true
+   * @default false
    */
   hidePersonal?: boolean;
   /**


### PR DESCRIPTION
## Description

Corrects the JSDoc for `hidePersonal` on `OrganizationSwitcherProps` and `OrganizationListProps`. It said setting the prop to `false` hides the personal account entry and that the default is `true`. The implementation is the reverse: the entry is shown by default, and `true` hides it. No runtime change.

## Checklist

- [x] `pnpm test` runs as expected.
- [x] `pnpm build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other: